### PR TITLE
Fix filepaths for config

### DIFF
--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -1,31 +1,36 @@
 var fs      = require('fs'),
     url     = require('url'),
     when    = require('when'),
-    errors  = require('./server/errorHandling');
+    errors  = require('./server/errorHandling'),
+    path    = require('path'),
+
+    appRoot = path.resolve(__dirname, '../'),
+    configexample = path.join(appRoot, 'config.example.js'),
+    config = path.join(appRoot, 'config.js');
 
 function writeConfigFile() {
     var written = when.defer();
 
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
-    fs.exists('config.example.js', function checkTemplate(templateExists) {
+    fs.exists(configexample, function checkTemplate(templateExists) {
         var read,
             write;
 
         if (!templateExists) {
-            return errors.logError(new Error('Could not locate a configuration file.'), process.cwd(), 'Please check your deployment for config.js or config.example.js.');
+            return errors.logError(new Error('Could not locate a configuration file.'), appRoot, 'Please check your deployment for config.js or config.example.js.');
         }
 
         // Copy config.example.js => config.js
-        read = fs.createReadStream('config.example.js');
+        read = fs.createReadStream(configexample);
         read.on('error', function (err) {
-            return errors.logError(new Error('Could not open config.example.js for read.'), process.cwd(), 'Please check your deployment for config.js or config.example.js.');
+            return errors.logError(new Error('Could not open config.example.js for read.'), appRoot, 'Please check your deployment for config.js or config.example.js.');
         });
         read.on('end', written.resolve);
 
-        write = fs.createWriteStream('config.js');
+        write = fs.createWriteStream(config);
         write.on('error', function (err) {
-            return errors.logError(new Error('Could not open config.js for write.'), process.cwd(), 'Please check your deployment for config.js or config.example.js.');
+            return errors.logError(new Error('Could not open config.js for write.'), appRoot, 'Please check your deployment for config.js or config.example.js.');
         });
 
         read.pipe(write);
@@ -77,7 +82,7 @@ exports.loadConfig = function () {
     var loaded = when.defer();
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
-    fs.exists('config.js', function checkConfig(configExists) {
+    fs.exists(config, function checkConfig(configExists) {
         if (configExists) {
             validateConfigEnvironment().then(loaded.resolve).otherwise(loaded.reject);
         } else {

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -76,7 +76,8 @@ adminControllers = {
             month = currentDate.format('MMM'),
             year =  currentDate.format('YYYY'),
             tmp_path = req.files.uploadimage.path,
-            dir = path.join('content/images', year, month),
+            imagespath = path.join(ghost.paths().appRoot, 'content/images'),
+            dir = path.join(imagespath, year, month),
             ext = path.extname(req.files.uploadimage.name).toLowerCase(),
             type = req.files.uploadimage.type,
             basename = path.basename(req.files.uploadimage.name, ext).replace(/[\W]/gi, '_');
@@ -99,7 +100,7 @@ adminControllers = {
                         }
 
                         // the src for the image must be in URI format, not a file system path, which in Windows uses \
-                        var src = path.join('/', target_path).replace(new RegExp('\\' + path.sep, 'g'), '/');
+                        var src = path.join('/', target_path.replace(ghost.paths().appRoot, "")).replace(new RegExp('\\' + path.sep, 'g'), '/');
                         return res.send(src);
                     });
                 });

--- a/core/test/unit/admin_spec.js
+++ b/core/test/unit/admin_spec.js
@@ -4,6 +4,8 @@ var testUtils = require('./testUtils'),
     sinon = require('sinon'),
     when = require('when'),
     fs = require('fs-extra'),
+    path = require('path'),
+    appRoot = path.resolve(__dirname, '../../../'),
 
     // Stuff we are testing
     admin = require('../../server/controllers/admin');
@@ -143,13 +145,13 @@ describe('Admin Controller', function() {
             it('can upload two different images with the same name without overwriting the first', function(done) {
                 // Sun Sep 08 2013 10:57
                 clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE.jpg').yields(true);
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE-1.jpg').yields(false);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE-1.jpg')).yields(false);
 
                 // if on windows need to setup with back slashes
                 // doesn't hurt for the test to cope with both
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE.jpg').yields(true);
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-1.jpg').yields(false);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(false);
 
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2013/Sep/IMAGE-1.jpg');
@@ -162,18 +164,18 @@ describe('Admin Controller', function() {
             it('can upload five different images with the same name without overwriting the first', function(done) {
                 // Sun Sep 08 2013 10:57
                 clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE.jpg').yields(true);
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE-1.jpg').yields(true);
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE-2.jpg').yields(true);
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE-3.jpg').yields(true);
-                fs.exists.withArgs('content/images/2013/Sep/IMAGE-4.jpg').yields(false);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE-1.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE-2.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE-3.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content/images/2013/Sep/IMAGE-4.jpg')).yields(false);
 
                 // windows setup
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE.jpg').yields(true);
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-1.jpg').yields(true);
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-2.jpg').yields(true);
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-3.jpg').yields(true);
-                fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-4.jpg').yields(false);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE-2.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE-3.jpg')).yields(true);
+                fs.exists.withArgs(path.join(appRoot, 'content\\images\\2013\\Sep\\IMAGE-4.jpg')).yields(false);
 
                 sinon.stub(res, 'send', function(data) {
                     data.should.equal('/content/images/2013/Sep/IMAGE-4.jpg');


### PR DESCRIPTION
no issue
- added appRoot to config-loader.js

Fix is necessary to allow starting Ghost from a directory other than the source code directory.
Example: `node code/Ghost/index.js`
