### PR TITLE
Theme globals

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -44,11 +44,25 @@ coreHelpers = function (ghost) {
         return date;
     });
 
+    // ### URL helper
+    //
+    // *Usage example:*
+    // `{{url}}`
+    // `{{url absolute}}`
+    //
+    // Returns the URL for the current object context
+    // i.e. If inside a post context will return post permalink
+    // absolute flag outputs absolute URL, else URL is relative
     ghost.registerThemeHelper('url', function (context, options) {
-        if (models.isPost(this)) {
-            return "/" + this.slug;
+        var output = '';
+
+        if (options && options.absolute) {
+            output += ghost.config().env[process.NODE_ENV].url;
         }
-        return '';
+        if (models.isPost(this)) {
+            output += "/" + this.slug;
+        }
+        return output;
     });
 
     // ### Author Helper

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -20,9 +20,22 @@ coreHelpers = function (ghost) {
      * @return {Object} A Moment time / date object
      */
     ghost.registerThemeHelper('date', function (context, options) {
+        if (!options && context.hasOwnProperty('hash')) {
+            options = context;
+            context = undefined;
+
+            // set to published_at by default, if it's available
+            // otherwise, this will print the current date
+            if (this.published_at) {
+                context = this.published_at;
+            }
+        }
+
         var f = options.hash.format || "MMM Do, YYYY",
             timeago = options.hash.timeago,
             date;
+
+
         if (timeago) {
             date = moment(context).fromNow();
         } else {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -45,6 +45,20 @@ User = GhostBookshelf.Model.extend({
         };
     },
 
+    parse: function (attrs) {
+        // temporary alias of name for full_name (will get changed in the schema)
+        if (attrs.full_name && !attrs.name) {
+            attrs.name = attrs.full_name;
+        }
+
+        // temporary alias of website for url (will get changed in the schema)
+        if (attrs.url && !attrs.website) {
+            attrs.website = attrs.url;
+        }
+
+        return attrs;
+    },
+
     initialize: function () {
         this.on('saving', this.saving, this);
         this.on('saving', this.validate, this);

--- a/index.js
+++ b/index.js
@@ -108,10 +108,8 @@ function ghostLocals(req, res, next) {
     if (!res.isAdmin) {
         // filter the navigation items
         ghost.doFilter('ghostNavItems', {path: req.path, navItems: []}, function (navData) {
-            // pass the theme navigation items and settings
-            _.extend(res.locals, navData, {
-                settings: ghost.settings()
-            });
+            // pass the theme navigation items, settings get configured as globals
+            _.extend(res.locals, navData);
 
             next();
         });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "engineStrict": true,
     "dependencies": {
         "express": "3.3.4",
-        "express-hbs": "0.2.0",
+        "express-hbs": "0.2.1",
         "node-polyglot": "0.2.1",
         "moment": "2.1.0",
         "underscore": "1.5.1",


### PR DESCRIPTION
Various theme helper updates:

{{settings.#}} becomes {{@blog.#}} thanks to PR on express-hbs
{{date}} no longer requires published_at to be passed
{{author.name}} and {{author.website}} aliases added for full_name, and url until columns can be modified
{{url}} gets the absolute option so {{url absolute}} outputs absolute version of url
