### PR TITLE
Fix settings multi save

### DIFF
--- a/core/admin/assets/js/views/settings.js
+++ b/core/admin/assets/js/views/settings.js
@@ -61,6 +61,7 @@
     Settings.Pane = Ghost.View.extend({
         destroy: function () {
             this.$el.removeClass('active');
+            this.undelegateEvents();
         },
 
         render: function () {


### PR DESCRIPTION
We were not undelegating our events on the element which was causing the
view to live on indefinitely in the background with its events still
bound.  

To combat this in the future we should be using client side templates and removing views with backbones `View.remove(...)`.

Should close #174.
