### PR TITLE
Display keyboard shortcut appropriate to OS

### DIFF
--- a/core/client/tpl/modals/markdown.hbs
+++ b/core/client/tpl/modals/markdown.hbs
@@ -10,17 +10,17 @@
         <tr>
             <td><strong>Bold</strong></td>
             <td>**text**</td>
-            <td>Ctrl / Cmd + B</td>
+            <td>Ctrl + B</td>
         </tr>
         <tr>
             <td><em>Emphasize</em></td>
             <td>__text__</td>
-            <td>Ctrl / Cmd + I</td>
+            <td>Ctrl + I</td>
         </tr>
         <tr>
             <td><code>Inline Code</code></td>
             <td>`code`</td>
-            <td>Cmd + K / Ctrl + Shift + K</td>
+            <td>Ctrl + Shift + K</td>
         </tr>
         <tr>
             <td>Strike-through</td>

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -301,7 +301,12 @@
                         close: true,
                         type: "info",
                         style: ["wide"],
-                        animation: 'fade'
+                        animation: 'fade',
+                        afterRender: function () {
+                            if (navigator.userAgent.indexOf('Mac OS X') !== -1) {
+                                this.$(".modal-content").html(this.$(".modal-content").html().replace(/Ctrl/g, '&#8984;'));
+                            }
+                        }
                     },
                     content: {
                         template: 'markdown',


### PR DESCRIPTION
Closes #348
- Changed markdown.hbs so that all keyboard shortcuts are written in Windows format (e.g. Ctrl + B)
- Changed markdown.hbs to use Ctrl/Cmd + Shift + K for `code` shortcut. This is a change for Mac functionality from previous shortcut of Cmd + K
- Added afterRender callback to the Markdown modal that replaces instances of Ctrl with ⌘
