### PR TITLE
fixed typo in comments of manage.scss

### DIFF
--- a/core/client/assets/sass/layouts/manage.scss
+++ b/core/client/assets/sass/layouts/manage.scss
@@ -1,5 +1,5 @@
 /*
- * These styles control elements specific to the mage posts screen
+ * These styles control elements specific to the manage posts screen
  * used for previewing and reading existing content in Ghost.
  *
  * Table of Contents:


### PR DESCRIPTION
The mage posts screen is probably supposed to be the manage posts screen.
