### PR TITLE
Trim version number to major and minor numbers only in meta tag

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -208,8 +208,11 @@ coreHelpers = function (ghost) {
     });
 
     ghost.registerThemeHelper('ghost_head', function (options) {
-        var head = [];
-        head.push('<meta name="generator" content="Ghost ' + this.version + '" />');
+        var head = [],
+            majorMinor = /^(\d+\.)?(\d+)/,
+            trimmedVersion = this.version.match(majorMinor)[0];
+
+        head.push('<meta name="generator" content="Ghost ' + trimmedVersion + '" />');
         head.push('<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
 
         return ghost.doFilter('ghost_head', head, function (head) {

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -189,9 +189,15 @@ describe('Core Helpers', function () {
         });
 
         it('returns meta tag string', function () {
-            var rendered = handlebars.helpers.ghost_head.call({version: "0.3"});
+            var rendered = handlebars.helpers.ghost_head.call({version: "0.3.0"});
             should.exist(rendered);
             rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
+        });
+
+        it('returns meta tag string even if version is invalid', function () {
+            var rendered = handlebars.helpers.ghost_head.call({version: "0.9"});
+            should.exist(rendered);
+            rendered.string.should.equal('<meta name="generator" content="Ghost 0.9" />\n<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
         });
     });
 


### PR DESCRIPTION
closes #880
- as the version number is under control from package.json use regex to trim
