### PR TITLE
Upgrade express-hbs, and switch to using registerPartial

### DIFF
--- a/core/server/helpers/template.js
+++ b/core/server/helpers/template.js
@@ -17,8 +17,7 @@ templates.execute = function (name, context) {
 
     // If the partial view is not compiled, it compiles and saves in handlebars
     if (typeof partial === 'string') {
-        partial = hbs.handlebars.compile(partial);
-        hbs.handlebars.partials[name] = partial;
+        hbs.registerPartial(partial);
     }
 
     return new hbs.handlebars.SafeString(partial(context));

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "connect-slashes": "1.2.0",
         "downsize": "0.0.4",
         "express": "3.4.6",
-        "express-hbs": "0.5.2",
+        "express-hbs": "0.7.6",
         "fs-extra": "0.8.1",
         "knex": "0.5.0",
         "moment": "2.4.0",


### PR DESCRIPTION
fixes #1964, fixes #1975
- Issues with partial handling which caused #1964  have been part fixed by handlebars, part worked around by express-hbs, we must use `registerPartials` to ensure partials are handled correctly.
- Issue with error handling which caused #1975 has also been fixed in express-hbs, which now catches the error from handlebars and passes it to express so that we can handle the error with an error page.
