### PR TITLE
Filter priorities

### DIFF
--- a/core/frontend/filters/index.js
+++ b/core/frontend/filters/index.js
@@ -2,10 +2,11 @@
     "use strict";
 
     var _ = require('underscore'),
+        defaultCoreFilterPriority = 4,
         coreFilters;
 
     coreFilters = function (ghost) {
-        ghost.registerFilter('ghostNavItems', function (args) {
+        ghost.registerFilter('ghostNavItems', defaultCoreFilterPriority, function (args) {
             var selectedItem;
 
             // Set the nav items based on the config

--- a/core/test/ghost/ghost_spec.js
+++ b/core/test/ghost/ghost_spec.js
@@ -46,6 +46,56 @@
 
         });
 
+        it("can register filters with specific priority", function () {
+            var ghost = new Ghost(),
+                filterName = 'test',
+                filterPriority = 9,
+                testFilterHandler = sinon.spy();
+
+            ghost.registerFilter(filterName, filterPriority, testFilterHandler);
+
+            should.exist(ghost.filterCallbacks[filterName]);
+            should.exist(ghost.filterCallbacks[filterName][filterPriority]);
+
+            ghost.filterCallbacks[filterName][filterPriority].should.include(testFilterHandler);
+        });
+
+        it("can register filters with default priority", function () {
+            var ghost = new Ghost(),
+                filterName = 'test',
+                defaultPriority = 5,
+                testFilterHandler = sinon.spy();
+
+            ghost.registerFilter(filterName, testFilterHandler);
+
+            should.exist(ghost.filterCallbacks[filterName]);
+            should.exist(ghost.filterCallbacks[filterName][defaultPriority]);
+
+            ghost.filterCallbacks[filterName][defaultPriority].should.include(testFilterHandler);
+        });
+
+        it("executes filters in priority order", function (done) {
+            var ghost = new Ghost(),
+                filterName = 'testpriority',
+                testFilterHandler1 = sinon.spy(),
+                testFilterHandler2 = sinon.spy(),
+                testFilterHandler3 = sinon.spy();
+
+            ghost.registerFilter(filterName, 0, testFilterHandler1);
+            ghost.registerFilter(filterName, 2, testFilterHandler2);
+            ghost.registerFilter(filterName, 9, testFilterHandler3);
+
+            ghost.doFilter(filterName, null, function () {
+
+                testFilterHandler1.calledBefore(testFilterHandler2).should.equal(true);
+                testFilterHandler2.calledBefore(testFilterHandler3).should.equal(true);
+
+                testFilterHandler3.called.should.equal(true);
+
+                done();
+            });
+        });
+
     });
 
 }());


### PR DESCRIPTION
Add the ability to specify a priority level when registering filters.
Also change doFilter to execute filters in priority order.

Closes #86
