### PR TITLE
Removed author tag inside channel tag in RSS

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -155,7 +155,6 @@ frontendControllers = {
                 title: title,
                 description: description,
                 generator: 'Ghost v' + res.locals.version,
-                author: user ? user.name : null,
                 feed_url: feedUrl,
                 site_url: siteUrl,
                 ttl: '60'
@@ -184,7 +183,8 @@ frontendControllers = {
                                 guid: post.uuid,
                                 url: config.paths.urlFor('post', {post: post, permalinks: permalinks}, true),
                                 date: post.published_at,
-                                categories: _.pluck(post.tags, 'name')
+                                categories: _.pluck(post.tags, 'name'),
+                                author: user ? user.name : null
                             },
                             content = post.html;
 

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -29,6 +29,19 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     });
 }, false);
 
+CasperTest.begin('Ensure that author element is not included. Only dc:creator', 3, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run('off');
+    casper.thenOpen(url + 'rss/', function (response) {
+        var content = this.getPageContent(),
+            author = '<author>',
+            postCreator = '<dc:creator><![CDATA[Test User]]>';
+
+        test.assertEqual(response.status, 200, 'Response status should be 200.');
+        test.assert(content.indexOf(author) < 0, 'Author element should not be included');
+        test.assert(content.indexOf(postCreator) >= 0, 'Welcome post should have Test User as the creator.');
+    });
+}, false);
+
 CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('on');
     casper.thenOpen(url + 'rss/', function (response) {


### PR DESCRIPTION
closes #2114
- instead of putting author in feedOptions of node-rss, it was moved to itemOptions
- supplying author: user ? user.name : null in itemOptions will still result to creating a dc:creator tag inside item tags so the info needed to have the author is still there like before
- node-rss should however still fix this quirk to not have that nasty author tag in channel tag when you supply author in feedOptions
