### PR TITLE
Fix settings back button functionality

### DIFF
--- a/core/client/router.js
+++ b/core/client/router.js
@@ -33,6 +33,15 @@
         },
 
         settings: function (pane) {
+            if (!pane) {
+                // Redirect to settings/general if no pane supplied
+                this.navigate('/settings/general', {
+                    trigger: true,
+                    replace: true
+                });
+                return;
+            }
+
             // only update the currentView if we don't already have a Settings view
             if (!Ghost.currentView || !(Ghost.currentView instanceof Ghost.Views.Settings)) {
                 Ghost.currentView = new Ghost.Views.Settings({ el: '#main', pane: pane });

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -9,11 +9,26 @@
     Ghost.Views.Settings = Ghost.View.extend({
         initialize: function (options) {
             $(".settings-content").removeClass('active');
-            this.addSubview(new Settings.Sidebar({
+
+            this.sidebar = new Settings.Sidebar({
                 el: '.settings-sidebar',
                 pane: options.pane,
                 model: this.model
-            }));
+            });
+
+            this.addSubview(this.sidebar);
+
+            this.listenTo(Ghost.router, "route:settings", this.changePane);
+        },
+
+        changePane: function (pane) {
+            if (!pane) {
+                // Can happen when trying to load /settings with no pane specified
+                // let the router navigate itself to /settings/general
+                return;
+            }
+
+            this.sidebar.showContent(pane);
         }
     });
 
@@ -23,7 +38,7 @@
         initialize: function (options) {
             this.render();
             this.menu = this.$('.settings-menu');
-            this.showContent(options.pane || 'general');
+            this.showContent(options.pane);
         },
 
         models: {},
@@ -36,6 +51,7 @@
             e.preventDefault();
             var item = $(e.currentTarget),
                 id = item.find('a').attr('href').substring(1);
+
             this.showContent(id);
         },
 


### PR DESCRIPTION
Added a redirect call to the router instead of defaulting the pane. To
handle using the back button after clicking through to other tabs I
added an event listener on the route:settings event.

Closes #557.
