### PR TITLE
Rename classes applied to {{bodyclass}} to be less generic

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -106,9 +106,9 @@ coreHelpers = function (ghost) {
     ghost.registerThemeHelper('bodyclass', function (options) {
         var classes = [];
         if (!this.path || this.path === '/' || this.path === '') {
-            classes.push('home');
+            classes.push('home-template');
         } else {
-            classes.push('post');
+            classes.push('post-template');
         }
 
         return ghost.doFilter('bodyclass', classes, function (classes) {

--- a/core/test/unit/frontend_helpers_index_spec.js
+++ b/core/test/unit/frontend_helpers_index_spec.js
@@ -149,7 +149,7 @@ describe('Core Helpers', function () {
             var rendered = handlebars.helpers.bodyclass.call({});
             should.exist(rendered);
 
-            rendered.string.should.equal('home');
+            rendered.string.should.equal('home-template');
         });
 
         it('can render class string for context', function () {
@@ -159,8 +159,8 @@ describe('Core Helpers', function () {
             should.exist(rendered1);
             should.exist(rendered2);
 
-            rendered1.string.should.equal('home');
-            rendered2.string.should.equal('post');
+            rendered1.string.should.equal('home-template');
+            rendered2.string.should.equal('post-template');
         });
     });
 


### PR DESCRIPTION
Fuckup on my part  due to poor instructions - the previous names were just a bit too generic and immediately started conflicting with existing styles on the page. Also `{{bodyclass}}` and `{{postclass}}` were both outputting the same thing ("post") on the single post template - resulting in both `<body class="post">` and `<article class="post">`.
