### PR TITLE
Added legacy support for Wordpress URL routing

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -303,6 +303,10 @@ when(ghost.init()).then(function () {
     server.get('/rss/:page/', frontend.rss);
     server.get('/page/:page/', frontend.homepage);
     server.get('/:slug/', frontend.single);
+
+		//built in legacy Wordpress support
+		server.get('/:year/:month/:day/:slug/', frontend.single);
+		server.get('/:slug/', frontend.single);
     server.get('/', frontend.homepage);
 
     // Are we using sockets? Custom socket or the default?


### PR DESCRIPTION
Currently Ghost only has routing for /ROOT/slug and many blogs (like mine) have adopted a Wordpress style of /ROOT/year/month/day/slug. This PR allows for both options and simply adds a route that accepts the WP style.

Given that I just pushed my blog (http://www.wekeroad.com) I thought about how I wanted to handle some of my old links. The first choice is to push back a 301 and redirect to the Ghost /ROOT/slug way of doing things. The other part of me thought "why break history?". 

This PR allows for incoming URLs to be routed correctly, and is the simplest way to address this problem.
