### PR TITLE
Latin support for google fonts

### DIFF
--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -27,7 +27,7 @@
     <meta name="msapplication-square150x150logo" content="/ghost/img/medium.png"/>
     <meta name="msapplication-square310x310logo" content="/ghost/img/large.png"/>
 
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700">
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700&subset=latin,latin-ext">
     <link rel="stylesheet" href="/ghost/css/screen.css">
     {{{block "pageStyles"}}}
 </head>

--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -16,7 +16,7 @@
 		<link rel="shortcut icon" href="/favicon.ico">
 		<meta http-equiv="cleartype" content="on">
 
-		<link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
+		<link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700&subset=latin,latin-ext'>
 		<link rel="stylesheet" href="/ghost/css/screen.css">
 		{{{block "pageStyles"}}}
 	</head>


### PR DESCRIPTION
I've added latin/latin-ext subset for google fonts - without it special characters in different languages (like polish letters: ą ę ł etc.) don't display correctly.
