### PR TITLE
Fixes 'All Posts' menu not being the right location and also not hiding properly

### DIFF
--- a/core/admin/assets/sass/layouts/manage.scss
+++ b/core/admin/assets/sass/layouts/manage.scss
@@ -46,6 +46,10 @@
                 padding: 5px;
                 margin-left:-5px;
             }
+
+            .menu-drop {
+                display: block;
+            }
         }
 
         .button-add {

--- a/core/admin/assets/tpl/preview.hbs
+++ b/core/admin/assets/tpl/preview.hbs
@@ -10,8 +10,6 @@
         <a class="post-edit" href="#"><span class="hidden">Edit Post</span></a>
         <a class="post-settings" href="#" data-toggle=".menu-drop-right"><span class="hidden">Post Settings</span></a>
         <ul class="menu-drop-right overlay">
-            <li><a href="#" class="url">URL</a></li>
-            <li><a href="#" class="something">Something</a></li>
             <li><a href="#" class="delete">Delete</a></li>
         </ul>
     </section>

--- a/core/admin/views/content.hbs
+++ b/core/admin/views/content.hbs
@@ -3,7 +3,7 @@
   <header class="floatingheader">
       <section class="content-filter">
           <a class="dropdown" href="#" data-toggle=".menu-drop">All Posts</a>
-          <ul class="menu-drop" style="display:none;">
+          <ul class="menu-drop overlay" style="display:none;">
               <li class="active"><a href="#">All Posts</a></li>
               <li><a href="#">Recently Edited</a></li>
               <li><a href="#">By Author...</a></li>


### PR DESCRIPTION
Forgot to add it to the commit message, but this also fixes 'Remove the 'something' option from settings menu in content preview pane [Note: Can remove everything except "Delete" for now]'.

See #188
