### PR TITLE
Address race condition when creating users. Addresses #1834

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -101,38 +101,39 @@ User = ghostBookshelf.Model.extend({
         var self = this,
             // Clone the _user so we don't expose the hashed password unnecessarily
             userData = _.extend({}, _user);
+
+        userData.password = "";
         /**
          * This only allows one user to be added to the database, otherwise fails.
          * @param  {object} user
          * @author javorszky
          */
-        return validatePasswordLength(userData.password).then(function () {
-            return self.forge().fetch();
-        }).then(function (user) {
-            // Check if user exists
-            if (user) {
-                return when.reject(new Error('A user is already registered. Only one user for now!'));
+        return validatePasswordLength(_user.password).then(function () {
+            return ghostBookshelf.Model.add.call(self, userData);
+        }).then(function (addedUser) {
+            if (addedUser.id !== 1) {
+                return addedUser.destroy().then(function () {
+                    return when.reject(new Error('A user is already registered. Only one user for now!'));
+                });
             }
-        }).then(function () {
+            return when.resolve(addedUser);
+        }).then(function (addedUser) {
+            userData = addedUser;
+            // LookupGravatar
+            return self.gravatarLookup(userData.toJSON());
+        }).then(function (jsonUser) {
             // Generate a new password hash
+            userData.set("image", jsonUser.image);
             return generatePasswordHash(_user.password);
         }).then(function (hash) {
             // Assign the hashed password
-            userData.password = hash;
-            // LookupGravatar
-            return self.gravatarLookup(userData);
-        }).then(function (userData) {
-            // Save the user with the hashed password
-            return ghostBookshelf.Model.add.call(self, userData);
-        }).then(function (addedUser) {
-            // Assign the userData to our created user so we can pass it back
-            userData = addedUser;
+            userData.set("password", hash);
+            return userData.save();
+        }).then(function () {
             // Add this user to the admin role (assumes admin = role_id: 1)
             return userData.roles().attach(1);
         }).then(function (addedUserRole) {
             /*jslint unparam:true*/
-            // Return the added user as expected
-
             return when.resolve(userData);
         });
 


### PR DESCRIPTION
This is a second attempt at preventing multiple users from being created. My previous PR on issue #1834 still had a race condition. I'm pretty sure this doesn't, but it depends on the application rejecting users when their password is empty.

This is more difficult to address than it seems because the correct way to do this is with an atomic operation on the DB, such as a conditional INSERT, but SQLite does not support conditional INSERTs and it if did, it would require bypassing Bookshelf.  

I think this this about as close as we can get to solving this issue w/out doing heavy lifting on the data model. 

There maybe other places in the application which have similar race conditions which depend on counters in the DB -- for example creating slugs for posts and users.
