### PR TITLE
Adding a warning message if js is not built

### DIFF
--- a/core/client/init.js
+++ b/core/client/init.js
@@ -34,6 +34,9 @@
     };
 
     Ghost.init = function () {
+        // remove the temporary message which appears
+        $('.js-msg').remove();
+
         Ghost.router = new Ghost.Router();
 
         // This is needed so Backbone recognizes elements already rendered server side

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -43,6 +43,10 @@
 
         {{{body}}}
 
+        <div class="js-msg">
+            <p>Hello There! Looks like something went wrong with your JavaScript.</p>
+            <p>Either you need to enable JavaScript, or you haven't built the JavaScript files yet. See the README and CONTRIBUTING files for more info.</p>
+        </div>
     </main>
 
     <div id="modal-container">


### PR DESCRIPTION
closes #1205

adds a simple message which will get hidden once the js is built

This is a completely temporary measure which will only exist until we have server-side pre-rendering in place.

The point is to reduce the number of people wondering why they get a blank screen from Ghost because they haven't run either `grunt init`, or `grunt prod`
