### PR TITLE
Improving the use of paths in Ghost

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,9 +13,6 @@ config.forceI18n = true;
 
 // ## Themes & Plugins
 
-// Themes directory, relative to `content/`
-config.themeDir = 'themes';
-
 // Current active theme
 config.activeTheme = 'casper';
 

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -17,8 +17,9 @@ var config = require('./../config'),
     requireTree = require('./server/require-tree'),
 
 // Variables
-    themePath = path.resolve(__dirname + '../../content/themes'),
-    pluginPath = path.resolve(__dirname + '../../content/plugins'),
+    appRoot = path.resolve(__dirname, '../'),
+    themePath = path.resolve(appRoot + '/content/themes'),
+    pluginPath = path.resolve(appRoot + '/content/plugins'),
     themeDirectories = requireTree(themePath),
     pluginDirectories = requireTree(pluginPath),
 
@@ -102,10 +103,13 @@ Ghost = function () {
             },
             paths: function () {
                 return {
-                    'activeTheme':      __dirname + '/../content/' + config.themeDir + '/' + config.activeTheme + '/',
-                    'adminViews':       __dirname + '/server/views/',
-                    'helperTemplates':  __dirname + '/server/helpers/tpl/',
-                    'lang':             __dirname + '/shared/lang/',
+                    'appRoot':          appRoot,
+                    'themePath':        themePath,
+                    'pluginPath':       pluginPath,
+                    'activeTheme':      path.join(themePath, config.activeTheme),
+                    'adminViews':       path.join(appRoot, '/core/server/views/'),
+                    'helperTemplates':  path.join(appRoot, '/core/server/helpers/tpl/'),
+                    'lang':             path.join(appRoot, '/core/shared/lang/'),
                     'availableThemes':  instance.themeDirectories,
                     'availablePlugins': instance.pluginDirectories
                 };
@@ -265,7 +269,7 @@ Ghost.prototype.initTheme = function (app) {
 
         if (!res.isAdmin) {
             app.engine('hbs', hbs.express3(
-                {partialsDir: self.paths().activeTheme + 'partials'}
+                {partialsDir: path.join(self.paths().activeTheme, 'partials')}
             ));
             app.set('views', self.paths().activeTheme);
         } else {

--- a/core/server/plugins/loader.js
+++ b/core/server/plugins/loader.js
@@ -3,7 +3,6 @@ var path = require("path"),
     _ = require("underscore"),
     when = require("when"),
     ghostInstance,
-    pluginRootDirectory = path.join(process.cwd(), "content/plugins"),
     loader;
 
 function getGhostInstance() {
@@ -18,11 +17,21 @@ function getGhostInstance() {
     return ghostInstance;
 }
 
+// Get a relative path to the given plugins root, defaults
+// to be relative to __dirname
+function getPluginRelativePath(name, relativeTo, ghost) {
+    ghost = ghost || getGhostInstance();
+    relativeTo = relativeTo || __dirname;
+
+    return path.relative(relativeTo, path.join(ghost.paths().pluginPath, name));
+}
+
+
 function getPluginByName(name, ghost) {
     ghost = ghost || getGhostInstance();
 
     // Grab the plugin class to instantiate
-    var PluginClass = require(loader.getPluginRelativePath(name)),
+    var PluginClass = require(getPluginRelativePath(name)),
         plugin;
 
     // Check for an actual class, otherwise just use whatever was returned
@@ -37,14 +46,6 @@ function getPluginByName(name, ghost) {
 
 // The loader is responsible for loading plugins
 loader = {
-    // Get a relative path to the given plugins root, defaults
-    // to be relative to __dirname
-    getPluginRelativePath: function (name, relativeTo) {
-        relativeTo = relativeTo || __dirname;
-
-        return path.relative(relativeTo, path.join(pluginRootDirectory, name));
-    },
-
     // Load a plugin and return the instantiated plugin
     installPluginByName: function (name, ghost) {
         var plugin = getPluginByName(name, ghost);


### PR DESCRIPTION
fixes #392
- adds appRoot, and uses this to calculate other paths
- removes path calculations from loader
- remove the themedir setting in config.. completely unnecessary
- highlights just how important #360 is
