### PR TITLE
Switch to grunt-mocha-cli

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,7 @@ var path = require('path'),
                 }
             },
 
-            mochaTest: {
+            mochacli: {
                 options: {
                     ui: "bdd",
                     reporter: "spec"
@@ -229,7 +229,7 @@ var path = require('path'),
         grunt.initConfig(cfg);
 
         grunt.loadNpmTasks("grunt-jslint");
-        grunt.loadNpmTasks("grunt-mocha-test");
+        grunt.loadNpmTasks("grunt-mocha-cli");
         grunt.loadNpmTasks("grunt-shell");
         grunt.loadNpmTasks("grunt-bump");
 
@@ -253,13 +253,13 @@ var path = require('path'),
         grunt.registerTask("init", ["shell:bourbon", "sass:admin", 'handlebars']);
 
         // Run API tests only
-        grunt.registerTask("test-api", ["mochaTest:api"]);
+        grunt.registerTask("test-api", ["mochacli:api"]);
 
         // Run permisisons tests only
-        grunt.registerTask("test-p", ["mochaTest:perm"]);
+        grunt.registerTask("test-p", ["mochacli:perm"]);
 
         // Run tests and lint code
-        grunt.registerTask("validate", ["jslint", "mochaTest:all"]);
+        grunt.registerTask("validate", ["jslint", "mochacli:all"]);
 
         // Generate Docs
         grunt.registerTask("docs", ["groc"]);

--- a/core/test/ghost/permissions_spec.js
+++ b/core/test/ghost/permissions_spec.js
@@ -13,19 +13,13 @@ var _ = require("underscore"),
 
 describe('permissions', function () {
 
-    should.exist(permissions);
-
     beforeEach(function (done) {
         helpers.resetData().then(function (result) {
-            return when(helpers.insertDefaultUser());
+            return helpers.insertDefaultUser();
         }).then(function (results) {
             done();
         }).otherwise(errors.logAndThrowError);
     });
-
-    // beforeEach(function (done) {
-    //     helpers.resetData().then(function () { done(); }, errors.throwError);
-    // });
 
     var testPerms = [
             { act: "edit", obj: "post" },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "grunt": "~0.4.1",
     "grunt-jslint": "git+https://github.com/ErisDS/grunt-jslint.git#custom",
     "should": "~1.2.2",
-    "grunt-mocha-test": "~0.4.0",
     "grunt-shell": "~0.2.2",
     "grunt-contrib-sass": "~0.3.0",
     "sinon": "~1.7.2",
@@ -37,6 +36,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-compress": "~0.5.2",
     "mocha-as-promised": "~1.4.0",
-    "grunt-groc": "~0.3.0"
+    "grunt-groc": "~0.3.0",
+    "grunt-mocha-cli": "~1.0.6"
   }
 }


### PR DESCRIPTION
The grunt-mocha-test task seems to be causing problems with our
beforeEach handlers in some cases. The grunt-mocha-cli task runs the
mocha command using grunt.util.spawn for more consistent results.
