### PR TITLE
Refactor helpers tests to not rely on handlebars

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -5,359 +5,397 @@ var _ = require('underscore'),
     hbs = require('express-hbs'),
     errors = require('../errorHandling'),
     models = require('../models'),
-    coreHelpers;
+    coreHelpers = {},
+    registerHelpers;
 
+/**
+ * [ description]
+ * @todo ghost core helpers + a way for themes to register them
+ * @param  {Object} context date object
+ * @param  {*} options
+ * @return {Object} A Moment time / date object
+ */
+coreHelpers.date = function (context, options) {
+    if (!options && context.hasOwnProperty('hash')) {
+        options = context;
+        context = undefined;
 
-coreHelpers = function (ghost) {
-    var paginationHelper;
-
-    /**
-     * [ description]
-     * @todo ghost core helpers + a way for themes to register them
-     * @param  {Object} context date object
-     * @param  {*} options
-     * @return {Object} A Moment time / date object
-     */
-    ghost.registerThemeHelper('date', function (context, options) {
-        if (!options && context.hasOwnProperty('hash')) {
-            options = context;
-            context = undefined;
-
-            // set to published_at by default, if it's available
-            // otherwise, this will print the current date
-            if (this.published_at) {
-                context = this.published_at;
-            }
+        // set to published_at by default, if it's available
+        // otherwise, this will print the current date
+        if (this.published_at) {
+            context = this.published_at;
         }
+    }
 
-        var f = options.hash.format || "MMM Do, YYYY",
-            timeago = options.hash.timeago,
-            date;
-
-
-        if (timeago) {
-            date = moment(context).fromNow();
-        } else {
-            date = moment(context).format(f);
-        }
-        return date;
-    });
-
-    // ### Page URL Helper
-    // 
-    // *Usage example:*
-    // `{{pageUrl 2}}`
-    // 
-    // Returns the URL for the page specified in the current object
-    // context.
-    //
-    ghost.registerThemeHelper('pageUrl', function (context, block) {
-        return context === 1 ? '/' : ('/page/' + context + '/');
-    });
-
-    // ### URL helper
-    //
-    // *Usage example:*
-    // `{{url}}`
-    // `{{url absolute}}`
-    //
-    // Returns the URL for the current object context
-    // i.e. If inside a post context will return post permalink
-    // absolute flag outputs absolute URL, else URL is relative
-    ghost.registerThemeHelper('url', function (options) {
-        var output = '';
-
-        if (options && options.hash.absolute) {
-            output += ghost.config().url;
-        }
-
-        if (models.isPost(this)) {
-            output += "/" + this.slug;
-        }
-
-        return output;
-    });
-
-    // ### Author Helper
-    //
-    // *Usage example:*
-    // `{{author}}`
-    //
-    // Returns the full name of the author of a given post, or a blank string
-    // if the author could not be determined.
-    //
-    ghost.registerThemeHelper('author', function (context, options) {
-        return this.author ? this.author.full_name : "";
-    });
-
-    // ### Tags Helper
-    //
-    // *Usage example:*
-    // `{{tags}}`
-    // `{{tags separator=" - "}}`
-    //
-    // Returns a string of the tags on the post.
-    // By default, tags are separated by commas.
-    //
-    // Note that the standard {{#each tags}} implementation is unaffected by this helper
-    // and can be used for more complex templates.
-    ghost.registerThemeHelper('tags', function (options) {
-        var separator = ", ",
-            tagNames;
-
-        if (typeof options.hash.separator === "string") {
-            separator = options.hash.separator;
-        }
-
-        tagNames = _.pluck(this.tags, 'name');
-        return tagNames.join(separator);
-    });
-
-    // ### Content Helper
-    //
-    // *Usage example:*
-    // `{{content}}`
-    // `{{content words=20}}`
-    // `{{content characters=256}}`
-    //
-    // Turns content html into a safestring so that the user doesn't have to
-    // escape it or tell handlebars to leave it alone with a triple-brace.
-    //
-    // Enables tag-safe truncation of content by characters or words.
-    //
-    // **returns** SafeString content html, complete or truncated.
-    //
-    ghost.registerThemeHelper('content', function (options) {
-        var truncateOptions = (options || {}).hash || {};
-        truncateOptions = _.pick(truncateOptions, ["words", "characters"]);
-
-        if (truncateOptions.words || truncateOptions.characters) {
-            return new hbs.handlebars.SafeString(
-                downsize(this.content, truncateOptions)
-            );
-        }
-
-        return new hbs.handlebars.SafeString(this.content);
-    });
+    var f = options.hash.format || "MMM Do, YYYY",
+        timeago = options.hash.timeago,
+        date;
 
 
-    // ### Excerpt Helper
-    //
-    // *Usage example:*
-    // `{{excerpt}}`
-    // `{{excerpt words=50}}`
-    // `{{excerpt characters=256}}`
-    //
-    // Attempts to remove all HTML from the string, and then shortens the result according to the provided option.
-    //
-    // Defaults to words=50
-    //
-    // **returns** SafeString truncated, HTML-free content.
-    //
-    ghost.registerThemeHelper('excerpt', function (options) {
-        var truncateOptions = (options || {}).hash || {},
-            excerpt;
+    if (timeago) {
+        date = moment(context).fromNow();
+    } else {
+        date = moment(context).format(f);
+    }
+    return date;
+};
 
-        truncateOptions = _.pick(truncateOptions, ["words", "characters"]);
+// ### Page URL Helper
+// 
+// *Usage example:*
+// `{{pageUrl 2}}`
+// 
+// Returns the URL for the page specified in the current object
+// context.
+//
+coreHelpers.pageUrl = function (context, block) {
+    return context === 1 ? '/' : ('/page/' + context + '/');
+};
 
-        /*jslint regexp:true */
-        excerpt = String(this.content).replace(/<\/?[^>]+>/gi, "");
-        /*jslint regexp:false */
+// ### URL helper
+//
+// *Usage example:*
+// `{{url}}`
+// `{{url absolute}}`
+//
+// Returns the URL for the current object context
+// i.e. If inside a post context will return post permalink
+// absolute flag outputs absolute URL, else URL is relative
+coreHelpers.url = function (options) {
+    var output = '';
 
-        if (!truncateOptions.words && !truncateOptions.characters) {
-            truncateOptions.words = 50;
-        }
+    if (options && options.hash.absolute) {
+        output += coreHelpers.ghost.config().url;
+    }
 
+    if (models.isPost(this)) {
+        output += "/" + this.slug;
+    }
+
+    return output;
+};
+
+// ### Author Helper
+//
+// *Usage example:*
+// `{{author}}`
+//
+// Returns the full name of the author of a given post, or a blank string
+// if the author could not be determined.
+//
+coreHelpers.author = function (context, options) {
+    return this.author ? this.author.full_name : "";
+};
+
+// ### Tags Helper
+//
+// *Usage example:*
+// `{{tags}}`
+// `{{tags separator=" - "}}`
+//
+// Returns a string of the tags on the post.
+// By default, tags are separated by commas.
+//
+// Note that the standard {{#each tags}} implementation is unaffected by this helper
+// and can be used for more complex templates.
+coreHelpers.tags = function (options) {
+    var separator = ", ",
+        tagNames;
+
+    if (typeof options.hash.separator === "string") {
+        separator = options.hash.separator;
+    }
+
+    tagNames = _.pluck(this.tags, 'name');
+    return tagNames.join(separator);
+};
+
+// ### Content Helper
+//
+// *Usage example:*
+// `{{content}}`
+// `{{content words=20}}`
+// `{{content characters=256}}`
+//
+// Turns content html into a safestring so that the user doesn't have to
+// escape it or tell handlebars to leave it alone with a triple-brace.
+//
+// Enables tag-safe truncation of content by characters or words.
+//
+// **returns** SafeString content html, complete or truncated.
+//
+coreHelpers.content = function (options) {
+    var truncateOptions = (options || {}).hash || {};
+    truncateOptions = _.pick(truncateOptions, ["words", "characters"]);
+
+    if (truncateOptions.words || truncateOptions.characters) {
         return new hbs.handlebars.SafeString(
-            downsize(excerpt, truncateOptions)
+            downsize(this.content, truncateOptions)
         );
+    }
+
+    return new hbs.handlebars.SafeString(this.content);
+};
+
+// ### Excerpt Helper
+//
+// *Usage example:*
+// `{{excerpt}}`
+// `{{excerpt words=50}}`
+// `{{excerpt characters=256}}`
+//
+// Attempts to remove all HTML from the string, and then shortens the result according to the provided option.
+//
+// Defaults to words=50
+//
+// **returns** SafeString truncated, HTML-free content.
+//
+coreHelpers.excerpt = function (options) {
+    var truncateOptions = (options || {}).hash || {},
+        excerpt;
+
+    truncateOptions = _.pick(truncateOptions, ["words", "characters"]);
+
+    /*jslint regexp:true */
+    excerpt = String(this.content).replace(/<\/?[^>]+>/gi, "");
+    /*jslint regexp:false */
+
+    if (!truncateOptions.words && !truncateOptions.characters) {
+        truncateOptions.words = 50;
+    }
+
+    return new hbs.handlebars.SafeString(
+        downsize(excerpt, truncateOptions)
+    );
+};
+
+coreHelpers.body_class = function (options) {
+    var classes = [];
+    if (_.isString(this.path) && this.path.match(/\/page/)) {
+        classes.push('archive-template');
+    } else if (!this.path || this.path === '/' || this.path === '') {
+        classes.push('home-template');
+    } else {
+        classes.push('post-template');
+    }
+
+    return coreHelpers.ghost.doFilter('body_class', classes, function (classes) {
+        var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+        return new hbs.handlebars.SafeString(classString.trim());
     });
+};
 
+coreHelpers.post_class = function (options) {
+    var classes = ['post'];
 
-    ghost.registerThemeHelper('body_class', function (options) {
-        var classes = [];
-        if (_.isString(this.path) && this.path.match(/\/page/)) {
-            classes.push('archive-template');
-        } else if (!this.path || this.path === '/' || this.path === '') {
-            classes.push('home-template');
+    if (this.tags) {
+        classes = classes.concat(this.tags.map(function (tag) { return "tag-" + tag.name; }));
+    }
+
+    return coreHelpers.ghost.doFilter('post_class', classes, function (classes) {
+        var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+        return new hbs.handlebars.SafeString(classString.trim());
+    });
+};
+
+coreHelpers.ghost_head = function (options) {
+    var head = [];
+    head.push('<meta name="generator" content="Ghost ' + this.version + '" />');
+    head.push('<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
+
+    return coreHelpers.ghost.doFilter('ghost_head', head, function (head) {
+        var headString = _.reduce(head, function (memo, item) { return memo + "\n" + item; }, '');
+        return new hbs.handlebars.SafeString(headString.trim());
+    });
+};
+
+coreHelpers.ghost_foot = function (options) {
+    var foot = [];
+    foot.push('<script src="/shared/vendor/jquery/jquery.js"></script>');
+
+    return coreHelpers.ghost.doFilter('ghost_foot', foot, function (foot) {
+        var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');
+        return new hbs.handlebars.SafeString(footString.trim());
+    });
+};
+
+/**
+ * [ description]
+ *
+ * @param String key
+ * @param String default translation
+ * @param {Object} options
+ * @return String A correctly internationalised string
+ */
+coreHelpers.e = function (key, defaultString, options) {
+    var output;
+
+    if (coreHelpers.ghost.settings().defaultLang === 'en' && _.isEmpty(options.hash) && !coreHelpers.ghost.settings().forceI18n) {
+        output = defaultString;
+    } else {
+        output = coreHelpers.ghost.polyglot().t(key, options.hash);
+    }
+
+    return output;
+};
+
+coreHelpers.json = function (object, options) {
+    return JSON.stringify(object);
+};
+
+coreHelpers.foreach = function (context, options) {
+    var fn = options.fn,
+        inverse = options.inverse,
+        i = 0,
+        j = 0,
+        columns = options.hash.columns,
+        key,
+        ret = "",
+        data;
+
+    if (options.data) {
+        data = hbs.handlebars.createFrame(options.data);
+    }
+
+    function setKeys(_data, _i, _j, _columns) {
+        if (_i === 0) {
+            _data.first = true;
+        }
+        if (_i === _j - 1) {
+            _data.last = true;
+        }
+        // first post is index zero but still needs to be odd
+        if (_i % 2 === 1) {
+            _data.even = true;
         } else {
-            classes.push('post-template');
+            _data.odd = true;
         }
-
-        return ghost.doFilter('body_class', classes, function (classes) {
-            var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
-            return new hbs.handlebars.SafeString(classString.trim());
-        });
-    });
-
-    ghost.registerThemeHelper('post_class', function (options) {
-        var classes = ['post'];
-
-        if (this.tags) {
-            classes = classes.concat(this.tags.map(function (tag) { return "tag-" + tag.name; }));
+        if (_i % _columns === 0) {
+            _data.rowStart = true;
+        } else if (_i % _columns === (_columns - 1)) {
+            _data.rowEnd = true;
         }
-
-        return ghost.doFilter('post_class', classes, function (classes) {
-            var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
-            return new hbs.handlebars.SafeString(classString.trim());
-        });
-    });
-
-    ghost.registerThemeHelper('ghost_head', function (options) {
-        var head = [];
-        head.push('<meta name="generator" content="Ghost ' + this.version + '" />');
-        head.push('<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
-
-        return ghost.doFilter('ghost_head', head, function (head) {
-            var headString = _.reduce(head, function (memo, item) { return memo + "\n" + item; }, '');
-            return new hbs.handlebars.SafeString(headString.trim());
-        });
-    });
-
-    ghost.registerThemeHelper('ghost_foot', function (options) {
-        var foot = [];
-        foot.push('<script src="/shared/vendor/jquery/jquery.js"></script>');
-
-        return ghost.doFilter('ghost_foot', foot, function (foot) {
-            var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');
-            return new hbs.handlebars.SafeString(footString.trim());
-        });
-    });
-    /**
-     * [ description]
-     *
-     * @param String key
-     * @param String default translation
-     * @param {Object} options
-     * @return String A correctly internationalised string
-     */
-    ghost.registerThemeHelper('e', function (key, defaultString, options) {
-        var output;
-
-        if (ghost.settings().defaultLang === 'en' && _.isEmpty(options.hash) && !ghost.settings().forceI18n) {
-            output = defaultString;
+        return _data;
+    }
+    if (context && typeof context === 'object') {
+        if (context instanceof Array) {
+            for (j = context.length; i < j; i += 1) {
+                if (data) {
+                    data.index = i;
+                    data.first = data.rowEnd = data.rowStart = data.last = data.even = data.odd = false;
+                    data = setKeys(data, i, j, columns);
+                }
+                ret = ret + fn(context[i], { data: data });
+            }
         } else {
-            output = ghost.polyglot().t(key, options.hash);
-        }
-
-        return output;
-    });
-
-    ghost.registerThemeHelper('json', function (object, options) {
-        return JSON.stringify(object);
-    });
-
-    ghost.registerThemeHelper('foreach', function (context, options) {
-        var fn = options.fn,
-            inverse = options.inverse,
-            i = 0,
-            j = 0,
-            columns = options.hash.columns,
-            key,
-            ret = "",
-            data;
-
-        if (options.data) {
-            data = hbs.handlebars.createFrame(options.data);
-        }
-
-        function setKeys(_data, _i, _j, _columns) {
-            if (_i === 0) {
-                _data.first = true;
+            for (key in context) {
+                if (context.hasOwnProperty(key)) {
+                    j += 1;
+                }
             }
-            if (_i === _j - 1) {
-                _data.last = true;
-            }
-            // first post is index zero but still needs to be odd
-            if (_i % 2 === 1) {
-                _data.even = true;
-            } else {
-                _data.odd = true;
-            }
-            if (_i % _columns === 0) {
-                _data.rowStart = true;
-            } else if (_i % _columns === (_columns - 1)) {
-                _data.rowEnd = true;
-            }
-            return _data;
-        }
-        if (context && typeof context === 'object') {
-            if (context instanceof Array) {
-                for (j = context.length; i < j; i += 1) {
+            for (key in context) {
+                if (context.hasOwnProperty(key)) {
                     if (data) {
-                        data.index = i;
+                        data.key = key;
                         data.first = data.rowEnd = data.rowStart = data.last = data.even = data.odd = false;
                         data = setKeys(data, i, j, columns);
                     }
-                    ret = ret + fn(context[i], { data: data });
-                }
-            } else {
-                for (key in context) {
-                    if (context.hasOwnProperty(key)) {
-                        j += 1;
-                    }
-                }
-                for (key in context) {
-                    if (context.hasOwnProperty(key)) {
-                        if (data) {
-                            data.key = key;
-                            data.first = data.rowEnd = data.rowStart = data.last = data.even = data.odd = false;
-                            data = setKeys(data, i, j, columns);
-                        }
-                        ret = ret + fn(context[key], {data: data});
-                        i += 1;
-                    }
+                    ret = ret + fn(context[key], {data: data});
+                    i += 1;
                 }
             }
         }
+    }
 
-        if (i === 0) {
-            ret = inverse(this);
-        }
-        return ret;
-    });
+    if (i === 0) {
+        ret = inverse(this);
+    }
+    return ret;
+};
 
-    // ## Template driven helpers
-    // Template driven helpers require that their template is loaded before they can be registered.
+// ## Template driven helpers
+// Template driven helpers require that their template is loaded before they can be registered.
+coreHelpers.paginationTemplate = null;
 
-    // ### Pagination Helper
-    // `{{pagination}}`
-    // Outputs previous and next buttons, along with info about the current page
+// ### Pagination Helper
+// `{{pagination}}`
+// Outputs previous and next buttons, along with info about the current page
+coreHelpers.pagination = function (options) {
+    if (!_.isObject(this.pagination) || _.isFunction(this.pagination)) {
+        errors.logAndThrowError('pagination data is not an object or is a function');
+        return;
+    }
+    if (_.isUndefined(this.pagination.page) || _.isUndefined(this.pagination.pages)
+            || _.isUndefined(this.pagination.total) || _.isUndefined(this.pagination.limit)) {
+        errors.logAndThrowError('All values must be defined for page, pages, limit and total');
+        return;
+    }
+    if ((!_.isUndefined(this.pagination.next) && !_.isNumber(this.pagination.next))
+            || (!_.isUndefined(this.pagination.prev) && !_.isNumber(this.pagination.prev))) {
+        errors.logAndThrowError('Invalid value, Next/Prev must be a number');
+        return;
+    }
+    if (!_.isNumber(this.pagination.page) || !_.isNumber(this.pagination.pages)
+            || !_.isNumber(this.pagination.total) || !_.isNumber(this.pagination.limit)) {
+        errors.logAndThrowError('Invalid value, check page, pages, limit and total are numbers');
+        return;
+    }
+    return new hbs.handlebars.SafeString(coreHelpers.paginationTemplate(this.pagination));
+};
+
+coreHelpers.helperMissing = function (arg) {
+    if (arguments.length === 2) {
+        return undefined;
+    }
+    errors.logError("Missing helper: '" + arg + "'");
+};
+
+registerHelpers = function (ghost) {
+    var paginationHelper;
+
+    coreHelpers.ghost = ghost;
+
+    ghost.registerThemeHelper('date', coreHelpers.date);
+
+    ghost.registerThemeHelper('pageUrl', coreHelpers.pageUrl);
+
+    ghost.registerThemeHelper('url', coreHelpers.url);
+
+    ghost.registerThemeHelper('author', coreHelpers.author);
+
+    ghost.registerThemeHelper('tags', coreHelpers.tags);
+
+    ghost.registerThemeHelper('content', coreHelpers.content);
+
+    ghost.registerThemeHelper('excerpt', coreHelpers.excerpt);
+
+    ghost.registerThemeHelper('body_class', coreHelpers.body_class);
+
+    ghost.registerThemeHelper('post_class', coreHelpers.post_class);
+
+    ghost.registerThemeHelper('ghost_head', coreHelpers.ghost_head);
+
+    ghost.registerThemeHelper('ghost_foot', coreHelpers.ghost_foot);
+
+    ghost.registerThemeHelper('e', coreHelpers.e);
+
+    ghost.registerThemeHelper('json', coreHelpers.json);
+
+    ghost.registerThemeHelper('foreach', coreHelpers.foreach);
+
     paginationHelper = ghost.loadTemplate('pagination').then(function (templateFn) {
-        ghost.registerThemeHelper('pagination', function (options) {
-            if (!_.isObject(this.pagination) || _.isFunction(this.pagination)) {
-                errors.logAndThrowError('pagination data is not an object or is a function');
-                return;
-            }
-            if (_.isUndefined(this.pagination.page) || _.isUndefined(this.pagination.pages)
-                    || _.isUndefined(this.pagination.total) || _.isUndefined(this.pagination.limit)) {
-                errors.logAndThrowError('All values must be defined for page, pages, limit and total');
-                return;
-            }
-            if ((!_.isUndefined(this.pagination.next) && !_.isNumber(this.pagination.next))
-                    || (!_.isUndefined(this.pagination.prev) && !_.isNumber(this.pagination.prev))) {
-                errors.logAndThrowError('Invalid value, Next/Prev must be a number');
-                return;
-            }
-            if (!_.isNumber(this.pagination.page) || !_.isNumber(this.pagination.pages)
-                    || !_.isNumber(this.pagination.total) || !_.isNumber(this.pagination.limit)) {
-                errors.logAndThrowError('Invalid value, check page, pages, limit and total are numbers');
-                return;
-            }
-            return new hbs.handlebars.SafeString(templateFn(this.pagination));
-        });
+        coreHelpers.paginationTemplate = templateFn;
+
+        ghost.registerThemeHelper('pagination', coreHelpers.pagination);
     });
 
-    ghost.registerThemeHelper('helperMissing', function (arg) {
-        if (arguments.length === 2) {
-            return undefined;
-        }
-        errors.logError("Missing helper: '" + arg + "'");
-    });
+    ghost.registerThemeHelper('helperMissing', coreHelpers.helperMissing);
+
     // Return once the template-driven helpers have loaded
     return when.join(
         paginationHelper
     );
 };
 
-module.exports.loadCoreHelpers = coreHelpers;
+module.exports = coreHelpers;
+module.exports.loadCoreHelpers = registerHelpers;

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -29,7 +29,7 @@ describe('Core Helpers', function () {
 
         it('can render content', function () {
             var content = "Hello World",
-                rendered = handlebars.helpers.content.call({content: content});
+                rendered = helpers.content.call({content: content});
 
             should.exist(rendered);
             rendered.string.should.equal(content);
@@ -38,7 +38,7 @@ describe('Core Helpers', function () {
         it('can truncate content by word', function () {
             var content = "<p>Hello <strong>World! It's me!</strong></p>",
                 rendered = (
-                    handlebars.helpers.content
+                    helpers.content
                         .call(
                             {content: content},
                             {"hash":{"words": 2}}
@@ -52,7 +52,7 @@ describe('Core Helpers', function () {
         it('can truncate content by character', function () {
             var content = "<p>Hello <strong>World! It's me!</strong></p>",
                 rendered = (
-                    handlebars.helpers.content
+                    helpers.content
                         .call(
                             {content: content},
                             {"hash":{"characters": 8}}
@@ -72,14 +72,14 @@ describe('Core Helpers', function () {
 
         it("Returns the full name of the author from the context",function() {
             var content = {"author":{"full_name":"abc123"}},
-                result = handlebars.helpers.author.call(content);
+                result = helpers.author.call(content);
 
             String(result).should.equal("abc123");
         });
 
         it("Returns a blank string where author data is missing",function() {
             var content = {"author":null},
-                result = handlebars.helpers.author.call(content);
+                result = helpers.author.call(content);
 
             String(result).should.equal("");
         });
@@ -94,7 +94,7 @@ describe('Core Helpers', function () {
 
         it('can render excerpt', function () {
             var content = "Hello World",
-                rendered = handlebars.helpers.excerpt.call({content: content});
+                rendered = helpers.excerpt.call({content: content});
 
             should.exist(rendered);
             rendered.string.should.equal(content);
@@ -107,7 +107,7 @@ describe('Core Helpers', function () {
                         + "< test > those<<< test >>> who mistake it &lt;for&gt; binary.",
                 expected = "There are 10 types of people in the world: those who understand trinary, those who don't "
                          + "and those>> who mistake it &lt;for&gt; binary.",
-                rendered = handlebars.helpers.excerpt.call({content: content});
+                rendered = helpers.excerpt.call({content: content});
 
             should.exist(rendered);
             rendered.string.should.equal(expected);
@@ -118,7 +118,7 @@ describe('Core Helpers', function () {
             var content = "<p>Hello <strong>World! It's me!</strong></p>",
                 expected = "Hello World",
                 rendered = (
-                    handlebars.helpers.excerpt.call(
+                    helpers.excerpt.call(
                         {content: content},
                         {"hash": {"words": 2}}
                     )
@@ -132,7 +132,7 @@ describe('Core Helpers', function () {
             var content = "<p>Hello <strong>World! It's me!</strong></p>",
                 expected = "Hello Wo",
                 rendered = (
-                    handlebars.helpers.excerpt.call(
+                    helpers.excerpt.call(
                         {content: content},
                         {"hash": {"characters": 8}}
                     )
@@ -149,16 +149,16 @@ describe('Core Helpers', function () {
         });
 
         it('can render class string', function () {
-            var rendered = handlebars.helpers.body_class.call({});
+            var rendered = helpers.body_class.call({});
             should.exist(rendered);
 
             rendered.string.should.equal('home-template');
         });
 
         it('can render class string for context', function () {
-            var rendered1 = handlebars.helpers.body_class.call({path: '/'}),
-                rendered2 = handlebars.helpers.body_class.call({path: '/a-post-title'}),
-                rendered3 = handlebars.helpers.body_class.call({path: '/page/4'});
+            var rendered1 = helpers.body_class.call({path: '/'}),
+                rendered2 = helpers.body_class.call({path: '/a-post-title'}),
+                rendered3 = helpers.body_class.call({path: '/page/4'});
 
             should.exist(rendered1);
             should.exist(rendered2);
@@ -176,7 +176,7 @@ describe('Core Helpers', function () {
         });
 
         it('can render class string', function () {
-            var rendered = handlebars.helpers.post_class.call({});
+            var rendered = helpers.post_class.call({});
             should.exist(rendered);
 
             rendered.string.should.equal('post');
@@ -189,7 +189,7 @@ describe('Core Helpers', function () {
         });
 
         it('returns meta tag string', function () {
-            var rendered = handlebars.helpers.ghost_head.call({version: "0.3"});
+            var rendered = helpers.ghost_head.call({version: "0.3"});
             should.exist(rendered);
             rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
         });
@@ -201,7 +201,7 @@ describe('Core Helpers', function () {
         });
 
         it('returns meta tag string', function () {
-            var rendered = handlebars.helpers.ghost_foot.call();
+            var rendered = helpers.ghost_foot.call();
             should.exist(rendered);
             rendered.string.should.equal('<script src="/shared/vendor/jquery/jquery.js"></script>');
         });
@@ -213,7 +213,7 @@ describe('Core Helpers', function () {
         });
 
         it('should return a the slug with a prefix slash if the context is a post', function () {
-            var rendered = handlebars.helpers.url.call({content: 'content', content_raw: "ff", title: "title", slug: "slug"});
+            var rendered = helpers.url.call({content: 'content', content_raw: "ff", title: "title", slug: "slug"});
             should.exist(rendered);
             rendered.should.equal('/slug');
         });
@@ -223,7 +223,7 @@ describe('Core Helpers', function () {
                     return { url: 'http://testurl.com' };
                 }),
 
-                rendered = handlebars.helpers.url.call(
+                rendered = helpers.url.call(
                     {content: 'content', content_raw: "ff", title: "title", slug: "slug"},
                     {hash: { absolute: 'true'}}
                 );
@@ -235,10 +235,10 @@ describe('Core Helpers', function () {
         });
 
         it('should return empty string if not a post', function () {
-            handlebars.helpers.url.call({content_raw: "ff", title: "title", slug: "slug"}).should.equal('');
-            handlebars.helpers.url.call({content: 'content', title: "title", slug: "slug"}).should.equal('');
-            handlebars.helpers.url.call({content: 'content', content_raw: "ff", slug: "slug"}).should.equal('');
-            handlebars.helpers.url.call({content: 'content', content_raw: "ff", title: "title"}).should.equal('');
+            helpers.url.call({content_raw: "ff", title: "title", slug: "slug"}).should.equal('');
+            helpers.url.call({content: 'content', title: "title", slug: "slug"}).should.equal('');
+            helpers.url.call({content: 'content', content_raw: "ff", slug: "slug"}).should.equal('');
+            helpers.url.call({content: 'content', content_raw: "ff", title: "title"}).should.equal('');
         });
     });
 
@@ -248,9 +248,9 @@ describe('Core Helpers', function () {
         });
 
         it('can return a valid url', function () {
-            handlebars.helpers.pageUrl(1).should.equal('/');
-            handlebars.helpers.pageUrl(2).should.equal('/page/2/');
-            handlebars.helpers.pageUrl(50).should.equal('/page/50/');
+            helpers.pageUrl(1).should.equal('/');
+            helpers.pageUrl(2).should.equal('/page/2/');
+            helpers.pageUrl(50).should.equal('/page/50/');
         });
     });
 
@@ -267,7 +267,7 @@ describe('Core Helpers', function () {
         it('can render single page with no pagination necessary', function (done) {
             var rendered;
             helpers.loadCoreHelpers(ghost).then(function () {
-                rendered = handlebars.helpers.pagination.call({pagination: {page: 1, prev: undefined, next: undefined, limit: 15, total: 8, pages: 1}});
+                rendered = helpers.pagination.call({pagination: {page: 1, prev: undefined, next: undefined, limit: 15, total: 8, pages: 1}});
                 should.exist(rendered);
                 // strip out carriage returns and compare.
                 rendered.string.should.match(paginationRegex);
@@ -282,7 +282,7 @@ describe('Core Helpers', function () {
         it('can render first page of many with older posts link', function (done) {
             var rendered;
             helpers.loadCoreHelpers(ghost).then(function () {
-                rendered = handlebars.helpers.pagination.call({pagination: {page: 1, prev: undefined, next: 2, limit: 15, total: 8, pages: 3}});
+                rendered = helpers.pagination.call({pagination: {page: 1, prev: undefined, next: 2, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
 
                 rendered.string.should.match(paginationRegex);
@@ -297,7 +297,7 @@ describe('Core Helpers', function () {
         it('can render middle pages of many with older and newer posts link', function (done) {
             var rendered;
             helpers.loadCoreHelpers(ghost).then(function () {
-                rendered = handlebars.helpers.pagination.call({pagination: {page: 2, prev: 1, next: 3, limit: 15, total: 8, pages: 3}});
+                rendered = helpers.pagination.call({pagination: {page: 2, prev: 1, next: 3, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
 
                 rendered.string.should.match(paginationRegex);
@@ -313,7 +313,7 @@ describe('Core Helpers', function () {
         it('can render last page of many with newer posts link', function (done) {
             var rendered;
             helpers.loadCoreHelpers(ghost).then(function () {
-                rendered = handlebars.helpers.pagination.call({pagination: {page: 3, prev: 2, next: undefined, limit: 15, total: 8, pages: 3}});
+                rendered = helpers.pagination.call({pagination: {page: 3, prev: 2, next: undefined, limit: 15, total: 8, pages: 3}});
                 should.exist(rendered);
 
                 rendered.string.should.match(paginationRegex);
@@ -330,7 +330,7 @@ describe('Core Helpers', function () {
             helpers.loadCoreHelpers(ghost).then(function () {
                 var runErrorTest = function (data) {
                     return function () {
-                        handlebars.helpers.pagination.call(data);
+                        helpers.pagination.call(data);
                     };
                 };
 


### PR DESCRIPTION
Moved the logic out of the register calls and into their own methods so we could test them in isolation.

If we allow promises to be returned from filters (#739) then the theme helpers have to be registered as Async Helpers.  Async helpers are rendered differently by handlebars (they put a token in the html and update it once the async is resolved).  The different rendering was breaking all these tests.  Instead of having our unit tests testing more handlebars functionality than our own, I figured this would be a better approach.  I moved each function that was passed to the registerThemeHelper to a value on the coreHelpers object, then just reference it directly from the registerHelpers method.  I also set the ghost instance to coreHelpers.ghost so we didn't have to pass it to each helper; it's kind of dirty to share the ghost instance, but I think it's easier than all our tests relying on express-hbs rendering synchronously.
