### PR TITLE
Use ajax for import

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -46,7 +46,7 @@ function invalidateCache(req, res, result) {
 // takes the API method and wraps it so that it gets data from the request and returns a sensible JSON response
 requestHandler = function (apiMethod) {
     return function (req, res) {
-        var options = _.extend(req.body, req.query, req.params),
+        var options = _.extend(req.body, req.files, req.query, req.params),
             apiContext = {
                 user: req.session && req.session.user
             };

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -234,9 +234,6 @@ module.exports = function (server, dbHash) {
     expressServer.use(express.json());
     expressServer.use(express.urlencoded());
 
-    expressServer.use(subdir + '/ghost/upload/', middleware.busboy);
-    expressServer.use(subdir + '/ghost/api/v0.1/db/', middleware.busboy);
-
     // ### Sessions
     cookie = {
         path: subdir + '/ghost',

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -43,8 +43,7 @@ module.exports = function (server) {
     server.get('/ghost/settings*', middleware.auth, admin.settings);
     server.get('/ghost/debug/', middleware.auth, admin.debug.index);
 
-    // We don't want to register bodyParser globally b/c of security concerns, so use multipart only here
-    server.post('/ghost/upload/', middleware.auth, admin.uploader);
+    server.post('/ghost/upload/', middleware.auth, middleware.busboy, admin.uploader);
 
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
     server.get(/\/((ghost-admin|admin|wp-admin|dashboard|signin)\/?)$/, function (req, res) {

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -24,7 +24,7 @@ module.exports = function (server) {
     server.del('/ghost/api/v0.1/notifications/:id', middleware.authAPI, api.requestHandler(api.notifications.destroy));
     server.post('/ghost/api/v0.1/notifications/', middleware.authAPI, api.requestHandler(api.notifications.add));
     // #### Import/Export
-    server.get('/ghost/api/v0.1/db/', middleware.auth, api.db['export']);
-    server.post('/ghost/api/v0.1/db/', middleware.auth, api.db['import']);
+    server.get('/ghost/api/v0.1/db/', middleware.auth, api.db.exportContent);
+    server.post('/ghost/api/v0.1/db/', middleware.authAPI, middleware.busboy, api.requestHandler(api.db.importContent));
     server.del('/ghost/api/v0.1/db/', middleware.authAPI, api.requestHandler(api.db.deleteAllContent));
 };

--- a/core/server/views/debug.hbs
+++ b/core/server/views/debug.hbs
@@ -25,13 +25,12 @@
                     </div>
                 </fieldset>
             </form>
-            <form id="settings-import" method="post" action="{{url}}/ghost/api/v0.1/db/" enctype="multipart/form-data">
-                <input type="hidden" name="_csrf" value="{{csrfToken}}" />
+            <form id="settings-import" enctype="multipart/form-data">
                 <fieldset>
                     <div class="form-group">
                         <label>Import</label>
-                        <input type="file" class="button-add" name="importfile" />
-                        <input type="submit" class="button-save" value="Import" />
+                        <input type="file" class="button-add" name="importfile" id="importfile" />
+                        <button type="submit" class="button-save" value="Import" id="startupload" >Import</button>
                         <p>Import from another Ghost installation. If you import a user, this will replace the current user & log you out.</p>
                     </div>
                 </fieldset>


### PR DESCRIPTION
closes #1854
- added blueimp file upload to debug.js
- changed POST /ghost/api/v0.1/db to be used with AJAX
- cache invalidation header should now work for import
- moved busboy middleware invocation to routes/api and routes/admin
- moved api.db.import to api.db.importContent (I hated the [] notation)
- moved api.db.export to api.db.exportContent (see above)
