### PR TITLE
Atomically add users. Addresses #1834

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -107,13 +107,6 @@ User = ghostBookshelf.Model.extend({
          * @author javorszky
          */
         return validatePasswordLength(userData.password).then(function () {
-            return self.forge().fetch();
-        }).then(function (user) {
-            // Check if user exists
-            if (user) {
-                return when.reject(new Error('A user is already registered. Only one user for now!'));
-            }
-        }).then(function () {
             // Generate a new password hash
             return generatePasswordHash(_user.password);
         }).then(function (hash) {
@@ -125,6 +118,11 @@ User = ghostBookshelf.Model.extend({
             // Save the user with the hashed password
             return ghostBookshelf.Model.add.call(self, userData);
         }).then(function (addedUser) {
+            if (addedUser.id !== 1) {
+                return addedUser.destroy().then(function () {
+                    return when.reject(new Error('A user is already registered. Only one user for now!'));
+                });
+            }
             // Assign the userData to our created user so we can pass it back
             userData = addedUser;
             // Add this user to the admin role (assumes admin = role_id: 1)


### PR DESCRIPTION
Atomically add users. This is done by always adding a user when requested, and then assuming the database’s auto increment function is atomic. If it is, and there is more than one user, the user's id will not be 1. In that case, delete the new user.
