### PR TITLE
Fix dash-to-triple-hyphen replacement in generateSlug function.

### DIFF
--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -243,13 +243,13 @@ describe('Post Model', function () {
 
     it('can generate slugs without duplicate hyphens', function (done) {
         var newPost = {
-            title: 'apprehensive  titles  have  too  many  spaces  ',
+            title: 'apprehensive  titles  have  too  many  spaces—and m-dashes  —  –  and also n-dashes  ',
             markdown: 'Test Content 1'
         };
 
         PostModel.add(newPost).then(function (createdPost) {
 
-            createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces');
+            createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
             done();
         }).then(null, done);


### PR DESCRIPTION
Second attempt for https://github.com/TryGhost/Ghost/pull/2050. Sorry for the confusion, I'm having trouble using Github correctly :sweat_smile:

`grunt test-integration` passed successfully. Took me a lot longer to figure out how this works, than anticipated :smile:

I hope this is all right now.
