### PR TITLE
Added comments to config for ports

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -34,7 +34,9 @@ config = {
             debug: false
         },
         server: {
+            // Host to be passed to node's `net.Server#listen()`
             host: '127.0.0.1',
+            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
             port: '2368'
         }
     },
@@ -53,7 +55,9 @@ config = {
             debug: false
         },
         server: {
+            // Host to be passed to node's `net.Server#listen()`
             host: '127.0.0.1',
+            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
             port: '2368'
         }
     },


### PR DESCRIPTION
Fixes #874
- Added comments to clarify that you should set the port to
  `process.env.PORT` when running ghost under iisnode.
