### PR TITLE
Install App Dependencies

### DIFF
--- a/core/server/apps/dependencies.js
+++ b/core/server/apps/dependencies.js
@@ -1,0 +1,52 @@
+
+var _ = require('lodash'),
+    fs = require('fs'),
+    path = require('path'),
+    when = require('when'),
+    spawn = require('child_process').spawn,
+    win32 = process.platform === 'win32';
+
+function AppDependencies(appPath) {
+    this.appPath = appPath;
+}
+
+AppDependencies.prototype.install = function installAppDependencies() {
+    var def = when.defer(),
+        spawnOpts;
+
+    fs.exists(path.join(this.appPath, 'package.json'), function (exists) {
+        if (!exists) {
+            // Nothing to do, resolve right away?
+            def.resolve();
+        } else {
+            // Run npm install in the app directory
+            spawnOpts = {
+                cwd: this.appPath
+            };
+
+            this.spawnCommand('npm', ['install', '--production'], spawnOpts)
+                .on('error', def.reject)
+                .on('exit', function (err) {
+                    if (err) {
+                        def.reject(err);
+                    }
+
+                    def.resolve();
+                });
+        }
+    }.bind(this));
+
+    return def.promise;
+};
+
+// Normalize a command across OS and spawn it; taken from yeoman/generator
+AppDependencies.prototype.spawnCommand = function (command, args, opt) {
+    var winCommand = win32 ? 'cmd' : command,
+        winArgs = win32 ? ['/c'].concat(command, args) : args;
+
+    opt = opt || {};
+
+    return spawn(winCommand, winArgs, _.defaults({ stdio: 'inherit' }, opt));
+};
+
+module.exports = AppDependencies;


### PR DESCRIPTION
Couldn't find an issue created for this yet.
- Spawns an npm install command from the App root
- Has some special OS checks for windows command spawning

Depends on #2091 for the app spec file rename stuff, just rebased on it to make it easier to start this, can separate it out before merging if you want this in before that.

I figured just spawning the npm install command was the easiest route, open to feedback.  

This could be abstracted up a little to be usable by both themes and apps (/cc @javorszky).
