### PR TITLE
Immediately log in when a new user account is created

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -129,7 +129,11 @@ adminControllers = {
                 email_address: email,
                 password: password
             }).then(function (user) {
-                res.json(200, {redirect: '/ghost/login/'});
+                // Automatically log the new user in, unless created by an existing account
+                if (req.session.user === undefined) {
+                    req.session.user = user.id;
+                }
+                res.json(200, {redirect: '/ghost/'});
             }, function (error) {
                 res.json(401, {message: error.message});
             });


### PR DESCRIPTION
Hi. I just set up an instance to have a peek around, and this _tiny_ detail annoyed me a bit, so I though it'd be a good place to introduce myself and see how things work around here.

Now, when you first create a user, you're taken straight to the dashboard.

I know that the user creation flow is probably subject to change, but it's a first impression and a tiny change in the code.

-a
