### PR TITLE
Fix a couple of issues when there are no posts

### DIFF
--- a/core/client/views/blog.js
+++ b/core/client/views/blog.js
@@ -35,6 +35,11 @@
 
         showNext: function () {
             if (this.isLoading) { return; }
+
+            if (!this.collection.length) {
+                return Backbone.trigger('blog:activeItem', null);
+            }
+
             var id = this.collection.at(0).id;
             if (id) {
                 Backbone.trigger('blog:activeItem', id);
@@ -192,10 +197,9 @@
         templateName: "preview",
 
         render: function () {
-            if (this.activeId) {
-                this.model = this.collection.get(this.activeId);
-                this.$el.html(this.template(this.templateData()));
-            }
+            this.model = this.collection.get(this.activeId);
+            this.$el.html(this.template(this.templateData()));
+
             this.$('.content-preview-content').scrollClass({target: '.content-preview', offset: 10});
             this.$('.wrapper').on('click', 'a', function (e) {
                 $(e.currentTarget).attr('target', '_blank');


### PR DESCRIPTION
Fixes #877
- Updated the blog/content view to check `collection.length` before
  attempting to pull another record.
- In the event an item is removed and the collection now has zero items,
  still redraw the preview pane, just with no data.
