### PR TITLE
Fix style issue on user-image on Firefox and Opera

### DIFF
--- a/core/client/assets/sass/layouts/users.scss
+++ b/core/client/assets/sass/layouts/users.scss
@@ -190,7 +190,7 @@
 
     .user-image {
         @include box-sizing(border-box);
-        display: table;
+        display: block;
         position: relative;
         width: 120px;
         height: 120px;
@@ -211,6 +211,7 @@
             background-image: url(/shared/img/user-image.png);
             background-size: cover;
             background-position: center center;
+            border-radius: 100%;
         }
 
         &:hover {


### PR DESCRIPTION
On both Firefox and Opera (OSX) the user image badge in
the settings page wasn't displayed.
Also, on firefox the badge overlay didn't have the proper size.

I don't know if there's a specific use case requiring a `display:
table` instead of a plain `display: block` but that was failing on
Firefox and Opera.

Using a block instead seems works perfectly (at least on Opera, Chrome,
Safari, Safari Mobile IOS7 and Firefox) regarding the badge size issue.

On Opera, though, the border radius wasn't applied properly to the
image. Adding a `border-radius: 100%;`fix that.
