### PR TITLE
Fixed style of modal in preview.

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -635,23 +635,6 @@ body.zen {
     position: absolute;
     bottom: 44px;
     right: -3px;
-
-    li {
-        a {
-            padding: 10px 15px;
-
-            &:before {
-                font-size: 11px;
-                line-height: 1em;
-            }
-        }
-    }
-
-    .delete {
-        @include icon($i-trash) { position: relative; top: -2px; };
-
-        &:hover { background: $red; }
-    }
 }
 
 #entry-actions {

--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -359,8 +359,7 @@ nav {
         border-top:$lightbrown 1px solid;
     }
 
-    li { font-size:1.1em;
-
+    li { 
         a {
             display:block;
             padding:10px 15px;
@@ -834,6 +833,28 @@ nav {
    Post Settings
    ========================================================================== */
 
+.post-settings-menu {
+    text-transform: none;
+
+    li {
+        a {
+            padding: 10px 15px;
+
+            &:before {
+                font-size: 11px;
+                line-height: 1em;
+                margin-right: 1em;
+            }
+        }
+    }
+
+    .delete {
+        @include icon($i-trash) { position: relative; top: -2px; };
+
+        &:hover { background: $red; }
+    }
+}
+
 .post-setting {
     min-width: 260px;
     border-bottom: 1px solid #35393b;
@@ -1167,7 +1188,6 @@ main {
     height: 40px;
     padding: 12px 15px;
     text-transform: uppercase;
-    font-size: 0.85em;
     color: $brown;
     //Transparent gradient to make bg fade out as it goes out the top.
     @include linear-gradient(top, white 0%, white 25%, rgba(255,255,255,0.9) 100%, $fallback: transparent);
@@ -1200,6 +1220,10 @@ main {
                 display: inline-block;
             }
         }
+    }
+
+    span {
+        font-size: 0.85em;
     }
 
     a {

--- a/core/client/tpl/preview.hbs
+++ b/core/client/tpl/preview.hbs
@@ -27,7 +27,7 @@
                     <input class="post-setting-date" type="text" value="">
                 </div>
             </li>
-            <li><a href="#" class="delete hidden">Delete</a></li>
+            <li><a href="#" class="delete hidden">Delete This Post</a></li>
         </ul>
     </section>
 </header>

--- a/core/server/views/editor.hbs
+++ b/core/server/views/editor.hbs
@@ -43,7 +43,7 @@
 
             <section id="entry-controls">
                 <a class="entry-settings" href="#" data-toggle=".entry-settings-menu"><span class="hidden">Post Settings</span></a>
-                <ul class="entry-settings-menu menu-right overlay">
+                <ul class="post-settings-menu entry-settings-menu menu-right overlay">
                     <li class="post-setting">
                         <div class="post-setting-label">
                             <label for="url">URL</label>


### PR DESCRIPTION
Fixes style of modal in preview panel. I think the modals in the preview panel and editor settings should both match and not have a different styling on them.

![selection_008](https://f.cloud.github.com/assets/176576/1369173/8df013f2-39da-11e3-9d98-a19469ff7616.png)

fixes #1179
