### PR TITLE
Remove fixed scheme from gravatar url

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -357,7 +357,7 @@ User = ghostBookshelf.Model.extend({
     },
 
     gravatarLookup: function (userData) {
-        var gravatarUrl = 'http://www.gravatar.com/avatar/' +
+        var gravatarUrl = '//www.gravatar.com/avatar/' +
                             crypto.createHash('md5').update(userData.email.toLowerCase().trim()).digest('hex') +
                             "?d=404",
             checkPromise = when.defer();


### PR DESCRIPTION
no issue
- removed scheme from gravatar url

Reason:
Gravatar supports ssl and the fixed scheme will cause 'insecure content' warnings.
