### PR TITLE
Documentation: Add Gmail service option to Gmail example

### DIFF
--- a/mail/index.md
+++ b/mail/index.md
@@ -97,6 +97,7 @@ Once you've created your new account, you can configure the settings in Ghost's 
 mail: {
     transport: 'SMTP',
     options: {
+        service: 'Gmail',
         auth: {
             user: 'youremail@gmail.com',
             pass: 'yourpassword'


### PR DESCRIPTION
The Gmail example was missing the service: option.
