### PR TITLE
Fix routing of posts and static pages

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -3,11 +3,11 @@
 
 var _             = require('underscore'),
     when          = require('when'),
+    config        = require('../config'),
     errors        = require('../errorHandling'),
     db            = require('./db'),
     settings      = require('./settings'),
     notifications = require('./notifications'),
-    config        = require('../config'),
     posts         = require('./posts'),
     users         = require('./users'),
     tags          = require('./tags'),
@@ -49,34 +49,15 @@ requestHandler = function (apiMethod) {
         var options = _.extend(req.body, req.query, req.params),
             apiContext = {
                 user: req.session && req.session.user
-            },
-            postRouteIndex,
-            i;
+            };
 
-        settings.read('permalinks').then(function (permalinks) {
-            // If permalinks have changed, find old post route
-            if (req.body.permalinks && req.body.permalinks !== permalinks) {
-                for (i = 0; i < req.app.routes.get.length; i += 1) {
-                    if (req.app.routes.get[i].path === config.paths().subdir + permalinks) {
-                        postRouteIndex = i;
-                        break;
-                    }
-                }
-            }
-
-            return apiMethod.call(apiContext, options).then(function (result) {
-                // Reload post route
-                if (postRouteIndex) {
-                    req.app.get(permalinks, req.app.routes.get.splice(postRouteIndex, 1)[0].callbacks);
-                }
-
-                invalidateCache(req, res, result);
-                res.json(result || {});
-            }, function (error) {
-                var errorCode = error.errorCode || 500,
-                    errorMsg = {error: _.isString(error) ? error : (_.isObject(error) ? error.message : 'Unknown API Error')};
-                res.json(errorCode, errorMsg);
-            });
+        return apiMethod.call(apiContext, options).then(function (result) {
+            invalidateCache(req, res, result);
+            res.json(result || {});
+        }, function (error) {
+            var errorCode = error.errorCode || 500,
+                errorMsg = {error: _.isString(error) ? error : (_.isObject(error) ? error.message : 'Unknown API Error')};
+            res.json(errorCode, errorMsg);
         });
     };
 };

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -1,8 +1,6 @@
 var admin       = require('../controllers/admin'),
-    api         = require('../api'),
     config      = require('../config'),
-    middleware  = require('../middleware').middleware,
-    url         = require('url');
+    middleware  = require('../middleware').middleware;
 
 module.exports = function (server) {
     var subdir = config.paths().subdir;

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -1,19 +1,19 @@
-var frontend    = require('../controllers/frontend'),
-    api         = require('../api');
+var frontend    = require('../controllers/frontend');
+
 module.exports = function (server) {
+    /*jslint regexp: true */
+
     // ### Frontend routes
     /* TODO: dynamic routing, homepage generator, filters ETC ETC */
     server.get('/rss/', frontend.rss);
     server.get('/rss/:page/', frontend.rss);
     server.get('/page/:page/', frontend.homepage);
+    // Only capture the :slug part of the URL
+    // This regex will always have two capturing groups,
+    // one for date, and one for the slug.
+    // Examples:
+    //  Given `/plain-slug/` the req.params would be ['', 'plain-slug']
+    //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24', 'plain-slug']
+    server.get(/^\/([0-9\/]*)([^\/.]*)\/$/, frontend.single);
     server.get('/', frontend.homepage);
-
-    api.settings.read('permalinks').then(function (permalinks) {
-        if (permalinks.value !== '/:slug/') {
-            server.get('/:slug/', frontend.page);
-            server.get(permalinks.value, frontend.post);
-        } else {
-            server.get(permalinks.value, frontend.single);
-        }
-    });
 };

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -209,6 +209,17 @@ CasperTest.Routines = (function () {
         }, id);
     }
 
+    function togglePermalinks(test) {
+        casper.thenOpen(url + "ghost/settings/");
+        casper.thenClick('#permalinks');
+        casper.thenClick('.button-save');
+        casper.waitFor(function successNotification() {
+            return this.evaluate(function () {
+                return document.querySelectorAll('.js-bb-notification section').length > 0;
+            });
+        });
+    }
+
     function _createRunner(fn) {
         fn.run = function run(test) {
             var routine = this;
@@ -225,7 +236,8 @@ CasperTest.Routines = (function () {
         register: _createRunner(register),
         login: _createRunner(login),
         logout: _createRunner(logout),
-        deletePost: _createRunner(deletePost)
+        deletePost: _createRunner(deletePost),
+        togglePermalinks: _createRunner(togglePermalinks)
     };
 
 }());

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -28,18 +28,8 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     });
 });
 
-CasperTest.begin('Ensures dated permalinks works with RSS', 4, function suite(test) {
-	casper.thenOpen(url + "ghost/settings/", function testTitleAndUrl() {
-        test.assertTitle("Ghost Admin", "Ghost admin has no title");
-        test.assertUrlMatch(/ghost\/settings\/general\/$/, "Ghost doesn't require login this time");
-    });
-	casper.thenClick('#permalinks');
-	casper.thenClick('.button-save');
-	casper.waitFor(function successNotification() {
-        return this.evaluate(function () {
-            return document.querySelectorAll('.js-bb-notification section').length > 0;
-        });
-    });
+CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run(test);
 	casper.thenOpen(url + 'rss/', function (response) {
 		var content = this.getPageContent(),
 			today = new Date(),

--- a/core/test/functional/frontend/post_test.js
+++ b/core/test/functional/frontend/post_test.js
@@ -3,7 +3,21 @@
  */
 
 /*globals CasperTest, casper, __utils__, url, testPost, falseUser, email */
+
+// Tests when permalinks is set to date (changed in feed_test)
+CasperTest.begin('Post page does not load as slug', 2, function suite(test) {
+    casper.start(url + 'welcome-to-ghost', function then(response) {
+        test.assertTitle('404 — Page Not Found', 'The post should return 404 page');
+        test.assertElementCount('.content .post', 0, 'There is no post on this page');
+    });
+}, true);
+
+CasperTest.begin('Toggle permalinks', 0, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run(test);
+});
+
 CasperTest.begin('Post page loads', 3, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run(test);
     casper.start(url + 'welcome-to-ghost', function then(response) {
         test.assertTitle('Welcome to Ghost', 'The post should have a title and it should be "Welcome to Ghost"');
         test.assertElementCount('.content .post', 1, 'There is exactly one post on this page');


### PR DESCRIPTION
closes #1757 and #1773
- switches routes.frontend for posts and pages
  to use a regex with two capturing groups.  This removes
  the need to dynamically remove an express route at a
  later point, leaving the decision making to frontend
  controller.
- added unit tests for all routing conditions that 
  can arise for posts and pages.
- updated functional tests to also test for same thing
  in unit tests
- removes old code from server/api/index that used
  to fix this issue, but is no longer needed
- removed some un-needed require statements in routes/admin
