### PR TITLE
Fix TypeError due to missing mail config

### DIFF
--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -69,7 +69,7 @@ function updateCheckData() {
     data.node_version    = process.versions.node;
     data.env             = process.env.NODE_ENV;
     data.database_type   = require('./models/base').client;
-    data.email_transport = mailConfig && mailConfig.options && mailConfig.options.service ? mailConfig.options.service : mailConfig.transport;
+    data.email_transport = mailConfig && (mailConfig.options && mailConfig.options.service ? mailConfig.options.service : mailConfig.transport);
 
     return when.settle(ops).then(function (descriptors) {
         var hash             = descriptors[0].value,


### PR DESCRIPTION
Fixes this:

```
ERROR: Cannot read property 'transport' of undefined                         
Checking for updates failed, your blog will continue to function.
If you get this error repeatedly, please seek help from http://ghost.org/forum.                                                                           

TypeError: Cannot read property 'transport' of undefined
    at updateCheckData (/home/jakob/devel/Ghost/core/server/update-check.js:72:132)
    at updateCheckRequest (/home/jakob/devel/Ghost/core/server/update-check.js:97:12)
    at /home/jakob/devel/Ghost/core/server/update-check.js:180:24
    at NearFulfilledProxy.when (/home/jakob/devel/Ghost/node_modules/when/when.js:501:43)
    at Promise._message (/home/jakob/devel/Ghost/node_modules/when/when.js:426:25)
    at Array.deliver [as 0] (/home/jakob/devel/Ghost/node_modules/when/when.js:319:7)
    at runHandlers (/home/jakob/devel/Ghost/node_modules/when/when.js:385:12)
    at Array.14 (/home/jakob/devel/Ghost/node_modules/when/when.js:352:5)
    at runHandlers (/home/jakob/devel/Ghost/node_modules/when/when.js:385:12)
    at drainQueue (/home/jakob/devel/Ghost/node_modules/when/when.js:836:3) 
```
