### PR TITLE
[Docs] Add language switcher to the navbar

### DIFF
--- a/_includes/language_selector.html
+++ b/_includes/language_selector.html
@@ -1,0 +1,20 @@
+{% if page.lang %}
+  <a class="dropdown-toggle" data-toggle="dropdown" href="#">{% for lang in site.languages %}{% if lang.key == page.lang %}{{lang.name}}{% endif %}{% endfor %} <b class="caret"></b></a>
+{% else %}
+  <a class="dropdown-toggle" data-toggle="dropdown" href="#">English <b class="caret"></b></a>
+{% endif %}
+<ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
+  {% for lang in site.languages %}
+    <li>
+      {% if lang.key != page.lang and lang.key != 'en' %}
+        <a href="{{ site.url }}/{{ lang.key }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{lang.name}}</a>
+      {% elsif page.lang and lang.key == 'en' %}
+        <a href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{lang.name}}</a>
+      {% endif %}
+    </li>
+  {% endfor %}
+  {% unless page.lang %}
+    <li class="divider"></li>
+    <li><a href="{{ site.url }}/translations/">Translations</a></li>
+  {% endunless %}
+</ul>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -90,13 +90,6 @@
             {% endif %}
           </a>
         </li>
-        {% if page.lang == null %}
-        <li>
-          <a href="{{ site.url }}/translations/">
-              Translations
-          </a>
-        </li>
-        {% endif %}
         <li>
           <a href="http://ghost.org/forum/">
             {% if page.lang %}
@@ -105,6 +98,11 @@
               Help
             {% endif %}
           </a>
+        </li>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <li class="dropdown">
+          {% include language_selector.html %}
         </li>
       </ul>
     </div>
@@ -129,22 +127,9 @@
 </main>
 
 <footer id="global-footer">
-    <div class="dropdown">
-        {% if page.lang %}
-          <a class="dropdown-toggle" data-toggle="dropdown" href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}"><span class='icon down'></span>{% for lang in site.languages %}{% if lang.key == page.lang %}{{lang.name}}{% endif %}{% endfor %}</a>
-        {% else %}
-          <a class="dropdown-toggle" data-toggle="dropdown" href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}"><span class='icon down'></span>English</a>
-        {% endif %}
-        <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel">
-        {% for lang in site.languages %}
-        {% if lang.key != page.lang and lang.key != 'en' %}
-        <li><a href="{{ site.url }}/{{ lang.key }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{lang.name}}</a></li>
-        {% elsif page.lang and lang.key == 'en' %}
-        <li><a href="{{ site.url }}/{% if page.chapter %}{{ page.chapter }}/{% endif %}{% if page.section %}{{ page.section }}/{% endif %}">{{lang.name}}</a></li>
-        {% endif %}
-        {% endfor %}
-        </ul>
-    </div>
+  <div class="dropdown">
+    {% include language_selector.html %}
+  </div>
   <p>Lovingly created and maintained by <a href="http://john.onolan.org">John O'Nolan</a> + <a href="http://erisds.co.uk">Hannah Wolfe</a> + an amazing group of <a href="https://github.com/TryGhost/Ghost/contributors">contributors</a>.</p>
     <hr>
   <p>All code copyright (C) 2013 The Ghost Foundation - Released under the <a href="http://tryghost.org/about/license.html">MIT</a> License.<br />

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -95,6 +95,11 @@ h1:before, h2:before {
   }
 }
 
+/* This can be removed once bootstrap.css is up to date */
+.navbar-nav .caret, .navbar-nav a:hover .caret {
+    border-top-color: inherit;
+    border-bottom-color: inherit;
+}
 
 /* ==========================================================================
    Navigation
@@ -112,6 +117,13 @@ h1:before, h2:before {
 .navbar-nav > li > a {
     padding-top: 20px;
     padding-bottom: 20px;
+}
+
+@media (max-width: 991px) and (min-width: 768px) {
+    .navbar-brand, .navbar-nav > li > a {
+        padding-left: 10px;
+        padding-right: 10px;
+    }
 }
 
 .bs-sidenav li a {
@@ -316,6 +328,10 @@ span.warn {
 
 #global-footer a {
     color: #e2edf2;
+}
+
+#global-footer .caret {
+    border-top-color: #e2edf2;
 }
 
 #global-footer .dropdown {


### PR DESCRIPTION
@JohnONolan (as suggested on https://github.com/TryGhost/Ghost/pull/1649) I took a stab at tweaking the language switcher (inspired by Twitter). I think merely moving it to the top makes it useful/stand out enough. I decided not to use flags because [flags don't represent languages](http://flagsarenotlanguages.com/blog/why-flags-do-not-represent-language/). ISO country code and language code are different (e.g. Japan is JP but Japanese is JA), and a lot of the flag icons I found online use country code and not language code, so using flag icons might be too much of a hassle.
- Moved the language switcher to a partial and added it to the right hand side of the navbar
- **Translations** menu is now under the dropdown, to make a room on the navbar. It also makes sense because people who want to become a translator would want to see which languages are currently available.
- Shrink paddings on navbar items so they fit in one row on tablet
- I kept the dropdown on the bottom, there's no reason to remove it
### Collapsed

![image](https://f.cloud.github.com/assets/992008/1751106/ec44b950-65ca-11e3-9959-337753ac80d9.png)
### Open

![image](https://f.cloud.github.com/assets/992008/1751110/1e690300-65cb-11e3-980d-0855ef7ae0ae.png)
### In another language

![image](https://f.cloud.github.com/assets/992008/1751113/339de68c-65cb-11e3-8987-71930b9e3932.png)
### Mobile

![image](https://f.cloud.github.com/assets/992008/1751116/47cbab26-65cb-11e3-81f4-bcf739f7c914.png)
