### PR TITLE
Fix emphasize notation in Markdown modal.

### DIFF
--- a/core/client/tpl/modals/markdown.hbs
+++ b/core/client/tpl/modals/markdown.hbs
@@ -15,7 +15,7 @@
             </tr>
             <tr>
                 <td><em>Emphasize</em></td>
-                <td>__text__</td>
+                <td>_text_</td>
                 <td>Ctrl / Cmd + I</td>
             </tr>
             <tr>


### PR DESCRIPTION
fixes #1008
