### PR TITLE
Fixing 404 on page view when using PostgreSQL

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -58,12 +58,24 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return attrs;
     },
 
+    // Convert bools to ints to be consistent
+    // across db providers
+    fixBools: function (attrs) {
+        _.each(attrs, function (value, key) {
+            if (typeof value === "boolean") {
+                attrs[key] = value ? 1 : 0;
+            }
+        });
+
+        return attrs;
+    },
+
     format: function (attrs) {
-        return this.fixDates(attrs);
+        return this.fixBools(this.fixDates(attrs));
     },
 
     toJSON: function (options) {
-        var attrs = this.fixDates(_.extend({}, this.attributes)),
+        var attrs = this.fixBools(this.fixDates(_.extend({}, this.attributes))),
             relations = this.relations;
 
         if (options && options.shallow) {


### PR DESCRIPTION
closes #1801 
- adding fixBools method to `server/models/base.js` to convert bools to 1/0 to be consistent with MySQL & sqlite3 data providers (based on @ErisDS recommendation)
- this in turn fixes the check in `server/controllers/frontend.js`, which does an explicit `post.page === 0` comparison (in pgsql this is a `boolean`, since the schema declares it as "bool" in `server/data/schema.js`, but MySQL/sqlite3 don't have concept of Boolean, only an integer or bit)
- any model retrieved from persistence will pass through this (possible future refactoring is to combine fixBools & fixDates into one "canonicalize()" to have a single loop pass)
