### PR TITLE
Add LiveReload Grunt Dev Task

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
         "grunt-contrib-compress": "~0.5.2",
         "grunt-groc": "~0.3.0",
         "grunt-mocha-cli": "~1.0.6",
+        "grunt-express-server": "~0.4.2",
+        "grunt-open": "~0.2.2",
+        "matchdep": "~0.1.2",
         "sinon": "~1.7.3",
         "should": "~1.2.2",
         "mocha": "~1.12.0"


### PR DESCRIPTION
Adds the ability to run a new task via `grunt dev` that will watch our
sass, templates and javascript files for changes and reload them in the browser.

Also, refactored the Gruntfile to auto load all grunt-\* tasks to remove
some code.

I tested this by [installing the livereload chrome extension](http://feedback.livereload.com/knowledgebase/articles/86242-how-do-i-install-and-use-the-browser-extensions-) and running the `grunt dev` task locally.  It won't work on the VM right now because the livereload extension looks specifically for a localhost:[port] address for the livereload server.
