### PR TITLE
Improving regexes in functional tests

### DIFF
--- a/core/test/functional/admin/content_test.js
+++ b/core/test/functional/admin/content_test.js
@@ -17,7 +17,7 @@ CasperTest.begin("Content screen is correct", 20, function suite(test) {
 
     casper.thenClick('.js-publish-button');
 
-    casper.waitForResource(/posts/, function checkPostWasCreated() {
+    casper.waitForResource(/posts\/$/, function checkPostWasCreated() {
         test.assertExists('.notification-success', 'got success notification');
     });
 

--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -33,7 +33,7 @@ CasperTest.begin("Ghost editor is correct", 10, function suite(test) {
 
     casper.thenClick('.js-publish-button');
 
-    casper.waitForResource(/posts/, function checkPostWasCreated() {
+    casper.waitForResource(/\/posts\/$/, function checkPostWasCreated() {
         var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
         test.assertExists('.notification-success', 'got success notification');
@@ -164,7 +164,7 @@ CasperTest.begin('Publish menu - existing post', 22, function suite(test) {
     // Create a post in draft status
     casper.thenClick('.js-publish-button');
 
-    casper.waitForResource(/posts/, function checkPostWasCreated() {
+    casper.waitForResource(/posts\/$/, function checkPostWasCreated() {
         var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
     });
@@ -201,7 +201,7 @@ CasperTest.begin('Publish menu - existing post', 22, function suite(test) {
     // Publish the post
     casper.thenClick('.js-publish-button');
 
-    casper.waitForResource(/posts/, function checkPostWasCreated() {
+    casper.waitForResource(/posts\/$/, function checkPostWasCreated() {
         var urlRegExp = new RegExp("^" + escapedUrl + "ghost\/editor\/[0-9]*");
         test.assertUrlMatch(urlRegExp, 'got an id on our URL');
     });

--- a/core/test/functional/admin/flow_test.js
+++ b/core/test/functional/admin/flow_test.js
@@ -18,7 +18,7 @@ CasperTest.begin("Ghost edit draft flow works correctly", 8, function suite(test
     });
 
     casper.thenClick('.js-publish-button');
-    casper.waitForResource(/posts/);
+    casper.waitForResource(/posts\/$/);
 
     casper.waitForSelector('.notification-success', function onSuccess() {
         test.assert(true, 'Got success notification');
@@ -43,7 +43,7 @@ CasperTest.begin("Ghost edit draft flow works correctly", 8, function suite(test
     });
 
     casper.thenClick('.js-publish-button');
-    casper.waitForResource(/posts/);
+    casper.waitForResource(/posts\/[0-9]+\/$/);
 
     casper.waitForSelector('.notification-success', function onSuccess() {
         test.assert(true, 'Got success notification');

--- a/core/test/functional/admin/logout_test.js
+++ b/core/test/functional/admin/logout_test.js
@@ -20,8 +20,9 @@ CasperTest.begin("Ghost logout works correctly", 2, function suite(test) {
         });
     });
 
+    casper.waitForSelector('.usermenu-signout a');
     casper.thenClick('.usermenu-signout a');
-    casper.waitForResource(/signin/);
+    casper.waitForResource(/ghost\/signin/);
 
     casper.waitForSelector('.notification-success', function onSuccess() {
         test.assert(true, 'Got success notification');


### PR DESCRIPTION
- being more explicit about what resources we expect to load after saving
  a post
- should prevent #1839 from failing tests
