### PR TITLE
Adding fade transitions between settings tabs.

### DIFF
--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -86,7 +86,11 @@
             this.$el.removeClass('active');
             this.undelegateEvents();
         },
-
+        render: function () {
+            this.$el.hide();
+            Ghost.View.prototype.render.call(this);
+            this.$el.fadeIn(300);
+        },
         afterRender: function () {
             this.$el.attr('id', this.id);
             this.$el.addClass('active');


### PR DESCRIPTION
Closes #371
- Added a hide and fadeIn() to the render method in Settings.Pane
- Any Settings.Pane which overwrites render should now make sure the parent is called
- Run through grunt validate, all OK.
