### PR TITLE
Adds URL back into theme config

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -155,7 +155,7 @@ settings = {
                 return when(readSettingsResult(result)).then(function (settings) {
                     updateSettingsCache(settings);
                 }).then(function () {
-                    return config.theme.update(settings).then(function () {
+                    return config.theme.update(settings, config().url).then(function () {
                         return settingsObject(settingsFilter(settingsCache, type));
                     });
                 });
@@ -179,7 +179,7 @@ settings = {
             return dataProvider.Settings.edit(setting).then(function (result) {
                 settingsCache[_.first(result).attributes.key].value = _.first(result).attributes.value;
             }).then(function () {
-                return config.theme.update(settings).then(function () {
+                return config.theme.update(settings, config().url).then(function () {
                     return settingsObject(settingsCache);
                 });
             }).otherwise(errors.logAndThrowError);

--- a/core/server/config/paths.js
+++ b/core/server/config/paths.js
@@ -18,7 +18,7 @@ var path              = require('path'),
     availablePlugins;
 
 
-function getPaths() {
+function paths() {
     return {
         'appRoot':          appRoot,
         'path':             localPath,
@@ -41,7 +41,7 @@ function getPaths() {
 
 // TODO: remove configURL and give direct access to config object?
 // TODO: not called when executing tests
-function updatePaths(configURL) {
+function update(configURL) {
     localPath = url.parse(configURL).path;
 
     // Remove trailing slash
@@ -56,6 +56,5 @@ function updatePaths(configURL) {
     });
 }
 
-module.exports = getPaths;
-
-module.exports.updatePaths = updatePaths;
+module.exports = paths;
+module.exports.update = update;

--- a/core/server/config/theme.js
+++ b/core/server/config/theme.js
@@ -4,9 +4,7 @@
 var when          = require('when'),
 
 // Variables
-    theme,
-    themeConfig = {},
-    update;
+    themeConfig = {};
 
 
 function theme() {
@@ -18,7 +16,7 @@ function theme() {
 // If we were to require the api module here
 // there would be a race condition where the ./models/base
 // tries to access the config() object before it is created.
-function update(settings) {
+function update(settings, configUrl) {
     return when.all([
         settings.read('title'),
         settings.read('description'),
@@ -26,6 +24,7 @@ function update(settings) {
         settings.read('cover')
     ]).then(function (globals) {
 
+        themeConfig.url = configUrl;
         themeConfig.title = globals[0].value;
         themeConfig.description = globals[1].value;
         themeConfig.logo = globals[2] ? globals[2].value : '';

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -87,7 +87,7 @@ function setup(server) {
         // Initialise the models
         models.init(),
         // Calculate paths
-        config.paths.updatePaths(config().url)
+        config.paths.update(config().url)
     ).then(function () {
         // Populate any missing default settings
         return models.Settings.populateDefaults();
@@ -97,7 +97,7 @@ function setup(server) {
     }).then(function () {
         // We must pass the api.settings object
         // into this method due to circular dependencies.
-        return config.theme.update(api.settings);
+        return config.theme.update(api.settings, config().url);
     }).then(function () {
         return when.join(
             // Check for or initialise a dbHash.

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -1,0 +1,53 @@
+/*globals describe, it, beforeEach, afterEach */
+
+var should  = require('should'),
+    sinon   = require('sinon'),
+    when    = require('when'),
+
+    config  = require('../../server/config');
+
+describe('Config', function () {
+
+    describe('Theme', function () {
+
+        var sandbox,
+            settingsStub;
+
+        beforeEach(function (done) {
+            sandbox = sinon.sandbox.create();
+
+            var settings = {'read': function read() {}};
+
+            settingsStub = sandbox.stub(settings, 'read', function () {
+                return when({value: 'casper'});
+            });
+
+            config.theme.update(settings, 'http://my-ghost-blog.com')
+                .then(done)
+                .otherwise(done);
+        });
+
+        afterEach(function () {
+            sandbox.restore();
+        });
+
+        it('should have all of the values', function () {
+            var themeConfig = config.theme();
+
+            // This will fail if there are any extra keys
+            themeConfig.should.have.keys('url', 'title', 'description', 'logo', 'cover');
+
+            // Check values are as we expect
+            themeConfig.should.have.property('url', 'http://my-ghost-blog.com');
+            themeConfig.should.have.property('title', 'casper');
+            themeConfig.should.have.property('description', 'casper');
+            themeConfig.should.have.property('logo', 'casper');
+            themeConfig.should.have.property('cover', 'casper');
+
+            // Check settings.read gets called exactly 4 times
+            settingsStub.callCount.should.equal(4);
+
+        });
+    });
+
+});

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -1,4 +1,4 @@
-/*globals describe, beforeEach, it*/
+/*globals describe, beforeEach, afterEach, it*/
 var testUtils = require('../utils'),
     should    = require('should'),
     sinon     = require('sinon'),
@@ -22,14 +22,12 @@ describe('Core Helpers', function () {
     beforeEach(function (done) {
         var adminHbs = hbs.create();
         sandbox = sinon.sandbox.create();
-        apiStub = sandbox.stub(api.settings , 'read', function () {
+        apiStub = sandbox.stub(api.settings, 'read', function () {
             return when({value: 'casper'});
         });
 
         config.theme = sandbox.stub(config, 'theme', function () {
             return {
-                path: '',
-                //url: 'http://127.0.0.1:2368',
                 title: 'Ghost',
                 description: 'Just a blogging platform.',
                 url: 'http://testurl.com'
@@ -39,9 +37,9 @@ describe('Core Helpers', function () {
         helpers.loadCoreHelpers(adminHbs);
         // Load template helpers in handlebars
         hbs.express3({ partialsDir: [config.paths().helperTemplates] });
-        hbs.cachePartials(function(){
+        hbs.cachePartials(function () {
             done();
-        })
+        });
     });
 
     afterEach(function () {


### PR DESCRIPTION
fixes #1749
- pass config().url into theme.update
- rename paths functions to match theme functions
- adds tests for theme config
- We should probably try to eliminate passing config.url around
