### PR TITLE
Meta description for post

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -412,6 +412,8 @@ coreHelpers.meta_description = function (options) {
         if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '' || this.relativeUrl.match(/\/page/)) {
             blog = config.theme();
             description = blog.description;
+        } else if (this.post) {
+            description = coreHelpers.excerpt.call(this.post).toString() + '…';
         } else {
             description = '';
         }

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -693,11 +693,12 @@ describe('Core Helpers', function () {
             }).then(null, done);
         });
 
-        it('can return empty description on post', function (done) {
-            var post = {relativeUrl: '/nice-post', post: {title: 'Post Title'}};
+        it('can return post description', function (done) {
+            var content = '<p>Post Content</p>';
+            var post = {relativeUrl: '/nice-post', post: {title: 'Post Title', html: content}};
             helpers.meta_description.call(post).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.equal('');
+                rendered.string.should.startWith(helpers.excerpt.call({html:content}));
 
                 done();
             }).then(null, done);


### PR DESCRIPTION
Looks like many other blog engines or services(e.g. WordPress, Tumblr) are using `<meta name="description">` tag value as truncated blog content.
I thought this makes sense at least more than leaving it empty.
