### PR TITLE
<code>/<tt> elements should wrap since they're used inline

### DIFF
--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -257,7 +257,7 @@ mark {
 code, tt {
     font-family: $font-family-mono;
     font-size: 0.85em;
-    white-space: pre;
+    white-space: pre-wrap;
     background: lighten($lightbrown, 2%);
     border: 1px solid darken($lightbrown, 8%);
     border-radius: 2px;


### PR DESCRIPTION
This pull request changes the `code, tt` rule `white-space: pre` to `pre-wrap`. [Definitions](http://www.w3.org/TR/CSS21/text.html#white-space-prop):

> **pre**
> This value prevents user agents from collapsing sequences of white space. Lines are only broken at preserved newline characters.
> **pre-wrap**
> This value prevents user agents from collapsing sequences of white space. Lines are broken at preserved newline characters, and as necessary to fill line boxes.

Before:
![white-space: pre](https://f.cloud.github.com/assets/118362/1408117/50fabd94-3d7c-11e3-9821-10a956fb83c6.png)

After:
![white-space: pre-wrap](https://f.cloud.github.com/assets/118362/1408118/562280f4-3d7c-11e3-84c3-c162074c37a5.png)

See also TryGhost/Casper#48.
