### PR TITLE
Fixed intermittent test errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,7 +203,8 @@ var path           = require('path'),
             mochacli: {
                 options: {
                     ui: 'bdd',
-                    reporter: 'spec'
+                    reporter: 'spec',
+                    timeout: '15000'
                 },
 
                 all: {

--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -102,7 +102,7 @@ CasperTest.begin('Title Trimming', 2, function suite(test) {
     });
 });
 
-CasperTest.begin('Publish menu - new post', 11, function suite(test) {
+CasperTest.begin('Publish menu - new post', 10, function suite(test) {
     casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", 'Ghost admin has no title');
     });
@@ -127,17 +127,18 @@ CasperTest.begin('Publish menu - new post', 11, function suite(test) {
     });
 
     // ... check status, label, class
-    casper.then(function () {
-        test.assertExists('.js-publish-splitbutton.splitbutton-delete', 'Publish split button should have .splitbutton-delete');
+    casper.waitForSelector('.js-publish-splitbutton.splitbutton-delete', function onSuccess() {
         test.assertExists('.js-publish-button.button-delete', 'Publish button should have .button-delete');
         test.assertSelectorHasText('.js-publish-button', 'Publish Now');
         test.assertEval(function() {
             return (__utils__.findOne('.js-publish-button').getAttribute('data-status') === 'published');
         }, 'Publish button\'s updated status should be "published"');
+    }, function onTimeout() {
+        test.assert(false, 'Publish split button should have .splitbutton-delete');
     });
 });
 
-CasperTest.begin('Publish menu - existing post', 24, function suite(test) {
+CasperTest.begin('Publish menu - existing post', 22, function suite(test) {
     // Create a post, save it and test refreshed editor
     casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", 'Ghost admin has no title');
@@ -179,13 +180,14 @@ CasperTest.begin('Publish menu - existing post', 24, function suite(test) {
     casper.thenClick('.js-publish-splitbutton li[data-set-status="published"]');
 
     // ... check status, label, class
-    casper.then(function () {
-        test.assertExists('.js-publish-splitbutton.splitbutton-delete', 'Publish split button should have .splitbutton-delete');
+    casper.waitForSelector('.js-publish-splitbutton.splitbutton-delete', function onSuccess() {
         test.assertExists('.js-publish-button.button-delete', 'Publish button should have .button-delete');
         test.assertSelectorHasText('.js-publish-button', 'Publish Now');
         test.assertEval(function() {
             return (__utils__.findOne('.js-publish-button').getAttribute('data-status') === 'published');
         }, 'Publish button\'s updated status should be "published"');
+    }, function onTimeout() {
+        test.assert(false, 'Publish split button should have .splitbutton-delete');
     });
 
     // Publish the post
@@ -215,12 +217,13 @@ CasperTest.begin('Publish menu - existing post', 24, function suite(test) {
     casper.thenClick('.js-publish-splitbutton li[data-set-status="draft"]');
 
     // ... check status, label, class
-    casper.then(function () {
-        test.assertExists('.js-publish-splitbutton.splitbutton-delete', 'Publish split button should have .splitbutton-delete');
+    casper.waitForSelector('.js-publish-splitbutton.splitbutton-delete', function onSuccess() {
         test.assertExists('.js-publish-button.button-delete', 'Publish button should have .button-delete');
         test.assertSelectorHasText('.js-publish-button', 'Unpublish');
         test.assertEval(function() {
             return (__utils__.findOne('.js-publish-button').getAttribute('data-status') === 'draft');
         }, 'Publish button\'s updated status should be "draft"');
+    }, function onTimeout() {
+        test.assert(false, 'Publish split button should have .splitbutton-delete');
     });
 });

--- a/core/test/unit/api_posts_spec.js
+++ b/core/test/unit/api_posts_spec.js
@@ -16,7 +16,6 @@ describe('Post API', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData()
             .then(function () {
                 return testUtils.insertDefaultFixtures();

--- a/core/test/unit/export_spec.js
+++ b/core/test/unit/export_spec.js
@@ -22,7 +22,6 @@ describe("Exporter", function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData().then(function () {
             done();
         }, done);

--- a/core/test/unit/ghost_spec.js
+++ b/core/test/unit/ghost_spec.js
@@ -22,7 +22,6 @@ describe("Ghost API", function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         sandbox = sinon.sandbox.create();
 
         testUtils.initData().then(function () {

--- a/core/test/unit/import_spec.js
+++ b/core/test/unit/import_spec.js
@@ -43,8 +43,6 @@ describe("Import", function () {
     });
 
     describe("000", function () {
-        this.timeout(4000);
-
         should.exist(Importer000);
 
         it("imports data from 000", function (done) {

--- a/core/test/unit/model_permissions_spec.js
+++ b/core/test/unit/model_permissions_spec.js
@@ -19,7 +19,6 @@ describe("Permission Model", function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData().then(function () {
             done();
         }, done);

--- a/core/test/unit/model_posts_spec.js
+++ b/core/test/unit/model_posts_spec.js
@@ -20,7 +20,6 @@ describe('Post Model', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData()
             .then(function () {
                 return testUtils.insertDefaultFixtures();
@@ -84,7 +83,6 @@ describe('Post Model', function () {
     });
 
     it('can findOne, returning author and user data', function (done) {
-        this.timeout(5000);
         var firstPost;
 
         PostModel.findOne({}).then(function (result) {
@@ -185,8 +183,6 @@ describe('Post Model', function () {
                 title: 'Test Title',
                 markdown: 'Test Content 1'
             };
-
-        this.timeout(5000); // this is a patch to ensure it doesn't timeout.
 
         // Create 12 posts with the same title
         sequence(_.times(12, function (i) {
@@ -322,8 +318,6 @@ describe('Post Model', function () {
     });
 
     it('can fetch a paginated set, with various options', function (done) {
-        this.timeout(10000); // this is a patch to ensure it doesn't timeout.
-
         testUtils.insertMorePosts().then(function () {
 
             return PostModel.findPage({page: 2});

--- a/core/test/unit/model_roles_spec.js
+++ b/core/test/unit/model_roles_spec.js
@@ -19,7 +19,6 @@ describe("Role Model", function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData().then(function () {
             done();
         }, done);

--- a/core/test/unit/model_settings_spec.js
+++ b/core/test/unit/model_settings_spec.js
@@ -18,7 +18,6 @@ describe('Settings Model', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData().then(function () {
             done();
         }, done);

--- a/core/test/unit/model_tags_spec.js
+++ b/core/test/unit/model_tags_spec.js
@@ -19,7 +19,6 @@ describe('Tag Model', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData()
             .then(function () {
                 done();

--- a/core/test/unit/model_users_spec.js
+++ b/core/test/unit/model_users_spec.js
@@ -26,7 +26,6 @@ describe('User Model', function run() {
 
     describe('Registration', function runRegistration() {
         beforeEach(function (done) {
-            this.timeout(5000);
             testUtils.initData().then(function () {
                 done();
             }, done);
@@ -49,7 +48,6 @@ describe('User Model', function run() {
     describe('Basic Operations', function () {
 
         beforeEach(function (done) {
-            this.timeout(5000);
             testUtils.initData()
                 .then(function () {
                     return when(testUtils.insertDefaultUser());

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -23,7 +23,6 @@ describe('Permissions', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         testUtils.initData()
             .then(testUtils.insertDefaultUser)
             .then(function () {

--- a/core/test/unit/plugins_spec.js
+++ b/core/test/unit/plugins_spec.js
@@ -22,7 +22,6 @@ describe('Plugins', function () {
     });
 
     beforeEach(function (done) {
-        this.timeout(5000);
         sandbox = sinon.sandbox.create();
 
         testUtils.initData().then(function () {


### PR DESCRIPTION
Fixes #1124
- Updated default mocha timeout to 15 seconds. Any future tests that
  depend on a timeout (and thus might be better off with a lower value)
  can override the default setting which is now 15 seconds.
- Removed test-specific timeout overrides for the mocha tests.
- Fixed the editor/splitbutton tests to wait for the appropriate
  selector instead of assuming the dom has been updated immediately.
  Should resolve intermittent timeouts when checking the splitbutton's
  applied classes.
