### PR TITLE
Include conditional configuration based on NODE_ENV, Adds warning at boot

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var express = require('express'),
     when = require('when'),
     _ = require('underscore'),
+    colors = require("colors"),
     errors = require('./core/server/errorHandling'),
     admin = require('./core/server/controllers/admin'),
     frontend = require('./core/server/controllers/frontend'),
@@ -116,17 +117,25 @@ disableCachedResult = function (req, res, next) {
     next();
 };
 
-ghost.app().configure('development', function () {
+ghost.app().configure(function() {
     ghost.app().use(isGhostAdmin);
     ghost.app().use(express.favicon(__dirname + '/content/images/favicon.ico'));
-    ghost.app().use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-    ghost.app().use(express.logger('dev'));
     ghost.app().use(I18n.load(ghost));
     ghost.app().use(express.bodyParser({}));
     ghost.app().use(express.cookieParser('try-ghost'));
     ghost.app().use(express.cookieSession({ cookie: { maxAge: 60000000 }}));
     ghost.app().use(ghost.initTheme(ghost.app()));
     ghost.app().use(flash());
+
+    if (process.env.NODE_ENV !== "development") {
+        ghost.app().use(express.logger());
+        ghost.app().use(express.errorHandler({ dumpExceptions: false, showStack: false }));
+    }
+});
+
+ghost.app().configure("development", function() {
+    ghost.app().use(express.errorHandler({ dumpExceptions: true, showStack: true }));
+    ghost.app().use(express.logger('dev'));
 });
 
 
@@ -187,13 +196,18 @@ when.all([ghost.init(), filters.loadCoreFilters(ghost), helpers.loadCoreHelpers(
     ghost.app().get('/', frontend.homepage);
     ghost.app().get('/page/:page/', frontend.homepage);
 
-
-
-
     ghost.app().listen(
         ghost.config().env[process.env.NODE_ENV || 'development'].url.port,
         ghost.config().env[process.env.NODE_ENV || 'development'].url.host,
-        function () {
+        function() {
+
+            // Remove once software becomes suitably 'ready'
+            console.log(
+                "\n !!! ALPHA SOFTWARE WARNING !!!\n".red,
+                "Ghost is in the early stages of development.\n".red,
+                "Expect to see bugs and other issues (but please report them.)\n".red
+            );
+
             console.log("Express server listening on address:",
                 ghost.config().env[process.env.NODE_ENV || 'development'].url.host + ':'
                     + ghost.config().env[process.env.NODE_ENV || 'development'].url.port);

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "knex": "0.1.7",
     "when": "2.1.1",
     "bcrypt-nodejs": "0.0.3",
-    "node-uuid": "1.4.0"
+    "node-uuid": "1.4.0",
+    "colors": "~0.6.0-1"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
As detailed in issue #308, NODE_ENV was ignored in app configuration. I'm proposing a few configuration defaults, but it's possible there's stuff in there we'll want to move into config.js, such as wether to show a stack trace on error or not.

Also added a warning message on boot so people can be doubly aware they're using development software.
