### PR TITLE
Autoconfigure port for iisnode

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -356,7 +356,7 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
 
     // ## Start Ghost App
     server.listen(
-        ghost.config().server.port,
+        process.env.PORT || ghost.config().server.port,
         ghost.config().server.host,
         function () {
 


### PR DESCRIPTION
Fixes #874
- When running on azure or any iisnode environment, the port is dynamic
  and is available in `process.env.PORT`, so we check that environment
  variable before pulling from the config.
