### PR TITLE
Fix CSRF property deprecated warning

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -111,7 +111,7 @@ function ghostLocals(req, res, next) {
     res.locals = res.locals || {};
     res.locals.version = packageInfo.version;
     res.locals.path = req.path;
-    res.locals.csrfToken = req.session._csrf;
+    res.locals.csrfToken = req.csrfToken();
 
     if (res.isAdmin) {
         _.extend(res.locals,  {


### PR DESCRIPTION
Express middleware is throwing `req.session._csrf is deprecated, use req.csrfToken() instead`. This fixes the warning in `core/server.js`. Another warning is produced by `node_modules/express/node_modules/connect/lib/middleware/cookieSession.js:101`. 
