### PR TITLE
Add "lang" option to "date" helper, enabling i18n for dates

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -46,8 +46,10 @@ coreHelpers.date = function (context, options) {
 
     var f = options.hash.format || 'MMM Do, YYYY',
         timeago = options.hash.timeago,
+        lang = options.hash.lang,
         date;
 
+    if (lang) moment.lang(lang);
 
     if (timeago) {
         date = moment(context).fromNow();

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -49,7 +49,9 @@ coreHelpers.date = function (context, options) {
         lang = options.hash.lang,
         date;
 
-    if (lang) moment.lang(lang);
+    if (lang) {
+        moment.lang(lang);
+    }
 
     if (timeago) {
         date = moment(context).fromNow();


### PR DESCRIPTION
This adds a `lang` option to the `date` helper, allowing the user to change the date locale. The value gets passed to `moment.js`. Use:

```
{{date format="DD MMMM YYYY" lang="es"}}
```

Related: issue #897
