### PR TITLE
Rename /logout/ to /signout/ and /login/ to /signin/

### DIFF
--- a/core/client/router.js
+++ b/core/client/router.js
@@ -14,7 +14,7 @@
             'debug/'           : 'debug',
             'register/'        : 'register',
             'signup/'          : 'signup',
-            'login/'           : 'login'
+            'signin/'          : 'login'
         },
 
         signup: function () {

--- a/core/client/views/login.js
+++ b/core/client/views/login.js
@@ -56,7 +56,7 @@
                 self = this;
 
             $.ajax({
-                url: '/ghost/login/',
+                url: '/ghost/signin/',
                 type: 'POST',
                 data: {
                     email: email,

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -159,7 +159,7 @@ adminControllers = {
         delete req.session.user;
         var msg = {
             type: 'success',
-            message: 'You were successfully logged out',
+            message: 'You were successfully signed out',
             status: 'passive',
             id: 'successlogout'
         };
@@ -168,7 +168,7 @@ adminControllers = {
             ghost.notifications.push(msg);
         }
 
-        res.redirect('/ghost/login/');
+        res.redirect('/ghost/signin/');
     },
     'index': function (req, res) {
         res.render('dashboard', {
@@ -310,7 +310,7 @@ adminControllers = {
 
                     return api.notifications.add(notification).then(function () {
                         delete req.session.user;
-                        res.redirect('/ghost/login/');
+                        res.redirect('/ghost/signin/');
                     });
 
                 }, function importFailure(error) {

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -18,7 +18,7 @@
                     <li class="usermenu-help"><a href="#">Help / Support</a></li>
                     <li class="usermenu-shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                     <li class="divider"></li>
-                    <li class="usermenu-signout"><a href="/logout/">Sign Out</a></li>
+                    <li class="usermenu-signout"><a href="/signout/">Sign Out</a></li>
                 </ul>
             </li>
         </ul>

--- a/core/test/functional/admin/01_login_test.js
+++ b/core/test/functional/admin/01_login_test.js
@@ -5,7 +5,7 @@ casper.test.begin("Ghost admin will load login page", 2, function suite(test) {
 
     casper.start(url + "ghost", function testTitleAndUrl() {
         test.assertTitle("", "Ghost admin has no title");
-        test.assertEquals(this.getCurrentUrl(), url + "ghost/login/", "Ghost requires login");
+        test.assertEquals(this.getCurrentUrl(), url + "ghost/signin/", "Ghost requires login");
     }).viewport(1280, 1024);
 
     casper.run(function () {
@@ -13,12 +13,24 @@ casper.test.begin("Ghost admin will load login page", 2, function suite(test) {
     });
 });
 
+casper.test.begin('Redirects to signin', 2, function suite(test) {
+    casper.test.filename = 'login_redirect_test.png';
+
+    casper.start(url + 'ghost/login/', function testRedirect(response) {
+        test.assertEqual(response.status, 200, 'Response status should be 200.');
+        test.assert(/\/signin\/$/.test(response.url), 'Should be redirected to /signin/. Actual response url: ' + response.url + '.');
+    });
+
+    casper.run(function () {
+        test.done();
+    });
+});
 
 casper.test.begin("Can login to Ghost", 3, function suite(test) {
 
     casper.test.filename = "login_test.png";
 
-    casper.start(url + "ghost/login/", function testTitle() {
+    casper.start(url + "ghost/signin/", function testTitle() {
         test.assertTitle("", "Ghost admin has no title");
     }).viewport(1280, 1024);
 
@@ -50,7 +62,7 @@ casper.test.begin("Can't spam it", 2, function suite(test) {
 
     casper.test.filename = "login_test.png";
 
-    casper.start(url + "ghost/login/", function testTitle() {
+    casper.start(url + "ghost/signin/", function testTitle() {
         test.assertTitle("", "Ghost admin has no title");
     }).viewport(1280, 1024);
 

--- a/core/test/html/404.html
+++ b/core/test/html/404.html
@@ -52,7 +52,7 @@
                     <li class="usermenu-help"><a href="#">Help / Support</a></li>
                     <li class="usermenu-shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                     <li class="divider"></li>
-                    <li class="usermenu-signout"><a href="/logout/">Sign Out</a></li>
+                    <li class="usermenu-signout"><a href="/signout/">Sign Out</a></li>
                 </ul>
             </li>
         </ul>

--- a/core/test/html/user_settings.html
+++ b/core/test/html/user_settings.html
@@ -45,7 +45,7 @@
                     <li class="usermenu-help"><a href="#">Help / Support</a></li>
                     <li class="usermenu-shortcuts"><a href="#">Keyboard Shortcuts</a></li>
                     <li class="divider"></li>
-                    <li class="usermenu-signout"><a href="/logout/">Sign Out</a></li>
+                    <li class="usermenu-signout"><a href="/signout/">Sign Out</a></li>
                 </ul>
             </li>
         </ul>

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function auth(req, res, next) {
         if (path !== '') {
             msg = {
                 type: 'error',
-                message: 'Please Log In',
+                message: 'Please Sign In',
                 status: 'passive',
                 id: 'failedauth'
             };
@@ -54,7 +54,7 @@ function auth(req, res, next) {
             }
             redirect = '?r=' + encodeURIComponent(path);
         }
-        return res.redirect('/ghost/login/' + redirect);
+        return res.redirect('/ghost/signin/' + redirect);
     }
 
     next();
@@ -114,7 +114,7 @@ function signupValidate(req, res, next) {
 function authAPI(req, res, next) {
     if (!req.session.user) {
         // TODO: standardize error format/codes/messages
-        var err = { code: 42, message: 'Please login' };
+        var err = { code: 42, message: 'Please sign in' };
         res.json(401, { error: err });
         return;
     }
@@ -247,10 +247,16 @@ when.all([ghost.init(), filters.loadCoreFilters(ghost), helpers.loadCoreHelpers(
 
     // ### Admin routes
     /* TODO: put these somewhere in admin */
-    ghost.app().get(/^\/logout\/?$/, admin.logout);
-    ghost.app().get('/ghost/login/', redirectToDashboard, admin.login);
+    ghost.app().get(/^\/logout\/?$/, function redirect(req, res) {
+        res.redirect(301, '/signout/');
+    });
+    ghost.app().get(/^\/signout\/?$/, admin.logout);
+    ghost.app().get('/ghost/login/', function redirect(req, res) {
+        res.redirect(301, '/ghost/signin/');
+    });
+    ghost.app().get('/ghost/signin/', redirectToDashboard, admin.login);
     ghost.app().get('/ghost/signup/', redirectToDashboard, admin.signup);
-    ghost.app().post('/ghost/login/', admin.auth);
+    ghost.app().post('/ghost/signin/', admin.auth);
     ghost.app().post('/ghost/signup/', signupValidate, admin.doRegister);
     ghost.app().post('/ghost/changepw/', auth, admin.changepw);
     ghost.app().get('/ghost/editor/:id', auth, admin.editor);
@@ -262,7 +268,7 @@ when.all([ghost.init(), filters.loadCoreFilters(ghost), helpers.loadCoreHelpers(
     ghost.app().post('/ghost/debug/db/import/', auth, admin.debug['import']);
     ghost.app().get('/ghost/debug/db/reset/', auth, admin.debug.reset);
     ghost.app().post('/ghost/upload', admin.uploader);
-    ghost.app().get(/^\/(ghost$|(ghost-admin|admin|wp-admin|dashboard|login)\/?)/, auth, function (req, res) {
+    ghost.app().get(/^\/(ghost$|(ghost-admin|admin|wp-admin|dashboard|signin)\/?)/, auth, function (req, res) {
         res.redirect('/ghost/');
     });
     ghost.app().get('/ghost/', auth, admin.index);


### PR DESCRIPTION
Closes #443
- Renamed routes
- Added redirects for old routes
- Added unit test for redirect
- Updated references to old routes in templates, html
