### PR TITLE
Shortcut for italic inserts _ instead of *

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -136,7 +136,7 @@
         style: null,
         syntax: {
             bold: "**$1**",
-            italic: "_$1_",
+            italic: "*$1*",
             strike: "~~$1~~",
             code: "`$1`",
             link: "[$1](http://)",


### PR DESCRIPTION
Closes #643

Pressing Ctrl + I/Cmd + I when text is selected in Markdown mode now inserts _ instead of \* around the selected text.
