### PR TITLE
Adds support for additional permalink structures

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -9,13 +9,17 @@ var moment      = require('moment'),
     _           = require('lodash'),
     url         = require('url'),
     when        = require('when'),
+    Route       = require('express').Route,
 
     api         = require('../api'),
     config      = require('../config'),
     errors      = require('../errorHandling'),
     filters     = require('../../server/filters'),
 
-    frontendControllers;
+    frontendControllers,
+    // Cache static post permalink regex
+    staticPostPermalink = new Route(null, '/:slug/:edit?');
+
 
 frontendControllers = {
     'homepage': function (req, res, next) {
@@ -65,22 +69,52 @@ frontendControllers = {
         });
     },
     'single': function (req, res, next) {
-        // From route check if a date was parsed
-        // from the regex
-        var dateInSlug = req.params[0] ? true : false;
-        when.join(
-            api.settings.read('permalinks'),
-            api.posts.read({slug: req.params[1]})
-        ).then(function (promises) {
-            var permalink = promises[0].value,
-                post = promises[1];
+        var path = req.path,
+            params,
+            editFormat,
+            usingStaticPermalink = false;
+
+        api.settings.read('permalinks').then(function (permalink) {
+            editFormat = permalink.value[permalink.value.length - 1] === '/' ? ':edit?' : '/:edit?';
+
+            // Convert saved permalink into an express Route object
+            permalink = new Route(null, permalink.value + editFormat);
+
+            // Check if the path matches the permalink structure.
+            //
+            // If there are no matches found we then
+            // need to verify it's not a static post,
+            // and test against that permalink structure.
+            if (permalink.match(path) === false) {
+                // If there are still no matches then return.
+                if (staticPostPermalink.match(path) === false) {
+                    // Throw specific error
+                    // to break out of the promise chain.
+                    throw new Error('no match');
+                }
+
+                permalink = staticPostPermalink;
+                usingStaticPermalink = true;
+            }
+
+            params = permalink.params;
+
+            // Sanitize params we're going to use to lookup the post.
+            var postLookup = _.pick(permalink.params, 'slug', 'id');
+
+            // Query database to find post
+            return api.posts.read(postLookup);
+        }).then(function (post) {
+
+            if (!post) {
+                return next();
+            }
 
             function render() {
                 // If we're ready to render the page but the last param is 'edit' then we'll send you to the edit page.
-                if (req.params[2] && req.params[2] === 'edit') {
+                if (params.edit !== undefined) {
                     return res.redirect(config().paths.subdir + '/ghost/editor/' + post.id + '/');
                 }
-
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {
                         var paths = config().paths.availableThemes[activeTheme.value],
@@ -90,34 +124,59 @@ frontendControllers = {
                 });
             }
 
-            if (!post) {
-                return next();
-            }
-
-            // Check that the date in the URL matches the published date of the post, else 404
-            if (dateInSlug && req.params[0] !== moment(post.published_at).format('YYYY/MM/DD/')) {
-                return next();
-            }
-
-            // A page can only be rendered when there is no date in the url.
-            // A post can either be rendered with a date in the url depending on the permalink setting.
-            // For all other conditions return 404.
-            if (post.page === 1 && dateInSlug === false) {
-                return render();
-            }
-
-            if (post.page === 0) {
-                // Handle post rendering
-                if ((permalink === '/:slug/' && dateInSlug === false) ||
-                        (permalink !== '/:slug/' && dateInSlug === true)) {
+            // If we've checked the path with the static permalink structure
+            // then the post must be a static post.
+            // If it is not then we must return.
+            if (usingStaticPermalink) {
+                if (post.page === 1) {
                     return render();
                 }
+
+                return next();
             }
 
-            next();
+            // If there is any date based paramter in the slug
+            // we will check it against the post published date
+            // to verify it's correct.
+            if (params.year || params.month || params.day) {
+                var slugDate = [],
+                    slugFormat = [];
 
+                if (params.year) {
+                    slugDate.push(params.year);
+                    slugFormat.push('YYYY');
+                }
+
+                if (params.month) {
+                    slugDate.push(params.month);
+                    slugFormat.push('MM');
+                }
+
+                if (params.day) {
+                    slugDate.push(params.day);
+                    slugFormat.push('DD');
+                }
+
+                slugDate = slugDate.join('/');
+                slugFormat = slugFormat.join('/');
+
+                if (slugDate === moment(post.published_at).format(slugFormat)) {
+                    return render();
+                }
+
+                return next();
+            }
+
+            render();
 
         }).otherwise(function (err) {
+            // If we've thrown an error message
+            // of 'no match' then we found
+            // no path match.
+            if (err.message === 'no match') {
+                return next();
+            }
+
             var e = new Error(err.message);
             e.status = err.errorCode;
             return next(e);

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -57,8 +57,8 @@
         "permalinks": {
             "defaultValue": "/:slug/",
             "validations": {
-                "is": "^(/:?[a-z]+){1,}/$",
-                "regex": "(:id|:slug)",
+                "is": "^(\/:?[a-z0-9_-]+){1,5}\/$",
+                "regex": "(:id|:slug|:year|:month|:day)",
                 "notContains": "/ghost/"
             }
         }

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -7,14 +7,6 @@ module.exports = function (server) {
     server.get('/rss/', frontend.rss);
     server.get('/rss/:page/', frontend.rss);
     server.get('/page/:page/', frontend.homepage);
-    // Only capture the :slug part of the URL
-    // This regex will always have two capturing groups,
-    // one for date, and one for the slug.
-    // Examples:
-    //  Given `/plain-slug/` the req.params would be [undefined, 'plain-slug']
-    //  Given `/2012/12/24/plain-slug/` the req.params would be ['2012/12/24/', 'plain-slug']
-    //  Given `/plain-slug/edit/` the req.params would be [undefined, 'plain-slug', 'edit']
-    server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/$/, frontend.single);
-    server.get(/^\/([0-9]{4}\/[0-9]{2}\/[0-9]{2}\/)?([^\/.]*)\/edit\/$/, frontend.edit);
     server.get('/', frontend.homepage);
+    server.get('*', frontend.single);
 };


### PR DESCRIPTION
fixes #2057
- uses express’ Route object to create RegExp’s
  that we use to check the incoming path
- refactored structure of fronted controller single
  tests to be easier to read
- amend regex to incorporate new allowed permalink
  structure
