### PR TITLE
Remove languages drop down from footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -127,9 +127,6 @@
 </main>
 
 <footer id="global-footer">
-  <div class="dropdown">
-    {% include language_selector.html %}
-  </div>
   <p>Lovingly created and maintained by <a href="http://john.onolan.org">John O'Nolan</a> + <a href="http://erisds.co.uk">Hannah Wolfe</a> + an amazing group of <a href="https://github.com/TryGhost/Ghost/contributors">contributors</a>.</p>
     <hr>
   <p>All code copyright (C) 2013 The Ghost Foundation - Released under the <a href="http://tryghost.org/about/license.html">MIT</a> License.<br />


### PR DESCRIPTION
This is no longer needed to due to the epic navbar dropdown.
