### PR TITLE
Improved comma tag completion on international keyboard layouts

### DIFF
--- a/core/client/views/editor-tag-widget.js
+++ b/core/client/views/editor-tag-widget.js
@@ -10,6 +10,7 @@
         events: {
             'keyup [data-input-behaviour="tag"]': 'handleKeyup',
             'keydown [data-input-behaviour="tag"]': 'handleKeydown',
+            'keypress [data-input-behaviour="tag"]': 'handleKeypress',
             'click ul.suggestions li': 'handleSuggestionClick',
             'click .tags .tag': 'handleTagClick',
             'click .tag-label': 'mobileTags'
@@ -20,7 +21,6 @@
             DOWN: 40,
             ESC: 27,
             ENTER: 13,
-            COMMA: 188,
             BACKSPACE: 8
         },
 
@@ -154,28 +154,6 @@
                 }
             } else if (e.keyCode === this.keys.ESC) {
                 this.$suggestions.hide();
-            } else if ((e.keyCode === this.keys.ENTER || e.keyCode === this.keys.COMMA) && searchTerm) {
-                // Submit tag using enter or comma key
-                e.preventDefault();
-
-                $selectedSuggestion = this.$suggestions.children(".selected");
-                if (this.$suggestions.is(":visible") && $selectedSuggestion.length !== 0) {
-
-                    if ($('.tag:containsExact("' + $selectedSuggestion.data('tag-name') + '")').length === 0) {
-                        tag = {id: $selectedSuggestion.data('tag-id'), name: $selectedSuggestion.data('tag-name')};
-                        this.addTag(tag);
-                    }
-                } else {
-                    if (e.keyCode === this.keys.COMMA) {
-                        searchTerm = searchTerm.replace(/,/g, "");
-                    }  // Remove comma from string if comma is used to submit.
-                    if ($('.tag:containsExact("' + searchTerm + '")').length === 0) {
-                        this.addTag({id: null, name: searchTerm});
-                    }
-                }
-                $target.val('').focus();
-                searchTerm = ""; // Used to reset search term
-                this.$suggestions.hide();
             }
 
             if (e.keyCode === this.keys.UP || e.keyCode === this.keys.DOWN) {
@@ -199,6 +177,39 @@
                 lastBlock.remove();
                 tag = {id: lastBlock.data('tag-id'), name: lastBlock.text()};
                 this.model.removeTag(tag);
+            }
+        },
+
+        handleKeypress: function (e) {
+            var $target = $(e.currentTarget),
+                searchTerm = $.trim($target.val()),
+                tag,
+                $selectedSuggestion,
+                isComma = ",".localeCompare(String.fromCharCode(e.keyCode)) === 0;
+
+            // use localeCompare in case of international keyboard layout
+            if ((e.keyCode === this.keys.ENTER || isComma) && searchTerm) {
+                // Submit tag using enter or comma key
+                e.preventDefault();
+
+                $selectedSuggestion = this.$suggestions.children(".selected");
+                if (this.$suggestions.is(":visible") && $selectedSuggestion.length !== 0) {
+
+                    if ($('.tag:containsExact("' + $selectedSuggestion.data('tag-name') + '")').length === 0) {
+                        tag = {id: $selectedSuggestion.data('tag-id'), name: $selectedSuggestion.data('tag-name')};
+                        this.addTag(tag);
+                    }
+                } else {
+                    if (isComma) {
+                        searchTerm = searchTerm.replace(/,/g, "");
+                    }  // Remove comma from string if comma is used to submit.
+                    if ($('.tag:containsExact("' + searchTerm + '")').length === 0) {
+                        this.addTag({id: null, name: searchTerm});
+                    }
+                }
+                $target.val('').focus();
+                searchTerm = ""; // Used to reset search term
+                this.$suggestions.hide();
             }
         },
 


### PR DESCRIPTION
Reported in issue #1475
- `String.localeCompare` can be more reliable for keys that do not relate to cursor movement
- Adds a third key handler (`keypress`) that contains the character code rather than physical key
- `COMMA` key constant no longer required (unless `,` char should be a constant?)

There don't appear to be any tagging ui tests yet, but I tried this manually using the Russian keyboard layout. The `б` key no longer submits tags, and the `,` key does despite being mapped to what would otherwise be a `?` key.

Not sure how this fits in to the greater scope of issue #1463 but it fixes the problem for now.
