### PR TITLE
Updated to express-hbs v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "engineStrict": true,
     "dependencies": {
         "express": "3.3.4",
-        "express-hbs": "0.2.2",
+        "express-hbs": "0.3.0",
         "connect-slashes": "0.0.9",
         "node-polyglot": "0.2.1",
         "moment": "2.1.0",


### PR DESCRIPTION
Closes #876
- Updated to `express-hbs` v0.3.0 which allows for support of UNC paths.
