### PR TITLE
Use Mincer for asset pipeline

### DIFF
--- a/core/client/assets/vendor/vendor.js
+++ b/core/client/assets/vendor/vendor.js
@@ -1,0 +1,14 @@
+//= require ../lib/jquery-utils
+//= require ../lib/uploader
+//= require ./icheck/jquery.icheck.min.js
+//= require ./codemirror/codemirror
+//= require ./codemirror/addon/mode/overlay
+//= require ./codemirror/mode/markdown/markdown
+//= require ./codemirror/mode/gfm/gfm
+//= require ./showdown/showdown
+//= require ./showdown/extensions/ghostdown
+//= require ./shortcuts
+//= require ./countable
+//= require ./to-title-case
+//= require ./packery.pkgd.min.js
+//= require ./jquery.hammer.min.js

--- a/core/client/main.js
+++ b/core/client/main.js
@@ -1,0 +1,11 @@
+//= require ./init
+//= require ./router
+
+//= require ./tpl/hbs-tpl
+//= require ./mobile-interactions
+//= require ./toggle
+//= require ./markdown-actions
+//= require ./helpers/index
+
+//= require_directory ./models
+//= require_directory ./views

--- a/core/server/views/dashboard.hbs
+++ b/core/server/views/dashboard.hbs
@@ -1,5 +1,5 @@
 {{#contentFor 'bodyScripts'}}
-    <script src="/public/vendor/chart.min.js"></script>
+    <script src="{{assetPath '/public/assets/vendor/chart.min'}}"></script>
     <script>
     $(document).ready(function(){
           var ctx = $("#poststats").get(0).getContext("2d");

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -18,7 +18,8 @@
         <meta http-equiv="cleartype" content="on">
 
         <link rel="stylesheet" type='text/css' href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
-        <link rel="stylesheet" href="/public/css/screen.css">
+        <link rel="stylesheet" href="{{assetPath "/public/assets/css/screen"}}">
+
         {{{block "pageStyles"}}}
     </head>
     <body class="{{bodyClass}}">
@@ -36,61 +37,21 @@
 
         <aside id="modal-container">
         </aside>
+        
+        <!-- Shared Vendor Files -->
+        <script src="{{assetPath '/shared/vendor/vendor'}}"></script>
+        <!-- Client Vendor Files -->
+        <script src="{{assetPath '/public/assets/vendor/vendor'}}"></script>
 
-        <script src="/shared/vendor/jquery/jquery.js"></script>
-        <script src="/shared/vendor/jquery/jquery-ui-1.10.3.custom.min.js"></script>
-        <script src="/public/lib/jquery-utils.js"></script>
-        <script src="/shared/vendor/underscore.js"></script>
-        <script src="/shared/vendor/backbone/backbone.js"></script>
-        <script src="/shared/vendor/handlebars/handlebars-runtime.js"></script>
-        <script src="/shared/vendor/moment.js"></script>
+        <!-- 
+        TODO: This file is weird because it has to come after the showdown library reference, but I can't figure out 
+        how to reference it in the /shared/vendor/vendor file 
+        -->
+        <script src="{{assetPath '/shared/vendor/showdown/extensions/github'}}"></script>
 
-        <script src="/public/vendor/icheck/jquery.icheck.min.js"></script>
-
-        <script src="/shared/vendor/jquery/jquery.ui.widget.js"></script>
-        <script src="/shared/vendor/jquery/jquery.iframe-transport.js"></script>
-        <script src="/shared/vendor/jquery/jquery.fileupload.js"></script>
-
-        <script src="/public/vendor/codemirror/codemirror.js"></script>
-        <script src="/public/vendor/codemirror/addon/mode/overlay.js"></script>
-        <script src="/public/vendor/codemirror/mode/markdown/markdown.js"></script>
-        <script src="/public/vendor/codemirror/mode/gfm/gfm.js"></script>
-        <script src="/public/vendor/showdown/showdown.js"></script>
-        <script src="/public/vendor/showdown/extensions/ghostdown.js"></script>
-        <script src="/shared/vendor/showdown/extensions/github.js"></script>
-        <script src="/public/vendor/shortcuts.js"></script>
-        <script src="/public/vendor/countable.js"></script>
-        <script src="/public/vendor/to-title-case.js"></script>
-        <script src="/public/vendor/packery.pkgd.min.js"></script>
-        <script src="/public/vendor/jquery.hammer.min.js"></script>
-
-        <script src="/public/init.js"></script>
-
-        <script src="/public/assets/lib/uploader.js"></script>
-
-        <script src="/public/tpl/hbs-tpl.js"></script>
-        <script src="/public/mobile-interactions.js"></script>
-        <script src="/public/toggle.js"></script>
-        <script src="/public/markdown-actions.js"></script>
-        <script src="/public/helpers/index.js"></script>
-
-        <!-- // require '/public/models/*' -->
-        <script src="/public/models/post.js"></script>
-        <script src="/public/models/user.js"></script>
-        <script src="/public/models/tag.js"></script>
-        <script src="/public/models/widget.js"></script>
-        <script src="/public/models/settings.js"></script>
-        <script src="/public/models/themes.js"></script>
-        <!-- // require '/public/views/*' -->
-        <script src="/public/views/base.js"></script>
-        <script src="/public/views/dashboard.js"></script>
-        <script src="/public/views/blog.js"></script>
-        <script src="/public/views/editor.js"></script>
-        <script src="/public/views/editor-tag-widget.js"></script>
-        <script src="/public/views/login.js"></script>
-        <script src="/public/views/settings.js"></script>
-        <script src="/public/views/debug.js"></script>
-        <script src="/public/router.js"></script>
+        <!-- Main Ghost Files -->
+        <script src="{{assetPath '/public/main'}}"></script>
+        
         {{{block "bodyScripts"}}}
         <script>
             Ghost.init();

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -9,7 +9,7 @@
 
             <li id="usermenu" class="subnav">
                 <a href="#" data-toggle="ul" class="dropdown">
-                    <img class="avatar" src="{{#if currentUser.profile}}{{currentUser.profile}}{{else}}/public/img/user.jpg{{/if}}" alt="Avatar" />
+                    <img class="avatar" src="{{#if currentUser.profile}}{{currentUser.profile}}{{else}}{{assetPath '/public/assets/img/user.jpg'}}{{/if}}" alt="Avatar" />
                     <span class="name">{{#if currentUser.name}}{{currentUser.name}}{{else}}Ghost{{/if}} v{{version}}</span>
                 </a>
                 <ul class="overlay">

--- a/core/shared/vendor/vendor.js
+++ b/core/shared/vendor/vendor.js
@@ -1,0 +1,11 @@
+//= require ./jquery/jquery
+//= require ./jquery/jquery-ui-1.10.3.custom.min.js
+//= require ./jquery/jquery.ui.widget
+//= require ./jquery/jquery.iframe-transport
+//= require ./jquery/jquery.fileupload
+//= require ./underscore
+//= require ./backbone/backbone
+//= require ./handlebars/handlebars-runtime
+//= require ./moment
+
+// This file is built by the Mincer middleware.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "downsize": "0.0.2",
         "validator": "1.4.0",
         "rss": "0.2.0",
-        "nodemailer": "~0.5.2"
+        "nodemailer": "~0.5.2",
+        "mincer": "~0.5.7"
     },
     "devDependencies": {
         "grunt": "~0.4.1",


### PR DESCRIPTION
Add the mincer dependency and move most of the asset declarations into
their own initAsset method.  Have the initTheme method call the
initAsset method directly for now, could be separated later.

A proof of concept for #584.
