### PR TITLE
content management preview pane displays post title

### DIFF
--- a/core/client/tpl/preview.hbs
+++ b/core/client/tpl/preview.hbs
@@ -15,5 +15,5 @@
     </section>
 </header>
 <section class="content-preview-content">
-    <div class="wrapper">{{{content}}}</div>
+    <div class="wrapper"><h1>{{{title}}}</h1>{{{content}}}</div>
 </section>


### PR DESCRIPTION
closes #477
- change to preview.hbs to show title as a h1
