### PR TITLE
Implement a permissable interface on models

### DIFF
--- a/core/shared/permissions/index.js
+++ b/core/shared/permissions/index.js
@@ -7,6 +7,7 @@
     var _ = require('underscore'),
         when = require('when'),
         Models = require('../models'),
+        objectTypeModelMap = require('./objectTypeModelMap'),
         UserProvider = Models.User,
         PermissionsProvider = Models.Permission,
         init,
@@ -20,12 +21,13 @@
         this.userPermissionLoad = false;
     };
 
-    CanThisResult.prototype.buildObjectTypeHandlers = function (obj_types, act_type) {
+    CanThisResult.prototype.buildObjectTypeHandlers = function (obj_types, act_type, userId) {
         var self = this,
             obj_type_handlers = {};
 
         // Iterate through the object types, i.e. ['post', 'tag', 'user']
         _.each(obj_types, function (obj_type) {
+            var TargetModel = objectTypeModelMap[obj_type];
 
             // Create the 'handler' for the object type;
             // the '.post()' in canThis(user).edit.post()
@@ -42,33 +44,49 @@
 
                 // Wait for the user loading to finish
                 return self.userPermissionLoad.then(function (userPermissions) {
-
                     // Iterate through the user permissions looking for an affirmation
-                    var hasPermission = _.any(userPermissions, function (userPermission) {
-                            var permObjId;
+                    var hasPermission;
 
-                            // Look for a matching action type and object type first
-                            if (userPermission.get('action_type') !== act_type || userPermission.get('object_type') !== obj_type) {
-                                return false;
-                            }
+                    // Allow for a target model to implement a "Permissable" interface
+                    if (TargetModel && _.isFunction(TargetModel.permissable)) {
+                        return TargetModel.permissable(modelId, userId, act_type, userPermissions);
+                    }
 
-                            // Grab the object id (if specified, could be null)
-                            permObjId = userPermission.get('object_id');
+                    // Otherwise, check all the permissions for matching object id
+                    hasPermission = _.any(userPermissions, function (userPermission) {
+                        var permObjId;
 
-                            // If we didn't specify a model (any thing)
-                            // or the permission didn't have an id scope set
-                            // then the user has permission
-                            if (!modelId || !permObjId) {
-                                return true;
-                            }
+                        // Look for a matching action type and object type first
+                        if (userPermission.get('action_type') !== act_type || userPermission.get('object_type') !== obj_type) {
+                            return false;
+                        }
 
-                            // Otherwise, check if the id's match
-                            // TODO: String vs Int comparison possibility here?
-                            return modelId === permObjId;
-                        });
+                        // Grab the object id (if specified, could be null)
+                        permObjId = userPermission.get('object_id');
+
+                        // If we didn't specify a model (any thing)
+                        // or the permission didn't have an id scope set
+                        // then the user has permission
+                        if (!modelId || !permObjId) {
+                            return true;
+                        }
+
+                        // Otherwise, check if the id's match
+                        // TODO: String vs Int comparison possibility here?
+                        return modelId === permObjId;
+                    });
 
                     if (hasPermission) {
                         return when.resolve();
+                    }
+
+                    return when.reject();
+                }).otherwise(function() {
+                    // No permissions loaded, or error loading permissions
+
+                    // Still check for permissable without permissions
+                    if (TargetModel && _.isFunction(TargetModel.permissable)) {
+                        return TargetModel.permissable(modelId, userId, act_type, []);
                     }
 
                     return when.reject();
@@ -80,12 +98,13 @@
     };
 
     CanThisResult.prototype.beginCheck = function (user) {
-        var self = this;
+        var self = this,
+            userId = user.id || user;
 
         // TODO: Switch logic based on object type; user, role, post.
 
         // Kick off the fetching of the user data
-        this.userPermissionLoad = UserProvider.effectivePermissions(user.id || user);
+        this.userPermissionLoad = UserProvider.effectivePermissions(userId);
 
         // Iterate through the actions and their related object types
         // We should have loaded these through a permissions.init() call previously
@@ -93,7 +112,7 @@
         _.each(exported.actionsMap, function (obj_types, act_type) {
             // Build up the object type handlers;
             // the '.post()' parts in canThis(user).edit.post()
-            var obj_type_handlers = self.buildObjectTypeHandlers(obj_types, act_type);
+            var obj_type_handlers = self.buildObjectTypeHandlers(obj_types, act_type, userId);
 
             // Define a property for the action on the result;
             // the '.edit' in canThis(user).edit.post()

--- a/core/shared/permissions/objectTypeModelMap.js
+++ b/core/shared/permissions/objectTypeModelMap.js
@@ -1,0 +1,11 @@
+(function () {
+    "use strict";
+
+    module.exports = {
+        'post': require('../models/post').Post,
+        'role': require('../models/role').Role,
+        'user': require('../models/user').User,
+        'permission': require('../models/permission').Permission,
+        'setting': require('../models/setting').Setting
+    };
+}());


### PR DESCRIPTION
Added checks to the canThis process for a `permissable()` function
that would allow Models to override the permissions process.
