### PR TITLE
Fix curl command in german docs.

### DIFF
--- a/de/installation/deploy.md
+++ b/de/installation/deploy.md
@@ -94,7 +94,7 @@ Linux-Systeme führen Init-Scripte beim Systemstart aus. Sie liegen in /etc/init
 *   Lege die Datei /etc/init.d/ghost mit folgendem Befehl an:
 
     ```
-    $ curl https://github.com/TryGhost/Ghost-Config/blob/master/init.d/ghost \
+    $ curl https://raw.github.com/TryGhost/Ghost-Config/master/init.d/ghost \
       -o /etc/init.d/ghost
     ```
 


### PR DESCRIPTION
I added the init script to my setup recently and noticed that the `curl` command isn't working. I pointed it to the raw version of the script now.

Also, `deploy.md` for other languages is entirely different, some even without a curl command.
