### PR TITLE
Fix : redirect to correct slug when switching between  param and keep 30...

### DIFF
--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -84,14 +84,13 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-        it('should not work with date permalinks', function (done) {
+        it('should 301 with date permalinks', function (done) {
             // get today's date
             var date  = moment().format("YYYY/MM/DD");
 
             request.get('/' + date + '/welcome-to-ghost/')
-                .expect('Cache-Control', cacheRules.hour)
-                .expect(404)
-                .expect(/Page Not Found/)
+                .expect('Location', '/welcome-to-ghost/')
+                .expect(301)
                 .end(doEnd(done));
         });
 

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -306,6 +306,23 @@ describe('Frontend Controller', function () {
                     done();
                 });
             });
+
+            it('will redirect to normal post without date accessed with date url', function (done) {
+                var req = {
+                        params: ['2012/12/30/', mockPost.slug]
+                    },
+                    res = {
+                        render: sinon.spy(),
+                        writeHead: function(code, data) {
+                            res.render.called.should.be.false;
+                            code.should.eql(301);
+                            data.Location.should.eql('/' + mockPost.slug + '/');
+                            done();
+                        }
+                    };
+
+                frontend.single(req, res);
+            });
         });
 
         describe('permalink set to date', function () {
@@ -453,6 +470,23 @@ describe('Frontend Controller', function () {
                     res.redirect.called.should.be.false;
                     done();
                 });
+            });
+
+            it('will redirect to normal post with date accessed without date url', function (done) {
+                var req = {
+                        params: [null, mockPost.slug]
+                    },
+                    res = {
+                        render: sinon.spy(),
+                        writeHead: function(code, data) {
+                            res.render.called.should.be.false;
+                            code.should.eql(301);
+                            data.Location.should.eql('/2014/01/02/' + mockPost.slug + '/');
+                            done();
+                        }
+                    };
+
+                frontend.single(req, res);
             });
         });
     });


### PR DESCRIPTION
...1 instead of losing SEO

If I have old post without date indexed, then I tell in configuration I want dates, so when I access the old URL without date, I will be redirected to the one with date.
