### PR TITLE
Removing error handling using process.stderr

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -28,9 +28,6 @@ var config       = require('./server/config'),
 // stderr messages from bluebird promises.
 if (process.env.NODE_ENV === 'development') {
     require('when/monitor/console');
-    process.stderr.on('data', function (msg) {
-        console.log(msg);
-    });
 }
 
 // Sets up the express server instance.


### PR DESCRIPTION
- process.stdin/out/error is problematic, see https://github.com/joyent/node/issues/3584
