### PR TITLE
Move styling from some elements from IDs to classes

### DIFF
--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -55,7 +55,7 @@
    1. Login
    ============================================================================= */
 
-#login {
+.login-form {
     @include box-sizing(border-box);
     max-width: 530px;
     color: lighten($midgrey, 15%);
@@ -182,7 +182,7 @@
    2. Signup and Reset
    ============================================================================= */
 
-#signup, #reset {
+.signup-form, .reset-form {
     @include box-sizing(border-box);
     max-width: 280px;
     color: lighten($midgrey, 15%);
@@ -270,7 +270,7 @@
    3. Forgotten
    ============================================================================= */
 
-#forgotten {
+.forgotten-form {
     @include box-sizing(border-box);
     max-width: 280px;
     color: lighten($midgrey, 15%);

--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -18,7 +18,7 @@
 
 .editor {
 
-    #notifications {
+    .notifications {
         @include breakpoint($biggerthan-mobile) {
             bottom: 40px;
         }
@@ -376,7 +376,7 @@
 
 body.zen {
     background: lighten($lightbrown, 3%);
-    #usermenu {display: none;}
+    .usermenu {display: none;}
     #global-header, #publish-bar {
         opacity: 0;
         height: 0;

--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -540,7 +540,7 @@ nav {
 }//.navbar
 
 // The user menu in the top right corner of the screen
-#usermenu {
+.usermenu.subnav {
     position:absolute;
     top:0;
     right:0;
@@ -636,7 +636,7 @@ nav {
 
         }
 
-        #usermenu {
+        .usermenu {
             position:fixed;
             top:0;
             right:auto;
@@ -928,7 +928,7 @@ nav {
    Notifications
    ========================================================================== */
 
-#notifications {
+.notifications {
     @include breakpoint($biggerthan-mobile) {
         position: absolute;
         bottom: 0;

--- a/core/client/tpl/forgotten.hbs
+++ b/core/client/tpl/forgotten.hbs
@@ -1,4 +1,4 @@
-<form id="forgotten" method="post" novalidate="novalidate">
+<form id="forgotten" class="forgotten-form" method="post" novalidate="novalidate">
     <div class="email-wrap">
         <input class="email" type="email" placeholder="Email Address" name="email" autocapitalize="off" autocorrect="off">
     </div>

--- a/core/client/tpl/login.hbs
+++ b/core/client/tpl/login.hbs
@@ -1,4 +1,4 @@
-<form id="login" method="post" novalidate="novalidate">
+<form id="login" class="login-form" method="post" novalidate="novalidate">
     <div class="email-wrap">
         <input class="email" type="email" placeholder="Email Address" name="email" autocapitalize="off" autocorrect="off">
     </div>

--- a/core/client/tpl/reset.hbs
+++ b/core/client/tpl/reset.hbs
@@ -1,4 +1,4 @@
-<form id="reset" method="post" novalidate="novalidate">
+<form id="reset" class="reset-form" method="post" novalidate="novalidate">
     <div class="password-wrap">
         <input class="password" type="password" placeholder="Password" name="newpassword" />
     </div>

--- a/core/client/tpl/signup.hbs
+++ b/core/client/tpl/signup.hbs
@@ -1,4 +1,4 @@
-<form id="signup" method="post" novalidate="novalidate">
+<form id="signup" class="signup-form" method="post" novalidate="novalidate">
     <div class="name-wrap">
         <input class="name" type="text" placeholder="Full Name" name="name" autocorrect="off" />
     </div>

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -39,7 +39,7 @@
     <main role="main" id="main">
         {{updateNotification}}
 
-        <aside id="notifications">
+        <aside id="notifications" class="notifications">
             {{> notifications}}
         </aside>
 

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -8,7 +8,7 @@
                 <li class="{{navClass}}{{#if selected}} active{{/if}}"><a href="{{adminUrl}}{{path}}">{{name}}</a></li>
             {{/each}}
 
-            <li id="usermenu" class="subnav">
+            <li id="usermenu" class="usermenu subnav">
                 <a href="#" data-toggle="ul" class="dropdown">
                     <img class="avatar" src="{{#if currentUser.image}}{{currentUser.image}}{{else}}{{asset "shared/img/user-image.png"}}{{/if}}" alt="Avatar" />
                     <span class="name">{{#if currentUser.name}}{{currentUser.name}}{{else}}{{currentUser.email}}{{/if}}</span>


### PR DESCRIPTION
Closes #1605
- Move styling for `#signup`, `#forgotten`, `#reset`, `#login`, `#usermenu` and `#notifications` to classes

No IDs have been added or removed, so any events shouldn't be affected and it passes all tests.
