### PR TITLE
sqlite3@2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "0.3.1",
-        "sqlite3": "2.1.19",
+        "sqlite3": "2.2.0",
         "underscore": "1.5.2",
         "unidecode": "0.1.3",
         "validator": "1.4.0",


### PR DESCRIPTION
Updates node-sqlite3 to v2.2.0

This version is compatible with 2.1.x but includes:
- updated internal libsqlite3 from 3.7.17 -> 3.8.2 (http://www.sqlite.org/news.html) which includes the next-generation query planner http://www.sqlite.org/queryplanner-ng.html
- improved binary deploy system using https://github.com/springmeyer/node-pre-gyp
- binary install now supports http proxies
- source compile now supports freebsd
- fixed support for node-webkit
- binaries are available: http://node-sqlite3.s3.amazonaws.com/index.html?path=Release/

Because of the update of the internally bundled libsqlite3 version this should be tested before going into production.
