### PR TITLE
Removed author tag inside channel tag in RSS

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -155,7 +155,6 @@ frontendControllers = {
                 title: title,
                 description: description,
                 generator: 'Ghost v' + res.locals.version,
-                author: user ? user.name : null,
                 feed_url: feedUrl,
                 site_url: siteUrl,
                 ttl: '60'
@@ -184,7 +183,8 @@ frontendControllers = {
                                 guid: post.uuid,
                                 url: config.paths.urlFor('post', {post: post, permalinks: permalinks}, true),
                                 date: post.published_at,
-                                categories: _.pluck(post.tags, 'name')
+                                categories: _.pluck(post.tags, 'name'),
+                                author: user ? user.name : null
                             },
                             content = post.html;
 

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -29,32 +29,14 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     });
 }, false);
 
-CasperTest.begin('Ensure that RSS is available and author element should be after item element NOT before which is channel element', 12, function suite(test) {
+CasperTest.begin('Ensure that RSS is available and author element should be after item element NOT before which is channel element', 2, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('off');
     casper.thenOpen(url + 'rss/', function (response) {
         var content = this.getPageContent(),
-            siteTitle = '<title><![CDATA[Ghost]]></title>',
-            siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
-            siteUrl = '<link>http://127.0.0.1:2369/</link>',
-            postTitle = '<![CDATA[Welcome to Ghost]]>',
-            postStart = '<description><![CDATA[<p>You\'re live!',
-            postEnd = 'you think :)</p>]]></description>',
-            postLink = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
-            postCreator = '<dc:creator><![CDATA[Test User]]>',
             author = '<author>';
 
         test.assertEqual(response.status, 200, 'Response status should be 200.');
-        test.assert(content.indexOf('<rss') >= 0, 'Feed should contain <rss');
-        test.assert(content.indexOf(siteTitle) >= 0, 'Feed should contain blog title.');
-        test.assert(content.indexOf(siteDescription) >= 0, 'Feed should contain blog description.');
-        test.assert(content.indexOf(siteUrl) >= 0, 'Feed should contain link to blog.');
-        test.assert(content.indexOf(postTitle) >= 0, 'Feed should contain welcome post title.');
-        test.assert(content.indexOf(postStart) >= 0, 'Feed should contain start of welcome post content.');
-        test.assert(content.indexOf(postEnd) >= 0, 'Feed should contain end of welcome post content.');
-        test.assert(content.indexOf(postLink) >= 0, 'Feed should have link to the welcome post.');
-        test.assert(content.indexOf(postCreator) >= 0, 'Welcome post should have Test User as the creator.');
         test.assert(content.indexOf(author) < 0, 'Author should not be included since there is dc:creator already');
-        test.assert(content.indexOf('</rss>') >= 0, 'Feed should contain </rss>');
     });
 }, false);
 

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -29,6 +29,35 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     });
 }, false);
 
+CasperTest.begin('Ensure that RSS is available and author element should be after item element NOT before which is channel element', 12, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run('off');
+    casper.thenOpen(url + 'rss/', function (response) {
+        var content = this.getPageContent(),
+            siteTitle = '<title><![CDATA[Ghost]]></title>',
+            siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
+            siteUrl = '<link>http://127.0.0.1:2369/</link>',
+            postTitle = '<![CDATA[Welcome to Ghost]]>',
+            postStart = '<description><![CDATA[<p>You\'re live!',
+            postEnd = 'you think :)</p>]]></description>',
+            postLink = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
+            postCreator = '<dc:creator><![CDATA[Test User]]>',
+            author = '<author>';
+
+        test.assertEqual(response.status, 200, 'Response status should be 200.');
+        test.assert(content.indexOf('<rss') >= 0, 'Feed should contain <rss');
+        test.assert(content.indexOf(siteTitle) >= 0, 'Feed should contain blog title.');
+        test.assert(content.indexOf(siteDescription) >= 0, 'Feed should contain blog description.');
+        test.assert(content.indexOf(siteUrl) >= 0, 'Feed should contain link to blog.');
+        test.assert(content.indexOf(postTitle) >= 0, 'Feed should contain welcome post title.');
+        test.assert(content.indexOf(postStart) >= 0, 'Feed should contain start of welcome post content.');
+        test.assert(content.indexOf(postEnd) >= 0, 'Feed should contain end of welcome post content.');
+        test.assert(content.indexOf(postLink) >= 0, 'Feed should have link to the welcome post.');
+        test.assert(content.indexOf(postCreator) >= 0, 'Welcome post should have Test User as the creator.');
+        test.assert(content.indexOf(author) < 0, 'Author should not be included since there is dc:creator already');
+        test.assert(content.indexOf('</rss>') >= 0, 'Feed should contain </rss>');
+    });
+}, false);
+
 CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('on');
     casper.thenOpen(url + 'rss/', function (response) {


### PR DESCRIPTION
closes #2114
- instead of putting `author: user ? user.name : null` in feedOptions of node-rss, it was moved to itemOptions
- supplying `author: user ? user.name : null` in itemOptions will still result to creating a dc:creator tag inside item tags so the info needed to have the author is still there like before
- node-rss should still however fix it to not have that nasty author tag in channel tag when you supply author in feedOptions
- added a functional test
