### PR TITLE
Prefer readonly submodule to one that needs ssh

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,7 +143,9 @@ var path           = require('path'),
                         // allow unused parameters
                         unparam: true,
                         // don't require use strict pragma
-                        sloppy: true
+                        sloppy: true,
+                        // allow unfiltered for in
+                        forin: true
                     },
                     files: {
                         src: [

--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -47,7 +47,7 @@ function validateConfigEnvironment() {
         parsedUrl;
 
     try {
-        config = require('../config')[envVal];
+        config = require(config)[envVal];
     } catch (ignore) {
 
     }

--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -6,7 +6,7 @@ var fs      = require('fs'),
 
     appRoot = path.resolve(__dirname, '../'),
     configexample = path.join(appRoot, 'config.example.js'),
-    config = path.join(appRoot, 'config.js');
+    config = process.argv[2] || path.join(appRoot, 'config.js');
 
 function writeConfigFile() {
     var written = when.defer();

--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -43,57 +43,66 @@ function validateConfigEnvironment() {
     var envVal = process.env.NODE_ENV || 'undefined',
         hasHostAndPort,
         hasSocket,
-        config,
+        globalConf,
+        conf,
         parsedUrl;
 
     try {
-        config = require(config)[envVal];
+        globalConf = require(config);
+        conf = globalConf[envVal];
     } catch (ignore) {
 
     }
 
 
     // Check if we don't even have a config
-    if (!config) {
+    if (!conf) {
         errors.logError(new Error('Cannot find the configuration for the current NODE_ENV'), "NODE_ENV=" + envVal, 'Ensure your config.js has a section for the current NODE_ENV value');
         return when.reject();
     }
 
     // Check that our url is valid
-    parsedUrl = url.parse(config.url || 'invalid', false, true);
+    parsedUrl = url.parse(conf.url || 'invalid', false, true);
     if (!parsedUrl.host) {
-        errors.logError(new Error('Your site url in config.js is invalid.'), config.url, 'Please make sure this is a valid url before restarting');
+        errors.logError(new Error('Your site url in config.js is invalid.'), conf.url, 'Please make sure this is a valid url before restarting');
         return when.reject();
     }
 
     // Check that we have database values
-    if (!config.database) {
-        errors.logError(new Error('Your database configuration in config.js is invalid.'), JSON.stringify(config.database), 'Please make sure this is a valid Bookshelf database configuration');
+    if (!conf.database) {
+        errors.logError(new Error('Your database configuration in config.js is invalid.'), JSON.stringify(conf.database), 'Please make sure this is a valid Bookshelf database configuration');
         return when.reject();
     }
 
-    hasHostAndPort = config.server && !!config.server.host && !!config.server.port;
-    hasSocket = config.server && !!config.server.socket;
+    hasHostAndPort = conf.server && !!conf.server.host && !!conf.server.port;
+    hasSocket = conf.server && !!conf.server.socket;
 
     // Check for valid server host and port values
-    if (!config.server || !(hasHostAndPort || hasSocket)) {
-        errors.logError(new Error('Your server values (socket, or host and port) in config.js are invalid.'), JSON.stringify(config.server), 'Please provide them before restarting.');
+    if (!conf.server || !(hasHostAndPort || hasSocket)) {
+        errors.logError(new Error('Your server values (socket, or host and port) in config.js are invalid.'), JSON.stringify(conf.server), 'Please provide them before restarting.');
         return when.reject();
     }
 
-    return when.resolve();
+    return when.resolve(globalConf);
+}
+
+function assignConfig(config) {
+    var i;
+    for (i in config) {
+        exports[i] = config[i];
+    }
 }
 
 exports.loadConfig = function () {
-    var loaded = when.defer();
+    var loaded = when.defer(),
+        pendingConfig;
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
     fs.exists(config, function checkConfig(configExists) {
-        if (configExists) {
-            validateConfigEnvironment().then(loaded.resolve).otherwise(loaded.reject);
-        } else {
-            writeConfigFile().then(validateConfigEnvironment).then(loaded.resolve).otherwise(loaded.reject);
+        if (!configExists) {
+            pendingConfig = writeConfigFile();
         }
+        when(pendingConfig).then(validateConfigEnvironment).then(assignConfig).then(loaded.resolve).otherwise(loaded.reject);
     });
     return loaded.promise;
 };

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -2,7 +2,7 @@
 // Defines core methods required to build the application
 
 // Module dependencies
-var config      = require('../config'),
+var config      = require('./config-loader'),
     when        = require('when'),
     express     = require('express'),
     errors      = require('./server/errorHandling'),

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -4,7 +4,7 @@ var GhostBookshelf,
     moment    = require('moment'),
     _         = require('underscore'),
     uuid      = require('node-uuid'),
-    config    = require('../../../config'),
+    config    = require('../../config-loader'),
     Validator = require('validator').Validator,
     sanitize  = require('validator').sanitize;
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -8,7 +8,7 @@ var Post,
     github = require('../../shared/vendor/showdown/extensions/github'),
     converter = new Showdown.converter({extensions: [github]}),
     User = require('./user').User,
-    config = require('../../../config'),
+    config = require('../../config-loader'),
     Tag = require('./tag').Tag,
     Tags = require('./tag').Tags,
     GhostBookshelf = require('./base');

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -9,7 +9,7 @@ var testUtils = require('./testUtils'),
 
     // Stuff we are testing
     Ghost = require('../../ghost'),
-    defaultConfig = require('../../../config'),
+    defaultConfig = require('../../config-loader'),
     SMTP,
     SENDMAIL,
     fakeConfig,


### PR DESCRIPTION
The current submodule will only help people with write access to TryGhost/Casper, and will only cause grief for everyone else (set them up with an ssh they cannot write to or break their checkout if they tried checking out on https). This pull request makes Ghost safe to download over git for everyone.
