### PR TITLE
Changed socket permissions

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -215,7 +215,7 @@ function setup(server) {
                         getSocket(),
                         startGhost
                     );
-                    fs.chmod(getSocket(), '0744');
+                    fs.chmod(getSocket(), '0660');
                 });
 
             } else {


### PR DESCRIPTION
In a production environment it is often necessary for groups to have write permissions over a socket.

For instance, I have a _ghost_ user which runs the application behind an Nginx server running as _nginx_ and group _www-data_. I want _ghost_ to own the socket with read/write permissions but I also want _www-data_ to have write access.

I can't think of a security downside to a 0774 configuration?
