### PR TITLE
Content Security Policy Middleware

### DIFF
--- a/core/client/init.js
+++ b/core/client/init.js
@@ -60,4 +60,5 @@
 
     window.Ghost = Ghost;
 
+    window.addEventListener("load", Ghost.init, false);
 }());

--- a/core/server.js
+++ b/core/server.js
@@ -314,6 +314,15 @@ when.all([ghost.init(), helpers.loadCoreHelpers(ghost)]).then(function () {
 
 
     // ### Admin routes
+    // CSP for admin
+    server.all("/ghost/*", function (req, res, next) {
+        res.set({
+            "Content-Security-Policy": "script-src 'self' style-src 'self'"
+        });
+
+        next();
+    });
+
     /* TODO: put these somewhere in admin */
     server.get(/^\/logout\/?$/, function redirect(req, res) {
         res.redirect(301, '/signout/');

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -40,9 +40,5 @@
         {{{ghostScriptTags}}}
 
         {{{block "bodyScripts"}}}
-
-        <script>
-            Ghost.init();
-        </script>
     </body>
 </html>


### PR DESCRIPTION
Fixes #332
- Added middleware for delivery of CSP headers.
- Set basic policy which blocks remote scripts and styles from /ghost/
- CSP blocks inline scripts by default. Therefore the Ghost.init()
  had to be removed from the HBS and shifted into the init script.
