### PR TITLE
backbonejs model conflict with connect-slashes

### DIFF
--- a/core/client/init.js
+++ b/core/client/init.js
@@ -41,6 +41,13 @@
         return Backbone.oldsync(method, model, options, error);
     };
 
+    Backbone.oldModelProtoUrl = Backbone.Model.prototype.url;
+    //overwrite original url method to add slash to end of the url if needed.
+    Backbone.Model.prototype.url = function () {
+        var url = Backbone.oldModelProtoUrl.apply(this, arguments);
+        return url + (url.charAt(url.length - 1) === '/' ? '' : '/');
+    };
+
     Ghost.init = function () {
         // remove the temporary message which appears
         $('.js-msg').remove();


### PR DESCRIPTION
close #1648
- backbonejs model doesn't include tailing slash by default
- connect-slashes returns 301 for GET without tailing slash
- overwrote backbone model url method to include tailing slash
