### PR TITLE
Add Coverage report for Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ config.js
 
 # Built asset files
 /core/built
+
+# Coverage reports
+coverage_integration.html
+coverage_unit.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -251,6 +251,15 @@ var path           = require('path'),
             shell: {
                 bourbon: {
                     command: 'bourbon install --path <%= paths.adminAssets %>/sass/modules/'
+                },
+                jscoverage: {
+                    command: 'jscoverage core core-cov'
+                },
+                mocha_unit_coverage: {
+                    command: 'NODE_ENV=testing APP_COVERAGE=1 ./node_modules/.bin/mocha --timeout 15000 --reporter html-cov > coverage_unit.html ./core-cov/test/unit'
+                },
+                mocha_integration_coverage: {
+                    command: 'NODE_ENV=testing APP_COVERAGE=1 ./node_modules/.bin/mocha --timeout 15000 --reporter html-cov > coverage_integration.html ./core-cov/test/integration'
                 }
             },
 
@@ -296,6 +305,9 @@ var path           = require('path'),
                 },
                 test: {
                     src: ['content/data/ghost-test.db']
+                },
+                jscoverage: {
+                    src: ['core-cov']
                 }
             },
 
@@ -863,6 +875,11 @@ var path           = require('path'),
         grunt.registerTask('test-functional', 'Run casperjs tests only', ['clean:test', 'setTestEnv', 'express:test', 'spawn-casperjs']);
 
         grunt.registerTask('validate', 'Run tests and lint code', ['jslint', 'test-unit', 'test-integration', 'test-functional']);
+
+
+        // ## Coverage report for Unit and Integration Tests
+
+        grunt.registerTask('test-coverage', 'Generate unit and integration tests coverage report', ['clean:test', 'setTestEnv', 'loadConfig', 'express:test', 'shell:jscoverage', 'shell:mocha_unit_coverage', 'shell:mocha_integration_coverage', 'clean:jscoverage']);
 
 
         // ## Documentation

--- a/index.js
+++ b/index.js
@@ -1,13 +1,16 @@
 // # Ghost bootloader
 // Orchestrates the loading of Ghost
 
-var configLoader = require('./core/config-loader.js'),
-    error        = require('./core/server/errorHandling');
+var core_path = process.env.APP_COVERAGE
+    ? './core-cov'
+    : './core',
+    configLoader = require(core_path + '/config-loader.js'),
+    error        = require(core_path + '/server/errorHandling');
 
 // If no env is set, default to development
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
 configLoader.loadConfig().then(function () {
     // The server and its dependencies require a populated config
-    require('./core/server');
+    require(core_path + '/server');
 }).otherwise(error.logAndThrowError);


### PR DESCRIPTION
Fixes #361

Pre-requisites: Install JSCoverage (https://github.com/visionmedia/node-jscoverage)

I don't know what is the best way to get it installed automatically. Installing JSCoverage through a Grunt Task can be possible, but I think it's not the best way to do it.
