### PR TITLE
Passive notifications are dismissed on settings pane change

### DIFF
--- a/core/client/views/base.js
+++ b/core/client/views/base.js
@@ -110,7 +110,11 @@
     Ghost.Views.NotificationCollection = Ghost.View.extend({
         el: '#flashbar',
         initialize: function () {
+            var self = this;
             this.render();
+            Backbone.history.on('route', function () {
+                self.clearEverything();
+            });
         },
         events: {
             'animationend .js-notification': 'removeItem',
@@ -132,6 +136,9 @@
         addItem: function (item) {
             this.model.push(item);
             this.renderItem(item);
+        },
+        clearEverything: function () {
+            this.$el.find('.js-notification.notification-passive').fadeOut(200,  function () { $(this).remove(); });
         },
         removeItem: function (e) {
             e.preventDefault();

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -43,7 +43,7 @@
             var self = this,
                 model;
 
-            Backbone.history.navigate('/settings/' + id);
+            Backbone.history.navigate('/settings/' + id, {trigger: true});
             if (this.pane && id === this.pane.el.id) {
                 return;
             }


### PR DESCRIPTION
Closes #342.
It would be totally cool if we could have a Ghost.PubSub so we could hurl events there and pick them up somewhere else. For some reason all the backbone bits work on models, like `trigger` and `listenTo` and `delegateEvents`.
