### PR TITLE
Enable Escape key to close tag suggestion popup

### DIFF
--- a/core/client/views/editor-tag-widget.js
+++ b/core/client/views/editor-tag-widget.js
@@ -134,6 +134,12 @@
             var $target = $(e.currentTarget),
                 searchTerm = $.trim($target.val());
 
+            if (searchTerm) {
+                this.showSuggestions($target, searchTerm);
+            } else {
+                this.$suggestions.hide();
+            }
+
             if (e.keyCode === this.keys.UP) {
                 e.preventDefault();
                 if (this.$suggestions.is(":visible")) {
@@ -158,12 +164,6 @@
 
             if (e.keyCode === this.keys.UP || e.keyCode === this.keys.DOWN) {
                 return false;
-            }
-
-            if (searchTerm) {
-                this.showSuggestions($target, searchTerm);
-            } else {
-                this.$suggestions.hide();
             }
         },
 


### PR DESCRIPTION
closes #1893
- Checking the contents of search term after evaluating the keycode caused the suggestion box to be hidden and immediately reshown
- Moving the if/else to the top of the function enables us to fix the issue without complicating the suggestion update logic
