### PR TITLE
Restored files that were refactored away.

### DIFF
--- a/core/server.js
+++ b/core/server.js
@@ -1,0 +1,14 @@
+/*
+This file is a shim to accomodate simple file system merge upgrade from 0.3.3 to 0.4.
+During a file system merge upgrade from 0.3.3 to 0.4, the old version of this file will
+persist unless this shim is in place. Problems arise when the stale 0.3.3 version of 
+this file exists as well as the new directory of files bearing the same name in 0.4.
+Node's require defaults to loading the 0.3.3 version causing errors. This file replaces
+the old 0.3.3 version. This allows all dependent modules to continue requiring their
+dependencies the way they always have. See issue 1873 for more information.
+
+https://github.com/TryGhost/Ghost/issues/1873
+*/
+var server = require('./server/index.js');
+
+module.exports = server;

--- a/core/server/api.js
+++ b/core/server/api.js
@@ -1,0 +1,14 @@
+/*
+This file is a shim to accomodate simple file system merge upgrade from 0.3.3 to 0.4.
+During a file system merge upgrade from 0.3.3 to 0.4, the old version of this file will
+persist unless this shim is in place. Problems arise when the stale 0.3.3 version of 
+this file exists as well as the new directory of files bearing the same name in 0.4.
+Node's require defaults to loading the 0.3.3 version causing errors. This file replaces
+the old 0.3.3 version. This allows all dependent modules to continue requiring their
+dependencies the way they always have. See issue 1873 for more information.
+
+https://github.com/TryGhost/Ghost/issues/1873
+*/
+var api = require('./api/index.js');
+
+module.exports = api;

--- a/core/server/middleware.js
+++ b/core/server/middleware.js
@@ -1,0 +1,14 @@
+/*
+This file is a shim to accomodate simple file system merge upgrade from 0.3.3 to 0.4.
+During a file system merge upgrade from 0.3.3 to 0.4, the old version of this file will
+persist unless this shim is in place. Problems arise when the stale 0.3.3 version of 
+this file exists as well as the new directory of files bearing the same name in 0.4.
+Node's require defaults to loading the 0.3.3 version causing errors. This file replaces
+the old 0.3.3 version. This allows all dependent modules to continue requiring their
+dependencies the way they always have. See issue 1873 for more information.
+
+https://github.com/TryGhost/Ghost/issues/1873
+*/
+var middleware = require('./middleware/index.js');
+
+module.exports = middleware;


### PR DESCRIPTION
Resolves #1873.

During unzip based deployments of new releases, old files are not removed and node's require loads the old file instead of all the new ones in the new directory. The newly restored files in this commit act as a delegate for all other dependent scripts. They simply load all the new files from the new directory by using the trailing slash to disambiguate.
