### PR TITLE
Cache control headers & query string asset management

### DIFF
--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -8,7 +8,9 @@ var _           = require('underscore'),
     config      = require('../config'),
     path        = require('path'),
     api         = require('../api'),
-    expressServer;
+
+    expressServer,
+    ONE_HOUR_MS = 60 * 60 * 1000;
 
 function isBlackListedFileType(file) {
     var blackListedFileTypes = ['.hbs', '.md', '.json'],
@@ -89,16 +91,26 @@ var middleware = {
         });
     },
 
-    // ### DisableCachedResult Middleware
-    // Disable any caching until it can be done properly
-    disableCachedResult: function (req, res, next) {
+    // ### CacheControl Middleware
+    // provide sensible cache control headers
+    cacheControl: function (options) {
         /*jslint unparam:true*/
-        res.set({
-            'Cache-Control': 'no-cache, must-revalidate',
-            'Expires': 'Sat, 26 Jul 1997 05:00:00 GMT'
-        });
+        var profiles = {
+                'public': 'public, max-age=0',
+                'private': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+            },
+            output;
 
-        next();
+        if (_.isString(options) && profiles.hasOwnProperty(options)) {
+            output = profiles[options];
+        }
+
+        return function cacheControlHeaders(req, res, next) {
+            if (output) {
+                res.set({'Cache-Control': output});
+            }
+            next();
+        };
     },
 
     // ### whenEnabled Middleware
@@ -128,7 +140,8 @@ var middleware = {
     // to allow unit testing
     forwardToExpressStatic: function (req, res, next) {
         api.settings.read('activeTheme').then(function (activeTheme) {
-            express['static'](path.join(config.paths().themePath, activeTheme.value))(req, res, next);
+            // For some reason send divides the max age number by 1000
+            express['static'](path.join(config.paths().themePath, activeTheme.value), {maxAge: ONE_HOUR_MS})(req, res, next);
         });
     },
 

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -5,26 +5,26 @@ module.exports = function (server) {
     // ### API routes
     /* TODO: auth should be public auth not user auth */
     // #### Posts
-    server.get('/ghost/api/v0.1/posts', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.posts.browse));
-    server.post('/ghost/api/v0.1/posts', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.posts.add));
-    server.get('/ghost/api/v0.1/posts/:id', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.posts.read));
-    server.put('/ghost/api/v0.1/posts/:id', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.posts.edit));
-    server.del('/ghost/api/v0.1/posts/:id', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.posts.destroy));
+    server.get('/ghost/api/v0.1/posts', middleware.authAPI, api.requestHandler(api.posts.browse));
+    server.post('/ghost/api/v0.1/posts', middleware.authAPI, api.requestHandler(api.posts.add));
+    server.get('/ghost/api/v0.1/posts/:id', middleware.authAPI, api.requestHandler(api.posts.read));
+    server.put('/ghost/api/v0.1/posts/:id', middleware.authAPI, api.requestHandler(api.posts.edit));
+    server.del('/ghost/api/v0.1/posts/:id', middleware.authAPI, api.requestHandler(api.posts.destroy));
     // #### Settings
-    server.get('/ghost/api/v0.1/settings/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.settings.browse));
-    server.get('/ghost/api/v0.1/settings/:key/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.settings.read));
-    server.put('/ghost/api/v0.1/settings/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.settings.edit));
+    server.get('/ghost/api/v0.1/settings/', middleware.authAPI, api.requestHandler(api.settings.browse));
+    server.get('/ghost/api/v0.1/settings/:key/', middleware.authAPI, api.requestHandler(api.settings.read));
+    server.put('/ghost/api/v0.1/settings/', middleware.authAPI, api.requestHandler(api.settings.edit));
     // #### Users
-    server.get('/ghost/api/v0.1/users/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.users.browse));
-    server.get('/ghost/api/v0.1/users/:id/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.users.read));
-    server.put('/ghost/api/v0.1/users/:id/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.users.edit));
+    server.get('/ghost/api/v0.1/users/', middleware.authAPI, api.requestHandler(api.users.browse));
+    server.get('/ghost/api/v0.1/users/:id/', middleware.authAPI, api.requestHandler(api.users.read));
+    server.put('/ghost/api/v0.1/users/:id/', middleware.authAPI, api.requestHandler(api.users.edit));
     // #### Tags
-    server.get('/ghost/api/v0.1/tags/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.tags.all));
+    server.get('/ghost/api/v0.1/tags/', middleware.authAPI, api.requestHandler(api.tags.all));
     // #### Notifications
-    server.del('/ghost/api/v0.1/notifications/:id', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.notifications.destroy));
-    server.post('/ghost/api/v0.1/notifications/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.notifications.add));
+    server.del('/ghost/api/v0.1/notifications/:id', middleware.authAPI, api.requestHandler(api.notifications.destroy));
+    server.post('/ghost/api/v0.1/notifications/', middleware.authAPI, api.requestHandler(api.notifications.add));
     // #### Import/Export
     server.get('/ghost/api/v0.1/db/', middleware.auth, api.db['export']);
     server.post('/ghost/api/v0.1/db/', middleware.auth, api.db['import']);
-    server.del('/ghost/api/v0.1/db/', middleware.authAPI, middleware.disableCachedResult, api.requestHandler(api.db.deleteAllContent));
+    server.del('/ghost/api/v0.1/db/', middleware.authAPI, api.requestHandler(api.db.deleteAllContent));
 };

--- a/core/server/storage/localfilesystem.js
+++ b/core/server/storage/localfilesystem.js
@@ -56,7 +56,11 @@ localFileStore = _.extend(baseStore, {
 
     // middleware for serving the files
     'serve': function () {
-        return express['static'](configPaths().imagesPath);
+        var ONE_HOUR_MS = 60 * 60 * 1000,
+            ONE_YEAR_MS = 365 * 24 * ONE_HOUR_MS;
+
+        // For some reason send divides the max age number by 1000
+        return express['static'](configPaths().imagesPath, {maxAge: ONE_YEAR_MS});
     }
 });
 

--- a/core/test/functional/admin/content_test.js
+++ b/core/test/functional/admin/content_test.js
@@ -1,6 +1,6 @@
 /*globals casper, __utils__, url, testPost */
 
-CasperTest.begin("Content screen is correct", 21, function suite(test) {
+CasperTest.begin("Content screen is correct", 20, function suite(test) {
     // Create a sample post
     casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
@@ -37,10 +37,6 @@ CasperTest.begin("Content screen is correct", 21, function suite(test) {
         test.assertSelectorHasText("#usermenu .usermenu-profile a", "Your Profile");
         test.assertSelectorHasText("#usermenu .usermenu-help a", "Help / Support");
         test.assertSelectorHasText("#usermenu .usermenu-signout a", "Sign Out");
-
-        test.assertResourceExists(function (resource) {
-            return resource.url.match(/user-image\.png$/) && (resource.status === 200 || resource.status === 304);
-        }, 'Default user image');
     });
 
     casper.then(function testViews() {

--- a/core/test/functional/admin/settings_test.js
+++ b/core/test/functional/admin/settings_test.js
@@ -1,6 +1,6 @@
 /*globals casper, __utils__, url */
 
-CasperTest.begin("Settings screen is correct", 17, function suite(test) {
+CasperTest.begin("Settings screen is correct", 15, function suite(test) {
     casper.thenOpen(url + "ghost/settings/", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
         test.assertUrlMatch(/ghost\/settings\/general\/$/, "Ghost doesn't require login this time");
@@ -32,16 +32,6 @@ CasperTest.begin("Settings screen is correct", 17, function suite(test) {
         test.assertEval(function testContentIsUser() {
             return document.querySelector('.settings-content').id === 'user';
         }, "loaded content is user screen");
-
-        test.assertResourceExists(function (resource) {
-            return resource.url.match(/user-image\.png$/) && (resource.status === 200 || resource.status === 304);
-        }, 'Default user image');
-
-        test.assertResourceExists(function (resource) {
-            return resource.url.match(/user-cover\.png$/) && (resource.status === 200 || resource.status === 304);
-        }, 'Default cover image');
-
-
     }, function onTimeOut() {
         test.fail('User screen failed to load');
     });

--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -1,0 +1,121 @@
+/*global describe, it, before, after */
+
+// # Frontend Route tests
+// As it stands, these tests depend on the database, and as such are integration tests.
+// Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
+// But then again testing real code, rather than mock code, might be more useful...
+
+var request    = require('supertest'),
+    should     = require('should'),
+    moment     = require('moment'),
+
+    testUtils  = require('../../utils'),
+    config     = require('../../../server/config'),
+
+    ONE_HOUR_S = 60 * 60,
+    ONE_YEAR_S = 365 * 24 * ONE_HOUR_S,
+    cacheRules = {
+        'public': 'public, max-age=0',
+        'hour':  'public, max-age=' + ONE_HOUR_S,
+        'year':  'public, max-age=' + ONE_YEAR_S,
+        'private': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+    };
+
+describe('Admin Routing', function () {
+    function doEnd(done) {
+        return function (err, res) {
+            if (err) {
+                return done(err);
+            }
+
+            should.not.exist(res.headers['x-cache-invalidate']);
+            should.not.exist(res.headers['X-CSRF-Token']);
+            should.exist(res.headers['set-cookie']);
+            should.exist(res.headers.date);
+
+            done();
+        };
+    }
+
+    before(function (done) {
+        testUtils.clearData().then(function () {
+            // we initialise data, but not a user. No user should be required for navigating the frontend
+            return testUtils.initData();
+        }).then(function () {
+            done();
+        }, done);
+
+        // Setup the request object with the correct URL
+        request = request(config().url);
+    });
+
+    describe('Ghost Admin Signup', function () {
+        it('should have a session cookie which expires in 12 hours', function (done) {
+            request.get('/ghost/signup/')
+                .end(function firstRequest(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    should.not.exist(res.headers['X-CSRF-Token']);
+                    should.exist(res.headers['set-cookie']);
+                    should.exist(res.headers.date);
+
+                    var expires;
+                    // Session should expire 12 hours after the time in the date header
+                    expires = moment(res.headers.date).add('Hours', 12).format("ddd, DD MMM YYYY HH:mm");
+                    expires = new RegExp("Expires=" + expires);
+
+                    res.headers['set-cookie'].should.match(expires);
+
+                    done();
+                });
+        });
+
+        it('should redirect from /ghost to /ghost/signup when no user', function (done) {
+            request.get('/ghost/')
+                .expect('Location', /ghost\/signup/)
+                .expect('Cache-Control', cacheRules['private'])
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should redirect from /ghost/signin to /ghost/signup when no user', function (done) {
+            request.get('/ghost/signin/')
+                .expect('Location', /ghost\/signup/)
+                .expect('Cache-Control', cacheRules['private'])
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should respond with html for /ghost/signup', function (done) {
+            request.get('/ghost/signup/')
+                .expect('Content-Type', /html/)
+                .expect('Cache-Control', cacheRules['private'])
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        // Add user
+
+//        it('should redirect from /ghost/signup to /ghost/signin with user', function (done) {
+//           done();
+//        });
+
+//        it('should respond with html for /ghost/signin', function (done) {
+//           done();
+//        });
+
+        // Do Login
+
+//        it('should redirect from /ghost/signup to /ghost/ when logged in', function (done) {
+//           done();
+//        });
+
+//        it('should redirect from /ghost/signup to /ghost/ when logged in', function (done) {
+//           done();
+//        });
+
+    });
+});


### PR DESCRIPTION
closes #1470
issue #1405
- added cache control middleware
- added defaults for all routes, assets, etc
- updated asset helper to add a query string with a timestamp hash to all assets
- added unit tests for asset and ghostScriptTags helpers
