### PR TITLE
[Translations: /es] Add Spanish (ES) translation for Ghost documentation.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,8 @@ languages:
       key: 'zh'
     - name: '한국의'
       key: 'ko'
+    - name: 'Español'
+      key: 'es'
 port:         4478
 
 translations:
@@ -28,7 +30,14 @@ translations:
     themes:       'Themes'
     translations: 'Translations'
     help:         'Help'
-
+  es:
+    site_title:   'Guía Ghost'
+    installation: 'Instalación'
+    usage:        'Uso'
+    email:        'Email'
+    themes:       'Temas'
+    translations: 'Traducciones'
+    help:         'Ayuda' 
 # If running locally, simply comment out the line below to make all urls relative
 
 #url:          http://docs.ghost.org

--- a/es/index.html
+++ b/es/index.html
@@ -1,0 +1,44 @@
+---
+lang: es
+layout: default
+meta_title: Getting Started with Ghost
+---
+
+<div id="fb-root"></div>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/all.js#xfbml=1&appId=596756540369391";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+
+<div class="bs-masthead">
+  <div class="container">
+    <h1>The Ghost Guide</h1>
+    <p class="lead">Everything you need to know to set up a blog with Ghost.</p>
+    <p>
+      <a href="{{ site.url }}/{{page.lang}}/installation/" class="btn btn-success btn-large">Click Here to Get Started</a>
+    </p>
+  </div>
+</div>
+
+<div id="social">
+  <div class="container">
+    <ul>
+      <li>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
+      </li>
+      <li>
+        <iframe class="github-btn" src="http://ghbtns.com/github-btn.html?user=tryghost&repo=ghost&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="102px" height="20px"></iframe>
+      </li>
+      <li class="follow-btn">
+        <a href="https://twitter.com/tryghost" class="twitter-follow-button" data-link-color="#0069D6" data-show-count="true">Follow @TryGhost</a>
+      </li>
+      <li class="tweet-btn">
+        <div class="fb-like" data-href="http://www.facebook.com/TryGhostApp" data-send="false" data-layout="button_count" data-width="100" data-show-faces="false"></div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/es/installation/deploy.md
+++ b/es/installation/deploy.md
@@ -1,0 +1,282 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+permalink: /es/installation/deploy/
+chapter: installation
+section: deploy
+prev_section: linux
+next_section: upgrading
+---
+
+## Getting Ghost Live <a id="deploy"></a>
+
+So you're ready to get Ghost live? Excellent!
+
+The first decision you need to make, is whether you want to install and setup Ghost yourself, or whether you prefer to use an installer.
+
+### Installers
+
+There are a couple of options for simple installers at the moment:
+
+*   Deploy to the cloud with [Bitnami](http://wiki.bitnami.com/Applications/BitNami_Ghost).
+*   Launch Ghost with [Rackspace deployments](http://developer.rackspace.com/blog/launch-ghost-with-rackspace-deployments.html).
+*   Get up and running with a [DigitalOcean Droplet](https://www.digitalocean.com/community/articles/how-to-use-the-digitalocean-ghost-application).
+
+### Manual Setup
+
+You're going to need a hosting package that already has, or will allow you to install [Node.js](http://nodejs.org).
+    This means something like a cloud ([Amazon EC2](http://aws.amazon.com/ec2/), [DigitalOcean](http://www.digitalocean.com), [Rackspace Cloud](http://www.rackspace.com/cloud/)), VPS ([Webfaction](https://www.webfaction.com/), [Dreamhost](http://www.dreamhost.com/servers/vps/)) or other package that has SSH (terminal) access & will allow you to install Node.js. There are plenty around and they can be very cheap.
+
+What won't work at the moment, is cPanel-style shared hosting as this is usually aimed specifically at hosting PHP. Although some offer Ruby, and so may offer Node.js in the future as they are somewhat similar.
+
+<p>Unfortunately, many of the Node-specific cloud hosting solutions such as **Nodejitsu** & **Heroku** are **NOT** compatible with Ghost. They will work at first, but they will delete your files and therefore all image uploads and your database will disappear. Heroku supports MySQL so you could use this, but you will still lose any uploaded images.
+
+The following links contain instructions on how to get up and running with:
+
+*   [Dreamhost](http://www.howtoinstallghost.com/how-to-install-ghost-on-dreamhost/) - from [howtoinstallghost.com](http://howtoinstallghost.com)
+*   [DigitalOcean](http://ghosted.co/install-ghost-digitalocean/) - from [Corbett Barr](http://ghosted.co)
+*   [Webfaction](http://www.howtoinstallghost.com/how-to-install-ghost-on-webfaction-hosting/) - from [howtoinstallghost.com](http://howtoinstallghost.com)
+*   [Rackspace](http://ghost.pellegrom.me/installing-ghost-on-ubuntu/) (Ubuntu 13.04 + linux service) - from [Gilbert Pellegrom](http://ghost.pellegrom.me/)
+*   [Ubuntu + nginx + forever](http://0v.org/installing-ghost-on-ubuntu-nginx-and-mysql/) - from [Gregg Housh](http://0v.org/)
+*   ...check the [installation forum](https://en.ghost.org/forum/installation) for more guides ...
+
+## Making Ghost run forever
+
+The previously described method to start Ghost is `npm start`. This is a good way to do local develpment and tests, but if you start Ghost using the command line it will stop whenever you are closing the terminal window or log out from SSH. To prevent Ghost from stopping you have to run Ghost as a service. There are two ways to accomplish this.
+
+### Forever ([https://npmjs.org/package/forever](https://npmjs.org/package/forever))
+
+You can use `forever` to run Ghost as a background task. `forever` will also take care of your Ghost installation and it will restart the node process if it crashes.
+
+*   To install `forever` type `npm install forever -g`
+*   To start Ghost using `forever` from the Ghost installation directory type `NODE_ENV=production forever start index.js`
+*   To stop Ghost type `forever stop index.js`
+*   To check if Ghost is currently running type `forever list`
+
+### Supervisor ([http://supervisord.org/](http://supervisord.org/))
+
+Popular Linux distributions&mdash;such as Fedora, Debian, and Ubuntu&mdash;maintain a package for Supervisor: A process control system which allows you to run Ghost at startup without using init scripts. Unlike an init script, Supervisor is portable between Linux distributions and versions.
+
+*   [Install Supervisor](http://supervisord.org/installing.html) as required for your Linux distribution. Typically, this will be:
+    *   Debian/Ubuntu: `apt-get install supervisor`
+    *   Fedora: `yum install supervisor`
+    *   Most other distributions: `easy_install supervisor`
+*   Ensure that Supervisor is running, by running `service supervisor start`
+*   Create the startup script for your Ghost installation. Typically this will go in `/etc/supervisor/conf.d/ghost.conf` For example:
+
+    ```
+    [program:ghost]
+    command = node /path/to/ghost/index.js
+    directory = /path/to/ghost
+    user = ghost
+    autostart = true
+    autorestart = true
+    stdout_logfile = /var/log/supervisor/ghost.log
+    stderr_logfile = /var/log/supervisor/ghost_err.log
+    environment = NODE_ENV="production"
+    ```
+
+*   Start Ghost using Supervisor: `supervisorctl start ghost`
+*   To stop Ghost: `supervisorctl stop ghost`
+
+You can see the [documentation for Supervisor](http://supervisord.org) for more information.
+
+### Init Script
+
+Linux systems use init scripts to run on system boot. These scripts exist in /etc/init.d. To make Ghost run forever and even survive a reboot you could set up an init script to accomplish that task. The following example will work on Ubuntu and was tested on **Ubuntu 12.04**.
+
+*   Create the file /etc/init.d/ghost with the following content:
+
+    ```
+    #! /bin/sh
+    ### BEGIN INIT INFO
+    # Provides:          ghost
+    # Required-Start:    $network $syslog
+    # Required-Stop:     $network $syslog
+    # Default-Start:     2 3 4 5
+    # Default-Stop:      0 1 6
+    # Short-Description: Ghost Blogging Platform
+    # Description:       Ghost: Just a blogging platform
+    ### END INIT INFO
+
+    # Do NOT "set -e"
+
+    # PATH should only include /usr/* if it runs after the mountnfs.sh script
+    PATH=/sbin:/usr/sbin:/bin:/usr/bin
+    DESC="Ghost"
+    NAME=ghost
+    GHOST_ROOT=/var/www/ghost
+    GHOST_GROUP=ghost
+    GHOST_USER=ghost
+    DAEMON=/usr/bin/node
+    DAEMON_ARGS="$GHOST_ROOT/index.js"
+    PIDFILE=/var/opt/ghost/run/$NAME.pid
+    SCRIPTNAME=/etc/init.d/$NAME
+    export NODE_ENV=production
+
+    # Exit if the package is not installed
+    [ -x "$DAEMON" ] || exit 0
+
+    # Read configuration variable file if it is present
+    [ -r /etc/default/$NAME ] && . /etc/default/$NAME
+
+    # Load the VERBOSE setting and other rcS variables
+    . /lib/init/vars.sh
+    # I like to know what is going on
+    VERBOSE = yes
+
+    # Define LSB log_* functions.
+    # Depend on lsb-base (>= 3.2-14) to ensure that this file is present
+    # and status_of_proc is working.
+    . /lib/lsb/init-functions
+
+    #
+    # Function that starts the daemon/service
+    #
+    do_start()
+    {
+        # Set up folder structure
+        mkdir -p /var/opt/ghost
+        mkdir -p /var/opt/ghost/run
+        chown -R ghost:ghost /var/opt/ghost
+        # Return
+        #   0 if daemon has been started
+        #   1 if daemon was already running
+        #   2 if daemon could not be started
+        start-stop-daemon --start --quiet \
+            --chuid $GHOST_USER:$GHOST_GROUP --chdir $GHOST_ROOT --background \
+            --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+            || return 1
+        start-stop-daemon --start --quiet \
+            --chuid $GHOST_USER:$GHOST_GROUP --chdir $GHOST_ROOT --background \
+            --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS \
+            || return 2
+        # Add code here, if necessary, that waits for the process to be ready
+        # to handle requests from services started subsequently which depend
+        # on this one.  As a last resort, sleep for some time.
+    }
+
+    #
+    # Function that stops the daemon/service
+    #
+    do_stop()
+    {
+        # Return
+        #   0 if daemon has been stopped
+        #   1 if daemon was already stopped
+        #   2 if daemon could not be stopped
+        #   other if a failure occurred
+        start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 \
+            --pidfile $PIDFILE --name $NAME
+        RETVAL="$?"
+        [ "$RETVAL" = 2 ] && return 2
+        # Wait for children to finish too if this is a daemon that forks
+        # and if the daemon is only ever run from this initscript.
+        # If the above conditions are not satisfied then add some other code
+        # that waits for the process to drop all resources that could be
+        # needed by services started subsequently.  A last resort is to
+        # sleep for some time.
+        start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 \
+            --exec $DAEMON
+        [ "$?" = 2 ] && return 2
+        # Many daemons don't delete their pidfiles when they exit.
+        rm -f $PIDFILE
+        return "$RETVAL"
+    }
+
+    #
+    # Function that sends a SIGHUP to the daemon/service
+    #
+    do_reload() {
+        #
+        # If the daemon can reload its configuration without
+        # restarting (for example, when it is sent a SIGHUP),
+        # then implement that here.
+        #
+        start-stop-daemon --stop --signal 1 --quiet --pidfile $PIDFILE \
+            --name $NAME
+        return 0
+    }
+
+    case "$1" in
+    start)
+            [ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME"
+            do_start
+            case "$?" in
+                    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+                    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            esac
+            ;;
+    stop)
+            [ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
+            do_stop
+            case "$?" in
+                    0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
+                    2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
+            esac
+            ;;
+    status)
+        status_of_proc "$DAEMON" "$NAME" && exit 0 || exit $?
+        ;;
+    #reload|force-reload)
+            #
+            # If do_reload() is not implemented then leave this commented out
+            # and leave 'force-reload' as an alias for 'restart'.
+            #
+            #log_daemon_msg "Reloading $DESC" "$NAME"
+            #do_reload
+            #log_end_msg $?
+            #;;
+    restart|force-reload)
+            #
+            # If the "reload" option is implemented then remove the
+            # 'force-reload' alias
+            #
+            log_daemon_msg "Restarting $DESC" "$NAME"
+            do_stop
+            case "$?" in
+            0|1)
+                    do_start
+                    do_start
+                    case "$?" in
+                            0) log_end_msg 0 ;;
+                            1) log_end_msg 1 ;; # Old process is still running
+                            *) log_end_msg 1 ;; # Failed to start
+                    esac
+                    ;;
+            *)
+                    # Failed to stop
+                    log_end_msg 1
+                    ;;
+            esac
+            ;;
+    *)
+            #echo "Usage: $SCRIPTNAME {start|stop|restart|reload|force-reload}" >&2
+            echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+            exit 3
+            ;;
+    esac
+
+    :
+    ```
+
+*   Change the execution permission for the init script by typing
+        `chmod 755 /etc/init.d/ghost`
+*   Use the script:
+
+    *   start: `service ghost start`
+    *   stop: `service ghost stop`
+    *   restart: `service ghost restart`
+    *   status: `service ghost status`
+*   To start Ghost on system start the newly created init script has to be registered for start up. Type the following two commands in command line: `update-rc.d ghost defaults` and `update-rc.d ghost enable`
+
+Documentation on using node forever, and how to daemonize Ghost on ubuntu coming very soon!
+
+## Setting up Ghost with a domain name
+
+Documentation on using nginx as a reverse proxy on their way.
+

--- a/es/installation/index.md
+++ b/es/installation/index.md
@@ -1,0 +1,51 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+chapter: installation
+next_section: mac
+---
+
+## Overview <a id="overview"></a>
+
+The Ghost documentation is very much a work in progress, it is updated and improved regularly. If you get stuck or have suggestions for improvements, let us know.
+
+Ghost is built on [Node.js](http://nodejs.org), and requires version `0.10.*` (latest stable version).
+
+Running Ghost locally on your computer is straight forward, but requires that you install Node.js first.
+
+### What is Node.js?
+
+[Node.js](http://nodejs.org) is a modern platform for building fast, scalable and efficient web applications.
+    Over the past 20 years, the web has evolved from a collection of static pages into a platform capable of supporting complex web applications like Gmail and facebook.
+    JavaScript is the programming language which has enabled this progress.
+
+[Node.js](http://nodejs.org) provides us with the ability to write JavaScript on server. In the past JavaScript has only existed in the browser, and a second programming language, such as PHP, was required to do server side programming. Having a web application consist of a single programming language is a great benefit, and this also makes Node.js accessible to developers who might have traditionally stayed on the client side.
+
+The way that [Node.js](http://nodejs.org) makes this possible, is by wrapping up the JavaScript engine from Google's Chrome browser and making it installable anywhere. This means that you can get Ghost installed on your computer to try it out very quickly and easily.
+    The following sections detail how to install Ghost locally on [Mac]({% if page.lang %}/{{ page.lang }}{% endif %}/installation/mac/),  [Windows]({% if page.lang %}/{{ page.lang }}{% endif %}/installation/windows/) or [Linux]({% if page.lang %}/{{ page.lang }}{% endif %}/installation/linux/) or alternatively will help you get Ghost deployed on a [server or hosting]({% if page.lang %}/{{ page.lang }}{% endif %}/installation/deploy) account.
+
+### Getting started
+
+If you don't fancy following instructions on installing Node.js and Ghost manually, the lovely people over at [BitNami](http://bitnami.com/) have created [Ghost installers](http://bitnami.com/stack/ghost) for all major platforms.
+
+I want to install Ghost on:
+
+<div class="text-center install-ghost">
+    <a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/mac/" class="btn btn-success btn-large">Mac</a>
+    <a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/windows/" class="btn btn-success btn-large">Windows</a>
+    <a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/linux/" class="btn btn-success btn-large">Linux</a>
+</div>
+
+If you've already decided to deploy Ghost to your server or hosting account, that's great news! The following documentation will walk you through various options for deploying Ghost, from manual setups, to one-click installers.
+
+<div class="text-center install-ghost">
+    <a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/deploy/" class="btn btn-success btn-large">Get Ghost Live</a>
+</div>
+
+Remember that Ghost is brand new, and the team are working hard to deliver features at a furious pace. If you need to upgrade Ghost to the latest version, follow our [upgrading documentation](/installation/upgrading/).
+    If you get stuck, checkout the [troubleshooting guide]({% if page.lang %}/{{ page.lang }}{% endif %}/installation/troubleshooting/), or if that doesn't help, please get in touch via the [Ghost forum](http://ghost.org/forum) where the Ghost staff and community are on hand to help you with any problems.
+

--- a/es/installation/linux.md
+++ b/es/installation/linux.md
@@ -1,0 +1,40 @@
+---
+lang: es
+layout: installation
+meta_title: Cómo instalar Ghost en tu propio servidor - Ghost Docs
+meta_description: Todo lo que necesitas para tener la plataforma de blogging Ghost corriendo en tu entorno local o remoto.
+heading: Instalando Ghost &amp; Empezando
+subheading: Los primeros pasos para poner a punto tu nuevo blog por primera vez.
+permalink: /es/installation/linux/
+chapter: installation
+section: linux
+prev_section: windows
+next_section: deploy
+---
+
+
+# Instalando en Linux <a id="install-linux"></a>
+
+### Instalar Node
+
+*   Puedes bajarte el `.tar.gz` de [http://nodejs.org](http://nodejs.org), o quizás prefieras seguir las instrucciones para [instalarlo desde un gestor de paquetes](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+*   Comprueba que tienes Node y npm instalados escribiendo `node -v` and `npm -v` en tu terminal
+
+### Instalar y levantar Ghost
+
+*   Haz login en [http://ghost.org](http://ghost.org) y haz click sobre el botón azul 'Descargar Ghost'
+*   Ya en la página de descargas, bájate el último zip y extraelo en la ruta desde la que quieras correr Ghost
+*   En tu terminal, muévete al directorio donde extrajiste el código de Ghost
+*   En tu terminal, escribe `npm install --production` <span class="note">ojo con los 2 guiones</span>
+*   Una vez que npm ya está instalado, escribe `npm start` para arrancar Ghost en modo desarrollo
+*   En un navegador, ve a <code class="path">127.0.0.1:2368</code> para ver tu recién estrenado Ghost blog
+*   Cambia la url apuntando a <code class="path">127.0.0.1:2368/ghost</code> para crear tu usuario admin y hacer login en el admin de Ghost
+
+Si estás utilizando Linux en un entorno virtual o a través de SSH, y sólo dispones de terminal, entonces:
+
+*   Utiliza tu sistema operativo para encontrar la URL del zip de Ghost(cambia con cada versión), y salva la url pero cambia '/zip/' port '/archives/'
+*   In the terminal use `wget url-of-ghost.zip` to download Ghost
+*   Descomprimer el archivo con `unzip -uo Ghost-#.#.#.zip -d ghost`, y entonces `cd ghost`
+*   Escribe `npm install --production` para instalar Ghost <span class="note">ojo con los 2 guiones</span>
+*   Una vez que npm ya está instalado, escribe `npm start` para arrancar Ghost en modo desarrollo
+*   Ghost ya estará corriendo en localhost

--- a/es/installation/mac.md
+++ b/es/installation/mac.md
@@ -1,0 +1,45 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+permalink: /es/installation/mac/
+chapter: installation
+section: mac
+prev_section: installation
+next_section: windows
+---
+
+
+# Installing on Mac <a id="install-mac"></a>
+
+To install Node.js and Ghost on your mac you'll need an open terminal window. You can get one by opening spotlight and typing "Terminal".
+
+### Install Node
+
+*   On [http://nodejs.org](http://nodejs.org) press install, a '.pkg' file will be downloaded
+*   Click on the download to open the installer, this is going to install both node and npm.
+*   Click through the installer, finally entering your password and clicking 'install software'.
+*   Once the installer is complete, go into your open Terminal window and type `echo $PATH` to check that '/usr/local/bin/' is in your path.
+
+<p class="note"><strong>Note:</strong> If '/usr/local/bin' does not appear in your $PATH, see the <a href="#export-path">troubleshooting tips</a> to find out how to add it</p>
+
+If you get stuck you can watch the whole [process in action here](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-node-mac.gif "Install Node on Mac").
+
+### Install and Run Ghost
+
+*   Log in to [http://ghost.org](http://ghost.org), and then click the blue 'Download Ghost Source Code' button.
+*   On the downloads page, press the button to download the latest zip file.
+*   Click on the arrow next to the newly downloaded file, and choose 'show in finder'.
+*   In finder, double-click on the downloaded zip file to extract it.
+*   Next, grab the newly extracted 'ghost-#.#.#' folder and drag it onto the tab bar of your open terminal window, this will make a new terminal tab which is open at the correct location.
+*   In the new terminal tab type `npm install --production` <span class="note">note the two dashes</span>
+*   When npm is finished installing, type `npm start` to start Ghost in development mode
+*   In a browser, navigate to <code class="path">127.0.0.1:2368</code> to see your newly setup Ghost blog
+*   Change the url to <code class="path">127.0.0.1:2368/ghost</code> and create your admin user to login to the Ghost admin.
+*   See the [usage docs](/usage) for instructions on the next steps
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-mac.gif)
+

--- a/es/installation/troubleshooting.md
+++ b/es/installation/troubleshooting.md
@@ -1,0 +1,49 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+permalink: /es/installation/troubleshooting/
+chapter: installation
+section: troubleshooting
+prev_section: upgrading
+---
+
+
+# Troubleshooting & FAQ <a id="troubleshooting"></a>
+
+<dl>
+    <dt id="export-path">'/usr/local/bin' doesn't appear in my $PATH</dt>
+    <dd>You can add it by doing the following:
+        <ul>
+            <li>In your terminal window type <code>cd ~</code>, this will take you to your home directory</li>
+            <li>Now type <code>ls -al</code> to show all the files and folders in this directory, including hidden ones</li>
+            <li>You should see a file called <code class="path">.profile</code> or <code class="path">.bash_profile</code> if not type <code>touch .bash_profile</code> to create a file</li>
+            <li>Next, type <code>open -a Textedit .bash_profile</code> to open the file with Textedit.</li>
+            <li>Add <code>export PATH=$PATH:/usr/local/bin/</code> at the end of the file and save it</li>
+            <li>This new setting will get loaded when a new terminal starts, so open a new terminal tab or window and type <code>echo $PATH</code> to see that '/usr/local/bin/' is now present.</li>
+        </ul>
+    </dd>
+    <dt id="sqlite3-errors">SQLite3 doesn't install</dt>
+    <dd>
+        <p>The SQLite3 package comes with pre-built binaries for the most common architectures. If you are using a less popular linux or other unix flavor, you may find that SQLite3 will give you a 404 as it cannot find a binary for your platform.</p>
+        <p>This can be fixed by forcing SQLite3 to compile. This will require python & gcc. Try it out by running <code>npm install sqlite3 --build-from-source</code></p>
+        <p>If it won't build you're probably missing one of the python or gcc dependencies, on linux try running <code>sudo npm install -g node-gyp</code>, <code>sudo apt-get install build-essential</code> and <code>sudo apt-get install python-software-properties python g++ make</code> before retrying the build from source.</p>
+        <p>For more information about building the binaries please see: <a href="https://github.com/developmentseed/node-sqlite3/wiki/Binaries">https://github.com/developmentseed/node-sqlite3/wiki/Binaries</a></p>
+        <p>Once you have successfully built a binary for your platform, please follow the <a href="https://github.com/developmentseed/node-sqlite3/wiki/Binaries#creating-new-binaries">instructions here</a> to submit the binary to the node-sqlite project, so that future users won't have the same problem.</p>
+    </dd>
+    <dt id="image-uploads">I can't upload images</dt>
+    <dd>
+        <p>If you're on a DigitalOcean Droplet setup when Ghost was at v0.3.2, or you're using nginx on some other platform, you may find you cannot upload images.</p>
+        <p>What's actually happening, is you cannot upload images bigger than 1MB (try a small image, it should work). That's a pretty small limit!</p>
+        <p>To increase the limit you need to edit your nginx config file, and set the limit to something else.</p>
+        <ul>
+            <li>Log into your server, and type <code>sudo nano /etc/nginx/conf.d/default.conf</code> to open your config file.</li>
+            <li>After the <code>server_name</code> line, add the following: <code>client_max_body_size 10M;</code></li>
+            <li>Finally, press <kbd>ctrl</kbd> + <kbd>x</kbd> to exit. Nano will ask you if you want to save, type <kbd>y</kbd> for yes, and press <kbd>enter</kbd> to save the file.</li>
+        </ul>
+    </dd>
+</dl>
+

--- a/es/installation/upgrading.md
+++ b/es/installation/upgrading.md
@@ -1,0 +1,108 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+permalink: /es/installation/upgrading/
+chapter: installation
+section: upgrading
+prev_section: deploy
+next_section: troubleshooting
+---
+
+# Upgrading Ghost <a id="upgrade"></a>
+
+Upgrading Ghost is super straightforward.
+
+There is a couple of different ways you might want to go about it. The following describes what needs to happen, and then covers the process step-by-step for both doing it [point-and-click style](#how-to) and via a [command line](#cli), so that you are free to choose the method you are most comfortable with.
+
+<p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
+
+## Overview
+
+<img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/folder-structure.png" style="float:left" />
+
+Ghost, once installed, has a folder structure similar to that shown on the left. There are two main directories <code class="path">content</code> and <code class="path">core</code>, plus some files in the root.
+
+Upgrading Ghost is matter of replacing the old files with the new files, re-running `npm install` to update the <code class="path">node_modules</code> folder and then restarting Ghost to make it all take affect.
+
+Remember, by default Ghost stores all your custom data, themes, images, etc in the <code class="path">content</code> directory, so take care to keep this safe! Replace only the files in <code class="path">core</code> and the root, and all will be fine.
+
+## Backing Up <a id="backing-up"></a>
+
+<img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/export.png" style="float:right" />
+
+*   To backup all the data from your database, log into your Ghost install and go to <code class="path">/ghost/debug/</code>. Press the export button to download a JSON file containing all of your data. Job done
+*   To back up your custom themes and images, you need to take a copy of the files inside of <code class="path">content/themes</code> and <code class="path">content/images</code>
+
+<p class="note"><strong>Note:</strong> You can, if you like, take a copy of your database from <code class="path">content/data</code> but <strong>be warned</strong> you should not do this whilst Ghost is running. Please stop it first.</p>
+
+
+## How to Upgrade <a id="how-to"></a>
+
+How to upgrade on your local machine
+
+<p class="warn"><strong>WARNING:</strong> Do <strong>NOT</strong> copy and paste the entire Ghost folder over the top of an existing installation on mac. Do <strong>NOT</strong> choose <kbd>REPLACE</kbd> if uploading with Transmit or other FTP software, choose <strong>MERGE</strong>.</p>
+
+*   Download the latest version of Ghost from [Ghost.org](http://ghost.org/download/)
+*   Extract the zip file to a temporary location
+*   Copy all of the root level files from the latest version. This includes: index.js, package.json, Gruntfile.js, config.example.js, the license and readme files.
+*   Next replace the old <code class="path">core</code> directory with the new `core` directory
+*   For releases which include update to Casper (the default theme), replace the old <code class="path">content/themes/casper</code> directory with the new one
+*   Run `npm install --production`
+*   Finally, Restart Ghost so that the changes take effect
+
+## Command line only <a id="cli"></a>
+
+<p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
+
+### Command line only on mac <a id="cli-mac"></a>
+
+The screencast below shows the steps for upgrading Ghost where the zip file has been downloaded to <code class="path">~/Downloads</code> and Ghost is installed in <code class="path">~/ghost</code> <span class="note">**Note:** `~` means the user's home directory on mac and linux</span>
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/upgrade-ghost.gif)
+
+The steps in the screencast are:
+
+*   <code class="path">cd ~/Downloads</code> - change directory to the Downloads directory where the latest version of Ghost has been saved
+*   `unzip ghost-0.3.1.zip -d ghost-0.3.3` - unzip ghost into the folder <code class="path">ghost-0.3.3</code>
+*   <code class="path">cd ghost-0.3.3</code> - change directory into the <code class="path">ghost-0.3.3</code> directory
+*   `ls` - show all the files and folders inside this directory
+*   `cp *.md *.js *.txt *.json ~/ghost` - copy all .md .js .txt and .json files from this location to <code class="path">~/ghost</code>
+*   `cp -R core ~/ghost` - copy the <code class="path">core</code> directory and all of its contents to the <code class="path">~/ghost</code>
+*   `cp -R content/themes/casper ~/ghost/content/themes` - copy the <code class="path">casper</code> directory and all of its contents to <code class="path">~/ghost/content/themes</code>
+*   `cd ~/ghost` - change directory to the <code class="path">~/ghost</code> directory
+*   `npm install --production` - install Ghost
+*   `npm start` - start Ghost
+
+### Command line only on linux servers <a id="cli-server"></a>
+
+*   First you'll need to find out the URL of the latest Ghost version. It should be something like `http://ghost.org/zip/ghost-latest.zip`.
+*   Fetch the zip file with `wget http://ghost.org/zip/ghost-latest.zip` (or whatever the URL for the latest Ghost version is).
+*   Unzip the archive with `unzip -uo ghost-0.3.*.zip -d path-to-your-ghost-install`
+*   Run `npm install --production` to get any new dependencies
+*   Finally, restart Ghost so that the changes will take effect
+
+**Additionally**, [howtoinstallghost.com](http://www.howtoinstallghost.com/how-to-update-ghost/) also has instructions for upgrading Ghost on linux servers.
+
+### How to update a DigitalOcean Droplet <a id="digitalocean"></a>
+
+<p class="note"><strong>Back-it-up!</strong> Always perform a backup before upgrading. Read the <a href="#backing-up">backup instructions</a> first!</p>
+
+*   First you'll need to find out the URL of the latest Ghost version. It should be something like `http://ghost.org/zip/ghost-latest.zip`.
+*   Once you've got the URL for the latest version, in your Droplet console type `cd /var/www/` to change directory to where the Ghost codebase lives.
+*   Next, type `wget http://ghost.org/zip/ghost-latest.zip` (or whatever the URL for the latest Ghost version is).
+*   Unzip the archive with `unzip -uo ghost-0.3.*.zip -d ghost`
+*   Make sure all of the files have the right permissions with `chown -R ghost:ghost ghost/*`
+*   Run `npm install` to get any new dependencies
+*   Finally, restart Ghost so that the changes take effect using `service ghost restart`
+
+## How to upgrade Node.js to the latest version <a id="upgrading-node"></a>
+
+If you originally installed Node.js from the [Node.js](nodejs.org) website, you can upgrade Node.js to the latest version by downloading and running the latest installer. This will replace your current version with the new version.
+
+If you are on Ubuntu, or another linux distribution which uses `apt-get`, the command to upgrade node is the same as to install: `sudo apt-get install nodejs`.
+
+You do **not** need to restart the server or Ghost.

--- a/es/installation/windows.md
+++ b/es/installation/windows.md
@@ -1,0 +1,45 @@
+---
+lang: es
+layout: installation
+meta_title: How to Install Ghost on Your Server - Ghost Docs
+meta_description: Everything you need to get the Ghost blogging platform up and running on your local or remote environement.
+heading: Installing Ghost &amp; Getting Started
+subheading: The first steps to setting up your new blog for the first time.
+permalink: /es/installation/windows/
+chapter: installation
+section: windows
+prev_section: mac
+next_section: linux
+---
+
+# Installing on Windows <a id="install-windows"></a>
+
+### Install Node
+
+*   On [http://nodejs.org](http://nodejs.org) press install, an '.msi' file will be downloaded
+*   Click on the download to open the installer, this is going to install both Node and npm.
+*   Click through the installer, until you get to the screen telling you Node.js is installed.
+
+If you get stuck you can watch the whole [process in action here](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-node-win.gif "Install node on Windows").
+
+### Download & Extract Ghost
+
+*   Log in to [http://ghost.org](http://ghost.org), and then click the blue 'Download Ghost Source Code' button.
+*   On the downloads page, press the button to download the latest zip file.
+*   Click on the arrow next to the newly downloaded file, and choose 'show in folder'.
+*   When the folder opens, right click on the downloaded zip file and choose 'Extract all'.
+
+If you get stuck you can watch the whole [process in action here](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-win.gif "Install Ghost on Windows Part 1").
+
+### Install and Run Ghost
+
+*   In your start menu, find 'Node.js' and then choose 'Node.js Command Prompt'
+*   In the Node command prompt, you need to change directory to where you extracted Ghost. Type: `cd Downloads/ghost-#.#.#` (replace hashes with the version of Ghost you downloaded).
+*   Next, in the command prompt type `npm install --production` <span class="note">note the two dashes</span>
+*   When npm is finished installing, type `npm start` to start Ghost in development mode
+*   In a browser, navigate to <code class="path">127.0.0.1:2368</code> to see your newly setup Ghost blog
+*   Change the url to <code class="path">127.0.0.1:2368/ghost</code> and create your admin user to login to the Ghost admin.
+*   See the [usage docs](/usage) for instructions on the next steps
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-win-2.gif "Install Ghost on Windows - Part 2")
+

--- a/es/mail/index.md
+++ b/es/mail/index.md
@@ -1,0 +1,117 @@
+---
+lang: es
+layout: mail
+meta_title: Ghost Mail Configuration - Ghost Docs
+meta_description: How to configure your email server and send emails with the Ghost blogging platform. Everything you need to know.
+heading: Setting up Email
+chapter: mail
+---
+
+
+## Mail Configuration <a id="email-config"></a>
+
+The following documentation details how to configure email in Ghost. Ghost uses [Nodemailer](https://github.com/andris9/Nodemailer), their documentation contains even more examples. 
+
+### Wait what?
+
+If you're familiar with PHP land, then you're probably very used to having email just magically work on your hosting platform. Node is a bit different, it's shiny and new and still a little rough around the edges in places.
+
+But don't fear, setting up your email is a one-time thing and we're here to walk you through it.
+
+### But why?
+
+At the moment, the only thing Ghost uses email for is sending you an email with a new password if you forget yours. It's not much, but don't underestimate how useful that feature is if you ever happen to need it.
+
+In the future, Ghost will also support setting up email-based subscriptions to your blogs. Emailing new users account details, and other little helpful features that depend on the ability to send mail.
+
+## Ok, so how do I do it? <a id="how-to"></a>
+
+The first thing you're going to need is an account with an email sending service. We highly recommend Mailgun. They have a nice free starter account which allows you to send more email than all but the most prolific email-subscription based blogs could manage. You could also use Gmail or Amazon SES.
+
+Once you've decided on what email service to use, you need to add your settings to Ghost's config file. Wherever you have installed Ghost, you should find a <code class="path">config.js</code> file in the route directory along with <code class="path">index.js</code>. If you don't have a <code class="path">config.js</code> file yet, then copy <code class="path">config.example.js</code> and rename it.
+
+### Mailgun <a id="mailgun"></a>
+
+Head along to [mailgun.com](http://www.mailgun.com/) and sign up for an account. You'll need to have an email address on hand, and it will ask you to either provide a domain name, or think up a subdomain. You can change this later, so for now why not register a subdomain similar to the name of the blog you're setting up.
+
+Verify your email address with Mailgun, and then you'll have access to their lovely control panel. You're going to need to find your new email service username and password that Mailgun have created for you (they're not the ones you sign up with), by clicking on your domain on the right hand side… see the little screencast below to help you find your details.
+
+<img src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/mailgun.gif" alt="Mailgun details" width="100%" />   
+  
+Right, now you've got everything you need, it's time to open up your config file. Open your <code class="path">config.js</code> file in the editor of your choice. Navigate to the environment you want to setup mail for, and change your mail settings to look like this:
+
+```
+mail: {
+transport: 'SMTP',
+    options: {
+        service: 'Mailgun',
+        auth: {
+            user: '',
+            pass: ''
+        }
+    }
+}
+```
+
+Put your 'Login' from mailgun between the quote marks next to 'user' and your 'Password' from mailgun inside the quotes next to 'pass'. If I was configuring mailgun for the 'tryghosttest' account, it would look like this:
+
+```
+mail: {
+    transport: 'SMTP',
+    options: {
+        service: 'Mailgun',
+        auth: {
+            user: 'postmaster@tryghosttest.mailgun.org',
+            pass: '25ip4bzyjwo1'
+        }
+    }
+}
+```
+
+Keep an eye out for all of the colons, quotes and curly brackets. Misplace one of those and you'll find you get weird errors.
+
+You can reuse your settings for both your development and production environment if you have both.
+
+### Amazon SES <a id="ses"></a>
+
+You can sign up for an Amazon Simple Email Service account over at <http://aws.amazon.com/ses/>. Once you finish signing up, you'll be given an access key and a secret.
+
+Open Ghost's <code class="path">config.js</code> file in the editor of your choice. Navigate to the environment you want to setup mail for, and add your Amazon credentials to your mail settings as shown below:
+
+```
+mail: {
+    transport: 'SES',
+    options: {
+        AWSAccessKeyID: "AWSACCESSKEY",
+        AWSSecretKey: "/AWS/SECRET"
+    }
+}
+```
+
+### Gmail <a id="gmail"></a>
+
+It is possible to use Gmail to send email from Ghost. If you are going to do this, we recommend that you [create a new account](https://accounts.google.com/SignUp) for the purpose, rather than using any existing personal email account details.
+
+Once you've created your new account, you can configure the settings in Ghost's <code class="path">config.js</code> file. Open the file in the editor of your choice. Navigate to the environment you want to setup mail for, and change your mail settings to look like this:
+
+```
+mail: {
+    transport: 'SMTP',
+    options: {
+        auth: {
+            user: 'youremail@gmail.com',
+            pass: 'yourpassword'
+        }
+    }
+}
+```
+
+### From Address <a id="from"></a>
+
+By default the 'from' address for mail sent from Ghost will be set to the email address on the general settings page. If you want to override this to something different, you can also configure it in the <code class="path">config.js</code> file.
+
+```
+mail: {
+    fromaddress: 'myemail@address.com',
+}
+```

--- a/es/quickstart/quickstart.md
+++ b/es/quickstart/quickstart.md
@@ -1,0 +1,37 @@
+---
+lang: es
+layout: quickstart
+meta_title: Ghost Quickstart
+heading: Ghost Quickstart
+subheading: Get up and running with Ghost.
+chapter: quickstart
+section: quickstart
+---
+
+# Overview <a id="overview"></a>
+
+The Quickstart Guide to getting Ghost up and running is aimed at those of you who are already familiar with [Node](http://nodejs.org), or something similar like ruby on rails. If you're new in town, we recommend taking a look at the more in depth [Installation Guide](/installation.html).
+
+## Get Ghost running locally <a id="ghost-local"></a>
+
+Ghost requires node `0.10.*` (the latest stable version).
+
+If you haven't already got it, head over to <http://nodejs.org> and download the latest version of Node.js. The installer will set up both Node and Node's excellent package manager, npm.
+
+For users on Linux, rather than installing from the .tar.gz archive, you may want to [install from a package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
+
+Download the latest version of Ghost from [Ghost.org](http://ghost.org). Unpack the archive to a folder where you'd like to run Ghost - anywhere will do!
+
+Fire up your terminal (mac/linux) or command prompt (windows) and navigate to the root directory of your unpacked Ghost archive (where package.json lives).
+
+To install Ghost, run `npm install --production`
+
+<!--<h2 id="customise">Customise & Configure Ghost</h2>
+
+<h2 id="ghost-deploy">Deploy Ghost</h2>
+
+<ol>
+    <li>In the Terminal / Command Prompt, type <code>npm start</code></li>
+    <li><p>This will have launched your Ghost blog, visit one  <a href="http://localhost:2368/">http://localhost:2368/</a> to see</p></li>
+</ol>
+-->

--- a/es/themes/index.md
+++ b/es/themes/index.md
@@ -1,0 +1,368 @@
+---
+lang: es
+layout: themes
+meta_title: How to Make Ghost Themes - Ghost Docs
+meta_description: An in depth guide to making themes for the Ghost blogging platform. Everything you need to know to build themes for Ghost.
+heading: Ghost Themes
+subheading: Get started creating your own themes for Ghost
+chapter: themes
+---
+
+{% raw %}
+
+## Switching Theme <a id="switching-theme"></a>
+
+Ghost themes live in <code class="path">content/themes/</code>
+
+If you want to use a different theme to the default Casper theme, check out the custom themes on our [marketplace gallery](http://marketplace.ghost.org/). Download the theme package of your choice, extract it and place it in <code class="path">content/themes</code> alongside Casper.
+
+If you want to make your own, we recommend copying and renaming the casper directory & editing the templates to look and work how you want.
+
+To switch to your newly added theme:
+
+1.  Restart Ghost. At the moment, Ghost won't notice that you've added a new folder to <code class="path">content/themes</code> so you'll need to restart it
+2.  Login to your Ghost admin, and navigate to <code class="path">/ghost/settings/general/</code>
+3.  Select your Theme name in the 'Theme' options dropdown
+4.  Click 'Save'
+5.  Visit the frontend of your blog and marvel at the new theme
+
+
+##  What is Handlebars? <a id="what-is-handlebars"></a>
+
+[Handlebars](http://handlebarsjs.com/) is the templating language used by Ghost.
+
+> Handlebars provides the power necessary to let you build semantic templates effectively with no frustration.
+
+If you're looking to get started writing your own theme, you'll probably want to get yourself familiar with handlebars syntax first. Have a read of the [handlebars documentation](http://handlebarsjs.com/expressions.html), or checkout this [tutorial from Treehouse](http://blog.teamtreehouse.com/getting-started-with-handlebars-js) – you can skip the first section on installation and usage (we’ve done that bit for you) and get stuck in with ‘Basic Expressions’.
+
+## About Ghost themes <a id="about"></a>
+
+Ghost themes are intended to be simple to build and maintain. They advocate strong separation between templates (the HTML) and any business logic (JavaScript). Handlebars is (almost) logicless and enforces this separation, providing the helper mechanism so that business logic for displaying content remains separate and self-contained. This separation lends itself towards easier collaboration between designers and developers when building themes.
+
+Handlebars templates are hierarchical (one template can extend another template) and also support partial templates. Ghost uses these features to reduce code duplication and keep individual templates focused on doing a single job, and doing it well. A well structured theme will be easy to maintain and keeping components separated makes them easier to reuse between themes.
+
+We really hope you'll enjoy our approach to theming.
+
+## The File Structure of a Ghost Theme <a id="file-structure"></a>
+
+The recommended file structure is:
+
+```
+.
+├── /assets
+|   └── /css
+|       ├── screen.css
+|   ├── /fonts
+|   ├── /images
+|   ├── /js
+├── default.hbs
+├── index.hbs [required]
+└── post.hbs [required]
+```
+
+For the time being there is no requirement that default.hbs or any of the folders exist. <code class="path">index.hbs</code> and <code class="path">post.hbs</code> are required – Ghost will not work if these two templates are not present. <code class="path">partials</code> is a special directory. This should include any part templates you want to use across your blog, for example <code class="path">list-post.hbs</code> might include your template for outputting a single post in a list, which might then be used on the homepage, and in future archive & tag pages. <code class="path">partials</code> is also where you can put templates to override the built-in templates used by certain helpers like pagination. Including a <code class="path">pagination.hbs</code> file inside <code class="path">partials</code> will let you specify your own HTML for pagination.
+
+### default.hbs
+
+This is the base template which contains all the boring bits of HTML that have to appear on every page – the `<html>`, `<head>` and `<body>` tags along with the `{{ghost_head}}` and `{{ghost_foot}}` helpers, as well as any HTML which makes up a repeated header and footer for the blog.
+
+The default template contains the handlebars expression `{{{body}}}` to denote where the content from templates which extend the default template goes.
+
+Page templates then have `{{!< default}}` as the very first line to specify that they extend the default template, and that their content should be placed into the place in default.hbs where `{{{body}}}` is defined.
+
+### index.hbs
+
+This is the template for the homepage, and extends <code class="path">default.hbs</code>. The homepage gets passed a list of posts which should be displayed, and <code class="path">index.hbs</code> defines how each posts should be displayed.
+
+In Casper (the current default theme), the homepage has a large header which uses `@blog` global settings to output the blog logo, title and description. This is followed by using the `{{#foreach}}` helper to output a list of the latest posts.
+
+### post.hbs
+
+This is the template for a single post, which also extends <code class="path">default.hbs</code>.
+
+In Casper (the current default theme), the single post template has it's own header, also using `@blog` global settings and then uses the `{{#post}}` data accessor to output all of the post details.
+
+### Post styling & previewing
+
+When building themes for Ghost please consider the scope of your classes, and in particular your IDs, to try to avoid clashes between your main styling and your post styling. You never know when a class name or in particular an ID (because of the auto-generation of IDs for headings) will get used inside a post. Therefore it's best to always scope things to a particular part of the page. E.g. #my-id could match things you don't expect whereas #themename-my-id would be safer.
+
+Ghost aims to offer a realistic preview of your posts as part of the split screen editor, but in order to do this we must load a theme's custom styling for a post in the admin. This feature is not yet implemented, but we highly recommend keeping your post styles in a separate file (post.css) from other styles for your theme (style.css) so that you will quickly be able to take advantage of this feature in the future.
+
+## Creating Your Own Theme <a id="create-your-own"></a>
+
+Create your own Ghost theme by either copying Casper, or adding a new folder to the <code class="path">content/themes</code> directory with the name of your theme, E.g. my-theme (names should be lowercase, and contain letters, numbers and hyphens only). Then add two empty files to your new theme folder: index.hbs and post.hbs. It won't display anything, but this is effectively a valid theme.
+
+### The post list
+
+<code class="path">index.hbs</code> gets handed an object called `posts` which can be used with the foreach helper to output each post. E.g.
+
+```
+{{#foreach posts}}
+// here we are in the context of a single post
+// whatever you put here gets run for each post in posts
+{{/foreach}}
+```
+
+See the section on the [`{{#foreach}}`](#foreach-helper) helper for more details.
+
+#### Pagination
+
+See the section on the [`{{pagination}}`](#pagination-helper) helper.
+
+### Outputting individual posts
+
+Once you are in the context of a single post, either by looping through the posts list with `foreach` or inside of <code class="path">post.hbs</code> you have access to the properties of a post.
+
+For the time being, these are:
+
+*   id – *post id*
+*   title – *post title*
+*   url – *the relative URL for a post*
+*   content – *post HTML*
+*   published_at – *date the post was published*
+*   author – *full details of the post author* (see below for more details)
+
+Each of these properties can be output using the standard handlebars expression, e.g. `{{title}}`.
+
+<div class="note">
+  <p>
+    <strong>Notes:</strong> <ul>
+      <li>
+        the content property is overridden and output by the <code>{{content}}</code> helper which ensures the HTML is output safely & correctly. See the section on the <a href="#content-helper"><code>{{content}}</code> helper</a> for more info.
+      </li>
+      <li>
+        the url property provided by the <code>{{url}}</code> helper. See the section on the <a href="#url-helper"><code>{{url}}</code> helper</a> for more info.
+      </li>
+    </ul>
+  </p>
+</div>
+
+#### Post author
+
+When inside the context of a single post, the following author data is available:
+
+*   `{{author.name}}` – the name of the author 
+*   `{{author.email}}` – the author's email address
+*   `{{author.bio}}` – the author's bio
+*   `{{author.website}}` – the author's website
+*   `{{author.image}}` – the author's profile image
+*   `{{author.cover}}` – the author's cover image
+
+You can use just`{{author}}` to output the author's name.
+
+This can also be done by using a block expression:
+
+```
+{{#author}}
+    <a href="mailto:{{email}}">Email {{name}}</a>
+{{/author}}
+```
+
+#### Post Tags
+
+When inside the context of a single post, the following tag data is available
+
+*   `{{tag.name}}` – the name of the tag 
+
+You can use `{{tags}}` to output a comma separated list of tags, or if you prefer, specify your own separator `{{tags separator=""}}`
+
+This can also be done by using a block expression:
+
+```
+<ul>
+    {{#tags}}
+        <li>{{name}}</li>
+    {{/tags}}
+</ul>
+```
+
+### Global Settings
+
+Ghost themes have access to a number of global settings via the `@blog` global data accessor.
+
+*   `{{@blog.url}}` – the url specified for this env in <code class="path">config.js</code>
+*   `{{@blog.title}}` – the blog title from the settings page
+*   `{{@blog.description}}` – the blog description from the settings page
+*   `{{@blog.logo}}` – the blog logo from the settings page
+
+## Built-in Helpers <a id="helpers"></a>
+
+Ghost has a number of built in helpers which give you the tools you need to build your theme. Helpers are classified into two types: block and output helpers.
+
+**[Block Helpers](http://handlebarsjs.com/block_helpers.html)** have a start and end tag E.g. `{{#foreach}}{{/foreach}}`. The context between the tags changes and these helpers may also provide you with additional properties which you can access with the `@` symbol.
+
+**Output Helpers** look much the same as the expressions used for outputting data e.g. `{{content}}`. They perform useful operations on the data before outputting it, and often provide you with options for how to format the data. Some output helpers use templates to format the data with HTML a bit like partials. Some output helpers are also block helpers, providing a variation of their functionality.
+
+### <code>foreach</code> <a id="foreach-helper"></a>
+
+*   Helper type: block
+*   Options: `columns` (number)
+
+`{{#foreach}}` is a special loop helper designed for working with lists of posts. By default the each helper in handlebars adds the private properties `@index` for arrays and `@key` for objects, which can be used inside the each loop.
+
+`foreach` extends this and adds the additional private properties of `@first`, `@last`, `@even`, `@odd`, `@rowStart` and `@rowEnd` to both arrays and objects. This can be used to produce more complex layouts for post lists and other content. For examples see below:
+
+#### `@first` & `@last`
+
+The following example checks through an array or object e.g `posts` and tests for the first entry.
+
+```
+{{#foreach posts}}
+    {{#if @first}}
+        <div>First post</div>
+    {{/if}}
+{{/foreach}}
+```
+
+We can also nest `if` statements to check multiple properties. In this example we are able to output the first and last post separately to other posts.
+
+```
+{{#foreach posts}}
+    {{#if @first}}
+    <div>First post</div>
+    {{else}}
+        {{#if @last}}
+            <div>Last post</div>
+        {{else}}
+            <div>All other posts</div>
+        {{/if}}
+    {{/if}}
+{{/foreach}}
+```
+
+#### `@even` & `@odd`
+
+The following example adds a class of even or odd, which could be used for zebra striping content:
+
+```
+{{#foreach posts}}
+        <div class="{{#if @even}}even{{else}}odd{{/if}}">{{title}}</div>
+{{/foreach}}
+```
+
+#### `@rowStart` & `@rowEnd`
+
+The following example shows you how to pass in a column argument so that you can set properties for the first and last element in a row. This allows for outputting content in a grid layout.
+
+```
+{{#foreach posts columns=3}}
+    <li class="{{#if @rowStart}}first{{/if}}{{#if @rowEnd}}last{{/if}}">{{title}}</li>
+{{/foreach}}
+```
+
+### <code>content</code> <a id="content-helper"></a>
+
+*   Helper type: output
+*   Options: `words` (number), `characters` (number) [defaults to show all]
+
+`{{content}}` is a very simple helper used for outputting post content. It makes sure that your HTML gets output correctly.
+
+You can limit the amount of HTML content to output by passing one of the options:
+
+`{{content words="100"}}` will output just 100 words of HTML with correctly matched tags.
+
+### <code>excerpt</code> <a id="excerpt-helper"></a>
+
+*   Helper type: output
+*   Options: `words` (number), `characters` (number) [defaults to 50 words]
+
+`{{excerpt}}` outputs content but strips all HTML. This is useful for creating excerpts of posts.
+
+You can limit the amount of text to output by passing one of the options:
+
+`{{excerpt characters="140"}}` will output 140 characters of text.
+
+### <code>date</code> <a id="date-helper"></a>
+
+*   Helper type: output
+*   Options: `format` (date format, default “MMM Do, YYYY”), `timeago` (boolean)
+
+`{{date}}` is a formatting helper for outputting dates in various format. You can either pass it a date and a format string to be used to output the date like so:
+
+```
+// outputs something like 'July 11, 2013'
+{{date published_at format="MMMM DD, YYYY"}}
+```
+
+Or you can pass it a date and the timeago flag:
+
+```
+// outputs something like '5 mins ago'
+{{date published_at timeago="true"}}
+```
+
+If you call `{{date}}` without a format, it will default to “MMM Do, YYYY”.
+
+If you call `{{date}}` in the context of a post without telling it which date to display, it will default to `published_at`.
+
+If you call `{{date}}` outside the context of a post without telling it which date to display, it will default to the current date.
+
+`date` uses [moment.js](http://momentjs.com/) for formatting dates. See their [documentation](http://momentjs.com/docs/#/parsing/string-format/) for a full explanation of all the different format strings that can be used.
+
+### <code>url</code> <a id="url-helper"></a>
+
+*   Helper type: output
+*   Options: `absolute`
+
+`{{url}}` outputs the relative url for a post when inside the post context. Outside of the post context it will output nothing
+
+You can force the url helper to output an absolute url by using the absolute option, E.g. `{{url absolute="true"}}`
+
+###  <code>pagination</code> <a href="pagination-helper"></a>
+
+*   Helper type: output, template-driven
+*   Options: none (coming soon)
+
+`{{pagination}}` is a template driven helper which outputs HTML for 'newer posts' and 'older posts' links if they are available and also says which page you are on.
+
+You can override the HTML output by the pagination helper by placing a file called <code class="path">pagination.hbs</code> inside of <code class="path">content/themes/your-theme/partials</code>.
+
+### <code>body_class</code> <a id="bodyclass-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{body_class}}` – outputs classes intended for the `<body>` tag in <code class="path">default.hbs</code>, useful for targeting specific pages with styles.
+
+### <code>post_class</code> <a id="postclass-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{post_class}}` – outputs classes intended your post container, useful for targeting posts with styles.
+
+### <code>ghost_head</code> <a id="ghosthead-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{ghost_head}}` – belongs just before the `</head>` tag in <code class="path">default.hbs</code>, used for outputting meta tags, scripts and styles. Will be hookable.
+
+### <code>ghost_foot</code> <a id="ghostfoot-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{ghost_foot}}` – belongs just before the `</body>` tag in <code class="path">default.hbs</code>, used for outputting scripts. Outputs jquery by default. Will be hookable.
+
+### <code>meta_title</code> <a id="metatitle-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{meta_title}}` – outputs the post title on posts, or otherwise the blog title. Used for outputting title tags in the `</head>` block. E.g. `<title>{{meta_title}}</title>`. Will be hookable.
+
+### <code>meta_description</code> <a id="metatitledescription-helper"></a>
+
+*   Helper type: output
+*   Options: none
+
+`{{meta_description}}` - outputs nothing (yet) on posts, outputs the blog description on all other pages. Used for outputing the description meta tag. E.g. `<meta name="description" content="{{meta_description}}" />`. Will be hookable.
+
+## Troubleshooting Themes <a id="troubleshooting"></a>
+
+#### 1. I see Error: Failed to lookup view "index" or "post"
+
+Check that your theme folder contains a correctly named index.hbs and post.hbs as these are required
+
+{% endraw %}

--- a/es/translations/index.md
+++ b/es/translations/index.md
@@ -1,0 +1,79 @@
+---
+lang: es
+layout: translations
+meta_title: Cómo traducir Ghost - Ghost Docs
+meta_description: Una guía sobre cómo ayudar a tradurcir Ghost
+heading: Traduciendo Ghost
+subheading: Una guía sobre cómo ayudar a traducir Ghost
+chapter: translations
+---
+
+{% raw %}
+
+## Traduciendo la documentación <a id="doc-translating"></a>
+
+### Conseguir los documentos más recientes de Ghost
+
+Todo la documentación de Ghost (<http://docs.ghost.org>) se encuentra en el branch [<code class="path">gh-pages</code>](https://github.com/TryGhost/Ghost/tree/gh-pages) ddentro del [repositorio en GitHub](https://github.com/TryGhost/Ghost/).
+
+To start translating you will first need to 'fork' the [GitHub repository](https://github.com/TryGhost/Ghost/) branch to your own account. You can do this by clicking the 'fork' button in the top right corner of GitHub.
+
+It looks like this: ![fork button](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/translations-GitHub-fork.png)
+
+You should now be able to access you fork by navigating to <code class="path">github.com/\<your username\>/Ghost</code>.
+
+Once you have verified you have a working fork, you will need to download it to your computer. To download the fork to your machine, you will need to follow these steps (in the Terminal / Command prompt);
+
+1. Run `git clone https://github.com/<your username>/Ghost.git -b gh-pages`
+![GitHub Clone](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/translations-gitclone.png)
+2. Run `cd Ghost`
+
+You should now be in the Ghost directory in your Terminal / Command Prompt. If you also open the Ghost folder in your directory browser of choice, you will see all the files for the Ghost documentation.
+
+### Adding your translation
+
+After following how to get the most recent Ghost documentation.
+
+1. Duplicate the <code class="path">/example_translation/</code> folder.
+2. Rename the duplicated folder to your appropriate language code ([IETF language tag](http://en.wikipedia.org/wiki/IETF_language_tag)). e.g. <code class="path">en</code> or <code class="path">pt_BR</code>
+<p class="note">
+If you're unsure of your language code, feel free to ask on the [forum](http://ghost.org/forum).
+</p>
+3. Update all the `lang: example_translation` fields at the top of each <code class="path">.md</code> file in your new directory to the same language code as your new directory.
+4. Update all the `permalink: /example_translation/*` fields at the the top of the <code class="path">.md</code> files that require it (not in all the files), to `permalink: /your_language_code/*`. <span class="note">Be sure to keep the content where `*` is, the same.</span>
+5. Add your language and translations to the <code class="path">_config.yml</code> file. Follow the format already present, and remember to use the country code you have used in the above steps.
+5. Start translating the <code class="path">.md</code> files in your new directory :)
+
+#### Submitting your change
+
+1. Open the terminal back up, where you should still be in your <code class="path">/Ghost</code> directory.
+2. Run `git commit -a`
+3. Name your commit message to sensibly reflect your addition / change. (press `i` to start typing your message) e.g "Included Welsh translations" or "Updated Welsh 'usage' docs". <span class="note">Save your commit message by pressing `ESC` and typing `:wq`, then press enter.</span>
+4. Submit your changes to your GitHub fork by running `git push origin gh-pages`. This sometimes prompts your for your GitHub username / password - enter those. You should then see some success messages.
+5. Navigate to your GitHub fork (<code class="path">github.com/\<your username\>/Ghost/tree/gh-pages</code>)
+6. Click on the Pull Request button. ![GitHub Pull Request](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/translations-pullrequest.png)
+7. Enter any additional details that need to be known in the 'description' box.
+8. Submit your Pull Request to the <code class="path">TryGhost:gh-pages</code> branch (should be automatically set).
+9. That's it, you're done. The Ghost team will review it and comment on any additional changes which need to be made.
+
+### Updating a translation
+
+To update a translation you can simply follow the steps in "Adding your translation", but ignoring all the setup and simply changing the required areas, or if you would prefer to follow a simpler alternative you can do it directly in [GitHub](http://github.com).
+
+#### In GitHub
+
+1. Locate the file that needs changing in the <https://github.com/TryGhost/Ghost/tree/gh-pages> repository.
+2. Click on file
+3. Click 'Edit'
+4. Make your changes
+5. Add a sensible commit message e.g. "Updated Welsh 'usage' docs"
+6. Add a sensible description e.g. "Fixed a typo in the 'usage' docs where ..."
+7. Read over your submission
+8. Click "Propose this file change"
+9. Feel good.
+
+##  Translating the Ghost platform <a id="ghost-translating"></a>
+
+**Coming soon**
+
+{% endraw %}

--- a/es/usage/configuration.md
+++ b/es/usage/configuration.md
@@ -1,0 +1,49 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+section: configuration
+permalink: /es/usage/configuration/
+prev_section: usage
+next_section: settings
+---
+
+
+## Configuring Ghost <a id="configuration"></a>
+
+After you run Ghost for the first time, you'll find a file called `config.js` in the root directory of Ghost, along with the `index.js`. This file allows you to set environment level configuration for things like your URL, database, and mail settings.
+
+If you haven't yet run Ghost for the first time, you won't have this file yet. You can create one by copying the `config.example.js` file - that's what Ghost does when it starts. 
+
+To configure your Ghost URL, mail or database settings, open `config.js` in your favourite editor, and start changing the settings for your desired environment. If environments aren't something you've come across yet, read the documentation below.
+
+## About Environments <a id="environments"></a>
+
+Node.js, and therefore Ghost, has the concept of environments built in. Environments allow you to create different configurations for different modes in which you might want to run Ghost. By default Ghost has two built-in modes: **development** and **production**.
+
+There are a few, very subtle differences between the two modes or environments. Essentially **development** is geared towards developing and particularly debugging Ghost. Meanwhile "production" is intended to be used when you're running Ghost publicly. The differences include things like what logging & error messaging is output, and also how much static assets are concatenated and minified. In **production**, you'll get just one JavaScript file containing all the code for the admin, in **development** you'll get several.
+
+As Ghost progresses, these differences will grow and become more apparent, and therefore it will become more and more important that any public blog runs in the **production** environment. This perhaps begs the question, why **development** mode by default, if most people are going to want to run it in **production** mode? Ghost has **development** as the default because this is the environment that is best for debugging problems, which you're most likely to need when getting set up for the first time.
+
+##  Using Environments <a id="using-env"></a>
+
+In order to set Ghost to run under a different environment, you need to use an environment variable. For example if you normally start Ghost with `node index.js` you would use:
+
+`NODE_ENV=production node index.js`
+
+Or if you normally use forever:
+
+`NODE_ENV=production forever start index.js`
+
+Or if you're used to using `npm start` you could use the slightly easier to remember:
+
+`npm start --production`
+
+### Why use `npm install --production`?
+
+We have been asked a few times why, if Ghost starts in development mode by default, does the installation documentation say to run `npm install --production`? This is a good question! If you don't include `--production` when installing Ghost, nothing bad will happen, but it will install a tonne of extra packages which are only useful for people who want to develop Ghost core itself. This also requires that you have one particular package, `grunt-cli` installed globally, which has to be done with `npm install -g grunt-cli`, it's an extra step and it's not needed if you just want to run Ghost as a blog.
+

--- a/es/usage/faq.md
+++ b/es/usage/faq.md
@@ -1,0 +1,24 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+section: faq
+permalink: /es/usage/faq/
+prev_section: writing
+---
+
+
+## FAQ <a id="faq"></a>
+
+### (When) Will Ghost support feature X?
+
+Please see the [Planned Features](https://github.com/TryGhost/Ghost/wiki/Planned-Features) listing and [Roadmap](https://github.com/TryGhost/Ghost/wiki/Roadmap) on the [Github wiki](https://github.com/TryGhost/Ghost/wiki).
+
+### How do I insert images into a post?
+
+Please see the [Markdown Guide](/usage/writing/#markdown) for a full explanation of how image uploads work in the Ghost editor.
+

--- a/es/usage/index.md
+++ b/es/usage/index.md
@@ -1,0 +1,41 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+next_section: configuration
+---
+
+## Overview <a id="overview"></a>
+
+Hopefully at this point you've got Ghost installed and running, and you're ready to get blogging. The following sections are going to walk you through absolutely everything you need to know about Ghost, so that you are familiar with everything, and set up exactly how you want to be.
+
+### First run
+
+If you are running Ghost for the very first time, then you need to create your admin user account. Navigate to your new blog in your favourite browser, and then change the URL to <code class="path">&lt;your URL&gt;/ghost/signup/</code>. You should see a screen just like this one:
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/ghost-signup.png)
+
+*   Fill in your **Full Name** as the name you want to appear as the author of blog posts.
+*   Then enter your **Email Address** - make sure it's valid, and carefully enter a sensible **Password** (it needs to be at least 8 characters long).
+*   Hit the big blue **Sign Up** button, and you will be logged in to your blog.
+
+That's it! You can now start writing blog posts.
+
+#### Messages
+
+On your first run of Ghost you should see a blue info message at the top of the screen that looks a little like this:
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/first-run-info.png)
+
+It let's you know some information about the way Ghost is configured, such as which environment you've started it in, and what you've got your URL set to. Jump to the [configuration](/usage/configuration/) section to find out more about environments, and how to configure Ghost. You won't be able to get rid of this message until you log in (this is a bug we're working on), but once you have, and you're familiar with the info, close it by pressing the x. It won't appear again.
+
+You may also see an orange warning message with regard to email:
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/email-warning.png)
+
+This isn't critical to setting up your blog so you can get started writing, but it is a good idea to mosey on over to the [email documentation](/mail) at some point, and learn about configuring Ghost to send email. This is currently only used to send you a reset email if you forget your password. Not important for blogging, but really useful if you ever need it!
+

--- a/es/usage/managing.md
+++ b/es/usage/managing.md
@@ -1,0 +1,48 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+section: managing
+permalink: /es/usage/managing/
+prev_section: settings
+next_section: writing
+---
+
+
+##  Managing your blog <a id="managing"></a>
+
+1.  Go to <code class="path">&lt;your URL&gt;/ghost/editor/</code>
+2.  Enter a Post Title
+3.  Enter your post content using [Markdown](http://daringfireball.net/projects/markdown/syntax)
+4.  Save your Post as "Draft" by clicking the 'Save Draft' button, or press Ctrl / CMD + S.<br/> ![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/draft.gif)
+
+### Publish a Post
+
+Once you have written your Post.
+
+1.  Click the arrow next to "Save Draft"
+2.  Select "Publish Now"<br/> ![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/publish.gif)
+
+This will set the save state to 'Publish Now' and the button will turn Red, once you press this button the Post will be published. To return the Post to a 'Draft' state;
+
+1.  return to the 'Save Menu'.
+2.  Select "Unpublish".
+3.  Click the "Unpublish" button.
+
+To change the "Slug" or "Publish date" of a post once published;
+
+1.  Click the 'Settings' icon.
+2.  Proceed to update the information as required (this will be saved automatically when you naviagte away).
+<img style="max-width:100%;" src="hhttps://s3-eu-west-1.amazonaws.com/ghost-website-cdn/updateSlug.gif" /> 
+
+### Delete a Post
+
+1.  Navigate to the 'Settings' icon in either the 'Content' page or 'Editor' page.
+2.  Click "Delete".
+3.  Accept the Modal
+<img width="100%" src="https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/deletePost.gif" />
+ 

--- a/es/usage/settings.md
+++ b/es/usage/settings.md
@@ -1,0 +1,54 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+section: settings
+permalink: /es/usage/settings/
+prev_section: configuration
+next_section: managing
+---
+
+##  Ghost Settings <a id="settings"></a>
+
+Go to <code class="path">&lt;your URL&gt;/ghost/settings/</code>.
+
+After you are finished adjusting the settings the "Save" button *must* be pressed, this will save your changes.
+
+You can check your changes by visiting the Blog URL.
+
+### Blog Settings (<code class="path">/general/</code>)
+
+These are the Blog specific settings.
+
+*   **Blog Title**: Changes your Blog's title. Theme reference `@blog.title`.
+*   **Blog Description**: Changes your Blog's description. Theme reference `@blog.description`.
+*   **Blog Logo**: Upload a Logo for your blog in either '.png', '.jpg' or '.gif'. Theme reference `@blog.logo`.
+*   **Blog Cover**: Upload your blog cover image in either '.png', '.jpg' or '.gif'. Theme reference `@blog.cover`.
+*   **Email Address**: This is the email admin notifications are sent too. It *must* be a valid email.
+*   **Posts per page**: This is how many posts are displayed per page. This should be a numeric value.
+*   **Theme**: This will list all the themes in your <code class="path">content/themes</code> directory. Selecting one from the dropdown will change your blog's look.
+
+### User Settings (<code class="path">/user/</code>)
+
+These are the settings that control your user / author profile.
+
+*   **Your Name**: This is your name that will be used to credit you when you publish a post. Theme reference (post) `author.name`.
+*   **Cover Image**: Your profile cover image is uploaded here, in either '.png', '.jpg' or '.gif' format. Theme reference (post) `author.cover`.
+*   **Display Picture**: This is where you upload your personal display picture, in either '.png', '.jpg' or '.gif' format. Theme reference (post) `author.image`.
+*   **Email Address**: This email will be available as your public email and also where you wish to receive notifications. Theme reference (post) `author.email`.
+*   **Location**: This should be your current location. Theme reference (post) `author.location`.
+*   **Website**: This is your personal website URL or even one of your social network URLs. Theme reference (post) `author.website`.
+*   **Bio**: Your bio is where you can enter a 200 charater or less description about yourself. Theme reference (post) `author.bio`.
+
+#### Changing your password
+
+1.  Fill out the input boxes with the appropriate password (current / new password).
+2.  Now click **Change Password**.
+<p class="note">
+    <strong>Note:</strong> For your password to change you must click the "Change Password" button, the "Save" button does not change the password.
+</p>
+

--- a/es/usage/writing.md
+++ b/es/usage/writing.md
@@ -1,0 +1,66 @@
+---
+lang: es
+layout: usage
+meta_title: How to Use Ghost - Ghost Docs
+meta_description: An in depth guide to using the Ghost blogging platform. Got Ghost but not sure how to get going? Start here!
+heading: Using Ghost
+subheading: Finding your way around, and getting set up the way you want
+chapter: usage
+section: writing
+permalink: /es/usage/writing/
+prev_section: managing
+next_section: faq
+---
+
+##  Writing posts <a id="writing"></a>
+
+Blog posts in Ghost are written using Markdown. Markdown is a minimal syntax for marking up documents with formatting using punctuation and special characters. It's syntax is intended to prevent interuptions to the flow of writing, allowing you to focus on your content, rather than how it looks.
+
+###  Markdown Guide <a id="markdown"></a>
+
+[Markdown](http://daringfireball.net/projects/markdown/) is a markup language designed to improve the efficiency in which you can write, whilst keep the writing as easy-to-read as possible.
+
+Ghost uses all the default Markdown shortcuts plus a few of our own additions. The full list of shortcuts is listed below.
+
+####  Headers
+
+Headers can be set using a hash before the title text. The number of hashes before the title text determines the depth of the header. The headers depths are from 1-6.
+
+*   H1 : `# Header 1`
+*   H2 : `## Header 2`
+*   H3 : `### Header 3`
+*   H4 : `#### Header 4`
+*   H5 : `##### Header 5`
+*   H6 : `###### Header 6`
+
+####  Text Styling
+
+*   Links : `[Title](URL)`
+*   Bold : `**Bold**`
+*   Italic : `*Italic*`
+*   Paragraphs : Line space inbetween paragraphs
+*   Lists : `* An asterix on every new list item`
+*   Quotes : `> Quote`
+*   Code : `` `code` ``
+*   HR : `==========`
+
+####  Images
+
+To insert an image into your post, you need to first enter `![]()` into the Markdown editor panel.
+This should create an image upload box in your preview panel.
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/Screen%20Shot%202013-10-14%20at%2012.45.08.png)
+
+You can now drag and drop any image (.png, .gif, .jpg) from your Desktop over the image upload box to include it into your post, or alternatively click the image upload box to use a standard image upload popup.
+If you would prefer to include an image url, click the 'link' icon in the bottom left of the image upload box, this will then present you with the ability to insert an image URL.
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/Screen%20Shot%202013-10-14%20at%2012.34.21.png)
+
+To title your image, all you need to do is place your title text inbetween the square brackets, e.g; `![This is a title]()`. 
+
+##### Removing Images
+
+![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/Screen%20Shot%202013-10-14%20at%2012.56.44.png)
+
+To remove an image click the 'remove' icon, in the top right corner of the currently inserted image. This will present you with the blank image upload box for you to re-insert a new image.
+


### PR DESCRIPTION
I've started to translate documentation to Spanish, beginning with the global structure and specifically with Linux installation, my daily environment.
