### PR TITLE
Add Dockerfile and config reading db/url from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:13.10
+MAINTAINER Johannes 'fish' Ziemke <fish@docker.com>
+
+RUN apt-get update && apt-get -y -q upgrade && apt-get -y -q install software-properties-common
+
+RUN apt-get -y -q install python-software-properties python g++ make && \
+    add-apt-repository ppa:chris-lea/node.js && \
+    apt-get update
+
+RUN apt-get -y -q install nodejs ruby python python-pygments curl git
+
+RUN curl https://phantomjs.googlecode.com/files/phantomjs-1.9.2-linux-x86_64.tar.bz2 | \
+    tar -C /usr/local -xjf - && ln -sf ../phantomjs-1.9.2-linux-x86_64/bin/phantomjs /usr/local/bin/
+
+RUN git clone git://github.com/n1k0/casperjs.git /usr/local/casperjs && \
+    ln -sf ../casperjs/bin/casperjs /usr/local/bin
+
+WORKDIR /ghost
+EXPOSE 8080
+ENTRYPOINT [ "./run.sh" ]
+CMD [ "start" ]
+
+ADD . /ghost
+RUN git submodule update --init && gem install bundler && bundle install && \
+    npm install -g grunt-cli && npm install && grunt init && \
+    cp config.docker.js config.js
+
+RUN printf '#!/bin/sh\nDB_HOST=$(echo $DB_PORT | sed "s|^tcp://||;s/:.*//") exec npm $@' > \
+    run.sh && chmod a+x run.sh
+
+ENV NODE_ENV production

--- a/config.docker.js
+++ b/config.docker.js
@@ -1,0 +1,32 @@
+// # Ghost Configuration
+// Setup your Ghost install for various environments
+
+var config;
+
+config = {
+    // ### Production
+    // When running Ghost in the wild, use the production environment
+    // Configure your URL and mail settings here
+    production: {
+        url: process.env.URL,
+        database: {
+            client: 'mysql',
+            connection: {
+                    host: process.env.DB_HOST,
+                    user: process.env.DB_USER,
+                    password: process.env.DB_PASSWORD,
+                    database: process.env.DB_NAME,
+                    charset: 'utf8'
+            }
+        },
+        server: {
+            // Host to be passed to node's `net.Server#listen()`
+            host: '0.0.0.0',
+            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
+            port: '8080'
+        }
+    },
+};
+
+// Export config
+module.exports = config;


### PR DESCRIPTION
This includes a config which will read env variables and expect a linked mysql container. It would be run like this:

```
docker run -link mysql-server:db -e DB_NAME=ghost -e DB_USER=ghost -e DB_PASSWORD=foobar23 ghost
```

I know that not everyone is using docker, but if you search for 'docker ghost blog' there are a lot people running ghost on docker and I bet they would be happy to have a always up to date Dockerfile right in the source. Beside that, you could add this repo to index.docker.io as trusted build and installing a always up to date ghost would be just a 'docker pull <user>/ghost'.

So what do you think?
