### PR TITLE
Initial 404 Error Handling Support

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -277,12 +277,19 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
     server.use(server.router);
 
     // ### Error handling
-    // TODO: replace with proper 400 and 500 error pages
-    // 404's
-    server.use(function error404Handler(req, res, next) {
-        console.log('test', req.url);
-        next();
-        //res.send(404, {message: "Page not found"});
+    // 404 Handler
+    server.use(errors.render404Page);
+
+    // TODO: Handle all application errors (~500)
+    // Just stubbed at this stage!
+    server.use(function error500Handler(err, req, res, next) {
+        if (!err || !(err instanceof Error)) {
+            next();
+        }
+
+        // For the time being, just log and continue.
+        errors.logError(err, "Middleware", "Ghost caught a processing error in the middleware layer.");
+        next(err);
     });
 
     // All other errors

--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -1,0 +1,10 @@
+{{!< default}}
+<section class="error-content error-404 js-error-container">
+	<figure class="error-image">
+	  <img class="error-ghost" src="/ghost/img/404-ghost@2x.png" srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
+	</figure>
+	<section class="error-message">
+	  <h1 class="error-code">{{code}}</h1>
+	  <h2 class="error-description">{{message}}</h2>
+	</section>
+</section>


### PR DESCRIPTION
Fixes #356
- Adds new generic methods for handling errors to errorHandling.js
- Initialises generic methods as middleware
- Created error.hbs view in admin
- Error handler searches for error.hbs view file in user theme folder
  and renders it if available, otherwise lets the error fall through
  to express.
## Notes
- We _could_ change the final behaviour to render a default ghost
  template should the user template be missing
- Because it currently isn't possible to require(ghost) in errorHandling.js,
  it was necessary to duplicate some aspects of the ghost path init code
  inside errorhandling.js. This should be cleaned up and moved back
  into ghost.js when possible.
