### PR TITLE
Improved Image keyboard shortcut

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -67,7 +67,11 @@
                 pass = false;
                 break;
             case "image":
+                cursor = this.elem.getCursor();
                 md = this.options.syntax.image.replace('$1', text);
+                if (this.elem.getLine(cursor.line) !== "") {
+                    md = "\n\n" + md;
+                }
                 this.elem.replaceSelection(md, "end");
                 cursor = this.elem.getCursor();
                 this.elem.setSelection({line: cursor.line, ch: cursor.ch - 8}, {line: cursor.line, ch: cursor.ch - 1});


### PR DESCRIPTION
Closes #594.

Image keyboard shortcut now inserts a new line when on a line with text

![images](https://f.cloud.github.com/assets/367517/1149447/f9ee0228-1eda-11e3-81c1-94a09a05c993.gif)
