### PR TITLE
Fix image upload tests on windows

### DIFF
--- a/core/test/unit/admin_spec.js
+++ b/core/test/unit/admin_spec.js
@@ -119,6 +119,11 @@ describe('Admin Controller', function() {
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-1.jpg').yields(false);
 
+                // if on windows need to setup with back slashes
+                // doesn't hurt for the test to cope with both
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE.jpg').yields(true);
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-1.jpg').yields(false);
+
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2013/Sep/IMAGE-1.jpg');
                     return done();
@@ -135,6 +140,13 @@ describe('Admin Controller', function() {
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-2.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-3.jpg').yields(true);
                 fs.exists.withArgs('content/images/2013/Sep/IMAGE-4.jpg').yields(false);
+
+                // windows setup
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE.jpg').yields(true);
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-1.jpg').yields(true);
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-2.jpg').yields(true);
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-3.jpg').yields(true);
+                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-4.jpg').yields(false);
 
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2013/Sep/IMAGE-4.jpg');


### PR DESCRIPTION
closes #826
- on windows the fs.exists call had windows style back slashes
- set up the test to cope with either (not the most elegant but works)
