### PR TITLE
The scroll bar is hidden in chrome and alignment is off in IE and FF.

### DIFF
--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -1162,7 +1162,7 @@ main {
     position: absolute;
     top:0;
     left:0;
-    right:0;
+    right:16px;
     z-index: 400;
     height: 40px;
     padding: 12px 15px;


### PR DESCRIPTION
Tiny change to the floating headers in markdown view. Scroll bar was hidden, checked in Chrome, FF and IE10.
![hidden scroll bars](https://f.cloud.github.com/assets/448410/1346111/4fadf56a-369b-11e3-8319-561aa68b36ea.gif)
