### PR TITLE
[WIP] Serving static assets via asset-rack

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -157,32 +157,29 @@ coreHelpers.url = function (options) {
 //
 // *Usage example:*
 // `{{asset "css/screen.css"}}`
-// `{{asset "css/screen.css" ghost="true"}}`
+//
 // Returns the path to the specified asset. The ghost
 // flag outputs the asset path for the Ghost admin
-coreHelpers.asset = function (context, options) {
-    var output = '',
-        isAdmin = options && options.hash && options.hash.ghost;
+// It does assume an asset folder, but does not require it
+coreHelpers.asset = function (context) {
+    var output = context[0] !== '/' ? '/' : "",
+        subDir = config.paths().path,
+        asset_url,
+        asset_folder_url;
 
-    output += config().paths.subdir + '/';
-
-    if (!context.match(/^favicon\.ico$/) && !context.match(/^shared/) && !context.match(/^asset/)) {
-        if (isAdmin) {
-            output += 'ghost/';
-        } else {
-            output += 'assets/';
-        }
+    if (subDir !== '/') {
+        output += subDir + '/';
     }
 
-    // Get rid of any leading slash on the context
-    context = context.replace(/^\//, '');
-    output += context;
+    asset_url = assets.url(output + context);
+    asset_folder_url = assets.url(output + 'assets/' + context);
 
-    if (!context.match(/^favicon\.ico$/)) {
-        output = assetTemplate({
-            source: output,
-            version: coreHelpers.assetHash
-        });
+    if (asset_url) {
+        output = asset_url;
+    } else if (asset_folder_url && !asset_url) {
+        output = asset_folder_url;
+    } else {
+        output = context;
     }
 
     return new hbs.handlebars.SafeString(output);

--- a/core/server/middleware/asset-rack-ext.js
+++ b/core/server/middleware/asset-rack-ext.js
@@ -1,0 +1,179 @@
+var _      = require('underscore'),
+    rack   = require('asset-rack'),
+    config = require('../config'),
+    api    = require('../api'),
+    fs     = require('fs-extra'),
+    async  = require('async'),
+    api    = require('../api'),
+    when   = require('when'),
+    path   = require('path'),
+
+    root     = config.paths().webroot;
+
+rack.Asset.prototype.constructor_without_host = rack.Asset.prototype.constructor;
+rack.Asset.prototype.constructor = function (options) {
+    // Enable hashing of asset-urls only in none development environments
+    if (!options.hash) {
+        this.hash = process.env.NODE_ENV !== 'development';
+    }
+
+    // If a asset host is configured set it as host name
+    if (config().assets && config().assets.host) {
+        this.hostname = config().assets.host;
+    }
+
+    this.constructor_without_host(options);
+};
+
+rack.Asset.prototype.checkUrl = function (url) {
+    var url_with_host;
+
+    if (this.hostname) {
+        url_with_host = '//' + this.hostname + url;
+    }
+
+    return url === this.specificUrl || url_with_host === this.specificUrl || url === this.url;
+};
+
+rack.Asset.prototype.reload = function () {
+    var that = this;
+
+    // Clear out old assets from an associated rack
+    if (this.rack && this.assets) {
+        this.rack.completed = false;
+        _.each(this.assets, function (asset) {
+            var removable_asset = _.find(that.rack.assets, function (rack_asset) {
+                return rack_asset.filename === asset.filename;
+            });
+            return that.rack.assets.splice(that.rack.assets.indexOf(removable_asset));
+        });
+    }
+
+    // Reset asset
+    this.completed = false;
+    this.assets = [];
+    this.on('complete', function () {
+        if (this.rack) {
+            _.each(this.assets, function (asset) {
+                return that.rack.assets.push(asset);
+            });
+            this.rack.emit('complete');
+        }
+    });
+
+    // trigger actual reloading of the asset's assets
+    this.emit('start');
+};
+
+rack.Rack.prototype.deploy_to_cdn = rack.Rack.prototype.deploy;
+rack.Rack.prototype.deploy = function () {
+    if (!config().assets) {
+        return;
+    }
+
+    var options = {};
+
+    if (config().assets.provider) {
+        options.provider  = config().assets.provider;
+        options.container = config().assets.container;
+        options.keyId = config().assets.accessKey;
+        options.key   = config().assets.secretKey;
+
+        this.deploy_to_cdn(options);
+    }
+
+    if (config().assets.dirname) {
+        options.dirname = config().assets.dirname;
+
+        this.deploy_to_local(options);
+    }
+};
+
+rack.Rack.prototype.deploy_to_local = function (options) {
+    var destination = options.dirname;
+
+    async.forEachSeries(this.assets, function (asset, next) {
+        var specificFilename = asset.specificUrl.replace("//" + asset.hostname + root, '');
+
+        // copy hashed version
+        fs.copy(asset.filename, path.join(destination, specificFilename), function (err) {
+            if (err) {
+                return err;
+            }
+        });
+        // copy original file as well
+        // We need to do this for now in order to serve assets that a refernced relative in a CSS file.
+        // Only until we find a solution
+        fs.copy(asset.filename, path.join(destination, asset.url), function (err) {
+            if (err) {
+                return err;
+            }
+        });
+        next();
+    });
+};
+
+// Copied from asset-rack and slightly modified to serve a single asset
+rack.StaticAsset = rack.Asset.extend({
+    create: function (options) {
+        var that = this;
+        this.filename = path.resolve(options.filename);
+
+        return fs.readFile(this.filename, function (error, data) {
+            if (error !== null) {
+                return that.emit('error', error);
+            }
+            return that.emit('created', {
+                contents: data
+            });
+        });
+    }
+});
+
+rack.ThemeAssets = rack.DynamicAssets.extend({
+    create: function (options) {
+        var that = this;
+
+        this.type = rack.StaticAsset;
+        this.urlPrefix = options.urlPrefix;
+        this.filter = options.filter;
+
+        if (this.urlPrefix === null) {
+            this.urlPrefix = '/';
+        }
+        this.assets = [];
+        // The setting for activeTheme is not readable when initialising the app, but will be on first request
+        api.settings.read('activeTheme').then(function (activeTheme) {
+            that.dirname = path.join(config.paths().themePath, activeTheme.value);
+            return that.addAssets();
+        }, function () {
+            return that.emit('created');
+        });
+    },
+    addAssets: function () {
+        var that = this;
+
+        return rack.util.walk(this.dirname, {
+            ignoreFolders: true,
+            filter: this.filter
+        }, function (file, done) {
+            var url, opts;
+
+            url = path.dirname(file.relpath);
+            url = url.split(path.sep);
+            url.push(file.name);
+
+            opts = {
+                url: that.urlPrefix + url.join('/'),
+                filename: file.path
+            };
+            that.addAsset(new that.type(opts));
+
+            return done();
+        }, function () {
+            return that.emit('created');
+        });
+    }
+});
+
+module.exports = rack;

--- a/core/server/middleware/assets.js
+++ b/core/server/middleware/assets.js
@@ -1,0 +1,72 @@
+var rack   = require('./asset-rack-ext'),
+    config = require('../config'),
+    path   = require('path'),
+    url    = require('url'),
+    fs     = require('fs-extra'),
+    _      = require('underscore'),
+
+    assets   = {},
+    root     = config.paths().webroot,
+    corePath = path.join(config.paths().appRoot, 'core'),
+    oneYear  = 31536000000;
+
+function isBlackListedFileType(file) {
+    var blackListedFileTypes = ['.hbs', '.md', '.json', '.rb',
+                                '.scss', '.coffee', '.less', '.scssc'];
+
+    return !_.contains(blackListedFileTypes, file.ext);
+}
+
+// Theme Assets
+assets.theme = new rack.ThemeAssets({
+    urlPrefix: config.paths().webroot === '' ? '/' : config.paths().webroot,
+    filter: isBlackListedFileType
+});
+
+assets.ghost = new rack.Rack([
+    // Favicon
+    new rack.StaticAsset({
+        hash: false,
+        url: root + '/favicon.ico',
+        filename: path.join(corePath + '/shared/favicon.ico')
+    }),
+    // Shared Assets
+    new rack.StaticAssets({
+        urlPrefix: root + '/shared',
+        dirname: path.join(corePath, 'shared'),
+        filter: isBlackListedFileType
+    }),
+    // Built scripts
+    new rack.StaticAssets({
+        maxAge: oneYear,
+        urlPrefix: root + '/ghost/scripts',
+        dirname: path.join(corePath, '/built/scripts'),
+        filter: isBlackListedFileType
+    }),
+    // Admin assets
+    new rack.StaticAssets({
+        urlPrefix: root + '/ghost',
+        dirname: path.join(corePath, '/client/assets'),
+        filter: isBlackListedFileType
+    }),
+    assets.theme
+]);
+
+assets.ghost.on('complete', function () {
+    assets.ghost.deploy();
+});
+
+assets.url = function (path) {
+    var combined_assets = _.compact(_.flatten(_.map(assets, function (asset) {
+            return asset.assets;
+        }))),
+        asset = _.find(combined_assets, function (asset) {
+            return asset.url === path;
+        });
+
+    if (asset) {
+        return asset.specificUrl;
+    }
+};
+
+module.exports = assets;

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -11,12 +11,18 @@ var api         = require('../api'),
     hbs         = require('express-hbs'),
     middleware  = require('./middleware'),
     packageInfo = require('../../../package.json'),
+<<<<<<< HEAD
     path        = require('path'),
     slashes     = require('connect-slashes'),
     storage     = require('../storage'),
     url         = require('url'),
     when        = require('when'),
     _           = require('lodash'),
+=======
+    BSStore     = require('../bookshelf-session'),
+    models      = require('../models'),
+    assets      = require('./assets'),
+>>>>>>> Serving static assets via asset-rack
 
     expressServer,
     ONE_HOUR_S  = 60 * 60,
@@ -90,20 +96,23 @@ function initViews(req, res, next) {
 // ### Activate Theme
 // Helper for manageAdminAndTheme
 function activateTheme(activeTheme) {
+<<<<<<< HEAD
     var hbsOptions,
         themePartials = path.join(config().paths.themePath, activeTheme, 'partials'),
         stackLocation = _.indexOf(expressServer.stack, _.find(expressServer.stack, function (stackItem) {
             return stackItem.route === config().paths.subdir && stackItem.handle.name === 'settingEnabled';
         }));
+=======
+    var hbsOptions;
+>>>>>>> Serving static assets via asset-rack
 
     // clear the view cache
     expressServer.cache = {};
     expressServer.disable(expressServer.get('activeTheme'));
     expressServer.set('activeTheme', activeTheme);
     expressServer.enable(expressServer.get('activeTheme'));
-    if (stackLocation) {
-        expressServer.stack[stackLocation].handle = middleware.whenEnabled(expressServer.get('activeTheme'), middleware.staticTheme());
-    }
+
+    assets.theme.reload();
 
     // set view engine
     hbsOptions = { partialsDir: [ config().paths.helperTemplates ] };
@@ -210,7 +219,7 @@ function robots() {
                     if (err) {
                         return next(err);
                     }
-                    
+
                     content = {
                         headers: {
                             'Content-Type': 'text/plain',
@@ -252,6 +261,7 @@ module.exports = function (server, dbHash) {
         }
     }
 
+<<<<<<< HEAD
     // Favicon
     expressServer.use(subdir, express.favicon(corePath + '/shared/favicon.ico'));
 
@@ -278,6 +288,19 @@ module.exports = function (server, dbHash) {
 
     // Serve robots.txt if not found in theme
     expressServer.use(robots());
+=======
+    // First determine whether we're serving admin or theme content
+    expressServer.use(manageAdminAndTheme);
+
+    // Force SSL
+    server.use(checkSSL);
+
+    // Assets
+    expressServer.use(assets.ghost);
+
+    // Uploaded Assets
+    expressServer.use(root + '/content/images', storage.get_storage().serve());
+>>>>>>> Serving static assets via asset-rack
 
     // Add in all trailing slashes
     expressServer.use(slashes(true, {headers: {'Cache-Control': 'public, max-age=' + ONE_YEAR_S}}));

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -158,6 +158,7 @@ var middleware = {
         };
     },
 
+
     staticTheme: function () {
         return function blackListStatic(req, res, next) {
             if (isBlackListedFileType(req.url)) {

--- a/core/server/storage/localfilesystem.js
+++ b/core/server/storage/localfilesystem.js
@@ -10,6 +10,7 @@ var _       = require('lodash'),
     errors  = require('../errorHandling'),
     config  = require('../config'),
     baseStore   = require('./base'),
+    assets        = require('../middleware/assets'),
 
     localFileStore;
 

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -17,20 +17,21 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Ghost" />
 
-    <link rel="shortcut icon" href="{{asset "favicon.ico"}}" />
-    <link rel="apple-touch-icon-precomposed" href="{{asset "img/touch-icon-iphone.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{asset "img/touch-icon-ipad.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{asset "img/small.png" ghost="true"}}" />
-    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{asset "img/medium.png" ghost="true"}}" />
+    <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
+    <link rel="apple-touch-icon-precomposed" href="{{asset "ghost/img/touch-icon-iphone.png"}}" />
+    <link rel="apple-touch-icon-precomposed" sizes="76x76" href="{{asset "ghost/img/touch-icon-ipad.png"}}" />
+    <link rel="apple-touch-icon-precomposed" sizes="120x120" href="{{asset "ghost/img/small.png"}}" />
+    <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{asset "ghost/img/medium.png"}}" />
 
-    <meta name="application-name" content="Ghost" />
-    <meta name="msapplication-TileColor" content="#ffffff" />
-    <meta name="msapplication-square70x70logo" content="{{asset "img/small.png" ghost="true"}}" />
-    <meta name="msapplication-square150x150logo" content="{{asset "img/medium.png" ghost="true"}}" />
-    <meta name="msapplication-square310x310logo" content="{{asset "img/large.png" ghost="true"}}" />
+    <meta name="application-name" content="Ghost"/>
+    <meta name="msapplication-TileColor" content="#ffffff"/>
+    <meta name="msapplication-square70x70logo" content="{{asset "ghost/img/small.png"}}" />
+    <meta name="msapplication-square150x150logo" content="{{asset "ghost/img/medium.png"}}" />
+    <meta name="msapplication-square310x310logo" content="{{asset "ghost/img/large.png"}}" />
 
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />
-    <link rel="stylesheet" href="{{asset "css/ghost-ui.min.css" ghost="true"}}" />
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700">
+    <link rel="stylesheet" href="{{asset "ghost/css/screen.css"}}">
+    {{{block "pageStyles"}}}
 </head>
 <body class="{{bodyClass}}{{update_notification classOnly="true"}}">
     {{#unless hideNavbar}}

--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -2,7 +2,7 @@
 <section class="error-content error-404 js-error-container">
     <section class="error-details">
         <figure class="error-image">
-            <img class="error-ghost" src="{{asset "img/404-ghost@2x.png" ghost="true"}}" srcset="{{asset "img/404-ghost.png" ghost="true"}} 1x, {{asset "img/404-ghost@2x.png" ghost="true"}} 2x"/>
+            <img class="error-ghost" src="{{asset "ghost/img/404-ghost@2x.png"}} srcset="{{asset "ghost/img/404-ghost.png"}} 1x, {{asset "ghost/img/404-ghost@2x.png"}} 2x"/>
         </figure>
         <section class="error-message">
             <h1 class="error-code">{{code}}</h1>

--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -16,40 +16,41 @@
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
     <meta http-equiv="cleartype" content="on">
 
-    <link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
-    <link rel="stylesheet" href="{{asset "css/ghost-ui.min.css" ghost="true"}}">
-  </head>
-  <body class="{{bodyClass}}">
-    <main role="main" id="main">
-      <section class="error-content error-404 js-error-container">
-        <section class="error-details">
-          <figure class="error-image">
-            <img
-              class="error-ghost"
-              src="{{asset "img/404-ghost@2x.png" ghost="true"}}"
-              srcset="{{asset "img/404-ghost.png" ghost="true"}} 1x, {{asset "img/404-ghost@2x.png" ghost="true"}} 2x"/>
-          </figure>
-          <section class="error-message">
-            <h1 class="error-code">{{code}}</h1>
-            <h2 class="error-description">{{message}}</h2>
-          </section>
-        </section>
-      </section>
-      {{#if stack}}
-        <section class="error-stack">
-          <h3>Stack Trace</h3>
-          <p><strong>{{message}}</strong></p>
-          <ul class="error-stack-list">
-            {{#foreach stack}}
-              <li>
-                at
-                {{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
-                <span class="error-stack-file">({{at}})</span>
-              </li>
-            {{/foreach}}
-          </ul>
-        </section>
-      {{/if}}
-    </main>
-  </body>
+		<link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
+		<link rel="stylesheet" href="{{asset "ghost/css/screen.css"}}">
+		{{{block "pageStyles"}}}
+	</head>
+	<body class="{{bodyClass}}">
+		<main role="main" id="main">
+			<section class="error-content error-404 js-error-container">
+				<section class="error-details">
+					<figure class="error-image">
+						<img
+							class="error-ghost"
+							src="{{asset "ghost/img/404-ghost@2x.png"}}"
+							srcset="{{asset "ghost/img/404-ghost.png"}} 1x, {{asset "ghost/img/404-ghost@2x.png"}} 2x"/>
+					</figure>
+					<section class="error-message">
+						<h1 class="error-code">{{code}}</h1>
+						<h2 class="error-description">{{message}}</h2>
+					</section>
+				</section>
+			</section>
+			{{#if stack}}
+				<section class="error-stack">
+					<h3>Stack Trace</h3>
+					<p><strong>{{message}}</strong></p>
+					<ul class="error-stack-list">
+						{{#foreach stack}}
+							<li>
+								at
+								{{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
+								<span class="error-stack-file">({{at}})</span>
+							</li>
+						{{/foreach}}
+					</ul>
+				</section>
+			{{/if}}
+		</main>
+	</body>
 </html>

--- a/core/test/unit/middleware_spec.js
+++ b/core/test/unit/middleware_spec.js
@@ -315,4 +315,3 @@ describe('Middleware', function () {
         });
     });
 });
-

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     },
     "engineStrict": true,
     "dependencies": {
+        "asset-rack": "2.2.2",
+        "async": "0.2.9",
         "bcryptjs": "0.7.10",
         "bookshelf": "0.6.1",
         "busboy": "0.0.12",


### PR DESCRIPTION
closes #1405
- adds asset-rack to package
- moves all assets previously served via express.static into a rack
- handles url generation for statically served assets
- updates the asset-helper for hbs-templates to get the right url

Missing:
- [ ] allowing asset-hostname and CDN-configuration in config.js
- [ ] setting Cache-header and verify with tests (see  #1470)
- [ ] tests to verify functionality when in subdir
- [ ] Grunt-task to precompile assets
- [ ] add storage to upload uploaded Assets directly to the configured CDN
- [ ] more tests
