### PR TITLE
Load plugins from config; add minimal documentation on plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ projectFilesBackup
 /_site
 /content/data/*
 /content/plugins/**/*
+!/content/plugins/example.js
 /content/themes/**/*
 /content/images/**/*
 !/content/themes/casper/**

--- a/config.example.js
+++ b/config.example.js
@@ -7,6 +7,11 @@ var path = require('path'),
 config = {
     // ### Development **(default)**
     development: {
+        // Allowed plugins. For example, if you had
+        // `content/plugins/example.json`,
+        // then you put it in the list as `example`, i.e.,
+        // `activePlugins: ['example'],`
+        activePlugins: [],
         // The url to use when providing links to the site, E.g. in RSS and email.
         url: 'http://my-ghost-blog.com',
 
@@ -44,6 +49,7 @@ config = {
     // When running Ghost in the wild, use the production environment
     // Configure your URL and mail settings here
     production: {
+        activePlugins: [],
         url: 'http://my-ghost-blog.com',
         mail: {},
         database: {
@@ -67,6 +73,7 @@ config = {
     // Used when developing Ghost to run tests and check the health of Ghost
     // Uses a different port number
     testing: {
+        activePlugins: [],
         url: 'http://127.0.0.1:2369',
         database: {
             client: 'sqlite3',
@@ -83,6 +90,7 @@ config = {
     // ### Travis
     // Automated testing run through Github
     travis: {
+        activePlugins: [],
         url: 'http://127.0.0.1:2368',
         database: {
             client: 'sqlite3',

--- a/content/plugins/README.md
+++ b/content/plugins/README.md
@@ -1,3 +1,9 @@
 # Content / Plugins
 
-Coming soon, Ghost plugins will appear here.
+Insert here any plugins for Ghost.
+
+A minimalistic example is included in `example.js`.
+
+A plugin is an exported object that contains `install` and `activate` methods,
+at a minimum.
+The `activate` method is called just before the server starts up.

--- a/content/plugins/example.js
+++ b/content/plugins/example.js
@@ -1,0 +1,15 @@
+// Minimal example plugin.
+var example = function (ghost) {
+    this.app = ghost;
+};
+
+example.prototype.install = function(ghost) {};
+
+// Called when the server starts up.
+example.prototype.activate = function(ghost) {
+		console.log("Started example plugin");
+		console.log("Current config:");
+		console.log(ghost.config());
+};
+
+module.exports = example;

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -342,8 +342,8 @@ Ghost.prototype.doFilter = function (name, args, callback) {
 
 // Initialise plugins.  Will load from config.activePlugins by default
 Ghost.prototype.initPlugins = function (pluginsToLoad) {
-    pluginsToLoad = pluginsToLoad || models.Settings.activePlugins;
     var self = this;
+    pluginsToLoad = pluginsToLoad || self.config().activePlugins;
 
     return plugins.init(this, pluginsToLoad).then(function (loadedPlugins) {
         // Extend the loadedPlugins onto the available plugins


### PR DESCRIPTION
It looks like there was is some basic support for plugins in Ghost, but the hooks to activate them were not loading from the config file (as the comments suggest they should). This fixes that.

In addition, there was essentially no documentation on the plugin system, nor were there any examples, so I threw together a minimal plugin and some documentation on how to use them (including updating the example configuration file with details on how to load it).
