### PR TITLE
Date permalinks use published date

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -4,14 +4,16 @@
 
 /*global require, module */
 
-var config  = require('../config'),
-    api     = require('../api'),
-    RSS     = require('rss'),
-    _       = require('underscore'),
-    errors  = require('../errorHandling'),
-    when    = require('when'),
-    url     = require('url'),
-    filters = require('../../server/filters'),
+var moment      = require('moment'),
+    RSS         = require('rss'),
+    _           = require('underscore'),
+    url         = require('url'),
+    when        = require('when'),
+
+    api         = require('../api'),
+    config      = require('../config'),
+    errors      = require('../errorHandling'),
+    filters     = require('../../server/filters'),
     coreHelpers = require('../helpers'),
 
     frontendControllers;
@@ -90,6 +92,11 @@ frontendControllers = {
             }
 
             if (!post) {
+                return next();
+            }
+
+            // Check that the date in the URL matches the published date of the post, else 404
+            if (dateInSlug && req.params[0] !== moment(post.published_at).format('YYYY/MM/DD/')) {
                 return next();
             }
 

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -94,9 +94,9 @@ coreHelpers.url = function (options) {
     var output = '',
         self = this,
         tags = {
-            year: function () { return moment(self.created_at).format('YYYY'); },
-            month: function () { return moment(self.created_at).format('MM'); },
-            day: function () { return moment(self.created_at).format('DD'); },
+            year: function () { return moment(self.published_at).format('YYYY'); },
+            month: function () { return moment(self.published_at).format('MM'); },
+            day: function () { return moment(self.published_at).format('DD'); },
             slug: function () { return self.slug; },
             id: function () { return self.id; }
         },

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -12,7 +12,7 @@ module.exports = function (server) {
     // one for date, and one for the slug.
     // Examples:
     //  Given `/plain-slug/` the req.params would be [undefined, 'plain-slug']
-    //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24', 'plain-slug']
+    //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24/', 'plain-slug']
     server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/$/, frontend.single);
     server.get('/', frontend.homepage);
 };

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -1,11 +1,12 @@
 /*globals describe, beforeEach, afterEach, it*/
-var assert  = require('assert'),
-    should  = require('should'),
-    sinon   = require('sinon'),
-    when    = require('when'),
+var assert   = require('assert'),
+    moment   = require('moment'),
+    should   = require('should'),
+    sinon    = require('sinon'),
+    when     = require('when'),
 
-    // Stuff we are testing
-    config  = require('../../server/config'),
+// Stuff we are testing
+    config   = require('../../server/config'),
     api      = require('../../server/api'),
     frontend = require('../../server/controllers/frontend');
 
@@ -28,38 +29,37 @@ describe('Frontend Controller', function () {
         // No tests yet, shows up in coverage report
     });
 
-    describe('single', function() {
+    describe('single', function () {
         var mockStaticPost = {
-            'status': 'published',
-            'id': 1,
-            'title': 'Test static page',
-            'slug': 'test-static-page',
-            'markdown': 'Test static page content',
-            'page': 1
-        };
-
-        var mockPost = {
-            'status': 'published',
-            'id': 2,
-            'title': 'Test normal post',
-            'slug': 'test-normal-post',
-            'markdown': 'The test normal post content',
-            'page': 0
-        };
+                'status': 'published',
+                'id': 1,
+                'title': 'Test static page',
+                'slug': 'test-static-page',
+                'markdown': 'Test static page content',
+                'page': 1
+            },
+            mockPost = {
+                'status': 'published',
+                'id': 2,
+                'title': 'Test normal post',
+                'slug': 'test-normal-post',
+                'markdown': 'The test normal post content',
+                'page': 0
+            };
 
         beforeEach(function () {
-            sandbox.stub(api.posts , 'read', function (args) {
+            sandbox.stub(api.posts, 'read', function (args) {
                 return when(args.slug === mockStaticPost.slug ? mockStaticPost : mockPost);
             });
 
-            apiSettingsStub = sandbox.stub(api.settings , 'read');
+            apiSettingsStub = sandbox.stub(api.settings, 'read');
 
             apiSettingsStub.withArgs('activeTheme').returns(when({
                 'key': 'activeTheme',
                 'value': 'casper'
             }));
 
-            sandbox.stub(config , 'paths', function () {
+            sandbox.stub(config, 'paths', function () {
                 return {
                     'availableThemes': {
                         'casper': {
@@ -74,148 +74,154 @@ describe('Frontend Controller', function () {
             });
         });
 
-        describe('permalink set to slug', function() {
-            beforeEach(function() {
+        describe('permalink set to slug', function () {
+            beforeEach(function () {
                 apiSettingsStub.withArgs('permalinks').returns(when({
                     value: '/:slug/'
                 }));
             });
 
-            it('can render a static page', function(done) {
+            it('can render a static page', function (done) {
                 var req = {
-                    params: ['', 'test-static-page']
-                };
-
-                var res = {
-                    render: function(view, context) {
-                        assert.equal(view, 'page');
-                        assert.equal(context.post, mockStaticPost);
-                        done();
-                    }
-                };
+                        params: [undefined, 'test-static-page']
+                    },
+                    res = {
+                        render: function (view, context) {
+                            assert.equal(view, 'page');
+                            assert.equal(context.post, mockStaticPost);
+                            done();
+                        }
+                    };
 
                 frontend.single(req, res, null);
             });
 
-            it('won\'t render a static page accessed as a date url', function(done) {
+            it('will NOT render a static page accessed as a date url', function (done) {
                 var req = {
-                    params: ['2012/12/30', 'test-static-page']
-                };
+                        params: ['2012/12/30/', 'test-static-page']
+                    },
+                    res = {
+                        render: sinon.spy()
+                    };
 
-                var res = {
-                    render: sinon.spy()
-                };
-
-                frontend.single(req, res, function() {
+                frontend.single(req, res, function () {
                     res.render.called.should.be.false;
                     done();
                 });
             });
 
-            it('can render a normal post', function(done) {
+            it('can render a normal post', function (done) {
                 var req = {
-                    params: ['', 'test-normal-post']
-                };
-
-                var res = {
-                    render: function(view, context) {
-                        assert.equal(view, 'post');
-                        assert(context.post, 'Context object has post attribute');
-                        assert.equal(context.post, mockPost);
-                        done();
-                    }
-                };
+                        params: [undefined, 'test-normal-post']
+                    },
+                    res = {
+                        render: function (view, context) {
+                            assert.equal(view, 'post');
+                            assert(context.post, 'Context object has post attribute');
+                            assert.equal(context.post, mockPost);
+                            done();
+                        }
+                    };
 
                 frontend.single(req, res, null);
             });
 
-            it('won\'t render a normal post accessed as a date url', function(done) {
+            it('will NOT render a normal post accessed as a date url', function (done) {
                 var req = {
-                    params: ['2012/12/30', 'test-normal-post']
-                };
+                        params: ['2012/12/30/', 'test-normal-post']
+                    },
+                    res = {
+                        render: sinon.spy()
+                    };
 
-                var res = {
-                    render: sinon.spy()
-                };
-
-                frontend.single(req, res, function() {
+                frontend.single(req, res, function () {
                     res.render.called.should.be.false;
                     done();
                 });
             });
         });
 
-        describe('permalink set to date', function() {
-            beforeEach(function() {
+        describe('permalink set to date', function () {
+            beforeEach(function () {
                 apiSettingsStub.withArgs('permalinks').returns(when({
                     value: '/:year/:month/:day/:slug/'
                 }));
             });
 
-            it('can render a static page', function(done) {
+            it('can render a static page', function (done) {
                 var req = {
-                    params: ['', 'test-static-page']
-                };
-
-                var res = {
-                    render: function(view, context) {
-                        assert.equal(view, 'page');
-                        assert.equal(context.post, mockStaticPost);
-                        done();
-                    }
-                };
+                        params: [undefined, 'test-static-page']
+                    },
+                    res = {
+                        render: function (view, context) {
+                            assert.equal(view, 'page');
+                            assert.equal(context.post, mockStaticPost);
+                            done();
+                        }
+                    };
 
                 frontend.single(req, res, null);
             });
 
-            it('won\'t render a static page accessed as a date url', function(done) {
+            it('will NOT render a static page accessed as a date url', function (done) {
                 var req = {
-                    params: ['2012/12/30', 'test-static-page']
-                };
+                        params: ['2012/12/30/', 'test-static-page']
+                    },
+                    res = {
+                        render: sinon.spy()
+                    };
 
-                var res = {
-                    render: sinon.spy()
-                };
-
-                frontend.single(req, res, function() {
+                frontend.single(req, res, function () {
                     res.render.called.should.be.false;
                     done();
                 });
             });
 
-            it('can render a normal post', function(done) {
-                var req = {
-                    params: ['2012/12/30', 'test-normal-post']
-                };
-
-                var res = {
-                    render: function(view, context) {
-                        assert.equal(view, 'post');
-                        assert(context.post, 'Context object has post attribute');
-                        assert.equal(context.post, mockPost);
-                        done();
-                    }
-                };
+            it('can render a normal post', function (done) {
+                var date = moment().format('YYYY/MM/DD/'),
+                    req = {
+                        params: [date, 'test-normal-post']
+                    },
+                    res = {
+                        render: function (view, context) {
+                            assert.equal(view, 'post');
+                            assert(context.post, 'Context object has post attribute');
+                            assert.equal(context.post, mockPost);
+                            done();
+                        }
+                    };
 
                 frontend.single(req, res, null);
             });
 
-            it('won\'t render a normal post accessed as a slug url', function(done) {
+            it('will NOT render a normal post with the wrong date', function (done) {
+                var date = moment().subtract('days', 1).format('YYYY/MM/DD/'),
+                    req = {
+                        params: [date, 'test-normal-post']
+                    },
+                    res = {
+                        render: sinon.spy()
+                    };
+
+                frontend.single(req, res, function () {
+                    res.render.called.should.be.false;
+                    done();
+                });
+            });
+
+            it('will NOT render a normal post accessed as a slug url', function (done) {
                 var req = {
-                    params: ['', 'test-normal-post']
-                };
+                        params: [undefined, 'test-normal-post']
+                    },
+                    res = {
+                        render: sinon.spy()
+                    };
 
-                var res = {
-                    render: sinon.spy()
-                };
-
-                frontend.single(req, res, function() {
+                frontend.single(req, res, function () {
                     res.render.called.should.be.false;
                     done();
                 });
             });
         });
-
-
     });
 });


### PR DESCRIPTION
fixes #1803
- switches date permalinks from created_at to published_at
- enforces that the post will ONLY render if the date is valid and correct
