### PR TITLE
Removed global registration of express.bodyParser

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -260,8 +260,10 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
     // Add in all trailing slashes
     server.use(slashes());
 
-    server.use(express.bodyParser({}));
-    server.use(express.bodyParser({uploadDir: __dirname + '/content/images'}));
+    server.use(express.json());
+    server.use(express.urlencoded());
+    server.use('/ghost/upload/', express.multipart());
+    server.use('/ghost/upload/', express.multipart({uploadDir: __dirname + '/content/images'}));
     server.use(express.cookieParser(ghost.dbHash));
     server.use(express.cookieSession({ cookie: { maxAge: 60000000 }}));
 
@@ -351,6 +353,7 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
     server.get('/ghost/debug/db/export/', auth, admin.debug['export']);
     server.post('/ghost/debug/db/import/', auth, admin.debug['import']);
     server.get('/ghost/debug/db/reset/', auth, admin.debug.reset);
+    // We don't want to register bodyParser globally b/c of security concerns, so use multipart only here
     server.post('/ghost/upload/', admin.uploader);
     server.get(/^\/(ghost$|(ghost-admin|admin|wp-admin|dashboard|signin)\/?)/, auth, function (req, res) {
         res.redirect('/ghost/');


### PR DESCRIPTION
Fixes #824
- Removed global registration of `express.bodyParser` middleware.
- Replaced with `express.bodyParser`'s constituents: `express.json` and
  `express.urlencoded`, then registered `express.multipart` against _only_
  the upload route.
