### PR TITLE
Fix notification bug

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -90,7 +90,7 @@
                 newPubDate = pubDateEl.value;
 
             // Ensure the published date has changed
-            if (newPubDate.length === 0 || pubDate === newPubDate) {
+            if (newPubDate.length === 0 || moment(pubDate).format("DD MMM YY") === newPubDate) {
                 pubDateEl.value = pubDate === undefined ? 'Not Published' : moment(pubDate).format("DD MMM YY");
                 return;
             }


### PR DESCRIPTION
The date stored in the model is in a different format and needs to be converted before being checked. Otherwise, any blur event will trigger the notification that the date has been changed, even if the date is the same.
