### PR TITLE
Static pages do not use dated permalinks

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -68,7 +68,7 @@ frontendControllers = {
         });
     },
     'single': function (req, res, next) {
-        api.posts.read(_.pick(req.params, ['id', 'slug'])).then(function (post) {
+        api.posts.read(_.pick(req.params, ['id', 'slug', 'page'])).then(function (post) {
             if (post) {
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {
@@ -89,6 +89,14 @@ frontendControllers = {
             e.status = err.errorCode;
             return next(e);
         });
+    },
+    'post': function (req, res, next) {
+        req.params.page = 0;
+        return frontendControllers.single(req, res, next);
+    },
+    'page': function (req, res, next) {
+        req.params.page = 1;
+        return frontendControllers.single(req, res, next);
     },
     'rss': function (req, res, next) {
         // Initialize RSS

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -110,7 +110,11 @@ coreHelpers.url = function (options) {
             output += path;
         }
         if (models.isPost(self)) {
-            output += permalinks.value;
+            if (self.page === 1) {
+                output += '/:slug/';
+            } else {
+                output += permalinks.value;
+            }
             output = output.replace(/(:[a-z]+)/g, function (match) {
                 if (_.has(tags, match.substr(1))) {
                     return tags[match.substr(1)]();

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -9,6 +9,11 @@ module.exports = function (server) {
     server.get('/', frontend.homepage);
 
     api.settings.read('permalinks').then(function (permalinks) {
-        server.get(permalinks.value, frontend.single);
+        if (permalinks.value !== '/:slug/') {
+            server.get('/:slug/', frontend.page);
+            server.get(permalinks.value, frontend.post);
+        } else {
+            server.get(permalinks.value, frontend.single);
+        }
     });
 };


### PR DESCRIPTION
closes #1753
- Pages are registered to '/:slug/' route if posts are using dated permalinks

I'm new to working with backbone.js so these changes might include some obvious bad practices.

Right now this pull request doesn't have unit tests. Are there unit tests which include routing? The can't seem to find any tests which address changes to the `permalinks` variable.
