### PR TITLE
Bug Fix: Login form now maintains the right layout on reize

### DIFF
--- a/core/client/assets/sass/layouts/login.scss
+++ b/core/client/assets/sass/layouts/login.scss
@@ -19,8 +19,7 @@
     }
 
     main { 
-        top: 15px;
-        @include breakpoint($mobile) { top: 0; }
+        top: 0;
     }
 }//.ghost-login
 

--- a/core/client/views/login.js
+++ b/core/client/views/login.js
@@ -24,7 +24,13 @@
         },
 
         centerOnResize: _.debounce(function (e) {
-            $(".js-login-container").center();
+            var container = $(".js-login-container");
+            container.css({
+                'position': 'relative'
+            }).animate({
+                'top': Math.round($(window).height() / 2) - container.outerHeight() / 2 + 'px'
+            });
+            $(window).trigger("centered");
         }, 100),
 
         remove: function () {


### PR DESCRIPTION
Closes https://github.com/TryGhost/Ghost/issues/476.

This reverts the login form back to using CSS for horizontal centering.
It also removes a weird `top: 15px` style which was causing vertical centering to be off, I can only assume this was left from past login form versions.
