### PR TITLE
Remove jQuery from `ghost_footer` helper.

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -370,10 +370,7 @@ coreHelpers.ghost_foot = function (options) {
     /*jslint unparam:true*/
     var foot = [];
 
-    foot.push(scriptTemplate({
-        source: config.paths().subdir + '/shared/vendor/jquery/jquery.js',
-        version: coreHelpers.assetHash
-    }));
+    // Saved for future use; this helper doesn't actually do anything right now
 
     return filters.doFilter('ghost_foot', foot).then(function (foot) {
         var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -385,13 +385,13 @@ describe('Core Helpers', function () {
             should.exist(handlebars.helpers.ghost_foot);
         });
 
-        it('returns meta tag string', function (done) {
+        it('should return empty string', function (done) {
 
             helpers.assetHash = 'abc';
 
             helpers.ghost_foot.call().then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<script src=".*\/shared\/vendor\/jquery\/jquery.js\?v=abc"><\/script>/);
+                rendered.string.should.equal('');
 
                 done();
             }).then(null, done);


### PR DESCRIPTION
closes #1161
- Remove the script that adds jQuery to the `ghost_foot` helper.
- Add comment so future devs know why `ghost_foot` doesn’t currently do anything.
- Update test to expect the result of `ghost_foot` to be an empty string.
- Update Casper theme to include jQuery in a more direct manner (see TryGhost/Casper#68).
