### PR TITLE
Update grunt-bump min version and add bump:git

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -280,7 +280,7 @@ var path = require('path'),
             "sass:admin",
             "handlebars",
             "validate",
-            "bump",
+            "bump:git",
             "updateCurrentPackageInfo",
             "copy:nightly",
             "compress:nightly"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "mocha": "~1.10.0",
     "grunt-contrib-handlebars": "~0.5.9",
     "grunt-contrib-watch": "~0.4.4",
-    "grunt-bump": "~0.0.2",
+    "grunt-bump": "~0.0.11",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-compress": "~0.5.2",
     "mocha-as-promised": "~1.4.0",


### PR DESCRIPTION
The latest version of grunt-bump adds bump:build and bump:git support
