### PR TITLE
Fixes bug at content list pagination

### DIFF
--- a/core/client/views/blog.js
+++ b/core/client/views/blog.js
@@ -35,6 +35,7 @@
         initialize: function (options) {
             this.$('.content-list-content').scrollClass({target: '.content-list', offset: 10});
             this.listenTo(this.collection, 'remove', this.showNext);
+            this.listenTo(this.collection, 'add', this.renderPost);
             // Can't use backbone event bind (see: http://stackoverflow.com/questions/13480843/backbone-scroll-event-not-firing)
             this.$('.content-list-content').scroll($.proxy(this.checkScroll, this));
         },
@@ -91,10 +92,11 @@
                     status: 'all',
                     page: (self.collection.currentPage + 1),
                     orderBy: ['updated_at', 'DESC']
-                }
+                },
+                remove: false
             }).then(function onSuccess(response) {
-                self.render();
                 self.isLoading = false;
+                self.showNext();
             }, function onError(e) {
                 self.reportLoadError(e);
             });
@@ -102,9 +104,13 @@
 
         render: function () {
             this.collection.each(function (model) {
-                this.$('ol').append(this.addSubview(new ContentItem({model: model})).render().el);
+                this.renderPost(model);
             }, this);
             this.showNext();
+        },
+
+        renderPost: function (newPost) {
+            this.$('ol').append(this.addSubview(new ContentItem({model: newPost})).render().el);
         }
 
     });


### PR DESCRIPTION
Fixes #818. This bug was caused by `this.collection.fetch`, which is called when the content list scroll bar passes the threshold and we have to load more posts. With no options passed, `Backbone.Collection.fetch` will clear its collection and populate with new data retrieved from the server. So every time you scroll down till AJAX request happens, then scroll up and select the first post for example, preview pane will be empty.

Following changes are made:
- Pass `remove: false` to  `this.collection.fetch` so that collection is not reset.
- Added function `renderNew(newModel)` which will render only new items.
