### PR TITLE
App Permissions from package.json

### DIFF
--- a/core/server/apps/permissions.js
+++ b/core/server/apps/permissions.js
@@ -1,0 +1,75 @@
+
+var fs = require('fs'),
+    when = require('when'),
+    path = require('path'),
+    parsePackageJson = require('../require-tree').parsePackageJson;
+
+function AppPermissions(appPath) {
+    this.appPath = appPath;
+    this.packagePath = path.join(this.appPath, 'package.json');
+}
+
+AppPermissions.prototype.read = function () {
+    var self = this,
+        def = when.defer();
+
+    this.checkPackageContentsExists()
+        .then(function (exists) {
+            if (!exists) {
+                // If no package.json, return default permissions
+                return def.resolve(AppPermissions.DefaultPermissions);
+            }
+
+            // Read and parse the package.json
+            self.getPackageContents()
+                .then(function (parsed) {
+                    // If no permissions in the package.json then return the default permissions.
+                    if (!(parsed.ghost && parsed.ghost.permissions)) {
+                        return def.resolve(AppPermissions.DefaultPermissions);
+                    }
+
+                    // TODO: Validation on permissions object?
+
+                    def.resolve(parsed.ghost.permissions);
+                })
+                .otherwise(def.reject);
+        })
+        .otherwise(def.reject);
+
+    return def.promise;
+};
+
+AppPermissions.prototype.checkPackageContentsExists = function () {
+    // Mostly just broken out for stubbing in unit tests
+    var def = when.defer();
+
+    fs.exists(this.packagePath, function (exists) {
+        def.resolve(exists);
+    });
+
+    return def.promise;
+};
+
+// Get the contents of the package.json in the appPath root
+AppPermissions.prototype.getPackageContents = function () {
+    var messages = {
+        errors: [],
+        warns: []
+    };
+
+    return parsePackageJson(this.packagePath, messages)
+        .then(function (parsed) {
+            if (!parsed) {
+                return when.reject(new Error(messages.errors[0].message));
+            }
+
+            return parsed;
+        });
+};
+
+// Default permissions for an App.
+AppPermissions.DefaultPermissions = {
+    posts: ['browse', 'read']
+};
+
+module.exports = AppPermissions;

--- a/core/server/require-tree.js
+++ b/core/server/require-tree.js
@@ -25,11 +25,11 @@ var _        = require('lodash'),
                 if (jsonContainer.hasOwnProperty('name') && jsonContainer.hasOwnProperty('version')) {
                     packageDeferred.resolve(jsonContainer);
                 } else {
-                    messages.errors.push({message: '"name" or "version" is missing from theme package.json file.', context: path});
+                    messages.errors.push({message: '"name" or "version" is missing from package.json file.', context: path});
                     packageDeferred.resolve(false);
                 }
             } catch (e) {
-                messages.errors.push({message: 'Theme package.json file is malformed', context: path});
+                messages.errors.push({message: 'package.json file is malformed', context: path});
                 packageDeferred.resolve(false);
             }
         });


### PR DESCRIPTION
Progress on #2095 and #2059
- Add new AppPermissions class with read() method
- has default permissions to read and browse posts
- uses default permissions if no package.json
- uses default permissions if no ghost object in package.json
- ~~uses default permissions~~ errors when reading malformed package.json
- uses ghost.permissions if found in package.json
