### PR TITLE
Clean up test database after tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -300,6 +300,9 @@ var path           = require('path'),
             clean: {
                 build: {
                     src: ['<%= paths.buildBuild %>/**']
+                },
+                test: {
+                    src: ['content/data/ghost-test.db']
                 }
             },
 
@@ -859,10 +862,10 @@ var path           = require('path'),
         grunt.registerTask('init', ['shell:bourbon', 'default']);
 
         // Run unit tests
-        grunt.registerTask('test-unit', ['setTestEnv', 'loadConfig', 'express:test', 'mochacli:all']);
+        grunt.registerTask('test-unit', ['clean:test', 'setTestEnv', 'loadConfig', 'express:test', 'mochacli:all']);
 
         // Run casperjs tests only
-        grunt.registerTask('test-functional', ['setTestEnv', 'express:test', 'spawn-casperjs']);
+        grunt.registerTask('test-functional', ['clean:test', 'setTestEnv', 'express:test', 'spawn-casperjs']);
 
         // Run tests and lint code
         grunt.registerTask('validate', ['jslint', 'test-unit', 'test-functional']);

--- a/core/test/functional/admin/logout_test.js
+++ b/core/test/functional/admin/logout_test.js
@@ -4,6 +4,8 @@
 
 /*globals casper, __utils__, url, testPost, falseUser, email */
 CasperTest.begin("Ghost logout works correctly", 2, function suite(test) {
+    CasperTest.Routines.register.run(test);
+    CasperTest.Routines.logout.run(test);
     CasperTest.Routines.login.run(test);
 
     casper.thenOpen(url + "ghost/", function then() {

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -109,7 +109,7 @@ var CasperTest = (function() {
         var runTest = function (test) {
             test.filename = testName.toLowerCase().replace(/ /g, '-').concat('.png');
 
-            casper.start().viewport(1280, 1024);
+            casper.start('about:blank').viewport(1280, 1024);
 
             if (!doNotAutoLogin) {
                 // Only call register once for the lifetime of Mindless
@@ -171,7 +171,10 @@ CasperTest.Routines = (function () {
         });
 
         casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-            this.echo('It appears as though a user is already registered.');
+            var errorText = casper.evaluate(function () {
+                return document.querySelector('.notification-error').innerText;
+            });
+            this.echo('It appears as though a user is already registered. Error text: ' + errorText);
         }, function onTimeout() {
             this.echo('It appears as though a user was not already registered.');
         }, 2000);


### PR DESCRIPTION
Fixes #1064
- Updated grunt config for unit and functional tests to remove the test
  database after each is run.
- Cleaned up a couple of issues with the functional tests that may have
  been causing travis builds to fail randomly, including: the start page
  is now `about:blank` instead of whatever page the last test suite left
  off at, added some checks in the logout tests to ensure they're truly
  independent of the other test suites.
