### PR TITLE
stops image/file drop onto editor markdown causing havoc

### DIFF
--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -343,7 +343,8 @@
                 mode: 'markdown',
                 tabMode: 'indent',
                 tabindex: "2",
-                lineWrapping: true
+                lineWrapping: true,
+                dragDrop: false
             });
 
             var view = this;


### PR DESCRIPTION
 closes #391
- added dragDrop falsey value to codemirror instance
