### PR TITLE
Remove the template method in Ghost.Views.Notification, because it has already inherits from Ghost.TemplateView.

### DIFF
--- a/core/client/views/base.js
+++ b/core/client/views/base.js
@@ -140,9 +140,6 @@
     Ghost.Views.Notification = Ghost.View.extend({
         templateName: 'notification',
         className: 'js-bb-notification',
-        template: function (data) {
-            return JST[this.templateName](data);
-        },
         render: function () {
             var html = this.template(this.model);
             this.$el.html(html);


### PR DESCRIPTION
Remove the template method in Ghost.Views.Notification, because it has already inherits from Ghost.TemplateView.
