### PR TITLE
Add lost id's on Installation/Upgrading

### DIFF
--- a/example_translation/installation/upgrading.md
+++ b/example_translation/installation/upgrading.md
@@ -12,7 +12,7 @@ prev_section: deploy
 next_section: troubleshooting
 ---
 
-# Upgrading Ghost
+# Upgrading Ghost <a id="upgrade"></a>
 
 Upgrading Ghost is super straightforward.
 
@@ -30,7 +30,7 @@ Upgrading Ghost is matter of replacing the old files with the new files, re-runn
 
 Remember, by default Ghost stores all your custom data, themes, images, etc in the <code class="path">content</code> directory, so take care to keep this safe! Replace only the files in <code class="path">core</code> and the root, and all will be fine.
 
-## Backing Up
+## Backing Up <a id="backing-up"></a>
 
 <img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/export.png" style="float:right" />
 
@@ -40,7 +40,7 @@ Remember, by default Ghost stores all your custom data, themes, images, etc in t
 <p class="note"><strong>Note:</strong> You can, if you like, take a copy of your database from <code class="path">content/data</code> but <strong>be warned</strong> you should not do this whilst Ghost is running. Please stop it first.</p>
 
 
-## How to Upgrade
+## How to Upgrade <a id="how-to"></a>
 
 How to upgrade on your local machine
 
@@ -54,11 +54,11 @@ How to upgrade on your local machine
 *   Run `npm install --production`
 *   Finally, Restart Ghost so that the changes take effect
 
-## Command line only
+## Command line only <a id="cli"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
-### Command line only on mac
+### Command line only on mac <a id="cli-mac"></a>
 
 The screencast below shows the steps for upgrading Ghost where the zip file has been downloaded to <code class="path">~/Downloads</code> and Ghost is installed in <code class="path">~/ghost</code> <span class="note">**Note:** `~` means the user's home directory on mac and linux</span>
 
@@ -77,7 +77,7 @@ The steps in the screencast are:
 *   `npm install --production` - install Ghost
 *   `npm start` - start Ghost
 
-### Command line only on linux servers
+### Command line only on linux servers <a id="cli-server"></a>
 
 *   First you'll need to find out the URL of the latest Ghost version. It should be something like `http://ghost.org/zip/ghost-latest.zip`.
 *   Fetch the zip file with `wget http://ghost.org/zip/ghost-latest.zip` (or whatever the URL for the latest Ghost version is).
@@ -87,7 +87,7 @@ The steps in the screencast are:
 
 **Additionally**, [howtoinstallghost.com](http://www.howtoinstallghost.com/how-to-update-ghost/) also has instructions for upgrading Ghost on linux servers.
 
-### How to update a DigitalOcean Droplet
+### How to update a DigitalOcean Droplet <a id="digitalocean"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
@@ -99,7 +99,7 @@ The steps in the screencast are:
 *   Run `npm install` to get any new dependencies
 *   Finally, restart Ghost so that the changes take effect using `service ghost restart`
 
-## How to upgrade Node.js to the latest version
+## How to upgrade Node.js to the latest version <a id="upgrading-node"></a>
 
 If you originally installed Node.js from the [Node.js](nodejs.org) website, you can upgrade Node.js to the latest version by downloading and running the latest installer. This will replace your current version with the new version.
 

--- a/installation/upgrading.md
+++ b/installation/upgrading.md
@@ -11,7 +11,7 @@ prev_section: deploy
 next_section: troubleshooting
 ---
 
-# Upgrading Ghost
+# Upgrading Ghost <a id="upgrade"></a>
 
 Upgrading Ghost is super straightforward.
 
@@ -29,7 +29,7 @@ Upgrading Ghost is matter of replacing the old files with the new files, re-runn
 
 Remember, by default Ghost stores all your custom data, themes, images, etc in the <code class="path">content</code> directory, so take care to keep this safe! Replace only the files in <code class="path">core</code> and the root, and all will be fine.
 
-## Backing Up
+## Backing Up <a id="backing-up"></a>
 
 <img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/export.png" style="float:right" />
 
@@ -39,7 +39,7 @@ Remember, by default Ghost stores all your custom data, themes, images, etc in t
 <p class="note"><strong>Note:</strong> You can, if you like, take a copy of your database from <code class="path">content/data</code> but <strong>be warned</strong> you should not do this whilst Ghost is running. Please stop it first.</p>
 
 
-## How to Upgrade
+## How to Upgrade <a id="how-to"></a>
 
 How to upgrade on your local machine
 
@@ -53,11 +53,11 @@ How to upgrade on your local machine
 *   Run `npm install --production`
 *   Finally, Restart Ghost so that the changes take effect
 
-## Command line only
+## Command line only <a id="cli"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
-### Command line only on mac
+### Command line only on mac <a id="cli-mac"></a>
 
 The screencast below shows the steps for upgrading Ghost where the zip file has been downloaded to <code class="path">~/Downloads</code> and Ghost is installed in <code class="path">~/ghost</code> <span class="note">**Note:** `~` means the user's home directory on mac and linux</span>
 
@@ -76,7 +76,7 @@ The steps in the screencast are:
 *   `npm install --production` - install Ghost
 *   `npm start` - start Ghost
 
-### Command line only on linux servers
+### Command line only on linux servers <a id="cli-server"></a>
 
 *   First you'll need to find out the URL of the latest Ghost version. It should be something like `http://ghost.org/zip/ghost-latest.zip`.
 *   Fetch the zip file with `wget http://ghost.org/zip/ghost-latest.zip` (or whatever the URL for the latest Ghost version is).
@@ -86,7 +86,7 @@ The steps in the screencast are:
 
 **Additionally**, [howtoinstallghost.com](http://www.howtoinstallghost.com/how-to-update-ghost/) also has instructions for upgrading Ghost on linux servers.
 
-### How to update a DigitalOcean Droplet
+### How to update a DigitalOcean Droplet <a id="digitalocean"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
@@ -98,7 +98,7 @@ The steps in the screencast are:
 *   Run `npm install` to get any new dependencies
 *   Finally, restart Ghost so that the changes take effect using `service ghost restart`
 
-## How to upgrade Node.js to the latest version
+## How to upgrade Node.js to the latest version <a id="upgrading-node"></a>
 
 If you originally installed Node.js from the [Node.js](nodejs.org) website, you can upgrade Node.js to the latest version by downloading and running the latest installer. This will replace your current version with the new version.
 

--- a/ko/installation/upgrading.md
+++ b/ko/installation/upgrading.md
@@ -12,7 +12,7 @@ prev_section: deploy
 next_section: troubleshooting
 ---
 
-# Upgrading Ghost
+# Upgrading Ghost <a id="upgrade"></a>
 
 Upgrading Ghost is super straightforward.
 
@@ -30,7 +30,7 @@ Upgrading Ghost is matter of replacing the old files with the new files, re-runn
 
 Remember, by default Ghost stores all your custom data, themes, images, etc in the <code class="path">content</code> directory, so take care to keep this safe! Replace only the files in <code class="path">core</code> and the root, and all will be fine.
 
-## Backing Up
+## Backing Up <a id="backing-up"></a>
 
 <img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/export.png" style="float:right" />
 
@@ -40,7 +40,7 @@ Remember, by default Ghost stores all your custom data, themes, images, etc in t
 <p class="note"><strong>Note:</strong> You can, if you like, take a copy of your database from <code class="path">content/data</code> but <strong>be warned</strong> you should not do this whilst Ghost is running. Please stop it first.</p>
 
 
-## How to Upgrade
+## How to Upgrade <a id="how-to"></a>
 
 How to upgrade on your local machine
 
@@ -54,11 +54,11 @@ How to upgrade on your local machine
 *   Run `npm install --production`
 *   Finally, Restart Ghost so that the changes take effect
 
-## Command line only
+## Command line only <a id="cli"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
-### Command line only on mac
+### Command line only on mac <a id="cli-mac"></a>
 
 The screencast below shows the steps for upgrading Ghost where the zip file has been downloaded to <code class="path">~/Downloads</code> and Ghost is installed in <code class="path">~/ghost</code> <span class="note">**Note:** `~` means the user's home directory on mac and linux</span>
 
@@ -77,7 +77,7 @@ The steps in the screencast are:
 *   `npm install --production` - install Ghost
 *   `npm start` - start Ghost
 
-### Command line only on linux servers
+### Command line only on linux servers <a id="cli-server"></a>
 
 *   First you'll need to find out the URL of the latest Ghost version. It should be something like `http://ghost.org/zip/ghost-latest.zip`.
 *   Fetch the zip file with `wget http://ghost.org/zip/ghost-latest.zip` (or whatever the URL for the latest Ghost version is).
@@ -87,7 +87,7 @@ The steps in the screencast are:
 
 **Additionally**, [howtoinstallghost.com](http://www.howtoinstallghost.com/how-to-update-ghost/) also has instructions for upgrading Ghost on linux servers.
 
-### How to update a DigitalOcean Droplet
+### How to update a DigitalOcean Droplet <a id="digitalocean"></a>
 
 <p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
 
@@ -99,7 +99,7 @@ The steps in the screencast are:
 *   Run `npm install` to get any new dependencies
 *   Finally, restart Ghost so that the changes take effect using `service ghost restart`
 
-## How to upgrade Node.js to the latest version
+## How to upgrade Node.js to the latest version <a id="upgrading-node"></a>
 
 If you originally installed Node.js from the [Node.js](nodejs.org) website, you can upgrade Node.js to the latest version by downloading and running the latest installer. This will replace your current version with the new version.
 

--- a/zh/installation/upgrading.md
+++ b/zh/installation/upgrading.md
@@ -12,7 +12,7 @@ prev_section: deploy
 next_section: troubleshooting
 ---
 
-# 更新 Ghost
+# 更新 Ghost <a id="upgrade"></a>
 
 更新 Ghost 是非常简单的。
 
@@ -30,7 +30,7 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 
 记住，Ghost 默认将所有的自定义数据，主题，图片等存储到 <code class="path">content</code> 目录下，所以确保此目录安全！只替换 <code class="path">core</code> 目录和根目录下的文件，一切就会正常。
 
-## 备份
+## 备份 <a id="backing-up"></a>
 
 <img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/export.png" style="float:right" />
 
@@ -39,7 +39,7 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 
 <p class="note"><strong>注意:</strong> 如果你喜欢的话，你也可以通过复制 <code class="path">content/data</code> 实现数据库的备份。但是 <strong>记住</strong> 要先停止 Ghost 后再去复制。</p>
 
-## 如何更新
+## 如何更新 <a id="how-to"></a>
 
 如何更新本地机器上的 Ghost 呢？
 
@@ -53,11 +53,11 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 *   运行 `npm install --production` 
 *   最后，重启 Ghost 使改变生效
 
-## 使用命令行
+## 使用命令行 <a id="cli"></a>
 
 <p class="note"><strong>备份！</strong> 总是在更新前执行一次备份。首先请阅读 <a href="#backing-up">备份指南</a> 。</p>
 
-### 在 mac 上使用命令行
+### 在 mac 上使用命令行 <a id="cli-mac"></a>
 
 下面的截屏视频显示了如何按步更新 Ghost ，在从下载了 zip 文件到 <code class="path">~/Downloads</code> 并且安装 Ghost到 <code class="path">~/ghost</code> 的前提下。<span class="note">**注意：**`~`在 mac 和 linux 中表示用户主目录。</span>
 
@@ -76,7 +76,7 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 *   `npm install --production` - 安装 Ghost
 *   `npm start` - 启动 Ghost
 
-### 在 linux 上使用命令行
+### 在 linux 上使用命令行 <a id="cli-server"></a>
 
 *   首先你需要知道最新版本 Ghost 的 URL。通常为 `http://ghost.org/zip/ghost-latest.zip` 
 *   通过 `wget http://ghost.org/zip/ghost-latest.zip` 下载最新的 zip 文件（或者带着版本号的 Ghost 文件的 URL）
@@ -86,7 +86,7 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 
 **此外**， [howtoinstallghost.com](http://www.howtoinstallghost.com/how-to-update-ghost/) 也介绍了如何在 linux 上更新 Ghost。
 
-### 如何更新 DigitalOcean Droplet
+### 如何更新 DigitalOcean Droplet <a id="digitalocean"></a>
 
 <p class="note"><strong>备份！</strong> 总是在更新前执行一次备份。首先请阅读 <a href="#backing-up">备份指南</a> 。</p>
 
@@ -98,7 +98,7 @@ Ghost 安装后，有一个与左边图片相似的文件夹结构，包括两�
 *   运行 `npm install` 安装最新的依赖包
 *   最后，使用 `service ghost restart` 重启 Ghost 使改变生效
 
-## 怎样更新 Node.js 到最新版本
+## 怎样更新 Node.js 到最新版本 <a id="upgrading-node"></a>
 
 如果你最初已经从 [Node.js](nodejs.org) 安装了 Node.js 了，你可以通过下载并安装最新版本的 Node.js 实现更新。这样新版本会覆盖之前安装的旧版本。
 


### PR DESCRIPTION
I forgot to add the IDs during the markdown conversion. Also applied to all translations an the example_translation.
