### PR TITLE
Fix warnings (errors in Sass 3.3) when compiling stylesheets

### DIFF
--- a/core/client/assets/sass/modules/icons.scss
+++ b/core/client/assets/sass/modules/icons.scss
@@ -38,8 +38,7 @@
  * actually unreal. http://cl.ly/O40t 
  */
 
-%icon:before, 
-%icon:after {
+@mixin icon-before-after {
     font-family: "Icons";
     font-weight: normal;
     font-style: normal;
@@ -52,7 +51,7 @@
 }
 
 @mixin icon($char, $size: '', $color: '') {
-    @extend %icon;
+    @include icon-before-after;
 
     &:before {
         content: '#{$char}';
@@ -76,7 +75,7 @@
  */
 
 @mixin icon-after($char, $size: '', $color: '') {
-    @extend %icon;
+    @include icon-before-after;
 
     &:after {
         content: '#{$char}';


### PR DESCRIPTION
closes #509
- Use mixin syntax instead of selector inheritance
