### PR TITLE
Correct Chinese language code, cross-link language versions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ languages:
     - name: 'Español'
       key: 'es'
     - name: '中文'
-      key: 'cn'
+      key: 'zh'
 port:         4478
 
 translations:
@@ -18,7 +18,7 @@ translations:
     email:        'Email'
     themes:       'temas'
     help:         'ayudar'
-  cn:
+  zh:
     site_title:   'Ghost使用指南'
     installation: '安装'
     usage:        '使用'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,10 @@
   <meta name="description" content="{{ page.meta_description }}" />
   {% endif %}
 
-  <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+  <link rel="canonical" href="{{ site.url }}/{% if page.lang %}{{ page.lang }}/{% endif %}{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">
+  {% for lang in site.languages %}
+  <link rel="alternate" hreflang="{{ lang.key }}" href="{{ site.url }}/{% if lang.key != 'en' %}{{ lang.key }}/{% endif %}{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">
+  {% endfor %}
 
   <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap.css" >
   <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css">
@@ -96,6 +99,20 @@
             {% endif %}
           </a>
         </li>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        {% if page.lang %}
+          <li>
+            <a href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">English</a>
+          </li>
+        {% endif %}
+        {% for lang in site.languages %}
+          {% if lang.key != page.lang and lang.key != 'en' %}
+            <li>
+              <a href="{{ site.url }}/{{ lang.key }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{ lang.name }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
       </ul>
     </div>
   </nav>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -45,6 +45,57 @@ h1:before, h2:before {
     position: relative;
 }
 
+
+/* ==========================================================================
+   Navigation - filling in styles that are not in Ghost's version of
+   bootstrap.css (even though it is v3.0.0) but are in Twitter's version of
+   Bootstrap v3.0.0. This is to get .navbar-right working in the expected
+   manner to enable cross-linking between language versions.
+   ========================================================================== */
+
+@media (min-width: 768px) {
+  .navbar-right .dropdown-menu {
+    right: 0;
+    left: auto;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-collapse {
+    width: auto;
+    border-top: 0;
+    box-shadow: none;
+  }
+  .navbar-collapse.collapse {
+    display: block !important;
+    height: auto !important;
+    padding-bottom: 0;
+    overflow: visible !important;
+  }
+  .navbar-collapse.in {
+    overflow-y: auto;
+  }
+  .navbar-collapse .navbar-nav.navbar-left:first-child {
+    margin-left: -15px;
+  }
+  .navbar-collapse .navbar-nav.navbar-right:last-child {
+    margin-right: -15px;
+  }
+  .navbar-collapse .navbar-text:last-child {
+    margin-right: 0;
+  }
+}
+
+@media (min-width: 768px) {
+  .navbar-left {
+    float: left !important;
+  }
+  .navbar-right {
+    float: right !important;
+  }
+}
+
+
 /* ==========================================================================
    Navigation
    ========================================================================== */

--- a/cn/index.html
+++ b/cn/index.html
@@ -1,45 +1,152 @@
 ---
-lang: cn
-layout: default
+lang: zh
+permalink: /cn/
 meta_title: Ghost使用指南 - Ghost中文文档
 meta_description: Ghost使用完全指南。包括安装、使用以及如何制作主题和插件。
 ---
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="3; {{ site.url }}/zh/">
+  <meta name="description" content="{{ page.meta_description }}" />
+  <title>{{ page.meta_title }}</title>
 
-<div id="fb-root"></div>
-<script>(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) return;
-  js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=596756540369391";
-  fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));</script>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+  <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap.css" >
+  <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css">
+
+  <!--[if lt IE 9]>
+    <script src="{{ site.url }}/assets/js/html5shiv.js"></script>
+    <script src="{{ site.url }}/assets/js/respond.min.js"></script>
+  <![endif]-->
+
+  <link rel="shortcut icon" href="{{ site.url }}/assets/img/favicon.ico">
+  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css'>
+</head>
+<body>
+<header class="navbar navbar-fixed-top bs-docs-nav">
+  <nav class="container">
+    <a href="{{ site.url }}/{% if page.lang %}{{page.lang}}/{% endif %}" class="navbar-brand">
+      {% if page.lang %}
+        {{site.translations.[page.lang].site_title}}
+      {% else %}
+        Ghost Guide
+      {% endif %}
+    </a>
+    <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".bs-navbar-collapse">
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <div class="nav-collapse collapse bs-navbar-collapse">
+      <ul class="nav navbar-nav">
+        <li>
+          <a href="{{ site.url }}/{% if page.lang %}{{page.lang}}/{% endif %}installation/">
+            {% if page.lang %}
+              {{site.translations.[page.lang].installation}}
+            {% else %}
+              Installation
+            {% endif %}
+          </a>
+        </li>
+        <li>
+          <a href="{{ site.url }}/{% if page.lang %}{{page.lang}}/{% endif %}usage/">
+            {% if page.lang %}
+              {{site.translations.[page.lang].usage}}
+            {% else %}
+              Usage
+            {% endif %}
+          </a>
+        </li>
+        <li>
+          <a href="{{ site.url }}/{% if page.lang %}{{page.lang}}/{% endif %}mail/">
+            {% if page.lang %}
+              {{site.translations.[page.lang].email}}
+            {% else %}
+              Email
+            {% endif %}
+          </a>
+        </li>
+        <li>
+          <a href="{{ site.url }}/{% if page.lang %}{{page.lang}}/{% endif %}themes/">
+            {% if page.lang %}
+              {{site.translations.[page.lang].themes}}
+            {% else %}
+              Themes
+            {% endif %}
+          </a>
+        </li>
+        <li>
+          <a href="http://ghost.org/forum/">
+            {% if page.lang %}
+              {{site.translations.[page.lang].help}}
+            {% else %}
+              Help
+            {% endif %}
+          </a>
+        </li>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        {% if page.lang %}
+          <li>
+            <a href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">English</a>
+          </li>
+        {% endif %}
+        {% for lang in site.languages %}
+          {% if lang.key != page.lang and lang.key != 'en' %}
+            <li>
+              <a href="{{ site.url }}/{{ lang.key }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{ lang.name }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+      </ul>
+    </div>
+  </nav>
+</header>
+
+<main id="main" role="main">
+
+  {% if page.heading %}
+  <header class="bs-header">
+      <div class="container">
+          <h1>{{ page.heading }}</h1>
+          {% if page.subheading %}
+          <p>{{ page.subheading }}</p>
+          {% endif %}
+      </div>
+  </header>
+  {% endif %}
 
 <div class="bs-masthead">
   <div class="container">
     <h1>Ghost使用指南</h1>
     <p class="lead">这里包含了完整的Ghost使用指南中文文档。</p>
-    <p>
-      <a href="{{ site.url }}/installation" class="btn btn-success btn-large">开始Ghost之旅吧</a>
-    </p>
+    <p><strong>This page has moved permanently to <a href="{{ site.url }}/zh/">{{ site.url }}/zh/</a>.</strong></p>
   </div>
 </div>
 
-<div id="social">
-  <div class="container">
-    <ul>
-      <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
-      </li>
-      <li>
-        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
-      </li>
-      <li class="follow-btn">
-        <a href="https://twitter.com/tryghost" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @TryGhost</a>
-      </li>
-      <li class="tweet-btn">
-        <div class="fb-like" data-href="http://www.facebook.com/TryGhostApp" data-send="false" data-layout="button_count" data-width="100" data-show-faces="false"></div>
-      </li>
-    </ul>
-  </div>
-</div>
+</main>
+
+<footer id="global-footer">
+    <!-- <div class="dropdown">
+        {% for item in site.languages %}
+        {% if page.lang == item.key %}
+        <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class='icon down'></span>{{item.name}}</a>
+        {% endif %}
+        {% endfor %}
+        <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+            <li><a href="{{ site.url }}/">English</a></li>
+            <li><a href="{{ site.url }}/es/">Español</a></li>
+        </ul>
+    </div> -->
+  <p>Lovingly created and maintained by <a href="http://john.onolan.org">John O'Nolan</a> + <a href="http://erisds.co.uk">Hannah Wolfe</a> + an amazing group of <a href="https://github.com/TryGhost/Ghost/contributors">contributors</a>.</p>
+    <hr>
+  <p>All code copyright (C) 2013 The Ghost Foundation - Released under the <a href="http://tryghost.org/about/license.html">MIT</a> License.<br />
+    All documentation is released under the Creative Commons <a href="http://creativecommons.org/licenses/by/3.0/">By-3.0</a> License.</p>
+</footer>
+
+<script src="{{ site.url }}/assets/js/jquery.js"></script>
+<script src="{{ site.url }}/assets/js/bootstrap.min.js"></script>
+<script src="{{ site.url }}/assets/js/main.js"></script>
+
+</body>
+</html>

--- a/es/installation/deploy.html
+++ b/es/installation/deploy.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/deploy/
 chapter: installation
+section: deploy
 prev_section: linux
 next_section: upgrading
 ---

--- a/es/installation/linux.html
+++ b/es/installation/linux.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/linux/
 chapter: installation
+section: linux
 prev_section: windows
 next_section: deploy
 ---

--- a/es/installation/mac.html
+++ b/es/installation/mac.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/mac/
 chapter: installation
+section: mac
 prev_section: installation
 next_section: windows
 ---

--- a/es/installation/troubleshooting.html
+++ b/es/installation/troubleshooting.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/troubleshooting/
 chapter: installation
+section: troubleshooting
 prev_section: upgrading
 ---
 

--- a/es/installation/upgrading.html
+++ b/es/installation/upgrading.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/upgrading/
 chapter: installation
+section: upgrading
 prev_section: deploy
 next_section: troubleshooting
 ---

--- a/es/installation/windows.html
+++ b/es/installation/windows.html
@@ -7,6 +7,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /es/installation/windows/
 chapter: installation
+section: windows
 prev_section: mac
 next_section: linux
 ---

--- a/es/mail/index.html
+++ b/es/mail/index.html
@@ -3,6 +3,7 @@ lang: es
 layout: default
 meta_title: Setup Email
 heading: Setting up Email
+chapter: mail
 ---
 
 <div class="container">

--- a/es/quickstart/quickstart.html
+++ b/es/quickstart/quickstart.html
@@ -4,6 +4,8 @@ layout: default
 meta_title: Ghost Quickstart
 heading: Ghost Quickstart
 subheading: Get up and running with Ghost.
+chapter: quickstart
+section: quickstart
 ---
 
 <div class="container">

--- a/es/themes/index.html
+++ b/es/themes/index.html
@@ -4,6 +4,7 @@ layout: default
 meta_title: Theming Ghost
 heading: Ghost Themes
 subheading: Get started creating your own themes for Ghost
+chapter: themes
 ---
 
 <div class="container">

--- a/es/usage/configuration.html
+++ b/es/usage/configuration.html
@@ -7,6 +7,7 @@ heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
 permalink: /es/usage/configuration/
+section: configuration
 prev_section: usage
 next_section: settings
 ---

--- a/es/usage/faq.html
+++ b/es/usage/faq.html
@@ -7,6 +7,7 @@ heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
 permalink: /es/usage/faq/
+section: faq
 prev_section: writing
 ---
 

--- a/es/usage/managing.html
+++ b/es/usage/managing.html
@@ -6,6 +6,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: managing
 permalink: /es/usage/managing/
 prev_section: settings
 next_section: writing

--- a/es/usage/settings.html
+++ b/es/usage/settings.html
@@ -6,6 +6,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: settings
 permalink: /es/usage/settings/
 prev_section: configuration
 next_section: managing

--- a/es/usage/writing.html
+++ b/es/usage/writing.html
@@ -6,6 +6,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: writing
 permalink: /es/usage/writing/
 prev_section: managing
 next_section: faq

--- a/installation/deploy.html
+++ b/installation/deploy.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/deploy/
 chapter: installation
+section: deploy
 prev_section: linux
 next_section: upgrading
 ---

--- a/installation/linux.html
+++ b/installation/linux.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/linux/
 chapter: installation
+section: linux
 prev_section: windows
 next_section: deploy
 ---

--- a/installation/mac.html
+++ b/installation/mac.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/mac/
 chapter: installation
+section: mac
 prev_section: installation
 next_section: windows
 ---

--- a/installation/troubleshooting.html
+++ b/installation/troubleshooting.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/troubleshooting/
 chapter: installation
+section: troubleshooting
 prev_section: upgrading
 ---
 

--- a/installation/upgrading.html
+++ b/installation/upgrading.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/upgrading/
 chapter: installation
+section: upgrading
 prev_section: deploy
 next_section: troubleshooting
 ---

--- a/installation/windows.html
+++ b/installation/windows.html
@@ -6,6 +6,7 @@ heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
 permalink: /installation/windows/
 chapter: installation
+section: windows
 prev_section: mac
 next_section: linux
 ---

--- a/mail/index.html
+++ b/mail/index.html
@@ -3,6 +3,7 @@ layout: default
 meta_title: Ghost Mail Configuration - Ghost Docs
 meta_description: How to configure your email server and send emails with the Ghost blogging platform. Everything you need to know.
 heading: Setting up Email
+chapter: mail
 ---
 
 <div class="container">

--- a/quickstart/quickstart.html
+++ b/quickstart/quickstart.html
@@ -3,6 +3,8 @@ layout: default
 meta_title: Ghost Quickstart
 heading: Ghost Quickstart
 subheading: Get up and running with Ghost.
+chapter: quickstart
+section: quickstart
 ---
 
 <div class="container">

--- a/themes/index.html
+++ b/themes/index.html
@@ -4,6 +4,7 @@ meta_title: How to Make Ghost Themes - Ghost Docs
 meta_description: An in depth guide to making themes for the Ghost blogging platform. Everything you need to know to build themes for Ghost.
 heading: Ghost Themes
 subheading: Get started creating your own themes for Ghost
+chapter: themes
 ---
 
 <div class="container">

--- a/usage/configuration.html
+++ b/usage/configuration.html
@@ -5,6 +5,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: configuration
 permalink: /usage/configuration/
 prev_section: usage
 next_section: settings

--- a/usage/faq.html
+++ b/usage/faq.html
@@ -5,6 +5,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: faq
 permalink: /usage/faq/
 prev_section: writing
 ---

--- a/usage/managing.html
+++ b/usage/managing.html
@@ -5,6 +5,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: managing
 permalink: /usage/managing/
 prev_section: settings
 next_section: writing

--- a/usage/settings.html
+++ b/usage/settings.html
@@ -5,6 +5,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: settings
 permalink: /usage/settings/
 prev_section: configuration
 next_section: managing

--- a/usage/writing.html
+++ b/usage/writing.html
@@ -5,6 +5,7 @@ meta_description: An in depth guide to using the Ghost blogging platform. Got Gh
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
+section: writing
 permalink: /usage/writing/
 prev_section: managing
 next_section: faq

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,0 +1,45 @@
+---
+lang: zh
+layout: default
+meta_title: Ghost使用指南 - Ghost中文文档
+meta_description: Ghost使用完全指南。包括安装、使用以及如何制作主题和插件。
+---
+
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=596756540369391";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+<div class="bs-masthead">
+  <div class="container">
+    <h1>Ghost使用指南</h1>
+    <p class="lead">这里包含了完整的Ghost使用指南中文文档。</p>
+    <p>
+      <a href="{{ site.url }}/{% if page.lang %}{{ page.lang }}{% endif %}/installation/" class="btn btn-success btn-large">开始Ghost之旅吧</a>
+    </p>
+  </div>
+</div>
+
+<div id="social">
+  <div class="container">
+    <ul>
+      <li>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      </li>
+      <li>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
+      </li>
+      <li class="follow-btn">
+        <a href="https://twitter.com/tryghost" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @TryGhost</a>
+      </li>
+      <li class="tweet-btn">
+        <div class="fb-like" data-href="http://www.facebook.com/TryGhostApp" data-send="false" data-layout="button_count" data-width="100" data-show-faces="false"></div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/zh/installation/deploy.html
+++ b/zh/installation/deploy.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/deploy/
+permalink: /zh/installation/deploy/
 chapter: installation
+section: deploy
 prev_section: linux
 next_section: upgrading
 ---

--- a/zh/installation/index.html
+++ b/zh/installation/index.html
@@ -1,5 +1,5 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: 如何在服务器上安装Ghost - Ghost中文文档
 meta_description: 这里详细讲述如何在你本地或远程环境中安装Ghost博客平台。
@@ -30,7 +30,7 @@ next_section: mac
             <p><a href="http://nodejs.org">Node.js</a>让我们具有了开发服务器端JavaScript程序的能力。而在以前，JavaScript只能在浏览器上运行，如果要开发服务器端的程序，就要使用PHP一类的编程语言了。如果能够用同一种开发语言来完成web应用的开发，这将是多么棒！并且，Node.js还赋予了前端开发工程师更大的能力。</p>
 
             <p><a href="http://nodejs.org">Node.js</a>让这一切变为可能，其原理是对Google Chrome浏览器所用的JavaScript引擎进行了包装，让它能够跨平台运行。也就是说，你能在自己的电脑上非常快速的安装Ghost并让它非常快捷、方便的跑起来。
-                接下来我们详细讲解如何在<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/mac/">Mac</a>、<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/window/">Windows</a>或<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/linux/">Linux</a>上安装Ghost，另外还介绍了如何在<a href="/cn/installation/deploy">服务器或托管空间</a>上部署Ghost。</p>
+                接下来我们详细讲解如何在<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/mac/">Mac</a>、<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/window/">Windows</a>或<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/linux/">Linux</a>上安装Ghost，另外还介绍了如何在<a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/deploy">服务器或托管空间</a>上部署Ghost。</p>
 
 
             <h3>起步</h3>

--- a/zh/installation/linux.html
+++ b/zh/installation/linux.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/linux/
+permalink: /zh/installation/linux/
 chapter: installation
+section: linux
 prev_section: windows
 next_section: deploy
 ---

--- a/zh/installation/mac.html
+++ b/zh/installation/mac.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/mac/
+permalink: /zh/installation/mac/
 chapter: installation
+section: mac
 prev_section: installation
 next_section: windows
 ---

--- a/zh/installation/troubleshooting.html
+++ b/zh/installation/troubleshooting.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/troubleshooting/
+permalink: /zh/installation/troubleshooting/
 chapter: installation
+section: troubleshooting
 prev_section: upgrading
 ---
 

--- a/zh/installation/upgrading.html
+++ b/zh/installation/upgrading.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/upgrading/
+permalink: /zh/installation/upgrading/
 chapter: installation
+section: upgrading
 prev_section: deploy
 next_section: troubleshooting
 ---

--- a/zh/installation/windows.html
+++ b/zh/installation/windows.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Install Ghost on Your Server - Ghost Docs
 meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
 heading: Installing Ghost &amp; Getting Started
 subheading: The first steps to setting up your new blog for the first time.
-permalink: /cn/installation/windows/
+permalink: /zh/installation/windows/
 chapter: installation
+section: windows
 prev_section: mac
 next_section: linux
 ---

--- a/zh/mail/index.html
+++ b/zh/mail/index.html
@@ -1,9 +1,10 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: Ghost Mail Configuration - Ghost Docs
 meta_description: How to configure your email server and send emails with the Ghost blogging platform. Everything you need to know.
 heading: Setting up Email
+chapter: mail
 ---
 
 <div class="container">

--- a/zh/quickstart/quickstart.html
+++ b/zh/quickstart/quickstart.html
@@ -1,9 +1,11 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: Ghost Quickstart
 heading: Ghost Quickstart
 subheading: Get up and running with Ghost.
+chapter: quickstart
+section: quickstart
 ---
 
 <div class="container">

--- a/zh/themes/index.html
+++ b/zh/themes/index.html
@@ -1,10 +1,11 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Make Ghost Themes - Ghost Docs
 meta_description: An in depth guide to making themes for the Ghost blogging platform. Everything you need to know to build themes for Ghost.
 heading: Ghost Themes
 subheading: Get started creating your own themes for Ghost
+chapter: themes
 ---
 
 <div class="container">

--- a/zh/usage/configuration.html
+++ b/zh/usage/configuration.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
-permalink: /cn/usage/configuration/
+section: configuration
+permalink: /zh/usage/configuration/
 prev_section: usage
 next_section: settings
 ---

--- a/zh/usage/faq.html
+++ b/zh/usage/faq.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
-permalink: /cn/usage/faq/
+section: faq
+permalink: /zh/usage/faq/
 prev_section: writing
 ---
 

--- a/zh/usage/index.html
+++ b/zh/usage/index.html
@@ -1,5 +1,5 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!

--- a/zh/usage/managing.html
+++ b/zh/usage/managing.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
-permalink: /cn/usage/managing/
+section: managing
+permalink: /zh/usage/managing/
 prev_section: settings
 next_section: writing
 ---

--- a/zh/usage/settings.html
+++ b/zh/usage/settings.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
-permalink: /cn/usage/settings/
+section: settings
+permalink: /zh/usage/settings/
 prev_section: configuration
 next_section: managing
 ---

--- a/zh/usage/writing.html
+++ b/zh/usage/writing.html
@@ -1,12 +1,13 @@
 ---
-lang: cn
+lang: zh
 layout: default
 meta_title: How to Use Ghost - Ghost Docs
 meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
 heading: Using Ghost
 subheading: Finding your way around, and getting set up the way you want
 chapter: usage
-permalink: /cn/usage/writing/
+section: writing
+permalink: /zh/usage/writing/
 prev_section: managing
 next_section: faq
 ---


### PR DESCRIPTION
As also discussed in #1233
- corrected Chinese language code (`cn` => `zh`) to conform with [BCP 47](http://en.wikipedia.org/wiki/BCP_47); added custom redirect page at `/cn/index.html`
- added `{{page.section}}` metadata so as to be able to reference URI components (`site_url`, `page.lang`, `page.chapter`, `page.section`) individually
- refactored canonical meta tag in default layout to refer to the same page with trailing slash: `site_url/[page.lang/][page.chapter/][page.section/]`
- added alternate-hreflang meta tags in default layout to help search engines understand about different language versions
- added visible cross-language links in top navbar with `.navbar-right` styling for each page, using the URI components mentioned above to construct the different language links (essentially but not quite the same logic as for alternate-hreflang meta tags)
- included Bootstrap v3's `.navbar-right` styles in main.css, seeing as they seem to be missing from bootstrap.css at the moment and I don't want to mess with it. :D

It may be appropriate to edit README.md or add a CONTRIBUTING or TRANSLATING file to explain how to get started with new translations, and/or move translations to a more formal mechanism...
