### PR TITLE
Implement e-mail sending.

### DIFF
--- a/core/ghost.js
+++ b/core/ghost.js
@@ -12,6 +12,7 @@ var config = require('./../config'),
     nodefn = require('when/node/function'),
     _ = require('underscore'),
     Polyglot = require('node-polyglot'),
+    Mailer = require('./server/mail'),
     models = require('./server/models'),
     plugins = require('./server/plugins'),
     requireTree = require('./server/require-tree'),
@@ -95,6 +96,7 @@ Ghost = function () {
             dataProvider: models,
             statuses: function () { return statuses; },
             polyglot: function () { return polyglot; },
+            mail: new Mailer(),
             getPaths: function () {
                 return when.all([themeDirectories, pluginDirectories]).then(function (paths) {
                     instance.themeDirectories = paths[0];
@@ -124,8 +126,11 @@ Ghost = function () {
 Ghost.prototype.init = function () {
     var self = this;
 
-    return when.join(instance.dataProvider.init(), instance.getPaths()).then(function () {
-        // Initialize plugins
+    return when.join(
+        instance.dataProvider.init(),
+        instance.getPaths(),
+        instance.mail.init(self)
+    ).then(function () {
         return self.initPlugins();
     }).then(function () {
         // Initialize the settings cache

--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -1,0 +1,124 @@
+var cp = require('child_process'),
+    url = require('url'),
+    _ = require('underscore'),
+    when = require('when'),
+    nodefn = require('when/node/function'),
+    nodemailer = require('nodemailer');
+
+function GhostMailer(opts) {
+    opts = opts || {};
+    this.transport = opts.transport || null;
+}
+
+// ## E-mail transport setup
+// *This promise should always resolve to avoid halting Ghost::init*.
+GhostMailer.prototype.init = function (ghost) {
+    this.ghost = ghost;
+    // TODO: fix circular reference ghost -> mail -> api -> ghost, remove this late require
+    this.api = require('./api');
+
+    var self = this,
+        config = ghost.config();
+
+    if (config.mail && config.mail.transport && config.mail.options) {
+        this.createTransport(config);
+        return when.resolve();
+    }
+
+    // Attempt to detect and fallback to `sendmail`
+    return this.detectSendmail().then(function (binpath) {
+        self.transport = nodemailer.createTransport('sendmail', {
+            path: binpath
+        });
+        self.usingSendmail();
+    }, function () {
+        self.emailDisabled();
+    }).ensure(function () {
+        return when.resolve();
+    });
+};
+
+GhostMailer.prototype.isWindows = function () {
+    return process.platform === 'win32';
+};
+
+GhostMailer.prototype.detectSendmail = function () {
+    if (this.isWindows()) {
+        return when.reject();
+    }
+    return when.promise(function (resolve, reject) {
+        cp.exec('which sendmail', function (err, stdout) {
+            if (err && !/bin\/sendmail/.test(stdout)) {
+                return reject();
+            }
+            resolve(stdout.toString());
+        });
+    });
+};
+
+GhostMailer.prototype.createTransport = function (config) {
+    this.transport = nodemailer.createTransport(config.mail.transport, _.clone(config.mail.options));
+};
+
+GhostMailer.prototype.usingSendmail = function () {
+    this.api.notifications.add({
+        type: 'info',
+        message: [
+            "Ghost is attempting to use your server's <b>sendmail</b> to send e-mail.",
+            "It is recommended that you explicitly configure an e-mail service,",
+            "see <a href=\"https://github.com/TryGhost/Ghost/wiki/\">instructions in the wiki</a>."
+        ].join(' '),
+        status: 'persistent',
+        id: 'ghost-mail-fallback'
+    });
+};
+
+GhostMailer.prototype.emailDisabled = function () {
+    this.api.notifications.add({
+        type: 'warn',
+        message: [
+            "Ghost is currently unable to send e-mail.",
+            "See <a href=\"https://github.com/TryGhost/Ghost/wiki/\">instructions for configuring",
+            "an e-mail service</a>."
+        ].join(' '),
+        status: 'persistent',
+        id: 'ghost-mail-disabled'
+    });
+    this.transport = null;
+};
+
+// Sends an e-mail message enforcing `to` (blog owner) and `from` fields
+GhostMailer.prototype.send = function (message) {
+    if (!this.transport) {
+        return when.reject(new Error('No e-mail transport configured.'));
+    }
+    if (!(message && message.subject && message.html)) {
+        return when.reject(new Error('Incomplete message data.'));
+    }
+
+    var settings = this.ghost.settings(),
+        from = 'ghost-mailer@' + url.parse(settings.url).hostname,
+        to = settings.email,
+        sendMail = nodefn.lift(this.transport.sendMail.bind(this.transport));
+
+    message = _.extend(message, {
+        from: from,
+        to: to,
+        generateTextFromHTML: true
+    });
+
+    return sendMail(message);
+};
+
+GhostMailer.prototype.sendWelcomeMessage = function () {
+    var adminURL = this.ghost.settings().url + "/ghost";
+
+    return this.send({
+        subject: "Welcome to Ghost",
+        html: "<p><strong>Hello!</strong></p>" +
+            "<p>Welcome to the Ghost platform.</p>" +
+            "<p>Your dashboard is ready at <a href=\"" + adminURL + "\">" + adminURL + "</a>"
+    });
+};
+
+module.exports = GhostMailer;

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -1,0 +1,167 @@
+var cp = require('child_process'),
+    _ = require("underscore"),
+    when = require('when'),
+    sinon = require('sinon'),
+    should = require('should'),
+    Ghost = require('../../ghost'),
+    defaultConfig = require('../../../config'),
+    SMTP,
+    SENDMAIL,
+    fakeConfig,
+    fakeSettings,
+    fakeSendmail,
+    sandbox = sinon.sandbox.create(),
+    ghost;
+
+// Mock SMTP config
+SMTP = {
+    transport: 'SMTP',
+    options: {
+        service: 'Gmail',
+        auth: {
+            user: 'nil',
+            pass: '123'
+        }
+    }
+};
+
+// Mock Sendmail config
+SENDMAIL = {
+    transport: 'sendmail',
+    options: {
+        path: '/nowhere/sendmail'
+    }
+};
+
+describe("Mail", function () {
+
+    beforeEach(function () {
+        // Mock config and settings
+        fakeConfig = _.extend({}, defaultConfig);
+        fakeSettings = {
+            url: 'http://test.tryghost.org',
+            email: 'ghost-test@localhost'
+        };
+        fakeSendmail = '/fake/bin/sendmail';
+
+        ghost = new Ghost();
+
+        sandbox.stub(ghost, "config", function () {
+            return fakeConfig;
+        });
+
+        sandbox.stub(ghost, "settings", function () {
+            return fakeSettings;
+        });
+
+        sandbox.stub(ghost.mail, "isWindows", function () {
+            return false;
+        });
+
+        sandbox.stub(ghost.mail, "detectSendmail", function () {
+            return when.resolve(fakeSendmail);
+        });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('should attach mail provider to ghost instance', function () {
+        should.exist(ghost.mail);
+        ghost.mail.should.have.property('init');
+        ghost.mail.should.have.property('transport');
+        ghost.mail.should.have.property('send').and.be.a('function');
+    });
+
+    it('should setup SMTP transport on initialization', function (done) {
+        fakeConfig.mail = SMTP;
+        ghost.mail.init(ghost).then(function(){
+            ghost.mail.should.have.property('transport');
+            ghost.mail.transport.transportType.should.eql('SMTP');
+            ghost.mail.transport.sendMail.should.be.a('function');
+            done();
+        }).then(null, done);
+    });
+
+    it('should setup sendmail transport on initialization', function (done) {
+        fakeConfig.mail = SENDMAIL;
+        ghost.mail.init(ghost).then(function(){
+            ghost.mail.should.have.property('transport');
+            ghost.mail.transport.transportType.should.eql('SENDMAIL');
+            ghost.mail.transport.sendMail.should.be.a('function');
+            done();
+        }).then(null, done);
+    });
+
+    it('should fallback to sendmail if no config set', function (done) {
+        fakeConfig.mail = null;
+        ghost.mail.init(ghost).then(function(){
+            ghost.mail.should.have.property('transport');
+            ghost.mail.transport.transportType.should.eql('SENDMAIL');
+            ghost.mail.transport.options.path.should.eql(fakeSendmail);
+            done();
+        }).then(null, done);
+    });
+
+    it('should fallback to sendmail if config is empty', function (done) {
+        fakeConfig.mail = {};
+        ghost.mail.init(ghost).then(function(){
+            ghost.mail.should.have.property('transport');
+            ghost.mail.transport.transportType.should.eql('SENDMAIL');
+            ghost.mail.transport.options.path.should.eql(fakeSendmail);
+            done();
+        }).then(null, done);
+    });
+
+    it('should disable transport if config is empty & sendmail not found', function (done) {
+        fakeConfig.mail = {};
+        ghost.mail.detectSendmail.restore();
+        sandbox.stub(ghost.mail, "detectSendmail", when.reject);
+        ghost.mail.init(ghost).then(function(){
+            should.not.exist(ghost.mail.transport);
+            done();
+        }).then(null, done);
+    });
+
+    it('should disable transport if config is empty & platform is win32', function (done) {
+        fakeConfig.mail = {};
+        ghost.mail.detectSendmail.restore();
+        ghost.mail.isWindows.restore();
+        sandbox.stub(ghost.mail, 'isWindows', function(){ return false });
+        ghost.mail.init(ghost).then(function(){
+            should.not.exist(ghost.mail.transport);
+            done();
+        }).then(null, done);
+    });
+
+    it('should fail to send messages when no transport is set', function (done) {
+        ghost.mail.detectSendmail.restore();
+        sandbox.stub(ghost.mail, "detectSendmail", when.reject);
+        ghost.mail.init(ghost).then(function(){
+            ghost.mail.send().then(function(){
+                should.fail();
+                done();
+            }, function (err) {
+                err.should.be.an.instanceOf(Error);
+                done();
+            });
+        });
+    });
+
+    it('should fail to send messages when given insufficient data', function (done) {
+        when.settle([
+            ghost.mail.send(),
+            ghost.mail.send({}),
+            ghost.mail.send({ subject: '123' }),
+            ghost.mail.send({ subject: '', html: '123' })
+        ]).then(function (descriptors) {
+            descriptors.forEach(function (d) {
+                d.state.should.equal('rejected');
+                d.reason.should.be.an.instanceOf(Error);
+            });
+            done();
+        });
+    });
+
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "semver": "2.1.0",
         "fs-extra": "0.6.3",
         "downsize": "0.0.2",
-        "validator": "1.4.0"
+        "validator": "1.4.0",
+        "nodemailer": "~0.5.2"
     },
     "devDependencies": {
         "grunt": "~0.4.1",


### PR DESCRIPTION
Implements the behaviour described in https://github.com/TryGhost/Ghost/issues/53#issuecomment-22374025.

For the tests, I decided to mock the `ghost` object itself, so they run in a few ms and never touch disk or the database, except for require calls.

There is a `ghost.mail.sendWelcomeMessage` method, as suggested by @jgable (I think). It should be called during the first run, not sure where that would go.

Suggestions appreciated, I'll continue updating this PR as needed.
