### PR TITLE
Bump connect-slashes to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dependencies": {
         "express": "3.3.4",
         "express-hbs": "0.2.2",
-        "connect-slashes": "0.0.9",
+        "connect-slashes": "0.0.10",
         "node-polyglot": "0.2.1",
         "moment": "2.1.0",
         "underscore": "1.5.1",


### PR DESCRIPTION
seems to kill warning `npm WARN package.json connect-slashes@0.0.9 No repository field.` on `npm install --production`. Unit tests pass.
