### PR TITLE
Undefined post data causing server to crash

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -261,7 +261,7 @@ coreHelpers = function (ghost) {
                 blog = ghost.blogGlobals();
                 title = blog.title;
             } else {
-                title = this.post.title;
+                title = this.post ? this.post.title : '';
             }
         }
 


### PR DESCRIPTION
The issue occurs when the page is not the index, static (I assume that's what /page/ refers to), or a post. The default condition assumes there is post data associated with the page to be rendered, but if there isn't, the server chokes.

```
/home/action/core/server/helpers/index.js:239 
title = this.post.title; 
                 ^ 
TypeError: Cannot read property ‘title’ of undefined 
```

---

Personally I have only ran into this issue hacking around, but this was an issue brought up on the forums: [Crash when i refer to another domain](https://en.ghost.org/forum/bugs-suggestions/1761-crash-when-i-refer-to-another-domain).

This commit fixes this issue by checking if the post data exists before trying to dereference it.
