### PR TITLE
Fix for #938, escaping select fields on toJSON

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -51,7 +51,7 @@ Post = GhostBookshelf.Model.extend({
 
         this.set('html', converter.makeHtml(this.get('markdown')));
 
-        this.set('title', this.get('title').trim());
+        this.set('title', this.escape('title').trim());
 
         if (this.hasChanged('status') && this.get('status') === 'published') {
             if (!this.get('published_at')) {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -73,7 +73,19 @@ Settings = GhostBookshelf.Model.extend({
                 validation[validationName].apply(validation, validationOptions);
             }, this);
         }
+    },
+
+
+    saving: function () {
+
+        // All blog setting keys that need their values to be escaped.
+        if (this.get('type') === 'blog' && _.contains(['title', 'description', 'email'], this.get('key'))) {
+            this.set('value', this.escape('value'));
+        }
+
+        return GhostBookshelf.Model.prototype.saving.apply(this, arguments);
     }
+
 }, {
     read: function (_key) {
         // Allow for just passing the key instead of attributes

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -55,6 +55,13 @@ User = GhostBookshelf.Model.extend({
         }
     },
 
+    saving: function () {
+
+        this.set('name', this.escape('name'));
+
+        return GhostBookshelf.Model.prototype.saving.apply(this, arguments);
+    },
+
     posts: function () {
         return this.hasMany(Posts, 'created_by');
     },

--- a/core/test/unit/api_posts_spec.js
+++ b/core/test/unit/api_posts_spec.js
@@ -367,4 +367,16 @@ describe('Post Model', function () {
             done();
         }).then(null, done);
     });
+
+    it('should escape the title', function (done) {
+
+        new PostModel().fetch().then(function(model) {
+            return model.set({'title': '<script>alert("hello world")</script>'}).save();
+        }).then(function(saved) {
+            saved.get('title').should.eql('&lt;script&gt;alert(&quot;hello world&quot;)&lt;&#x2F;script&gt;');
+            done();
+        }).otherwise(done);
+
+    });
+
 });


### PR DESCRIPTION
Here's one approach... define a `escaped` array on the model and escape them on `toJSON`... Basic test and example with post title included.
