### PR TITLE
Move config path.update to config.load

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -21,9 +21,13 @@ function loadConfig() {
     return loader().then(function (config) {
         // Cache the config.js object's environment
         // object so we can later refer to it.
-        // Note: this is not the entirity of config.js,
+        // Note: this is not the entirety of config.js,
         // just the object appropriate for this NODE_ENV
         ghostConfig = config;
+
+        // can't load theme settings yet as we don't have the API,
+        // but we can load the paths
+        return paths.update(config.url);
     });
 }
 

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -87,12 +87,9 @@ function setup(server) {
     Polyglot.instance = new Polyglot();
 
     // ### Initialisation
-    when.join(
-        // Initialise the models
-        models.init(),
-        // Calculate paths
-        config.paths.update(config().url)
-    ).then(function () {
+
+    // Initialise the models
+    models.init().then(function () {
         // Populate any missing default settings
         return models.Settings.populateDefaults();
     }).then(function () {


### PR DESCRIPTION
issue #1789
- we can do this step a bit earlier and it aids with neatness
- also means for tests that config.load() is enough to get config & paths initialised
