### PR TITLE
Move plugin init code into plugin.js and have it called from server.js

### DIFF
--- a/core/ghost.js
+++ b/core/ghost.js
@@ -14,7 +14,6 @@ var config      = require('../config'),
     Polyglot    = require('node-polyglot'),
     Mailer      = require('./server/mail'),
     models      = require('./server/models'),
-    plugins     = require('./server/plugins'),
     requireTree = require('./server/require-tree'),
     permissions = require('./server/permissions'),
     uuid        = require('node-uuid'),
@@ -350,37 +349,6 @@ Ghost.prototype.doFilter = function (name, args) {
     });
 
     return when.pipeline(priorityCallbacks, args);
-};
-
-// Initialise plugins.  Will load from config.activePlugins by default
-Ghost.prototype.initPlugins = function (pluginsToLoad) {
-    var self = this;
-
-    if (!_.isArray(pluginsToLoad)) {
-
-        try {
-            // We have to parse the value because it's a string
-            pluginsToLoad = JSON.parse(this.settings('activePlugins')) || [];
-        } catch (e) {
-            errors.logError(
-                'Failed to parse activePlugins setting value: ' + e.message,
-                'Your plugins will not be loaded.',
-                'Check your settings table for typos in the activePlugins value. It should look like: ["plugin-1", "plugin2"] (double quotes required).'
-            );
-            return when.resolve();
-        }
-    }
-
-    return plugins.init(self, pluginsToLoad).then(function (loadedPlugins) {
-        // Extend the loadedPlugins onto the available plugins
-        _.extend(self.availablePlugins, loadedPlugins);
-    }).otherwise(function (err) {
-        errors.logError(
-            err.message || err,
-            'The plugin will not be loaded',
-            'Check with the plugin creator, or read the plugin documentation for more details on plugin requirements'
-        );
-    });
 };
 
 module.exports = Ghost;

--- a/core/server.js
+++ b/core/server.js
@@ -10,6 +10,7 @@ var express     = require('express'),
     admin       = require('./server/controllers/admin'),
     frontend    = require('./server/controllers/frontend'),
     api         = require('./server/api'),
+    plugins     = require('./server/plugins'),
     path        = require('path'),
     hbs         = require('express-hbs'),
     Ghost       = require('./ghost'),
@@ -373,7 +374,7 @@ when(ghost.init()).then(function () {
     ghost.server = server;
 
     // Initialize plugins then start the server
-    ghost.initPlugins().then(function () {
+    plugins.init(ghost).then(function () {
 
         // ## Start Ghost App
         if (getSocket()) {


### PR DESCRIPTION
This continues my effort to clean up and improve the flow of the application architecture.  

This is one small step to moving plugin initialization code to `plugins.js`, reducing the amount of miscellaneous things that `ghost.js` does currently.

Hopefully I can continue to whittle down at ghost.js until we're left with a golden core of wonderful code. :)
