### PR TITLE
Fix for post with '?'

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -109,6 +109,10 @@ Post = GhostBookshelf.Model.extend({
         slug = /^(ghost|ghost\-admin|admin|wp\-admin|dashboard|login|archive|archives|category|categories|tag|tags|page|pages|post|posts)$/g
             .test(slug) ? slug + '-post' : slug;
 
+        //if slug is empty after trimming use "post"
+        if (!slug) {
+            slug = "post";
+        }
         // Test for duplicate slugs.
         return checkIfSlugExists(slug);
     },


### PR DESCRIPTION
closes #433
- if slug is empty after trimming use "post" as slug instead
