### PR TITLE
Allow user to set static page before saving

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -150,7 +150,6 @@
         },
 
         toggleStaticPage: function (e) {
-            e.preventDefault();
             var pageEl = $(e.currentTarget),
                 page = this.model ? !this.model.get('page') : false;
 


### PR DESCRIPTION
- jQuery event.preventDefault() stops the user from selecting the checkbox
