### PR TITLE
Prevent stacking of password mismatch notification on /reset/

### DIFF
--- a/core/client/views/login.js
+++ b/core/client/views/login.js
@@ -212,6 +212,7 @@
                 ne2Password = this.$('input[name="ne2password"]').val();
 
             if (newPassword !== ne2Password) {
+                Ghost.notifications.clearEverything();
                 Ghost.notifications.addItem({
                     type: 'error',
                     message: "Your passwords do not match.",


### PR DESCRIPTION
closes #1902
- Missing call to clearEverything caused the new notifications to pile up on multiple failed submissions
