### PR TITLE
Fix bug with running Ghost from external directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@
 var configLoader = require('./core/config-loader.js'),
     error        = require('./core/server/errorHandling');
 
+// Set CWD to current directory to allow ghost launching from anywhere
+process.chdir(__dirname);
+
 // If no env is set, default to development
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 


### PR DESCRIPTION
Hi there!

We currently cannot run Ghost from another directory than the root as it uses relative paths all over the place. This mean that when the CWD is not the index.js directory, paths breaks.

So here I just enforce the CWD of the Ghost process to be the root of the project.

``` bash
# Currently this break, the fix allow this
$ node /www/ghost/index.js
```

This may be minor, but when running Ghost/Node as a service on a Unix server, being able to launch Ghost from an external directory is useful.
