### PR TITLE
Notifications are too long

### DIFF
--- a/core/client/views/blog.js
+++ b/core/client/views/blog.js
@@ -131,8 +131,7 @@
 
         deletePost: function (e) {
             e.preventDefault();
-            var self = this,
-                title = self.model.get('title');
+            var self = this;
             this.addSubview(new Ghost.Views.Modal({
                 model: {
                     options: {
@@ -145,13 +144,13 @@
                                     }).then(function () {
                                         Ghost.notifications.addItem({
                                             type: 'success',
-                                            message: 'Your post: ' + title + ' has been deleted',
+                                            message: 'Your post has been deleted.',
                                             status: 'passive'
                                         });
                                     }, function () {
                                         Ghost.notifications.addItem({
                                             type: 'error',
-                                            message: 'Your post: ' + title + ' has not been deleted.',
+                                            message: 'Your post could not be deleted. Please try again.',
                                             status: 'passive'
                                         });
                                     });

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -64,6 +64,14 @@
             'publish-on': 'Publish on...'
         },
 
+        notificationMap: {
+            'draft': 'has been saved as a draft',
+            'published': 'has been published',
+            'scheduled': 'has been scheduled',
+            'queue': 'has been added to the queue',
+            'publish-on': 'will be published'
+        },
+
         initialize: function () {
             var self = this;
             // Toggle publish
@@ -102,7 +110,7 @@
             }).then(function () {
                 Ghost.notifications.addItem({
                     type: 'success',
-                    message: 'Your post: ' + model.get('title') + ' has been ' + keys[newIndex],
+                    message: 'Your post ' + this.notificationMap[newIndex] + '.',
                     status: 'passive'
                 });
             }, function (xhr) {
@@ -148,7 +156,8 @@
         updatePost: function (status) {
             var self = this,
                 model = this.model,
-                prevStatus = model.get('status');
+                prevStatus = model.get('status'),
+                notificationMap = this.notificationMap;
 
             // Default to same status if not passed in
             status = status || prevStatus;
@@ -175,7 +184,7 @@
             }).then(function () {
                 Ghost.notifications.addItem({
                     type: 'success',
-                    message: ['Your post "', model.get('title'), '" has been ', status, '.'].join(''),
+                    message: ['Your post ', notificationMap[status], '.'].join(''),
                     status: 'passive'
                 });
             }, function (xhr) {


### PR DESCRIPTION
Closes #560, #436, #545, #437
- Added .s to the end of all post notification messages, per #437.
- Added nice message when saving a draft per #436, also for other post statuses (your post will be published), etc.
- Removed post name from notifications per #560 and #545.
- Changed delete post error message to be "Your post could not be deleted. Please try again."
