### PR TITLE
Keep the status code generate by connect in case of error.

### DIFF
--- a/core/server/errorHandling.js
+++ b/core/server/errorHandling.js
@@ -191,7 +191,7 @@ errors = {
             }
             errors.renderErrorPage(500, err, req, res, next);
         } else {
-            res.send(500, err);
+            res.send(err.status || 500, err);
         }
     }
 };


### PR DESCRIPTION
The status code generate by connect/express in case of error was always
replace by 500 status.
