### PR TITLE
Fix 'dbHash' not found

### DIFF
--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -2,6 +2,9 @@
     "core": {
         "databaseVersion": {
             "defaultValue": "001"
+        },
+        "dbHash": {
+            "defaultValue": null
         }
     },
     "blog": {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -57,19 +57,19 @@ function doFirstRun() {
 }
 
 function initDbHashAndFirstRun() {
-    return when(models.Settings.read('dbHash')).then(function (hash) {
+    return when(api.settings.read('dbHash')).then(function (hash) {
         // we already ran this, chill
         // Holds the dbhash (mainly used for cookie secret)
-        dbHash = hash.attributes.value;
-        return dbHash;
-    }).otherwise(function (error) {
-        /*jslint unparam:true*/
-        // this is where all the "first run" functionality should go
-        var hash = uuid.v4();
-        return when(models.Settings.add({key: 'dbHash', value: hash, type: 'core'})).then(function () {
-            dbHash = hash;
-            return dbHash;
-        }).then(doFirstRun);
+        dbHash = hash.value;
+
+        if (dbHash === null) {
+            var initHash = uuid.v4();
+            return when(api.settings.edit('dbHash', initHash)).then(function (settings) {
+                dbHash = settings.dbHash;
+                return dbHash;
+            }).then(doFirstRun);
+        }
+        return dbHash.value;
     });
 }
 

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -9,8 +9,8 @@ var _ = require('underscore'),
         post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
             'featured', 'image', 'status', 'language', 'author_id', 'created_at', 'created_by', 'updated_at', 'updated_by',
             'published_at', 'published_by', 'page', 'author', 'user', 'tags'],
-        // TODO: remove databaseVersion
-        settings: ['databaseVersion', 'title', 'description', 'email', 'logo', 'cover', 'defaultLang', "permalinks",
+        // TODO: remove databaseVersion, dbHash
+        settings: ['databaseVersion', 'dbHash', 'title', 'description', 'email', 'logo', 'cover', 'defaultLang', "permalinks",
             'postsPerPage', 'forceI18n', 'activeTheme', 'activePlugins', 'installedPlugins', 'availableThemes'],
         tag: ['id', 'uuid', 'name', 'slug', 'description', 'parent_id',
             'meta_title', 'meta_description', 'created_at', 'created_by', 'updated_at', 'updated_by'],


### PR DESCRIPTION
closes #1685
- changed dbHash initialization from db direct access to api access
- added dbHash to default-settings.json
- added dbHash to tests
