### PR TITLE
Added friendly handling/error message for nonexistent plugin

### DIFF
--- a/core/server/plugins/index.js
+++ b/core/server/plugins/index.js
@@ -62,6 +62,12 @@ module.exports = {
                     if (_.contains(installedPlugins, plugin)) {
                         return loader.activatePluginByName(plugin).then(function (loadedPlugin) {
                             return recordLoadedPlugin(plugin, loadedPlugin);
+                        }).otherwise(function (err) {
+                            errors.logError(
+                                err.message || err,
+                                'The plugin will not be loaded',
+                                'Check with the plugin creator, or read the plugin documentation for more details on plugin requirements'
+                            );
                         });
                     }
 
@@ -70,6 +76,12 @@ module.exports = {
                         return loader.activatePluginByName(plugin);
                     }).then(function (loadedPlugin) {
                         return recordLoadedPlugin(plugin, loadedPlugin);
+                    }).otherwise(function (err) {
+                        errors.logError(
+                            err.message || err,
+                            'The plugin will not be loaded',
+                            'Check with the plugin creator, or read the plugin documentation for more details on plugin requirements'
+                        );
                     });
                 });
 

--- a/core/server/plugins/loader.js
+++ b/core/server/plugins/loader.js
@@ -36,7 +36,12 @@ function getPluginByName(name) {
 loader = {
     // Load a plugin and return the instantiated plugin
     installPluginByName: function (name) {
-        var plugin = getPluginByName(name);
+        var plugin;
+        try {
+            plugin = getPluginByName(name);
+        } catch (e) {
+            return when.reject(new Error("Error loading plugin named " + name + "; plugin directory (/content/plugins/" + name + ") does not exist."));
+        }
 
         // Check for an install() method on the plugin.
         if (!_.isFunction(plugin.install)) {


### PR DESCRIPTION
Fixes #1829
- Added try-catch block in `core/server/plugins/loader.js` to catch and reject with an error when `getPluginByName` fails (meaning `require(getPluginRelativePath(name))` failed, meaning the plugin directory doesn't exist).  Error message as follows:

> Error loading plugin named <name>; plugin directory (/content/plugins/<name>) does not exist."
- Added .otherwise blocks with error logs to `core/server/plugins/index.js` to catch the new rejections and log error message to console
