### PR TITLE
Correctly order posts by published_at rather than updated_at

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -281,7 +281,6 @@ Post = ghostBookshelf.Model.extend({
             .query('limit', opts.limit)
             .query('offset', opts.limit * (opts.page - 1))
             .query('orderBy', 'status', 'ASC')
-            .query('orderBy', 'updated_at', 'DESC')
             .query('orderBy', 'published_at', 'DESC')
             .fetch(_.omit(opts, 'page', 'limit'))
             .then(function (collection) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -282,6 +282,7 @@ Post = ghostBookshelf.Model.extend({
             .query('offset', opts.limit * (opts.page - 1))
             .query('orderBy', 'status', 'ASC')
             .query('orderBy', 'published_at', 'DESC')
+            .query('orderBy', 'updated_at', 'DESC')
             .fetch(_.omit(opts, 'page', 'limit'))
             .then(function (collection) {
                 var qb;


### PR DESCRIPTION
On the fronted of the site posts are being ordered by updated_at which breaks the use of published_at.

Unfortunately this change also changes the way the admin displays posts, however personally I find this a more useful way of display posts to update.
