### PR TITLE
Store the Bookshelf instance on the Bookshelf module

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -9,7 +9,7 @@ var ghostBookshelf,
     sanitize  = require('validator').sanitize;
 
 // Initializes a new Bookshelf instance, for reference elsewhere in Ghost.
-ghostBookshelf = Bookshelf.initialize(config[process.env.NODE_ENV || 'development'].database);
+ghostBookshelf = Bookshelf.ghost = Bookshelf.initialize(config[process.env.NODE_ENV || 'development'].database);
 ghostBookshelf.client = config[process.env.NODE_ENV].database.client;
 
 ghostBookshelf.validator = new Validator();


### PR DESCRIPTION
- Assigns the ghostBookshelf instance to the Bookshelf.ghost property

This will help in the long run with being able to retrieve the Bookshelf and Knex instances that are used by Ghost.  For example, in plugins it will replace

``` javascript
// Old and busted...
knex = require('../../../core/server/models/base').Knex;

// New hotness
knex = require('bookshelf').ghost.Knex;
```
