### PR TITLE
Create config module to standardise getting paths and abs URLs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ var path           = require('path'),
     spawn          = require('child_process').spawn,
     buildDirectory = path.resolve(process.cwd(), '.build'),
     distDirectory  = path.resolve(process.cwd(), '.dist'),
-    configLoader   = require('./core/config-loader.js'),
+    configLoader   = require('./core/server/config/loader'),
 
     buildGlob = [
         '**',
@@ -499,7 +499,7 @@ var path           = require('path'),
 
         grunt.registerTask('loadConfig', function () {
             var done = this.async();
-            configLoader.loadConfig().then(function () {
+            configLoader().then(function () {
                 done();
             });
         });

--- a/core/server.js
+++ b/core/server.js
@@ -3,7 +3,8 @@
 // modules to ensure config gets right setting.
 
 // Module dependencies
-var express      = require('express'),
+var config       = require('./server/config'),
+    express      = require('express'),
     when         = require('when'),
     _            = require('underscore'),
     semver       = require('semver'),
@@ -34,7 +35,7 @@ if (process.env.NODE_ENV === 'development') {
 // Finally it starts the http server.
 function setup(server) {
     when(ghost.init()).then(function () {
-        return helpers.loadCoreHelpers(ghost);
+        return helpers.loadCoreHelpers(ghost, config);
     }).then(function () {
 
         // ##Configuration
@@ -63,8 +64,8 @@ function setup(server) {
 
         // Are we using sockets? Custom socket or the default?
         function getSocket() {
-            if (ghost.config().server.hasOwnProperty('socket')) {
-                return _.isString(ghost.config().server.socket) ? ghost.config().server.socket : path.join(__dirname, '../content/', process.env.NODE_ENV + '.socket');
+            if (config().server.hasOwnProperty('socket')) {
+                return _.isString(config().server.socket) ? config().server.socket : path.join(__dirname, '../content/', process.env.NODE_ENV + '.socket');
             }
             return false;
         }
@@ -89,7 +90,7 @@ function setup(server) {
                 console.log(
                     "Ghost is running...".green,
                     "\nYour blog is now available on",
-                    ghost.config().url,
+                    config().url,
                     "\nCtrl+C to shut down".grey
                 );
 
@@ -105,9 +106,9 @@ function setup(server) {
                 console.log(
                     ("Ghost is running in " + process.env.NODE_ENV + "...").green,
                     "\nListening on",
-                    getSocket() || ghost.config().server.host + ':' + ghost.config().server.port,
+                    getSocket() || config().server.host + ':' + config().server.port,
                     "\nUrl configured as:",
-                    ghost.config().url,
+                    config().url,
                     "\nCtrl+C to shut down".grey
                 );
                 // ensure that Ghost exits correctly on Ctrl+C
@@ -144,8 +145,8 @@ function setup(server) {
 
             } else {
                 server.listen(
-                    ghost.config().server.port,
-                    ghost.config().server.host,
+                    config().server.port,
+                    config().server.host,
                     startGhost
                 );
             }

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -1,0 +1,16 @@
+
+var ghostConfig   = require('../../../config'),
+    loader        = require('./loader'),
+    paths         = require('./paths');
+
+
+function configIndex() {
+    return ghostConfig[process.env.NODE_ENV];
+}
+
+
+configIndex.loader = loader;
+configIndex.paths = paths;
+
+
+module.exports = configIndex;

--- a/core/server/config/loader.js
+++ b/core/server/config/loader.js
@@ -1,10 +1,10 @@
 var fs      = require('fs'),
     url     = require('url'),
     when    = require('when'),
-    errors  = require('./server/errorHandling'),
+    errors  = require('../errorHandling'),
     path    = require('path'),
 
-    appRoot = path.resolve(__dirname, '../'),
+    appRoot = path.resolve(__dirname, '../../../'),
     configexample = path.join(appRoot, 'config.example.js'),
     config = path.join(appRoot, 'config.js');
 
@@ -49,7 +49,7 @@ function validateConfigEnvironment() {
         parsedUrl;
 
     try {
-        config = require('../config')[envVal];
+        config = require('../../../config')[envVal];
     } catch (ignore) {
 
     }
@@ -86,7 +86,7 @@ function validateConfigEnvironment() {
     return when.resolve();
 }
 
-exports.loadConfig = function () {
+function loadConfig() {
     var loaded = when.defer();
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
@@ -98,4 +98,6 @@ exports.loadConfig = function () {
         }
     });
     return loaded.promise;
-};
+}
+
+module.exports = loadConfig;

--- a/core/server/config/paths.js
+++ b/core/server/config/paths.js
@@ -1,0 +1,49 @@
+
+
+var path              = require('path'),
+    when              = require('when'),
+    requireTree       = require('../require-tree'),
+    appRoot           = path.resolve(__dirname, '../../../'),
+    themePath         = path.resolve(appRoot + '/content/themes'),
+    pluginPath        = path.resolve(appRoot + '/content/plugins'),
+    themeDirectories  = requireTree(themePath),
+    pluginDirectories = requireTree(pluginPath),
+    activeTheme       = '',
+    availableThemes,
+    availablePlugins;
+
+
+function getPaths() {
+    return {
+        'appRoot':          appRoot,
+        'themePath':        themePath,
+        'pluginPath':       pluginPath,
+        'activeTheme':      path.join(themePath, activeTheme),
+        'adminViews':       path.join(appRoot, '/core/server/views/'),
+        'helperTemplates':  path.join(appRoot, '/core/server/helpers/tpl/'),
+        'lang':             path.join(appRoot, '/core/shared/lang/'),
+        'availableThemes':  availableThemes,
+        'availablePlugins': availablePlugins
+    };
+}
+
+
+function updatePaths() {
+    return when.all([themeDirectories, pluginDirectories]).then(function (paths) {
+        availableThemes = paths[0];
+        availablePlugins = paths[1];
+        return;
+    });
+}
+
+function setActiveTheme(ghost) {
+    if (ghost && ghost.settingsCache) {
+        activeTheme = ghost.settingsCache.activeTheme.value;
+    }
+}
+
+module.exports = getPaths;
+
+module.exports.updatePaths = updatePaths;
+
+module.exports.setActiveTheme = setActiveTheme;

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -1,4 +1,5 @@
 var Ghost         = require('../../ghost'),
+    config        = require('../config'),
     _             = require('underscore'),
     path          = require('path'),
     when          = require('when'),
@@ -154,8 +155,8 @@ adminControllers = {
         var email = req.body.email;
 
         api.users.generateResetToken(email).then(function (token) {
-            var siteLink = '<a href="' + ghost.config().url + '">' + ghost.config().url + '</a>',
-                resetUrl = ghost.config().url + '/ghost/reset/' + token + '/',
+            var siteLink = '<a href="' + config().url + '">' + config().url + '</a>',
+                resetUrl = config().url + '/ghost/reset/' + token + '/',
                 resetLink = '<a href="' + resetUrl + '">' + resetUrl + '</a>',
                 message = {
                     to: email,

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -5,6 +5,7 @@
 /*global require, module */
 
 var Ghost  = require('../../ghost'),
+    config = require('../config'),
     api    = require('../api'),
     RSS    = require('rss'),
     _      = require('underscore'),
@@ -68,7 +69,7 @@ frontendControllers = {
         api.posts.read(_.pick(req.params, ['id', 'slug'])).then(function (post) {
             if (post) {
                 ghost.doFilter('prePostsRender', post).then(function (post) {
-                    var paths = ghost.paths().availableThemes[ghost.settings('activeTheme')];
+                    var paths = config.paths().availableThemes[ghost.settings('activeTheme')];
                     if (post.page && paths.hasOwnProperty('page')) {
                         res.render('page', {post: post});
                     } else {
@@ -87,7 +88,7 @@ frontendControllers = {
     },
     'rss': function (req, res, next) {
         // Initialize RSS
-        var siteUrl = ghost.config().url,
+        var siteUrl = config().url,
             pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
             feed;
         //needs refact for multi user to not use first user as default

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -97,7 +97,7 @@ coreHelpers.url = function (options) {
         output += blog.url;
     }
 
-    if (blog.path !== '/') {
+    if (blog.path && blog.path !== '/') {
         output += blog.path;
     }
 
@@ -219,8 +219,8 @@ coreHelpers.excerpt = function (options) {
 // Returns the config value for fileStorage.
 coreHelpers.fileStorage = function (context, options) {
     /*jslint unparam:true*/
-    if (coreHelpers.ghost.config().hasOwnProperty('fileStorage')) {
-        return coreHelpers.ghost.config().fileStorage.toString();
+    if (coreHelpers.config().hasOwnProperty('fileStorage')) {
+        return coreHelpers.config().fileStorage.toString();
     }
     return "true";
 };
@@ -531,11 +531,14 @@ coreHelpers.helperMissing = function (arg) {
     errors.logError('Missing helper: "' + arg + '"');
 };
 
-registerHelpers = function (ghost) {
+registerHelpers = function (ghost, config) {
     var paginationHelper;
 
     // Expose this so our helpers can use it in their code.
     coreHelpers.ghost = ghost;
+
+    // And expose config
+    coreHelpers.config = config;
 
     ghost.registerThemeHelper('date', coreHelpers.date);
 

--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -12,13 +12,16 @@ function GhostMailer(opts) {
 
 // ## E-mail transport setup
 // *This promise should always resolve to avoid halting Ghost::init*.
-GhostMailer.prototype.init = function (ghost) {
+GhostMailer.prototype.init = function (ghost, configModule) {
     this.ghost = ghost;
     // TODO: fix circular reference ghost -> mail -> api -> ghost, remove this late require
     this.api = require('./api');
+    // We currently pass in the config module to avoid
+    // circular references, similar to above.
+    this.config = configModule;
 
     var self = this,
-        config = ghost.config();
+        config = this.config();
 
     if (config.mail && config.mail.transport && config.mail.options) {
         this.createTransport(config);
@@ -95,7 +98,7 @@ GhostMailer.prototype.send = function (message) {
         return when.reject(new Error('Email Error: Incomplete message data.'));
     }
 
-    var from = this.ghost.config().mail.fromaddress || this.ghost.settings('email'),
+    var from = this.config().mail.fromaddress || this.ghost.settings('email'),
         to = message.to || this.ghost.settings('email'),
         sendMail = nodefn.lift(this.transport.sendMail.bind(this.transport));
 

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -2,6 +2,7 @@
 var _           = require('underscore'),
     express     = require('express'),
     Ghost       = require('../../ghost'),
+    config      = require('../config'),
     path        = require('path'),
     ghost       = new Ghost();
 
@@ -100,20 +101,19 @@ var middleware = {
         };
     },
 
-    staticTheme: function (g) {
-        var ghost = g;
+    staticTheme: function () {
         return function blackListStatic(req, res, next) {
             if (isBlackListedFileType(req.url)) {
                 return next();
             }
 
-            return middleware.forwardToExpressStatic(ghost, req, res, next);
+            return middleware.forwardToExpressStatic(req, res, next);
         };
     },
 
     // to allow unit testing
-    forwardToExpressStatic: function (ghost, req, res, next) {
-        return express['static'](ghost.paths().activeTheme)(req, res, next);
+    forwardToExpressStatic: function (req, res, next) {
+        return express['static'](config.paths().activeTheme)(req, res, next);
     }
 };
 

--- a/core/server/plugins/loader.js
+++ b/core/server/plugins/loader.js
@@ -3,6 +3,7 @@ var path = require('path'),
     _    = require('underscore'),
     when = require('when'),
     createProxy = require('./proxy'),
+    config = require('../config'),
     ghostInstance,
     loader;
 
@@ -24,7 +25,7 @@ function getPluginRelativePath(name, relativeTo, ghost) {
     ghost = ghost || getGhostInstance();
     relativeTo = relativeTo || __dirname;
 
-    return path.relative(relativeTo, path.join(ghost.paths().pluginPath, name));
+    return path.relative(relativeTo, path.join(config.paths().pluginPath, name));
 }
 
 

--- a/core/shared/lang/i18n.js
+++ b/core/shared/lang/i18n.js
@@ -1,4 +1,5 @@
-var fs = require('fs'),
+var fs     = require('fs'),
+    config = require('../../server/config'),
     /**
      * Create new Polyglot object
      * @type {Polyglot}
@@ -9,7 +10,7 @@ I18n = function (ghost) {
 
     // TODO: validate
     var lang = ghost.settings('defaultLang'),
-        path = ghost.paths().lang,
+        path = config.paths().lang,
         langFilePath = path + lang + '.json';
 
     return function (req, res, next) {

--- a/core/test/unit/ghost_spec.js
+++ b/core/test/unit/ghost_spec.js
@@ -7,7 +7,8 @@ var testUtils = require('../utils'),
     _ = require('underscore'),
 
     // Stuff we are testing
-    Ghost = require('../../ghost');
+    config = require('../../server/config'),
+    Ghost  = require('../../ghost');
 
 describe("Ghost API", function () {
     var testTemplatePath = 'core/test/utils/fixtures/',
@@ -177,7 +178,7 @@ describe("Ghost API", function () {
         should.exist(ghost.loadTemplate, 'load template function exists');
 
         // In order for the test to work, need to replace the path to the template
-        pathsStub = sandbox.stub(ghost, "paths", function () {
+        pathsStub = sandbox.stub(config, "paths", function () {
             return {
                 // Forcing the theme path to be the same
                 activeTheme: path.join(process.cwd(), testTemplatePath),
@@ -209,7 +210,7 @@ describe("Ghost API", function () {
         should.exist(ghost.loadTemplate, 'load template function exists');
 
         // In order for the test to work, need to replace the path to the template
-        pathsStub = sandbox.stub(ghost, "paths", function () {
+        pathsStub = sandbox.stub(config, "paths", function () {
             return {
                 activeTheme: path.join(process.cwd(), themeTemplatePath),
                 helperTemplates: path.join(process.cwd(), testTemplatePath)

--- a/core/test/unit/middleware_spec.js
+++ b/core/test/unit/middleware_spec.js
@@ -277,9 +277,9 @@ describe('Middleware', function () {
                     url: 'myvalidfile.css'
                 };
 
-            middleware.staticTheme(ghostStub)(req, null, function (req, res, next) {
+            middleware.staticTheme(null)(req, null, function (reqArg, res, next) {
                 middleware.forwardToExpressStatic.calledOnce.should.be.true;
-                assert.deepEqual(middleware.forwardToExpressStatic.args[0][0], ghostStub);
+                assert.deepEqual(middleware.forwardToExpressStatic.args[0][0], req);
                 return done();
             });
         });

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -283,7 +283,7 @@ describe('Core Helpers', function () {
         });
 
         it('should output an absolute URL if the option is present', function () {
-            var configStub = sinon.stub(ghost, "config", function () {
+            var configStub = sinon.stub(ghost, "blogGlobals", function () {
                     return { url: 'http://testurl.com' };
                 }),
 

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@
 // Orchestrates the loading of Ghost
 // When run from command line.
 
-var configLoader = require('./core/config-loader.js'),
-    errors       = require('./core/server/errorHandling');
+var configLoader       = require('./core/server/config/loader'),
+    errors             = require('./core/server/errorHandling');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-configLoader.loadConfig().then(function () {
+configLoader().then(function () {
     var ghost = require('./core/server');
     ghost();
 }).otherwise(errors.logAndThrowError);


### PR DESCRIPTION
This PR is for issue #1390.  Currently a WIP, with one tasks remaining: fix broken tests.  Rest of code is complete.

I followed the lead of rails (refer to the example app's https://github.com/RailsApps/learn-rails) and created a `config` directory where all configurations should reside.

This involved:
- Moving `./core/config-loader.js` to `./core/server/config/loader.js` pretty much in its entirety.   I removed the `loadConfig` function and made it directly exported from the file as that is all that the file does.
- Creating the `./core/server/config/paths.js`.  Most of this file's contents comes from ghost.js' `ghost.paths()` and `ghost.getPaths()`.  Those were moved into this new file and modified to not depend on the ghost singleton.
- Also moved `ghost.config()` directly to `config()`

This change to the config directory has had the lovely side effect of reducing the dependency on the ghost singleton object.

I have yet to go through the code base and update all string references to paths, however I did go through and update all `ghost.paths()` references.  That task can be a nice easy follow-up once this PR is merged.
