### PR TITLE
Removed special character from SCSS

### DIFF
--- a/core/client/assets/sass/layouts/errors.scss
+++ b/core/client/assets/sass/layouts/errors.scss
@@ -95,7 +95,7 @@
     
     &::before {
         color: #BBB;
-        content: "↪︎";
+        content: "\21AA";
         display: inline-block;
         font-size: 1.2em;
         margin-right: 0.5em;


### PR DESCRIPTION
Fixes #1173.

Replaced the special character with the escaped unicode version (\21AA).
