### PR TITLE
Added handling for undefined errors and test coverage

### DIFF
--- a/core/server/errorHandling.js
+++ b/core/server/errorHandling.js
@@ -56,7 +56,11 @@ errors = {
 
     logError: function (err, context, help) {
         var stack = err ? err.stack : null;
-        err = err.message || err || 'Unknown';
+        if (err) {
+            err = err.message || err || 'An unknown error occurred.';
+        } else {
+            err = 'An unknown error occurred.';
+        }
         // TODO: Logging framework hookup
         // Eventually we'll have better logging which will know about envs
         if ((process.env.NODE_ENV === 'development' ||

--- a/core/test/unit/errorHandling_spec.js
+++ b/core/test/unit/errorHandling_spec.js
@@ -115,6 +115,86 @@ describe("Error handling", function () {
             logStub.lastCall.calledWith('').should.be.true;
         });
 
+        it("logs errors from an undefined error argument", function () {
+            var message = "Testing";
+
+            errors.logError(undefined, message, message);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(4);
+            logStub.firstCall.calledWith("\nERROR:".red, "An unknown error occurred.".red).should.be.true;
+            logStub.secondCall.calledWith(message.white).should.be.true;
+            logStub.thirdCall.calledWith(message.green).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
+        it("logs errors from an undefined context argument", function () {
+            var message = "Testing";
+
+            errors.logError(message, undefined, message);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(3);
+            logStub.firstCall.calledWith("\nERROR:".red, message.red).should.be.true;
+            logStub.secondCall.calledWith(message.green).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
+        it("logs errors from an undefined help argument", function () {
+            var message = "Testing";
+
+            errors.logError(message, message, undefined);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(3);
+            logStub.firstCall.calledWith("\nERROR:".red, message.red).should.be.true;
+            logStub.secondCall.calledWith(message.white).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
+        it("logs errors from a null error argument", function () {
+            var message = "Testing";
+
+            errors.logError(null, message, message);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(4);
+            logStub.firstCall.calledWith("\nERROR:".red, "An unknown error occurred.".red).should.be.true;
+            logStub.secondCall.calledWith(message.white).should.be.true;
+            logStub.thirdCall.calledWith(message.green).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
+        it("logs errors from a null context argument", function () {
+            var message = "Testing";
+
+            errors.logError(message, null, message);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(3);
+            logStub.firstCall.calledWith("\nERROR:".red, message.red).should.be.true;
+            logStub.secondCall.calledWith(message.green).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
+        it("logs errors from a null help argument", function () {
+            var message = "Testing";
+
+            errors.logError(message, message, null);
+
+            // Calls log with message on Error objects
+
+            logStub.callCount.should.equal(3);
+            logStub.firstCall.calledWith("\nERROR:".red, message.red).should.be.true;
+            logStub.secondCall.calledWith(message.white).should.be.true;
+            logStub.lastCall.calledWith('').should.be.true;
+        });
+
         it("logs promise errors and redirects", function (done) {
             var def = when.defer(),
                 prom = def.promise,


### PR DESCRIPTION
Fixes #1827

If `error.logError(err, context, help)` is called with an undefined or null `err` parameter, the message 

> An unknown error occurred.

is displayed, instead of the error handler blowing up.  Added test coverage for this case, as well as cases with a null or undefined `context` or `help` parameter (these cases were already working but not tested).
