### PR TITLE
Modified github.js to ensure __ is not escaped at the beginning of a line

### DIFF
--- a/core/shared/vendor/showdown/extensions/github.js
+++ b/core/shared/vendor/showdown/extensions/github.js
@@ -43,7 +43,7 @@
 
 
                     //prevent foo_bar and foo_bar_baz from ending up with an italic word in the middle
-                    text = text.replace(/(^(?! {4}|\t)\w+_\w+_\w[\w_]*)/gm, function (x) {
+                    text = text.replace(/(^(?! {4}|\t)(?!__)\w+_\w+_\w[\w_]*)/gm, function (x) {
                         return x.replace(/_/gm, '\\_');
                     });
 

--- a/core/test/unit/client_showdown_int_spec.js
+++ b/core/test/unit/client_showdown_int_spec.js
@@ -60,6 +60,18 @@ describe("Showdown client side converter", function () {
         });
     });
 
+    it("should not escape double underscores at the beginning of a line", function () {
+        var testPhrases = [
+                {input: "\n__test__\n", output: /^<p><strong>test<\/strong><\/p>$/}
+            ],
+            processedMarkup;
+
+        testPhrases.forEach(function (testPhrase) {
+            processedMarkup = converter.makeHtml(testPhrase.input);
+            processedMarkup.should.match(testPhrase.output);
+        });
+    });
+
     it("should not treat pre blocks with pre-text differently", function () {
         var testPhrases = [
                 {input: "<pre>\nthis is `a\\_test` and this\\_too and finally_this_is\n</pre>", output: /^<pre>\nthis is `a\\_test` and this\\_too and finally_this_is\n<\/pre>$/},


### PR DESCRIPTION
fixes #1791

Added (?!__), which ensures that the regex will not match expressions that begin with __.  This never happens in a legitimate case (foo_bar_baz never begins with __) but resolves the case at the beginning of a line (__test__).
