### PR TITLE
refactoring image storage and implementing S3 storage

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -38,6 +38,11 @@ config = {
             host: '127.0.0.1',
             // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
             port: '2368'
+        },
+        images: {
+            store: 'localfilesystem', // 'localfilesystem' or 's3'
+            bucket: '', // Used for S3 storage only eg. my-bucket.com
+            region: 'us-east-1' // Used for S3 storage only
         }
     },
 

--- a/config.example.js
+++ b/config.example.js
@@ -41,8 +41,12 @@ config = {
         },
         images: {
             store: 'localfilesystem', // 'localfilesystem' or 's3'
-            bucket: '', // Used for S3 storage only eg. my-bucket.com
-            region: 'us-east-1' // Used for S3 storage only
+            s3 : {
+                bucket: '', // eg. my-bucket.com
+                region: 'us-east-1',
+                accessKeyId: 'akid',
+                secretAccessKey: 'secret'
+            }
         }
     },
 
@@ -64,7 +68,17 @@ config = {
             host: '127.0.0.1',
             // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
             port: '2368'
+        },
+        images: {
+            store: 'localfilesystem', // 'localfilesystem' or 's3'
+            s3 : {
+                bucket: '', // eg. my-bucket.com
+                region: 'us-east-1',
+                accessKeyId: 'akid',
+                secretAccessKey: 'secret'
+            }
         }
+
     },
 
     // **Developers only need to edit below here**
@@ -83,7 +97,17 @@ config = {
         server: {
             host: '127.0.0.1',
             port: '2369'
+        },
+        images: {
+            store: 'localfilesystem',
+            s3 : {
+                bucket: '',
+                region: 'us-east-1',
+                accessKeyId: 'akid',
+                secretAccessKey: 'secret'
+            }
         }
+
     },
 
     // ### Travis
@@ -99,6 +123,15 @@ config = {
         server: {
             host: '127.0.0.1',
             port: '2368'
+        },
+        images: {
+            store: 'localfilesystem',
+            s3 : {
+                bucket: '',
+                region: 'us-east-1',
+                accessKeyId: 'akid',
+                secretAccessKey: 'secret'
+            }
         }
     }
 };

--- a/core/server.js
+++ b/core/server.js
@@ -265,7 +265,7 @@ when(ghost.init()).then(function () {
 
     server.use(express.json());
     server.use(express.urlencoded());
-    server.use('/ghost/upload/', express.multipart());
+    server.use('/ghost/upload/', express.multipart({hash: 'sha1'}));
     server.use('/ghost/upload/', express.multipart({uploadDir: __dirname + '/content/images'}));
     server.use('/ghost/debug/db/import/', express.multipart());
     server.use(express.cookieParser(ghost.dbHash));

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -48,23 +48,25 @@ function setSelected(list, name) {
 }
 
 adminControllers = {
+    'get_config': function () {
+        // allows unit testing
+        return ghost.config();
+    },
     'get_storage': function () {
-        // TODO get storage choice from config
-        var storageChoice = 'localfilesystem.js';
+        var storageChoice = adminControllers.get_config().images.store;
         return require('./storage/' + storageChoice);
     },
     'uploader': function (req, res) {
 
         var type = req.files.uploadimage.type,
-            storage = adminControllers.get_storage(),
-            rootToUrl = '/'; // TODO for local storage this works, for external storage not
+            storage = adminControllers.get_storage();
 
         if (type !== 'image/jpeg' && type !== 'image/png' && type !== 'image/gif') {
             return res.send(404, 'Invalid filetype');
         }
 
         storage
-            .save(new Date().getTime(), req.files.uploadimage, rootToUrl)
+            .save(new Date().getTime(), req.files.uploadimage, adminControllers.get_config().images)
             .then(function (url) {
 
                 // delete the temporary file

--- a/core/server/controllers/storage/localfilesystem.js
+++ b/core/server/controllers/storage/localfilesystem.js
@@ -34,17 +34,12 @@ function getUniqueFileName(dir, name, ext, i, done) {
 
 // ## Module interface  
 localfilesystem = {
-    // TODO use promises!!
-    // QUESTION pass date or month and year? And should the date be ticks or an object? Gone with ticks.
-    // QUESTION feels wrong to pass in the ghostUrl, the local file system needs it but something like S3 won't?
-
     // ### Save
     // Saves the image to storage (the file system)
     // - date is current date in ticks
     // - image is the express image object
-    // - ghosturl is thr base url for the site
     // - returns a promise which ultimately returns the full url to the uploaded image
-    'save': function (date, image, ghostUrl) {
+    'save': function (date, image) {
 
         // QUESTION is it okay for this module to know about content/images?
         var saved = when.defer(),
@@ -62,7 +57,9 @@ localfilesystem = {
                 return nodefn.call(fs.copy, image.path, target_path);
             }).then(function () {
                 // The src for the image must be in URI format, not a file system path, which in Windows uses \
-                var fullUrl = path.join(ghostUrl, filename).replace(new RegExp('\\' + path.sep, 'g'), '/');
+                // For local file system storage can use relative path so add a slash
+                var fullUrl = ('/' + filename).replace(new RegExp('\\' + path.sep, 'g'), '/');
+
                 return saved.resolve(fullUrl);
             }).otherwise(function (e) {
                 errors.logError(e);

--- a/core/server/controllers/storage/s3.js
+++ b/core/server/controllers/storage/s3.js
@@ -10,14 +10,20 @@ var s3ImageStore = {
         var saved = when.defer(),
             path = 'ghost/images/',
             key = path + image.hash,
-            fullUrl = 'https://s3.amazonaws.com/' + config.bucket + '/' + key,
+            fullUrl = 'https://s3.amazonaws.com/' + config.s3.bucket + '/' + key,
             stream = fs.createReadStream(image.path),
-            s3 = new AWS.S3();
+            s3 = null;
 
-        AWS.config.update({region: config.region});
+        AWS.config.update({
+            region: config.s3.region,
+            accessKeyId: config.s3.accessKeyId,
+            secretAccessKey: config.s3.secretAccessKey
+        });
+
+        s3 = new AWS.S3();
 
         // TODO optimise by checking if object exists using headObject
-        s3.client.putObject({Bucket: config.bucket, Key: key, Body: stream}).
+        s3.client.putObject({ Bucket: config.s3.bucket, Key: key, Body: stream }).
             on('complete', function (res) {
                 if (res.error) {
                     errors.logError(res.error);

--- a/core/server/controllers/storage/s3.js
+++ b/core/server/controllers/storage/s3.js
@@ -1,5 +1,6 @@
 // S3 image storage
 var AWS = require('aws-sdk'),
+    errors = require('../../errorHandling'),
     fs = require('fs'),
     path = require('path'),
     when = require('when');
@@ -19,6 +20,7 @@ var s3ImageStore = {
         s3.client.putObject({Bucket: config.bucket, Key: key, Body: stream}).
             on('complete', function (res) {
                 if (res.error) {
+                    errors.logError(res.error);
                     return saved.reject(res.error);
                 }
 

--- a/core/server/controllers/storage/s3.js
+++ b/core/server/controllers/storage/s3.js
@@ -1,0 +1,33 @@
+// S3 image storage
+var AWS = require('aws-sdk'),
+    fs = require('fs'),
+    path = require('path'),
+    when = require('when');
+
+var s3ImageStore = {
+    save: function (date, image, config) {
+        var saved = when.defer(),
+            path = 'ghost/images/',
+            key = path + image.hash,
+            fullUrl = 'https://s3.amazonaws.com/' + config.bucket + '/' + key,
+            stream = fs.createReadStream(image.path),
+            s3 = new AWS.S3();
+
+        AWS.config.update({region: config.region});
+
+        // TODO optimise by checking if object exists using headObject
+        s3.client.putObject({Bucket: config.bucket, Key: key, Body: stream}).
+            on('complete', function (res) {
+                if (res.error) {
+                    return saved.reject(res.error);
+                }
+
+                return saved.resolve(fullUrl);
+            }).
+            send();
+
+        return saved.promise;
+    }
+};
+
+module.exports = s3ImageStore;

--- a/core/test/unit/storage_localfilesystem_spec.js
+++ b/core/test/unit/storage_localfilesystem_spec.js
@@ -30,8 +30,8 @@ describe('Local File System Storage', function() {
     it('should send correct path to image when date is in Sep 2013', function (done) {
         // Sat Sep 07 2013 21:24
         var date = new Date(2013, 8, 7, 21, 24).getTime();
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-            url.should.equal('GHOSTURL/content/images/2013/Sep/IMAGE.jpg');
+        localfilesystem.save(date, image).then(function (url) {
+            url.should.equal('/content/images/2013/Sep/IMAGE.jpg');
             return done();
         });
     });
@@ -39,8 +39,8 @@ describe('Local File System Storage', function() {
     it('should send correct path to image when original file has spaces', function (done) {
         var date = new Date(2013, 8, 7, 21, 24).getTime();
         image.name = 'AN IMAGE.jpg';
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-            url.should.equal('GHOSTURL/content/images/2013/Sep/AN_IMAGE.jpg');
+        localfilesystem.save(date, image).then(function (url) {
+            url.should.equal('/content/images/2013/Sep/AN_IMAGE.jpg');
             return done();
         });
     });
@@ -48,8 +48,8 @@ describe('Local File System Storage', function() {
     it('should send correct path to image when date is in Jan 2014', function (done) {
         // Jan 1 2014 12:00
         var date = new Date(2014, 0, 1, 12).getTime();
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-            url.should.equal('GHOSTURL/content/images/2014/Jan/IMAGE.jpg');
+        localfilesystem.save(date, image).then(function (url) {
+            url.should.equal('/content/images/2014/Jan/IMAGE.jpg');
             return done();
         });
     });
@@ -57,21 +57,21 @@ describe('Local File System Storage', function() {
     it('should create month and year directory', function (done) {
        // Sat Sep 07 2013 21:24
         var date = new Date(2013, 8, 7, 21, 24).getTime();
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
+        localfilesystem.save(date, image).then(function (url) {
             fs.mkdirs.calledOnce.should.be.true;
             fs.mkdirs.args[0][0].should.equal(path.join('content/images/2013/Sep'));
-            done();
+            return done();
         }).then(null, done);
     });
 
     it('should copy temp file to new location', function (done) {
        // Sat Sep 07 2013 21:24
         var date = new Date(2013, 8, 7, 21, 24).getTime();
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
+        localfilesystem.save(date, image).then(function (url) {
             fs.copy.calledOnce.should.be.true;
             fs.copy.args[0][0].should.equal('tmp/123456.jpg');
             fs.copy.args[0][1].should.equal(path.join('content/images/2013/Sep/IMAGE.jpg'));
-            done();
+            return done();
         }).then(null, done);
     });
 
@@ -87,8 +87,8 @@ describe('Local File System Storage', function() {
         fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE.jpg').yields(true);
         fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-1.jpg').yields(false);
 
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-            url.should.equal('GHOSTURL/content/images/2013/Sep/IMAGE-1.jpg');
+        localfilesystem.save(date, image).then(function (url) {
+            url.should.equal('/content/images/2013/Sep/IMAGE-1.jpg');
             return done();
         });
     });
@@ -110,15 +110,14 @@ describe('Local File System Storage', function() {
         fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-3.jpg').yields(true);
         fs.exists.withArgs('content\\images\\2013\\Sep\\IMAGE-4.jpg').yields(false);
 
-        localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-            url.should.equal('GHOSTURL/content/images/2013/Sep/IMAGE-4.jpg');
+        localfilesystem.save(date, image).then(function (url) {
+            url.should.equal('/content/images/2013/Sep/IMAGE-4.jpg');
             return done();
         });
     });
 
 
     describe('on Windows', function () {
-        // TODO tests to check for working on windows
 
         var truePathSep = path.sep;
 
@@ -133,11 +132,10 @@ describe('Local File System Storage', function() {
 
         it('should return url in proper format for windows', function (done) {
             path.sep = '\\';
-            path.join.returns('/content/images/2013/Sep/IMAGE.jpg');
-            path.join.withArgs('GHOSTURL', '/content/images/2013/Sep/IMAGE.jpg').returns('GHOSTURL\\content\\images\\2013\\Sep\\IMAGE.jpg');
+            path.join.returns('content\\images\\2013\\Sep\\IMAGE.jpg');
             var date = new Date(2013, 8, 7, 21, 24).getTime();
-            localfilesystem.save(date, image, 'GHOSTURL').then(function (url) {
-                url.should.equal('GHOSTURL/content/images/2013/Sep/IMAGE.jpg');
+            localfilesystem.save(date, image).then(function (url) {
+                url.should.equal('/content/images/2013/Sep/IMAGE.jpg');
                 return done();
             });
         });

--- a/core/test/unit/storage_s3.js
+++ b/core/test/unit/storage_s3.js
@@ -34,8 +34,12 @@ describe('S3 File Storage', function() {
         sinon.stub(fs, 'createReadStream').returns('STREAM');
 
         config = {
-            bucket: 'BUCKET',
-            region: 'REGION'
+            s3: {
+                bucket: 'BUCKET',
+                region: 'REGION',
+                accessKeyId: 'ACCESSKEYID',
+                secretAccessKey: 'SECRET'
+            }
         };
 
         image = {
@@ -78,7 +82,13 @@ describe('S3 File Storage', function() {
     it('should set AWS region', function (done) {
         s3Store.save(null, image, config).then(function (url) {
             awsConfigUpdate.calledOnce.should.be.true;
-            awsConfigUpdate.args[0][0].should.eql({ region: 'REGION'});
+            var expectedConfig = {
+                region: 'REGION',
+                accessKeyId: 'ACCESSKEYID',
+                secretAccessKey: 'SECRET'
+            };
+
+            awsConfigUpdate.args[0][0].should.eql(expectedConfig);
             return done();
         }); 
     });

--- a/core/test/unit/storage_s3.js
+++ b/core/test/unit/storage_s3.js
@@ -1,0 +1,115 @@
+/*globals describe, beforeEach, afterEach, it*/
+var AWS = require('aws-sdk'),
+    assert = require('assert'),
+    fs = require('fs'),
+    should = require('should'),
+    sinon = require('sinon'),
+    when = require('when'),
+    s3Store = require('../../server/controllers/storage/s3');
+
+describe('S3 File Storage', function() {
+
+    var image, putObject, config, awsConfigUpdate, putResult;
+
+    beforeEach(function () {
+        putResult = {};
+
+        on = {
+            on: sinon.stub().yields(putResult).returns({ send: function (){}})
+        };
+
+        putObject = sinon.stub().returns(on);
+        var mockS3 = {
+            client: {
+                putObject: putObject
+            }
+        };
+
+        awsConfigUpdate = sinon.stub();
+        AWS.config = {
+            update: awsConfigUpdate
+        };
+
+        sinon.stub(AWS, 'S3').returns(mockS3);
+        sinon.stub(fs, 'createReadStream').returns('STREAM');
+
+        config = {
+            bucket: 'BUCKET',
+            region: 'REGION'
+        };
+
+        image = {
+            path: "tmp/123456.jpg",
+            name: "IMAGE.jpg",
+            type: "image/jpeg",
+            hash: "HASH"
+        };
+    });
+
+    afterEach(function () {
+        AWS.S3.restore();
+        fs.createReadStream.restore();
+    });
+
+    it('should return correct url', function (done) {
+        s3Store.save(null, image, config).then(function (url) {
+            url.should.equal('https://s3.amazonaws.com/BUCKET/ghost/images/HASH');
+            return done();
+        }); 
+    });
+
+    it('should createReadStream correctly', function (done) {
+        s3Store.save(null, image, config).then(function (url) {
+            fs.createReadStream.calledOnce.should.be.true;
+            fs.createReadStream.args[0][0].should.equal('tmp/123456.jpg');
+            return done();
+        }); 
+    });
+
+    it('should call putObject correctly', function (done) {
+        s3Store.save(null, image, config).then(function (url) {
+            url.should.equal('https://s3.amazonaws.com/BUCKET/ghost/images/HASH');
+            putObject.calledOnce.should.be.true;
+            putObject.args[0][0].should.eql({ Bucket: 'BUCKET', Key: 'ghost/images/HASH', Body: 'STREAM' });
+            return done();
+        }); 
+    });
+
+    it('should set AWS region', function (done) {
+        s3Store.save(null, image, config).then(function (url) {
+            awsConfigUpdate.calledOnce.should.be.true;
+            awsConfigUpdate.args[0][0].should.eql({ region: 'REGION'});
+            return done();
+        }); 
+    });
+
+    it('should raise error if putObject fails', function (done) {
+        putResult = { 
+            error: { 
+                code: 'SigningError', 
+                name: 'SigningError' 
+            } 
+        };   
+   
+        var on = {
+            on: sinon.stub().yields(putResult).returns({ send: function (){}})
+        };
+
+        putObject = sinon.stub().returns(on);
+        var mockS3 = {
+            client: {
+                putObject: putObject
+            }
+        };
+
+        AWS.S3.returns(mockS3);
+
+        s3Store.save(null, image, config).then(function (url) {
+            assert(false);
+            return done();
+        }).otherwise(function(e) {
+            assert.deepEqual(e, { code: 'SigningError', name: 'SigningError' });
+            return done();
+        }); 
+    });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "downsize": "0.0.2",
         "validator": "1.4.0",
         "rss": "0.2.0",
-        "nodemailer": "~0.5.2"
+        "nodemailer": "~0.5.2",
+        "aws-sdk": "1.9.0"
     },
     "devDependencies": {
         "grunt": "~0.4.1",


### PR DESCRIPTION
part of #635
- in order to crystallise whether local storage module was correct it was easiest to implement S3 module
- config is currently only in development section
- implemented as a config option rather than a plugin, as discussed previously
- may want to restructure config depending on what other storage comes along
- the S3 bucket must have read permissions as the link is direct to the bucket
- turns on file upload hash to use as filename, rather than use incremental filenames as in local storage, because each file stored in S3 is cost, so don't want duplicates
- error handling still needs some work
- used aws-sdk for S3 interaction because:
  - it is by Amazon
  - it is active
  - it has all AWS services
  - it has built in retries
  - I have used it since early versions with no issues
