### PR TITLE
Update Contributing Docs to include Developer tips

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,11 +206,15 @@ templates
 If something goes wrong, please see the 
 [troubleshooting tips](https://github.com/TryGhost/Ghost/blob/master/CONTRIBUTING.md#troubleshooting--faq) below.
 
-Front-end can be located at <http://localhost:2368>, Admin is at <http://localhost:2368/ghost/>.
+### Developer Tips
+Whilst developing, you can take advantage of the [Grunt toolkit](https://github.com/TryGhost/Ghost/wiki/Grunt-Toolkit) to automatically compile assets, such as handlebar templates, stylesheets and javascripts. Some useful commands include:
+- `grunt dev` => Automatically compile assets in development environment
+- `grunt prod` => Automatically compile assets in production environment
+- `grunt watch` => Automatically compile sass and handlebars
 
-Whist developing you may wish to use **grunt watch** to watch for changes to handlebars and sass and recompile 
-automatically, if you run Ghost in **production** mode, you will need to run **grunt prod** - 
-please see the [Grunt Toolkit docs](https://github.com/TryGhost/Ghost/wiki/Grunt-Toolkit).
+Addresses for development:
+- Front-end => <http://localhost:2368>
+- Admin => <http://localhost:2368/ghost/>
 
 ### Updating with the latest changes
 


### PR DESCRIPTION
Found that the documentation for automatic asset compilation wasn't immediately apparent (unfinished Grunt docs), so added clear developer tips in the contributing guide.
