### PR TITLE
Remove publish status reversion on failed save

### DIFF
--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -190,8 +190,6 @@
             }, function (xhr) {
                 // Show a notification about the error
                 self.reportSaveError(xhr, model, status);
-                // Set the button text back to previous
-                model.set({ status: prevStatus });
             });
         },
 


### PR DESCRIPTION
Fixes #511
- Removed logic to revert publish status back to page default on error.
