### PR TITLE
Don't use unnecessary (and unescaped) regex

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -118,12 +118,7 @@ function activateTheme(activeTheme) {
 // Uses the URL to detect whether this response should be an admin response
 // This is used to ensure the right content is served, and is not for security purposes
 function manageAdminAndTheme(req, res, next) {
-    // TODO improve this regex
-    if (config.paths().path === '/') {
-        res.isAdmin = /(^\/ghost\/)/.test(req.url);
-    } else {
-        res.isAdmin = new RegExp("^\\" + config.paths().path + "\\/ghost\\/").test(req.url);
-    }
+    res.isAdmin = req.url.lastIndexOf(config.paths().webroot + '/ghost/', 0) === 0;
 
     if (res.isAdmin) {
         expressServer.enable('admin');


### PR DESCRIPTION
There are two issues with the original code:
1. It doesn't escape the path for use in regex
2. A regex really is unnecessary for testing if a string [starts with a substring](http://stackoverflow.com/questions/646628/javascript-startswith)
