### PR TITLE
Debounce post settings events

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -53,7 +53,7 @@
             e.currentTarget.select();
         },
 
-        editSlug: function (e) {
+        editSlug: _.debounce(function (e) {
             e.preventDefault();
             var self = this,
                 slug = self.model.get('slug'),
@@ -88,9 +88,9 @@
                     });
                 }
             });
-        },
+        }, 500),
 
-        editDate: function (e) {
+        editDate: _.debounce(function (e) {
             e.preventDefault();
             var self = this,
                 parseDateFormats = ['DD MMM YY HH:mm', 'DD MMM YYYY HH:mm', 'DD/MM/YY HH:mm', 'DD/MM/YYYY HH:mm', 'DD-MM-YY HH:mm', 'DD-MM-YYYY HH:mm'],
@@ -177,11 +177,11 @@
                 }
             });
 
-        },
+        }, 500),
 
-        toggleStaticPage: function (e) {
+        toggleStaticPage: _.debounce(function (e) {
             var pageEl = $(e.currentTarget),
-                page = this.model ? !this.model.get('page') : false;
+                page = pageEl.prop('checked');
 
             this.model.save({
                 page: page
@@ -204,7 +204,7 @@
                     });
                 }
             });
-        },
+        }, 500),
 
         deletePost: function (e) {
             e.preventDefault();


### PR DESCRIPTION
This fixes #1582.

I wrapped the relevant event handlers in `_.debounce` with a buffer of 0.5 to prevent over-eager updates.

I also changed the `toggleStaticPage` function to use the actual checkbox property because otherwise after the function is run it would only inverse the current setting.  So clicking the checkbox 3 times (back to the initial state) would end up just toggling it to the opposite. 

Let me know what needs modifying, I didn't fully understand the issue but this is my first shot at fixing it.
