### PR TITLE
Fixes #1017. Save all settings when the logo or cover is saved

### DIFF
--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -214,7 +214,7 @@
                         success: self.saveSuccess,
                         error: self.saveError
                     }).then(function () {
-                        self.render();
+                        self.saveSettings();
                     });
 
                     return true;
@@ -275,7 +275,7 @@
                         success: self.saveSuccess,
                         error: self.saveError
                     }).then(function () {
-                        self.render();
+                        self.saveUser();
                     });
                     return true;
                 },


### PR DESCRIPTION
Updates both User and General settings <tt>showUpload</tt> callbacks to call <tt>saveSettings</tt> / <tt>saveUser</tt> when a cover, profile or logo image is saved, so that changes to other settings are not lost. 
