### PR TITLE
Users can change password

### DIFF
--- a/core/client/tpl/settings/user-profile.hbs
+++ b/core/client/tpl/settings/user-profile.hbs
@@ -69,6 +69,7 @@
                 <label><strong>Verify Password</strong></label>
                 <input type="password" id="user-new-password-verification">
             </div>
+            <button class="button-change-password">Change Password</button>
 
         </fieldset>
 

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -176,7 +176,8 @@
         },
 
         events: {
-            'click .button-save': 'saveUser'
+            'click .button-save': 'saveUser',
+            'click .button-change-password': 'changePassword'
         },
 
         saveUser: function () {
@@ -191,6 +192,55 @@
             }, {
                 success: this.saveSuccess,
                 error: this.saveError
+            });
+        },
+
+        changePassword: function (event) {
+            event.preventDefault();
+
+            var self = this,
+                email = this.$('#user-email').val(),
+                oldPassword = this.$('#user-password-old').val(),
+                newPassword = this.$('#user-password-new').val(),
+                ne2Password = this.$('#user-new-password-verification').val();
+
+            if (newPassword !== ne2Password || newPassword.length < 6 || oldPassword.length < 6) {
+                this.saveError();
+                return;
+            }
+
+            $.ajax({
+                url: '/ghost/changepw/',
+                type: 'POST',
+                data: {
+                    email: email,
+                    password: oldPassword,
+                    newpassword: newPassword,
+                    ne2password: ne2Password
+                },
+                success: function (msg) {
+
+                    self.addSubview(new Ghost.Views.NotificationCollection({
+                        model: [{
+                            type: 'success',
+                            message: msg.msg,
+                            status: 'passive',
+                            id: 'success-98'
+                        }]
+                    }));
+                    self.$('#user-password-old').val('');
+                    self.$('#user-password-new').val('');
+                    self.$('#user-new-password-verification').val('');
+                },
+                error: function (obj, string, status) {
+                    self.addSubview(new Ghost.Views.NotificationCollection({
+                        model: [{
+                            type: 'error',
+                            message: 'Invalid username or password',
+                            status: 'passive'
+                        }]
+                    }));
+                }
             });
         },
 

--- a/core/server/api.js
+++ b/core/server/api.js
@@ -65,6 +65,9 @@ users = {
     },
     check: function check(postData) {
         return dataProvider.User.check(postData);
+    },
+    changePassword: function changePassword(postData) {
+        return dataProvider.User.changePassword(postData);
     }
 };
 

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -69,6 +69,19 @@ adminControllers = {
             res.send(401);
         });
     },
+    changepw: function (req, res) {
+        api.users.changePassword({
+            email: req.body.email,
+            oldpw: req.body.password,
+            newpw: req.body.newpassword,
+            ne2pw: req.body.ne2password
+        }).then(function (user) {
+            res.json(200, {msg: 'Password changed successfully'});
+        }, function (error) {
+            res.send(401);
+        });
+
+    },
     'signup': function (req, res) {
         res.render('signup', {
             bodyClass: 'ghost-login',

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ when.all([ghost.init(), filters.loadCoreFilters(ghost), helpers.loadCoreHelpers(
     ghost.app().get('/ghost/signup/', admin.signup);
     ghost.app().post('/ghost/login/', admin.auth);
     ghost.app().post('/ghost/signup/', admin.doRegister);
+    ghost.app().post('/ghost/changepw/', auth, admin.changepw);
     ghost.app().get('/ghost/editor/:id', auth, admin.editor);
     ghost.app().get('/ghost/editor', auth, admin.editor);
     ghost.app().get('/ghost/content', auth, admin.content);


### PR DESCRIPTION
Closes #282
- Added a new route
- Added new methods
- Triple security!
- Passwords are actually changed
- Also added a change password button, because 'save' has too much baggage.

On security: checks whether you're logged in. Then checks whether your old password is actually the one that belongs to you (gets value from the email field for the email, see caveat no2). Checks the new passwords for === and length > 6 on client and server side as well. And THEN changes passwords.

Caveats:
- didn't add a test, as mocha fails spectacularly on my machine. SQLITE_CORRUPT: database disk image is malformed. Cute, huh?
- Because we don't have / I'm not aware of / could not find a "currentuser" variable, I need to get the email address of the user we want to change from the email field. Theoretically if they replace that with another user's email address, and supply their pw, they will change THEIR password instead of their own.
