### PR TITLE
Guard against multiple signup events

### DIFF
--- a/core/client/views/login.js
+++ b/core/client/views/login.js
@@ -64,6 +64,7 @@
     Ghost.Views.Signup = Ghost.View.extend({
 
         initialize: function () {
+            this.submitted = "no";
             this.render();
         },
 
@@ -95,10 +96,12 @@
             Ghost.Validate.check(name, "Please enter a name").len(1);
             Ghost.Validate.check(email, "Please enter a correct email address").isEmail();
             Ghost.Validate.check(password, "Your password is not long enough. It must be at least 8 characters long.").len(8);
+            Ghost.Validate.check(this.submitted, "Ghost is signing you up. Please wait...").equals("no");
 
             if (Ghost.Validate._errors.length > 0) {
                 Ghost.Validate.handleErrors();
             } else {
+                this.submitted = "yes";
                 $.ajax({
                     url: Ghost.paths.subdir + '/ghost/signup/',
                     type: 'POST',
@@ -114,6 +117,7 @@
                         window.location.href = msg.redirect;
                     },
                     error: function (xhr) {
+                        this.submitted = "no";
                         Ghost.notifications.clearEverything();
                         Ghost.notifications.addItem({
                             type: 'error',


### PR DESCRIPTION
Fixes #1841
- Added initial flag "no" for submission into Signup View
- Flag set to "yes" if submit button clicked
- Error thrown if flag is "yes", thus no subsequent submission sent to API
- Flag set to "no" if ajax returns with error

Resubmitted against 0.4-maintenance
