### PR TITLE
Exclude config.js from validation

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,10 @@ var path           = require('path'),
                             'core/*.js',
                             'core/server/**/*.js'
                         ]
-                    }
+                    },
+                    exclude: [
+                        'config.js'
+                    ]
                 },
                 client: {
                     directives: {


### PR DESCRIPTION
I find it quite annoying when `grunt validate` exits due to an JSLint error in the `config.js`. This adds it to the ignore list.
