### PR TITLE
Removed mailto auto-linking.

### DIFF
--- a/core/shared/vendor/showdown/extensions/github.js
+++ b/core/shared/vendor/showdown/extensions/github.js
@@ -115,11 +115,6 @@
                             return lookBehind ? wholeMatch : "<a href='" + wholeMatch + "'>" + wholeMatch + "</a>";
                         });
 
-                    // match email
-                    text = text.replace(/[a-z0-9_\-+=.]+@[a-z0-9\-]+(\.[a-z0-9-]+)+/gmi, function (wholeMatch) {
-                        return "<a href='mailto:" + wholeMatch + "'>" + wholeMatch + "</a>";
-                    });
-
                     // replace extractions
                     text = text.replace(/\{gfm-js-extract-pre-([0-9]+)\}/gm, function (x, y) {
                         return preExtractions[y];

--- a/core/test/unit/client_showdown_int_spec.js
+++ b/core/test/unit/client_showdown_int_spec.js
@@ -208,13 +208,6 @@ describe("Showdown client side converter", function () {
         });
     });
 
-    it("should auto-link Email", function () {
-        var testPhrase = {input: "info@tryghost.org", output: /^<p><a href=\'mailto:info@tryghost.org\'>info@tryghost.org<\/a><\/p>$/},
-            processedMarkup = converter.makeHtml(testPhrase.input);
-
-        processedMarkup.should.match(testPhrase.output);
-    });
-
     it("should convert reference format URL", function () {
         var testPhrases = [
                 {

--- a/core/test/unit/shared_gfm_spec.js
+++ b/core/test/unit/shared_gfm_spec.js
@@ -121,13 +121,6 @@ describe("Github showdown extensions", function () {
         });
     });
 
-    it("should auto-link Email", function () {
-        var testPhrase = {input: "info@tryghost.org", output: /^<a href=\'mailto:info@tryghost.org\'>info@tryghost.org<\/a>$/},
-            processedMarkup = _ConvertPhrase(testPhrase.input);
-
-        processedMarkup.should.match(testPhrase.output);
-    });
-
     it("should NOT auto-link URL in HTML", function () {
         var testPhrases = [
                 {


### PR DESCRIPTION
As shortly discussed in IRC, mailto auto-linking is causing several issues and can safely be removed. If someone still wants a mailto link, the normal linking syntax can be used.

fixes #1617
- Removed tests
- Removed auto-linking from showdown gfm extension
