### PR TITLE
Fixes showing tag suggestions and tag container padding

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -521,7 +521,6 @@ body.zen {
         @include linear-gradient(right, rgba(26, 28, 29, 0.00), rgba(26, 28, 29, 1.00));
     }
 
-
     .tags {
         position: relative;
         display: inline-block;
@@ -530,7 +529,7 @@ body.zen {
         max-width: 80%;
         max-width: calc(100% - 320px);
         height: 26px;
-        padding-left: 20px;
+        padding-left: 8px;
         padding-bottom: 20px;
         overflow-x: auto;
         overflow-y: hidden;

--- a/core/client/views/editor-tag-widget.js
+++ b/core/client/views/editor-tag-widget.js
@@ -101,7 +101,6 @@
         },
 
         showSuggestions: function ($target, _searchTerm) {
-            this.$suggestions.show();
             var searchTerm = _searchTerm.toLowerCase(),
                 matchingTags = this.findMatchingTags(searchTerm),
                 styles = {
@@ -115,6 +114,9 @@
             this.$suggestions.html("");
 
             matchingTags = _.first(matchingTags, maxSuggestions);
+            if (matchingTags.length > 0) {
+                this.$suggestions.show();
+            }
             _.each(matchingTags, function (matchingTag) {
                 var highlightedName,
                     suggestionHTML;


### PR DESCRIPTION
Fixes #1774
- Delayed showing the tag suggestions popup unless matching tags were found
- Changed the padding-left on the added tag container to 8px from 20px to fall in line with the left shadow overlay
