### PR TITLE
Fix CasperJS warning when running tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -519,7 +519,7 @@ var path           = require('path'),
         grunt.registerTask('spawn-casperjs', function () {
             var done = this.async(),
                 options = ['host', 'noPort', 'port', 'email', 'password'],
-                args = ['test', 'admin/', 'frontend/', '--includes=base.js', '--direct', '--log-level=debug', '--port=2369'];
+                args = ['test', 'admin/', 'frontend/', '--includes=base.js', '--verbose', '--log-level=debug', '--port=2369'];
 
             // Forward parameters from grunt to casperjs
             _.each(options, function processOption(option) {


### PR DESCRIPTION
Running the tests will make CasperJS complain about the `--direct` parameter which has been replaced by `--verbose` in 1.1. 
