### PR TITLE
Nightly build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,111 +1,199 @@
 (function () {
     "use strict";
 
-    var configureGrunt = function (grunt) {
+    var path = require('path'),
+        buildDirectory = path.resolve(process.cwd(), '../build'),
+        distDirectory =  path.resolve(process.cwd(), '../dist'),
+        configureGrunt = function (grunt) {
 
-        var cfg = {
-            // JSLint all the things!
-            jslint: {
-                directives: {
-                    node: true,
-                    browser: true,
-                    nomen: true,
-                    todo: true,
-                    unparam: true
-                },
-                files: [
-                    // Lint files in the root, including Gruntfile.js
-                    "*.js",
-                    // Lint core files, but not libs
-                    ["core/**/*.js", "!**/assets/lib/**/*.js", "!**/assets/tmpl/*.js"]
-                ]
-            },
-
-            mochaTest: {
-                options: {
-                    ui: "bdd",
-                    reporter: "spec"
+            var cfg = {
+                // Common paths to be used by tasks
+                paths: {
+                    build: buildDirectory,
+                    nightlyBuild: path.join(buildDirectory, 'nightly'),
+                    dist: distDirectory,
+                    nightlyDist: path.join(distDirectory, 'nightly')
                 },
 
-                all: {
-                    src: ['core/test/**/*_spec.js']
+                pkg: grunt.file.readJSON('package.json'),
+
+                // JSLint all the things!
+                jslint: {
+                    directives: {
+                        node: true,
+                        browser: true,
+                        nomen: true,
+                        todo: true,
+                        unparam: true
+                    },
+                    files: [
+                        // Lint files in the root, including Gruntfile.js
+                        "*.js",
+                        // Lint core files, but not libs
+                        ["core/**/*.js", "!**/assets/lib/**/*.js", "!**/assets/tmpl/*.js"]
+                    ]
                 },
 
-                api: {
-                    src: ['core/test/**/api*_spec.js']
-                }
-            },
-
-            // Compile all the SASS!
-            sass: {
-                admin: {
-                    files: {
-                        'core/admin/assets/css/screen.css': 'core/admin/assets/sass/screen.scss'
-                    }
-                }
-            },
-
-            shell: {
-                bourbon: {
-                    command: 'bourbon install --path core/admin/assets/sass/modules/'
-                }
-            },
-
-            handlebars: {
-
-                core: {
-
+                mochaTest: {
                     options: {
-
-                        namespace: "JST",
-
-                        processName: function (filename) {
-                            filename = filename.replace('./core/admin/assets/tmpl/', '');
-                            return filename.replace('.hbs', '');
-                        }
+                        ui: "bdd",
+                        reporter: "spec"
                     },
 
-                    files: {
-                        "./core/admin/assets/tmpl/hbs-tmpl.js": "./core/admin/assets/tmpl/**/*.hbs"
+                    all: {
+                        src: ['core/test/**/*_spec.js']
+                    },
+
+                    api: {
+                        src: ['core/test/**/api*_spec.js']
                     }
+                },
 
-                }
-            },
+                // Compile all the SASS!
+                sass: {
+                    admin: {
+                        files: {
+                            'core/admin/assets/css/screen.css': 'core/admin/assets/sass/screen.scss'
+                        }
+                    }
+                },
 
-            watch:  {
+                shell: {
+                    bourbon: {
+                        command: 'bourbon install --path core/admin/assets/sass/modules/'
+                    },
+
+                    commitNightly: {
+                        command: 'git commit package.json -m "Nightly build <%= pkg.version %>"'
+                    },
+
+                    tagNightly: {
+                        command: 'git tag <%= pkg.version %> -a -m "Nightly build <%= pkg.version %>"'
+                    },
+
+                    pushMaster: {
+                        command: 'git push origin master'
+                    },
+
+                    pushMasterTags: {
+                        command: 'git push origin master --tags'
+                    }
+                },
+
                 handlebars: {
-                    files: './core/admin/assets/tmpl/**/*.hbs',
-                    tasks: ['handlebars']
+
+                    core: {
+
+                        options: {
+
+                            namespace: "JST",
+
+                            processName: function (filename) {
+                                filename = filename.replace('./core/admin/assets/tmpl/', '');
+                                return filename.replace('.hbs', '');
+                            }
+                        },
+
+                        files: {
+                            "./core/admin/assets/tmpl/hbs-tmpl.js": "./core/admin/assets/tmpl/**/*.hbs"
+                        }
+
+                    }
+                },
+
+                watch: {
+                    handlebars: {
+                        files: './core/admin/assets/tmpl/**/*.hbs',
+                        tasks: ['handlebars']
+                    }
+                },
+
+                copy: {
+                    nightly: {
+                        files: [{
+                            expand: true,
+                            src: [
+                                '**',
+
+                                '!node_modules/**',
+                                '!core/shared/data/*.db',
+                                '!.sass*',
+                                '!.af*',
+                                '!.git*',
+                                '!.groc*',
+                                '!.travis.yml'
+                            ],
+                            dest: "<%= paths.nightlyBuild %>/<%= pkg.version %>/"
+                        }]
+                    }
+                },
+
+                zip: {
+                    nightly: {
+                        cwd: "<%= paths.nightlyBuild %>/<%= pkg.version %>/",
+                        src: ["<%= paths.nightlyBuild %>/<%= pkg.version %>/**"],
+                        dest: "<%= paths.nightlyDist %>/Ghost-Nightly-<%= pkg.version %>.zip"
+                    }
                 }
-            }
+            };
 
+            grunt.initConfig(cfg);
+
+            grunt.loadNpmTasks("grunt-jslint");
+            grunt.loadNpmTasks("grunt-mocha-test");
+            grunt.loadNpmTasks("grunt-shell");
+            grunt.loadNpmTasks("grunt-bump");
+            grunt.loadNpmTasks("grunt-zip");
+
+            grunt.loadNpmTasks("grunt-contrib-copy");
+            grunt.loadNpmTasks("grunt-contrib-watch");
+            grunt.loadNpmTasks("grunt-contrib-sass");
+            grunt.loadNpmTasks("grunt-contrib-handlebars");
+
+            // Update the package information after changes
+            grunt.registerTask('updateCurrentPackageInfo', function () {
+                cfg.pkg = grunt.file.readJSON('package.json');
+            });
+
+            // Prepare the project for development
+            // TODO: Git submodule init/update (https://github.com/jaubourg/grunt-update-submodules)?
+            grunt.registerTask("init", ["shell:bourbon", "sass:admin"]);
+
+            // Run API tests only
+            grunt.registerTask("test-api", ["mochaTest:api"]);
+
+            // Run tests and lint code
+            grunt.registerTask("validate", ["jslint", "mochaTest:all"]);
+
+            /* Nightly builds
+             * - Bump patch version in package.json, 
+             * - Copy files to build-folder/nightly/#{version} directory
+             * - Clean out unnecessary files (travis, .git*, .af*, .groc*)
+             * - Zip files in build folder to dist-folder/#{version} directory
+             * - git commit package.json -m "Nightly build #{version}"
+             * - git tag -a -m "Nightly build #{version}"
+             * - git push origin master
+             * - git push origin master --tags
+             * - TODO: POST to pubsubhubub to notify of new build?
+             */
+            grunt.registerTask("nightly", [
+                "sass:admin",
+                "handlebars",
+                "validate",
+                "bump",
+                "updateCurrentPackageInfo",
+                "copy:nightly",
+                "zip:nightly",
+                /* Caution: shit gets real below here */
+                //"shell:commitNightly",
+                //"shell:tagNightly",
+                //"shell:pushMaster",
+                //"shell:pushMasterTags"
+            ]);
+
+            // When you just say "grunt"
+            grunt.registerTask("default", ['sass:admin', 'handlebars', 'watch']);
         };
-
-
-        grunt.initConfig(cfg);
-
-        grunt.loadNpmTasks("grunt-jslint");
-        grunt.loadNpmTasks("grunt-mocha-test");
-        grunt.loadNpmTasks("grunt-shell");
-
-        grunt.loadNpmTasks("grunt-contrib-watch");
-        grunt.loadNpmTasks("grunt-contrib-sass");
-        grunt.loadNpmTasks("grunt-contrib-handlebars");
-
-
-        // Prepare the project for development
-        // TODO: Git submodule init/update (https://github.com/jaubourg/grunt-update-submodules)?
-        grunt.registerTask("init", ["shell:bourbon", "sass:admin"]);
-
-        // Run API tests only
-        grunt.registerTask("test-api", ["mochaTest:api"]);
-
-        // Run tests and lint code
-        grunt.registerTask("validate", ["jslint", "mochaTest:all"]);
-
-        // When you just say "grunt"
-        grunt.registerTask("default", ['sass:admin', 'handlebars', 'watch']);
-    };
 
     module.exports = configureGrunt;
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "sinon": "~1.7.2",
     "mocha": "~1.10.0",
     "grunt-contrib-handlebars": "~0.5.9",
-    "grunt-contrib-watch": "~0.4.4"
+    "grunt-contrib-watch": "~0.4.4",
+    "grunt-bump": "0.0.2",
+    "grunt-zip": "~0.9.0",
+    "grunt-contrib-copy": "~0.4.1"
   }
 }


### PR DESCRIPTION
Add a `grunt nightly` build task that copies needed files to a build
folder, then zips them up for distribution. We can also add a tag and
push it to github but I've only tested it with throwaway branches.

I made some guesses about the build folder and dist folder.  If you
have a better way feel free to give some recommendations.  Apologies for the Wonky Gruntfile diff, it really isn't as much changes as it looks but the indentation did change.

Related to #102.
