### PR TITLE
Update express-hbs to fix block helper issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "connect-slashes": "1.2.0",
         "downsize": "0.0.5",
         "express": "3.4.6",
-        "express-hbs": "0.7.6",
+        "express-hbs": "0.7.9",
         "fs-extra": "0.8.1",
         "knex": "0.5.0",
         "lodash": "2.4.1",


### PR DESCRIPTION
fixes #2127
- Update express-hbs to 0.7.9
