### PR TITLE
Adds login limiter

### DIFF
--- a/core/test/functional/admin/login_test.js
+++ b/core/test/functional/admin/login_test.js
@@ -74,6 +74,32 @@ CasperTest.begin("Can't spam it", 3, function suite(test) {
     casper.wait(2000);
 }, true);
 
+
+CasperTest.begin("Login limit is in place", 3, function suite(test) {
+    casper.thenOpen(url + "ghost/signin/", function testTitle() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    casper.waitForOpaque(".login-box",
+        function then() {
+            this.fill("#login", falseUser, true);
+        },
+        function onTimeout() {
+            test.fail('Sign in form didn\'t fade in.');
+        });
+
+    casper.wait(2100, function doneWait() {
+        this.fill("#login", falseUser, true);
+    });
+
+    casper.waitForText('remaining', function onSuccess() {
+        test.assert(true, 'The login limit is in place.');
+        test.assertSelectorDoesntHaveText('.notification-error', '[object Object]');
+    }, function onTimeout() {
+        test.assert(false, 'We did not trip the login limit.');
+    });
+}, true);
+
 CasperTest.begin("Can login to Ghost", 4, function suite(test) {
     casper.thenOpen(url + "ghost/login/", function testTitle() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");


### PR DESCRIPTION
Closes #499
- On wrong passwords, statuses: `active` -> `warn-1` -> `warn-2` -> `warn-3` -> `locked`
- On login check, if user's status is `locked`, login automatically fails and user is encouraged to reset password. Does not even bother to check for passwords.
- login attempts tell user how many attempts she has remaining in notification box
- successful login will reset status to `active`
- resetting password with forgotten password emailed token resets status to `active`
