### PR TITLE
Additional Keyboard Shortcuts and improvements to text highlighting

### DIFF
--- a/core/client/assets/vendor/to-title-case.js
+++ b/core/client/assets/vendor/to-title-case.js
@@ -1,0 +1,22 @@
+/*
+ * To Title Case 2.0.1 – http://individed.com/code/to-title-case/
+ * Copyright © 2008–2012 David Gouch. Licensed under the MIT License.
+ */
+
+String.prototype.toTitleCase = function () {
+    var smallWords = /^(a|an|and|as|at|but|by|en|for|if|in|of|on|or|the|to|vs?\.?|via)$/i;
+
+    return this.replace(/([^\W_]+[^\s-]*) */g, function (match, p1, index, title) {
+        if (index > 0 && index + p1.length !== title.length &&
+            p1.search(smallWords) > -1 && title.charAt(index - 2) !== ":" &&
+            title.charAt(index - 1).search(/[^\s-]/) < 0) {
+            return match.toLowerCase();
+        }
+
+        if (p1.substr(1).search(/[A-Z]|\../) > -1) {
+            return match;
+        }
+
+        return match.charAt(0).toUpperCase() + match.substr(1);
+    });
+};

--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -38,7 +38,7 @@
                 md = text.toLocaleLowerCase();
                 break;
             case "titlecase":
-                md = text.replace(/\w\S*/g, function (text) {return text.charAt(0).toUpperCase() + text.substr(1).toLowerCase(); });
+                md = text.toTitleCase();
                 break;
             case "selectword":
                 cursor = this.elem.getCursor();

--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -1,6 +1,6 @@
 // # Surrounds given text with Markdown syntax
 
-/*global $, CodeMirror */
+/*global $, window, CodeMirror, Showdown */
 (function () {
     "use strict";
     var Markdown = {
@@ -15,7 +15,7 @@
             self.replace();
         },
         replace: function () {
-            var text = this.elem.getSelection(), pass = true, md, cursor, word;
+            var text = this.elem.getSelection(), pass = true, md, cursor, word, converter;
             switch (this.style) {
             case "link":
                 md = this.options.syntax.link.replace('$1', text);
@@ -48,6 +48,12 @@
                 } else {
                     this.elem.setSelection({line: cursor.line, ch: word.start}, {line: cursor.line, ch: word.end});
                 }
+                break;
+            case "copyHTML":
+                converter = new Showdown.converter();
+                md = converter.makeHtml(text);
+                window.prompt("Copy to clipboard: Ctrl+C, Enter", md);
+                pass = false;
                 break;
             case "list":
                 md = text.replace(/^/gm, "* ");

--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -15,10 +15,52 @@
             self.replace();
         },
         replace: function () {
-            var text = this.elem.getSelection(), md;
-            if (this.options.syntax[this.style]) {
-                md = this.options.syntax[this.style].replace('$1', text);
-                this.elem.replaceSelection(md);
+            var text = this.elem.getSelection(), pass = true, md, cursor, word;
+            switch (this.style) {
+            case "link":
+                md = this.options.syntax.link.replace('$1', text);
+                this.elem.replaceSelection(md, "end");
+                cursor = this.elem.getCursor();
+                this.elem.setSelection({line: cursor.line, ch: cursor.ch - 8}, {line: cursor.line, ch: cursor.ch - 1});
+                pass = false;
+                break;
+            case "image":
+                md = this.options.syntax.image.replace('$1', text);
+                this.elem.replaceSelection(md, "end");
+                cursor = this.elem.getCursor();
+                this.elem.setSelection({line: cursor.line, ch: cursor.ch - 8}, {line: cursor.line, ch: cursor.ch - 1});
+                pass = false;
+                break;
+            case "uppercase":
+                md = text.toLocaleUpperCase();
+                break;
+            case "lowercase":
+                md = text.toLocaleLowerCase();
+                break;
+            case "titlecase":
+                md = text.replace(/\w\S*/g, function (text) {return text.charAt(0).toUpperCase() + text.substr(1).toLowerCase(); });
+                break;
+            case "selectword":
+                cursor = this.elem.getCursor();
+                word = this.elem.getTokenAt(cursor);
+                if (!/\w$/g.test(word.string)) {
+                    this.elem.setSelection({line: cursor.line, ch: word.start}, {line: cursor.line, ch: word.end - 1});
+                } else {
+                    this.elem.setSelection({line: cursor.line, ch: word.start}, {line: cursor.line, ch: word.end});
+                }
+                break;
+            case "list":
+                md = text.replace(/^/gm, "* ");
+                this.elem.replaceSelection("\n" + md + "\n", "end");
+                pass = false;
+                break;
+            default:
+                if (this.options.syntax[this.style]) {
+                    md = this.options.syntax[this.style].replace('$1', text);
+                }
+            }
+            if (pass && md) {
+                this.elem.replaceSelection(md, "end");
             }
         }
     };

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -28,7 +28,9 @@
             {'key': 'Ctrl+Shift+U', 'style': 'lowercase'},
             {'key': 'Ctrl+Alt+Shift+U', 'style': 'titlecase'},
             {'key': 'Ctrl+Alt+W', 'style': 'selectword'},
-            {'key': 'Ctrl+L', 'style': 'list'}
+            {'key': 'Ctrl+L', 'style': 'list'},
+            {'key': 'Ctrl+Alt+C', 'style': 'copyHTML'},
+            {'key': 'CMD+Alt+C', 'style': 'copyHTML'}
         ];
 
     // The publish bar associated with a post, which has the TagWidget and

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -23,7 +23,12 @@
             {'key': 'Ctrl+Shift+L', 'style': 'link'},
             {'key': 'Ctrl+Shift+I', 'style': 'image'},
             {'key': 'Ctrl+Q', 'style': 'blockquote'},
-            {'key': 'Ctrl+Shift+1', 'style': 'currentdate'}
+            {'key': 'Ctrl+Shift+1', 'style': 'currentdate'},
+            {'key': 'Ctrl+U', 'style': 'uppercase'},
+            {'key': 'Ctrl+Shift+U', 'style': 'lowercase'},
+            {'key': 'Ctrl+Alt+Shift+U', 'style': 'titlecase'},
+            {'key': 'Ctrl+Alt+W', 'style': 'selectword'},
+            {'key': 'Ctrl+L', 'style': 'list'}
         ];
 
     // The publish bar associated with a post, which has the TagWidget and

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -44,6 +44,7 @@
         <script src="/public/vendor/showdown/extensions/ghostdown.js"></script>
         <script src="/public/vendor/shortcuts.js"></script>
         <script src="/public/vendor/countable.js"></script>
+        <script src="/public/vendor/to-title-case.js"></script>
         <script src="/public/vendor/jquery/jquery-ui-1.10.3.custom.min.js"></script>
         <script src="/public/vendor/packery.pkgd.min.js"></script>
 


### PR DESCRIPTION
This fixes the event where text would be selected after manipulation from shortcut, the cursor is now placed after the text. On links and images the url field text is highlighted.
Additional shortcuts;
- Ctrl+U: Make text uppercase
- Ctrl+Shift+U: Make text lowercase
- Ctrl+Alt+Shift+U: Make text titlecase
- Ctrl+Alt+W: Select word
- Ctrl+L: Make into list

Fixes #9.
