### PR TITLE
add a `target` arg to `grunt test-functional`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -519,7 +519,9 @@ var path           = require('path'),
         grunt.registerTask('spawn-casperjs', function () {
             var done = this.async(),
                 options = ['host', 'noPort', 'port', 'email', 'password'],
-                args = ['test', 'admin/', 'frontend/', '--includes=base.js', '--verbose', '--log-level=debug', '--port=2369'];
+                args = ['test']
+                           .concat(grunt.option('target') || ['admin/', 'frontend/'])
+                           .concat(['--includes=base.js', '--verbose', '--log-level=debug', '--port=2369']);
 
             // Forward parameters from grunt to casperjs
             _.each(options, function processOption(option) {


### PR DESCRIPTION
The idea here is to slightly speed up test development by allowing you
to specify a single test file to run.

Sample invocation:
`grunt test-functional --target=admin/content_test.js`
