### PR TITLE
Fix for Issue #2106

### DIFF
--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -103,6 +103,34 @@ describe('Core Helpers', function () {
             rendered.string.should.equal("<p><img src='example.jpg' /></p>");
         });
 
+        it('can truncate html to 0 words, leaving image tag if it is first and if it has an alt text with a single quote in the string', function () {
+            var html = "<p><img src='example.jpg' alt=\"It's me!\" />Hello <strong>World! It's me!</strong></p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            { html: html },
+                            { "hash": { "words": "0" } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<p><img src='example.jpg' alt=\"It's me!\" /></p>");
+        });
+
+        it('can truncate html to 0 words, leaving image tag if it is first and if it has an alt text with a double quote in the string', function () {
+            var html = "<p><img src='example.jpg' alt='A double quote is \"' />Hello <strong>World! It's me!</strong></p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            { html: html },
+                            { "hash": { "words": "0" } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<p><img src='example.jpg' alt='A double quote is \"' /></p>");
+        });
+
         it('can truncate html by character', function () {
             var html = "<p>Hello <strong>World! It's me!</strong></p>",
                 rendered = (

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "busboy": "0.0.12",
         "colors": "0.6.2",
         "connect-slashes": "1.2.0",
-        "downsize": "0.0.4",
+        "downsize": "0.0.5",
         "express": "3.4.6",
         "express-hbs": "0.7.6",
         "fs-extra": "0.8.1",


### PR DESCRIPTION
This is a fix for Issue #2106 {{content words="#"}} returns all content if the first html word is an image markdown that has single quote in its alt text

Changelog:
Updated downsize.js and added unit tests.

Notes:
Passed `grunt validate`

Reference 
https://github.com/TryGhost/Ghost/issues/2106
