### PR TITLE
Removing multiple hyphens

### DIFF
--- a/core/shared/models/post.js
+++ b/core/shared/models/post.js
@@ -85,29 +85,12 @@ Post = GhostBookshelf.Model.extend({
             };
 
         // Remove reserved chars: `:/?#[]@!$&'()*+,;=` as well as `\` and convert spaces to hyphens
-        slug = title.replace(/[:\/\?#\[\]@!$&'()*+,;=\\]/g, '').replace(/\s/g, '-').toLowerCase();
-        // Remove trailing hyphen
-        slug = slug.charAt(slug.length - 1) === '-' ? slug.substr(0, slug.length - 2) : slug;
+        slug = title.replace(/[:\/\?#\[\]@!$&'()*+,;=\\]/g, '').replace(/(\s|\.)/g, '-').replace(/-+/g, '-').toLowerCase();
+        // Remove trailing hypen
+        slug = slug.charAt(slug.length - 1) === '-' ? slug.substr(0, slug.length - 1) : slug;
         // Check the filtered slug doesn't match any of the reserved keywords
         slug = /^(ghost|ghost\-admin|admin|wp\-admin|dashboard|login|archive|archives|category|categories|tag|tags|page|pages|post|posts)$/g
             .test(slug) ? slug + '-post' : slug;
-
-        // Replace multiple hyphens and anything with less than two letters with one hyphen
-        shortSlug = _.filter(slug.split('-'), function (part) {
-            return part.length > 2;
-        }).join('-');
-
-        // If we've gotten rid of everything, come back through with lower threshold
-        if (shortSlug.length < 1) {
-            shortSlug = _.filter(slug.split('-'), function (part) {
-                return part.length > 1;
-            }).join('-');
-
-            // If we've still got no slug, default to just 'post'
-            if (shortSlug.length < 1) {
-                shortSlug = "post";
-            }
-        }
 
         // Test for duplicate slugs.
         return checkIfSlugExists(shortSlug);

--- a/core/test/ghost/api_posts_spec.js
+++ b/core/test/ghost/api_posts_spec.js
@@ -121,19 +121,6 @@ describe('Post Model', function () {
         }).otherwise(done);
     });
 
-    it('can generate slugs without 2 letter words', function (done) {
-        var newPost = {
-            title: 'I am an idiot',
-            content: 'Test Content 1'
-        };
-
-        PostModel.add(newPost).then(function (createdPost) {
-
-            createdPost.get('slug').should.equal('idiot');
-
-            done();
-        });
-    });
 
     it('can generate slugs without duplicate hyphens', function (done) {
         var newPost = {


### PR DESCRIPTION
Closes #228. Also deals with the fact that if there's a trailing hyphen, it no longer removes one extra character.

Also see #239 by @jgable and compare. He also did some modifications along these lines, although my solution is stupidly simple. On the other hand I did not exclude words of less than 2 characters (because personally I think it's not a good idea).
