### PR TITLE
Fix #125

### DIFF
--- a/core/admin/views/settings.hbs
+++ b/core/admin/views/settings.hbs
@@ -10,7 +10,7 @@
         </header>
         <nav class="settings-menu">
             <ul>
-                <li class="general active"><a href="#general">General</a></li>
+                <li class="general"><a href="#general">General</a></li>
                 <li class="publishing"><a href="#content">Content</a></li>
                 <li class="users"><a href="#users">Users</a></li>
                 <li class="appearance"><a href="#appearance">Appearance</a></li>
@@ -19,7 +19,7 @@
             </ul>
         </nav>
     </aside>
-    <section id="general" class="settings-content active">
+    <section id="general" class="settings-content">
         <header>
             <h2 class="title">General</h2>
             <section class="page-actions">


### PR DESCRIPTION
Removes the `active` classes from `settings.hbs`. Content will end up being rendered on the client instead of toggling classes anyway.
