### PR TITLE
Infinite Scroll Pagination for content screen

### DIFF
--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -44,8 +44,15 @@
     });
 
     Ghost.Collections.Posts = Backbone.Collection.extend({
+        currentPage: 1,
+        totalPages: 0,
+        totalPosts: 0,
+        nextPage: 0,
+        prevPage: 0,
+
         url: Ghost.settings.apiRoot + '/posts',
         model: Ghost.Models.Post,
+
         parse: function (resp) {
             if (_.isArray(resp.posts)) {
                 this.limit = resp.limit;

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -259,7 +259,7 @@ Post = GhostBookshelf.Model.extend({
                     var totalPosts = resp[0].aggregate,
                         data = {
                             posts: collection.toJSON(),
-                            page: opts.page,
+                            page: parseInt(opts.page, 10),
                             limit: opts.limit,
                             pages: Math.ceil(totalPosts / opts.limit),
                             total: totalPosts

--- a/core/test/functional/admin/04_content_test.js
+++ b/core/test/functional/admin/04_content_test.js
@@ -48,3 +48,17 @@ casper.test.begin("Content screen is correct", 17, function suite(test) {
         test.done();
     });
 });
+
+casper.test.begin('Infinite scrolling', 1, function suite(test) {
+    test.filename = 'content_infinite_scrolling_test.png';
+
+    // Placeholder for infinite scrolling/pagination tests (will need to setup 16+ posts).
+
+    casper.start(url + "ghost/content/", function testTitleAndUrl() {
+        test.assertTitle("", "Ghost admin has no title");
+    }).viewport(1280, 1024);
+
+    casper.run(function () {
+        test.done();
+    });
+});


### PR DESCRIPTION
Fixes #258
- Modified post collection to have default values for paging.
- Added scroll handler to content view to check for more posts and load
  as appropriate.
- Sanitized result from server-side post paging, ensure page # is
  returned as an integer.
- Added a functional test stub.
