### PR TITLE
[WIP] Replace validator's xss() with caja's sanitize()

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -7,7 +7,7 @@ var ghostBookshelf,
     config    = require('../config'),
     Validator = require('validator').Validator,
     unidecode = require('unidecode'),
-    sanitize  = require('validator').sanitize;
+    sanitize  = require('caja-sanitizer').sanitize;
 
 // Initializes a new Bookshelf instance, for reference elsewhere in Ghost.
 ghostBookshelf = Bookshelf.ghost = Bookshelf.initialize(config().database);
@@ -80,7 +80,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     sanitize: function (attr) {
-        return sanitize(this.get(attr)).xss();
+        if (this.get(attr) === null || this.get(attr) === undefined) {
+            return this.get(attr);
+        }
+        return sanitize(this.get(attr));
     },
 
     // #### generateSlug

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -370,9 +370,9 @@ describe('Post Model', function () {
 
     it('should sanitize the title', function (done) {
         new PostModel().fetch().then(function (model) {
-            return model.set({'title': "</title></head><body><script>alert('blogtitle');</script>"}).save();
+            return model.set({'title': '<b onclick="alert(\'foo\')" class="bar">title</b></title></head><body><script>alert("blogtitle");</script>'}).save();
         }).then(function (saved) {
-                saved.get('title').should.eql("&lt;/title&gt;&lt;/head>&lt;body&gt;[removed]alert&#40;'blogtitle'&#41;;[removed]");
+                saved.get('title').should.eql('<b class="bar">title</b>');
                 done();
             }).otherwise(done);
     });

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
         "underscore": "1.5.2",
         "unidecode": "0.1.3",
         "validator": "1.4.0",
-        "when": "2.7.0"
+        "when": "2.7.0",
+        "caja-sanitizer": "0.1.1"
     },
     "optionalDependencies": {
         "mysql": "2.0.0-alpha9"


### PR DESCRIPTION
This is not yet ready (tests fail for some reason), just putting it here for feedback.

As discussed in #1378, this replaces node-validator's xss filter with the one from caja.

When you look at the changes, you will notice that this does not escape or replace the elements, instead it removes them entirely. This means that if you enter something like `<script></script>` in the title, you get told that an empty value isn't allowed. Probably not the best way to handle this.

I did some digging and as far as I can see, escaping would require us to modify caja heavily. What we could easily do is white/blacklisting of elements & attributes (sanitize() uses a internal list of elements that it considers unsafe, probably fine for our use case), but escaping instead of removing them is not really what it's been made for.
