### PR TITLE
Improvement for published posts with no published_at

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -61,6 +61,9 @@ Post = ghostBookshelf.Model.extend({
             }
             // This will need to go elsewhere in the API layer.
             this.set('published_by', 1);
+        } else if (this.get('status') === 'published' && !this.get('published_at')) {
+            // If somehow this is a published post with no date, fix it... see #2015
+            this.set('published_at', new Date());
         }
 
         ghostBookshelf.Model.prototype.saving.call(this);


### PR DESCRIPTION
This is not a fix, merely an improvement for 0.4.1.

I think the real issue stems from the problems documented in #1655 and will require major refactoring work.

Here we at least make sure that the published date gets set on a future save.

issue #2015
- this is another little workaround / improvement to try to reduce the number of people who end up with a published post with no published_at set
- I assume we need to complete #1655 to fix this properly
