### PR TITLE
Block saving to avoid multiple saves

### DIFF
--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -87,6 +87,8 @@
             'published': 'Your post could not be published.'
         },
 
+        savingPost: false,
+
         initialize: function () {
             var self = this;
             // Toggle publish
@@ -202,6 +204,12 @@
         },
 
         savePost: function (data) {
+            if(this.savingPost) {
+                return;
+            } else {
+              this.savingPost = true;
+            }
+              
             _.each(this.model.blacklist, function (item) {
                 this.model.unset(item);
             }, this);
@@ -215,6 +223,7 @@
             // TODO: Take this out if #2489 gets merged in Backbone. Or patch Backbone
             // ourselves for more consistent promises.
             if (saved) {
+                this.savingPost = false;
                 return saved;
             }
             return $.Deferred().reject();

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -204,12 +204,11 @@
         },
 
         savePost: function (data) {
-            if(this.savingPost) {
+            if (this.savingPost) {
                 return;
-            } else {
-              this.savingPost = true;
             }
-              
+            this.savingPost = true;
+
             _.each(this.model.blacklist, function (item) {
                 this.model.unset(item);
             }, this);

--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -66,6 +66,7 @@
         },
 
         statusMap: null,
+        savingPost: false,
 
         createStatusMap: {
             'draft': 'Save Draft',
@@ -86,8 +87,6 @@
             'draft': 'Your post could not be saved as a draft.',
             'published': 'Your post could not be published.'
         },
-
-        savingPost: false,
 
         initialize: function () {
             var self = this;


### PR DESCRIPTION
When rapidly (maybe accidentally) clicking save or using the shortcut creates multiple new posts.
This blocks further saving when a save is in progress.
