### PR TITLE
500 Series Error Handling & Stack Traces

### DIFF
--- a/core/client/assets/sass/layouts/errors.scss
+++ b/core/client/assets/sass/layouts/errors.scss
@@ -77,10 +77,31 @@
     }
 }
 
-/* =============================================================================
-   404
-   ============================================================================= */
+.error-stack {
+    margin: 1em auto;
+    padding: 2em;
+    max-width: 800px;
+    background-color: rgba(255,255,255,0.3);
+}
 
-.error-404 {
-    width: 300px;
+.error-stack-list {
+    list-style-type: none;
+    padding: 0;
+    margin: 0;
+}
+
+.error-stack-list li {
+    display: block;
+    
+    &::before {
+        color: #BBB;
+        content: "↪︎";
+        display: inline-block;
+        font-size: 1.2em;
+        margin-right: 0.5em;
+    }
+}
+
+.error-stack-function {
+    font-weight: bold;
 }

--- a/core/server.js
+++ b/core/server.js
@@ -283,24 +283,8 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
     // 404 Handler
     server.use(errors.render404Page);
 
-    // TODO: Handle all application errors (~500)
-    // Just stubbed at this stage!
-    server.use(function error500Handler(err, req, res, next) {
-        if (!err || !(err instanceof Error)) {
-            next();
-        }
-
-        // For the time being, just log and continue.
-        errors.logError(err, "Middleware", "Ghost caught a processing error in the middleware layer.");
-        next(err);
-    });
-
-    // All other errors
-    if (server.get('env') === "production") {
-        server.use(express.errorHandler({ dumpExceptions: false, showStack: false }));
-    } else {
-        server.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
-    }
+    // 500 Handler
+    server.use(errors.render500Page);
 
     // ## Routing
 

--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -2,11 +2,26 @@
 <section class="error-content error-404 js-error-container">
     <section class="error-details">
         <figure class="error-image">
-          <img class="error-ghost" src="/ghost/img/404-ghost@2x.png" srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
+            <img class="error-ghost" src="/ghost/img/404-ghost@2x.png" srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
         </figure>
         <section class="error-message">
-          <h1 class="error-code">{{code}}</h1>
-          <h2 class="error-description">{{message}}</h2>
+            <h1 class="error-code">{{code}}</h1>
+            <h2 class="error-description">{{message}}</h2>
         </section>
     </section>
 </section>
+{{#if stack}}
+    <section class="error-stack">
+        <h3>Stack Trace</h3>
+        <p><strong>{{message}}</strong></p>
+        <ul class="error-stack-list">
+            {{#foreach stack}}
+                <li>
+                    at
+                    {{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
+                    <span class="error-stack-file">({{at}})</span>
+                </li>
+            {{/foreach}}
+        </ul>
+    </section>
+{{/if}}

--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -25,14 +25,32 @@
 			<section class="error-content error-404 js-error-container">
 				<section class="error-details">
 					<figure class="error-image">
-					  <img class="error-ghost" src="/ghost/img/404-ghost@2x.png" srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
+						<img
+							class="error-ghost"
+							src="/ghost/img/404-ghost@2x.png"
+							srcset="/ghost/img/404-ghost.png 1x, /ghost/img/404-ghost@2x.png 2x"/>
 					</figure>
 					<section class="error-message">
-					  <h1 class="error-code">{{code}}</h1>
-					  <h2 class="error-description">{{message}}</h2>
+						<h1 class="error-code">{{code}}</h1>
+						<h2 class="error-description">{{message}}</h2>
 					</section>
 				</section>
 			</section>
+			{{#if stack}}
+				<section class="error-stack">
+					<h3>Stack Trace</h3>
+					<p><strong>{{message}}</strong></p>
+					<ul class="error-stack-list">
+						{{#foreach stack}}
+							<li>
+								at
+								{{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
+								<span class="error-stack-file">({{at}})</span>
+							</li>
+						{{/foreach}}
+					</ul>
+				</section>
+			{{/if}}
 		</main>
 	</body>
 </html>

--- a/core/test/unit/errorHandling_spec.js
+++ b/core/test/unit/errorHandling_spec.js
@@ -43,7 +43,7 @@ describe("Error handling", function () {
 
     it("logs errors", function () {
         var err = new Error("test1"),
-            logStub = sinon.stub(console, "log");
+            logStub = sinon.stub(console, "error");
 
         // give environment a value that will console log
         process.env.NODE_ENV = "development";
@@ -75,7 +75,7 @@ describe("Error handling", function () {
                     return;
                 }
             },
-            logStub = sinon.stub(console, "log"),
+            logStub = sinon.stub(console, "error"),
             redirectStub = sinon.stub(res, "redirect");
 
         // give environment a value that will console log


### PR DESCRIPTION
Fixes #825
- Changes the way the error middleware is delivered in server.js, moving
  all the logic back into errorHandling.js
- Alters error logging to use console.error (probably more appropriate) instead
  of console.log
- Changes error tests to accomodate for these alterations
- Alters user-error and error hbs templates to incorporate stack traces
- Adds additional styling for error pages to accomodate stack traces
- Added logic to parse and deliver formatted stack traces
## Notes:
- Jslint gets in the way of the regex I've got to use to parse the stack.
  (It cites 'security reasons' which are not relevant in this case.)
  I needed to add a condition to relax it at the top of errorHandling.js
- The stack trace should probably be added as a partial, but I figured it
  was out of scope for this PR.
## Screenshot

![ghost stack trace](https://files.app.net/pstlpaqn.gif)
