### PR TITLE
Add otherwise error callback to redirectToSignup promise. Fixes #1071

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -74,9 +74,10 @@ function redirectToSignup(req, res, next) {
         if (users.length === 0) {
             return res.redirect('/ghost/signup/');
         }
+        next();
+    }).otherwise(function (err) {
+        return next(new Error(err));
     });
-
-    next();
 }
 
 // While we're here, let's clean up on aisle 5


### PR DESCRIPTION
Attach errorHandling via `otherwise` callback to `redirectToSignup` promise.

Manually tested by forcing error conditions, experienced valid error behavior.

`grunt validate` results look ok:
PASS 133 tests executed in 149.622s, 133 passed, 0 failed, 0 dubious, 0 skipped.
