### PR TITLE
Keyboard shortcut improvements

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -15,7 +15,7 @@
             self.replace();
         },
         replace: function () {
-            var text = this.elem.getSelection(), pass = true, md, cursor, line, word, converter;
+            var text = this.elem.getSelection(), pass = true, md, cursor, line, word, letterCount, converter;
             switch (this.style) {
             case "h1":
                 cursor = this.elem.getCursor();
@@ -93,13 +93,18 @@
                 break;
             case "copyHTML":
                 converter = new Showdown.converter();
-                md = converter.makeHtml(text);
+                if (text) {
+                    md = converter.makeHtml(text);
+                } else {
+                    md = converter.makeHtml(this.elem.getValue());
+                }
+
                 $(".modal-copyToHTML-content").text(md).selectText();
                 $(".js-modal").center();
                 pass = false;
                 break;
             case "list":
-                md = text.replace(/^/gm, "* ");
+                md = text.replace(/^(\s*)(\w\W*)/gm, "$1* $2");
                 this.elem.replaceSelection(md, "end");
                 pass = false;
                 break;
@@ -113,6 +118,11 @@
             }
             if (pass && md) {
                 this.elem.replaceSelection(md, "end");
+                if (!text) {
+                    letterCount = md.length;
+                    cursor = this.elem.getCursor();
+                    this.elem.setCursor({line: cursor.line, ch: cursor.ch - (letterCount / 2)});
+                }
             }
         }
     };

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -14,6 +14,7 @@
             {'key': 'Meta+I', 'style': 'italic'},
             {'key': 'Ctrl+Alt+U', 'style': 'strike'},
             {'key': 'Ctrl+Shift+K', 'style': 'code'},
+            {'key': 'Meta+K', 'style': 'code'},
             {'key': 'Ctrl+Alt+1', 'style': 'h1'},
             {'key': 'Ctrl+Alt+2', 'style': 'h2'},
             {'key': 'Ctrl+Alt+3', 'style': 'h3'},


### PR DESCRIPTION
Closes #416, #421.
This further improves the Keyboard Shortcuts to match Mou. When a user uses a keyboard shortcut and no text is selected, the cursor is now placed ready for insertion. When a user now turns selected text into a list, the tabbed format is preserved.

No selected text improvement;
![markdown](https://f.cloud.github.com/assets/367517/986832/89209610-08e0-11e3-889c-08a040499ab3.gif)

List with tabs;
![markdown2](https://f.cloud.github.com/assets/367517/986834/8fa11c9e-08e0-11e3-8c2e-bd85e5c871fc.gif)
List with tabs Mou;
![mou](https://f.cloud.github.com/assets/367517/986839/99fae4b8-08e0-11e3-86b1-d26a2ebbcd87.gif)
