### PR TITLE
Enforce 2-digit dates in permalinks

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -71,7 +71,8 @@ frontendControllers = {
     'single': function (req, res, next) {
         // From route check if a date was parsed
         // from the regex
-        var dateInSlug = req.params[0] !== '';
+        var dateInSlug = req.params[0] ? true : false;
+        console.log('SINGLE', req.params, dateInSlug);
         when.join(
             api.settings.read('permalinks'),
             api.posts.read({slug: req.params[1]})

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -94,9 +94,9 @@ coreHelpers.url = function (options) {
     var output = '',
         self = this,
         tags = {
-            year: function () { return self.created_at.getFullYear(); },
-            month: function () { return self.created_at.getMonth() + 1; },
-            day: function () { return self.created_at.getDate(); },
+            year: function () { return moment(self.created_at).format('YYYY'); },
+            month: function () { return moment(self.created_at).format('MM'); },
+            day: function () { return moment(self.created_at).format('DD'); },
             slug: function () { return self.slug; },
             id: function () { return self.id; }
         },

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -14,6 +14,7 @@ module.exports = function (server) {
     // Examples:
     //  Given `/plain-slug/` the req.params would be ['', 'plain-slug']
     //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24', 'plain-slug']
-    server.get(/^\/([0-9\/]*)([^\/.]*)\/$/, frontend.single);
+    //server.get(/^\/([0-9\/]*)([^\/.]*)\/$/, frontend.single);
+    server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/$/, frontend.single);
     server.get('/', frontend.homepage);
 };

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -209,14 +209,23 @@ CasperTest.Routines = (function () {
         }, id);
     }
 
-    function togglePermalinks(test) {
-        casper.thenOpen(url + "ghost/settings/");
-        casper.thenClick('#permalinks');
-        casper.thenClick('.button-save');
-        casper.waitFor(function successNotification() {
-            return this.evaluate(function () {
-                return document.querySelectorAll('.js-bb-notification section').length > 0;
+    function togglePermalinks(state) {
+        casper.thenOpen(url + "ghost/settings/general");
+
+        casper.waitForSelector('#general');
+        casper.waitForOpaque('#general', function then() {
+            var currentState = this.evaluate(function () {
+                return document.querySelector('#permalinks') && document.querySelector('#permalinks').checked ? 'on' : 'off';
             });
+            if (currentState !== state) {
+                casper.thenClick('#permalinks');
+                casper.thenClick('.button-save');
+                casper.waitFor(function successNotification() {
+                    return this.evaluate(function () {
+                        return document.querySelectorAll('.js-bb-notification section').length > 0;
+                    });
+                });
+            }
         });
     }
 

--- a/core/test/functional/frontend/error_test.js
+++ b/core/test/functional/frontend/error_test.js
@@ -7,11 +7,11 @@ CasperTest.begin('Check post not found (404)', 2, function suite(test) {
         test.assertEqual(response.status, 404, 'Response status should be 404.');
 		test.assertSelectorHasText('.error-code', '404');
     });
-});
+}, true);
 
 CasperTest.begin('Check frontend route not found (404)', 2, function suite(test) {
     casper.thenOpen(url + 'asdf/asdf/', function (response) {
         test.assertEqual(response.status, 404, 'Response status should be 404.');
 		test.assertSelectorHasText('.error-code', '404');
     });
-});
+}, true);

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -1,11 +1,11 @@
 /**
  * Tests if RSS exists and is working
  */
-/*globals CasperTest, casper */
+/*globals url, CasperTest, casper */
 CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     casper.thenOpen(url + 'rss/', function (response) {
         var content = this.getPageContent(),
-            siteTitle = '<title><![CDATA[Ghost]]></title',
+            siteTitle = '<title><![CDATA[Ghost]]></title>',
             siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
             siteUrl = '<link>http://127.0.0.1:2369</link>',
             postTitle = '<![CDATA[Welcome to Ghost]]>',
@@ -26,19 +26,19 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
         test.assert(content.indexOf(postCreator) >= 0, 'Welcome post should have Test User as the creator.');
         test.assert(content.indexOf('</rss>') >= 0, 'Feed should contain </rss>');
     });
-});
+}, false);
 
 CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(test) {
-    CasperTest.Routines.togglePermalinks.run(test);
-	casper.thenOpen(url + 'rss/', function (response) {
-		var content = this.getPageContent(),
-			today = new Date(),
-			dd = ("0" + today.getDate()).slice(-2),
-			mm = ("0" + (today.getMonth() + 1)).slice(-2),
-			yyyy = today.getFullYear(),
-			postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
+    CasperTest.Routines.togglePermalinks.run('on');
+    casper.thenOpen(url + 'rss/', function (response) {
+        var content = this.getPageContent(),
+            today = new Date(),
+            dd = ("0" + today.getDate()).slice(-2),
+            mm = ("0" + (today.getMonth() + 1)).slice(-2),
+            yyyy = today.getFullYear(),
+            postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
 
-		test.assertEqual(response.status, 200, 'Response status should be 200.');
-		test.assert(content.indexOf(postLink) >= 0, 'Feed should have dated permalink.');
-	});
-});
+        test.assertEqual(response.status, 200, 'Response status should be 200.');
+        test.assert(content.indexOf(postLink) >= 0, 'Feed should have dated permalink.');
+    });
+}, false);

--- a/core/test/functional/frontend/home_test.js
+++ b/core/test/functional/frontend/home_test.js
@@ -19,4 +19,4 @@ CasperTest.begin('Test helpers on homepage', 3, function suite(test) {
         test.assertExists('article.post', 'post_class outputs correct post class');
         test.assertExists('article.tag-getting-started', 'post_class outputs correct tag class');
     });
-});
+}, true);

--- a/core/test/functional/frontend/post_test.js
+++ b/core/test/functional/frontend/post_test.js
@@ -12,18 +12,14 @@ CasperTest.begin('Post page does not load as slug', 2, function suite(test) {
     });
 }, true);
 
-CasperTest.begin('Toggle permalinks', 0, function suite(test) {
-    CasperTest.Routines.togglePermalinks.run(test);
-});
-
 CasperTest.begin('Post page loads', 3, function suite(test) {
-    CasperTest.Routines.togglePermalinks.run(test);
-    casper.start(url + 'welcome-to-ghost', function then(response) {
+    CasperTest.Routines.togglePermalinks.run('off');
+    casper.thenOpen(url + 'welcome-to-ghost', function then(response) {
         test.assertTitle('Welcome to Ghost', 'The post should have a title and it should be "Welcome to Ghost"');
         test.assertElementCount('.content .post', 1, 'There is exactly one post on this page');
         test.assertSelectorHasText('.poweredby', 'Proudly published with Ghost');
     });
-}, true);
+});
 
 CasperTest.begin('Test helpers on homepage', 4, function suite(test) {
     casper.start(url + 'welcome-to-ghost', function then(response) {
@@ -34,4 +30,4 @@ CasperTest.begin('Test helpers on homepage', 4, function suite(test) {
         test.assertExists('article.post', 'post_class outputs correct post class');
         test.assertExists('article.tag-getting-started', 'post_class outputs correct tag class');
     });
-});
+}, true);


### PR DESCRIPTION
fixes #1800
- changed permalink regex to require 4/2/2/slug
- changed url helper to enforce the same
- changed permalink toggle to set a specific state, this means the
  functional tests are independent again
- chnaged permalink toggle to wait for the settings page to load
- change as many frontend tests to not login as possible
