### PR TITLE
Compile assets with grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ CHANGELOG.md
 /core/test/functional/*.png
 
 config.js
+
+# Built asset files
+/core/built

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,16 @@ var path = require('path'),
                     files: ['<%= paths.adminAssets %>/sass/**/*'],
                     tasks: ['sass:admin']
                 },
+                concat: {
+                    files: [
+                        'core/client/*.js',
+                        'core/client/helpers/*.js',
+                        'core/client/models/*.js',
+                        'core/client/tpl/*.js',
+                        'core/client/views/*.js'
+                    ],
+                    tasks: ['concat']
+                },
                 livereload: {
                     files: [
                         // Theme CSS
@@ -49,11 +59,7 @@ var path = require('path'),
                         // Admin CSS
                         '<%= paths.adminAssets %>/css/*.css',
                         // Admin JS
-                        'core/client/*.js',
-                        'core/client/helpers/*.js',
-                        'core/client/models/*.js',
-                        'core/client/tpl/*.js',
-                        'core/client/views/*.js'
+                        'core/built/scripts/*.js'
                     ],
                     options: {
                         livereload: true
@@ -342,6 +348,122 @@ var path = require('path'),
                     commitMessage: '<%= buildType %> Release %VERSION%',
                     tagMessage: '<%= buildType %> Release %VERSION%',
                     pushTo: "origin build"
+                }
+            },
+
+            concat: {
+                dev: {
+                    files: {
+                        "core/built/scripts/vendor.js": [
+                            "core/shared/vendor/jquery/jquery.js",
+                            "core/shared/vendor/jquery/jquery-ui-1.10.3.custom.min.js",
+                            "core/client/assets/lib/jquery-utils.js",
+                            "core/client/assets/lib/uploader.js",
+                            "core/shared/vendor/underscore.js",
+                            "core/shared/vendor/backbone/backbone.js",
+                            "core/shared/vendor/handlebars/handlebars-runtime.js",
+                            "core/shared/vendor/moment.js",
+
+                            "core/client/assets/vendor/icheck/jquery.icheck.min.js",
+
+                            "core/shared/vendor/jquery/jquery.ui.widget.js",
+                            "core/shared/vendor/jquery/jquery.iframe-transport.js",
+                            "core/shared/vendor/jquery/jquery.fileupload.js",
+
+                            "core/client/assets/vendor/codemirror/codemirror.js",
+                            "core/client/assets/vendor/codemirror/addon/mode/overlay.js",
+                            "core/client/assets/vendor/codemirror/mode/markdown/markdown.js",
+                            "core/client/assets/vendor/codemirror/mode/gfm/gfm.js",
+                            "core/client/assets/vendor/showdown/showdown.js",
+                            "core/client/assets/vendor/showdown/extensions/ghostdown.js",
+                            "core/shared/vendor/showdown/extensions/github.js",
+                            "core/client/assets/vendor/shortcuts.js",
+                            "core/client/assets/vendor/validator-client.js",
+                            "core/client/assets/vendor/countable.js",
+                            "core/client/assets/vendor/to-title-case.js",
+                            "core/client/assets/vendor/packery.pkgd.min.js",
+                            "core/client/assets/vendor/jquery.hammer.min.js"
+                        ],
+
+                        "core/built/scripts/helpers.js": [
+                            "core/client/init.js",
+
+                            "core/client/mobile-interactions.js",
+                            "core/client/toggle.js",
+                            "core/client/markdown-actions.js",
+                            "core/client/helpers/index.js"
+                        ],
+
+                        "core/built/scripts/templates.js": [
+                            "core/client/tpl/hbs-tpl.js"
+                        ],
+
+                        "core/built/scripts/models.js": [
+                            "core/client/models/**/*.js"
+                        ],
+
+                        "core/built/scripts/views.js": [
+                            "core/client/views/**/*.js",
+                            "core/client/router.js"
+                        ]
+                    }
+                },
+                prod: {
+                    files: {
+                        "core/built/scripts/ghost.js": [
+                            "core/shared/vendor/jquery/jquery.js",
+                            "core/shared/vendor/jquery/jquery-ui-1.10.3.custom.min.js",
+                            "core/client/assets/lib/jquery-utils.js",
+                            "core/client/assets/lib/uploader.js",
+                            "core/shared/vendor/underscore.js",
+                            "core/shared/vendor/backbone/backbone.js",
+                            "core/shared/vendor/handlebars/handlebars-runtime.js",
+                            "core/shared/vendor/moment.js",
+
+                            "core/client/assets/vendor/icheck/jquery.icheck.min.js",
+
+                            "core/shared/vendor/jquery/jquery.ui.widget.js",
+                            "core/shared/vendor/jquery/jquery.iframe-transport.js",
+                            "core/shared/vendor/jquery/jquery.fileupload.js",
+
+                            "core/client/assets/vendor/codemirror/codemirror.js",
+                            "core/client/assets/vendor/codemirror/addon/mode/overlay.js",
+                            "core/client/assets/vendor/codemirror/mode/markdown/markdown.js",
+                            "core/client/assets/vendor/codemirror/mode/gfm/gfm.js",
+                            "core/client/assets/vendor/showdown/showdown.js",
+                            "core/client/assets/vendor/showdown/extensions/ghostdown.js",
+                            "core/shared/vendor/showdown/extensions/github.js",
+                            "core/client/assets/vendor/shortcuts.js",
+                            "core/client/assets/vendor/validator-client.js",
+                            "core/client/assets/vendor/countable.js",
+                            "core/client/assets/vendor/to-title-case.js",
+                            "core/client/assets/vendor/packery.pkgd.min.js",
+                            "core/client/assets/vendor/jquery.hammer.min.js",
+
+                            "core/client/init.js",
+
+                            "core/client/mobile-interactions.js",
+                            "core/client/toggle.js",
+                            "core/client/markdown-actions.js",
+                            "core/client/helpers/index.js",
+
+                            "core/client/tpl/hbs-tpl.js",
+
+                            "core/client/models/**/*.js",
+
+                            "core/client/views/**/*.js",
+
+                            "core/client/router.js"
+                        ]
+                    }
+                }
+            },
+
+            uglify: {
+                prod: {
+                    files: {
+                        "core/built/scripts/ghost.min.js": "core/built/scripts/ghost.js"
+                    }
                 }
             }
         };
@@ -654,6 +776,8 @@ var path = require('path'),
             "shell:bourbon",
             "sass:admin",
             "handlebars",
+            "concat",
+            "uglify",
             "bump:build",
             "updateCurrentPackageInfo",
             "changelog",
@@ -666,6 +790,8 @@ var path = require('path'),
             "shell:bourbon",
             "sass:admin",
             "handlebars",
+            "concat",
+            "uglify",
             "bump:build",
             "updateCurrentPackageInfo",
             "changelog",
@@ -677,6 +803,8 @@ var path = require('path'),
             "shell:bourbon",
             "sass:admin",
             "handlebars",
+            "concat",
+            "uglify",
             "changelog",
             "copy:build",
             "compress:build"
@@ -692,7 +820,7 @@ var path = require('path'),
 
         // Prepare the project for development
         // TODO: Git submodule init/update (https://github.com/jaubourg/grunt-update-submodules)?
-        grunt.registerTask("init", ["shell:bourbon", "sass:admin", 'handlebars']);
+        grunt.registerTask("init", ["shell:bourbon", "default"]);
 
         // Run unit tests
         grunt.registerTask("test-unit", ['setTestEnv', 'loadConfig', "mochacli:all"]);
@@ -706,8 +834,10 @@ var path = require('path'),
         // Generate Docs
         grunt.registerTask("docs", ["groc"]);
 
+        // TODO: Production build task that minifies with uglify:prod
+
         // When you just say "grunt"
-        grunt.registerTask("default", ['sass:admin', 'handlebars']);
+        grunt.registerTask("default", ['sass:admin', 'handlebars', 'concat']);
     };
 
 module.exports = configureGrunt;

--- a/core/client/assets/vendor/shortcuts.js
+++ b/core/client/assets/vendor/shortcuts.js
@@ -220,4 +220,4 @@ shortcut = {
         else if(ele.removeEventListener) ele.removeEventListener(type, callback, false);
         else ele['on'+type] = false;
     }
-}
+};

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -36,63 +36,10 @@
         <aside id="modal-container">
         </aside>
 
-        <script src="/shared/vendor/jquery/jquery.js"></script>
-        <script src="/shared/vendor/jquery/jquery-ui-1.10.3.custom.min.js"></script>
-        <script src="/public/lib/jquery-utils.js"></script>
-        <script src="/shared/vendor/underscore.js"></script>
-        <script src="/shared/vendor/backbone/backbone.js"></script>
-        <script src="/shared/vendor/handlebars/handlebars-runtime.js"></script>
-        <script src="/shared/vendor/moment.js"></script>
+        {{{ghostScriptTags}}}
 
-        <script src="/public/vendor/icheck/jquery.icheck.min.js"></script>
-
-        <script src="/shared/vendor/jquery/jquery.ui.widget.js"></script>
-        <script src="/shared/vendor/jquery/jquery.iframe-transport.js"></script>
-        <script src="/shared/vendor/jquery/jquery.fileupload.js"></script>
-
-        <script src="/public/vendor/codemirror/codemirror.js"></script>
-        <script src="/public/vendor/codemirror/addon/mode/overlay.js"></script>
-        <script src="/public/vendor/codemirror/mode/markdown/markdown.js"></script>
-        <script src="/public/vendor/codemirror/mode/gfm/gfm.js"></script>
-        <script src="/public/vendor/showdown/showdown.js"></script>
-        <script src="/public/vendor/showdown/extensions/ghostdown.js"></script>
-        <script src="/shared/vendor/showdown/extensions/github.js"></script>
-        <script src="/public/vendor/shortcuts.js"></script>
-        <script src="/public/vendor/validator-client.js"></script>
-        <script src="/public/vendor/countable.js"></script>
-        <script src="/public/vendor/to-title-case.js"></script>
-        <script src="/public/vendor/packery.pkgd.min.js"></script>
-        <script src="/public/vendor/jquery.hammer.min.js"></script>
-
-        <script src="/public/init.js"></script>
-
-        <script src="/public/assets/lib/uploader.js"></script>
-
-        <script src="/public/tpl/hbs-tpl.js"></script>
-        <script src="/public/mobile-interactions.js"></script>
-        <script src="/public/toggle.js"></script>
-        <script src="/public/markdown-actions.js"></script>
-        <script src="/public/helpers/index.js"></script>
-
-        <!-- // require '/public/models/*' -->
-        <script src="/public/models/post.js"></script>
-        <script src="/public/models/user.js"></script>
-        <script src="/public/models/tag.js"></script>
-        <script src="/public/models/widget.js"></script>
-        <script src="/public/models/settings.js"></script>
-        <script src="/public/models/uploadModal.js"></script>
-        <!-- // require '/public/views/*' -->
-        <script src="/public/views/base.js"></script>
-        <script src="/public/views/post-settings.js"></script>
-        <script src="/public/models/uploadModal.js"></script>
-        <script src="/public/views/blog.js"></script>
-        <script src="/public/views/editor.js"></script>
-        <script src="/public/views/editor-tag-widget.js"></script>
-        <script src="/public/views/login.js"></script>
-        <script src="/public/views/settings.js"></script>
-        <script src="/public/views/debug.js"></script>
-        <script src="/public/router.js"></script>
         {{{block "bodyScripts"}}}
+        
         <script>
             Ghost.init();
         </script>

--- a/core/test/unit/admin_spec.js
+++ b/core/test/unit/admin_spec.js
@@ -90,7 +90,8 @@ describe('Admin Controller', function() {
             });
 
             it('should send correct path to image when today is in Sep 2013', function(done) {
-                clock = sinon.useFakeTimers(1378585460681); // Sat Sep 07 2013 21:24:20 GMT+0100 (BST)
+                // Sat Sep 07 2013 21:24
+                clock = sinon.useFakeTimers(new Date(2013, 8, 7, 21, 24).getTime());
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2013/Sep/IMAGE.jpg');
                     return done();
@@ -100,7 +101,8 @@ describe('Admin Controller', function() {
             });
 
             it('should send correct path to image when today is in Jan 2014', function(done) {
-                clock = sinon.useFakeTimers(1388707200000); // Wed Jan 03 2014 00:00:00 GMT+0000 (GMT)
+                // Jan 1 2014 12:00
+                clock = sinon.useFakeTimers(new Date(2014, 0, 1, 12).getTime());
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2014/Jan/IMAGE.jpg');
                     return done();
@@ -110,7 +112,8 @@ describe('Admin Controller', function() {
             });
 
             it('can upload two different images with the same name without overwriting the first', function(done) {
-                clock = sinon.useFakeTimers(1378634224614); // Sun Sep 08 2013 10:57:04 GMT+0100 (BST)
+                // Sun Sep 08 2013 10:57
+                clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-1.jpg').yields(false);
 
@@ -123,7 +126,8 @@ describe('Admin Controller', function() {
             });
 
             it('can upload five different images with the same name without overwriting the first', function(done) {
-                clock = sinon.useFakeTimers(1378634224614); // Sun Sep 08 2013 10:57:04 GMT+0100 (BST)
+                // Sun Sep 08 2013 10:57
+                clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-1.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-2.jpg').yields(true);

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
         "grunt-bump": "~0.0.11",
         "grunt-contrib-copy": "~0.4.1",
         "grunt-contrib-compress": "~0.5.2",
+        "grunt-contrib-concat": "~0.3.0",
+        "grunt-contrib-uglify": "~0.2.4",
         "grunt-groc": "~0.3.0",
         "grunt-mocha-cli": "~1.0.6",
         "grunt-express-server": "~0.4.2",


### PR DESCRIPTION
- Made a helper called ghostScriptTags that will spit out the relevant
  script tags with version parameter; 4 unminified files in development,
  1 minified file in production.
- Added grunt concat and uglify tasks to build files into core/built
- Fixed some unit tests by making them native date objects

Some off the cuff metrics on this that I could measure with the chrome dev tools
- Number of Requests on /ghost: 
  - 55 => 5 (10 in development)
- Load time on /ghost: 
  - ~260ms => ~140ms (~165ms in development)

The request size has also gone down but I'm not sure how to measure that fairly because of all the 304's and what-not after the first time you load the page.

I tested out the build task by running `grunt build` and then going to `.build/build/` and running `node index.js` and `NODE_ENV=production node index.js`.  Tell me what you think and let me know if you want anything changed in it.
