### PR TITLE
Update to `npm install` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "scripts": {
         "start": "node index",
         "test": "./node_modules/.bin/grunt validate --verbose",
-        "install": "git submodule update --init && bundle install && ./node_modules/.bin/grunt init"
+        "install": "bundle install && grunt init"
     },
     "engines": {
         "node": "~0.10.0"


### PR DESCRIPTION
fixes #1053
- npm install doesn't need a path to grunt, and fails on Windows if it has one
- submodule update is handled by grunt (albeit badly... but let's fix that!)
