### PR TITLE
Add `rss` to the list of reserved post titles/slugs.

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -227,7 +227,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         // Remove non ascii characters
         slug = unidecode(slug);
         // Check the filtered slug doesn't match any of the reserved keywords
-        slug = /^(ghost|ghost\-admin|admin|wp\-admin|wp\-login|dashboard|logout|login|signin|signup|signout|register|archive|archives|category|categories|tag|tags|page|pages|post|posts|user|users)$/g
+        slug = /^(ghost|ghost\-admin|admin|wp\-admin|wp\-login|dashboard|logout|login|signin|signup|signout|register|archive|archives|category|categories|tag|tags|page|pages|post|posts|user|users|rss)$/g
             .test(slug) ? slug + '-post' : slug;
 
         //if slug is empty after trimming use "post"

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -255,6 +255,18 @@ describe('Post Model', function () {
         }).then(null, done);
     });
 
+    it('can generate a safe slug when a reserved keyword is used', function(done) {
+        var newPost = {
+            title: 'rss',
+            markdown: 'Test Content 1'
+        };
+
+        PostModel.add(newPost).then(function (createdPost) {
+            createdPost.get('slug').should.not.equal('rss');
+            done();
+        });
+    });
+
     it('can generate slugs without non-ascii characters', function (done) {
         var newPost = {
             title: 'भुते धडकी भरवणारा आहेत',


### PR DESCRIPTION
closes #1880
- added `rss` to core/server/models `generateSlug` reserved keywords
- added integration test for safe slug generation to core/test/integration/model/model_posts_spec.js
