### PR TITLE
Fixes login box being off centred on small screens

### DIFF
--- a/core/admin/assets/js/admin-ui-temp.js
+++ b/core/admin/assets/js/admin-ui-temp.js
@@ -23,8 +23,8 @@
     $(window).resize(function () {
 
         var loginContainer = $(".js-login-container"),
-            marginTop = Math.round(($(window).height() / 2) - loginContainer.outerHeight());
-        loginContainer.css('margin-top', marginTop);
+            marginTop = Math.floor((loginContainer.parent().height() - loginContainer.height()) / 2) - 15;
+        loginContainer.css('margin-top', marginTop).fadeIn(400);
 
     });
 

--- a/core/admin/assets/sass/layouts/login.scss
+++ b/core/admin/assets/sass/layouts/login.scss
@@ -19,15 +19,16 @@
     }
 
     main { 
-        top: 15px; 
+        top: 15px;
         @include breakpoint($mobile) { top: 0; }
     }
 }//.ghost-login
 
 .login-box {
     max-width: 530px;
-    margin: 240px auto; // TODO: Change this to proper vertical centering with JS
+    margin: 0 auto;
     padding: 0;
+    display: none;
 
     @include breakpoint(630px) {
         max-width: 264px;


### PR DESCRIPTION
Had to remove stray CSS which was moving the login box down all the time. Also remove bottom margin which was causing scrollbars to appear on small screens.
Tested on a variety of window sizes and appears to be centred on all of them (measured it to make sure).
See #134.
