### PR TITLE
Fix tag input field

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -564,15 +564,18 @@ body.zen {
     }
 }
 
-.tag-input {
+input[type="text"].tag-input {
     display: inline-block;
+    padding: 0;
     vertical-align: top;
     color: $lightgrey;
     font-weight: 300;
     background: transparent;
     border: none;
 
-    &:focus {outline: none;}
+    &:focus {
+        outline: none;
+    }
 }
 
 .tag {


### PR DESCRIPTION
fixes #1532
- giving higher priority to css selector for .tag-input in order to override global input-style
- remove padding set by global input-style to align nicely with already set tags

![screen shot 2013-11-23 at 19 54 10](https://f.cloud.github.com/assets/7757/1607140/b82213b8-5470-11e3-93ce-040db9fe2e16.png)
