### PR TITLE
Show "Write a new Post" message when there are no posts

### DIFF
--- a/core/client/assets/sass/layouts/manage.scss
+++ b/core/client/assets/sass/layouts/manage.scss
@@ -250,4 +250,34 @@
 
     }//.preview-post
 
+    .no-posts-box {
+        position: relative;
+        height: 90%;
+        margin: 0px auto;
+        padding: 0px;
+        display: table;
+        z-index: 600;
+        @include breakpoint($tablet) {
+            position: fixed;
+            top: 45%;
+            left: 50%;
+        }
+
+        .no-posts {
+            vertical-align: middle;
+            display: table-cell;
+            text-align: center;
+            @include breakpoint($tablet) {
+                display: block;
+                position: relative;
+                left: -50%;
+            }
+
+            h3 {
+                color: $brown;
+                font-weight: 200;
+                font-size: 2em;
+            }
+        }
+    }//.no-posts-box
 }//.manage

--- a/core/client/tpl/preview.hbs
+++ b/core/client/tpl/preview.hbs
@@ -42,3 +42,11 @@
 <section class="content-preview-content">
     <div class="wrapper"><h1>{{{title}}}</h1>{{{html}}}</div>
 </section>
+{{#unless title}}
+    <div class="no-posts-box">
+        <div class="no-posts">
+            <h3>You Haven't Written Any Posts Yet!</h3>
+            <form action="/ghost/editor/"><button class="button-add large" title="New Post">Write a new Post</button></form>
+        </div>
+    </div>
+{{/unless}}


### PR DESCRIPTION
Implementation for #1308.

When there is no `title`, there can't be a post so we can then add the message. The mobile implementation was a bit tricky, right now it uses `position: fixed` which I'm not entirely happy about. On the other hand, duplicating the message in the post list template doesn't sound very good either. Will try to find a better solution, any suggestions are very welcome.
