### PR TITLE
[WIP] Initial auto update implementation

### DIFF
--- a/core/client/views/debug.js
+++ b/core/client/views/debug.js
@@ -1,10 +1,11 @@
-/*global window, document, Ghost, $, _, Backbone, JST */
+/*global window, document, Ghost, $, _, Backbone, NProgress, JST */
 (function () {
     "use strict";
 
     Ghost.Views.Debug = Ghost.View.extend({
         events: {
-            "click .settings-menu a": "handleMenuClick"
+            "click .settings-menu a": "handleMenuClick",
+            "click .js-update": "handleUpdateClick"
         },
 
         handleMenuClick: function (ev) {
@@ -19,6 +20,106 @@
             this.$("#debug-" + $target.attr("class")).show();
 
             return false;
+        },
+
+        confirmUpdate: function (updateInfo) {
+            this.addSubview(new Ghost.Views.Modal({
+                model: {
+                    options: {
+                        close: false,
+                        confirm: {
+                            accept: {
+                                func: function () {
+                                    NProgress.start();
+
+                                    $.ajax({
+                                        url: Ghost.settings.apiRoot + '/update/',
+                                        type: 'POST',
+                                        headers: {
+                                            'X-CSRF-Token': $("meta[name='csrf-param']").attr('content')
+                                        },
+                                        success: function onSuccess(data) {
+                                            if (!data) {
+                                                throw new Error('No response received from server.');
+                                            }
+                                            if (!data.success) {
+                                                throw new Error(data.detail || 'Unknown error');
+                                            }
+
+                                            Ghost.notifications.addItem({
+                                                type: 'success',
+                                                message: 'Successfully updated. Please restart Ghost for changes to take effect.',
+                                                status: 'passive'
+                                            });
+
+                                            NProgress.done();
+                                        },
+                                        error: function onError(response) {
+                                            var data = JSON.parse(response.responseText),
+                                                message = data && data.detail ? data.detail : 'unknown';
+
+                                            Ghost.notifications.addItem({
+                                                type: 'error',
+                                                message: ['A problem was encountered while performing update. Error: ', message].join(''),
+                                                status: 'passive'
+                                            });
+
+                                            NProgress.done();
+                                        }
+                                    });
+                                },
+                                text: "Yes"
+                            },
+                            reject: {
+                                func: function () {
+                                    return true;
+                                },
+                                text: "No"
+                            }
+                        },
+                        type: "action",
+                        style: ["wide", "centered"],
+                        animation: 'fade'
+                    },
+                    content: {
+                        template: 'blank',
+                        title: ['v', updateInfo.newVersion, ' is available! Proceed with installation?'].join('')
+                    }
+                }
+            }));
+        },
+
+        handleUpdateClick: function (e) {
+            e.preventDefault();
+            var self = this;
+
+            $.get(Ghost.settings.apiRoot + '/update/').done(function onResponse(data) {
+                if (!data) {
+                    return Ghost.notifications.addItem({
+                        type: 'error',
+                        message: 'Invalid response received.',
+                        status: 'passive'
+                    });
+                }
+                if (!data.isUpdateAvailable) {
+                    return Ghost.notifications.addItem({
+                        type: 'success',
+                        message: 'Ghost is up to date.',
+                        status: 'passive'
+                    });
+                }
+
+                self.confirmUpdate(data);
+            }).fail(function onError(response) {
+                var data = JSON.parse(response.responseText),
+                    message = data && data.detail ? data.detail : 'unknown';
+
+                return Ghost.notifications.addItem({
+                    type: 'error',
+                    message: ['Unable to check for update. Error: ', message].join(''),
+                    status: 'passive'
+                });
+            });
         }
     });
 

--- a/core/server.js
+++ b/core/server.js
@@ -337,6 +337,9 @@ when(ghost.init()).then(function () {
     // #### Import/Export
     server.get('/ghost/api/v0.1/db/', auth, api.db['export']);
     server.post('/ghost/api/v0.1/db/', auth, api.db['import']);
+    // #### Update
+    server.get('/ghost/api/v0.1/update/', auth, api.update.check);
+    server.post('/ghost/api/v0.1/update/', auth, api.update.run);
 
     // ### Admin routes
     /* TODO: put these somewhere in admin */

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -7,6 +7,7 @@ var Ghost        = require('../../ghost'),
     errors       = require('../errorHandling'),
     permissions  = require('../permissions'),
     db           = require('./db'),
+    update       = require('./update'),
     canThis      = permissions.canThis,
 
     ghost        = new Ghost(),
@@ -401,10 +402,13 @@ requestHandler = function (apiMethod) {
 };
 
 // Public API
-module.exports.posts = posts;
-module.exports.users = users;
-module.exports.tags = tags;
-module.exports.notifications = notifications;
-module.exports.settings = settings;
-module.exports.db = db.db;
-module.exports.requestHandler = requestHandler;
+module.exports = {
+    posts: posts,
+    users: users,
+    tags: tags,
+    notifications: notifications,
+    settings: settings,
+    db: db.db,
+    update: update,
+    requestHandler: requestHandler
+};

--- a/core/server/api/update.js
+++ b/core/server/api/update.js
@@ -1,0 +1,143 @@
+var Ghost         = require('../../ghost'),
+    package_json  = require('../../../package.json'),
+    dataExport    = require('../data/export'),
+    fs            = require('fs-extra'),
+    zlip          = require('zlib'),
+    path          = require('path'),
+    when          = require('when'),
+    nodefn        = require('when/node/function'),
+    _             = require('underscore'),
+    semver        = require('semver'),
+    request       = require('request'),
+    AdmZip        = require('adm-zip'),
+
+    ghost         = new Ghost(),
+    latestUrl     = 'https://ghost.org/zip/ghost-latest.zip',
+    versionRegEx  = /([0-9]+\.[0-9]+\.[0-9]+)\.zip$/;
+
+function check(req, res) {
+    var result,
+        versionMatches;
+
+    result = {
+        isUpdateAvailable: false,
+        currentVersion: package_json.version,
+        newVersion: null
+    };
+
+    request.get(latestUrl, { followRedirect: false }, function (error, response, body) {
+        if (error) {
+            return res.send(500, {
+                detail: error && error.message ? error.message : 'Unknown error'
+            });
+        }
+        if (response.statusCode !== 302) {
+            return res.send(500, {
+                detail: 'Received an unexpected response code of ' + response.statusCode + '.'
+            });
+        }
+        if (!response.headers || !response.headers.location) {
+            return res.send(500, {
+                detail: 'Unable to find "location" in response header.'
+            });
+        }
+
+        versionMatches = versionRegEx.exec(response.headers.location);
+
+        if (!versionMatches || versionMatches.length !== 2) {
+            return res.send(500, {
+                detail: 'Unable to parse "location" response header.'
+            });
+        }
+
+        result.newVersion = versionMatches[1];
+
+        try {
+            result.isUpdateAvailable = semver.lt(result.currentVersion, result.newVersion);
+        } catch (er) {
+            return res.send(500, {
+                detail: 'Unable to compare versions. Detail: ' + (er && er.message ? er.message : 'unknown') + '.'
+            });
+        }
+
+
+        return res.send(200, result);
+    });
+}
+
+function extractUpdate(result, targetFile, req, res) {
+    try {
+        var zip = new AdmZip(targetFile);
+        zip.extractAllTo(path.resolve('.'), true);
+
+        // Delete the zip file
+        fs.unlink(targetFile, function (error) {
+            if (error) {
+                result.detail = 'Failed to cleanup upgrade files. Detail: ' + error.message + '.';
+                return res.send(500, result);
+            }
+
+            result.success = true;
+            res.send(200, result);
+        });
+    } catch (error) {
+        result.detail = 'Failed to extract upgrade files. Detail: ' + error.message + '.';
+        res.send(500, result);
+    }
+}
+
+function getLatestVersion(result, req, res) {
+    var targetFile = path.resolve('content/tmp', 'ghost-latest.zip');
+
+    request.get(latestUrl).pipe(fs.createWriteStream(targetFile)).on('finish', function () {
+        return extractUpdate(result, targetFile, req, res);
+    }).on('error', function (error) {
+        result.detail = 'Unable to save upgrade archive to disk. Detail: ' + error.message + '.';
+        return res.send(500, result);
+    });
+}
+
+function backupDatabase(result, req, res) {
+    dataExport().then(function (exportedData) {
+        // Save the exported data to the file system for download
+        var fileName = path.resolve(__dirname + '/../../server/data/export/exported-' + (new Date().getTime()) + '.json');
+
+        return nodefn.call(fs.writeFile, fileName, JSON.stringify(exportedData));
+    }).then(function () {
+        return getLatestVersion(result, req, res);
+    }).otherwise(function onError(error) {
+        result.detail = 'Unable to backup database. Detail: ' + error.message + '.';
+        return res.send(500, result);
+    });
+}
+
+function run(req, res) {
+    var result,
+        tmpDirectory = path.resolve('content/tmp');
+
+    result = {
+        success: false,
+        detail: null
+    };
+
+    // Create 'tmp' directory if it doesn't exist already
+    fs.exists(tmpDirectory, function (exists) {
+        if (exists) {
+            return backupDatabase(result, req, res);
+        }
+
+        fs.mkdir(tmpDirectory, function (error) {
+            if (error) {
+                result.detail = 'Unable to create temporary directory. Detail: ' + error.message + '.';
+                return res.send(500, result);
+            }
+
+            return backupDatabase(result, req, res);
+        });
+    });
+}
+
+module.exports = {
+    check: check,
+    run: run
+};

--- a/core/server/views/debug.hbs
+++ b/core/server/views/debug.hbs
@@ -36,6 +36,15 @@
                     </div>
                 </fieldset>
             </form>
+            <form>
+                <fieldset>
+                    <div class="form-group">
+                        <label>Update</label>
+                        <a href="javascript:void(0);" class="button-save js-update">Check for Updates</a>
+                        <p>Runs on over to Ghost.org to see if there is a newer version of Ghost.</p>
+                    </div>
+                </fieldset>
+            </form>
         </section>
     </section>
 </div>

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
         "downsize": "0.0.2",
         "validator": "1.4.0",
         "rss": "0.2.0",
-        "nodemailer": "0.5.2"
+        "nodemailer": "0.5.2",
+        "request": "2.27.0",
+        "adm-zip": "0.4.3"
     },
     "optionalDependencies": {
         "mysql": "2.0.0-alpha9"


### PR DESCRIPTION
Fixes #1260
- Added update button to ugly debug UI.
- Button checks for updates by parsing the location header on the
  ghost-latest.zip redirect.
- If an update is available, a modal confirmation window is presented to
  confirm the installation of the update.
- Installation process includes creating the `content/tmp/` folder
  (unless it already exists), downloading the zip to that folder,
  extracting the zip on top of the current installation and then deleting
  the zip from `tmp`.
- Note the update process still requires you to manually run `npm
  install` and `npm update` and restart the server. See the comments in
  the associated item for more information to that end.
