### PR TITLE
Added server.js file to root so that Azure will build properly on deploy

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -301,6 +301,8 @@ when(ghost.init()).then(function () {
     server.get('/rss/', frontend.rss);
     server.get('/rss/:page/', frontend.rss);
     server.get('/page/:page/', frontend.homepage);
+    //HACK: Workaround for Wordpress routing and historical URL preservation
+    server.get('/:year/:month/:day/:slug/', frontend.single);
     server.get('/:slug/', frontend.single);
     server.get('/', frontend.homepage);
 

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+var GhostServer = require("./index");


### PR DESCRIPTION
When deploying Ghost to Azure the build fails because Azure expects there to be a server.js (or app.js) file in the Express app root. This small change allows Azure to build the site properly on first deploy.

In addition (sorry I meant to put this into another PR) I added a route for historical Wordpress-style URLs. This simply allows for their presence and routes to the slugged post - this is nice for backwards compatibility of imported blogs (like mine).
