### PR TITLE
Add charset declaration to protect OS/envs that don't default to utf-8.

### DIFF
--- a/core/client/assets/sass/layouts/errors.scss
+++ b/core/client/assets/sass/layouts/errors.scss
@@ -1,3 +1,4 @@
+@charset "utf-8";
 /*
  * These styles control elements specific to the error screens
  *


### PR DESCRIPTION
Fixes #1173

This declaration, though redundant for OSes and environments which autodetect the file as utf-8, is invaluable for those that do not.
