### PR TITLE
Fix live theme switching not working on subdirectories

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -89,7 +89,7 @@ function initViews(req, res, next) {
 function activateTheme(activeTheme) {
     var hbsOptions,
         stackLocation = _.indexOf(expressServer.stack, _.find(expressServer.stack, function (stackItem) {
-            return stackItem.route === '' && stackItem.handle.name === 'settingEnabled';
+            return stackItem.route === config.paths().subdir && stackItem.handle.name === 'settingEnabled';
         }));
 
     // clear the view cache
@@ -99,7 +99,6 @@ function activateTheme(activeTheme) {
     expressServer.enable(expressServer.get('activeTheme'));
     if (stackLocation) {
         expressServer.stack[stackLocation].handle = middleware.whenEnabled(expressServer.get('activeTheme'), middleware.staticTheme());
-        expressServer.stack[stackLocation].route = config.paths().subdir;
     }
 
     // set view engine
@@ -228,7 +227,7 @@ module.exports = function (server, dbHash) {
     expressServer.use(subdir + '/ghost', middleware.whenEnabled('admin', express['static'](path.join(corePath, '/client/assets'))));
 
     // Theme only config
-    expressServer.use(middleware.whenEnabled(expressServer.get('activeTheme'), middleware.staticTheme()));
+    expressServer.use(subdir, middleware.whenEnabled(expressServer.get('activeTheme'), middleware.staticTheme()));
 
     // Add in all trailing slashes
     expressServer.use(slashes());


### PR DESCRIPTION
Closes #1770
- Previously, the middleware would check that the route on the stack was an empty string, which worked when there was no subdirectories
- When subdirectories were added, the proper route was only set when
  updating the theme
- Because it was only set when updating, this explains themes working on
  initial load, since the stack location was looking for an empty
  string, which is what the middleware was initialized with
- However, once a new theme was set, it was still looking for an empty
  string, which would never exist, which caused the issue
- Now, the route is properly set on initialization of the middleware,
  and then the `config.paths().subdir` property is used for the check
