### PR TITLE
Including theme partials in a way that supports symbolically linked directories

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -10,6 +10,7 @@ var middleware = require('./middleware'),
     slashes     = require('connect-slashes'),
     errors      = require('../errorHandling'),
     api         = require('../api'),
+    fs          = require('fs'),
     path        = require('path'),
     hbs         = require('express-hbs'),
     config      = require('../config'),
@@ -106,10 +107,15 @@ function activateTheme(activeTheme) {
 
     // set view engine
     hbsOptions = { partialsDir: [ config.paths().helperTemplates ] };
-    if (config.paths().availableThemes[activeTheme].hasOwnProperty('partials')) {
+
+    var themePartials = path.join(config.paths().themePath, activeTheme, 'partials');
+
+    fs.stat(themePartials, function(err, stats) {
         // Check that the theme has a partials directory before trying to use it
-        hbsOptions.partialsDir.push(path.join(config.paths().themePath, activeTheme, 'partials'));
-    }
+        if(err == null && stats &&  stats.isDirectory()) {
+            hbsOptions.partialsDir.push(themePartials);
+        }
+    });
     expressServer.set('theme view engine', hbs.express3(hbsOptions));
 
     // Update user error template


### PR DESCRIPTION
The old way was breaking because config.paths().availableThemes[activeTheme] would just be a string.

By doing a fs.stat() on the full path (that was already being constructed a line later), all theme directories are supported.

This fixes issue #1937 that I just posted, which includes a reproducible case.
