### PR TITLE
Add core/server.js to grunt watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,7 +93,7 @@ var path           = require('path'),
                 },
                 express: {
                     // Restart any time client or server js files change
-                    files:  ['core/server/**/*.js'],
+                    files:  ['core/server.js', 'core/server/**/*.js'],
                     tasks:  ['express:dev'],
                     options: {
                         //Without this option specified express won't be reloaded


### PR DESCRIPTION
It's a bit annoying that `grunt watch` doesn't reload when server.js is modified - this PR adds server.js to the list of watched files.
