### PR TITLE
Modified ghostdown markdown extension to allow for 4+ inline underscores

### DIFF
--- a/core/client/assets/vendor/showdown/extensions/ghostdown.js
+++ b/core/client/assets/vendor/showdown/extensions/ghostdown.js
@@ -22,6 +22,16 @@
                                '</section>';
                     });
                 }
+            },
+
+            // 4 or more inline underscores e.g. Ghost rocks my _____!
+            {
+                type: 'lang',
+                filter: function (text) {
+                    return text.replace(/([^_\n\r])(_{4,})/g, function (match, prefix, underscores) {
+                        return prefix + underscores.replace(/_/g, '&#95;');
+                    });
+                }
             }
         ];
     };

--- a/core/test/unit/client_ghostdown_spec.js
+++ b/core/test/unit/client_ghostdown_spec.js
@@ -55,6 +55,15 @@ describe("Ghostdown showdown extensions", function () {
             });
     });
 
+    it("should allow 4 underscores", function () {
+        var processedMarkup =
+            ghostdown().reduce(function (prev, processor) {
+                return processor.filter(prev);
+            }, "Ghost ____");
+
+        processedMarkup.should.match(/Ghost\s(?:&#95;){4}$/);
+    });
+
     it("should correctly include an image", function () {
         [
             "![image and another,/ image](http://dsurl.stuff)",


### PR DESCRIPTION
See #1113 
update to #1127 
- added additional regex rule to replace 4+ underscores with their coded equivalent: &#95;
- add test for allowing 4 underscores in markdown
