### PR TITLE
More verbose error message for invalid JSON in config.js

### DIFF
--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -56,7 +56,7 @@ function validateConfigEnvironment() {
     // Check if we don't even have a config
     if (!config) {
         errors.logError(new Error('Cannot find the configuration for the current NODE_ENV'), "NODE_ENV=" + envVal,
-        'Ensure your config.js has a section for the current NODE_ENV value and is formatted properly.');
+            'Ensure your config.js has a section for the current NODE_ENV value and is formatted properly.');
         return when.reject();
     }
 

--- a/core/config-loader.js
+++ b/core/config-loader.js
@@ -55,7 +55,8 @@ function validateConfigEnvironment() {
 
     // Check if we don't even have a config
     if (!config) {
-        errors.logError(new Error('Cannot find the configuration for the current NODE_ENV'), "NODE_ENV=" + envVal, 'Ensure your config.js has a section for the current NODE_ENV value');
+        errors.logError(new Error('Cannot find the configuration for the current NODE_ENV'), "NODE_ENV=" + envVal,
+        'Ensure your config.js has a section for the current NODE_ENV value and is formatted properly.');
         return when.reject();
     }
 


### PR DESCRIPTION
if you enter an invalid json object such as:

```
{
server: "http://foo.com"
host: "0.0.0.0"
}
```

while configuring, you get errors but are still able to run forever and the message previously was not as indicative of other potential configuration problems.
