### PR TITLE
Renamed the notifications container

### DIFF
--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -889,7 +889,7 @@ nav {
    Notifications
    ========================================================================== */
 
-#flashbar {
+#notifications {
     @include breakpoint($mobile) {
         position: fixed;
         top: 0;

--- a/core/client/views/base.js
+++ b/core/client/views/base.js
@@ -122,7 +122,7 @@
 
     /**
      * This is the view to generate the markup for the individual
-     * notification. Will be included into #flashbar.
+     * notification. Will be included into #notifications.
      *
      * States can be
      * - persistent
@@ -152,7 +152,7 @@
      * This handles Notification groups
      */
     Ghost.Views.NotificationCollection = Ghost.View.extend({
-        el: '#flashbar',
+        el: '#notifications',
         initialize: function () {
             var self = this;
             this.render();

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -26,7 +26,7 @@
         {{/unless}}
 
         <main role="main" id="main">
-            <aside id="flashbar">
+            <aside id="notifications">
                 {{> notifications}}
             </aside>
 


### PR DESCRIPTION
Closes #651.

Renamed from `#flashbar` to `#notifications`
