### PR TITLE
Submodule fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/themes/casper"]
 	path = content/themes/casper
-	url = git@github.com:TryGhost/Casper.git
+	url = git://github.com:TryGhost/Casper.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "content/themes/casper"]
 	path = content/themes/casper
-	url = git://github.com:TryGhost/Casper.git
+	url = git://github.com/TryGhost/Casper.git


### PR DESCRIPTION
I was using the following instructions (http://www.howtoinstallghost.com/how-to-install-ghost-on-heroku/) to deploy Ghost to Heroku and I ran into an issue when pushing to heroku:

```
$ git push heroku master
Counting objects: 8529, done.
Delta compression using up to 8 threads.

  1 [submodule "content/themes/casper"]
Compressing objects: 100% (4519/4519), done.
Writing objects: 100% (8529/8529), 5.69 MiB | 674.00 KiB/s, done.
Total 8529 (delta 3985), reused 8345 (delta 3807)

-----> Git submodules detected, installing
       Submodule 'content/themes/casper' (git@github.com:TryGhost/Casper.git) registered for path 'content/themes/casper'
       Initialized empty Git repository in /tmp/build_c98e17a1-78b3-4dba-ba61-ca0a0dbd7217/content/themes/casper/.git/
       Host key verification failed.
       fatal: The remote end hung up unexpectedly
       Clone of 'git@github.com:TryGhost/Casper.git' into submodule path 'content/themes/casper' failed

 !     Push rejected, submodule install failed with exit code 1

To git@heroku.com:frozen-waters-8868.git
 ! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to 'git@heroku.com:frozen-waters-8868.git'
```

I believe it's caused by the Casper submodule being referenced by the github read/write SSH URL, if I changed to the read-only URL Heroku was able to initialize the submodule.
- http://stackoverflow.com/questions/11557759/gem-file-with-git-remote-failing-on-heroku-push
