### PR TITLE
Don't require mail.options to be set

### DIFF
--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -16,7 +16,7 @@ function GhostMailer(opts) {
 // *This promise should always resolve to avoid halting Ghost::init*.
 GhostMailer.prototype.init = function () {
     var self = this;
-    if (config().mail && config().mail.transport && config().mail.options) {
+    if (config().mail && config().mail.transport) {
         this.createTransport();
         return when.resolve();
     }
@@ -53,7 +53,7 @@ GhostMailer.prototype.detectSendmail = function () {
 };
 
 GhostMailer.prototype.createTransport = function () {
-    this.transport = nodemailer.createTransport(config().mail.transport, _.clone(config().mail.options));
+    this.transport = nodemailer.createTransport(config().mail.transport, _.clone(config().mail.options) || {});
 };
 
 GhostMailer.prototype.usingSendmail = function () {


### PR DESCRIPTION
Some `transport` methods (sendmail) don't require any `options`.

See https://ghost.org/forum/using-ghost/1059-disable-sendmail-warning/4/
