### PR TITLE
fix table scan for pg migrations

### DIFF
--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -144,9 +144,7 @@ function getTablesFromSqlite3() {
 
 function getTablesFromPgSQL() {
     return knex.raw("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'").then(function (response) {
-        return _.flatten(_.map(response[0], function (entry) {
-            return _.values(entry);
-        }));
+        return _.flatten(_.pluck(response.rows, 'table_name'));
     });
 }
 


### PR DESCRIPTION
trying to upgrade v0.3.3 -> master w/ a pg database it's trying to recreate all the tables. appears that the code in getTablesFromPgSQL() wasn't actually returning the existing table names - this should fix it
