### PR TITLE
Add tooltip text to icons in admin section

### DIFF
--- a/core/client/assets/lib/uploader.js
+++ b/core/client/assets/lib/uploader.js
@@ -8,7 +8,7 @@
     UploadUi = function ($dropzone, settings) {
         var source,
             $url = '<div class="js-url"><input class="url js-upload-url" type="url" placeholder="http://"/></div>',
-            $cancel = '<a class="image-cancel js-cancel"><span class="hidden">Delete</span></a>',
+            $cancel = '<a class="image-cancel js-cancel" title="Delete"><span class="hidden">Delete</span></a>',
             $progress =  $('<div />', {
                 "class" : "js-upload-progress progress progress-success active",
                 "role": "progressbar",

--- a/core/client/tpl/list-item.hbs
+++ b/core/client/tpl/list-item.hbs
@@ -1,4 +1,4 @@
-<a class="permalink{{#if featured}} featured{{/if}}" href="#">
+<a class="permalink{{#if featured}} featured{{/if}}" href="#" title="Edit this post">
     <h3 class="entry-title">{{{title}}}</h3>
     <section class="entry-meta">
         <time datetime="2013-01-04" class="date">

--- a/core/client/tpl/modal.hbs
+++ b/core/client/tpl/modal.hbs
@@ -1,7 +1,7 @@
 <article class="modal{{#if options.type}}-{{options.type}}{{/if}} {{#if options.style}}{{#each options.style}}modal-style-{{this}} {{/each}}{{/if}}{{options.animation}} js-modal">
     <section class="modal-content">
         {{#if content.title}}<header class="modal-header"><h1>{{content.title}}</h1></header>{{/if}}
-        {{#if options.close}}<a class="close" href="#"><span class="hidden">Close</span></a>{{/if}}
+        {{#if options.close}}<a class="close" href="#" title="Close"><span class="hidden">Close</span></a>{{/if}}
         <section class="modal-body">
         </section>
         {{#if options.confirm}}

--- a/core/client/tpl/preview.hbs
+++ b/core/client/tpl/preview.hbs
@@ -1,6 +1,6 @@
 <header class="floatingheader">
     <button class="button-back" href="#">Back</button>
-    <a class="{{#if featured}}featured{{else}}unfeatured{{/if}}" href="#">
+    <a class="{{#if featured}}featured{{else}}unfeatured{{/if}}" href="#" title="{{#if featured}}Unfeature{{else}}Feature{{/if}} this post">
         <span class="hidden">Star</span>
     </a>
     {{! TODO: JavaScript toggle featured/unfeatured}}
@@ -8,8 +8,8 @@
     <span class="normal">by</span>
     <span class="author">{{#if author.name}}{{author.name}}{{else}}{{author.email}}{{/if}}</span>
     <section class="post-controls">
-        <a class="post-edit" href="#"><span class="hidden">Edit Post</span></a>
-        <a class="post-settings" href="#" data-toggle=".post-settings-menu"><span class="hidden">Post Settings</span></a>
+        <a class="post-edit" href="#" title="Edit Post"><span class="hidden">Edit Post</span></a>
+        <a class="post-settings" href="#" data-toggle=".post-settings-menu" title="Post Settings"><span class="hidden">Post Settings</span></a>
         <ul class="post-settings-menu menu-drop-right overlay">
             <li class="post-setting">
                 <div class="post-setting-label">

--- a/core/server/views/content.hbs
+++ b/core/server/views/content.hbs
@@ -5,7 +5,7 @@
           <section class="content-filter">
               <span>All Posts</span>
           </section>
-          <a href="/ghost/editor/" class="button button-add"><span class="hidden">New Post</span></a>
+          <a href="/ghost/editor/" class="button button-add" title="New Post"><span class="hidden">New Post</span></a>
       </header>
       <section class="content-list-content">
           <ol></ol>

--- a/core/server/views/editor.hbs
+++ b/core/server/views/editor.hbs
@@ -33,7 +33,7 @@
 <footer id="publish-bar">
     <nav>
         <section id="entry-tags" href="#" class="left">
-            <label class="tag-label" for="tags"><span class="hidden">Tags</span></label>
+            <label class="tag-label" for="tags" title="Tags"><span class="hidden">Tags</span></label>
             <div class="tags"></div>
             <input type="hidden" class="tags-holder" id="tags-holder">
             <input class="tag-input" id="tags" type="text" data-input-behaviour="tag" />
@@ -42,7 +42,7 @@
         <div class="right">
 
             <section id="entry-controls">
-                <a class="entry-settings" href="#" data-toggle=".entry-settings-menu"><span class="hidden">Post Settings</span></a>
+                <a class="entry-settings" href="#" data-toggle=".entry-settings-menu" title="Post Settings"><span class="hidden">Post Settings</span></a>
                 <ul class="entry-settings-menu menu-right overlay">
                     <li class="post-setting">
                         <div class="post-setting-label">
@@ -66,7 +66,7 @@
 
             <section id="entry-actions" class="js-publish-splitbutton splitbutton-save">
                 <button type="button" class="js-publish-button button-save"></button>
-                <a class="options up" data-toggle="ul" href="#"><span class="hidden">Options</span></a>
+                <a class="options up" data-toggle="ul" href="#" title="Post Settings"><span class="hidden">Post Settings</span></a>
                 <ul class="editor-options overlay" style="display:none">
                     <li data-set-status="published"><a href="#"></a></li>
                     <li data-set-status="draft"><a href="#"></a></li>

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -1,6 +1,5 @@
-
 <header id="global-header" class="navbar">
-    <a class="ghost-logo" href="{{url absolute="true"}}" data-off-canvas="left"><span class="hidden">Ghost </span></a>{{! TODO: Change this to actual Ghost homepage }}
+    <a class="ghost-logo" href="{{url absolute="true"}}" data-off-canvas="left" title="{{url absolute="true"}}"><span class="hidden">Ghost </span></a>{{! TODO: Change this to actual Ghost homepage }}
     <nav id="global-nav" role="navigation">
         <ul id="main-menu" >
             {{#each adminNav}}


### PR DESCRIPTION
As a user of Ghost I expect to see tooltips on clickable items when hovering my cursor over them. This gives me confidence that I will not click something that would be bad.

This PR adds tooltips to icons in a number of places within the Ghost editor. Including 
- Content Screen
  - Pencil Icon = "Edit"
  - Gear Icon = "Content Actions"
  - Plus Icon = "Create Content"
    *Notifications
  - Close Icon = "Close"
- Menu bar
  - Link to blog = URL of blog
- Editor
  - Question Mark Icon = "Help"
  - Tag Icon = "Tags"
  - Gear Icon = "Content Actions"
