### PR TITLE
Introduce default robots.txt

### DIFF
--- a/core/shared/robots.txt
+++ b/core/shared/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /ghost/


### PR DESCRIPTION
See #2062 

This is based on generally accepted advice on base robots.txt 
- http://moz.com/learn/seo/robotstxt
- http://yoast.com/example-robots-txt-wordpress/
