### PR TITLE
Fix duplication of entries in infinite scroll

### DIFF
--- a/core/client/views/blog.js
+++ b/core/client/views/blog.js
@@ -35,6 +35,7 @@
         initialize: function (options) {
             this.$('.content-list-content').scrollClass({target: '.content-list', offset: 10});
             this.listenTo(this.collection, 'remove', this.showNext);
+            this.listenTo(this.collection, 'add', this.renderPost);
             // Can't use backbone event bind (see: http://stackoverflow.com/questions/13480843/backbone-scroll-event-not-firing)
             this.$('.content-list-content').scroll($.proxy(this.checkScroll, this));
         },
@@ -102,9 +103,18 @@
             });
         },
 
+        renderPost: function (model) {
+            this.$('ol').append(this.addSubview(new ContentItem({model: model})).render().el);
+        },
+
         render: function () {
+            var $list = this.$('ol');
+
+            // Clear out any pre-existing subviews.
+            this.removeSubviews();
+
             this.collection.each(function (model) {
-                this.$('ol').append(this.addSubview(new ContentItem({model: model})).render().el);
+                $list.append(this.addSubview(new ContentItem({model: model})).render().el);
             }, this);
             this.showNext();
         }


### PR DESCRIPTION
Fixes #1242
- Switched to render each new item as it is added to the collection when
  retrieving via scroll checks.
- Added check to remove all subviews whenever `render` is called on
  `ContentList` as a preventative measure.
- Cached the jquery reference to the ordered list in `render`.
