### PR TITLE
API auth failures should respond with json, closes #49

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@
 
     // ## Variables
         auth,
+        authAPI,
 
         /**
          * Create new Ghost object
@@ -50,9 +51,19 @@
         if (!req.session.user) {
             req.flash('warn', "Please login");
             res.redirect('/ghost/login/?redirect=' + encodeURIComponent(req.path));
-        } else {
-            next();
+            return;
         }
+        next();
+    };
+
+    authAPI = function (req, res, next) {
+        if (!req.session.user) {
+            // TODO: standardize error format/codes/messages
+            var err = { code: 42, message: 'Please login' };
+            res.json(401, { error: err });
+            return;
+        }
+        next();
     };
 
     helpers.loadCoreHelpers(ghost);
@@ -62,14 +73,14 @@
      * API routes..
      * @todo auth should be public auth not user auth
      */
-    ghost.app().get('/api/v0.1/posts', auth, api.requestHandler(api.posts.browse));
-    ghost.app().post('/api/v0.1/posts', auth, api.requestHandler(api.posts.add));
-    ghost.app().get('/api/v0.1/posts/:id', auth, api.requestHandler(api.posts.read));
-    ghost.app().put('/api/v0.1/posts/:id', auth, api.requestHandler(api.posts.edit));
-    ghost.app().del('/api/v0.1/posts/:id', auth, api.requestHandler(api.posts.destroy));
-    ghost.app().get('/api/v0.1/settings', auth, api.requestHandler(api.settings.browse));
-    ghost.app().get('/api/v0.1/settings/:key', auth, api.requestHandler(api.settings.read));
-    ghost.app().put('/api/v0.1/settings', auth, api.requestHandler(api.settings.edit));
+    ghost.app().get('/api/v0.1/posts', authAPI, api.requestHandler(api.posts.browse));
+    ghost.app().post('/api/v0.1/posts', authAPI, api.requestHandler(api.posts.add));
+    ghost.app().get('/api/v0.1/posts/:id', authAPI, api.requestHandler(api.posts.read));
+    ghost.app().put('/api/v0.1/posts/:id', authAPI, api.requestHandler(api.posts.edit));
+    ghost.app().del('/api/v0.1/posts/:id', authAPI, api.requestHandler(api.posts.destroy));
+    ghost.app().get('/api/v0.1/settings', authAPI, api.requestHandler(api.settings.browse));
+    ghost.app().get('/api/v0.1/settings/:key', authAPI, api.requestHandler(api.settings.read));
+    ghost.app().put('/api/v0.1/settings', authAPI, api.requestHandler(api.settings.edit));
 
     /**
      * Admin routes..


### PR DESCRIPTION
^^

Pending definition on error formats.
