### PR TITLE
Set RSS link title to blog title

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -291,12 +291,13 @@ coreHelpers.ghost_head = function (options) {
     /*jslint unparam:true*/
     var head = [],
         majorMinor = /^(\d+\.)?(\d+)/,
-        trimmedVersion = this.version;
+        trimmedVersion = this.version,
+        blog = coreHelpers.ghost.blogGlobals();
 
     trimmedVersion = trimmedVersion ? trimmedVersion.match(majorMinor)[0] : '?';
 
     head.push('<meta name="generator" content="Ghost ' + trimmedVersion + '" />');
-    head.push('<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
+    head.push('<link rel="alternate" type="application/rss+xml" title="' + _.escape(blog.title)  + '" href="/rss/">');
     if (this.path) {
         head.push('<link rel="canonical" href="' + coreHelpers.ghost.config().url + this.path + '" />');
     }

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -242,7 +242,7 @@ describe('Core Helpers', function () {
         it('returns meta tag string', function (done) {
             helpers.ghost_head.call({version: "0.3.0"}).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
+                rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n<link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/">');
 
                 done();
             });
@@ -251,7 +251,7 @@ describe('Core Helpers', function () {
         it('returns meta tag string even if version is invalid', function () {
             var rendered = helpers.ghost_head.call({version: "0.9"}).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.equal('<meta name="generator" content="Ghost 0.9" />\n<link rel="alternate" type="application/rss+xml" title="RSS" href="/rss/">');
+                rendered.string.should.equal('<meta name="generator" content="Ghost 0.9" />\n<link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/">');
             });
         });
     });


### PR DESCRIPTION
As reported [here](https://ghost.org/forum/bugs-suggestions/2987-rss-fetched-title-in-feedly/), the title of the link element that links to the RSS feed is just `RSS`. Some programs like Feedly are actually using it; this commit sets it to the correct value, which is the blog title. Also updated the unit test.
