### PR TITLE
Restyle dropdown subnav

### DIFF
--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -360,7 +360,7 @@ nav {
         border-top:$lightbrown 1px solid;
     }
 
-    li { 
+    li {
         a {
             display:block;
             padding:10px 15px;
@@ -504,7 +504,6 @@ nav {
         // The dropdown menu
         ul {
             display: none;
-            padding: 7px 0;
             border-left: none;
             position: absolute;
             top:40px;
@@ -515,6 +514,12 @@ nav {
         }
 
         li {
+            border-bottom: 1px solid $grey;
+
+            &:last-of-type {
+                border-bottom: none;
+            }
+
             a {
                 color: $lightgrey;
 
@@ -526,13 +531,6 @@ nav {
 
                 &:before { margin-right: 1em; } // space for icons
             }
-        }
-
-        .divider {
-            height: 1px;
-            margin: 7px 0;
-            overflow: hidden;
-            background: $grey;
         }
 
     }//.subnav
@@ -913,10 +911,10 @@ nav {
     .delete {
         display: block;
         padding: 10px 15px;
-        @include icon($i-trash) { 
-            position: relative; 
-            top: -1px; 
-            margin-right: 10px 
+        @include icon($i-trash) {
+            position: relative;
+            top: -1px;
+            margin-right: 10px
         };
 
         &:hover { background: $red; }

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -15,9 +15,7 @@
                 </a>
                 <ul class="overlay">
                     <li class="usermenu-profile"><a href="{{adminUrl}}/settings/user/">Your Profile</a></li>
-                    <li class="divider"></li>
                     <li class="usermenu-help"><a href="http://ghost.org/forum/">Help / Support</a></li>
-                    <li class="divider"></li>
                     <li class="usermenu-signout"><a href="{{adminUrl}}/signout/">Sign Out</a></li>
                 </ul>
             </li>


### PR DESCRIPTION
![screenshot](https://f.cloud.github.com/assets/928675/1944490/097106fa-7fbb-11e3-83ee-7100ae7987c0.png)

This is more just a small nitpick, and my proposed solution. Personally, it seems weird in a hover state for the a link's background color to not extend flush to the divider. I propose a change to this in dropping the unnecessary padding and margin declarations, as well as the dividers in Handlebar templates to **compact the dropdown** and **use border-bottom to act as a stylistic divider**.

With restyle:

![screen shot 2014-01-17 at 3 40 24 pm](https://f.cloud.github.com/assets/928675/1944752/041a5cf6-7fc0-11e3-9052-79f6ead66203.png)
