### PR TITLE
Bug Fix: Date Keyboard Shortcut no-longer crashes the browser

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -113,6 +113,8 @@
                 break;
             case "currentDate":
                 md = moment(new Date()).format("D MMMM YYYY");
+                this.elem.replaceSelection(md, "end");
+                pass = false;
                 break;
             default:
                 if (this.options.syntax[this.style]) {


### PR DESCRIPTION
Closes #849.
![date](https://f.cloud.github.com/assets/367517/1192581/81d8b4a6-2464-11e3-8a1b-258f2c1fa49a.gif)

Whoops!
