### PR TITLE
Allows disabling of timestamps when importing posts

### DIFF
--- a/core/server/data/import/000.js
+++ b/core/server/data/import/000.js
@@ -92,7 +92,7 @@ function importTags(ops, tableData, transaction) {
 function importPosts(ops, tableData, transaction) {
     tableData = stripProperties(['id'], tableData);
     _.each(tableData, function (post) {
-        ops.push(models.Post.add(post, {transacting: transaction}));
+        ops.push(models.Post.add(post, {transacting: transaction, importing: true}));
     });
 }
 

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -196,7 +196,16 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     add: function (newObj, options) {
         options = options || {};
-        return this.forge(newObj).save(null, options);
+        var instance = this.forge(newObj);
+        // We allow you to disable timestamps
+        // when importing posts so that
+        // the new posts `updated_at` value
+        // is the same as the import json blob.
+        // More details refer to https://github.com/TryGhost/Ghost/issues/1696
+        if (options.importing) {
+            instance.hasTimestamps = false;
+        }
+        return instance.save(null, options);
     },
 
     create: function () {

--- a/core/test/unit/import_spec.js
+++ b/core/test/unit/import_spec.js
@@ -3,6 +3,7 @@ var testUtils = require('../utils'),
     should = require('should'),
     sinon = require('sinon'),
     when = require('when'),
+    assert = require('assert'),
     _ = require("underscore"),
     errors = require('../../server/errorHandling'),
 
@@ -116,7 +117,8 @@ describe("Import", function () {
         should.exist(Importer001);
 
         it("imports data from 001", function (done) {
-            var exportData;
+            var exportData,
+                timestamp = 1349928000000;
 
             // Migrate to version 001
             migration.migrateUp().then(function () {
@@ -132,6 +134,11 @@ describe("Import", function () {
             }).then(function (exported) {
                 exportData = exported;
 
+                // Modify timestamp data for testing
+                exportData.data.posts[0].created_at = timestamp;
+                exportData.data.posts[0].updated_at = timestamp;
+                exportData.data.posts[0].published_at = timestamp;
+
                 return importer("001", exportData);
             }).then(function () {
                 // Grab the data from tables
@@ -142,21 +149,35 @@ describe("Import", function () {
                     knex("tags").select()
                 ]);
             }).then(function (importedData) {
-
                 should.exist(importedData);
+
                 importedData.length.should.equal(4, 'Did not get data successfully');
 
+                var users = importedData[0],
+                    posts = importedData[1],
+                    settings = importedData[2],
+                    tags = importedData[3];
+
                 // we always have 0 users as there isn't one in fixtures
-                importedData[0].length.should.equal(0, 'There should not be a user');
+                users.length.should.equal(0, 'There should not be a user');
                 // import no longer requires all data to be dropped, and adds posts
-                importedData[1].length.should.equal(exportData.data.posts.length + 1, 'Wrong number of posts');
+                posts.length.should.equal(exportData.data.posts.length + 1, 'Wrong number of posts');
 
                 // test settings
-                importedData[2].length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(importedData[2], {key: "databaseVersion"}).value.should.equal("001", 'Wrong database version');
+                settings.length.should.be.above(0, 'Wrong number of settings');
+                _.findWhere(settings, {key: "databaseVersion"}).value.should.equal("001", 'Wrong database version');
 
                 // test tags
-                importedData[3].length.should.equal(exportData.data.tags.length, 'no new tags');
+                tags.length.should.equal(exportData.data.tags.length, 'no new tags');
+
+                // Ensure imported post retains set timestamp
+                // When in sqlite we are returned a unix timestamp number,
+                // in MySQL we're returned a date object.
+                // We pass the returned post always through the date object
+                // to ensure the return is consistant for all DBs.
+                assert.equal( new Date(posts[1].created_at).getTime(), timestamp);
+                assert.equal( new Date(posts[1].updated_at).getTime(), timestamp);
+                assert.equal( new Date(posts[1].published_at).getTime(), timestamp);
 
                 done();
             }).then(null, done);


### PR DESCRIPTION
fixes #1696
- this is a temp workaround until full fledged support
  is added directly to bookshelfjs
- when importing we use the import json blob’s timestamps
  as the value that’s set in the DB
