### PR TITLE
Bumped express-hbs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "engineStrict": true,
     "dependencies": {
         "express": "3.4.2",
-        "express-hbs": "0.3.0",
+        "express-hbs": "0.5.0",
         "connect-slashes": "0.0.10",
         "node-polyglot": "0.2.1",
         "moment": "2.1.0",


### PR DESCRIPTION
Fixes #830
- Bumped `express-hbs` version to `v0.5` which includes our updates to
  support azure (UNC paths) and a fix for caching of partials.
