### PR TITLE
adds prefix option to tag helper

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -120,14 +120,27 @@ coreHelpers = function (ghost) {
     // and can be used for more complex templates.
     ghost.registerThemeHelper('tags', function (options) {
         var separator = ', ',
+            prefix,
+            output,
             tagNames;
 
         if (_.isString(options.hash.separator)) {
             separator = options.hash.separator;
         }
 
+        if (_.isString(options.hash.prefix)) {
+            prefix = options.hash.prefix;
+        }
+
         tagNames = _.pluck(this.tags, 'name');
-        return tagNames.join(separator);
+
+        if (tagNames.length && prefix) {
+            output = prefix + tagNames.join(separator);
+        } else {
+            output = tagNames.join(separator);
+        }
+
+        return output;
     });
 
     // ### Content Helper

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -399,9 +399,9 @@ describe('Core Helpers', function () {
         });
 
         it('can return string with tags', function () {
-            var tags = [{name:'foo'}, {name:'bar'}],
+            var tags = [{name: 'foo'}, {name: 'bar'}],
                 rendered = handlebars.helpers.tags.call(
-                    {tags: tags}, 
+                    {tags: tags},
                     {"hash": {}}
                 );
             should.exist(rendered);
@@ -410,7 +410,7 @@ describe('Core Helpers', function () {
         });
 
         it('can use a different separator', function () {
-            var tags = [{name:'haunted'},{name:'ghost'}],
+            var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
                     {"hash": {separator: '|'}}
@@ -419,6 +419,29 @@ describe('Core Helpers', function () {
             should.exist(rendered);
 
             String(rendered).should.equal('haunted|ghost');
+        });
+
+        it('can add a single prefix to multiple tags', function () {
+            var tags = [{name: 'haunted'}, {name: 'ghost'}],
+                rendered = handlebars.helpers.tags.call(
+                    {tags: tags},
+                    {"hash": {prefix: 'on '}}
+                );
+
+            should.exist(rendered);
+
+            String(rendered).should.equal('on haunted, ghost');
+        });
+
+        it('does not add prefix if no tags exist', function () {
+            var rendered = handlebars.helpers.tags.call(
+                    {},
+                    {"hash": {prefix: 'on '}}
+                );
+
+            should.exist(rendered);
+
+            String(rendered).should.equal('');
         });
     });
 


### PR DESCRIPTION
```
    closes #607
```
- added prefix attributetor tags helper
- will add prefix only if tags are present
- adds unit tests for prefix
