### PR TITLE
[Docs] Fix back button to index page

### DIFF
--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,6 +1,6 @@
 <nav class="section-nav text-center">
     {% if page.prev_section != null %}
-      <a href="{{ site.url }}{% if page.lang %}/{{ page.lang }}{% endif %}/{{page.chapter}}/{{ page.prev_section }}/"
+      <a href="{{ site.url }}{% if page.lang %}/{{ page.lang }}{% endif %}/{{page.chapter}}/{% if page.chapter != page.prev_section %}{{ page.prev_section }}/{% endif %}"
          class="btn btn-prev btn-primary" title="{{ page.prev_section | capitalize  }}">
        Back
       </a>


### PR DESCRIPTION
Problem is described in #1278.

This allows us to continue to use the name of the chapter for `prev_section`, which makes a lot of sense.
