### PR TITLE
No select or text cursor on rendered preview

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -274,6 +274,8 @@
             overflow: auto;
             word-break: break-word;
             hyphens: auto;
+            @include user-select(none);
+            cursor: default;
 
             // Tweak padding for smaller screens
             @include breakpoint($netbook) {padding-top: 20px;}


### PR DESCRIPTION
fixes #1595
- prevents the backspace key from doing terrible things
