### PR TITLE
Corrected typo in code documentation

### DIFF
--- a/core/ghost.js
+++ b/core/ghost.js
@@ -43,7 +43,7 @@ defaults = {
 
 // ## Article Statuses
 /**
- * A list of atricle status types
+ * A list of article status types
  * @type {Object}
  */
 statuses = {


### PR DESCRIPTION
Corrected typo in code documentation
- Changed "atricle" to "article"
