### PR TITLE
Fixed admin 404 page broken image refrence

### DIFF
--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -2,7 +2,7 @@
 <section class="error-content error-404 js-error-container">
     <section class="error-details">
         <figure class="error-image">
-            <img class="error-ghost" src="{{asset "img/404-ghost@2x.png" ghost="true"}} srcset="{{asset "img/404-ghost.png" ghost="true"}} 1x, {{asset "img/404-ghost@2x.png" ghost="true"}} 2x"/>
+            <img class="error-ghost" src="{{asset "img/404-ghost@2x.png" ghost="true"}}" srcset="{{asset "img/404-ghost.png" ghost="true"}} 1x, {{asset "img/404-ghost@2x.png" ghost="true"}} 2x"/>
         </figure>
         <section class="error-message">
             <h1 class="error-code">{{code}}</h1>


### PR DESCRIPTION
The little ghost image tag was broken on the admin 404 page, resulting in the screenshot below. It was missing a double quote on the `src` attribute! This adds it back in.

![screen shot 2013-12-12 at 20 43 47](https://f.cloud.github.com/assets/390392/1737188/c3a0301e-636e-11e3-9292-c041a17b8afa.png)
