### PR TITLE
Remove github showdown extension

### DIFF
--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -396,7 +396,7 @@
         initMarkdown: function () {
             var self = this;
 
-            this.converter = new Showdown.converter({extensions: ['ghostdown', 'github']});
+            this.converter = new Showdown.converter({extensions: ['ghostdown']});
             this.editor = CodeMirror.fromTextArea(document.getElementById('entry-markdown'), {
                 mode: 'gfm',
                 tabMode: 'indent',


### PR DESCRIPTION
The github extension prevents links or email addresses being written inside code blocks.
