### PR TITLE
[WIP] Replace sendmail with direct in nodemail

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -170,13 +170,15 @@ adminControllers = {
                 };
 
             return mailer.send(message);
-        }).then(function success() {
-            var notification = {
-                type: 'success',
-                message: 'Check your email for further instructions',
-                status: 'passive',
-                id: 'successresetpw'
-            };
+        }).then(function success(successmessage) {
+            var message = (mailer.transport.transportType !== 'DIRECT') ? 'Check your email for further instructions' :
+                        successmessage,
+                notification = {
+                    type: 'success',
+                    message: message,
+                    status: 'passive',
+                    id: 'successresetpw'
+                };
 
             return api.notifications.add(notification).then(function () {
                 res.json(200, {redirect: config.paths().webroot + '/ghost/signin/'});

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -51,13 +51,6 @@ describe("Mail", function () {
 
         config = sinon.stub().returns(fakeConfig);
 
-        sandbox.stub(mailer, "isWindows", function () {
-            return false;
-        });
-
-        sandbox.stub(mailer, "detectSendmail", function () {
-            return when.resolve(fakeSendmail);
-        });
     });
 
     afterEach(function () {
@@ -81,71 +74,22 @@ describe("Mail", function () {
         }).then(null, done);
     });
 
-    it('should setup sendmail transport on initialization', function (done) {
-        fakeConfig[process.env.NODE_ENV].mail = SENDMAIL;
-        mailer.init().then(function () {
-            mailer.should.have.property('transport');
-            mailer.transport.transportType.should.eql('SENDMAIL');
-            mailer.transport.sendMail.should.be.a.function;
-            done();
-        }).then(null, done);
-    });
-
-    it('should fallback to sendmail if no config set', function (done) {
+    it('should fallback to direct if no config set', function (done) {
         fakeConfig[process.env.NODE_ENV].mail = null;
         mailer.init().then(function () {
             mailer.should.have.property('transport');
-            mailer.transport.transportType.should.eql('SENDMAIL');
-            mailer.transport.options.path.should.eql(fakeSendmail);
+            mailer.transport.transportType.should.eql('DIRECT');
             done();
         }).then(null, done);
     });
 
-    it('should fallback to sendmail if config is empty', function (done) {
+    it('should fallback to direct if config is empty', function (done) {
         fakeConfig[process.env.NODE_ENV].mail = {};
         mailer.init().then(function () {
             mailer.should.have.property('transport');
-            mailer.transport.transportType.should.eql('SENDMAIL');
-            mailer.transport.options.path.should.eql(fakeSendmail);
+            mailer.transport.transportType.should.eql('DIRECT');
             done();
         }).then(null, done);
-    });
-
-    it('should disable transport if config is empty & sendmail not found', function (done) {
-        fakeConfig[process.env.NODE_ENV].mail = {};
-        mailer.detectSendmail.restore();
-        sandbox.stub(mailer, "detectSendmail", when.reject);
-        mailer.init().then(function () {
-            should.not.exist(mailer.transport);
-            done();
-        }).then(null, done);
-    });
-
-    it('should disable transport if config is empty & platform is win32', function (done) {
-        fakeConfig[process.env.NODE_ENV].mail = {};
-        mailer.detectSendmail.restore();
-        mailer.isWindows.restore();
-        sandbox.stub(mailer, 'isWindows', function () {
-            return true;
-        });
-        mailer.init().then(function () {
-            should.not.exist(mailer.transport);
-            done();
-        }).then(null, done);
-    });
-
-    it('should fail to send messages when no transport is set', function (done) {
-        mailer.detectSendmail.restore();
-        sandbox.stub(mailer, "detectSendmail", when.reject);
-        mailer.init().then(function () {
-            mailer.send().then(function () {
-                should.fail();
-                done();
-            }, function (err) {
-                err.should.be.an.instanceOf(Error);
-                done();
-            });
-        });
     });
 
     it('should fail to send messages when given insufficient data', function (done) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "moment": "2.4.0",
         "node-polyglot": "0.3.0",
         "node-uuid": "1.4.1",
-        "nodemailer": "0.5.13",
+        "nodemailer": "0.5.15",
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "0.3.1",


### PR DESCRIPTION
Fixes #1538.
- upgraded nodemailer to 0.5.11 (current master as of commit)
- implemented direct mail sending, and ripped out sendmail (we don't need sendmail anymore with direct being in place)
- modified tests to look for direct instead of sendmail
