### PR TITLE
Add importJSONData to api/db.js for import plugins

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ var path           = require('path'),
                 },
 
                 integration: {
-                    src: ['core/test/integration/**/model*_spec.js']
+                    src: ['core/test/integration/**/*_spec.js']
                 }
             },
 

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -6,7 +6,7 @@ var Ghost        = require('../../ghost'),
     when         = require('when'),
     errors       = require('../errorHandling'),
     permissions  = require('../permissions'),
-    db           = require('./db'),
+    GhostDatabase = require('./db'),
     canThis      = permissions.canThis,
 
     ghost        = new Ghost(),
@@ -20,7 +20,8 @@ var Ghost        = require('../../ghost'),
     settingsObject,
     settingsCollection,
     settingsFilter,
-    filteredUserAttributes = ['password', 'created_by', 'updated_by'];
+    filteredUserAttributes = ['password', 'created_by', 'updated_by'],
+    exportedApi;
 
 // ## Posts
 posts = {
@@ -400,11 +401,16 @@ requestHandler = function (apiMethod) {
     };
 };
 
+exportedApi = {
+    posts: posts,
+    users: users,
+    tags: tags,
+    notifications: notifications,
+    settings: settings,
+    requestHandler: requestHandler
+};
+
+exportedApi.db = new GhostDatabase(ghost, exportedApi);
+
 // Public API
-module.exports.posts = posts;
-module.exports.users = users;
-module.exports.tags = tags;
-module.exports.notifications = notifications;
-module.exports.settings = settings;
-module.exports.db = db.db;
-module.exports.requestHandler = requestHandler;
+module.exports = exportedApi;

--- a/core/test/integration/api_db_spec.js
+++ b/core/test/integration/api_db_spec.js
@@ -1,0 +1,93 @@
+/*globals describe, before, beforeEach, afterEach, it */
+var testUtils = require('../unit/testUtils'),
+    should = require('should'),
+    sinon = require('sinon'),
+    when = require('when'),
+    _ = require('underscore'),
+    GhostDatabase = require('../../../core/server/api/db');
+
+describe('GhostDatabase', function () {
+
+    var user = testUtils.DataGenerator.forModel.users[0],
+        fakeGhost,
+        fakeApi,
+        db;
+
+    before(function (done) {
+        testUtils.clearData()
+            .then(function () {
+                done();
+            }, done);
+    });
+
+    beforeEach(function (done) {
+        testUtils.initData()
+            .then(function () {
+                return testUtils.insertDefaultFixtures();
+            })
+            .then(function () {
+
+                fakeGhost = {
+                    notifications: {
+                        add: sinon.stub()
+                    }
+                };
+
+                fakeApi = {
+                    settings: {
+                        read: sinon.stub().returns(when.resolve({ value: '000' }))
+                    }
+                };
+                
+                db = new GhostDatabase(fakeGhost, fakeApi);
+
+                done();
+            }, done);
+    });
+
+    afterEach(function (done) {
+        testUtils.clearData().then(function () {
+            done();
+        }, done);
+    });
+
+    it('can get the database version', function (done) {
+        db.getVersion().then(function (databaseVersion) {
+            should.exist(databaseVersion);
+
+            databaseVersion.should.equal('000');
+
+            done();
+        }, done);
+    });
+
+    it('can import data', function (done) {
+        var importData = {
+            meta: {
+                exported_at: Date.now(),
+                version: '000'
+            },
+            data: {
+                posts: [{
+                    title: 'Imported Post 1',
+                    html: 'Some <strong>content</strong> to import',
+                    status: 'published'
+                }]
+            }
+        };
+
+        sinon.spy(db, 'getVersion');
+
+        db._doDataImport = sinon.stub().returns(when.resolve());
+
+        db.importJSONData(importData).then(function () {
+
+            db.getVersion.called.should.equal(true);
+            db._doDataImport.called.should.equal(true);
+
+            // TODO: Verify we imported the posts
+
+            done();
+        }, done);
+    });
+});


### PR DESCRIPTION
- Abstract out the common functionality from the existing
  import function.
- Refactor to remove circular ghost and api references so we can add
  unit tests.
- Add unit tests for getVersion() and importJSONData()

While working on the [Wordpress Import Plugin](https://github.com/jgable/ghost-plugin/blob/wordpressImport/example/WordpressImport/index.js) I needed a way to import the parsed data and didn't have access to the req, res objects.  This change will make it easier for our import plugins to use the existing db import functionality.

``` javascript
}).then(function (ghostImportFormatData) {
    // Inject data using import api
    return self.app.api.db.importJSONData(ghostImportFormatData);
});
```
