### PR TITLE
Move pagination to class rather than ID

### DIFF
--- a/core/server/helpers/tpl/pagination.hbs
+++ b/core/server/helpers/tpl/pagination.hbs
@@ -1,5 +1,5 @@
 
-<nav id="pagination" role="pagination">
+<nav class="pagination" role="pagination">
     {{#if next}}
         <div class="previous-page"><a href="/page/{{next}}/">Older Posts →</a></div>
     {{/if}}

--- a/core/test/unit/frontend_helpers_index_spec.js
+++ b/core/test/unit/frontend_helpers_index_spec.js
@@ -249,7 +249,7 @@ describe('Core Helpers', function () {
                 rendered = handlebars.helpers.pagination.call({pagination: {page: 1, prev: undefined, next: undefined, limit: 15, total: 8, pages: 1}});
                 should.exist(rendered);
                 // strip out carriage returns and compare.
-                rendered.string.replace(/\r/g, '').should.equal('\n<nav id="pagination" role="pagination">\n    \n    <div class="page-number">Page 1<span class="extended"> of 1</span></div>\n    \n</nav>');
+                rendered.string.replace(/\r/g, '').should.equal('\n<nav class="pagination" role="pagination">\n    \n    <div class="page-number">Page 1<span class="extended"> of 1</span></div>\n    \n</nav>');
                 done();
             }).then(null, done);
         });
@@ -260,7 +260,7 @@ describe('Core Helpers', function () {
                 rendered = handlebars.helpers.pagination.call({pagination: {page: 1, prev: undefined, next: 2, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
                 // strip out carriage returns and compare.
-                rendered.string.replace(/\r/g, '').should.equal('\n<nav id="pagination" role="pagination">\n    \n        <div class="previous-page"><a href="/page/2/">Older Posts →</a></div>\n    \n    <div class="page-number">Page 1<span class="extended"> of 3</span></div>\n    \n</nav>');
+                rendered.string.replace(/\r/g, '').should.equal('\n<nav class="pagination" role="pagination">\n    \n        <div class="previous-page"><a href="/page/2/">Older Posts →</a></div>\n    \n    <div class="page-number">Page 1<span class="extended"> of 3</span></div>\n    \n</nav>');
                 done();
             }).then(null, done);
         });
@@ -271,7 +271,7 @@ describe('Core Helpers', function () {
                 rendered = handlebars.helpers.pagination.call({pagination: {page: 2, prev: 1, next: 3, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
                 // strip out carriage returns and compare.
-                rendered.string.replace(/\r/g, '').should.equal('\n<nav id="pagination" role="pagination">\n    \n        <div class="previous-page"><a href="/page/3/">Older Posts →</a></div>\n    \n    <div class="page-number">Page 2<span class="extended"> of 3</span></div>\n    \n        <div class="next-page"><a href="/page/1/">← Newer Posts</a></div>\n    \n</nav>');
+                rendered.string.replace(/\r/g, '').should.equal('\n<nav class="pagination" role="pagination">\n    \n        <div class="previous-page"><a href="/page/3/">Older Posts →</a></div>\n    \n    <div class="page-number">Page 2<span class="extended"> of 3</span></div>\n    \n        <div class="next-page"><a href="/page/1/">← Newer Posts</a></div>\n    \n</nav>');
                 done();
             }).then(null, done);
         });
@@ -282,7 +282,7 @@ describe('Core Helpers', function () {
                 rendered = handlebars.helpers.pagination.call({pagination: {page: 3, prev: 2, next: undefined, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
                 // strip out carriage returns and compare.
-                rendered.string.replace(/\r/g, '').should.equal('\n<nav id="pagination" role="pagination">\n    \n    <div class="page-number">Page 3<span class="extended"> of 3</span></div>\n    \n        <div class="next-page"><a href="/page/2/">← Newer Posts</a></div>\n    \n</nav>');
+                rendered.string.replace(/\r/g, '').should.equal('\n<nav class="pagination" role="pagination">\n    \n    <div class="page-number">Page 3<span class="extended"> of 3</span></div>\n    \n        <div class="next-page"><a href="/page/2/">← Newer Posts</a></div>\n    \n</nav>');
                 done();
             }).then(null, done);
         });


### PR DESCRIPTION
Pagination could conceivably be used in more than one place on a page (eg. both top and bottom). For that reason it should probably have a class rather than an ID.
