### PR TITLE
Add Customisable Permalinks

### DIFF
--- a/core/client/models/settings.js
+++ b/core/client/models/settings.js
@@ -4,7 +4,11 @@
     //id:0 is used to issue PUT requests
     Ghost.Models.Settings = Ghost.ProgressModel.extend({
         url: Ghost.settings.apiRoot + '/settings/?type=blog,theme',
-        id: '0'
+        id: '0',
+        parse: function (resp) {
+            resp.permalinks = resp.permalinks === "/:slug/" ? "" : "1";
+            return resp;
+        }
     });
 
 }());

--- a/core/client/tpl/settings/general.hbs
+++ b/core/client/tpl/settings/general.hbs
@@ -55,6 +55,13 @@
             </div>
 
             <div class="form-group">
+                <label for="permalinks">Dated Permalinks</label>
+                <input id="permalinks" name="general[permalinks]" type="checkbox" value="1" {{#if permalinks}}checked{{/if}}>
+                <label class="checkbox" for="permalinks"></label>
+                <p>Include date in your post's links</p>
+            </div>
+
+            <div class="form-group">
                 <label for="activeTheme">Theme</label>
                 <select id="activeTheme" name="general[activeTheme]">
                     {{#each availableThemes}}

--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -157,7 +157,8 @@
                 title = this.$('#blog-title').val(),
                 description = this.$('#blog-description').val(),
                 email = this.$('#email-address').val(),
-                postsPerPage = this.$('#postsPerPage').val();
+                postsPerPage = this.$('#postsPerPage').val(),
+                permalinks = this.$('#permalinks').is(':checked') ? "/:year/:month/:day/:slug/" : "/:slug/";
 
             Ghost.Validate._errors = [];
             Ghost.Validate
@@ -185,7 +186,8 @@
                     description: description,
                     email: email,
                     postsPerPage: postsPerPage,
-                    activeTheme: this.$('#activeTheme').val()
+                    activeTheme: this.$('#activeTheme').val(),
+                    permalinks: permalinks
                 }, {
                     success: this.saveSuccess,
                     error: this.saveError

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -65,7 +65,7 @@ frontendControllers = {
         });
     },
     'single': function (req, res, next) {
-        api.posts.read({'slug': req.params.slug}).then(function (post) {
+        api.posts.read(_.pick(req.params, ['id', 'slug'])).then(function (post) {
             if (post) {
                 ghost.doFilter('prePostsRender', post).then(function (post) {
                     var paths = ghost.paths().availableThemes[ghost.settings('activeTheme')];

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -44,6 +44,14 @@
                 "notNull": true,
                 "isIn": ["true", "false"]
             }
+        },
+        "permalinks": {
+            "defaultValue": "/:slug/",
+            "validations": {
+                "is": "^(/:?[a-z]+){1,}/$",
+                "regex": "(:id|:slug)",
+                "notContains": "/ghost/"
+            }
         }
     },
     "theme": {

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -80,14 +80,27 @@ coreHelpers.pageUrl = function (context, block) {
 // i.e. If inside a post context will return post permalink
 // absolute flag outputs absolute URL, else URL is relative
 coreHelpers.url = function (options) {
-    var output = '';
+    var output = '',
+        self = this,
+        tags = {
+            year: function () { return self.created_at.getFullYear(); },
+            month: function () { return self.created_at.getMonth() + 1; },
+            day: function () { return self.created_at.getDate(); },
+            slug: function () { return self.slug; },
+            id: function () { return self.id; }
+        };
 
     if (options && options.hash.absolute) {
         output += coreHelpers.ghost.config().url;
     }
 
     if (models.isPost(this)) {
-        output += '/' + this.slug + '/';
+        output += coreHelpers.ghost.settings('permalinks');
+        output = output.replace(/(:[a-z]+)/g, function (match) {
+            if (_.has(tags, match.substr(1))) {
+                return tags[match.substr(1)]();
+            }
+        });
     }
 
     return output;

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -1,4 +1,7 @@
-var frontend    = require('../controllers/frontend');
+var frontend    = require('../controllers/frontend'),
+    Ghost       = require('../../ghost'),
+
+    ghost       = new Ghost();
 
 module.exports = function (server) {
     // ### Frontend routes
@@ -6,6 +9,6 @@ module.exports = function (server) {
     server.get('/rss/', frontend.rss);
     server.get('/rss/:page/', frontend.rss);
     server.get('/page/:page/', frontend.homepage);
-    server.get('/:slug/', frontend.single);
+    server.get(ghost.settings('permalinks'), frontend.single);
     server.get('/', frontend.homepage);
 };

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -277,7 +277,7 @@ describe('Core Helpers', function () {
         });
 
         it('should return a the slug with a prefix slash if the context is a post', function () {
-            var rendered = helpers.url.call({html: 'content', markdown: "ff", title: "title", slug: "slug"});
+            var rendered = helpers.url.call({html: 'content', markdown: "ff", title: "title", slug: "slug", created_at: new Date(0)});
             should.exist(rendered);
             rendered.should.equal('/slug/');
         });
@@ -288,7 +288,7 @@ describe('Core Helpers', function () {
                 }),
 
                 rendered = helpers.url.call(
-                    {html: 'content', markdown: "ff", title: "title", slug: "slug"},
+                    {html: 'content', markdown: "ff", title: "title", slug: "slug", created_at: new Date(0)},
                     {hash: { absolute: 'true'}}
                 );
 

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -10,7 +10,7 @@ var _ = require('underscore'),
             'featured', 'image', 'status', 'language', 'author_id', 'created_at', 'created_by', 'updated_at', 'updated_by',
             'published_at', 'published_by', 'page', 'author', 'user', 'tags'],
         // TODO: remove databaseVersion
-        settings: ['databaseVersion', 'title', 'description', 'email', 'logo', 'cover', 'defaultLang',
+        settings: ['databaseVersion', 'title', 'description', 'email', 'logo', 'cover', 'defaultLang', "permalinks",
             'postsPerPage', 'forceI18n', 'activeTheme', 'activePlugins', 'installedPlugins', 'availableThemes'],
         tag: ['id', 'uuid', 'name', 'slug', 'description', 'parent_id',
             'meta_title', 'meta_description', 'created_at', 'created_by', 'updated_at', 'updated_by'],


### PR DESCRIPTION
This adds customisable permalinks (#1395).

They can be configured in the general settings and are regular express route strings. Because we need at least one uinque identifier, either `slug` or `id` must be provided; `year`, `month` and `day` are optional.

Eg: `/:year/:month/:day/:slug/` -> `my-ghost-blog.com/2013/11/20/myslug/`.

TODO:
- Live reloading. Routes can be removed from `server.routes` and then just registered again, however I am not sure where to put this. There is no way to get access to `server` outside of `server.js`, right?
- ~~Refactor the `url` helper in `core/server/helpers/index.js` that generates the permalink for a post.~~ This might be related to #1390, @hswolff do you think we should put this in the module you are working on?
- Multiple routes / redirects for compatibility. Not sure if necessary?
- ~~What should I use for name, description & error message in the settings? I think the error box is not really suited to provide a description of the valid values because these are rather complex; maybe add a link to the documentation?~~
- Write Tests ~~(and fix the current one's)~~
