### PR TITLE
Ensure that escape closes tag suggestions box

### DIFF
--- a/core/client/views/editor-tag-widget.js
+++ b/core/client/views/editor-tag-widget.js
@@ -160,7 +160,7 @@
                 return false;
             }
 
-            if (searchTerm) {
+            if (searchTerm && e.keyCode !== this.keys.ESC) {
                 this.showSuggestions($target, searchTerm);
             } else {
                 this.$suggestions.hide();

--- a/core/client/views/editor-tag-widget.js
+++ b/core/client/views/editor-tag-widget.js
@@ -134,6 +134,12 @@
             var $target = $(e.currentTarget),
                 searchTerm = $.trim($target.val());
 
+            if (searchTerm) {
+                this.showSuggestions($target, searchTerm);
+            } else {
+                this.$suggestions.hide();
+            }
+
             if (e.keyCode === this.keys.UP) {
                 e.preventDefault();
                 if (this.$suggestions.is(":visible")) {
@@ -158,12 +164,6 @@
 
             if (e.keyCode === this.keys.UP || e.keyCode === this.keys.DOWN) {
                 return false;
-            }
-
-            if (searchTerm && e.keyCode !== this.keys.ESC) {
-                this.showSuggestions($target, searchTerm);
-            } else {
-                this.$suggestions.hide();
             }
         },
 


### PR DESCRIPTION
Per issue #1893;

Core issue is that the suggestion was being reopened after Escape hid it. By moving the suggestions update to the top of the handleKeyUp function, we ensure that once it's hidden it's not going to be reopened.
