### PR TITLE
Publish button amendments

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -420,9 +420,11 @@ body.zen {
         box-shadow: rgba(255,255,255,0.4) 0 1px 0 inset;
     }
 
-    .splitbutton-save{
-        .button-save{
-            @include transition(width 0.25s ease);
+    .splitbutton-save,
+    .splitbutton-delete{
+        .button-save,
+        .button-delete{
+            @include transition(width 0.25s ease, background-color 0.3s linear);
         }
 
         .editor-options{

--- a/core/client/assets/sass/modules/forms.scss
+++ b/core/client/assets/sass/modules/forms.scss
@@ -315,6 +315,7 @@ input[type="reset"] {
             @include transition-duration(0.3);
             @include transition-timing-function(ease);
         };
+        @include transition(background-color 0.3s linear);
 
         // Keep the arrow spun when the associated menu is open
         &.active:before {

--- a/core/server/views/editor.hbs
+++ b/core/server/views/editor.hbs
@@ -64,14 +64,12 @@
                 </ul>
             </section>
 
-            <section id="entry-actions" class="splitbutton-save">
-                <button type="button" class="button-save js-post-button"></button>
+            <section id="entry-actions" class="js-publish-splitbutton splitbutton-save">
+                <button type="button" class="js-publish-button button-save"></button>
                 <a class="options up" data-toggle="ul" href="#"><span class="hidden">Options</span></a>
                 <ul class="editor-options overlay" style="display:none">
-                    <li data-set-status="published"><a href="#">Publish Now</a></li>
-                    <li data-set-status="queue"><a href="#">Add to Queue</a></li>
-                    <li data-set-status="publish-on"><a href="#">Publish on...</a></li>
-                    <li data-set-status="draft"><a href="#">Save Draft</a></li>
+                    <li data-set-status="published"><a href="#"></a></li>
+                    <li data-set-status="draft"><a href="#"></a></li>
                 </ul>
             </section>
         </div>

--- a/core/test/functional/admin/06_flow_test.js
+++ b/core/test/functional/admin/06_flow_test.js
@@ -21,7 +21,7 @@ casper.test.begin("Ghost edit draft flow works correctly", 7, function suite(tes
         this.echo("I've waited for 1 seconds.");
     });
 
-    casper.thenClick('.button-save');
+    casper.thenClick('.js-publish-button');
     casper.waitForResource(/posts/);
 
     casper.waitForSelector('.notification-success', function onSuccess() {
@@ -46,7 +46,7 @@ casper.test.begin("Ghost edit draft flow works correctly", 7, function suite(tes
         test.assertUrlMatch(/editor/, "Ghost sucessfully loaded the editor page again");
     });
 
-    casper.thenClick('.button-save');
+    casper.thenClick('.js-publish-button');
     casper.waitForResource(/posts/);
 
     casper.waitForSelector('.notification-success', function onSuccess() {


### PR DESCRIPTION
Fixes #667
- Removed superfluous as-of-yet-unused options in the publish menu.
- Adjusted display names of publish buttons according to differing
  states the publish menu can be in (new post, saved draft, published
  post).
- Added red highlight style to "important" status change options in the
  publish menu (draft => published, published => unpublished).
- Added suite of functional tests around new labels and classes.
