### PR TITLE
Fixes issue #186 - load plugins

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,6 +39,11 @@ config.themeDir = 'themes';
  */
 config.activeTheme = 'casper';
 
+
+config.activePlugins = [
+    'fancyFirstChar.js'
+];
+
 // Default Navigation Items
 /**
  * @property {Array} nav

--- a/content/plugins/fancyFirstChar.js
+++ b/content/plugins/fancyFirstChar.js
@@ -1,48 +1,39 @@
-/*globals exports */
-(function () {
-    "use strict";
+var FancyFirstChar;
 
-    var FancyFirstChar;
-
-    FancyFirstChar = function (ghost) {
-        this.ghost = function () {
-            return ghost;
-        };
+FancyFirstChar = function (ghost) {
+    this.ghost = function () {
+        return ghost;
     };
+};
 
-    FancyFirstChar.prototype.init = function () {
-        this.ghost().registerFilter('prePostsRender', function (posts) {
-            var post,
-                originalContent,
-                newContent,
-                firstCharIndex = 0;
+FancyFirstChar.prototype.init = function () {
+    this.ghost().registerFilter('prePostsRender', function (posts) {
+        var post,
+            originalContent,
+            newContent,
+            firstCharIndex = 0;
 
-
-
-            for (post in posts) {
-                if (posts.hasOwnProperty(post)) {
-                    originalContent = posts[post].content;
-                    if (originalContent.substr(0, 1) === '<') {
-                        firstCharIndex = originalContent.indexOf('>') + 1;
-                    }
-
-                    newContent = originalContent.substr(0, firstCharIndex);
-                    newContent += '<span class="fancyChar">';
-                    newContent += originalContent.substr(firstCharIndex, 1);
-                    newContent += '</span>';
-                    newContent += originalContent.substr(firstCharIndex + 1, originalContent.length - firstCharIndex - 1);
-
-                    posts[post].content = newContent;
+        for (post in posts) {
+            if (posts.hasOwnProperty(post)) {
+                originalContent = posts[post].content_html;
+                if (originalContent.substr(0, 1) === '<') {
+                    firstCharIndex = originalContent.indexOf('>') + 1;
                 }
+
+                newContent = originalContent.substr(0, firstCharIndex);
+                newContent += '<span class="fancyChar">';
+                newContent += originalContent.substr(firstCharIndex, 1);
+                newContent += '</span>';
+                newContent += originalContent.substr(firstCharIndex + 1, originalContent.length - firstCharIndex - 1);
+
+                posts[post].content_html = newContent;
             }
-            return posts;
-        });
-    };
+        }
+        return posts;
+    });
+};
 
-    FancyFirstChar.prototype.activate = function () {};
-    FancyFirstChar.prototype.deactivate = function () {};
+FancyFirstChar.prototype.activate = function () {};
+FancyFirstChar.prototype.deactivate = function () {};
 
-
-
-    module.exports = FancyFirstChar;
-}());
+module.exports = FancyFirstChar;

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -14,8 +14,10 @@ var config = require('./../config'),
     models = require('./shared/models'),
 
     requireTree = require('./shared/require-tree'),
-    themeDirectories = requireTree(path.resolve(__dirname + '../../content/themes')),
-    pluginDirectories = requireTree(path.resolve(__dirname + '../../content/plugins')),
+    themePath = path.resolve(__dirname + '../../content/themes'),
+    pluginPath = path.resolve(__dirname + '../../content/plugins'),
+    themeDirectories = requireTree(themePath),
+    pluginDirectories = requireTree(pluginPath),
 
     Ghost,
     instance,
@@ -113,10 +115,35 @@ Ghost.prototype.init = function () {
     var self = this;
 
     return when.join(instance.dataProvider.init(), instance.getPaths()).then(function () {
+        return self.loadPlugins();
+    }, errors.logAndThrowError).then(function () {
         return self.updateSettingsCache();
     }, errors.logAndThrowError);
 };
 
+Ghost.prototype.loadPlugins = function () {
+    var self = this,
+        pluginPaths = _.values(self.paths().availablePlugins),
+        pluginPromises = [];
+
+    _.each(self.config().activePlugins, function (plugin) {
+        var match = _.find(pluginPaths, function (path) {
+            return new RegExp(plugin + '$').test(path);
+        });
+
+        if (match) {
+            pluginPromises.push(require(path.join(pluginPath, plugin)));
+        }
+    });
+
+    return when.all(pluginPromises).then(function (plugins) {
+        _.each(plugins, function (Plugin) {
+            if (_.isFunction(Plugin.prototype.init)) {
+                new Plugin(self).init();
+            }
+        });
+    }, errors.logAndThrowError);
+};
 
 Ghost.prototype.updateSettingsCache = function (settings) {
     var self = this;


### PR DESCRIPTION
- Adding activePlugins array to config.js
- Adding a loadPlugins function to ghost.js
- Tweaking fancyFirstChar.js so that it works again & getting rid of the function wrapper

This solves the problem of being able to load plugins short term. 
However, I think we should get rid of the constructor and just have the init function take the Ghost object.

Also I'm concerned as the ghost object contains lots of things that the plugin shouldn't have access to
