### PR TITLE
fixes firefox user image disappearance

### DIFF
--- a/core/client/assets/sass/layouts/users.scss
+++ b/core/client/assets/sass/layouts/users.scss
@@ -206,8 +206,8 @@
 
         .img {
             display: block;
-            width: 100%;
-            height: 100%;
+            width: 110px;
+            height: 110px;
             background-image: url(/shared/img/user-image.png);
             background-size: cover;
             background-position: center center;


### PR DESCRIPTION
User image doesn't appear in FF because the `height: 100%` applied to `a` element doesn't get expressed. Setting height / width explicitly to match the wrapper. Tested in FF and Chrome on Linux.

![before](https://f.cloud.github.com/assets/99194/1335576/e486efb6-35ba-11e3-8a7f-41a87059aeff.png)

![after](https://f.cloud.github.com/assets/99194/1335577/e5efa046-35ba-11e3-998a-3f8806f68e89.png)
