### PR TITLE
[Feature Request] Theme API: add has_tag helper to coreHelpers. 

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -453,6 +453,24 @@ coreHelpers.foreach = function (context, options) {
     return ret;
 };
 
+// ### Check if a tag is contained on the tag list
+//
+// Usage example:*
+//
+// `{{#has_tag "test"}} {{tags}} {{else}} no tags {{/has_tag}}`
+//
+// @param  {String} tag name to search on tag list
+// @return {String} list of tags formatted according to `tag` helper
+//
+coreHelpers.has_tag = function (name, options) {
+    if (_.isArray(this.tags) && !_.isEmpty(this.tags)) {
+        return (!_.isEmpty(_.filter(this.tags, function (tag) {
+            return (_.has(tag, "name") && tag.name === name);
+        }))) ? options.fn(this) : options.inverse(this);
+    }
+    return options.inverse(this);
+};
+
 // ## Template driven helpers
 // Template driven helpers require that their template is loaded before they can be registered.
 coreHelpers.paginationTemplate = null;
@@ -524,6 +542,8 @@ registerHelpers = function (ghost) {
     ghost.registerThemeHelper('foreach', coreHelpers.foreach);
 
     ghost.registerThemeHelper('helperMissing', coreHelpers.helperMissing);
+
+    ghost.registerThemeHelper('has_tag', coreHelpers.has_tag);
 
     ghost.registerAsyncThemeHelper('body_class', coreHelpers.body_class);
 

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -555,4 +555,29 @@ describe('Core Helpers', function () {
         });
 
     });
+
+    describe("has_tag helper", function (done) {
+        var tags = [{name: 'haunted'}, {name: 'ghost'}];
+
+        it('has loaded has_tag helper', function () {
+            should.exist(handlebars.helpers.has_tag);
+        });
+
+        it('can call function if tag is found', function() {
+            helpers.has_tag.call({tags: tags}, 'haunted', {
+                fn: function(tags) {
+                    should.exist(tags);
+                }
+            });
+        });
+
+        it('can call inverse function if tag is not found', function() {
+            helpers.has_tag.call({tags: tags}, 'undefined', {
+                inverse: function(tags) {
+                    should.exist(tags);
+                }
+            });
+       });
+
+    });
 });


### PR DESCRIPTION
According to your observations made on #1525
- Added has_tag helper to coreHelpers foundation.
- Added unit tests to check has_tag works as expected.

This patch adds functionality to support the following use case:

``` html
        <section class="post-excerpt">
          {{#has_tag "snippet"}}
                <p class="code-snippet">{{content}}</p>
          {{ else }}
            <p>{{excerpt}}&hellip;</p>
          {{/has_tag}}
        </section>
```

This could be pretty useful to filter post types using tags.
