### PR TITLE
document that url currently must not have a path suffix

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -8,6 +8,7 @@ config = {
     // ### Development **(default)**
     development: {
         // The url to use when providing links to the site, E.g. in RSS and email.
+        // must not contain a path suffix after the hostname - "subdirs" are not (yet) supported! 
         url: 'http://my-ghost-blog.com',
 
         // Example mail config
@@ -44,6 +45,7 @@ config = {
     // When running Ghost in the wild, use the production environment
     // Configure your URL and mail settings here
     production: {
+        // must not contain a path suffix after the hostname - "subdirs" are not (yet) supported! 
         url: 'http://my-ghost-blog.com',
         mail: {},
         database: {


### PR DESCRIPTION
It seems like quite a bunch of people try to run ghost on an url having a path suffix in addition to the hostname, and that currently doesn't work yet.

While I want to look into that feature and see what needs to be done to get it implemented, I'd first get it documented to save other people the time to try it as long as it's not implemented.

see also https://ghost.org/forum/installation/341-how-do-i-run-ghost-on-a-subdirectory
