### PR TITLE
Refactor post.saving to set slug then save

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -61,15 +61,19 @@ Post = GhostBookshelf.Model.extend({
             this.set('published_by', 1);
         }
 
-        GhostBookshelf.Model.prototype.saving.call(this);
-
         if (this.hasChanged('slug')) {
             // Pass the new slug through the generator to strip illegal characters, detect duplicates
             return this.generateSlug(Post, this.get('slug'))
                 .then(function (slug) {
                     self.set({slug: slug});
+
+                    // Still need to call the super saving method
+                    return GhostBookshelf.Model.prototype.saving.call(self);
                 });
         }
+
+        // Just fall through to the super saving call if slug hasn't changed
+        GhostBookshelf.Model.prototype.saving.call(this);
     },
 
     creating: function () {

--- a/core/test/unit/api_posts_spec.js
+++ b/core/test/unit/api_posts_spec.js
@@ -262,6 +262,25 @@ describe('Post Model', function () {
         }).then(null, done);
     });
 
+    it('can create a new Post with a previous published_at date', function (done) {
+        var previousPublishedAtDate = new Date(2013, 8, 21, 12);
+
+        PostModel.add({
+            status: "published",
+            published_at: previousPublishedAtDate,
+            title: "published_at test",
+            markdown: "This is some content"
+        }).then(function (newPost) {
+
+            should.exist(newPost);
+
+            newPost.get("published_at").should.equal(previousPublishedAtDate);
+
+            done();
+
+        }).otherwise(done);
+    });
+
     it('can fetch a paginated set, with various options', function (done) {
         this.timeout(10000); // this is a patch to ensure it doesn't timeout.
 


### PR DESCRIPTION
Instead of saving then generating a new slug we should be generating the new slug and then saving.

The unit test is not really related, but was from testing out whether we were overriding previous published_at dates, figured it wouldn't hurt to add it in.
