### PR TITLE
Show message and don't start if javascript files have not been built

### DIFF
--- a/core/client/init.js
+++ b/core/client/init.js
@@ -49,9 +49,6 @@
     };
 
     Ghost.init = function () {
-        // remove the temporary message which appears
-        $('.js-msg').remove();
-
         Ghost.router = new Ghost.Router();
 
         // This is needed so Backbone recognizes elements already rendered server side

--- a/core/server/config/paths.js
+++ b/core/server/config/paths.js
@@ -41,7 +41,8 @@ function paths() {
         'lang':             path.join(corePath, '/shared/lang/'),
         'debugPath':        subdir + '/ghost/debug/',
         'availableThemes':  availableThemes,
-        'availablePlugins': availablePlugins
+        'availablePlugins': availablePlugins,
+        'builtScriptPath':  path.join(corePath, 'built/scripts/')
     };
 }
 

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -18,9 +18,20 @@ var downsize        = require('downsize'),
     isProduction    = process.env.NODE_ENV === 'production',
 
     coreHelpers     = {},
-    registerHelpers;
+    registerHelpers,
 
-
+    scriptFiles = {
+        production: [
+            'ghost.min.js'
+        ],
+        development: [
+            'vendor.js',
+            'helpers.js',
+            'templates.js',
+            'models.js',
+            'views.js'
+        ]
+    };
 
 /**
  * [ description]
@@ -262,28 +273,16 @@ coreHelpers.fileStorage = function (context, options) {
 };
 
 coreHelpers.ghostScriptTags = function () {
-    var scriptFiles = [];
+    var scriptList = isProduction ? scriptFiles.production : scriptFiles.development;
 
-    if (isProduction) {
-        scriptFiles.push("ghost.min.js");
-    } else {
-        scriptFiles = [
-            'vendor.js',
-            'helpers.js',
-            'templates.js',
-            'models.js',
-            'views.js'
-        ];
-    }
-
-    scriptFiles = _.map(scriptFiles, function (fileName) {
+    scriptList = _.map(scriptList, function (fileName) {
         return scriptTemplate({
             source: config.paths().subdir + '/ghost/scripts/' + fileName,
             version: coreHelpers.assetHash
         });
     });
 
-    return scriptFiles.join('');
+    return scriptList.join('');
 };
 
 /*
@@ -677,3 +676,4 @@ module.exports = coreHelpers;
 module.exports.loadCoreHelpers = registerHelpers;
 module.exports.registerThemeHelper = registerThemeHelper;
 module.exports.registerAsyncThemeHelper = registerAsyncThemeHelper;
+module.exports.scriptFiles = scriptFiles;

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -74,6 +74,43 @@ function initDbHashAndFirstRun() {
     });
 }
 
+// Checks for the existence of the "built" javascript files from grunt concat.
+// Returns a promise that will be resolved if all files exist or rejected if 
+// any are missing.
+function builtFilesExist() {
+    var deferreds = [],
+        location = config.paths().builtScriptPath,
+
+        fileNames = process.env.NODE_ENV === 'production' ?
+                helpers.scriptFiles.production : helpers.scriptFiles.development;
+
+    function checkExist(fileName) {
+        var deferred = when.defer(),
+            errorMessage = "Javascript files have not been built.",
+            errorHelp = "\nPlease read the getting started instructions at:" +
+                        "\nhttps://github.com/TryGhost/Ghost#getting-started-guide-for-developers";
+
+        fs.exists(fileName, function (exists) {
+            if (exists) {
+                deferred.resolve(true);
+            } else {
+                var err = new Error(errorMessage);
+
+                err.help = errorHelp;
+                deferred.reject(err);
+            }
+        });
+
+        return deferred.promise;
+    }
+
+    fileNames.forEach(function (fileName) {
+        deferreds.push(checkExist(location + fileName));
+    });
+
+    return when.all(deferreds);
+}
+
 // Sets up the express server instance.
 // Instantiates the ghost singleton,
 // helpers, routes, middleware, and plugins.
@@ -106,6 +143,9 @@ function setup(server) {
             // Initialize the permissions actions and objects
             permissions.init()
         );
+    }).then(function () {
+        // Make sure javascript files have been built via grunt concat
+        return builtFilesExist();
     }).then(function () {
         // Initialize mail
         return mailer.init();
@@ -230,7 +270,7 @@ function setup(server) {
 
         });
     }, function (err) {
-        errors.logErrorAndExit(err);
+        errors.logErrorAndExit(err, err.context, err.help);
     });
 }
 

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -44,11 +44,6 @@
         </aside>
 
         {{{body}}}
-
-        <div class="js-msg">
-            <p>Hello There! Looks like something went wrong with your JavaScript.</p>
-            <p>Either you need to enable JavaScript, or you haven't built the JavaScript files yet. See the README and CONTRIBUTING files for more info.</p>
-        </div>
     </main>
 
     <div id="modal-container">

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -303,7 +303,8 @@ describe('Config', function () {
                 'lang',
                 'debugPath',
                 'availableThemes',
-                'availablePlugins'
+                'availablePlugins',
+                'builtScriptPath'
             );
         });
 


### PR DESCRIPTION
closes #1782
- added builtFilesExist function to check for files during startup. If built files do not exist Ghost startup is stopped and a link to the documentation is displayed
- exported a scriptFiles object from server/helpers
- removed "js-msg" about missing javascript from the UI
