### PR TITLE
Prevented duplicate binding of upload button on debug importer

### DIFF
--- a/core/client/views/debug.js
+++ b/core/client/views/debug.js
@@ -21,6 +21,8 @@
                 dataType: 'json',
                 add: function (e, data) {
                     /*jslint unparam:true*/
+                    // unregister click event to preveng duplicate binding
+                    $('#startupload').off("click");
                     data.context = $('#startupload').prop('disabled', false)
                         .click(function () {
                             $('#startupload').prop('disabled', true);


### PR DESCRIPTION
Fixes #1899

Prevents multiple upload of the selected import file if more than one file is drag-and-dropped into the debug importer
