### PR TITLE
Show parse error message during a failed import

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -8,8 +8,8 @@ var dataExport       = require('../data/export'),
     _                = require('lodash'),
     schema           = require('../data/schema').tables,
     config           = require('../config'),
+    errors           = require('../../server/errorHandling'),
     api              = {},
-
     db;
 
 api.notifications    = require('./notifications');
@@ -76,7 +76,8 @@ db = {
             try {
                 importData = JSON.parse(fileContents);
             } catch (e) {
-                return when.reject(new Error("Failed to parse the import file"));
+                errors.logError(e, "API DB import content", "check that the import file is valid JSON.");
+                return when.reject(new Error("Failed to parse the import JSON file"));
             }
 
             if (!importData.meta || !importData.meta.version) {


### PR DESCRIPTION
adds support for outputting error message during a failed JSON.parse
This will help people identify the problem with their JSON source
and hopefully be able to aid them in resolving said issue.

![](http://dl.dropbox.com/u/47552986/Screenshots/l9.png)
