### PR TITLE
Fixed editor actions menu

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -416,7 +416,13 @@ body.zen {
             @include icon($i-chevron-down) {
                 margin-top:-5px;
                 @include transform(rotate(540deg));
-                @include transition(transform 0.6s ease);
+                /* Transition properties are split out due to a defect in 
+                    the vendor prefixing of transform transitions.
+                    See: http://github.com/thoughtbot/bourbon/pull/86
+                    */
+                @include transition-property(transform);
+                @include transition-duration(0.6s);
+                @include transition-timing-function(ease);
             };
         }
     }


### PR DESCRIPTION
Closes #352
- Updated editor.scss to break out transition shorthand into its
  constituent properties so that bourbon appends the correct vendor
  prefixes.
- Added full set of publish options to the statusMap.
- Added setActiveStatus function to handle toggling the active action
  for the publish menu.
- Cleaned up handleStatus and updatePost functions to match desired
  functionality of menu items toggling the selected action and the actual
  button on the split button invoking said action.
