### PR TITLE
Including theme partials in a way that supports symbolically linked directories

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -10,6 +10,7 @@ var middleware = require('./middleware'),
     slashes     = require('connect-slashes'),
     errors      = require('../errorHandling'),
     api         = require('../api'),
+    fs          = require('fs'),
     path        = require('path'),
     hbs         = require('express-hbs'),
     config      = require('../config'),
@@ -91,6 +92,7 @@ function initViews(req, res, next) {
 // Helper for manageAdminAndTheme
 function activateTheme(activeTheme) {
     var hbsOptions,
+        themePartials = path.join(config.paths().themePath, activeTheme, 'partials'),
         stackLocation = _.indexOf(expressServer.stack, _.find(expressServer.stack, function (stackItem) {
             return stackItem.route === config.paths().subdir && stackItem.handle.name === 'settingEnabled';
         }));
@@ -106,10 +108,14 @@ function activateTheme(activeTheme) {
 
     // set view engine
     hbsOptions = { partialsDir: [ config.paths().helperTemplates ] };
-    if (config.paths().availableThemes[activeTheme].hasOwnProperty('partials')) {
+
+    fs.stat(themePartials, function (err, stats) {
         // Check that the theme has a partials directory before trying to use it
-        hbsOptions.partialsDir.push(path.join(config.paths().themePath, activeTheme, 'partials'));
-    }
+        if (!err && stats && stats.isDirectory()) {
+            hbsOptions.partialsDir.push(themePartials);
+        }
+    });
+
     expressServer.set('theme view engine', hbs.express3(hbsOptions));
 
     // Update user error template


### PR DESCRIPTION
Including theme partials in a way that supports symbolically linked directories. This closes #1937

I fixed all the JSLint errors being reported by `grunt validate` but I'm not sure if everything's passing now. Excuse my unfamiliarly with node, I'm not a NodeJs developer, just making a blog!

The tests end the same way that a vanilla checkout does:

``` bash
Running "express:test" (express) task
Starting background Express server
Ghost is running in testing... 
Listening on 127.0.0.1:2369 
Url configured as: http://127.0.0.1:2369 
Ctrl+C to shut down

Running "spawn-casperjs" task
Fatal error: 
PROMPT>
```

Since it's behaving the same as `master`, I figure I'd throw it over the wall again.

Thanks for your patience on the first pull request
