### PR TITLE
Layout: Break long words in markdown preview

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -251,6 +251,12 @@
 			padding: 60px 40px 40px 40px;
 			overflow: auto;
 
+			// Breaking for long words in preview region
+			word-break: break-word;
+			word-break: break-all;
+			-webkit-hyphens: auto;
+			hyphens: auto;
+
 			// Tweak padding for smaller screens
 			@include breakpoint($netbook) {padding-top: 20px;}
 			@include breakpoint($mobile) {padding: 15px;}


### PR DESCRIPTION
Fixes #427
- Uses hyphenation and word-break to break and wrap long words in markdown
  preview.
