### PR TITLE
Add setting for posts per page

### DIFF
--- a/core/client/tpl/settings/general.hbs
+++ b/core/client/tpl/settings/general.hbs
@@ -57,9 +57,14 @@
                 <label for="activeTheme"><strong>Theme</strong></label>
                 <select id="activeTheme" name="general[activeTheme]">
                     {{#each availableThemes}}
-                        <option value="{{ name }}" {{#if active}}selected{{/if}}>{{ name }}</option>
+                        <option value="{{name}}" {{#if active}}selected{{/if}}>{{name}}</option>
                     {{/each}}
                 </select>
+            </div>
+            <div class="form-group">
+                <label for="postsPerPage"><strong>Posts per page</strong></label>
+                <input id="postsPerPage" name="general[postsPerPage]" type="number" value="{{postsPerPage}}">
+                <p>Number of posts per page displayed</p>
             </div>
 
         </fieldset>

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -164,7 +164,8 @@
                 email: this.$('#email-address').val(),
                 logo: this.$('#logo').attr("src"),
                 icon: this.$('#icon').attr("src"),
-                activeTheme: this.$('#activeTheme').val()
+                activeTheme: this.$('#activeTheme').val(),
+                postsPerPage: this.$('#postsPerPage').val()
             }, {
                 success: this.saveSuccess,
                 error: this.saveError

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -14,14 +14,24 @@ var Ghost = require('../../ghost'),
 frontendControllers = {
     'homepage': function (req, res) {
         // Parse the page number
-        var pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1;
+        var pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
+            postsPerPage = parseInt(ghost.settings().postsPerPage, 10),
+            options = {};
 
         // No negative pages
-        if (pageParam < 1) {
+        if (isNaN(pageParam) || pageParam < 1) {
+            //redirect to 404 page?
             return res.redirect("/page/1/");
         }
+        options.page = pageParam;
 
-        api.posts.browse({page: pageParam}).then(function (page) {
+        // No negative posts per page, must be number
+        if (!isNaN(postsPerPage) && postsPerPage > 0) {
+            options.limit = postsPerPage;
+        }
+
+        api.posts.browse(options).then(function (page) {
+
             var maxPage = page.pages;
 
             // A bit of a hack for situations with no content.

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -43,5 +43,11 @@
         "key":          "icon",
         "value":        "",
         "type":         "blog"
+    },
+    {
+        "key":          "postsPerPage",
+        "value":        "6",
+        "type":         "blog"
     }
+
 ]


### PR DESCRIPTION
closes #593
- added default setting of 6 posts per page
- added posts per page to settings page
- added limit to frontend.js (setting does not change API behavior)
