### PR TITLE
Switched to libsass from ruby sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "grunt": "~0.4.1",
         "grunt-jslint": "~1.0.0",
         "grunt-shell": "~0.3.1",
-        "grunt-contrib-sass": "~0.4.1",
+        "grunt-sass": "~0.7.0",
         "grunt-contrib-handlebars": "~0.5.10",
         "grunt-contrib-watch": "~0.5.1",
         "grunt-bump": "~0.0.11",


### PR DESCRIPTION
`grunt-sass` has a very similar interface to `grunt-contrib-sass` so most of the options should be similar, just the compression stuff that needs changing.

Bare in mind that libsass (via node-sass, via grunt-sass) doesn't have feature parity with the latest ruby sass at the moment, so it won't have all the wizzbang features yet.

Fixes #1346
