### PR TITLE
Correct spelling of GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ If you think you've found a problem with Ghost, or you'd like to make a request 
 
 1. **Search for existing issues** - The most important step! Help us keep duplicate issues to a minimum by checking to see if someone has already reported your problem or requested your idea.
 2. **Describe your issue in detail** - Help us help you. Before opening any issue, please read the [Issue Guidelines](https://github.com/necolas/issue-guidelines), written by [Nicolas Gallagher](https://github.com/necolas/). Include operating system and version, browser and version, version of Ghost, customized or vanilla build, etc. where appropriate. Also include steps to reproduce the bug.
-3. **Include a screencast if relevant** - Is your issue about a design or front end feature or bug? The most helpful thing in the world is if we can *see* what you're talking about. Use [LICEcap](http://www.cockos.com/licecap/) to quickly and easily record a short screencast (24fps) and save it as an animated gif! Embed it directly into your Github issue. Kapow.
+3. **Include a screencast if relevant** - Is your issue about a design or front end feature or bug? The most helpful thing in the world is if we can *see* what you're talking about. Use [LICEcap](http://www.cockos.com/licecap/) to quickly and easily record a short screencast (24fps) and save it as an animated gif! Embed it directly into your GitHub issue. Kapow.
 
 
 ## Working on Ghost Core
@@ -128,7 +128,7 @@ Ghost uses Grunt heavily to automate useful tasks such as building assets, testi
 
 ### I get "ERROR: Failed to lookup view "index"
 
-Sounds like you don't have our default theme - Casper, your content/themes/casper folder is probably empty. When cloning from Github be sure to use SSH and to run `git submodule update --init`. Don't use the release zip file on Github, if you want a zip file use the one from [Ghost.org](http://ghost.org/download).
+Sounds like you don't have our default theme - Casper, your content/themes/casper folder is probably empty. When cloning from GitHub be sure to use SSH and to run `git submodule update --init`. Don't use the release zip file on GitHub, if you want a zip file use the one from [Ghost.org](http://ghost.org/download).
 
 ### I get "Syntax error: File to import not found or unreadable: bourbon/_bourbon."
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 If you discover a security issue in Ghost, please report it by sending an email to security[at]ghost[dot]org
 
-This will allow us to assess the risk, and make a fix available before we add a bug report to the Github repo.
+This will allow us to assess the risk, and make a fix available before we add a bug report to the GitHub repo.
 
 Thanks for helping make Ghost safe for everyone.

--- a/config.example.js
+++ b/config.example.js
@@ -81,7 +81,7 @@ config = {
     },
 
     // ### Travis
-    // Automated testing run through Github
+    // Automated testing run through GitHub
     travis: {
         url: 'http://127.0.0.1:2368',
         database: {


### PR DESCRIPTION
GitHub is the proper way of spelling GitHub.
