### PR TITLE
Add postgres build and allow it to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
 env:
   - DB=sqlite3
   - DB=mysql
+  - DB=pg
+matrix:
+  allow_failures:
+    - env: DB=pg
 before_install:
   - git submodule update --init
   - gem update --system
@@ -15,6 +19,7 @@ before_install:
   - export PATH=$PATH:`pwd`/bin
   - cd -
   - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_travis'; fi
+  - if [ $DB == "pg" ]; then psql -c 'create database ghost_travis;' -U postgres; fi
 before_script:
   - phantomjs --version
   - casperjs --version

--- a/config.example.js
+++ b/config.example.js
@@ -116,6 +116,26 @@ config = {
             host: '127.0.0.1',
             port: '2369'
         }
+    },
+
+    // ### Travis
+    // Automated testing run through GitHub
+    'travis-pg': {
+        url: 'http://127.0.0.1:2369',
+        database: {
+            client: 'pg',
+            connection: {
+                host     : '127.0.0.1',
+                user     : 'postgres',
+                password : '',
+                database : 'ghost_travis',
+                charset  : 'utf8'
+            }
+        },
+        server: {
+            host: '127.0.0.1',
+            port: '2369'
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
         "when": "2.5.1"
     },
     "optionalDependencies": {
-        "mysql": "2.0.0-alpha9"
+        "mysql": "2.0.0-alpha9",
+        "pg": "~2.6.2"
     },
     "devDependencies": {
         "blanket": "~1.1.5",


### PR DESCRIPTION
This PR adds PostgreSQL as allowed failure to the travis builds. This will help working on PostgreSQL in the future as developers can easily check whether their changes break anything in PG. 

The build is currently failing for Postgres for something that looks like an issue with knex. Maybe @tgriesser can look into this.

refs #1333
