### PR TITLE
Edit Post Permissions

### DIFF
--- a/core/client/views/base.js
+++ b/core/client/views/base.js
@@ -54,13 +54,14 @@
         // by `addSubview`, which will in-turn remove any
         // children of those views, and so on.
         removeSubviews: function () {
-            var i, l, children = this.subviews;
+            var children = this.subviews;
+
             if (!children) {
                 return this;
             }
-            for (i = 0, l = children.length; i < l; i += 1) {
-                children[i].remove();
-            }
+
+            _(children).invoke("remove");
+
             this.subviews = [];
             return this;
         },
@@ -72,6 +73,32 @@
                 this.removeSubviews();
             }
             return Backbone.View.prototype.remove.apply(this, arguments);
+        },
+
+        // Used in API request fail handlers to parse a standard api error
+        // response json for the message to display
+        getRequestErrorMessage: function (request) {
+            var message;
+
+            // Can't really continue without a request
+            if (!request) {
+                return null;
+            }
+
+            // Seems like a sensible default
+            message = request.statusText;
+
+            // If a non 200 response
+            if (request.status !== 200) {
+                try {
+                    // Try to parse out the error, or default to "Unknown"
+                    message =  request.responseJSON.error || "Unknown Error";
+                } catch (e) {
+                    message = "The server returned an error (" + (request.status || "?") + ").";
+                }
+            }
+
+            return message;
         }
 
     });

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -157,17 +157,20 @@
             if (e) {
                 e.preventDefault();
             }
-            var model = this.model;
+            var view = this,
+                model = this.model;
             this.savePost().then(function () {
                 Ghost.notifications.addItem({
                     type: 'success',
                     message: 'Your post was saved as ' + model.get('status'),
                     status: 'passive'
                 });
-            }, function () {
+            }, function (request) {
+                var message = view.getRequestErrorMessage(request) || model.validationError;
+
                 Ghost.notifications.addItem({
                     type: 'error',
-                    message: model.validationError,
+                    message: message,
                     status: 'passive'
                 });
             });

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -15,6 +15,7 @@ var config = require('./../config'),
     models = require('./server/models'),
     plugins = require('./server/plugins'),
     requireTree = require('./server/require-tree'),
+    permissions = require('./server/permissions'),
 
 // Variables
     appRoot = path.resolve(__dirname, '../'),
@@ -124,9 +125,14 @@ Ghost.prototype.init = function () {
     var self = this;
 
     return when.join(instance.dataProvider.init(), instance.getPaths()).then(function () {
+        // Initialize plugins
         return self.initPlugins();
-    }, errors.logAndThrowError).then(function () {
+    }).then(function () {
+        // Initialize the settings cache
         return self.updateSettingsCache();
+    }).then(function () {
+        // Initialize the permissions actions and objects
+        return permissions.init();
     }, errors.logAndThrowError);
 };
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -220,20 +220,30 @@ Post = GhostBookshelf.Model.extend({
             }, errors.logAndThrowError);
         }
 
-        // TODO: This logic is temporary, will probably need to be updated
-
+        // Check if any permissions apply for this user and post.
         hasPermission = _.any(userPermissions, function (perm) {
-            if (perm.get('object_type') !== 'post') {
+            // Check for matching action type and object type
+            if (perm.get('action_type') !== action_type ||
+                    perm.get('object_type') !== 'post') {
                 return false;
             }
 
-            // True, if no object_id specified, or it matches
+            // If asking whether we can create posts,
+            // and we have a create posts permission then go ahead and say yes
+            if (action_type === 'create' && perm.get('action_type') === action_type) {
+                return true;
+            }
+
+            // Check for either no object id or a matching one
             return !perm.get('object_id') || perm.get('object_id') === postModel.id;
         });
 
         // If this is the author of the post, allow it.
-        hasPermission = hasPermission || userId === postModel.get('author_id');
+        // Moved below the permissions checks because there may not be a postModel
+        // in the case like canThis(user).create.post()
+        hasPermission = hasPermission || (postModel && userId === postModel.get('author_id'));
 
+        // Resolve if we have appropriate permissions
         if (hasPermission) {
             return when.resolve();
         }

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -13,6 +13,14 @@ var _ = require('underscore'),
     CanThisResult,
     exported;
 
+function hasActionsMap() {
+    // Just need to find one key in the actionsMap
+
+    return _.any(exported.actionsMap, function (val, key) {
+        return Object.hasOwnProperty(key);
+    });
+}
+
 // Base class for canThis call results
 CanThisResult = function () {
     this.userPermissionLoad = false;
@@ -98,14 +106,16 @@ CanThisResult.prototype.beginCheck = function (user) {
     var self = this,
         userId = user.id || user;
 
+    if (!hasActionsMap()) {
+        throw new Error("No actions map found, please call permissions.init() before use.");
+    }
+
     // TODO: Switch logic based on object type; user, role, post.
 
     // Kick off the fetching of the user data
     this.userPermissionLoad = UserProvider.effectivePermissions(userId);
 
     // Iterate through the actions and their related object types
-    // We should have loaded these through a permissions.init() call previously
-    // TODO: Throw error if not init() yet?
     _.each(exported.actionsMap, function (obj_types, act_type) {
         // Build up the object type handlers;
         // the '.post()' parts in canThis(user).edit.post()

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -224,7 +224,7 @@ describe('permissions', function () {
 
                 // TODO: Verify updatedUser.related('permissions') has the permission?
 
-                var canThisResult = permissions.canThis(updatedUser);
+                var canThisResult = permissions.canThis(updatedUser.id);
 
                 should.exist(canThisResult.edit);
                 should.exist(canThisResult.edit.post);


### PR DESCRIPTION
Added permissions checks around the main Post API methods.  Some notable changes are:
- Added 003 migration that sets **all users** to admins who may have previously been created.
- Added an "apiContext" scope to use as the `this` value in the `requestHandler`; didn't know whether to just pass a user id or not.
- In the course of testing the update, fixed the way we are showing error messages from the API.  Added a base view helper method to do this because I couldn't see a utils lib anywhere.
