### PR TITLE
Accept a config filename as an optional parameter to Ghost start-up.

### DIFF
--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -3,10 +3,11 @@ var fs      = require('fs'),
     when    = require('when'),
     errors  = require('./server/errorHandling'),
     path    = require('path'),
+    _       = require("underscore"),
 
     appRoot = path.resolve(__dirname, '../'),
     configexample = path.join(appRoot, 'config.example.js'),
-    config = path.join(appRoot, 'config.js');
+    configFile = process.argv[2] || process.env.GHOST_CONFIG || path.join(appRoot, 'config.js');
 
 function writeConfigFile() {
     var written = when.defer();
@@ -28,7 +29,7 @@ function writeConfigFile() {
         });
         read.on('end', written.resolve);
 
-        write = fs.createWriteStream(config);
+        write = fs.createWriteStream(configFile);
         write.on('error', function (err) {
             return errors.logError(new Error('Could not open config.js for write.'), appRoot, 'Please check your deployment for config.js or config.example.js.');
         });
@@ -47,7 +48,7 @@ function validateConfigEnvironment() {
         parsedUrl;
 
     try {
-        config = require('../config')[envVal];
+        config = require(configFile)[envVal];
     } catch (ignore) {
 
     }
@@ -81,19 +82,19 @@ function validateConfigEnvironment() {
         return when.reject();
     }
 
-    return when.resolve();
+    return when.resolve(config);
 }
 
 exports.loadConfig = function () {
-    var loaded = when.defer();
+    var loaded = when.defer(),
+        pendingConfig;
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
-    fs.exists(config, function checkConfig(configExists) {
-        if (configExists) {
-            validateConfigEnvironment().then(loaded.resolve).otherwise(loaded.reject);
-        } else {
-            writeConfigFile().then(validateConfigEnvironment).then(loaded.resolve).otherwise(loaded.reject);
+    fs.exists(configFile, function checkConfig(configExists) {
+        if (!configExists) {
+            pendingConfig = writeConfigFile();
         }
+        when(pendingConfig).then(validateConfigEnvironment).then(_.extend.bind(null, exports)).then(loaded.resolve).otherwise(loaded.reject);
     });
     return loaded.promise;
 };

--- a/core/ghost.js
+++ b/core/ghost.js
@@ -2,7 +2,7 @@
 // Defines core methods required to build the application
 
 // Module dependencies
-var config      = require('../config'),
+var config      = require('./config-loader'),
     when        = require('when'),
     express     = require('express'),
     errors      = require('./server/errorHandling'),

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -4,7 +4,7 @@ var GhostBookshelf,
     moment    = require('moment'),
     _         = require('underscore'),
     uuid      = require('node-uuid'),
-    config    = require('../../../config'),
+    config    = require('../../config-loader'),
     Validator = require('validator').Validator,
     sanitize  = require('validator').sanitize;
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -8,7 +8,7 @@ var Post,
     github = require('../../shared/vendor/showdown/extensions/github'),
     converter = new Showdown.converter({extensions: [github]}),
     User = require('./user').User,
-    config = require('../../../config'),
+    config = require('../../config-loader'),
     Tag = require('./tag').Tag,
     Tags = require('./tag').Tags,
     GhostBookshelf = require('./base');

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -9,7 +9,7 @@ var testUtils = require('./testUtils'),
 
     // Stuff we are testing
     Ghost = require('../../ghost'),
-    defaultConfig = require('../../../config'),
+    defaultConfig = require('../../config-loader'),
     SMTP,
     SENDMAIL,
     fakeConfig,


### PR DESCRIPTION
This feature pull-request permits a single argument to be passed into Ghost: a config filename to use, which will override the default ${appRoot}/config.js if specified.

This feature permits a single instance of Ghost to exist that any number of individual software users can use. Without this, any Ghost user needs a full checkout. For example, with this feature a sysadmin could install /opt/ghost read-only, and I could run `node /opt/ghost/index /home/rektide/.config/ghost/config.js` while my admin also starts `node /opt/ghost/index /srv/ghost/config.js`. Enabling this division between the software-package and a service's specific data is faithful to the Filesystem Hierarchy specs's division between /opt and /srv;
http://www.pathname.com/fhs/pub/fhs-2.3.html#OPTADDONAPPLICATIONSOFTWAREPACKAGES
http://www.pathname.com/fhs/pub/fhs-2.3.html#SRVDATAFORSERVICESPROVIDEDBYSYSTEM

Briefly on implementation, this pull-request enhances config-loader's current role as a validation pass, promoting it's own exports with the values it validates. The remainder of Ghost points to the config-loader instead of having a hardcoded path to the config file.

Thank you. Please let me know if there's anything I can do to help facilitate this patch.
