### PR TITLE
Api slashes

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -264,11 +264,10 @@ when(ghost.init()).then(function () {
     server.use(whenEnabled(server.get('activeTheme'), middleware.staticTheme(ghost)));
 
     // Add in all trailing slashes except api calls
-    server.use(function(req, res, next){
-        if(req.url.substring(0,5) !== "/api/"){
+    server.use(function (req, res, next) {
+        if (req.url.substring(0, 5) !== "/api/") {
             slashes()(req, res, next);
-        }
-        else{
+        } else {
             next();
         }
     });

--- a/core/server.js
+++ b/core/server.js
@@ -263,8 +263,16 @@ when(ghost.init()).then(function () {
     // Theme only config
     server.use(whenEnabled(server.get('activeTheme'), middleware.staticTheme(ghost)));
 
-    // Add in all trailing slashes
-    server.use(slashes());
+    // Add in all trailing slashes except api calls
+    server.use(function(req, res, next){
+        if(req.url.substring(0,5) !== "/api/"){
+            slashes()(req, res, next);
+        }
+        else{
+            next();
+        }
+    });
+
 
     server.use(express.json());
     server.use(express.urlencoded());


### PR DESCRIPTION
connect-slashes global causes a 301 Redirect on /api/ GET requests. This isn't really needed as these routes aren't used for history.

This commit causes connect-slashes to only be effective on routes not starting in /api/
