### PR TITLE
Default 404/500 Error Message

### DIFF
--- a/core/server/errorHandling.js
+++ b/core/server/errorHandling.js
@@ -7,6 +7,8 @@ var _ = require('underscore'),
     // Paths for views
     appRoot = path.resolve(__dirname, '../'),
     themePath = path.resolve(appRoot + '/content/themes'),
+    adminTemplatePath = path.resolve(appRoot + '/server/views/'),
+    defaultErrorTemplatePath = path.resolve(adminTemplatePath + '/user-error.hbs'),
     userErrorTemplatePath = path.resolve(themePath + '/error.hbs'),
     userErrorTemplateExists;
 
@@ -73,9 +75,9 @@ errors = {
 
     renderErrorPage: function (code, err, req, res, next) {
         // Render the error!
-        function renderErrorInt() {
+        function renderErrorInt(errorView) {
             // TODO: Attach node-polyglot
-            res.render('error', {
+            res.render((errorView || "error"), {
                 message: err.message || err,
                 code: code
             });
@@ -86,16 +88,13 @@ errors = {
         }
 
         // Are we admin? If so, don't worry about the user template
-        if (res.isAdmin) {
+        if (res.isAdmin || userErrorTemplateExists === true) {
             return renderErrorInt();
         }
 
+        // We're not admin and the template doesn't exist. Render the default.
         if (userErrorTemplateExists === false) {
-            return next();
-        }
-
-        if (userErrorTemplateExists === true) {
-            return renderErrorInt();
+            return renderErrorInt(defaultErrorTemplatePath);
         }
 
         // userErrorTemplateExists is undefined, which means we
@@ -113,12 +112,12 @@ errors = {
                 "Add an error.hbs template to the theme for customised errors."
             );
 
-            next();
+            renderErrorInt(defaultErrorTemplatePath);
         });
     },
 
     render404Page: function (req, res, next) {
-        var message = res.isAdmin ? "No Ghost Found" : "Resource Not Found";
+        var message = res.isAdmin ? "No Ghost Found" : "Page Not Found";
         this.renderErrorPage(404, message, req, res, next);
     }
 };

--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -1,0 +1,38 @@
+<!doctype html>
+<!--[if (IE 8)&!(IEMobile)]><html class="no-js lt-ie9" lang="en"><![endif]-->
+<!--[if (gte IE 9)| IEMobile |!(IE)]><!--><html class="no-js" lang="en"><!--<![endif]-->
+	<head>
+		<meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+
+		<title>{{code}} — {{message}}</title>
+		<meta name="description" content="{{siteDescription}}">
+		<meta name="author" content="">
+		<meta name="HandheldFriendly" content="True">
+		<meta name="MobileOptimized" content="320">
+		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+
+		<link rel="shortcut icon" href="/favicon.ico">
+		<meta http-equiv="cleartype" content="on">
+
+		<link rel="stylesheet" type='text/css' href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
+		<link rel="stylesheet" href="/ghost/css/screen.css">
+		{{{block "pageStyles"}}}
+	</head>
+	<body class="{{bodyClass}}">
+		<main role="main" id="main">
+			<section class="error-content error-404 js-error-container">
+				<section class="error-details">
+					<figure class="error-image">
+					  <img class="error-ghost" src="/ghost/img/404-ghost@2x.png" srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
+					</figure>
+					<section class="error-message">
+					  <h1 class="error-code">{{code}}</h1>
+					  <h2 class="error-description">{{message}}</h2>
+					</section>
+				</section>
+			</section>
+		</main>
+	</body>
+</html>


### PR DESCRIPTION
Fixes #792
- Added default template for errors where a user has not defined a custom
  template (error.hbs) in the theme folder
- Now searches for user-error.hbs in the server view folder should a user
  template not be present.
- Makes nice cocktail
