### PR TITLE
Escape URL for use in regex

### DIFF
--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -1,5 +1,7 @@
 /*globals casper, __utils__, url, testPost */
 
+var escapedUrl = url.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+
 CasperTest.begin("Ghost editor is correct", 10, function suite(test) {
     casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
@@ -32,7 +34,7 @@ CasperTest.begin("Ghost editor is correct", 10, function suite(test) {
     casper.thenClick('.js-publish-button');
 
     casper.waitForResource(/posts/, function checkPostWasCreated() {
-        var urlRegExp = new RegExp("^" + url + "ghost\/editor\/[0-9]*");
+        var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
         test.assertExists('.notification-success', 'got success notification');
         test.assertEvalEquals(function () {
@@ -163,7 +165,7 @@ CasperTest.begin('Publish menu - existing post', 22, function suite(test) {
     casper.thenClick('.js-publish-button');
 
     casper.waitForResource(/posts/, function checkPostWasCreated() {
-        var urlRegExp = new RegExp("^" + url + "ghost\/editor\/[0-9]*");
+        var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
     });
 
@@ -200,7 +202,7 @@ CasperTest.begin('Publish menu - existing post', 22, function suite(test) {
     casper.thenClick('.js-publish-button');
 
     casper.waitForResource(/posts/, function checkPostWasCreated() {
-        var urlRegExp = new RegExp("^" + url + "ghost\/editor\/[0-9]*");
+        var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
     });
 


### PR DESCRIPTION
Using a URL in regex without escaping it can cause issues (`.`, `?`, etc.). I'm trying to find any others in the project that use an unescaped URL in regex as well, as I fear it may potentially be exploited as a vulnerability if an unescaped URL is used in the wrong spot.
