### PR TITLE
GitHub recommends 'GitHub' and 'repository'.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 If you discover a security issue in Ghost, please report it by sending an email to security[at]ghost[dot]org
 
-This will allow us to assess the risk, and make a fix available before we add a bug report to the Github repo.
+This will allow us to assess the risk, and make a fix available before we add a bug report to the GitHub repository.
 
 Thanks for helping make Ghost safe for everyone.


### PR DESCRIPTION
Just improve words, per https://github.com/styleguide/words.
