### PR TITLE
Fix grunt default task fail

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -338,7 +338,7 @@ var path = require('path'),
         ]);
 
         // When you just say "grunt"
-        grunt.registerTask("default", ['sass:admin', 'handlebars']);
+        grunt.registerTask("default", ['init']);
     };
 
 module.exports = configureGrunt;


### PR DESCRIPTION
Switched over to just use the init task we already have.  Was failing because the bourbon command wasn't running.
