### PR TITLE
Fix {{content words=“0”}} to actually return 0 words

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -217,7 +217,13 @@ coreHelpers.content = function (options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
-    if (truncateOptions.words || truncateOptions.characters) {
+    if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
+        // Due to weirdness in downsize the 'words' option
+        // must be passed as a string. refer to #1796
+        // TODO: when downsize fixes this quirk remove this hack.
+        if (truncateOptions.hasOwnProperty('words')) {
+            truncateOptions.words = truncateOptions.words.toString();
+        }
         return new hbs.handlebars.SafeString(
             downsize(this.html, truncateOptions)
         );

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -75,6 +75,34 @@ describe('Core Helpers', function () {
             rendered.string.should.equal("<p>Hello <strong>World</strong></p>");
         });
 
+        it('can truncate html to 0 words', function () {
+            var html = "<p>Hello <strong>World! It's me!</strong></p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": "0"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<p></p>");
+        });
+
+        it('can truncate html to 0 words, leaving image tag if it is first', function () {
+            var html = "<p><img src='example.jpg' />Hello <strong>World! It's me!</strong></p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": "0"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<p><img src='example.jpg' /></p>");
+        });
+
         it('can truncate html by character', function () {
             var html = "<p>Hello <strong>World! It's me!</strong></p>",
                 rendered = (


### PR DESCRIPTION
fixes #1796
- adds in a workaround to the weirdness that currently
  exists in downsize module
- adds tests
