### PR TITLE
New URL helper - URL consistency fixes

### DIFF
--- a/core/client/helpers/index.js
+++ b/core/client/helpers/index.js
@@ -29,8 +29,8 @@
         return date;
     });
 
-    Handlebars.registerHelper('url', function () {
-        return Ghost.paths.subdir;
+    Handlebars.registerHelper('adminUrl', function () {
+        return Ghost.paths.subdir + '/ghost';
     });
 
     Handlebars.registerHelper('asset', function (context, options) {

--- a/core/client/tpl/login.hbs
+++ b/core/client/tpl/login.hbs
@@ -7,6 +7,6 @@
     </div>
     <button class="button-save" type="submit">Log in</button>
     <section class="meta">
-        <a class="forgotten-password" href="{{url}}/ghost/forgotten/">Forgotten password?</a>
+        <a class="forgotten-password" href="{{adminUrl}}/forgotten/">Forgotten password?</a>
     </section>
 </form>

--- a/core/client/tpl/preview.hbs
+++ b/core/client/tpl/preview.hbs
@@ -53,7 +53,7 @@
     <div class="no-posts-box">
         <div class="no-posts">
             <h3>You Haven't Written Any Posts Yet!</h3>
-            <form action="{{url}}/ghost/editor/"><button class="button-add large" title="New Post">Write a new Post</button></form>
+            <form action="{{adminUrl}}/editor/"><button class="button-add large" title="New Post">Write a new Post</button></form>
         </div>
     </div>
 {{/unless}}

--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -6,7 +6,7 @@ var dataExport       = require('../data/export'),
     when             = require('when'),
     nodefn           = require('when/node/function'),
     _                = require('underscore'),
-    schema           = require('../data/schema'),
+    schema           = require('../data/schema').tables,
     configPaths      = require('../config/paths'),
     api              = {},
 

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -106,9 +106,7 @@ posts = {
         return canThis(this.user).remove.post(args.id).then(function () {
             return when(posts.read({id : args.id, status: 'all'})).then(function (result) {
                 return dataProvider.Post.destroy(args.id).then(function () {
-                    var deletedObj = {};
-                    deletedObj.id = result.id;
-                    deletedObj.slug = result.slug;
+                    var deletedObj = result;
                     return deletedObj;
                 });
             });

--- a/core/server/config/paths.js
+++ b/core/server/config/paths.js
@@ -1,9 +1,11 @@
 // Contains all path information to be used throughout
 // the codebase.
 
-var path              = require('path'),
+var moment            = require('moment'),
+    path              = require('path'),
     when              = require('when'),
     url               = require('url'),
+    _                 = require('underscore'),
     requireTree       = require('../require-tree'),
     appRoot           = path.resolve(__dirname, '../../../'),
     corePath          = path.resolve(appRoot, 'core/'),
@@ -13,8 +15,9 @@ var path              = require('path'),
     themeDirectories  = requireTree(themePath),
     pluginDirectories = requireTree(pluginPath),
     localPath = '',
-    availableThemes,
+    configUrl = '',
 
+    availableThemes,
     availablePlugins;
 
 
@@ -45,6 +48,7 @@ function paths() {
 // TODO: remove configURL and give direct access to config object?
 // TODO: not called when executing tests
 function update(configURL) {
+    configUrl = configURL;
     localPath = url.parse(configURL).path;
 
     // Remove trailing slash
@@ -59,5 +63,129 @@ function update(configURL) {
     });
 }
 
+// ## createUrl
+// Simple url creation from a given path
+// Ensures that our urls contain the subdirectory if there is one
+// And are correctly formatted as either relative or absolute
+// Usage:
+// createUrl('/', true) -> http://my-ghost-blog.com/
+// E.g. /blog/ subdir
+// createUrl('/welcome-to-ghost/') -> /blog/welcome-to-ghost/
+// Parameters:
+// - urlPath - string which must start and end with a slash
+// - absolute (optional, default:false) - boolean whether or not the url should be absolute
+// Returns:
+//  - a URL which always ends with a slash
+function createUrl(urlPath, absolute) {
+    urlPath = urlPath || '/';
+    absolute = absolute || false;
+
+    var output = '';
+
+    // create base of url, always ends without a slash
+    if (absolute) {
+        output += configUrl.replace(/\/$/, '');
+    } else {
+        output += paths().subdir;
+    }
+
+    // append the path, always starts and ends with a slash
+    output += urlPath;
+
+    return output;
+}
+
+// ## urlPathForPost
+// Always sync
+// Creates the url path for a post, given a post and a permalink
+// Parameters:
+// - post - a json object representing a post
+// - permalinks - a json object containing the permalinks setting
+function urlPathForPost(post, permalinks) {
+    var output = '',
+        tags = {
+            year:   function () { return moment(post.published_at).format('YYYY'); },
+            month:  function () { return moment(post.published_at).format('MM'); },
+            day:    function () { return moment(post.published_at).format('DD'); },
+            slug: function () { return post.slug; },
+            id: function () { return post.id; }
+        };
+
+    if (post.page === 1) {
+        output += '/:slug/';
+    } else {
+        output += permalinks.value;
+    }
+
+    // replace tags like :slug or :year with actual values
+    output = output.replace(/(:[a-z]+)/g, function (match) {
+        if (_.has(tags, match.substr(1))) {
+            return tags[match.substr(1)]();
+        }
+    });
+
+    return output;
+}
+
+// ## urlFor
+// Synchronous url creation for a given context
+// Can generate a url for a named path, given path, or known object (post)
+// Determines what sort of context it has been given, and delegates to the correct generation method,
+// Finally passing to createUrl, to ensure any subdirectory is honoured, and the url is absolute if needed
+// Usage:
+// urlFor('home', true) -> http://my-ghost-blog.com/
+// E.g. /blog/ subdir
+// urlFor({relativeUrl: '/my-static-page/') -> /blog/my-static-page/
+// E.g. if post object represents welcome post, and slugs are set to standard
+// urlFor('post', {...}) -> /welcome-to-ghost/
+// E.g. if post object represents welcome post, and slugs are set to date
+// urlFor('post', {...}) -> /2014/01/01/welcome-to-ghost/
+// Parameters:
+// - context - a string, or json object describing the context for which you need a url
+// - data (optional) - a json object containing data needed to generate a url
+// - absolute (optional, default:false) - boolean whether or not the url should be absolute
+// This is probably not the right place for this, but it's the best place for now
+function urlFor(context, data, absolute) {
+    var urlPath = '/',
+        knownObjects = ['post', 'tag', 'user'],
+        knownPaths = {'home': '/', 'rss': '/rss/'}; // this will become really big
+
+    // Make data properly optional
+    if (_.isBoolean(data)) {
+        absolute = data;
+        data = null;
+    }
+
+    if (_.isObject(context) && context.relativeUrl) {
+        urlPath = context.relativeUrl;
+    } else if (_.isString(context) && _.indexOf(knownObjects, context) !== -1) {
+        // trying to create a url for an object
+        if (context === 'post' && data.post && data.permalinks) {
+            urlPath = urlPathForPost(data.post, data.permalinks);
+        }
+        // other objects are recognised but not yet supported
+    } else if (_.isString(context) && _.indexOf(_.keys(knownPaths), context) !== -1) {
+        // trying to create a url for a named path
+        urlPath = knownPaths[context] || '/';
+    }
+
+    return createUrl(urlPath, absolute);
+}
+
+// ## urlForPost
+// This method is async as we have to fetch the permalinks
+// Get the permalink setting and then get a URL for the given post
+// Parameters
+// - settings - passed reference to api.settings
+// - post - a json object representing a post
+// - absolute (optional, default:false) - boolean whether or not the url should be absolute
+function urlForPost(settings, post, absolute) {
+    return settings.read('permalinks').then(function (permalinks) {
+        return urlFor('post', {post: post, permalinks: permalinks}, absolute);
+    });
+}
+
 module.exports = paths;
 module.exports.update = update;
+module.exports.urlFor = urlFor;
+module.exports.urlForPost = urlForPost;

--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -2,7 +2,7 @@ var when      = require('when'),
     _         = require('underscore'),
     migration = require('../migration'),
     knex      = require('../../models/base').knex,
-    schema    = require('../schema'),
+    schema    = require('../schema').tables,
 
     excludedTables = ['sessions'],
     exporter;

--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -8,7 +8,7 @@ var _               = require('underscore'),
     defaultSettings = require('../default-settings'),
     Settings        = require('../../models/settings').Settings,
     fixtures        = require('../fixtures'),
-    schema          = require('../schema'),
+    schema          = require('../schema').tables,
 
     initialVersion  = '000',
     schemaTables    = _.keys(schema),

--- a/core/server/data/schema.js
+++ b/core/server/data/schema.js
@@ -118,4 +118,12 @@ var db = {
         }
     };
 
-module.exports = db;
+function isPost(jsonData) {
+    return jsonData.hasOwnProperty('html') && jsonData.hasOwnProperty('markdown')
+        && jsonData.hasOwnProperty('title') && jsonData.hasOwnProperty('slug');
+}
+
+module.exports.tables = db;
+module.exports.checks = {
+    isPost: isPost
+};

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -33,9 +33,8 @@ function ghostLocals(req, res, next) {
     // Make sure we have a locals value.
     res.locals = res.locals || {};
     res.locals.version = packageInfo.version;
-    res.locals.path = req.path;
-    // Strip off the subdir part of the path
-    res.locals.ghostRoot = req.path.replace(config.paths().subdir, '');
+    // relative path from the URL, not including subdir
+    res.locals.relativeUrl = req.path.replace(config.paths().subdir, '');
 
     if (res.isAdmin) {
         res.locals.csrfToken = req.csrfToken();

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -35,9 +35,5 @@ module.exports = {
                 });
             });
         });
-    },
-    isPost: function (jsonData) {
-        return jsonData.hasOwnProperty('html') && jsonData.hasOwnProperty('markdown')
-            && jsonData.hasOwnProperty('title') && jsonData.hasOwnProperty('slug');
     }
 };

--- a/core/server/views/content.hbs
+++ b/core/server/views/content.hbs
@@ -5,7 +5,7 @@
           <section class="content-filter">
               <small>All Posts</small>
           </section>
-          <a href="{{url}}/ghost/editor/" class="button button-add" title="New Post"><span class="hidden">New Post</span></a>
+          <a href="{{adminUrl}}/editor/" class="button button-add" title="New Post"><span class="hidden">New Post</span></a>
       </header>
       <section class="content-list-content">
           <ol></ol>

--- a/core/server/views/debug.hbs
+++ b/core/server/views/debug.hbs
@@ -20,12 +20,12 @@
                 <fieldset>
                     <div class="form-group">
                         <label>Export</label>
-                        <a href="{{url}}/ghost/api/v0.1/db/" class="button-save">Export</a>
+                        <a href="{{adminUrl}}/api/v0.1/db/" class="button-save">Export</a>
                         <p>Export the blog settings and data.</p>
                     </div>
                 </fieldset>
             </form>
-            <form id="settings-import" method="post" action="{{url}}/ghost/api/v0.1/db/" enctype="multipart/form-data">
+            <form id="settings-import" method="post" action="{{adminUrl}}/api/v0.1/db/" enctype="multipart/form-data">
                 <input type="hidden" name="_csrf" value="{{csrfToken}}" />
                 <fieldset>
                     <div class="form-group">

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -1,9 +1,11 @@
 <header id="global-header" class="navbar">
-    <a class="ghost-logo" href="{{url absolute="true"}}" data-off-canvas="left" title="{{url absolute="true"}}"><span class="hidden">Ghost </span></a>{{! TODO: Change this to actual Ghost homepage }}
+    <a class="ghost-logo" href="{{adminUrl absolute="true" frontend="true"}}" data-off-canvas="left" title="{{adminUrl absolute="true" frontend="true"}}">
+        <span class="hidden">Ghost </span>
+    </a>
     <nav id="global-nav" role="navigation">
         <ul id="main-menu" >
             {{#each adminNav}}
-                <li class="{{navClass}}{{#if selected}} active{{/if}}"><a href="{{url}}/ghost{{path}}">{{name}}</a></li>
+                <li class="{{navClass}}{{#if selected}} active{{/if}}"><a href="{{adminUrl}}{{path}}">{{name}}</a></li>
             {{/each}}
 
             <li id="usermenu" class="subnav">
@@ -12,11 +14,11 @@
                     <span class="name">{{#if currentUser.name}}{{currentUser.name}}{{else}}{{currentUser.email}}{{/if}}</span>
                 </a>
                 <ul class="overlay">
-                    <li class="usermenu-profile"><a href="{{url}}/ghost/settings/user/">Your Profile</a></li>
+                    <li class="usermenu-profile"><a href="{{adminUrl}}/settings/user/">Your Profile</a></li>
                     <li class="divider"></li>
                     <li class="usermenu-help"><a href="http://ghost.org/forum/">Help / Support</a></li>
                     <li class="divider"></li>
-                    <li class="usermenu-signout"><a href="{{url}}/ghost/signout/">Sign Out</a></li>
+                    <li class="usermenu-signout"><a href="{{adminUrl}}/signout/">Sign Out</a></li>
                 </ul>
             </li>
         </ul>

--- a/core/test/functional/api/posts_test.js
+++ b/core/test/functional/api/posts_test.js
@@ -1,10 +1,10 @@
-/*globals describe, before, beforeEach, afterEach, it */
+/*globals describe, before, after, beforeEach, afterEach, it */
 var testUtils = require('../../utils'),
     should = require('should'),
     _ = require('underscore'),
     request = require('request');
 
-request = request.defaults({jar:true});
+request = request.defaults({jar: true});
 
 describe('Post API', function () {
 
@@ -41,283 +41,374 @@ describe('Post API', function () {
     });
 
     // ## Browse
+    describe('Browse', function () {
 
-    it('retrieves all published posts only by default', function (done) {
-        request.get(testUtils.API.getApiURL('posts/'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.posts.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'posts');
-            jsonResponse.posts.should.have.length(5);
-            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-            done();
+        it('retrieves all published posts only by default', function (done) {
+            request.get(testUtils.API.getApiURL('posts/'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.posts.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(5);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                done();
+            });
         });
-    });
 
-    it('can retrieve all published posts and pages', function (done) {
-        request.get(testUtils.API.getApiURL('posts/?staticPages=all'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.posts.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'posts');
-            jsonResponse.posts.should.have.length(6);
-            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-            done();
+        it('can retrieve all published posts and pages', function (done) {
+            request.get(testUtils.API.getApiURL('posts/?staticPages=all'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.posts.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(6);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                done();
+            });
         });
-    });
 
-    // Test bits of the API we don't use in the app yet to ensure the API behaves properly
+        // Test bits of the API we don't use in the app yet to ensure the API behaves properly
 
-    it('can retrieve all status posts and pages', function (done) {
-        request.get(testUtils.API.getApiURL('posts/?staticPages=all&status=all'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.posts.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'posts');
-            jsonResponse.posts.should.have.length(8);
-            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-            done();
+        it('can retrieve all status posts and pages', function (done) {
+            request.get(testUtils.API.getApiURL('posts/?staticPages=all&status=all'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.posts.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(8);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                done();
+            });
         });
-    });
 
-    it('can retrieve just published pages', function (done) {
-        request.get(testUtils.API.getApiURL('posts/?staticPages=true'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.posts.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'posts');
-            jsonResponse.posts.should.have.length(1);
-            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-            done();
+        it('can retrieve just published pages', function (done) {
+            request.get(testUtils.API.getApiURL('posts/?staticPages=true'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.posts.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(1);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                done();
+            });
         });
-    });
 
-    it('can retrieve just draft posts', function (done) {
-        request.get(testUtils.API.getApiURL('posts/?status=draft'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.posts.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'posts');
-            jsonResponse.posts.should.have.length(1);
-            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-            done();
+        it('can retrieve just draft posts', function (done) {
+            request.get(testUtils.API.getApiURL('posts/?status=draft'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.posts.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'posts');
+                jsonResponse.posts.should.have.length(1);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                done();
+            });
         });
     });
 
     // ## Read
-
-    it('can retrieve a post', function (done) {
-        request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'post');
-            jsonResponse.page.should.eql(0);
-            done();
-        });
-    });
-
-    it('can retrieve a static page', function (done) {
-        request.get(testUtils.API.getApiURL('posts/7/'), function (error, response, body) {
-            response.should.have.status(200);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponse(jsonResponse, 'post');
-            jsonResponse.page.should.eql(1);
-            done();
-        });
-    });
-
-    it('can\'t retrieve non existent post', function (done) {
-        request.get(testUtils.API.getApiURL('posts/99/'), function (error, response, body) {
-            response.should.have.status(404);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponseValue(jsonResponse, ['error']);
-            done();
-        });
-    });
-
-    it('can\'t retrieve a draft post', function (done) {
-        request.get(testUtils.API.getApiURL('posts/5/'), function (error, response, body) {
-            response.should.have.status(404);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponseValue(jsonResponse, ['error']);
-            done();
-        });
-    });
-
-    it('can\'t retrieve a draft page', function (done) {
-        request.get(testUtils.API.getApiURL('posts/8/'), function (error, response, body) {
-            response.should.have.status(404);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponseValue(jsonResponse, ['error']);
-            done();
-        });
-    });
-
-    // ## Add
-
-    it('can create a new draft, publish post, update post', function (done) {
-        var newTitle = 'My Post',
-            changedTitle = 'My Post changed',
-            publishedState = 'published',
-            newPost = {status: 'draft', title: newTitle, markdown: 'my post'};
-
-        request.post({uri: testUtils.API.getApiURL('posts/'),
-            headers: {'X-CSRF-Token': csrfToken},
-            json: newPost}, function (error, response, draftPost) {
-            response.should.have.status(200);
-            //TODO: do drafts really need a x-cache-invalidate header
-            response.should.be.json;
-            draftPost.should.exist;
-            draftPost.title.should.eql(newTitle);
-            draftPost.status = publishedState;
-            testUtils.API.checkResponse(draftPost, 'post');
-            request.put({uri: testUtils.API.getApiURL('posts/' + draftPost.id + '/'),
-                headers: {'X-CSRF-Token': csrfToken},
-                json: draftPost}, function (error, response, publishedPost) {
+    describe('Read', function () {
+        it('can retrieve a post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
                 response.should.have.status(200);
-                response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + publishedPost.slug + '/');
+                should.not.exist(response.headers['x-cache-invalidate']);
                 response.should.be.json;
-                publishedPost.should.exist;
-                publishedPost.title.should.eql(newTitle);
-                publishedPost.status.should.eql(publishedState);
-                testUtils.API.checkResponse(publishedPost, 'post');
-                request.put({uri: testUtils.API.getApiURL('posts/' + publishedPost.id + '/'),
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'post');
+                jsonResponse.page.should.eql(0);
+                done();
+            });
+        });
+
+        it('can retrieve a static page', function (done) {
+            request.get(testUtils.API.getApiURL('posts/7/'), function (error, response, body) {
+                response.should.have.status(200);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponse(jsonResponse, 'post');
+                jsonResponse.page.should.eql(1);
+                done();
+            });
+        });
+
+        it('can\'t retrieve non existent post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/99/'), function (error, response, body) {
+                response.should.have.status(404);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponseValue(jsonResponse, ['error']);
+                done();
+            });
+        });
+
+        it('can\'t retrieve a draft post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/5/'), function (error, response, body) {
+                response.should.have.status(404);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponseValue(jsonResponse, ['error']);
+                done();
+            });
+        });
+
+        it('can\'t retrieve a draft page', function (done) {
+            request.get(testUtils.API.getApiURL('posts/8/'), function (error, response, body) {
+                response.should.have.status(404);
+                should.not.exist(response.headers['x-cache-invalidate']);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponseValue(jsonResponse, ['error']);
+                done();
+            });
+        });
+
+    });
+    // ## Add
+    describe('Add', function () {
+        it('can create a new draft, publish post, update post', function (done) {
+            var newTitle = 'My Post',
+                changedTitle = 'My Post changed',
+                publishedState = 'published',
+                newPost = {status: 'draft', title: newTitle, markdown: 'my post'};
+
+            request.post({uri: testUtils.API.getApiURL('posts/'),
+                headers: {'X-CSRF-Token': csrfToken},
+                json: newPost}, function (error, response, draftPost) {
+                response.should.have.status(200);
+                //TODO: do drafts really need a x-cache-invalidate header
+                response.should.be.json;
+                draftPost.should.exist;
+                draftPost.title.should.eql(newTitle);
+                draftPost.status = publishedState;
+                testUtils.API.checkResponse(draftPost, 'post');
+                request.put({uri: testUtils.API.getApiURL('posts/' + draftPost.id + '/'),
                     headers: {'X-CSRF-Token': csrfToken},
-                    json: publishedPost}, function (error, response, updatedPost) {
+                    json: draftPost}, function (error, response, publishedPost) {
                     response.should.have.status(200);
-                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + updatedPost.slug + '/');
+                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + publishedPost.slug + '/');
                     response.should.be.json;
-                    updatedPost.should.exist;
-                    updatedPost.title.should.eql(newTitle);
-                    testUtils.API.checkResponse(updatedPost, 'post');
-                    done();
+                    publishedPost.should.exist;
+                    publishedPost.title.should.eql(newTitle);
+                    publishedPost.status.should.eql(publishedState);
+                    testUtils.API.checkResponse(publishedPost, 'post');
+                    request.put({uri: testUtils.API.getApiURL('posts/' + publishedPost.id + '/'),
+                        headers: {'X-CSRF-Token': csrfToken},
+                        json: publishedPost}, function (error, response, updatedPost) {
+                        response.should.have.status(200);
+                        response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + updatedPost.slug + '/');
+                        response.should.be.json;
+                        updatedPost.should.exist;
+                        updatedPost.title.should.eql(newTitle);
+                        testUtils.API.checkResponse(updatedPost, 'post');
+                        done();
+                    });
                 });
             });
         });
     });
 
     // ## edit
+    describe('Edit', function () {
+        it('can edit a post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
+                var jsonResponse = JSON.parse(body),
+                    changedValue = 'My new Title';
+                jsonResponse.should.exist;
+                jsonResponse.title = changedValue;
 
-    it('can edit a post', function (done) {
-        request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
-            var jsonResponse = JSON.parse(body),
-                changedValue = 'My new Title';
-            jsonResponse.should.exist;
-            jsonResponse.title = changedValue;
+                request.put({uri: testUtils.API.getApiURL('posts/1/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse}, function (error, response, putBody) {
+                    response.should.have.status(200);
+                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + putBody.slug + '/');
+                    response.should.be.json;
+                    putBody.should.exist;
+                    putBody.title.should.eql(changedValue);
 
-            request.put({uri: testUtils.API.getApiURL('posts/1/'),
-                headers: {'X-CSRF-Token': csrfToken},
-                json: jsonResponse}, function (error, response, putBody) {
-                response.should.have.status(200);
-                response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + putBody.slug + '/');
-                response.should.be.json;
-                putBody.should.exist;
-                putBody.title.should.eql(changedValue);
-
-                testUtils.API.checkResponse(putBody, 'post');
-                done();
+                    testUtils.API.checkResponse(putBody, 'post');
+                    done();
+                });
             });
         });
     });
 
     // ## delete
+    describe('Delete', function () {
+        it('can\'t edit non existent post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
+                var jsonResponse = JSON.parse(body),
+                    changedValue = 'My new Title';
+                jsonResponse.title.exist;
+                jsonResponse.testvalue = changedValue;
+                jsonResponse.id = 99;
+                request.put({uri: testUtils.API.getApiURL('posts/99/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse}, function (error, response, putBody) {
+                    response.should.have.status(404);
+                    should.not.exist(response.headers['x-cache-invalidate']);
+                    response.should.be.json;
+                    testUtils.API.checkResponseValue(putBody, ['error']);
+                    done();
+                });
+            });
+        });
 
-    it('can\'t edit non existent post', function (done) {
-        request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
-            var jsonResponse = JSON.parse(body),
-                changedValue = 'My new Title';
-            jsonResponse.title.exist;
-            jsonResponse.testvalue = changedValue;
-            jsonResponse.id = 99;
-            request.put({uri: testUtils.API.getApiURL('posts/99/'),
-                headers: {'X-CSRF-Token': csrfToken},
-                json: jsonResponse}, function (error, response, putBody) {
+        it('can delete a post', function (done) {
+            var deletePostId = 1;
+            request.del({uri: testUtils.API.getApiURL('posts/' + deletePostId + '/'),
+                headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
+                response.should.have.status(200);
+                response.should.be.json;
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + jsonResponse.slug + '/');
+                testUtils.API.checkResponse(jsonResponse, 'post');
+                jsonResponse.id.should.eql(deletePostId);
+                done();
+            });
+        });
+
+        it('can\'t delete a non existent post', function (done) {
+            request.del({uri: testUtils.API.getApiURL('posts/99/'),
+                headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
                 response.should.have.status(404);
                 should.not.exist(response.headers['x-cache-invalidate']);
                 response.should.be.json;
-                testUtils.API.checkResponseValue(putBody, ['error']);
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.should.exist;
+                testUtils.API.checkResponseValue(jsonResponse, ['error']);
                 done();
+            });
+        });
+
+        it('can delete a new draft', function (done) {
+            var newTitle = 'My Post',
+                publishedState = 'draft',
+                newPost = {status: publishedState, title: newTitle, markdown: 'my post'};
+
+            request.post({uri: testUtils.API.getApiURL('posts/'),
+                headers: {'X-CSRF-Token': csrfToken},
+                json: newPost}, function (error, response, draftPost) {
+                response.should.have.status(200);
+                //TODO: do drafts really need a x-cache-invalidate header
+                response.should.be.json;
+                draftPost.should.exist;
+                draftPost.title.should.eql(newTitle);
+                draftPost.status = publishedState;
+                testUtils.API.checkResponse(draftPost, 'post');
+                request.del({uri: testUtils.API.getApiURL('posts/' + draftPost.id + '/'),
+                    headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
+                    response.should.have.status(200);
+                    //TODO: do drafts really need a x-cache-invalidate header
+                    response.should.be.json;
+                    var jsonResponse = JSON.parse(body);
+                    jsonResponse.should.exist;
+                    testUtils.API.checkResponse(jsonResponse, 'post');
+                    done();
+                });
             });
         });
     });
 
-    it('can delete a post', function (done) {
-        var deletePostId = 1;
-        request.del({uri: testUtils.API.getApiURL('posts/' + deletePostId + '/'),
-            headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
-            response.should.have.status(200);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + jsonResponse.slug + '/');
-            testUtils.API.checkResponseValue(jsonResponse, ['id', 'slug']);
-            jsonResponse.id.should.eql(deletePostId);
-            done();
+    describe('Dated Permalinks', function () {
+        before(function (done) {
+            request.get(testUtils.API.getApiURL('settings'), function (error, response, body) {
+                if (error) { done(error); }
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.permalinks = '/:year/:month/:day/:slug/';
+
+                request.put({
+                    uri: testUtils.API.getApiURL('settings/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse
+                }, function (error, response, putBody) {
+                    if (error) { done(error); }
+                    done();
+                });
+            });
         });
-    });
 
-    it('can\'t delete a non existent post', function (done) {
-        request.del({uri: testUtils.API.getApiURL('posts/99/'),
-            headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
-            response.should.have.status(404);
-            should.not.exist(response.headers['x-cache-invalidate']);
-            response.should.be.json;
-            var jsonResponse = JSON.parse(body);
-            jsonResponse.should.exist;
-            testUtils.API.checkResponseValue(jsonResponse, ['error']);
-            done();
+        after(function (done) {
+            request.get(testUtils.API.getApiURL('settings'), function (error, response, body) {
+                if (error) { done(error); }
+                var jsonResponse = JSON.parse(body);
+                jsonResponse.permalinks = '/:slug/';
+
+                request.put({
+                    uri: testUtils.API.getApiURL('settings/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse
+                }, function (error, response, putBody) {
+                    if (error) { done(error); }
+                    done();
+                });
+            });
         });
-    });
 
-    it('can delete a new draft', function (done) {
-        var newTitle = 'My Post',
-            publishedState = 'draft',
-            newPost = {status: publishedState, title: newTitle, markdown: 'my post'};
-
-        request.post({uri: testUtils.API.getApiURL('posts/'),
-            headers: {'X-CSRF-Token': csrfToken},
-            json: newPost}, function (error, response, draftPost) {
-            response.should.have.status(200);
-            //TODO: do drafts really need a x-cache-invalidate header
-            response.should.be.json;
-            draftPost.should.exist;
-            draftPost.title.should.eql(newTitle);
-            draftPost.status = publishedState;
-            testUtils.API.checkResponse(draftPost, 'post');
-            request.del({uri: testUtils.API.getApiURL('posts/' + draftPost.id + '/'),
-                headers: {'X-CSRF-Token': csrfToken}}, function (error, response, body) {
+        it('Can read a post', function (done) {
+            // nothing should have changed here
+            request.get(testUtils.API.getApiURL('posts/2/'), function (error, response, body) {
+                if (error) { done(error); }
                 response.should.have.status(200);
-                //TODO: do drafts really need a x-cache-invalidate header
+                should.not.exist(response.headers['x-cache-invalidate']);
                 response.should.be.json;
+
                 var jsonResponse = JSON.parse(body);
                 jsonResponse.should.exist;
-                testUtils.API.checkResponseValue(jsonResponse, ['id', 'slug']);
+                testUtils.API.checkResponse(jsonResponse, 'post');
+                jsonResponse.slug.should.not.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}/);
+                jsonResponse.page.should.eql(0);
                 done();
+            });
+        });
+
+        it('Can edit a post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/2/'), function (error, response, body) {
+                if (error) { done(error); }
+                var jsonResponse = JSON.parse(body),
+                    changedValue = 'My new Title';
+                jsonResponse.should.exist;
+                jsonResponse.title = changedValue;
+
+                request.put({
+                    uri: testUtils.API.getApiURL('posts/2/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse
+                }, function (error, response, putBody) {
+                    if (error) { done(error); }
+                    var today = new Date(),
+                        dd = ("0" + today.getDate()).slice(-2),
+                        mm = ("0" + (today.getMonth() + 1)).slice(-2),
+                        yyyy = today.getFullYear(),
+                        postLink = '/' + yyyy + '/' + mm + '/' + dd + '/' + putBody.slug + '/';
+
+                    response.should.have.status(200);
+                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, ' + postLink);
+                    response.should.be.json;
+                    putBody.should.exist;
+                    putBody.title.should.eql(changedValue);
+
+                    testUtils.API.checkResponse(putBody, 'post');
+                    done();
+                });
             });
         });
     });

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -3,11 +3,12 @@
  */
 /*globals url, CasperTest, casper */
 CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run('off');
     casper.thenOpen(url + 'rss/', function (response) {
         var content = this.getPageContent(),
             siteTitle = '<title><![CDATA[Ghost]]></title>',
             siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
-            siteUrl = '<link>http://127.0.0.1:2369</link>',
+            siteUrl = '<link>http://127.0.0.1:2369/</link>',
             postTitle = '<![CDATA[Welcome to Ghost]]>',
             postStart = '<description><![CDATA[<p>You\'re live!',
             postEnd = 'you think :)</p>]]></description>',
@@ -41,4 +42,5 @@ CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(te
         test.assertEqual(response.status, 200, 'Response status should be 200.');
         test.assert(content.indexOf(postLink) >= 0, 'Feed should have dated permalink.');
     });
+    CasperTest.Routines.togglePermalinks.run('off');
 }, false);

--- a/core/test/functional/frontend/home_test.js
+++ b/core/test/functional/frontend/home_test.js
@@ -20,3 +20,59 @@ CasperTest.begin('Test helpers on homepage', 3, function suite(test) {
         test.assertExists('article.tag-getting-started', 'post_class outputs correct tag class');
     });
 }, true);
+
+CasperTest.begin('Test navigating to Post', 4, function suite(test) {
+    casper.thenOpen(url, function then(response) {
+        var lastPost = '.content article:last-of-type',
+            lastPostLink = lastPost + ' .post-title a';
+
+        test.assertExists(lastPost, 'there is a last child on the page');
+        test.assertSelectorHasText(lastPostLink, 'Welcome to Ghost', 'Is correct post');
+
+        casper.then(function testLink() {
+            var link = this.evaluate(function (lastPostLink) {
+                return document.querySelector(lastPostLink).getAttribute('href');
+            }, lastPostLink);
+
+            test.assert(link === '/welcome-to-ghost/', 'Has correct link');
+        });
+
+        casper.thenClick(lastPostLink);
+
+        casper.waitForResource(/welcome-to-ghost/).then(function (resource) {
+            test.assert(resource.status === 200, 'resource got 200');
+        });
+    });
+}, true);
+
+CasperTest.begin('Test navigating to Post with date permalink', 4, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run('on');
+    casper.thenOpen(url, function then(response) {
+        var lastPost = '.content article:last-of-type',
+            lastPostLink = lastPost + ' .post-title a',
+            today = new Date(),
+            dd = ("0" + today.getDate()).slice(-2),
+            mm = ("0" + (today.getMonth() + 1)).slice(-2),
+            yyyy = today.getFullYear(),
+            postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
+
+        test.assertExists(lastPost, 'there is a last child on the page');
+        test.assertSelectorHasText(lastPostLink, 'Welcome to Ghost', 'Is correct post');
+
+        casper.then(function testLink() {
+            var link = this.evaluate(function (lastPostLink) {
+                return document.querySelector(lastPostLink).getAttribute('href');
+            }, lastPostLink);
+
+            test.assert(link === postLink, 'Has correct link');
+        });
+
+        casper.thenClick(lastPostLink);
+
+        casper.waitForResource(postLink).then(function (resource) {
+            test.assert(resource.status === 200, 'resource got 200');
+        });
+    });
+    CasperTest.Routines.togglePermalinks.run('off');
+}, false);
+

--- a/core/test/functional/frontend/post_test.js
+++ b/core/test/functional/frontend/post_test.js
@@ -6,20 +6,21 @@
 
 // Tests when permalinks is set to date
 CasperTest.begin('Post page does not load as slug', 2, function suite(test) {
-    casper.start(url + 'welcome-to-ghost', function then(response) {
+    CasperTest.Routines.togglePermalinks.run('on');
+    casper.thenOpen(url + 'welcome-to-ghost', function then(response) {
         test.assertTitle('404 — Page Not Found', 'The post should return 404 page');
         test.assertElementCount('.content .post', 0, 'There is no post on this page');
     });
-}, true);
+    CasperTest.Routines.togglePermalinks.run('off');
+}, false);
 
 CasperTest.begin('Post page loads', 3, function suite(test) {
-    CasperTest.Routines.togglePermalinks.run('off');
     casper.thenOpen(url + 'welcome-to-ghost', function then(response) {
         test.assertTitle('Welcome to Ghost', 'The post should have a title and it should be "Welcome to Ghost"');
         test.assertElementCount('.content .post', 1, 'There is exactly one post on this page');
         test.assertSelectorHasText('.poweredby', 'Proudly published with Ghost');
     });
-}, false);
+}, true);
 
 CasperTest.begin('Test helpers on welcome post', 4, function suite(test) {
     casper.start(url + 'welcome-to-ghost', function then(response) {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -289,7 +289,6 @@ describe('Frontend Routing', function () {
 //            // get today's date
 //            var date  = moment().format("YYYY/MM/DD");
 //
-//            console.log('date', date);
 //
 //            request.get('/' + date + '/welcome-to-ghost/')
 //                .expect(200)

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -26,8 +26,106 @@ describe('Frontend Controller', function () {
     });
 
 
-    describe('homepage', function () {
-        // No tests yet, shows up in coverage report
+    describe('homepage redirects', function () {
+        var res;
+
+        beforeEach(function () {
+            res = {
+                redirect: sandbox.spy(),
+                render: sandbox.spy()
+            };
+
+            sandbox.stub(api.posts, 'browse', function () {
+                return when({posts: {}, pages: 3});
+            });
+
+            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            apiSettingsStub.withArgs('postsPerPage').returns(when({
+                'key': 'postsPerPage',
+                'value': 6
+            }));
+        });
+
+        it('Redirects to home if page number is 0', function () {
+            var req = {params: {page: -1}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to home if page number is 0', function () {
+            var req = {params: {page: 0}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to home if page number is 1', function () {
+            var req = {params: {page: 1}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to home if page number is 0 with subdirectory', function () {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 0}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to home if page number is 1 with subdirectory', function () {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 1}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to last page if page number too big', function (done) {
+            var req = {params: {page: 4}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, done).then(function () {
+                res.redirect.called.should.be.true;
+                res.redirect.calledWith('/page/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+        });
+
+        it('Redirects to last page if page number too big with subdirectory', function (done) {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 4}, route: {path: '/page/:page/'}};
+
+            frontend.homepage(req, res, done).then(function () {
+                res.redirect.calledOnce.should.be.true;
+                res.redirect.calledWith('/blog/page/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+
+        });
     });
 
     describe('single', function () {
@@ -356,6 +454,120 @@ describe('Frontend Controller', function () {
                     done();
                 });
             });
+        });
+    });
+
+    describe('rss redirects', function () {
+        var res,
+            apiUsersStub;
+
+        beforeEach(function () {
+            res = {
+                locals: { version: '' },
+                redirect: sandbox.spy(),
+                render: sandbox.spy()
+            };
+
+            sandbox.stub(api.posts, 'browse', function () {
+                return when({posts: {}, pages: 3});
+            });
+
+            apiUsersStub = sandbox.stub(api.users, 'read').returns(when({}));
+
+            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            apiSettingsStub.withArgs('title').returns(when({
+                'key': 'title',
+                'value': 'Test'
+            }));
+            apiSettingsStub.withArgs('description').returns(when({
+                'key': 'description',
+                'value': 'Some Text'
+            }));
+            apiSettingsStub.withArgs('permalinks').returns(when({
+                'key': 'permalinks',
+                'value': '/:slug/'
+            }));
+        });
+
+        it('Redirects to rss if page number is 0', function () {
+            var req = {params: {page: -1}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/rss/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to rss if page number is 0', function () {
+            var req = {params: {page: 0}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/rss/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to home if page number is 1', function () {
+            var req = {params: {page: 1}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/rss/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to home if page number is 0 with subdirectory', function () {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 0}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/rss/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to home if page number is 1 with subdirectory', function () {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 1}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/rss/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to last page if page number too big', function (done) {
+            var req = {params: {page: 4}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, done).then(function () {
+                res.redirect.called.should.be.true;
+                res.redirect.calledWith('/rss/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+        });
+
+        it('Redirects to last page if page number too big with subdirectory', function (done) {
+            sandbox.stub(config, 'paths', function () { return {subdir: '/blog'}; });
+
+            var req = {params: {page: 4}, route: {path: '/rss/:page/'}};
+
+            frontend.rss(req, res, done).then(function () {
+                res.redirect.calledOnce.should.be.true;
+                res.redirect.calledWith('/blog/rss/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+
         });
     });
 });


### PR DESCRIPTION
fixes #1765
fixes #1811
issue #1833

New UrlFor functions
- moved body of url helper to config.path.urlFor, which can generate a URL for various scenarios
- urlFor can take a string (name) or object (relativeUrl: '/') as the first
  argument - this is the first step towards issue #1833
- also added config.path.urlForPost which is async and handles getting
  permalink setting
- frontend controller, ghost_head helper, cache invalidation all now use
  urlFor or urlForPost all urls should be correct and consistent

URL Consistency Improvements
- refactored invalidateCache into cacheInvalidationHeader which returns a
  promise so that url can be generated properly by urlForPost
- moved isPost from models to schema, and refactored schema to have a tables object
- deleted posts now return the whole object, not just id and slug,
  ensuring cache invalidation header can be set on delete
- frontend controller rss and archive page redirects work properly with subdirectory
- removes {{url}} helper from admin and client, and replaced with adminUrl
  helper which also uses urlFor
- in res.url ghostRoot becomes relativeUrl, and path is removed
