### PR TITLE
Fixing mail.html

### DIFF
--- a/mail.html
+++ b/mail.html
@@ -55,7 +55,6 @@ heading: Setting up Email
             <pre>
 mail: {
     transport: 'SMTP',
-    host: 'smtp.mailgun.org',
     options: {
         service: 'Mailgun',
         auth: {
@@ -71,7 +70,6 @@ mail: {
             <pre>
 mail: {
     transport: 'SMTP',
-    host: 'smtp.mailgun.org',
     options: {
         service: 'Mailgun',
         auth: {


### PR DESCRIPTION
The `host` option for mailgun is not needed apparently
