### PR TITLE
Link to the favicon using the asset helper

### DIFF
--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -13,7 +13,7 @@
 		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
 		<meta name="apple-mobile-web-app-capable" content="yes" />
 
-		<link rel="shortcut icon" href="/favicon.ico">
+		<link rel="shortcut icon" href="{{asset "favicon.ico"}}">
 		<meta http-equiv="cleartype" content="on">
 
 		<link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>


### PR DESCRIPTION
This new behavior matches that in `core/server/views/default.hbs`. Specifying the favicon as `/favicon.ico` is wrong because it doesn't obey subdirectory location, plus is just a wrong path.

However, I still get a 404 with the favicon, as the Ghost-core favicon is actually at `<subdir>/shared/favicon.ico`. Changing it to `{{asset "../shared/favicon.ico"}}` works, but feels wrong. I'm expecting #1611 will fix the 404.
