### PR TITLE
Fix relative paths for deployment

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,11 +6,14 @@
 (function () {
     "use strict";
 
+    var path = require('path'),
+        config;
+
     /**
      * @module config
      * @type {Object}
      */
-    var config = {};
+    config = {};
 
     // ## Admin settings
 
@@ -59,14 +62,14 @@
         testing: {
             client: 'sqlite3',
             connection: {
-                filename: './core/shared/data/tests.db'
+                filename: path.join(__dirname, '/core/shared/data/tests.db')
             }
         },
 
         travis: {
             client: 'sqlite3',
             connection: {
-                filename: './core/shared/data/tests.db'
+                filename: path.join(__dirname, '/core/shared/data/tests.db')
             }
             // debug: true
         },
@@ -74,7 +77,7 @@
         development: {
             client: 'sqlite3',
             connection: {
-                filename: './core/shared/data/testdb.db'
+                filename: path.join(__dirname, '/core/shared/data/testdb.db')
             },
             debug: false
             // debug: true

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -18,8 +18,8 @@
         ExampleFilter = require('../content/plugins/exampleFilters'),
 
         requireTree = require('./shared/require-tree'),
-        themeDirectories = requireTree('content/themes'),
-        pluginDirectories = requireTree('content/plugins'),
+        themeDirectories = requireTree(path.resolve(__dirname + '../../content/themes')),
+        pluginDirectories = requireTree(path.resolve(__dirname + '../../content/plugins')),
 
         Ghost,
         instance,


### PR DESCRIPTION
In order to run with forever / supervisorctl, the relative paths need to
be converted to full ones based on the __dirname.
