### PR TITLE
Fixes transitions on input elements and other globals not working in Firefox

### DIFF
--- a/core/admin/assets/sass/modules/forms.scss
+++ b/core/admin/assets/sass/modules/forms.scss
@@ -68,7 +68,7 @@ form {
         background: #fff;
         border: darken($lightbrown, 5%) 1px solid;
         border-radius: $rounded;
-        @include transition;
+        @include transition(all 0.15s ease-in-out);
     }
 
     textarea {
@@ -101,7 +101,6 @@ form {
         background:#fff;
         outline:none;
         outline-width:0;
-        @include transition;
     }
 
     select {

--- a/core/admin/assets/sass/modules/global.scss
+++ b/core/admin/assets/sass/modules/global.scss
@@ -177,7 +177,7 @@ aside + p {
 a {
     color:$blue;
     text-decoration:none;
-    @include transition;
+    @include transition(all 0.15s ease-in-out);
 
     &:hover {
         text-decoration:underline;
@@ -1100,7 +1100,7 @@ main {
         font-weight: bold;
         font-family: $font-family-mono;
         overflow: hidden;
-        @include transition;
+        @include transition(all 0.15s ease-in-out);
 
         &:hover {
             box-shadow: 
@@ -1108,7 +1108,7 @@ main {
                 rgba(0,0,0,0.05) -5px 0 0 inset,
                 rgba(0,0,0,0.05) 0 5px 0 inset,
                 rgba(0,0,0,0.05) 0 -5px 0 inset;
-            @include transition;
+            @include transition(all 0.15s ease-in-out);
         }
 
         small {
@@ -1121,12 +1121,12 @@ main {
             display: block;
             width:100px;
             opacity: 0.6;
-            @include transition;
+            @include transition(all 0.15s ease-in-out);
         }
 
         &:hover small {
             opacity: 1;
-            @include transition;
+            @include transition(all 0.15s ease-in-out);
         }
     }
 


### PR DESCRIPTION
Removed unnecessary :focus transition style and updated actual transitions to Bourbon syntax.

Fixes #176.
