### PR TITLE
Fixes admin session cookie test

### DIFF
--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -64,7 +64,7 @@ describe('Admin Routing', function () {
 
                     var expires;
                     // Session should expire 12 hours after the time in the date header
-                    expires = moment(res.headers.date).add('Hours', 12).format("ddd, DD MMM YYYY HH:mm");
+                    expires = moment.utc(res.headers.date).add('Hours', 12).format("ddd, DD MMM YYYY HH:mm");
                     expires = new RegExp("Expires=" + expires);
 
                     res.headers['set-cookie'].should.match(expires);


### PR DESCRIPTION
- Currently the test is taking the response date
  which is in UTC and passes it through moment()
  which by default parses input as local time.  We
  then add 12 hours to this now local time
  and when compared against the response set-cookie
  header the time spread is wrong.
- To fix we’re parsing the response date with
  moment.utc which parses the date in UTC.
