### PR TITLE
Prevent default drag/drop action.

### DIFF
--- a/core/client/views/editor.js
+++ b/core/client/views/editor.js
@@ -316,6 +316,10 @@
                 $(e.target).closest('section').addClass('active');
             });
 
+            // Deactivate default drag/drop action
+            $(document).bind('drop dragover', function (e) {
+                e.preventDefault();
+            });
         },
 
         events: {


### PR DESCRIPTION
This PR prevents the default drag&drop event in the browser. I think this is necessary since the default action on most browsers is to replace the website with the image being dragged. A simple "misdrag" will result in all unsaved text being lost.
