### PR TITLE
Ghost as a module, fixes #1326

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -1,22 +1,28 @@
+// If no env is set, default to development
+// This needs to be above all other require()
+// modules to ensure config gets right setting.
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
 // Module dependencies
-var express     = require('express'),
-    when        = require('when'),
-    _           = require('underscore'),
-    semver      = require('semver'),
-    fs          = require('fs'),
-    errors      = require('./server/errorHandling'),
-    plugins     = require('./server/plugins'),
-    path        = require('path'),
-    Ghost       = require('./ghost'),
-    helpers     = require('./server/helpers'),
-    middleware  = require('./server/middleware'),
-    routes      = require('./server/routes'),
-    packageInfo = require('../package.json'),
+var configLoader = require('./config-loader.js'),
+    express      = require('express'),
+    when         = require('when'),
+    _            = require('underscore'),
+    semver       = require('semver'),
+    fs           = require('fs'),
+    errors       = require('./server/errorHandling'),
+    plugins      = require('./server/plugins'),
+    path         = require('path'),
+    Ghost        = require('./ghost'),
+    helpers      = require('./server/helpers'),
+    middleware   = require('./server/middleware'),
+    routes       = require('./server/routes'),
+    packageInfo  = require('../package.json'),
 
 // Variables
-    loading = when.defer(),
-    server = express(),
-    ghost = new Ghost();
+    ghost = new Ghost(),
+    init,
+    setup;
 
 // If we're in development mode, require "when/console/monitor"
 // for help in seeing swallowed promise errors.
@@ -24,126 +30,142 @@ if (process.env.NODE_ENV === 'development') {
     require('when/monitor/console');
 }
 
-// Expose the promise we will resolve after our pre-loading
-ghost.loaded = loading.promise;
-
-when(ghost.init()).then(function () {
-    return helpers.loadCoreHelpers(ghost);
-}).then(function () {
-
-    // ##Configuration
-    // set the view engine
-    server.set('view engine', 'hbs');
-
-    // return the correct mime type for woff filess
-    express['static'].mime.define({'application/font-woff': ['woff']});
-
-    // ## Middleware
-    middleware(server);
-
-    // ## Routing
-
-    // Set up API routes
-    routes.api(server);
-
-    // Set up Admin routes
-    routes.admin(server);
-
-    // Set up Frontend routes
-    routes.frontend(server);
-
-    // Are we using sockets? Custom socket or the default?
-    function getSocket() {
-        if (ghost.config().server.hasOwnProperty('socket')) {
-            return _.isString(ghost.config().server.socket) ? ghost.config().server.socket : path.join(__dirname, '../content/', process.env.NODE_ENV + '.socket');
-        }
-        return false;
+// Initializes the ghost application.
+function init(app) {
+    if (!app) {
+        app = express();
     }
 
-    function startGhost() {
-        // Tell users if their node version is not supported, and exit
-        if (!semver.satisfies(process.versions.node, packageInfo.engines.node)) {
-            console.log(
-                "\nERROR: Unsupported version of Node".red,
-                "\nGhost needs Node version".red,
-                packageInfo.engines.node.yellow,
-                "you are using version".red,
-                process.versions.node.yellow,
-                "\nPlease go to http://nodejs.org to get the latest version".green
-            );
+    configLoader.loadConfig().then(function () {
+        // The server and its dependencies require a populated config
+        setup(app);
+    }).otherwise(errors.logAndThrowError);
+}
 
-            process.exit(0);
+
+// Sets up the express server instance.
+// Instantiates the ghost singleton,
+// helpers, routes, middleware, and plugins.
+// Finally it starts the http server.
+function setup(server) {
+    when(ghost.init()).then(function () {
+        return helpers.loadCoreHelpers(ghost);
+    }).then(function () {
+
+        // ##Configuration
+        // set the view engine
+        server.set('view engine', 'hbs');
+
+        // return the correct mime type for woff filess
+        express['static'].mime.define({'application/font-woff': ['woff']});
+
+        // ## Middleware
+        middleware(server);
+
+        // ## Routing
+
+        // Set up API routes
+        routes.api(server);
+
+        // Set up Admin routes
+        routes.admin(server);
+
+        // Set up Frontend routes
+        routes.frontend(server);
+
+        // Are we using sockets? Custom socket or the default?
+        function getSocket() {
+            if (ghost.config().server.hasOwnProperty('socket')) {
+                return _.isString(ghost.config().server.socket) ? ghost.config().server.socket : path.join(__dirname, '../content/', process.env.NODE_ENV + '.socket');
+            }
+            return false;
         }
 
-        // Startup & Shutdown messages
-        if (process.env.NODE_ENV === 'production') {
-            console.log(
-                "Ghost is running...".green,
-                "\nYour blog is now available on",
-                ghost.config().url,
-                "\nCtrl+C to shut down".grey
-            );
+        function startGhost() {
+            // Tell users if their node version is not supported, and exit
+            if (!semver.satisfies(process.versions.node, packageInfo.engines.node)) {
+                console.log(
+                    "\nERROR: Unsupported version of Node".red,
+                    "\nGhost needs Node version".red,
+                    packageInfo.engines.node.yellow,
+                    "you are using version".red,
+                    process.versions.node.yellow,
+                    "\nPlease go to http://nodejs.org to get the latest version".green
+                );
 
-            // ensure that Ghost exits correctly on Ctrl+C
-            process.on('SIGINT', function () {
-                console.log(
-                    "\nGhost has shut down".red,
-                    "\nYour blog is now offline"
-                );
                 process.exit(0);
-            });
-        } else {
-            console.log(
-                ("Ghost is running in " + process.env.NODE_ENV + "...").green,
-                "\nListening on",
-                getSocket() || ghost.config().server.host + ':' + ghost.config().server.port,
-                "\nUrl configured as:",
-                ghost.config().url,
-                "\nCtrl+C to shut down".grey
-            );
-            // ensure that Ghost exits correctly on Ctrl+C
-            process.on('SIGINT', function () {
+            }
+
+            // Startup & Shutdown messages
+            if (process.env.NODE_ENV === 'production') {
                 console.log(
-                    "\nGhost has shutdown".red,
-                    "\nGhost was running for",
-                    Math.round(process.uptime()),
-                    "seconds"
+                    "Ghost is running...".green,
+                    "\nYour blog is now available on",
+                    ghost.config().url,
+                    "\nCtrl+C to shut down".grey
                 );
-                process.exit(0);
-            });
+
+                // ensure that Ghost exits correctly on Ctrl+C
+                process.on('SIGINT', function () {
+                    console.log(
+                        "\nGhost has shut down".red,
+                        "\nYour blog is now offline"
+                    );
+                    process.exit(0);
+                });
+            } else {
+                console.log(
+                    ("Ghost is running in " + process.env.NODE_ENV + "...").green,
+                    "\nListening on",
+                    getSocket() || ghost.config().server.host + ':' + ghost.config().server.port,
+                    "\nUrl configured as:",
+                    ghost.config().url,
+                    "\nCtrl+C to shut down".grey
+                );
+                // ensure that Ghost exits correctly on Ctrl+C
+                process.on('SIGINT', function () {
+                    console.log(
+                        "\nGhost has shutdown".red,
+                        "\nGhost was running for",
+                        Math.round(process.uptime()),
+                        "seconds"
+                    );
+                    process.exit(0);
+                });
+            }
+
         }
 
-        // Let everyone know we have finished loading
-        loading.resolve();
-    }
+        // Expose the express server on the ghost instance.
+        ghost.server = server;
 
-    // Expose the express server on the ghost instance.
-    ghost.server = server;
+        // Initialize plugins then start the server
+        plugins.init(ghost).then(function () {
 
-    // Initialize plugins then start the server
-    plugins.init(ghost).then(function () {
+            // ## Start Ghost App
+            if (getSocket()) {
+                // Make sure the socket is gone before trying to create another
+                fs.unlink(getSocket(), function (err) {
+                    /*jslint unparam:true*/
+                    server.listen(
+                        getSocket(),
+                        startGhost
+                    );
+                    fs.chmod(getSocket(), '0744');
+                });
 
-        // ## Start Ghost App
-        if (getSocket()) {
-            // Make sure the socket is gone before trying to create another
-            fs.unlink(getSocket(), function (err) {
-                /*jslint unparam:true*/
+            } else {
                 server.listen(
-                    getSocket(),
+                    ghost.config().server.port,
+                    ghost.config().server.host,
                     startGhost
                 );
-                fs.chmod(getSocket(), '0744');
-            });
+            }
 
-        } else {
-            server.listen(
-                ghost.config().server.port,
-                ghost.config().server.host,
-                startGhost
-            );
-        }
-
+        });
+    }, function (err) {
+        errors.logErrorAndExit(err);
     });
-}, function (err) {
-    errors.logErrorAndExit(err);
-});
+}
+
+module.exports = init;

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -1,0 +1,29 @@
+/*globals describe, beforeEach, it*/
+var net             = require('net'),
+    assert          = require('assert'),
+    should          = require('should'),
+    request         = require('request'),
+    server          = require('../../server'),
+    Ghost           = require('../../ghost'),
+    config          = require('../../../config'),
+
+    ghost           = new Ghost();
+
+describe('Server', function () {
+    var port = config['development'].server.port,
+        host = config['development'].server.host,
+        url = 'http://' + host + ':' + port;
+
+
+    it('should not start a connect server when required', function (done) {
+        request(url, function (error, response, body) {
+            assert.equal(response, undefined);
+            assert.equal(body, undefined);
+            assert.notEqual(error, undefined);
+            assert.equal(error.code, 'ECONNREFUSED');
+            done();
+        });
+    });
+
+});
+

--- a/index.js
+++ b/index.js
@@ -1,13 +1,7 @@
 // # Ghost bootloader
 // Orchestrates the loading of Ghost
+// When run from command line.
 
-var configLoader = require('./core/config-loader.js'),
-    error        = require('./core/server/errorHandling');
+var ghost = require('./core/server');
 
-// If no env is set, default to development
-process.env.NODE_ENV = process.env.NODE_ENV || 'development';
-
-configLoader.loadConfig().then(function () {
-    // The server and its dependencies require a populated config
-    require('./core/server');
-}).otherwise(error.logAndThrowError);
+ghost();

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
             "url": "https://raw.github.com/TryGhost/Ghost/master/LICENSE"
         }
     ],
+    "main": "./core/server",
     "scripts": {
         "start": "node index",
         "test": "grunt validate --verbose"


### PR DESCRIPTION
This PR allows you to `require('ghost')` as an npm_module and instantiate it yourself.  It does not allow you to pass in a config object, that will require a separate PR (and require #1390 to land first, so the location of our files can be relative to the file instantiating ghost).  This is the first step towards getting to the ultimate goal of allowing ghost to be used as a module, one that I think is a good step towards that ultimate goal.

This works from a separate file where you can do this:

```
var ghost = require('ghost');
ghost();
```

or

```
var ghost = require('ghost'),
    express = require('express');
ghost(express());
```

This is mostly accomplished by changing `./core/server` to have it's functionality enclosed in functions, instead of having them execute as soon as the module is included elsewhere.

It also requires two different code paths:
1. When ghost is ran from the CLI it delegates to the `./index.js` file to start the ghost app.
2. When ghost is ran as a npm module from a seperate file, it leverages `package.json`'s `main` property to dictate what file is included. 

This is also built on top of my previous #1444, so that needs to be merged before this one can.

Sorry for the size of the PR, hope it's manageable enough to get merged.  Let me know how I can speed along the process (assuming this is the way we want to go).

fixes #1326
