### PR TITLE
Settings: Return 404 for unrecognised pages

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -260,7 +260,17 @@ adminControllers = {
             adminNav: setSelected(adminNavbar, 'content')
         });
     },
-    'settings': function (req, res) {
+    'settings': function (req, res, next) {
+
+        // TODO: Centralise list/enumeration of settings panes, so we don't
+        // run into trouble in future.
+        var allowedSections = ["", "general", "user"],
+            section = req.url.replace(/(^\/ghost\/settings[\/]*|\/$)/ig, "");
+
+        if (allowedSections.indexOf(section) < 0) {
+            return next();
+        }
+
         res.render('settings', {
             bodyClass: 'settings',
             adminNav: setSelected(adminNavbar, 'settings')


### PR DESCRIPTION
Fixes #798
- Now checks the request URL against a whitelist to determine whether the settings
  page exists.

**Notes**
- This works in the short term, but a better solution for enumerating the available
  settings views or centralising a list of recognised views that are available
  to client side code, (the router and sidebar, among others) as well as the backend
  controller will be required.
