### PR TITLE
Updated Ghostdown image regex

### DIFF
--- a/core/client/assets/vendor/showdown/extensions/ghostdown.js
+++ b/core/client/assets/vendor/showdown/extensions/ghostdown.js
@@ -5,7 +5,7 @@
             {
                 type: 'lang',
                 filter: function (source) {
-                    return source.replace(/\n?!image\[([\d\w\s]*)\]/gi, function (match, alt, a) {
+                    return source.replace(/\n?!(?:image)?\[([^\n\]]*)\](?:\(([^\n\)]*)\))?/gi, function (match, alt, a) {
                         return '<section  class="js-drop-zone image-uploader">' +
                             '<span class="media"><span class="hidden">Image Upload</span></span>' +
                             '<div class="description">Add image of <strong>' + alt + '</strong></div>' +

--- a/core/test/unit/frontend_ghostdown_spec.js
+++ b/core/test/unit/frontend_ghostdown_spec.js
@@ -1,0 +1,38 @@
+/*globals describe, it */
+var gdPath = "../../client/assets/vendor/showdown/extensions/ghostdown.js",
+    should = require('should'),
+    ghostdown = require(gdPath);
+
+describe("Ghostdown showdown extensions", function () {
+    
+    it("should export an array of methods for processing", function () {
+        
+        ghostdown.should.be.a("function");
+        ghostdown().should.be.an.instanceof(Array);
+        
+        ghostdown().forEach(function (processor) {
+            processor.should.be.a("object");
+            processor.should.have.property("type");
+            processor.should.have.property("filter");
+            processor.type.should.be.a("string");
+            processor.filter.should.be.a("function");
+        });
+    });
+
+    it("should accurately detect images in markdown", function () {
+        
+        [   "!image[image and another,/ image](http://dsurl stuff)",
+            "![image and another,/ image]",
+            "![]()",
+            "![]" ]
+            .forEach(function (imageMarkup) {
+                var processedMarkup = 
+                    ghostdown().reduce(function(prev,processor) {
+                        return processor.filter(prev);
+                    },imageMarkup);
+                
+                // The image is the entire markup, so the image box should be too
+                processedMarkup.should.match(/^<section.*?section>\n*$/);
+            });
+    });
+});


### PR DESCRIPTION
As per issue #39, I've updated the regex to support the shorter markdown image syntax `![alt](url)` and to capture the URL. Fixes #146.

The regex itself is a little ugly but maintains the sensibility of the function parameters (so we don't have to pad them with junk args to receive data from the redundant capture groups.)
