### PR TITLE
Added new paragraph keyboard shortcut

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -114,6 +114,13 @@
             case "currentDate":
                 md = moment(new Date()).format("D MMMM YYYY");
                 break;
+            case 'newLine':
+                cursor = this.elem.getCursor();
+                if (this.elem.getLine(cursor.line) !== "") {
+                    this.elem.setLine(cursor.line, this.elem.getLine(cursor.line) + "\n\n");
+                }
+                pass = false;
+                break;
             default:
                 if (this.options.syntax[this.style]) {
                     md = this.options.syntax[this.style].replace('$1', text);

--- a/core/client/tpl/modals/markdown.hbs
+++ b/core/client/tpl/modals/markdown.hbs
@@ -84,6 +84,11 @@
                 <td>Ctrl + Alt + W</td>
             </tr>
             <tr>
+                <td>New Paragraph</td>
+                <td></td>
+                <td>Ctrl / Cmd + Enter</td>
+            </tr>
+            <tr>
                 <td>Uppercase</td>
                 <td></td>
                 <td>Ctrl + U</td>

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -33,7 +33,9 @@
             {'key': 'Ctrl+Alt+W', 'style': 'selectword'},
             {'key': 'Ctrl+L', 'style': 'list'},
             {'key': 'Ctrl+Alt+C', 'style': 'copyHTML'},
-            {'key': 'Meta+Alt+C', 'style': 'copyHTML'}
+            {'key': 'Meta+Alt+C', 'style': 'copyHTML'},
+            {'key': 'Meta+Enter', 'style': 'newLine'},
+            {'key': 'Ctrl+Enter', 'style': 'newLine'}
         ],
         imageMarkdownRegex = /^(?:\{<(.*?)>\})?!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?$/gim,
         markerRegex = /\{<([\w\W]*?)>\}/;


### PR DESCRIPTION
Closes #645.

`Ctrl / Cmd + Enter` now enters a new paragraph, but only if the user is not on a new line.

![enter](https://f.cloud.github.com/assets/367517/1226003/66290d70-2778-11e3-8300-72a5a36fcb6d.gif)

Wont work if on blank line;
![enter2](https://f.cloud.github.com/assets/367517/1226010/80cfef90-2778-11e3-9645-e48a16bfaac9.gif)
^ I am pressing here.
