### PR TITLE
added ghost_head and ghost_foot helpers

### DIFF
--- a/core/ghost.js
+++ b/core/ghost.js
@@ -301,10 +301,9 @@ Ghost.prototype.initTheme = function (app) {
             app.set('views', self.paths().adminViews);
             app.use('/public', express['static'](path.join(__dirname, '/client/assets')));
             app.use('/public', express['static'](path.join(__dirname, '/client')));
-            app.use('/shared', express['static'](path.join(__dirname, '/shared/')));
-
         }
         app.use(express['static'](self.paths().activeTheme));
+        app.use('/shared', express['static'](path.join(__dirname, '/shared')));
         app.use('/content/images', express['static'](path.join(__dirname, '/../content/images')));
         next();
     };

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -127,7 +127,25 @@ coreHelpers = function (ghost) {
         });
     });
 
+    ghost.registerThemeHelper('ghost_head', function (options) {
+        var head = [];
+        head.push('<meta name="generator" content="Ghost ' + this.version + '" />');
 
+        return ghost.doFilter('ghost_head', head, function (head) {
+            var headString = _.reduce(head, function (memo, item) { return memo + ' ' + item; }, '');
+            return new hbs.handlebars.SafeString(headString.trim());
+        });
+    });
+
+    ghost.registerThemeHelper('ghost_foot', function (options) {
+        var foot = [];
+        foot.push('<script src="/shared/vendor/jquery/jquery.js"></script>');
+
+        return ghost.doFilter('ghost_foot', foot, function (foot) {
+            var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');
+            return new hbs.handlebars.SafeString(footString.trim());
+        });
+    });
     /**
      * [ description]
      *

--- a/core/test/unit/frontend_helpers_index_spec.js
+++ b/core/test/unit/frontend_helpers_index_spec.js
@@ -177,6 +177,30 @@ describe('Core Helpers', function () {
         });
     });
 
+    describe('ghost_head Helper', function () {
+        it('has loaded ghost_head helper', function () {
+            should.exist(handlebars.helpers.ghost_head);
+        });
+
+        it('returns meta tag string', function () {
+            var rendered = handlebars.helpers.ghost_head.call({version: "0.3"});
+            should.exist(rendered);
+            rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />');
+        });
+    });
+
+    describe('ghost_foot Helper', function () {
+        it('has loaded ghost_foot helper', function () {
+            should.exist(handlebars.helpers.ghost_foot);
+        });
+
+        it('returns meta tag string', function () {
+            var rendered = handlebars.helpers.ghost_foot.call();
+            should.exist(rendered);
+            rendered.string.should.equal('<script src="/shared/vendor/jquery/jquery.js"></script>');
+        });
+    });
+
     describe('Navigation Helper', function () {
 
         it('has loaded nav helper', function () {


### PR DESCRIPTION
closes #382, closes #383
- added helper called ghost_head to insert meta data with current version of ghost
- added helper called ghost_foot to insert script tag for jquery
- added unit test for both helpers
- removed trailing slash from ghost.js for 'shared' path and removed from outside of loop as it is shared on front and backend
