### PR TITLE
Remove unneeded info from /user api response

### DIFF
--- a/core/server/api.js
+++ b/core/server/api.js
@@ -114,7 +114,11 @@ users = {
             args = {id: this.user};
         }
 
-        return dataProvider.User.read(args);
+        var filteredAttributes = ['password', 'created_by', 'updated_by'];
+
+        return dataProvider.User.read(args).then(function omitAttrs(result) {
+            return _.omit(result, filteredAttributes);
+        });
     },
 
     // #### Edit


### PR DESCRIPTION
I noticed particularly that the hashed password is being returned in the API response for users. While this isn't a security concern as the API is authed, I feel like it probably shouldn't be in the response. While I was at it, removed a couple other pieces of info that are not needed there.

Sorry the promises piece is a little awkward there, but it works. A utility function lke [Q.fcall](https://github.com/kriskowal/q#using-qfcall) would have made it a bit cleaner, but I couldn't find one for `when`.
