### PR TITLE
Fix dash-to-triple-hyphen replacement in generateSlug function.

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -215,6 +215,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         // Remove URL reserved chars: `:/?#[]@!$&'()*+,;=` as well as `\%<>|^~£"`
         slug = base.trim().replace(/[:\/\?#\[\]@!$&'()*+,;=\\%<>\|\^~£"]/g, '')
+            // Replace n- and m-dash with single dash
+            .replace(/(–|—)/g, '-')
             // Replace dots and spaces with a dash
             .replace(/(\s|\.)/g, '-')
             // Convert 2 or more dashes into a single dash

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -243,13 +243,13 @@ describe('Post Model', function () {
 
     it('can generate slugs without duplicate hyphens', function (done) {
         var newPost = {
-            title: 'apprehensive  titles  have  too  many  spaces  ',
+            title: 'apprehensive  titles  have  too  many  spaces—and m-dashes  —  –  and also n-dashes  ',
             markdown: 'Test Content 1'
         };
 
         PostModel.add(newPost).then(function (createdPost) {
 
-            createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces');
+            createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
             done();
         }).then(null, done);


### PR DESCRIPTION
If you use a [common unicode dash](https://en.wikipedia.org/wiki/Dash#Common_dashes) in your post title, your slug/url will contain three hyphens. This looks rather strange. This commit replaces those with one hyphen instead.
