### PR TITLE
Template Helpers: Added author hbs helper

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -29,6 +29,19 @@ coreHelpers = function (ghost) {
         return date;
     });
 
+
+    // ### Author Helper
+    // 
+    // *Usage example:*
+    // `{{author}}`
+    // 
+    // Returns the full name of the author of a given post, or a blank string
+    // if the author could not be determined.
+    //
+    ghost.registerThemeHelper('author', function (context, options) {
+        return this.author ? this.author.full_name : "";
+    });
+
     // ### Content Helper
     // 
     // *Usage example:*

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -35,8 +35,8 @@ GhostBookshelf.Model = GhostBookshelf.Model.extend({
             return attrs;
         }
 
-        _.each(relations, function (key) {
-            attrs[key] = relations[key].toJSON();
+        _.each(relations, function (relation, key) {
+            attrs[key] = relation.toJSON ? relation.toJSON() : relation;
         });
 
         return attrs;

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -112,6 +112,22 @@ Post = GhostBookshelf.Model.extend({
 
 }, {
 
+    // #### findAll
+    // Extends base model findAll to eager-fetch author and user relationships.
+    findAll:  function (options) {
+        options = options || {};
+        options.withRelated = [ "author", "user" ];
+        return GhostBookshelf.Model.findAll.call(this, options);
+    },
+
+    // #### findOne
+    // Extends base model findOne to eager-fetch author and user relationships.
+    findOne: function (args, options) {
+        options = options || {};
+        options.withRelated = [ "author", "user" ];
+        return GhostBookshelf.Model.findOne.call(this, args, options);
+    },
+
      // #### findPage
      // Find results by page - returns an object containing the
      // information about the request (page, limit), along with the
@@ -161,6 +177,8 @@ Post = GhostBookshelf.Model.extend({
         if (opts.where) {
             postCollection.query('where', opts.where);
         }
+
+        opts.withRelated = [ "author", "user" ];
 
         // Set the limit & offset for the query, fetching
         // with the opts (to specify any eager relations, etc.)

--- a/core/test/unit/api_posts_spec.js
+++ b/core/test/unit/api_posts_spec.js
@@ -6,7 +6,8 @@ var _ = require("underscore"),
 
 describe('Post Model', function () {
 
-    var PostModel = Models.Post;
+    var PostModel = Models.Post,
+        UserModel = Models.User;
 
     beforeEach(function (done) {
         helpers.resetData().then(function () {
@@ -42,6 +43,65 @@ describe('Post Model', function () {
 
             done();
         }).then(null, done);
+    });
+
+    it('can findAll, returning author and user data', function (done) {
+        var firstPost,
+            userData = {
+                password: 'testpass1',
+                email_address: "test@test1.com",
+                full_name: "Mr Biscuits"
+            };
+
+        helpers.resetData().then(function () {
+            UserModel.add(userData).then(function (createdUser) {
+
+                PostModel.findAll({}).then(function (results) {
+                    should.exist(results);
+                    results.length.should.be.above(0);
+                    firstPost = results.models[0].toJSON();
+
+                    firstPost.author.should.be.a("object");
+                    firstPost.user.should.be.a("object");
+                    firstPost.author.full_name.should.equal("Mr Biscuits");
+                    firstPost.user.full_name.should.equal("Mr Biscuits");
+
+                    return true;
+
+                }).then(null, done);
+
+                done();
+            }).then(null, done);
+        });
+    });
+
+    it('can findOne, returning author and user data', function (done) {
+        var firstPost,
+            userData = {
+                password: 'testpass1',
+                email_address: "test@test1.com",
+                full_name: "Mr Biscuits"
+            };
+
+        helpers.resetData().then(function () {
+            UserModel.add(userData).then(function (createdUser) {
+
+                PostModel.findOne({}).then(function (result) {
+                    should.exist(result);
+                    firstPost = result.toJSON();
+
+                    firstPost.author.should.be.a("object");
+                    firstPost.user.should.be.a("object");
+                    firstPost.author.full_name.should.equal("Mr Biscuits");
+                    firstPost.user.full_name.should.equal("Mr Biscuits");
+
+                    return true;
+
+                }).then(null, done);
+
+                done();
+            }).then(null, done);
+        });
     });
 
     it('can edit', function (done) {

--- a/core/test/unit/frontend_helpers_index_spec.js
+++ b/core/test/unit/frontend_helpers_index_spec.js
@@ -60,6 +60,28 @@ describe('Core Helpers', function () {
             rendered.string.should.equal("<p>Hello <strong>Wo</strong></p>");
         });
     });
+    
+    describe('Author Helper', function () {
+        
+        it('has loaded author helper', function () {
+            should.exist(handlebars.helpers.author);
+        });
+        
+        it("Returns the full name of the author from the context",function() {
+            var content = {"author":{"full_name":"abc123"}},
+                result = handlebars.helpers.author.call(content);
+
+            String(result).should.equal("abc123");
+        });
+        
+        it("Returns a blank string where author data is missing",function() {
+            var content = {"author":null},
+                result = handlebars.helpers.author.call(content);
+
+            String(result).should.equal("");
+        });
+        
+    });
 
     describe('Navigation Helper', function () {
 


### PR DESCRIPTION
Template Helpers: Added author hbs helper

Fixes #358
- Altered post model to enable eager loading of author and user relationships
- Fixed broken base model toJSON method, which prevented eager resolution of relationships (thanks @tgriesser)
- Passes author information to template.
- Added unit tests for author helper.
- Added unit tests for findOne and findAll additions to Post Model which take into account the eager relationships

Usage:
`{{author}}` -- returns the full name of the post author
`{{author.attribute}}` -- returns property of the current post author as described by the user model
