### PR TITLE
Dropping our incomplete support for node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.10"
 git:
   submodules: false

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test": "grunt validate --verbose"
     },
     "engines": {
-        "node": ">=0.10.* <0.11.4"
+        "node": "0.10.*"
     },
     "engineStrict": true,
     "dependencies": {


### PR DESCRIPTION
issue #1287, issue #1147
- our support was partial, is based on node-sqlite3, which has dropped partial support as well
- node 0.11 is a dev version, and has lots of breaking changes
- we will add node 0.12 support when it is released
