### PR TITLE
Upgrade downsize to 0.0.4

### DIFF
--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -144,6 +144,20 @@ describe('Core Helpers', function () {
             rendered.string.should.equal(expected);
         });
 
+        it('can truncate html with non-ascii characters by word', function () {
+            var html = "<p>Едквюэ опортэат <strong>праэчынт ючю но, квуй эю</strong></p>",
+                expected = "Едквюэ опортэат",
+                rendered = (
+                    helpers.excerpt.call(
+                        {html: html},
+                        {"hash": {"words": "2"}}
+                    )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal(expected);
+        });
+
         it('can truncate html by character', function () {
             var html = "<p>Hello <strong>World! It's me!</strong></p>",
                 expected = "Hello Wo",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "bookshelf": "0.6.1",
         "colors": "0.6.2",
         "connect-slashes": "0.0.11",
-        "downsize": "0.0.3",
+        "downsize": "0.0.4",
         "express": "3.4.4",
         "express-hbs": "0.5.1",
         "fs-extra": "0.8.1",


### PR DESCRIPTION
refs #1095
- added new unicode test to excerpt helper

This addresses issues (e.g. #1095) with unicode languages and the excerpt/content helper failing to limit the content by words. Downsize 0.0.4 now uses XRegExp (https://github.com/cgiffard/Downsize/pull/3) in order to support matching unicode strings. This allows downsize to work on languages like greek or russian properly.

Some more thought will have to be put into supporting CJK since the notion of a "word" is different there.
