### PR TITLE
Trim title and don't allow negative pages

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -14,6 +14,12 @@ frontendControllers = {
     'homepage': function (req, res) {
         // Parse the page number
         var pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1;
+
+        // No negative pages
+        if (pageParam < 1) {
+            return res.redirect("/page/1/");
+        }
+
         api.posts.browse({page: pageParam}).then(function (page) {
             // If page is greater than number of pages we have, redirect to last page
             if (pageParam > page.pages) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -95,7 +95,7 @@ Post = GhostBookshelf.Model.extend({
             };
 
         // Remove URL reserved chars: `:/?#[]@!$&'()*+,;=` as well as `\%<>|^~£"`
-        slug = title.replace(/[:\/\?#\[\]@!$&'()*+,;=\\%<>\|\^~£"]/g, '')
+        slug = title.trim().replace(/[:\/\?#\[\]@!$&'()*+,;=\\%<>\|\^~£"]/g, '')
         // Replace dots and spaces with a dash
                     .replace(/(\s|\.)/g, '-')
         // Convert 2 or more dashes into a single dash


### PR DESCRIPTION
Added a .trim() to the slug generation and redirect to the first page if
the page parameter is parsed as less than 1.

Fixes #463, Fixes #464
