### PR TITLE
Settings pane switching was causing multiple events to be bound

### DIFF
--- a/core/client/init.js
+++ b/core/client/init.js
@@ -20,6 +20,8 @@
         router: null
     };
 
+    _.extend(Ghost, Backbone.Events);
+
     Ghost.init = function () {
         Ghost.router = new Ghost.Router();
 

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -33,7 +33,10 @@
         },
 
         settings: function (pane) {
-            Ghost.currentView = new Ghost.Views.Settings({ el: '#main', pane: pane });
+            // only update the currentView if we don't already have a Settings view
+            if (!Ghost.currentView || !(Ghost.currentView instanceof Ghost.Views.Settings)) {
+                Ghost.currentView = new Ghost.Views.Settings({ el: '#main', pane: pane });
+            }
         },
 
         editor: function (id) {

--- a/core/client/views/base.js
+++ b/core/client/views/base.js
@@ -153,7 +153,7 @@
         initialize: function () {
             var self = this;
             this.render();
-            Backbone.history.on('route', function () {
+            Ghost.on('urlchange', function () {
                 self.clearEverything();
             });
         },

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -43,7 +43,8 @@
             var self = this,
                 model;
 
-            Backbone.history.navigate('/settings/' + id, {trigger: true});
+            Ghost.router.navigate('/settings/' + id);
+            Ghost.trigger('urlchange');
             if (this.pane && id === this.pane.el.id) {
                 return;
             }
@@ -100,7 +101,6 @@
                 message: 'Saved',
                 status: 'passive'
             });
-
         },
         saveError: function (message) {
             message = message || 'Something went wrong, not saved :(';


### PR DESCRIPTION
closes #174
- Triggering router events for navigation between settings panes
  caused the route function to be re-executed, which caused all
  kinds of fun.
- Wrapped the settings route function in an if statement to preserve
  the current view if it already a settings view.
- Added Ghost pub-sub and using that instead of History API
