### PR TITLE
Add Coverage report for Unit and Integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ config.js
 
 # Built asset files
 /core/built
+
+# Coverage reports
+coverage.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,6 +258,9 @@ var path           = require('path'),
             shell: {
                 bourbon: {
                     command: 'bourbon install --path <%= paths.adminAssets %>/sass/modules/'
+                },
+                coverage: {
+                    command: './node_modules/mocha/bin/mocha --timeout 15000 --reporter html-cov > coverage.html ./core/test/blanket_coverage.js'
                 }
             },
 
@@ -871,6 +874,11 @@ var path           = require('path'),
         grunt.registerTask('test-functional', 'Run casperjs tests only', ['clean:test', 'setTestEnv', 'express:test', 'spawn-casperjs']);
 
         grunt.registerTask('validate', 'Run tests and lint code', ['jslint', 'test-unit', 'test-integration', 'test-functional']);
+
+
+        // ## Coverage report for Unit and Integration Tests
+
+        grunt.registerTask('test-coverage', 'Generate unit and integration tests coverage report', ['clean:test', 'setTestEnv', 'loadConfig', 'express:test', 'shell:coverage']);
 
 
         // ## Documentation

--- a/core/test/blanket_coverage.js
+++ b/core/test/blanket_coverage.js
@@ -1,0 +1,8 @@
+var blanket = require("blanket")({
+    "pattern": ["/core/server/", "/core/client/", "/core/shared/"],
+    "data-cover-only": ["/core/server/", "/core/client/", "/core/shared/"]
+    }),
+    requireDir = require("require-dir");
+
+requireDir("./unit");
+requireDir("./integration");

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "mysql": "2.0.0-alpha9"
     },
     "devDependencies": {
+        "blanket": "~1.1.5",
         "grunt": "~0.4.1",
         "grunt-bump": "~0.0.11",
         "grunt-contrib-clean": "~0.5.0",
@@ -74,6 +75,7 @@
         "matchdep": "~0.3.0",
         "mocha": "~1.13.0",
         "request": "~2.27.0",
+        "require-dir": "~0.1.0",
         "should": "~2.0.2",
         "sinon": "~1.7.3"
     }


### PR DESCRIPTION
issue #361
- Added shell:coverage task to generate coverage report
- Registered test-coverage Grunt task as shortcut of shell:coverage
- Added coverage files to .gitignore
- Added require-cli and blanket to package.json
