### PR TITLE
[WIP] added has_any_tag and has_all_tags core filters to Theme API

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -471,6 +471,42 @@ coreHelpers.has_tag = function (name, options) {
     return options.inverse(this);
 };
 
+// ### Check if a given tag list is enterely contained on the post tag list
+//
+// Usage example:*
+//
+// `{{#has_all_tags "oneTag" "otherTag" "anotherTag" }} {{tags}} {{else}} no tags {{/has_all_tags}}`
+//
+// @param  {String Array} One or more space separated strings of tags to search on the post tag list
+// @return {String} list of tags formatted according to `tag` helper
+//
+coreHelpers.has_all_tags = function () {
+    var opt = arguments[arguments.length - 1],
+        tagNames = _.pluck(this.tags, 'name');
+
+    return (_.filter(arguments, function (tag) {
+        return tagNames.indexOf(tag) !== -1;
+    })).length === (arguments.length - 1) ? opt.fn(this) : opt.inverse(this);
+};
+
+// ### Check if at least one tag is contained in tag list
+//
+// Usage example:*
+//
+// `{{#has_any_tag "oneTag" "otherTag" "anotherTag" }} {{tags}} {{else}} no tags {{/has_any_tag}}`
+//
+// @param  {String Array}  One or more space separated strings of tag name to search on the post tag list
+// @return {String} list of tags formatted according to `tag` helper
+//
+coreHelpers.has_any_tag = function () {
+    var opt = arguments[arguments.length - 1],
+        tagNames = _.pluck(this.tags, 'name');
+
+    return (_.filter(arguments, function (tag) {
+        return tagNames.indexOf(tag) !== -1;
+    })).length > 0 ? opt.fn(this) : opt.inverse(this);
+};
+
 // ## Template driven helpers
 // Template driven helpers require that their template is loaded before they can be registered.
 coreHelpers.paginationTemplate = null;
@@ -544,6 +580,10 @@ registerHelpers = function (ghost) {
     ghost.registerThemeHelper('helperMissing', coreHelpers.helperMissing);
 
     ghost.registerThemeHelper('has_tag', coreHelpers.has_tag);
+
+    ghost.registerThemeHelper('has_all_tags', coreHelpers.has_all_tags);
+
+    ghost.registerThemeHelper('has_any_tag', coreHelpers.has_any_tag);
 
     ghost.registerAsyncThemeHelper('body_class', coreHelpers.body_class);
 

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -580,4 +580,55 @@ describe('Core Helpers', function () {
        });
 
     });
+
+    describe("has_all_tags helper", function (done) {
+        var tags = [{name: 'haunted'}, {name: 'ghost'}];
+
+        it('has loaded has_all_tags helper', function () {
+            should.exist(handlebars.helpers.has_all_tags);
+        });
+
+        it('can call function if all tags are found', function() {
+            helpers.has_all_tags.apply({tags: tags}, ['haunted', 'ghost', {
+                fn: function(tags) {
+                    should.exist(tags);
+                }
+            }]);
+        });
+
+        it('can call inverse function if not tags found', function() {
+            helpers.has_all_tags.apply({tags: tags}, ['undefined', 'ghost', {
+                inverse: function(tags) {
+                    should.exist(tags);
+                }
+            }]);
+       });
+
+    });
+
+    describe("has_any_tag helper", function (done) {
+        var tags = [{name: 'haunted'}, {name: 'ghost'}];
+
+        it('has loaded has_any_tag helper', function () {
+            should.exist(handlebars.helpers.has_any_tag);
+        });
+
+        it('can call function if any of given tags are found', function() {
+            helpers.has_any_tag.apply({tags: tags}, ['haunted', 'undefined', {
+                fn: function(tags) {
+                    should.exist(tags);
+                }
+            }]);
+        });
+
+        it('can call inverse function if no tag is not found', function() {
+            helpers.has_any_tag.apply({tags: tags}, ['undefined', {
+                inverse: function(tags) {
+                    should.exist(tags);
+                }
+            }]);
+       });
+
+    });
+
 });


### PR DESCRIPTION
Continuation of #1539 pull request (has_tag (single tag) )
- Added has_all_tags (AND) helper to core Helpers.
- Added has_any_tag (OR) helper to core Helpers.
- Added unit tests to check works as expected.

This patch adds functionality to support the following use cases:
- has_all_tags:
  
  ``` html
        <section class="post-excerpt">
          {{#has_all_tags "summer of code" "snippet"}}
                <p class="code-snippet">{{content}}</p>
          {{ else }}
            <p>{{excerpt}}&hellip;</p>
          {{/has_all_tags}}
        </section>
  ```
- has_any_tag
  
  ``` html
        <section class="post-excerpt">
          {{#has_any_tag "snippet" "code" "programming" }}
                <p class="code-snippet">{{content}}</p>
          {{ else }}
            <p>{{excerpt}}&hellip;</p>
          {{/has_any_tag}}
        </section>
  ```

This could be pretty useful to filter post types using tags.
