### PR TITLE
Login is now on /ghost/ as well

### DIFF
--- a/core/client/router.js
+++ b/core/client/router.js
@@ -5,15 +5,14 @@
     Ghost.Router = Backbone.Router.extend({
 
         routes: {
-            ''                 : 'blog',
-            'content/'         : 'blog',
+            ''                  : 'blog',
+            'content/'          : 'blog',
             'settings(/:pane)/' : 'settings',
             'editor(/:id)/'     : 'editor',
-            'debug/'           : 'debug',
-            'register/'        : 'register',
-            'signup/'          : 'signup',
-            'signin/'          : 'login',
-            'forgotten/'       : 'forgotten'
+            'debug/'            : 'debug',
+            'register/'         : 'register',
+            'signup/'           : 'signup',
+            'forgotten/'        : 'forgotten'
         },
 
         signup: function () {
@@ -29,10 +28,16 @@
         },
 
         blog: function () {
-            var posts = new Ghost.Collections.Posts();
-            posts.fetch({ data: { status: 'all', orderBy: ['updated_at', 'DESC'] } }).then(function () {
-                Ghost.currentView = new Ghost.Views.Blog({ el: '#main', collection: posts });
-            });
+            // Hacky, but doesn't matter. Even if they add the element through the console, they still wouldn't be
+            // able to get the posts due to authentication reasons.
+            if ($('.login-box').length > 0) {
+                Ghost.currentView = new Ghost.Views.Login({ el: '.js-login-box' });
+            } else {
+                var posts = new Ghost.Collections.Posts();
+                posts.fetch({ data: { status: 'all', orderBy: ['updated_at', 'DESC'] } }).then(function () {
+                    Ghost.currentView = new Ghost.Views.Blog({ el: '#main', collection: posts });
+                });
+            }
         },
 
         settings: function (pane) {

--- a/core/server.js
+++ b/core/server.js
@@ -44,7 +44,10 @@ function auth(req, res, next) {
             }
             redirect = '?r=' + encodeURIComponent(path);
         }
-        return res.redirect('/ghost/signin/' + redirect);
+
+        if (req.path !== '/ghost/') {
+            return res.redirect('/ghost/' + redirect);
+        }
     }
 
     next();
@@ -319,7 +322,7 @@ when(ghost.init()).then(function () {
 
     // ### Admin routes
     /* TODO: put these somewhere in admin */
-    server.get(/^\/logout\/?$/, function redirect(req, res) {
+    server.get(/^\/logout\/?/, function redirect(req, res) {
         res.redirect(301, '/signout/');
     });
     server.get(/^\/signout\/?$/, admin.logout);

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -237,14 +237,19 @@ adminControllers = {
         };
 
         return api.notifications.add(notification).then(function () {
-            res.redirect('/ghost/signin/');
+            res.redirect('/ghost/');
         });
     },
     'index': function (req, res) {
-        res.render('content', {
-            bodyClass: 'manage',
-            adminNav: setSelected(adminNavbar, 'content')
-        });
+        if (!req.session.user) {
+            adminControllers.login(req, res);
+        } else {
+            res.render('content', {
+                bodyClass: 'manage',
+                adminNav: setSelected(adminNavbar, 'content')
+            });
+        }
+
     },
     'editor': function (req, res) {
         if (req.params.id !== undefined) {

--- a/core/test/functional/admin/01_login_test.js
+++ b/core/test/functional/admin/01_login_test.js
@@ -3,8 +3,8 @@
 casper.test.begin('Ensure Session is Killed', 1, function suite(test) {
     test.filename = 'login_logout_test.png';
 
-    casper.start(url + 'logout/', function (response) {
-        test.assertUrlMatch(/ghost\/sign/, 'We got redirected to signin or signup page');
+    casper.start(url + 'signout/', function (response) {
+        test.assertUrlMatch(/ghost(\/signup)?/, 'We got redirected to signin or signup page');
     });
 
     casper.run(function () {
@@ -43,7 +43,7 @@ casper.test.begin('Ensure Session is Killed after Registration', 1, function sui
     test.filename = 'login_logout2_test.png';
 
     casper.start(url + 'logout/', function then() {
-        test.assertUrlMatch(/ghost\/signin/, 'We got redirected to signin page');
+        test.assertUrlMatch(/ghost\//, 'We got redirected to signin page');
     });
 
     casper.run(function () {
@@ -56,7 +56,7 @@ casper.test.begin("Ghost admin will load login page", 2, function suite(test) {
 
     casper.start(url + "ghost", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
-        test.assertUrlMatch(/ghost\/signin\/$/, 'If we\'re not already registered, we should be logged in.');
+        test.assertUrlMatch(/ghost\/$/, 'If we\'re not already registered, we should be logged in.');
     }).viewport(1280, 1024);
 
     casper.run(function () {
@@ -64,23 +64,26 @@ casper.test.begin("Ghost admin will load login page", 2, function suite(test) {
     });
 });
 
-casper.test.begin('Redirects to signin', 2, function suite(test) {
-    test.filename = 'login_redirect_test.png';
 
-    casper.start(url + 'ghost/login/', function testRedirect(response) {
-        test.assertEqual(response.status, 200, 'Response status should be 200.');
-        test.assertUrlMatch(/ghost\/signin\/$/, 'Should be redirected to /signin/.');
-    });
+// Removed due to not needing because of fix for #484
 
-    casper.run(function () {
-        test.done();
-    });
-});
+// casper.test.begin('Redirects to signin', 2, function suite(test) {
+//     test.filename = 'login_redirect_test.png';
+
+//     casper.start(url + 'ghost/', function testRedirect(response) {
+//         test.assertEqual(response.status, 200, 'Response status should be 200.');
+//         test.assertUrlMatch(/ghost\/$/, 'Should be redirected to /signin/.');
+//     });
+
+//     casper.run(function () {
+//         test.done();
+//     });
+// });
 
 casper.test.begin("Can't spam it", 4, function suite(test) {
     test.filename = "login_spam_test.png";
 
-    casper.start(url + "ghost/signin/", function testTitle() {
+    casper.start(url + "ghost/", function testTitle() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
     }).viewport(1280, 1024);
 
@@ -116,7 +119,7 @@ casper.test.begin("Can't spam it", 4, function suite(test) {
 casper.test.begin("Can login to Ghost", 4, function suite(test) {
     test.filename = "login_test.png";
 
-    casper.start(url + "ghost/login/", function testTitle() {
+    casper.start(url + "ghost/", function testTitle() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
     }).viewport(1280, 1024);
 
@@ -124,6 +127,10 @@ casper.test.begin("Can login to Ghost", 4, function suite(test) {
         function then() {
             this.fill("#login", user, true);
         });
+
+    // had to add it because the waitforresource would run immediately before login would happen
+    // due to same url
+    casper.wait(500);
 
     casper.waitForResource(/ghost\/$/, function testForDashboard() {
         test.assertUrlMatch(/ghost\/$/, 'We got redirected to the Ghost page');

--- a/core/test/functional/admin/07_logout_test.js
+++ b/core/test/functional/admin/07_logout_test.js
@@ -19,7 +19,7 @@ casper.test.begin("Ghost logout works correctly", 2, function suite(test) {
     });
 
     casper.thenClick('.usermenu-signout a');
-    casper.waitForResource(/signin/);
+    casper.waitForResource(/ghost\//);
 
     casper.waitForSelector('.notification-success', function onSuccess() {
         test.assert(true, 'Got success notification');
@@ -36,7 +36,7 @@ casper.test.begin("Ghost logout works correctly", 2, function suite(test) {
 casper.test.begin("Can't spam signin", 3, function suite(test) {
     test.filename = "spam_test.png";
 
-    casper.start(url + "ghost/signin/", function testTitle() {
+    casper.start(url + "ghost/", function testTitle() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
     }).viewport(1280, 1024);
 


### PR DESCRIPTION
Closes #484.
Closes #596.
- Rewrote routes in server.js and routes.js
- Modified tests to accommodate the path change
- If you're not logged in, `/ghost/` will give you the login form
- If you're logged in, `/ghost/` gives you the admin area
- Logout will redirect you to `/ghost/`
