### PR TITLE
Update fixtures to remove references to me

### DIFF
--- a/core/server/data/fixtures/001.js
+++ b/core/server/data/fixtures/001.js
@@ -37,7 +37,7 @@ module.exports = {
         {
             "uuid":         uuid.v4(),
             "key":          "title",
-            "value":        "John O'Nolan",
+            "value":        "Ghost",
             "created_by":    1,
             "updated_by":    1,
             "type":         "blog"
@@ -45,7 +45,7 @@ module.exports = {
         {
             "uuid":         uuid.v4(),
             "key":          "description",
-            "value":        "Interactive designer, public speaker, startup advisor and writer. Living in Austria, attempting world domination via keyboard.",
+            "value":        "Just a blogging platform.",
             "created_by":    1,
             "updated_by":    1,
             "type":         "blog"
@@ -53,7 +53,7 @@ module.exports = {
         {
             "uuid":         uuid.v4(),
             "key":          "email",
-            "value":        "john@onolan.org",
+            "value":        "ghost@example.com",
             "created_by":    1,
             "updated_by":    1,
             "type":         "general"


### PR DESCRIPTION
Removed my personal information from fixtures as Ghost is starting to get deployed more frequently now for testing purposes.

Don't want random test sites accidentally ranking in search engines for my name.
