### PR TITLE
Change sign-up form styling from an ID to a class. Fixes #1605

### DIFF
--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -2,7 +2,7 @@
  * These styles control elements specific to the Ghost admin login / signup screens.
  *
  * Table of Contents:
- * 
+ *
  * 0. General
  * 1. Login
  * 2. Signup
@@ -30,7 +30,7 @@
 
     input:-webkit-autofill {
         -webkit-box-shadow: 0 0 0px 1000px $lightgrey inset !important;
-    } 
+    }
 
 }//.ghost-login
 
@@ -94,9 +94,9 @@
             width:264px;
             @include transition(none);
         }
-        
-        &:focus { 
-            background: lighten($darkgrey, 15%); 
+
+        &:focus {
+            background: lighten($darkgrey, 15%);
         }
 
     }
@@ -169,7 +169,7 @@
         color: darken($midgrey, 10%);
         font-size: 0.9em;
 
-        &:hover { 
+        &:hover {
             color: lighten($midgrey, 5%);
             text-decoration: none;
         }
@@ -182,7 +182,7 @@
    2. Signup and Reset
    ============================================================================= */
 
-#signup, #reset {
+.signup-form, #reset {
     @include box-sizing(border-box);
     max-width: 280px;
     color: lighten($midgrey, 15%);
@@ -219,8 +219,8 @@
             width: 264px;
         }
 
-        &:focus { 
-           background: lighten($darkgrey, 15%); 
+        &:focus {
+           background: lighten($darkgrey, 15%);
         }
 
     }
@@ -304,9 +304,9 @@
             @include transition(none);
             max-width: 244px;
         }
-        
-        &:focus { 
-            background: lighten($darkgrey, 15%); 
+
+        &:focus {
+            background: lighten($darkgrey, 15%);
         }
 
     }

--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -182,7 +182,7 @@
    2. Signup and Reset
    ============================================================================= */
 
-.signup-form, #reset {
+.signup-form, .reset-form {
     @include box-sizing(border-box);
     max-width: 280px;
     color: lighten($midgrey, 15%);

--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -55,7 +55,7 @@
    1. Login
    ============================================================================= */
 
-#login {
+.login-form {
     @include box-sizing(border-box);
     max-width: 530px;
     color: lighten($midgrey, 15%);

--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -270,7 +270,7 @@
    3. Forgotten
    ============================================================================= */
 
-#forgotten {
+.forgotten-form {
     @include box-sizing(border-box);
     max-width: 280px;
     color: lighten($midgrey, 15%);

--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -18,7 +18,7 @@
 
 .editor {
 
-    #notifications {
+    .notifications {
         @include breakpoint($biggerthan-mobile) {
             bottom: 40px;
         }

--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -360,7 +360,7 @@ nav {
         border-top:$lightbrown 1px solid;
     }
 
-    li { 
+    li {
         a {
             display:block;
             padding:10px 15px;
@@ -913,10 +913,10 @@ nav {
     .delete {
         display: block;
         padding: 10px 15px;
-        @include icon($i-trash) { 
-            position: relative; 
-            top: -1px; 
-            margin-right: 10px 
+        @include icon($i-trash) {
+            position: relative;
+            top: -1px;
+            margin-right: 10px
         };
 
         &:hover { background: $red; }
@@ -928,7 +928,7 @@ nav {
    Notifications
    ========================================================================== */
 
-#notifications {
+.notifications {
     @include breakpoint($biggerthan-mobile) {
         position: absolute;
         bottom: 0;

--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -1031,7 +1031,7 @@ nav {
 /* ==========================================================================
    Modals
    ========================================================================== */
-#modal-container {
+.modal-container {
     @include box-sizing(border-box);
     display: none;
     position: fixed;

--- a/core/client/tpl/forgotten.hbs
+++ b/core/client/tpl/forgotten.hbs
@@ -1,4 +1,4 @@
-<form id="forgotten" method="post" novalidate="novalidate">
+<form id="forgotten" class="forgotten-form" method="post" novalidate="novalidate">
     <div class="email-wrap">
         <input class="email" type="email" placeholder="Email Address" name="email" autocapitalize="off" autocorrect="off">
     </div>

--- a/core/client/tpl/login.hbs
+++ b/core/client/tpl/login.hbs
@@ -1,4 +1,4 @@
-<form id="login" method="post" novalidate="novalidate">
+<form id="login" class="login-form" method="post" novalidate="novalidate">
     <div class="email-wrap">
         <input class="email" type="email" placeholder="Email Address" name="email" autocapitalize="off" autocorrect="off">
     </div>

--- a/core/client/tpl/reset.hbs
+++ b/core/client/tpl/reset.hbs
@@ -1,4 +1,4 @@
-<form id="reset" method="post" novalidate="novalidate">
+<form id="reset" class="reset-form" method="post" novalidate="novalidate">
     <div class="password-wrap">
         <input class="password" type="password" placeholder="Password" name="newpassword" />
     </div>

--- a/core/client/tpl/signup.hbs
+++ b/core/client/tpl/signup.hbs
@@ -1,4 +1,4 @@
-<form id="signup" method="post" novalidate="novalidate">
+<form id="signup" class="signup-form" method="post" novalidate="novalidate">
     <div class="name-wrap">
         <input class="name" type="text" placeholder="Full Name" name="name" autocorrect="off" />
     </div>

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -39,7 +39,7 @@
     <main role="main" id="main">
         {{updateNotification}}
 
-        <aside id="notifications">
+        <aside id="notifications" class="notifications">
             {{> notifications}}
         </aside>
 

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -51,7 +51,7 @@
         </div>
     </main>
 
-    <div id="modal-container">
+    <div id="modal-container" class="modal-container">
     </div>
     <div class="modal-background fade"></div>
 


### PR DESCRIPTION
Move styling from some elements from IDs to classes

Closes #1605
- Move styling for `#signup`,   `#forgotten`, `#reset`, `#login`, `#notifications` and `#modal-container` to classes
- No IDs have been added or removed, so any events shouldn't be affected
- Introduces 6 new classes `signup-form`, `forgotten-form`, `reset-form`, `login-form`, `notifications` and `modal-container`
