### PR TITLE
Change message when unsupported node version is used

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -155,7 +155,7 @@ function setup(server) {
                     packageInfo.engines.node.yellow,
                     "you are using version".red,
                     process.versions.node.yellow,
-                    "\nPlease go to http://nodejs.org to get the latest version".green
+                    "\nPlease go to http://nodejs.org to get a supported version".green
                 );
 
                 process.exit(0);


### PR DESCRIPTION
no issue
- changed ‚the latest‘ to ‚a supported‘

Reason: the user is asked to update to the **latest** version of node.js when v0.11.\* is installed but v0.10.\* is required
