### PR TITLE
Adds ability to quickly get to post’s edit page

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -82,6 +82,13 @@ frontendControllers = {
                 post = promises[1];
 
             function render() {
+                // If we're ready to render the page
+                // but the last param is 'edit' then we'll
+                // actually kick you to the edit page.
+                if (req.params[2] && req.params[2] === 'edit') {
+                    return res.redirect(config.paths().subdir + '/ghost/editor/' + post.id + '/');
+                }
+
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {
                         var paths = config.paths().availableThemes[activeTheme.value],
@@ -124,6 +131,10 @@ frontendControllers = {
             e.status = err.errorCode;
             return next(e);
         });
+    },
+    'edit': function (req, res, next) {
+        req.params[2] = 'edit';
+        return frontendControllers.single(req, res, next);
     },
     'rss': function (req, res, next) {
         // Initialize RSS

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -13,6 +13,8 @@ module.exports = function (server) {
     // Examples:
     //  Given `/plain-slug/` the req.params would be [undefined, 'plain-slug']
     //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24/', 'plain-slug']
+    //  Given `/plain-slug/edit/` the req.params would be [undefined, 'plain-slug', 'edit']
     server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/$/, frontend.single);
+    server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/edit\/$/, frontend.edit);
     server.get('/', frontend.homepage);
 };

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -88,8 +88,6 @@ describe('Frontend Routing', function () {
             // get today's date
             var date  = moment().format("YYYY/MM/DD");
 
-            console.log('date', date);
-
             request.get('/' + date + '/welcome-to-ghost/')
                 .expect('Cache-Control', cacheRules.hour)
                 .expect(404)


### PR DESCRIPTION
fixes #1810
- updates frontend.single route to accept ‘edit’
  as the last param
- updates controller.frontend to handle redirection
  only when we would otherwise have rendered the page
- added unit tests for this behavior
