### PR TITLE
Adds ability to pass in configFile path when loading ghost as a npm module

### DIFF
--- a/core/bootstrap.js
+++ b/core/bootstrap.js
@@ -13,8 +13,8 @@ var fs      = require('fs'),
 
     appRoot = config().paths.appRoot,
     configExample = config().paths.configExample,
-    configFile =  process.env.GHOST_CONFIG || config().paths.config,
-    rejectMessage = 'Unable to load config';
+    rejectMessage = 'Unable to load config',
+    configFile;
 
 function readConfigFile(envVal) {
     return require(configFile)[envVal];
@@ -103,9 +103,14 @@ function validateConfigEnvironment() {
     return when.resolve(config);
 }
 
-function loadConfig() {
+function loadConfig(configFilePath) {
     var loaded = when.defer(),
         pendingConfig;
+
+    // Allow config file path to be taken from, in order of importance:
+    // environment process, passed in value, default location
+    configFile = process.env.GHOST_CONFIG || configFilePath || config().paths.config;
+
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
     fs.exists(configFile, function checkConfig(configExists) {

--- a/core/index.js
+++ b/core/index.js
@@ -7,10 +7,11 @@ var bootstrap = require('./bootstrap'),
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
-function startGhost(app) {
-    bootstrap().then(function () {
+function startGhost(options) {
+    options = options || {};
+    bootstrap(options.config).then(function () {
         var ghost = require('./server');
-        ghost(app);
+        ghost(options.app);
     }).otherwise(errors.logAndThrowError);
 }
 

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -47,7 +47,7 @@ function updateConfig(config) {
         paths: {
             'appRoot':          appRoot,
             'subdir':           subdir,
-            'config':           path.join(appRoot, 'config.js'),
+            'config':           ghostConfig.paths.config || path.join(appRoot, 'config.js'),
             'configExample':    path.join(appRoot, 'config.example.js'),
             'corePath':         corePath,
 

--- a/core/test/unit/bootstrap_spec.js
+++ b/core/test/unit/bootstrap_spec.js
@@ -51,6 +51,18 @@ describe('Bootstrap', function () {
         }).then(null, done);
     });
 
+    it('uses the passed in config file location', function (done) {
+        bootstrap(path.join(config().paths.appRoot, 'config.example.js')).then(function (config) {
+            config.url.should.equal(defaultConfig.url);
+            config.database.client.should.equal(defaultConfig.database.client);
+            config.database.connection.should.eql(defaultConfig.database.connection);
+            config.server.host.should.equal(defaultConfig.server.host);
+            config.server.port.should.equal(defaultConfig.server.port);
+
+            done();
+        }).then(null, done);
+    });
+
     it('creates the config file if one does not exist', function (done) {
 
         var deferred = when.defer(),

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -69,15 +69,13 @@ describe('Config', function () {
     });
 
     describe('Index', function () {
-        var defaultContentPath = config().paths.contentPath;
+        // Make a copy of the default config file
+        // so we can restore it after every test.
+        // Using _.merge to recursively apply every property.
+        var defaultConfigFile = _.merge({}, config());
 
         afterEach(function () {
-            configUpdate({
-                url: defaultConfig.url,
-                paths: {
-                    contentPath: defaultContentPath
-                }
-            });
+            configUpdate(defaultConfigFile);
         });
 
         it('should have exactly the right keys', function () {
@@ -136,15 +134,18 @@ describe('Config', function () {
             config().paths.should.have.property('subdir', '/my/blog');
         });
 
-        it('should set contentPath and sub-directories correctly', function () {
-            var contentPath = config().paths.appRoot + '/otherContent/';
+        it('should allow specific properties to be user defined', function () {
+            var contentPath = config().paths.appRoot + '/otherContent/',
+                configFile = 'configFileDanceParty.js';
 
             configUpdate({
+                config: configFile,
                 paths: {
                     contentPath: contentPath
                 }
             });
 
+            config().should.have.property('config', configFile);
             config().paths.should.have.property('contentPath', contentPath);
             config().paths.should.have.property('themePath', contentPath + 'themes');
             config().paths.should.have.property('appPath', contentPath + 'apps');


### PR DESCRIPTION
- modifies main script file to allow it to
  take in an options object that currently
  supports an express instance or a config file path
- added tests
