### PR TITLE
Update node-sqlite3 to v2.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "moment": "2.1.0",
         "underscore": "1.5.1",
         "showdown": "0.3.1",
-        "sqlite3": "2.1.16",
+        "sqlite3": "2.1.18",
         "bookshelf": "0.5.7",
         "knex": "0.4.11",
         "when": "2.2.1",


### PR DESCRIPTION
v2.1.18 brings in build fixes so that better errors are reported in the case of a fallback to a source compile + other minor build fixes (so functional code changes) - refs #1269.
