### PR TITLE
Update base.js

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -10,7 +10,7 @@ var ghostBookshelf,
     sanitize  = require('validator').sanitize;
 
 // Initializes a new Bookshelf instance, for reference elsewhere in Ghost.
-ghostBookshelf = Bookshelf.ghost = Bookshelf.initialize(config[process.env.NODE_ENV || 'development'].database);
+ghostBookshelf = Bookshelf.ghost = Bookshelf.initialize(config[process.env.NODE_ENV].database);
 ghostBookshelf.client = config[process.env.NODE_ENV].database.client;
 
 ghostBookshelf.validator = new Validator();


### PR DESCRIPTION
No longer need `|| 'development'`, since it is defaulted in the top index.   If we did need `|| 'development'` here, we'd need it on the next line too, otherwise it breaks.
