### PR TITLE
Simplify "Working on Core" setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,8 @@ developing Ghost.
 **Pre-requisites:**
 
 * Node 0.10.x
-* ruby and the gems 'sass' and 'bourbon' - you can use `bundle install` to install the gems
+* Ruby >= 1.9.3
+* Bundler Ruby Gem (`gem install bundler`)
 * for running functional tests: phantomjs 1.9.x and casperjs 1.1.x
 ([instructions](https://github.com/TryGhost/Ghost/wiki/Functional-testing-with-PhantomJS-and-CasperJS))
 * for building docs: python and pygments
@@ -190,6 +191,7 @@ developing Ghost.
 1. Clone the git repo
 1. cd into the project folder
 1. Run `git submodule update --init`
+1. Run `bundle install`
 1. Run `npm install -g grunt-cli`
 1. Run `npm install`.
 	* If the install fails with errors to do with "node-gyp rebuild" or "SQLite3", follow the SQLite3 install 


### PR DESCRIPTION
Second pass at #1694

This allows gem dependencies to be modified without the need to update instructions, and makes setup a bit more obvious.
