### PR TITLE
Modal Fixes

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -667,7 +667,9 @@ body.zen {
 /* =============================================================================
    Markdown Help Modal
    ============================================================================= */
-
+.markdown-help-container{
+    padding-bottom: 20px;
+}
 .modal-markdown-help-table {
     margin-top: 0;
 }

--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -984,30 +984,40 @@ nav {
    Modals
    ========================================================================== */
 #modal-container {
-    &.active {
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: 999;
-        @include transition(all 0.15s linear 0s);
-        @include transform(translateZ(0));
+    @include box-sizing(border-box);
+    display: none;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow-x: auto;
+    overflow-y: scroll;
+    z-index: 1040;
+    pointer-events: none;
+    @include transition(all 0.15s linear 0s);
+    @include transform(translateZ(0));
+}
 
-        &.dark {
-            background: rgba(0,0,0,0.4);
-        }
+.fade {
+    opacity: 0;
+    @include transition(opacity 0.2s linear 0s);
+    @include transform(translateZ(0));
 
-        .modal-background {
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            left: 0;
-            right: 0;
-            z-index: 999;
-        }
-
+    &.in {
+        opacity: 1;
     }
+}
+
+.modal-background {
+    display: none;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(0,0,0,0.4);
+    z-index: 1030;
 }
 
 body.blur > *:not(#modal-container) {
@@ -1022,30 +1032,29 @@ body.blur > *:not(#modal-container) {
 
 %modal, .modal {
     @include box-sizing(border-box);
-    max-height: 90%;
+    left: 50%;
+    right: auto;
     width: 450px;
-    padding: 0;
-    background: #fff;
-    border-radius: $rounded;
-    overflow:auto;
-    z-index: 1001;
-    box-shadow: rgba(0,0,0,0.2) 0 0 0 6px;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 30px;
+    padding-bottom: 30px;
+    z-index: 1050;
+    pointer-events: auto;
 
-    &.fade {
-        opacity: 0;
-        @include transition(opacity 0.2s linear 0s);
 
-        &.in {
-            opacity: 1;
-        }
-    }
+    @include breakpoint($tablet) {
+        width: auto;
+        padding: 10px;
+    };
 
     button {
         min-width: 100px;
     }
 
-    @include breakpoint($mobile) {
+    @include breakpoint($tablet) {
         width: 100%;
+        margin-left: 0;
     }
 }
 
@@ -1055,16 +1064,49 @@ body.blur > *:not(#modal-container) {
 
 .modal-action {
     @extend %modal;
+    padding: 60px 0 30px;
+
+    @include breakpoint($tablet) {
+        padding: 30px 0;
+    }
 
     .modal-footer {
         margin-top: 20px;
     }
 }
 
+.modal-content {
+    @include box-sizing(padding-box);
+    position: relative;
+    background-clip: padding-box;
+    background-color: #FFFFFF;
+    border-radius: $rounded;
+    box-shadow: rgba(0,0,0,0.2) 0 0 0 6px;
+
+    .close {
+        @include box-sizing(border-box);
+        position: absolute;
+        top: 15px;
+        right: 15px;
+        width: 16px;
+        min-height: 16px;
+        padding: 0;
+        margin: 0;
+        border: none;
+        z-index: 9999;
+
+        @include icon($i-x, 1em, $midgrey);
+        @include transition(opacity 0.3s linear);
+
+        &:hover {
+            color: $darkgrey;
+        }
+    }
+}
 .modal-header {
     position: relative;
     padding: 20px;
-    border-bottom: 1px solid $lightgrey;
+    border-bottom: 1px solid $lightbrown;
 
     h1 {
         display: inline-block;
@@ -1072,31 +1114,13 @@ body.blur > *:not(#modal-container) {
         font-size: 1.5em;
         font-weight: bold;
     }
-
-    .close {
-        @include box-sizing(border-box);
-        position: absolute;
-        top: 10px;
-        right: 20px;
-        width: 16px;
-        min-height: 16px;
-        padding: 0;
-        margin: 0;
-        border: none;
-        opacity: 0.4;
-
-        @include icon($i-close, 1em, $midgrey);
-        @include transition(opacity 0.3s linear);
-
-        &:hover{
-           opacity: 1;
-        }
-    }
 }
 
-.modal-content {
-    padding: 0 20px;
+.modal-body {
+    position: relative;
     min-height: 100px;
+    padding: 0 20px;
+    overflow-y: auto;
 }
 
 .modal-footer {
@@ -1107,7 +1131,7 @@ body.blur > *:not(#modal-container) {
 .modal-style-wide {
     width: 550px;
 
-    @include breakpoint($mobile) {
+    @include breakpoint($tablet) {
         width: 100%;
     }
 }
@@ -1322,6 +1346,9 @@ main {
     }
 }
 
+.modal-content .pre-image-uploader, .modal-content .image-uploader {
+    margin: 20px 0 0 0;
+}
 .pre-image-uploader {
     @include box-sizing(border-box);
     @include baseline;

--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -104,7 +104,6 @@
                 }
 
                 $(".modal-copyToHTML-content").text(md).selectText();
-                $(".js-modal").center();
                 pass = false;
                 break;
             case "list":

--- a/core/client/models/uploadModal.js
+++ b/core/client/models/uploadModal.js
@@ -4,10 +4,10 @@
     Ghost.Models.uploadModal = Backbone.Model.extend({
 
         options: {
-            close: false,
+            close: true,
             type: "action",
-            style: "wide",
-            animation: 'fadeIn',
+            style: ["wide"],
+            animation: 'fade',
             afterRender: function () {
                 this.$('.js-drop-zone').upload();
             },

--- a/core/client/tpl/modal.hbs
+++ b/core/client/tpl/modal.hbs
@@ -1,12 +1,14 @@
-<aside class="modal-background"></aside>
 <article class="modal{{#if options.type}}-{{options.type}}{{/if}} {{#if options.style}}{{#each options.style}}modal-style-{{this}} {{/each}}{{/if}}{{options.animation}} js-modal">
-    {{#if content.title}}<header class="modal-header"><h1>{{content.title}}</h1>{{#if options.close}}<a class="close" href="#"><span class="hidden">Close</span></a>{{/if}}</header>{{/if}}
     <section class="modal-content">
+        {{#if content.title}}<header class="modal-header"><h1>{{content.title}}</h1></header>{{/if}}
+        {{#if options.close}}<a class="close" href="#"><span class="hidden">Close</span></a>{{/if}}
+        <section class="modal-body">
+        </section>
+        {{#if options.confirm}}
+        <footer class="modal-footer">
+            <button class="js-button-accept {{#if options.confirm.accept.buttonClass}}{{options.confirm.accept.buttonClass}}{{else}}button-add{{/if}}">{{options.confirm.accept.text}}</button>
+            <button class="js-button-reject {{#if options.confirm.reject.buttonClass}}{{options.confirm.reject.buttonClass}}{{else}}button-delete{{/if}}">{{options.confirm.reject.text}}</button>
+        </footer>
+        {{/if}}
     </section>
-    {{#if options.confirm}}
-    <footer class="modal-footer">
-        <button class="js-button-accept {{#if options.confirm.accept.buttonClass}}{{options.confirm.accept.buttonClass}}{{else}}button-add{{/if}}">{{options.confirm.accept.text}}</button>
-        <button class="js-button-reject {{#if options.confirm.reject.buttonClass}}{{options.confirm.reject.buttonClass}}{{else}}button-delete{{/if}}">{{options.confirm.reject.text}}</button>
-    </footer>
-    {{/if}}
 </article>

--- a/core/client/tpl/modals/markdown.hbs
+++ b/core/client/tpl/modals/markdown.hbs
@@ -1,107 +1,109 @@
-<table class="modal-markdown-help-table">
-    <thead>
-        <tr>
-            <th>Result</th>
-            <th>Markdown</th>
-            <th>Shortcut</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><strong>Bold</strong></td>
-            <td>**text**</td>
-            <td>Ctrl / Cmd + B</td>
-        </tr>
-        <tr>
-            <td><em>Emphasize</em></td>
-            <td>__text__</td>
-            <td>Ctrl / Cmd + I</td>
-        </tr>
-        <tr>
-            <td><code>Inline Code</code></td>
-            <td>`code`</td>
-            <td>Cmd + K / Ctrl + Shift + K</td>
-        </tr>
-        <tr>
-            <td>Strike-through</td>
-            <td>~~text~~</td>
-            <td>Ctrl + Alt + U</td>
-        </tr>
-        <tr>
-            <td><a href="#">Link</a></td>
-            <td>[title](http://)</td>
-            <td>Ctrl + Shift + L</td>
-        </tr>
-        <tr>
-            <td>Image</td>
-            <td>![alt](http://)</td>
-            <td>Ctrl + Shift + I</td>
-        </tr>
-        <tr>
-            <td>List</td>
-            <td>* item</td>
-            <td>Ctrl + L</td>
-        </tr>
-        <tr>
-            <td>Blockquote</td>
-            <td>> quote</td>
-            <td>Ctrl + Q</td>
-        </tr>
-        <tr>
-            <td>H1</td>
-            <td># Heading</td>
-            <td>Ctrl + Alt + 1</td>
-        </tr>
-        <tr>
-            <td>H2</td>
-            <td>## Heading</td>
-            <td>Ctrl + Alt + 2</td>
-        </tr>
-        <tr>
-            <td>H3</td>
-            <td>### Heading</td>
-            <td>Ctrl + Alt + 3</td>
-        </tr>
-        <tr>
-            <td>H4</td>
-            <td>#### Heading</td>
-            <td>Ctrl + Alt + 4</td>
-        </tr>
-        <tr>
-            <td>H5</td>
-            <td>##### Heading</td>
-            <td>Ctrl + Alt + 5</td>
-        </tr>
-        <tr>
-            <td>H6</td>
-            <td>###### Heading</td>
-            <td>Ctrl + Alt + 6</td>
-        </tr>
-        <tr>
-            <td>Select Word</td>
-            <td></td>
-            <td>Ctrl + Alt + W</td>
-        </tr>
-        <tr>
-            <td>Uppercase</td>
-            <td></td>
-            <td>Ctrl + U</td>
-        </tr>
-        <tr>
-            <td>Lowercase</td>
-            <td></td>
-            <td>Ctrl + Shift + U</td>
-        </tr>
-        <tr>
-            <td>Titlecase</td>
-            <td></td>
-            <td>Ctrl + Alt + Shift + U</td>
-        </tr>
-        <tr>
-            <td>Insert Current Date</td>
-            <td></td>
-            <td>Ctrl + Shift + 1</td>
-        </tr>
-    </tbody>
-</table>
-For further Markdown syntax reference: <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank">Markdown Documentation</a>
+<section class="markdown-help-container">
+    <table class="modal-markdown-help-table">
+        <thead>
+            <tr>
+                <th>Result</th>
+                <th>Markdown</th>
+                <th>Shortcut</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Bold</strong></td>
+                <td>**text**</td>
+                <td>Ctrl / Cmd + B</td>
+            </tr>
+            <tr>
+                <td><em>Emphasize</em></td>
+                <td>__text__</td>
+                <td>Ctrl / Cmd + I</td>
+            </tr>
+            <tr>
+                <td><code>Inline Code</code></td>
+                <td>`code`</td>
+                <td>Cmd + K / Ctrl + Shift + K</td>
+            </tr>
+            <tr>
+                <td>Strike-through</td>
+                <td>~~text~~</td>
+                <td>Ctrl + Alt + U</td>
+            </tr>
+            <tr>
+                <td><a href="#">Link</a></td>
+                <td>[title](http://)</td>
+                <td>Ctrl + Shift + L</td>
+            </tr>
+            <tr>
+                <td>Image</td>
+                <td>![alt](http://)</td>
+                <td>Ctrl + Shift + I</td>
+            </tr>
+            <tr>
+                <td>List</td>
+                <td>* item</td>
+                <td>Ctrl + L</td>
+            </tr>
+            <tr>
+                <td>Blockquote</td>
+                <td>> quote</td>
+                <td>Ctrl + Q</td>
+            </tr>
+            <tr>
+                <td>H1</td>
+                <td># Heading</td>
+                <td>Ctrl + Alt + 1</td>
+            </tr>
+            <tr>
+                <td>H2</td>
+                <td>## Heading</td>
+                <td>Ctrl + Alt + 2</td>
+            </tr>
+            <tr>
+                <td>H3</td>
+                <td>### Heading</td>
+                <td>Ctrl + Alt + 3</td>
+            </tr>
+            <tr>
+                <td>H4</td>
+                <td>#### Heading</td>
+                <td>Ctrl + Alt + 4</td>
+            </tr>
+            <tr>
+                <td>H5</td>
+                <td>##### Heading</td>
+                <td>Ctrl + Alt + 5</td>
+            </tr>
+            <tr>
+                <td>H6</td>
+                <td>###### Heading</td>
+                <td>Ctrl + Alt + 6</td>
+            </tr>
+            <tr>
+                <td>Select Word</td>
+                <td></td>
+                <td>Ctrl + Alt + W</td>
+            </tr>
+            <tr>
+                <td>Uppercase</td>
+                <td></td>
+                <td>Ctrl + U</td>
+            </tr>
+            <tr>
+                <td>Lowercase</td>
+                <td></td>
+                <td>Ctrl + Shift + U</td>
+            </tr>
+            <tr>
+                <td>Titlecase</td>
+                <td></td>
+                <td>Ctrl + Alt + Shift + U</td>
+            </tr>
+            <tr>
+                <td>Insert Current Date</td>
+                <td></td>
+                <td>Ctrl + Shift + 1</td>
+            </tr>
+        </tbody>
+    </table>
+    For further Markdown syntax reference: <a href="http://daringfireball.net/projects/markdown/syntax" target="_blank">Markdown Documentation</a>
+</section>

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -33,8 +33,9 @@
             {{{body}}}
         </main>
 
-        <aside id="modal-container">
-        </aside>
+        <div id="modal-container">
+        </div>
+        <div class="modal-background fade"></div>
 
         {{{ghostScriptTags}}}
 


### PR DESCRIPTION
Closes #659.

Current changes;
- Smoother animations
- Removed blurring in Chrome temporarily
- Centering is now done in CSS (the height is calculated in JS to work in FF and Opera)
- Modals now need close: true to be set to enable the close icon and shortcuts for closing (ESC key, background clicking)
- Close icon now appears when hovering over the Modal

![modal](https://f.cloud.github.com/assets/367517/1131890/9616ff46-1bc1-11e3-8e3c-2380024d1ba3.gif)
