### PR TITLE
Use less markup for links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ If you think you've found a problem with Ghost, or you'd like to make a request 
 6. Run `grunt init` from the root - this installs Bourbon, compiles SASS and compiles Handlebars templates
 7. Run `npm start` from the root to start the server.
 
-Front-end can be located at [localhost:2368](http://localhost:2368), Admin is at [localhost:2368/ghost/](http://localhost:2368/ghost/)
+Front-end can be located at <http://localhost:2368>, Admin is at <http://localhost:2368/ghost/>.
 
 Whist developing you may wish to use **grunt watch** to watch for changes to handlebars and sass and recompile automatically, if you run Ghost in **production** mode, you will need to run **grunt prod** - please see the [Grunt Toolkit docs](https://github.com/TryGhost/Ghost/wiki/Grunt-Toolkit).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ghost is a free, open, simple blogging platform that's available to anyone who wants to use it. Lovingly created and maintained by [John O'Nolan](http://twitter.com/JohnONolan) + [Hannah Wolfe](http://twitter.com/ErisDS) + an amazing group of [contributors](https://github.com/TryGhost/Ghost/contributors).
 
-Visit the project's website at [http://ghost.org](http://ghost.org)!
+Visit the project's website at <http://ghost.org>!
 
 
 ## Getting Started

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 If you discover a security issue in Ghost, please report it by sending an email to security[at]ghost[dot]org
 
-This will allow us to assess the risk, and make a fix available before we add a bug report to the Github repo.
+This will allow us to assess the risk, and make a fix available before we add a bug report to the GitHub repository.
 
 Thanks for helping make Ghost safe for everyone.


### PR DESCRIPTION
This way to parse links is much easier and requires 2 times less markup.
