### PR TITLE
Update config.theme() after every settings edit

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -154,7 +154,10 @@ settings = {
                 result.models = result;
                 return when(readSettingsResult(result)).then(function (settings) {
                     updateSettingsCache(settings);
-                    return settingsObject(settingsFilter(settingsCache, type));
+                }).then(function () {
+                    return config.theme.update(settings).then(function () {
+                        return settingsObject(settingsFilter(settingsCache, type));
+                    });
                 });
             }).otherwise(function (error) {
                 return dataProvider.Settings.read(key.key).then(function (result) {
@@ -175,8 +178,11 @@ settings = {
             setting.set('value', value);
             return dataProvider.Settings.edit(setting).then(function (result) {
                 settingsCache[_.first(result).attributes.key].value = _.first(result).attributes.value;
-                return settingsObject(settingsCache);
-            }, errors.logAndThrowError);
+            }).then(function () {
+                return config.theme.update(settings).then(function () {
+                    return settingsObject(settingsCache);
+                });
+            }).otherwise(errors.logAndThrowError);
         });
     }
 };

--- a/core/server/config/theme.js
+++ b/core/server/config/theme.js
@@ -13,23 +13,19 @@ function theme() {
     return themeConfig;
 }
 
-// We must pass the api and config object
+// We must pass the api.settings object
 // into this method due to circular dependencies.
 // If we were to require the api module here
 // there would be a race condition where the ./models/base
 // tries to access the config() object before it is created.
-// And we can't require('./index') from here because it is circular.
-function update(api, config) {
+function update(settings) {
     return when.all([
-        api.settings.read('title'),
-        api.settings.read('description'),
-        api.settings.read('logo'),
-        api.settings.read('cover')
+        settings.read('title'),
+        settings.read('description'),
+        settings.read('logo'),
+        settings.read('cover')
     ]).then(function (globals) {
 
-        themeConfig.path = config.paths().path;
-
-        themeConfig.url = config().url;
         themeConfig.title = globals[0].value;
         themeConfig.description = globals[1].value;
         themeConfig.logo = globals[2] ? globals[2].value : '';

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -94,14 +94,14 @@ coreHelpers.url = function (options) {
             slug: function () { return self.slug; },
             id: function () { return self.id; }
         },
-        blog = coreHelpers.config.theme(),
+        path = coreHelpers.config.paths().path,
         isAbsolute = options && options.hash.absolute;
     return api.settings.read('permalinks').then(function (permalinks) {
         if (isAbsolute) {
-            output += blog.url;
+            output += coreHelpers.config().url;
         }
-        if (blog.path && blog.path !== '/') {
-            output += blog.path;
+        if (path && path !== '/') {
+            output += path;
         }
         if (models.isPost(self)) {
             output += permalinks.value;
@@ -125,7 +125,7 @@ coreHelpers.url = function (options) {
 // flag outputs the asset path for the Ghost admin
 coreHelpers.asset = function (context, options) {
     var output = '',
-        subDir = coreHelpers.config.theme().path,
+        subDir = coreHelpers.config.paths().path,
         isAdmin = options && options.hash && options.hash.ghost;
 
     if (subDir === '/') {
@@ -264,7 +264,7 @@ coreHelpers.fileStorage = function (context, options) {
 
 coreHelpers.ghostScriptTags = function () {
     var scriptFiles = [],
-        blog = coreHelpers.config.theme();
+        webroot = coreHelpers.config.paths().webroot;
 
     if (isProduction) {
         scriptFiles.push("ghost.min.js");
@@ -280,7 +280,7 @@ coreHelpers.ghostScriptTags = function () {
 
     scriptFiles = _.map(scriptFiles, function (fileName) {
         return scriptTemplate({
-            source: (blog.path === '/' ? '' : blog.path) + '/built/scripts/' + fileName,
+            source: webroot + '/built/scripts/' + fileName,
             version: version
         });
     });
@@ -348,7 +348,7 @@ coreHelpers.post_class = function (options) {
 coreHelpers.ghost_head = function (options) {
     /*jslint unparam:true*/
     var blog = coreHelpers.config.theme(),
-        root = blog.path === '/' ? '' : blog.path,
+        root = coreHelpers.config.paths().webroot,
         head = [],
         majorMinor = /^(\d+\.)?(\d+)/,
         trimmedVersion = this.version;
@@ -359,7 +359,7 @@ coreHelpers.ghost_head = function (options) {
 
     head.push('<link rel="alternate" type="application/rss+xml" title="' + _.escape(blog.title)  + '" href="' + root + '/rss/' + '">');
     if (this.ghostRoot) {
-        head.push('<link rel="canonical" href="' + coreHelpers.config.theme().url + this.ghostRoot + '" />');
+        head.push('<link rel="canonical" href="' + coreHelpers.config().url + this.ghostRoot + '" />');
     }
 
     return filters.doFilter('ghost_head', head).then(function (head) {
@@ -371,7 +371,7 @@ coreHelpers.ghost_head = function (options) {
 coreHelpers.ghost_foot = function (options) {
     /*jslint unparam:true*/
     var foot = [];
-    foot.push('<script src="' + coreHelpers.config.theme().url + '/shared/vendor/jquery/jquery.js"></script>');
+    foot.push('<script src="' + coreHelpers.config().url + '/shared/vendor/jquery/jquery.js"></script>');
 
     return filters.doFilter('ghost_foot', foot).then(function (foot) {
         var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -94,9 +94,9 @@ function setup(server) {
         // Initialize the settings cache
         return api.init();
     }).then(function () {
-        // We must pass the api and config object
+        // We must pass the api.settings object
         // into this method due to circular dependencies.
-        return config.theme.update(api, config);
+        return config.theme.update(api.settings);
     }).then(function () {
         return when.join(
             // Check for or initialise a dbHash.
@@ -117,9 +117,6 @@ function setup(server) {
         // ##Configuration
         // set the view engine
         server.set('view engine', 'hbs');
-
-        // set the configured URL
-        server.set('ghost root', config.theme().path);
 
         // return the correct mime type for woff filess
         express['static'].mime.define({'application/font-woff': ['woff']});

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -30,7 +30,7 @@ function ghostLocals(req, res, next) {
     res.locals.version = packageInfo.version;
     res.locals.path = req.path;
     // Strip off the subdir part of the path
-    res.locals.ghostRoot = req.path.replace(config.theme().path.replace(/\/$/, ''), '');
+    res.locals.ghostRoot = req.path.replace(config.paths().webroot, '');
 
     if (res.isAdmin) {
         res.locals.csrfToken = req.csrfToken();
@@ -117,10 +117,10 @@ function activateTheme(activeTheme) {
 // This is used to ensure the right content is served, and is not for security purposes
 function manageAdminAndTheme(req, res, next) {
     // TODO improve this regex
-    if (config.theme().path === '/') {
+    if (config.paths().path === '/') {
         res.isAdmin = /(^\/ghost\/)/.test(req.url);
     } else {
-        res.isAdmin = new RegExp("^\\" + config.theme().path + "\\/ghost\\/").test(req.url);
+        res.isAdmin = new RegExp("^\\" + config.paths().path + "\\/ghost\\/").test(req.url);
     }
 
     if (res.isAdmin) {
@@ -149,7 +149,7 @@ function manageAdminAndTheme(req, res, next) {
 
 // Redirect to signup if no users are currently created
 function redirectToSignup(req, res, next) {
-    var root = expressServer.get('ghost root').replace(/\/$/, '');
+    var root = config.paths().webroot;
     /*jslint unparam:true*/
     api.users.browse().then(function (users) {
         if (users.length === 0) {

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -1,10 +1,11 @@
 var admin       = require('../controllers/admin'),
     api         = require('../api'),
+    config      = require('../config'),
     middleware  = require('../middleware').middleware,
     url         = require('url');
 
 module.exports = function (server) {
-    var root = server.get('ghost root').replace(/\/$/, '');
+    var root = config.paths().webroot;
     // ### Admin routes
     /* TODO: put these somewhere in admin */
     server.get('/logout/', function redirect(req, res) {


### PR DESCRIPTION
fixes #1645
- removes server.get('ghost root') as it is only an alias
  to config.paths().path, and adds unnecessary indirection
- removes config.theme().path as its just an alias to
  config.paths().path, updated all relevant references
- update config.theme.update to only require the api/settings object,
  and no longer need the config object
- modify api/settings.edit to call config.theme.update so that
  the themeObject is ready for next rendering of template
