### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
         "bcryptjs": "0.7.10",
         "bookshelf": "0.6.1",
         "colors": "0.6.2",
-        "connect-slashes": "0.0.11",
+        "connect-slashes": "1.0.2",
         "downsize": "0.0.3",
-        "express": "3.4.4",
-        "express-hbs": "0.5.1",
+        "express": "3.4.6",
+        "express-hbs": "0.5.2",
         "fs-extra": "0.8.1",
         "knex": "0.5.0",
         "moment": "2.4.0",
         "node-polyglot": "0.3.0",
         "node-uuid": "1.4.1",
-        "nodemailer": "0.5.5",
+        "nodemailer": "0.5.13",
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "0.3.1",
@@ -52,7 +52,7 @@
         "underscore": "1.5.2",
         "unidecode": "0.1.3",
         "validator": "1.4.0",
-        "when": "2.5.1"
+        "when": "2.7.0"
     },
     "optionalDependencies": {
         "mysql": "2.0.0-alpha9"


### PR DESCRIPTION
This PR updates the core dependencies.

Reasons for updating dependencies:
- qs was recently released with the **proto** bugfix (https://github.com/visionmedia/node-querystring/issues/82)
- connect and express released new versions with the updated version of qs
- the qs package caused earlier 0.11 build failures in #1147 which lead us to remove 0.11 from the build
