### PR TITLE
Replace nodejs-bcrypt with bcryptjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "bookshelf": "0.5.7",
         "knex": "0.4.11",
         "when": "2.2.1",
-        "bcrypt-nodejs": "0.0.3",
+        "bcryptjs": "0.7.10",
         "node-uuid": "1.4.0",
         "colors": "0.6.1",
         "semver": "2.1.0",


### PR DESCRIPTION
Replaces nodejs-bcrypt module with bcryptjs module.

nodejs-bcrypt seems unmaintained and might contain some bugs as suggested by the issues raised at: 

https://github.com/shaneGirish/bcrypt-nodejs
Is replaced with
https://github.com/dcodeIO/bcrypt.js
