### PR TITLE
Bookshelf API Providers Abstraction and Tests; Closes #35

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,8 @@
                     node: true,
                     browser: true,
                     nomen: true,
-                    todo: true
+                    todo: true,
+                    unparam: true
                 },
                 files: [
                     // Lint files in the root, including Gruntfile.js
@@ -24,6 +25,17 @@
             nodeunit: {
                 all: ['core/test/ghost/**/test-*.js'],
                 api: ['core/test/ghost/test-api.js']
+            },
+
+            mochaTest: {
+                options: {
+                    ui: "bdd",
+                    reporter: "spec"
+                },
+
+                all: {
+                    src: ['core/test/**/*_spec.js']
+                }
             },
 
             // Compile all the SASS!
@@ -40,6 +52,7 @@
 
         grunt.loadNpmTasks("grunt-jslint");
         grunt.loadNpmTasks("grunt-contrib-nodeunit");
+        grunt.loadNpmTasks("grunt-mocha-test");
         grunt.loadNpmTasks("grunt-contrib-compass");
 
         // Prepare the project for development
@@ -47,10 +60,10 @@
         grunt.registerTask("init", ["compass:admin"]);
 
         // Run API tests only
-        grunt.registerTask("test-api", ["nodeunit:api"]);
+        grunt.registerTask("test-api", ["nodeunit:api", "mochaTest:all"]);
 
         // Run tests and lint code
-        grunt.registerTask("validate", ["jslint", "nodeunit:all"]);
+        grunt.registerTask("validate", ["jslint", "mochaTest:all"]);
     };
 
     module.exports = configureGrunt;

--- a/config.js
+++ b/config.js
@@ -61,7 +61,7 @@
             connection: {
                 filename: './core/shared/data/testdb.db'
             },
-            debug: true
+            debug: false
         },
 
         staging: {},

--- a/core/admin/assets/js/editor.js
+++ b/core/admin/assets/js/editor.js
@@ -58,10 +58,11 @@
                 title: document.getElementById('entry-title').value,
                 content: editor.getValue()
             },
-            urlSegments = window.location.pathname.split('/');
+            urlSegments = window.location.pathname.split('/'),
+            id;
 
         if (urlSegments[2] === 'editor' && urlSegments[3] && /^[a-zA-Z0-9]+$/.test(urlSegments[2])) {
-            var id = urlSegments[3];
+            id = urlSegments[3];
             $.ajax({
                 url: '/api/v0.1/posts/' + id,
                 method: 'PUT',

--- a/core/admin/controllers/index.js
+++ b/core/admin/controllers/index.js
@@ -5,7 +5,6 @@
     var Ghost = require('../../ghost'),
         _ = require('underscore'),
         fs = require('fs'),
-        when = require('when/node/function'),
         api = require('../../shared/api'),
 
         ghost = new Ghost(),

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -99,14 +99,18 @@
      * @param  {Function} fn
      * @return {*}
      */
-    Ghost.prototype.registerTheme = function (name, fn) {};
+    Ghost.prototype.registerTheme = function (name, fn) {
+        return this;
+    };
 
     /**
      * @param  {string}   name
      * @param  {Function} fn
      * @return {*}
      */
-    Ghost.prototype.registerPlugin = function (name, fn) {};
+    Ghost.prototype.registerPlugin = function (name, fn) {
+        return this;
+    };
 
     /**
      * @param  {string}   name

--- a/core/lang/i18n.js
+++ b/core/lang/i18n.js
@@ -27,7 +27,7 @@
             /** TODO potentially use req.acceptedLanguages rather than the default
             *   TODO handle loading language file for frontend on frontend request etc
             *   TODO switch this mess to be promise driven */
-            fs.stat(langFilePath, function (error, stat) {
+            fs.stat(langFilePath, function (error) {
                 if (error) {
                     console.log('No language file found for language ' + lang + '. Defaulting to en');
                     lang = 'en';

--- a/core/shared/data/migration/001.js
+++ b/core/shared/data/migration/001.js
@@ -69,7 +69,14 @@
         });
     };
 
-    down = function () {};
+    down = function () {
+
+        return when.all([
+            knex.Schema.dropTableIfExists("posts"),
+            knex.Schema.dropTableIfExists("users"),
+            knex.Schema.dropTableIfExists("settings")
+        ]);
+    };
 
     exports.up = up;
     exports.down = down;

--- a/core/shared/models/dataProvider.bookshelf.base.js
+++ b/core/shared/models/dataProvider.bookshelf.base.js
@@ -1,0 +1,72 @@
+(function () {
+    "use strict";
+
+    /**
+     * The base class for interacting with bookshelf models/collections.
+     * Provides naive implementations of CRUD/BREAD operations.
+     */
+    var BookshelfBase = function (model, collection) {
+        this.model = model;
+        this.collection = collection;
+    };
+
+    /**
+     * Naive find all
+     * @param args
+     * @param callback
+     */
+    BookshelfBase.prototype.findAll = function (args, callback) {
+        args = args || {};
+        this.collection.forge().fetch().then(function (results) {
+            callback(null, results);
+        }, callback);
+    };
+
+    /**
+     * Naive find one where args match
+     * @param args
+     * @param callback
+     */
+    BookshelfBase.prototype.findOne = function (args, callback) {
+        this.model.forge(args).fetch().then(function (result) {
+            callback(null, result);
+        }, callback);
+    };
+
+    /**
+     * Naive add
+     * @param newObj
+     * @param callback
+     */
+    BookshelfBase.prototype.add = function (newObj, callback) {
+        this.model.forge(newObj).save().then(function (createdObj) {
+            callback(null, createdObj);
+        }, callback);
+    };
+
+    /**
+     * Naive edit
+     * @param editedObj
+     * @param callback
+     */
+    BookshelfBase.prototype.edit = function (editedObj, callback) {
+        this.model.forge({id: editedObj.id}).fetch().then(function (foundObj) {
+            foundObj.set(editedObj).save().then(function (updatedObj) {
+                callback(null, updatedObj);
+            }, callback);
+        });
+    };
+
+    /**
+     * Naive destroy
+     * @param _identifier
+     * @param callback
+     */
+    BookshelfBase.prototype.destroy = function (_identifier, callback) {
+        this.model.forge({id: _identifier}).destroy().then(function () {
+            callback(null);
+        });
+    };
+
+    module.exports = BookshelfBase;
+}());

--- a/core/shared/models/dataProvider.bookshelf.js
+++ b/core/shared/models/dataProvider.bookshelf.js
@@ -9,10 +9,7 @@
     var knex = require('./knex_init'),
         PostsProvider = require('./dataProvider.bookshelf.posts'),
         UsersProvider = require('./dataProvider.bookshelf.users'),
-        models = require('./models'),
-        bcrypt = require('bcrypt'),
-        when = require("when"),
-        _ = require("underscore"),
+        SettingsProvider = require('./dataProvider.bookshelf.settings'),
         DataProvider,
         instance;
 
@@ -20,7 +17,7 @@
         if (!instance) {
             instance = this;
             knex.Schema.hasTable('posts').then(null, function () {
-                // Simple boostraping of the data model for now.
+                // Simple bootstraping of the data model for now.
                 var migration = require('../data/migration/001');
 
                 migration.down().then(function() {
@@ -36,31 +33,7 @@
 
     DataProvider.prototype.posts = new PostsProvider();
     DataProvider.prototype.users = new UsersProvider();
-
-    // ## Settings
-    DataProvider.prototype.settings = function () { };
-
-    DataProvider.prototype.settings.browse = function (_args, callback) {
-        models.Settings.forge(_args).fetch().then(function (settings) {
-            callback(null, settings);
-        }, callback);
-    };
-
-    DataProvider.prototype.settings.read = function (_key, callback) {
-        models.Setting.forge({ key: _key }).fetch().then(function (setting) {
-            callback(null, setting);
-        }, callback);
-    };
-
-    DataProvider.prototype.settings.edit = function (_data, callback) {
-        when.all(_.map(_data, function (value, key) {
-            return models.Setting.forge({ key: key }).fetch().then(function (setting) {
-                return setting.set('value', value).save();
-            });
-        })).then(function (settings) {
-            callback(null, settings);
-        }, callback);
-    };
+    DataProvider.prototype.settings = new SettingsProvider();
 
     module.exports = DataProvider;
 }());

--- a/core/shared/models/dataProvider.bookshelf.js
+++ b/core/shared/models/dataProvider.bookshelf.js
@@ -7,8 +7,8 @@
     "use strict";
 
     var knex = require('./knex_init'),
-        models = require('./models'),
-        bcrypt = require('bcrypt'),
+        PostsProvider = require('./dataProvider.bookshelf.posts'),
+        UsersProvider = require('./dataProvider.bookshelf.users'),
         DataProvider,
         instance;
 
@@ -17,7 +17,7 @@
             instance = this;
             knex.Schema.hasTable('posts').then(null, function () {
                 // Simple boostraping of the data model for now.
-                require('./../data/migration/001').up().then(function () {
+                require('../data/migration/001').up().then(function () {
                     console.log('all done....');
                 });
             });
@@ -26,102 +26,8 @@
         return instance;
     };
 
-    DataProvider.prototype.posts = function () { };
-    DataProvider.prototype.users = function () { };
-
-    /**
-     * Naive find all
-     * @param args
-     * @param callback
-     */
-    DataProvider.prototype.posts.findAll = function (args, callback) {
-        models.Posts.forge().fetch().then(function (posts) {
-            callback(null, posts);
-        }, callback);
-    };
-
-    /**
-     * Naive find one where args match
-     * @param args
-     * @param callback
-     */
-    DataProvider.prototype.posts.findOne = function (args, callback) {
-        models.Post.forge(args).fetch().then(function (post) {
-            callback(null, post);
-        }, callback);
-    };
-
-    /**
-     * Naive add
-     * @param _post
-     * @param callback
-     */
-    DataProvider.prototype.posts.add = function (_post, callback) {
-        console.log(_post);
-        models.Post.forge(_post).save().then(function (post) {
-            callback(null, post);
-        }, callback);
-    };
-
-    /**
-     * Naive edit
-     * @param _post
-     * @param callback
-     */
-    DataProvider.prototype.posts.edit = function (_post, callback) {
-        models.Post.forge({id: _post.id}).fetch().then(function (post) {
-            post.set(_post).save().then(function (post) {
-                callback(null, post);
-            }, callback);
-        });
-    };
-
-
-    DataProvider.prototype.posts.destroy = function (_identifier, callback) {
-        models.Post.forge({id: _identifier}).destroy().then(function () {
-            callback(null);
-        });
-    };
-
-    /**
-     * Naive user add
-     * @param  _user
-     * @param  callback
-     *
-     * Could probably do with some refactoring, but it works right now.
-     */
-    DataProvider.prototype.users.add = function (_user, callback) {
-        console.log('outside of forge', _user);
-        bcrypt.genSalt(10, function (err, salt) {
-            bcrypt.hash(_user.password, salt, function (err, hash) {
-                var test = {
-                    "password": hash,
-                    "email_address": _user.email
-                };
-                new models.User(test).save().then(function (user) {
-                    console.log('within the forge for the user bit', user);
-                    callback(null, user);
-                }, callback);
-            });
-        });
-    };
-
-    DataProvider.prototype.users.check = function (_userdata, callback) {
-        var test = {
-            email_address: _userdata.email
-        };
-        models.User.forge(test).fetch().then(function (user) {
-            var _user;
-            bcrypt.compare(_userdata.pw, user.attributes.password, function (err, res) {
-                if (res) {
-                    _user = user;
-                } else {
-                    _user = false;
-                }
-                callback(null, _user);
-            });
-        });
-    };
+    DataProvider.prototype.posts = new PostsProvider();
+    DataProvider.prototype.users = new UsersProvider();
 
     module.exports = DataProvider;
 }());

--- a/core/shared/models/dataProvider.bookshelf.posts.js
+++ b/core/shared/models/dataProvider.bookshelf.posts.js
@@ -2,7 +2,6 @@
     "use strict";
 
     var util = require('util'),
-
         models = require('./models'),
         BaseProvider = require('./dataProvider.bookshelf.base'),
         PostsProvider;

--- a/core/shared/models/dataProvider.bookshelf.posts.js
+++ b/core/shared/models/dataProvider.bookshelf.posts.js
@@ -1,0 +1,20 @@
+(function() {
+    "use strict";
+
+    var util = require('util'),
+
+        models = require('./models'),
+        BaseProvider = require('./dataProvider.bookshelf.base'),
+        PostsProvider;
+
+    /**
+     * The Posts data provider implementation for Bookshelf.
+     */
+    PostsProvider = function () {
+        BaseProvider.call(this, models.Post, models.Posts);
+    };
+
+    util.inherits(PostsProvider, BaseProvider);
+
+    module.exports = PostsProvider;
+}());

--- a/core/shared/models/dataProvider.bookshelf.settings.js
+++ b/core/shared/models/dataProvider.bookshelf.settings.js
@@ -1,0 +1,42 @@
+(function() {
+    "use strict";
+
+    var _ = require('underscore'),
+        when = require('when'),
+        util = require('util'),
+        models = require('./models'),
+        BaseProvider = require('./dataProvider.bookshelf.base'),
+        SettingsProvider;
+
+    /**
+     * The Posts data provider implementation for Bookshelf.
+     */
+    SettingsProvider = function () {
+        BaseProvider.call(this, models.Setting, models.Settings);
+    };
+
+    util.inherits(SettingsProvider, BaseProvider);
+
+    SettingsProvider.prototype.read = function(_key, callback) {
+        // Allow for just passing the key instead of attributes
+        if (_.isString(_key)) {
+            _key = { key: _key };
+        }
+
+        BaseProvider.prototype.read.call(this, _key, callback);
+    };
+
+    SettingsProvider.prototype.edit = function(_data, callback) {
+        var self = this;
+
+        when.all(_.map(_data, function (value, key) {
+            return self.model.forge({ key: key }).fetch().then(function (setting) {
+                return setting.set('value', value).save();
+            });
+        })).then(function (settings) {
+            callback(null, settings);
+        }, callback);
+    };
+
+    module.exports = SettingsProvider;
+}());

--- a/core/shared/models/dataProvider.bookshelf.users.js
+++ b/core/shared/models/dataProvider.bookshelf.users.js
@@ -1,0 +1,86 @@
+(function() {
+    "use strict";
+
+    var util = require('util'),
+        _ = require('underscore'),
+        bcrypt = require('bcrypt'),
+        models = require('./models.js'),
+        BaseProvider = require('./dataProvider.bookshelf.base.js'),
+        UsersProvider;
+
+    /**
+     * The Users data provider implementation for Bookshelf.
+     */
+    UsersProvider = function () {
+        BaseProvider.call(this, models.User, models.Users);
+    };
+
+    util.inherits(UsersProvider, BaseProvider);
+
+    /**
+     * Naive user add
+     * @param  _user
+     * @param  callback
+     *
+     * Hashes the password provided before saving to the database.
+     */
+    UsersProvider.prototype.add = function (_user, callback) {
+        var self = this,
+            // Clone the _user so we don't expose the hashed password unnecessarily
+            userData = _.extend({}, _user);
+
+        this._hashPassword(userData.password, function (err, hash) {
+            if (err) {
+                return callback(err);
+            }
+
+            userData.password = hash;
+
+            BaseProvider.prototype.add.call(self, userData, function (err, createdUser) {
+                if (err) {
+                    return callback(err);
+                }
+
+                callback(null, createdUser);
+            });
+        });
+    };
+
+    UsersProvider.prototype._hashPassword = function (password, callback) {
+        bcrypt.genSalt(10, function (err, salt) {
+            if (err) {
+                return callback(err);
+            }
+
+            bcrypt.hash(password, salt, function (err, hash) {
+                if (err) {
+                    return callback(err);
+                }
+
+                callback(null, hash);
+            });
+        });
+    };
+
+    UsersProvider.prototype.check = function (_userdata, callback) {
+        var test = {
+            email_address: _userdata.email
+        };
+        models.User.forge(test).fetch().then(function (user) {
+            var _user;
+            bcrypt.compare(_userdata.pw, user.attributes.password, function (err, res) {
+                if (err) {
+                    return callback(err);
+                }
+                if (res) {
+                    _user = user;
+                } else {
+                    _user = false;
+                }
+                callback(null, _user);
+            });
+        });
+    };
+
+    module.exports = UsersProvider;
+}());

--- a/core/shared/models/dataProvider.json.js
+++ b/core/shared/models/dataProvider.json.js
@@ -46,7 +46,9 @@
 
     /* Lets bootstrap with dummy data */
     d = new DataProvider();
-    d.globals.save(blogData, function (error, globals) {});
+    d.globals.save(blogData, function (error) {
+        if (error) { throw error; }
+    });
 
     module.exports = DataProvider;
 }());

--- a/core/shared/models/knex_init.js
+++ b/core/shared/models/knex_init.js
@@ -2,9 +2,10 @@
 (function () {
     "use strict";
 
-    var knex = require('knex');
+    var knex = require('knex'),
+        config = require('../../../config');
 
-    knex.Initialize(require('../../../config').database[process.env.NODE_ENV || 'development']);
+    knex.Initialize(config.database[process.env.NODE_ENV || 'development']);
 
     module.exports = knex;
 }());

--- a/core/shared/models/models.js
+++ b/core/shared/models/models.js
@@ -12,6 +12,7 @@
         Post,
         Posts,
         User,
+        Users,
         Setting;
 
     Post = Bookshelf.Model.extend({
@@ -67,6 +68,12 @@
         }
     });
 
+    Users = Bookshelf.Collection.extend({
+
+        model: User
+
+    });
+
     Setting = Bookshelf.Model.extend({
 
         tableName: 'settings'
@@ -77,6 +84,7 @@
         Post: Post,
         Posts: Posts,
         User: User,
+        Users: Users,
         Setting: Setting
     };
 }());

--- a/core/test/ghost/api_posts_spec.js
+++ b/core/test/ghost/api_posts_spec.js
@@ -1,0 +1,42 @@
+/*globals describe, beforeEach, it*/
+
+(function () {
+    "use strict";
+
+    var should = require('should'),
+        helpers = require('./helpers'),
+        PostProvider = require('../../shared/models/dataProvider.bookshelf.posts');
+
+    describe("dataProvider.bookshelf", function () {
+        describe('PostsProvider', function () {
+
+            var posts;
+
+            beforeEach(function (done) {
+                helpers.resetData().then(function () {
+                    posts = new PostProvider();
+                    done();
+                });
+            });
+
+            it('can create', function (done) {
+                var newPost = {
+                    title: 'Test Title 1',
+                    content: 'Test Content 1'
+                };
+
+                posts.add(newPost, function (err, createdPost) {
+                    if (err) { throw err; }
+
+                    should.exist(createdPost);
+
+                    createdPost.attributes.title.should.equal(newPost.title, "title is correct");
+                    createdPost.attributes.content.should.equal(newPost.content, "content is correct");
+                    createdPost.attributes.slug.should.equal(newPost.title.toLowerCase().replace(/ /g, '-'), 'slug is correct');
+
+                    done();
+                });
+            });
+        });
+    });
+}());

--- a/core/test/ghost/api_posts_spec.js
+++ b/core/test/ghost/api_posts_spec.js
@@ -3,38 +3,133 @@
 (function () {
     "use strict";
 
-    var should = require('should'),
+    var _ = require("underscore"),
+        should = require('should'),
         helpers = require('./helpers'),
         PostProvider = require('../../shared/models/dataProvider.bookshelf.posts');
 
-    describe("dataProvider.bookshelf", function () {
-        describe('PostsProvider', function () {
+    describe('Bookshelf PostsProvider', function () {
 
-            var posts;
+        var posts;
 
-            beforeEach(function (done) {
-                helpers.resetData().then(function () {
-                    posts = new PostProvider();
-                    done();
-                });
+        beforeEach(function (done) {
+            helpers.resetData().then(function () {
+                posts = new PostProvider();
+                done();
             });
+        });
 
-            it('can create', function (done) {
-                var newPost = {
-                    title: 'Test Title 1',
-                    content: 'Test Content 1'
-                };
+        it('can browse', function (done) {
+            posts.browse(function (err, results) {
+                if (err) { throw err; }
 
-                posts.add(newPost, function (err, createdPost) {
+                should.exist(results);
+
+                results.length.should.equal(2);
+
+                done();
+            });
+        });
+
+        it('can read', function (done) {
+            var firstPost;
+
+            posts.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstPost = results.models[0];
+
+                posts.read({slug: firstPost.attributes.slug}, function (err, found) {
                     if (err) { throw err; }
 
-                    should.exist(createdPost);
+                    should.exist(found);
 
-                    createdPost.attributes.title.should.equal(newPost.title, "title is correct");
-                    createdPost.attributes.content.should.equal(newPost.content, "content is correct");
-                    createdPost.attributes.slug.should.equal(newPost.title.toLowerCase().replace(/ /g, '-'), 'slug is correct');
+                    found.attributes.title.should.equal(firstPost.attributes.title);
 
                     done();
+                });
+
+            });
+        });
+
+        it('can edit', function (done) {
+            var firstPost;
+
+            posts.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstPost = results.models[0];
+
+                posts.edit({id: firstPost.id, title: "new title"}, function (err, edited) {
+                    if (err) { throw err; }
+
+                    should.exist(edited);
+
+                    edited.attributes.title.should.equal('new title');
+
+                    done();
+                });
+
+            });
+        });
+
+        it('can add', function (done) {
+            var newPost = {
+                title: 'Test Title 1',
+                content: 'Test Content 1'
+            };
+
+            posts.add(newPost, function (err, createdPost) {
+                if (err) { throw err; }
+
+                should.exist(createdPost);
+
+                createdPost.attributes.title.should.equal(newPost.title, "title is correct");
+                createdPost.attributes.content.should.equal(newPost.content, "content is correct");
+                createdPost.attributes.slug.should.equal(newPost.title.toLowerCase().replace(/ /g, '-'), 'slug is correct');
+
+                done();
+            });
+        });
+
+        it('can delete', function (done) {
+            var firstPostId,
+                ids,
+                hasDeletedId;
+
+            posts.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstPostId = results.models[0].id;
+
+                posts.destroy(firstPostId, function (err) {
+                    if (err) { throw err; }
+
+                    posts.browse(function (err, newResults) {
+                        if (err) { throw err; }
+
+                        ids = _.pluck(newResults.models, "id");
+
+                        hasDeletedId = _.any(ids, function (id) {
+                            return id === firstPostId;
+                        });
+
+                        hasDeletedId.should.equal(false);
+
+                        done();
+                    });
                 });
             });
         });

--- a/core/test/ghost/api_settings_spec.js
+++ b/core/test/ghost/api_settings_spec.js
@@ -1,0 +1,190 @@
+/*globals describe, beforeEach, it*/
+
+(function () {
+    "use strict";
+
+    var _ = require("underscore"),
+        should = require('should'),
+        helpers = require('./helpers'),
+        SettingProvider = require('../../shared/models/dataProvider.bookshelf.settings');
+
+    describe('Bookshelf SettingsProvider', function () {
+
+        var settings;
+
+        beforeEach(function (done) {
+            helpers.resetData().then(function () {
+                settings = new SettingProvider();
+                done();
+            });
+        });
+
+        it('can browse', function (done) {
+            settings.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                done();
+            });
+        });
+
+        it('can read', function (done) {
+            var firstSetting;
+
+            settings.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstSetting = results.models[0];
+
+                settings.read(firstSetting.attributes.key, function (err, found) {
+                    if (err) { throw err; }
+
+                    should.exist(found);
+
+                    found.attributes.value.should.equal(firstSetting.attributes.value);
+
+                    done();
+                });
+
+            });
+        });
+
+        it('can edit single', function (done) {
+            var firstPost,
+                toEdit = {};
+
+            settings.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstPost = results.models[0];
+
+                // The edit method has been modified to take an object of 
+                // key/value pairs
+                toEdit[firstPost.attributes.key] = "new value";
+
+                settings.edit(toEdit, function (err, edited) {
+                    if (err) { throw err; }
+
+                    should.exist(edited);
+
+                    edited.length.should.equal(1);
+
+                    edited = edited[0];
+
+                    edited.attributes.key.should.equal(firstPost.attributes.key);
+                    edited.attributes.value.should.equal('new value');
+
+                    done();
+                });
+
+            });
+        });
+
+        it('can edit multiple', function (done) {
+            var firstPost,
+                secondPost,
+                editedPost,
+                toEdit = {};
+
+            settings.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstPost = results.models[0];
+                secondPost = results.models[1];
+
+                // The edit method has been modified to take an object of 
+                // key/value pairs
+                toEdit[firstPost.attributes.key] = "new value1";
+                toEdit[secondPost.attributes.key] = "new value2";
+
+                settings.edit(toEdit, function (err, edited) {
+                    if (err) { throw err; }
+
+                    should.exist(edited);
+
+                    edited.length.should.equal(2);
+
+                    editedPost = edited[0];
+
+                    editedPost.attributes.key.should.equal(firstPost.attributes.key);
+                    editedPost.attributes.value.should.equal('new value1');
+
+                    editedPost = edited[1];
+
+                    editedPost.attributes.key.should.equal(secondPost.attributes.key);
+                    editedPost.attributes.value.should.equal('new value2');
+
+                    done();
+                });
+
+            });
+        });
+
+        it('can add', function (done) {
+            var newSetting = {
+                key: 'TestSetting1',
+                value: 'Test Content 1'
+            };
+
+            settings.add(newSetting, function (err, createdSetting) {
+                if (err) { throw err; }
+
+                should.exist(createdSetting);
+
+                createdSetting.attributes.key.should.equal(newSetting.key, "key is correct");
+                createdSetting.attributes.value.should.equal(newSetting.value, "value is correct");
+
+                done();
+            });
+        });
+
+        it('can delete', function (done) {
+            var firstSettingId,
+                ids,
+                hasDeletedId;
+
+            settings.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstSettingId = results.models[0].id;
+
+                settings.destroy(firstSettingId, function (err) {
+                    if (err) { throw err; }
+
+                    settings.browse(function (err, newResults) {
+                        if (err) { throw err; }
+
+                        ids = _.pluck(newResults.models, "id");
+
+                        hasDeletedId = _.any(ids, function (id) {
+                            return id === firstSettingId;
+                        });
+
+                        hasDeletedId.should.equal(false);
+
+                        done();
+                    });
+                });
+            });
+        });
+    });
+}());

--- a/core/test/ghost/api_users_spec.js
+++ b/core/test/ghost/api_users_spec.js
@@ -1,0 +1,44 @@
+/*globals describe, beforeEach, it*/
+
+(function () {
+    "use strict";
+
+    var should = require('should'),
+        helpers = require('./helpers'),
+        UserProvider = require('../../shared/models/dataProvider.bookshelf.users');
+
+    describe('dataProvider.bookshelf', function () {
+        describe('UsersProvider', function () {
+
+            var users;
+
+            beforeEach(function (done) {
+                helpers.resetData().then(function () {
+                    users = new UserProvider();
+                    done();
+                });
+            });
+
+            it('can create', function(done) {
+                var userData = {
+                    password: 'testpass1',
+                    email_address: "test@test1.com"
+                };
+
+                users.add(userData, function(err, createdUser) {
+                    if (err) {
+                        throw err;
+                    }
+
+                    should.exist(createdUser);
+
+                    createdUser.attributes.password.should.not.equal(userData.password, "password was hashed");
+                    createdUser.attributes.email_address.should.eql(userData.email_address, "email address corred");
+
+                    done();
+                });
+            });
+        });
+    });
+
+}());

--- a/core/test/ghost/api_users_spec.js
+++ b/core/test/ghost/api_users_spec.js
@@ -3,39 +3,139 @@
 (function () {
     "use strict";
 
-    var should = require('should'),
+    var _ = require('underscore'),
+        should = require('should'),
         helpers = require('./helpers'),
         UserProvider = require('../../shared/models/dataProvider.bookshelf.users');
 
-    describe('dataProvider.bookshelf', function () {
-        describe('UsersProvider', function () {
+    describe('Bookshelf UsersProvider', function () {
 
-            var users;
+        var users;
 
-            beforeEach(function (done) {
-                helpers.resetData().then(function () {
-                    users = new UserProvider();
+        beforeEach(function (done) {
+            helpers.resetData().then(function () {
+                users = new UserProvider();
+                done();
+            });
+        });
+
+        it('can browse', function (done) {
+            users.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                done();
+            });
+        });
+
+        it('can read', function (done) {
+            var firstUser;
+
+            users.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstUser = results.models[0];
+
+                users.read({email_address: firstUser.attributes.email_address}, function (err, found) {
+                    if (err) { throw err; }
+
+                    should.exist(found);
+
+                    found.attributes.username.should.equal(firstUser.attributes.username);
+
                     done();
                 });
+
             });
+        });
 
-            it('can create', function(done) {
-                var userData = {
-                    password: 'testpass1',
-                    email_address: "test@test1.com"
-                };
+        it('can edit', function (done) {
+            var firstUser;
 
-                users.add(userData, function(err, createdUser) {
-                    if (err) {
-                        throw err;
-                    }
+            users.browse(function (err, results) {
+                if (err) { throw err; }
 
-                    should.exist(createdUser);
+                should.exist(results);
 
-                    createdUser.attributes.password.should.not.equal(userData.password, "password was hashed");
-                    createdUser.attributes.email_address.should.eql(userData.email_address, "email address corred");
+                results.length.should.be.above(0);
+
+                firstUser = results.models[0];
+
+                users.edit({id: firstUser.id, url: "some.newurl.com"}, function (err, edited) {
+                    if (err) { throw err; }
+
+                    should.exist(edited);
+
+                    edited.attributes.url.should.equal('some.newurl.com');
 
                     done();
+                });
+
+            });
+        });
+
+        it('can add', function (done) {
+            var userData = {
+                password: 'testpass1',
+                email_address: "test@test1.com"
+            };
+
+            users.add(userData, function (err, createdUser) {
+                if (err) {
+                    throw err;
+                }
+
+                should.exist(createdUser);
+
+                createdUser.attributes.password.should.not.equal(userData.password, "password was hashed");
+                createdUser.attributes.email_address.should.eql(userData.email_address, "email address corred");
+
+                done();
+            });
+        });
+
+        it('can delete', function (done) {
+            var firstUserId,
+                ids,
+                hasDeletedId;
+
+            users.browse(function (err, results) {
+                if (err) { throw err; }
+
+                should.exist(results);
+
+                results.length.should.be.above(0);
+
+                firstUserId = results.models[0].id;
+
+                users.destroy(firstUserId, function (err) {
+                    if (err) { throw err; }
+
+                    users.browse(function (err, newResults) {
+                        if (err) { throw err; }
+
+                        if (newResults.length < 1) {
+                            // Bug out if we only had one user and deleted it.
+                            return done();
+                        }
+
+                        ids = _.pluck(newResults.models, "id");
+
+                        hasDeletedId = _.any(ids, function (id) {
+                            return id === firstUserId;
+                        });
+
+                        hasDeletedId.should.equal(false);
+
+                        done();
+                    });
                 });
             });
         });

--- a/core/test/ghost/helpers.js
+++ b/core/test/ghost/helpers.js
@@ -1,0 +1,18 @@
+(function() {
+    "use strict";
+
+    var migrations = {
+            one: require("../../shared/data/migration/001")
+        },
+        helpers;
+
+    helpers = {
+        resetData: function () {
+            return migrations.one.down().then(function () {
+                return migrations.one.up();
+            });
+        }
+    };
+
+    module.exports = helpers;
+}());

--- a/core/test/ghost/helpers.js
+++ b/core/test/ghost/helpers.js
@@ -1,6 +1,9 @@
 (function() {
     "use strict";
 
+    // Use 'testing' Ghost config
+    process.env.NODE_ENV = 'testing';
+
     var migrations = {
             one: require("../../shared/data/migration/001")
         },
@@ -8,6 +11,7 @@
 
     helpers = {
         resetData: function () {
+
             return migrations.one.down().then(function () {
                 return migrations.one.up();
             });

--- a/core/test/ghost/test-api.js
+++ b/core/test/ghost/test-api.js
@@ -5,14 +5,11 @@
     // Use 'testing' Ghost config
     process.env.NODE_ENV = 'testing';
 
-    var fs       = require('fs'),
-        path     = require('path'),
-        _        = require('underscore'),
+    var _        = require('underscore'),
         assert   = require('assert'),
-        delay    = require('when/delay'),
-        config   = require('../../../config'),
+        helpers  = require('./helpers'),
         fixtures = require('../../shared/data/fixtures/001'),
-        api;
+        api = require('../../shared/data/api');
 
     function fail(err) {
         process.nextTick(function () {
@@ -23,14 +20,9 @@
     module.exports = {
         setUp: function (done) {
             // Clear database
-            var dbpath = path.resolve(__dirname, '../../../', config.database.testing.connection.filename);
-            fs.unlink(dbpath, function () {
-                // There is currently no way to tell when Ghost is loaded. api instantiates it's own `Ghost`
-                // which will run migrations without making the promise externally accessible
-                api = require('../../shared/api');
-                // So we just sit for a while :/
-                setTimeout(done, 3000);
-            });
+            helpers.resetData().then(function () {
+                done();
+            }, fail);
         },
 
         'settings:browse': function (test) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-compass": "0.2.x",
     "nodeunit": "0.8.x",
     "grunt-jslint": "0.2.x",
-    "should": "~1.2.2"
+    "should": "~1.2.2",
+    "grunt-mocha-test": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "grunt-contrib-nodeunit": "0.1.x",
     "grunt-contrib-compass": "0.2.x",
     "nodeunit": "0.8.x",
-    "grunt-jslint": "0.2.x"
+    "grunt-jslint": "0.2.x",
+    "should": "~1.2.2"
   }
 }


### PR DESCRIPTION
Originally this started as the Users API, but then I noticed we were repeating a lot of code between the different providers that could be abstracted into a base class.

Based on Hannah's suggestion, I also included some mocha tests for all three providers and integrated it with the `grunt validate` task.  This includes some helpers to drop and recreate the database before each test.  We could easily translate over the other nodeunit test to the mocha style if we decide to go with mocha exclusively.

Additionally, I added the `unparam: true` JSLint option to get rid of the unused variable warnings for things like middleware (req, res, next handlers).  I've also updated all the code to fix JSLint errors that were found.

There are some other tasks that this provider refactor will likely affect.  I'll try to follow up with a comment that references them after I comb through the list.
