### PR TITLE
expand the sass task to compile theme sass files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,13 +66,13 @@ var path           = require('path'),
                 },
                 sass: {
                     files: [
-                        '<%= paths.adminAssets %>/sass/**/*'
+                        '<%= paths.adminAssets %>/sass/**/*',
                         'content/themes/**/sass/**/*',
-                        'content/themes/**/scss/**/*',
+                        'content/themes/**/scss/**/*'
                     ],
                     tasks: [
                         'sass:admin',
-                        'sass:themes',
+                        'sass:themes'
                     ]
                 },
                 concat: {
@@ -88,9 +88,9 @@ var path           = require('path'),
                 livereload: {
                     files: [
                         // Theme CSS
-                        'content/themes/casper/css/*.css',
+                        'content/themes/**/css/*.css',
                         // Theme JS
-                        'content/themes/casper/js/*.js',
+                        'content/themes/**/js/*.js',
                         // Admin CSS
                         '<%= paths.adminAssets %>/css/*.css',
                         // Admin JS
@@ -116,7 +116,6 @@ var path           = require('path'),
                 options: {
                     script: 'index.js'
                 },
-
                 dev: {
                     options: {
                         //output: 'Express server listening on address:.*$'
@@ -265,7 +264,7 @@ var path           = require('path'),
                 themes: {
                     files: grunt.file.expandMapping([
                         "content/themes/**/src/**/*.sass",
-                        "!content/themes/**/src/**/_*.sass",
+                        "!content/themes/**/src/**/_*.sass"
                       ], '', {
                       expand: true,
                       ext: '.css',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,8 +65,15 @@ var path           = require('path'),
                     tasks: ['handlebars']
                 },
                 sass: {
-                    files: ['<%= paths.adminAssets %>/sass/**/*'],
-                    tasks: ['sass:admin']
+                    files: [
+                        '<%= paths.adminAssets %>/sass/**/*'
+                        'content/themes/**/sass/**/*',
+                        'content/themes/**/scss/**/*',
+                    ],
+                    tasks: [
+                        'sass:admin',
+                        'sass:themes',
+                    ]
                 },
                 concat: {
                     files: [
@@ -254,6 +261,21 @@ var path           = require('path'),
                     files: {
                         '<%= paths.adminAssets %>/css/screen.css': '<%= paths.adminAssets %>/sass/screen.scss'
                     }
+                },
+                themes: {
+                    files: grunt.file.expandMapping([
+                        "content/themes/**/src/**/*.sass",
+                        "!content/themes/**/src/**/_*.sass",
+                      ], '', {
+                      expand: true,
+                      ext: '.css',
+                      rename: function(base, src) {
+                        var re = /(content\/themes)\/(\w+)\/src\/s[a|c]ss/;
+                        var output = src.replace(re, '$1/$2/assets/css');
+                        //grunt.log.writeln("[base: "+base+"] [src:" + src + "] > " + output);
+                        return output
+                      }
+                    })
                 }
             },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -265,15 +265,15 @@ var path           = require('path'),
                     files: grunt.file.expandMapping([
                         "content/themes/**/src/**/*.sass",
                         "!content/themes/**/src/**/_*.sass"
-                      ], '', {
-                      expand: true,
-                      ext: '.css',
-                      rename: function(base, src) {
-                        var re = /(content\/themes)\/(\w+)\/src\/s[a|c]ss/;
-                        var output = src.replace(re, '$1/$2/assets/css');
-                        //grunt.log.writeln("[base: "+base+"] [src:" + src + "] > " + output);
-                        return output
-                      }
+                    ], '', {
+                        expand: true,
+                        ext: '.css',
+                        rename: function (base, src) {
+                            var re = /(content\/themes)\/(\w+)\/src\/s[a|c]ss/,
+                                output = src.replace(re, '$1/$2/assets/css');
+                            grunt.log.writeln("[base: " + base + "] [src:" + src + "] > " + output);
+                            return output;
+                        }
                     })
                 }
             },


### PR DESCRIPTION
To help promote theme development, I thought it might be good for the gruntfile to compile sass files found in the theme directories.

It's just an idea, but this works for me.

It's assumed that your themes look like: 

```
content/
  ...
  themes/
    a-theme/
      src/
        sass/
           _colours.sass
           _mixins.sass
           screen.sass
           print.sass
           ie.sass
```

And the result is : 

```
content/
  ...
  themes/
    a-theme/
      assets/
        css/
           screen.css
           print.css
           ie.css
      src/
        sass/
           _colours.sass
           _mixins.sass
           screen.sass
           print.sass
           ie.sass
```
