### PR TITLE
Removed settings icon in editor

### DIFF
--- a/core/admin/views/editor.hbs
+++ b/core/admin/views/editor.hbs
@@ -40,7 +40,6 @@
             <ul class="suggestions overlay" data-populate=".categories"></ul>
         </section>
         <div class="right">
-            <button id="entry-settings" href="#" class="button-link"><span class="hidden">Settings</span></button>
             <section id="entry-actions" class="splitbutton-save">
                 <button type="button" class="button-save js-post-button"></button>
                 <a class="options up" href="#"><span class="hidden">Options</span></a>


### PR DESCRIPTION
Refers to 'Hide pencil and settings icon on editor - bottom nav bar'.

I can't see a pencil icon (possibly tag icon), so only removed the settings icon.

See #188
