### PR TITLE
fixed license url

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "licenses"    : [
         {
             "type": "MIT",
-            "url": "https://raw.github.com/TryGhost/Ghost/master/LICENSE.txt"
+            "url": "https://raw.github.com/TryGhost/Ghost/master/LICENSE"
         }
     ],
     "scripts": {


### PR DESCRIPTION
In my continued crusade (#1099) to ensure Ghost licensing is just right I have now updated and fixed the url typo in package.json. I know I am amazing. :)
