### PR TITLE
Package.json: Incorrect node version fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test": "grunt validate --verbose"
     },
     "engines": {
-        "node": "0.10.*"
+        "node": "~0.10.0"
     },
     "engineStrict": true,
     "dependencies": {


### PR DESCRIPTION
package.json is using [semver](https://npmjs.org/doc/misc/semver.html) for versioning and it does not support `*` but has a `~` which is pretty similar.
