### PR TITLE
Adds tag pages

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -92,7 +92,19 @@ coreHelpers.encode = function (context, str) {
 //
 coreHelpers.pageUrl = function (context, block) {
     /*jslint unparam:true*/
-    return config().paths.subdir + (context === 1 ? '/' : ('/page/' + context + '/'));
+    var url = config().paths.subdir;
+
+    if (this.tagSlug !== undefined) {
+        url += '/tag/' + this.tagSlug;
+    }
+
+    if (context > 1) {
+        url += '/page/' + context;
+    }
+
+    url += '/';
+
+    return url;
 };
 
 // ### URL helper
@@ -296,7 +308,7 @@ coreHelpers.body_class = function (options) {
         tags = this.post && this.post.tags ? this.post.tags : this.tags || [],
         page = this.post && this.post.page ? this.post.page : this.page || false;
 
-    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/page/)) {
+    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page|tag)/)) {
         classes.push('archive-template');
     } else if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
         classes.push('home-template');
@@ -542,7 +554,13 @@ coreHelpers.pagination = function (options) {
         errors.logAndThrowError('Invalid value, check page, pages, limit and total are numbers');
         return;
     }
-    return template.execute('pagination', this.pagination);
+    var context = _.merge({}, this.pagination);
+
+    if (this.tag !== undefined) {
+        context.tagSlug = this.tag.slug;
+    }
+
+    return template.execute('pagination', context);
 };
 
 coreHelpers.helperMissing = function (arg) {

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -6,6 +6,8 @@ module.exports = function (server) {
     // ### Frontend routes
     server.get('/rss/', frontend.rss);
     server.get('/rss/:page/', frontend.rss);
+    server.get('/tag/:slug/page/:page/', frontend.tag);
+    server.get('/tag/:slug/', frontend.tag);
     server.get('/page/:page/', frontend.homepage);
     server.get('/', frontend.homepage);
     server.get('*', frontend.single);

--- a/core/test/functional/api/tags_test.js
+++ b/core/test/functional/api/tags_test.js
@@ -47,7 +47,7 @@ describe('Tag API', function () {
             response.should.be.json;
             var jsonResponse = JSON.parse(body);
             jsonResponse.should.exist;
-            jsonResponse.should.have.length(5);
+            jsonResponse.should.have.length(6);
             testUtils.API.checkResponse(jsonResponse[0], 'tag');
             done();
         });

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -290,6 +290,68 @@ describe('Frontend Routing', function () {
         // });
     });
 
+    describe('Tag pages', function () {
+
+        // Add enough posts to trigger tag pages
+        before(function (done) {
+            testUtils.clearData().then(function () {
+                // we initialise data, but not a user. No user should be required for navigating the frontend
+                return testUtils.initData();
+            }).then(function () {
+
+                return testUtils.insertPosts();
+            }).then(function () {
+                return testUtils.insertMorePosts(22);
+            }).then(function() {
+                return testUtils.insertMorePostsTags(22);
+            }).then(function () {
+                done();
+            }).then(null, done);
+
+        });
+
+        it('should redirect without slash', function (done) {
+            request.get('/tag/injection/page/2')
+                .expect('Location', '/tag/injection/page/2/')
+                .expect('Cache-Control', cacheRules.year)
+                .expect(301)
+                .end(doEnd(done));
+        });
+
+        it('should respond with html', function (done) {
+            request.get('/tag/injection/page/2/')
+                .expect('Content-Type', /html/)
+                .expect('Cache-Control', cacheRules['public'])
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('should redirect page 1', function (done) {
+            request.get('/tag/injection/page/1/')
+                .expect('Location', '/tag/injection/')
+                .expect('Cache-Control', cacheRules['public'])
+                // TODO: This should probably be a 301?
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should redirect to last page is page too high', function (done) {
+            request.get('/tag/injection/page/4/')
+                .expect('Location', '/tag/injection/page/2/')
+                .expect('Cache-Control', cacheRules['public'])
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should redirect to first page is page too low', function (done) {
+            request.get('/tag/injection/page/0/')
+                .expect('Location', '/tag/injection/')
+                .expect('Cache-Control', cacheRules['public'])
+                .expect(302)
+                .end(doEnd(done));
+        });
+    });
+
     // ### The rest of the tests switch to date permalinks
 
 //    describe('Date permalinks', function () {

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -353,6 +353,8 @@ describe('Post Model', function () {
     it('can fetch a paginated set, with various options', function (done) {
         testUtils.insertMorePosts().then(function () {
 
+            return testUtils.insertMorePostsTags();
+        }).then(function () {
             return PostModel.findPage({page: 2});
         }).then(function (paginationResult) {
             paginationResult.page.should.equal(2);
@@ -384,6 +386,43 @@ describe('Post Model', function () {
             return PostModel.findPage({limit: 10, page: 2, status: 'all'});
         }).then(function (paginationResult) {
             paginationResult.pages.should.equal(11);
+
+            // Test tag filter
+            return PostModel.findPage({page: 1, tag: 'bacon'});
+        }).then(function (paginationResult) {
+            paginationResult.page.should.equal(1);
+            paginationResult.limit.should.equal(15);
+            paginationResult.posts.length.should.equal(2);
+            paginationResult.pages.should.equal(1);
+            paginationResult.aspect.tag.name.should.equal('bacon');
+            paginationResult.aspect.tag.slug.should.equal('bacon');
+
+            return PostModel.findPage({page: 1, tag: 'kitchen-sink'});
+        }).then(function (paginationResult) {
+            paginationResult.page.should.equal(1);
+            paginationResult.limit.should.equal(15);
+            paginationResult.posts.length.should.equal(2);
+            paginationResult.pages.should.equal(1);
+            paginationResult.aspect.tag.name.should.equal('kitchen sink');
+            paginationResult.aspect.tag.slug.should.equal('kitchen-sink');
+
+            return PostModel.findPage({page: 1, tag: 'injection'});
+        }).then(function (paginationResult) {
+            paginationResult.page.should.equal(1);
+            paginationResult.limit.should.equal(15);
+            paginationResult.posts.length.should.equal(15);
+            paginationResult.pages.should.equal(2);
+            paginationResult.aspect.tag.name.should.equal('injection');
+            paginationResult.aspect.tag.slug.should.equal('injection');
+
+            return PostModel.findPage({page: 2, tag: 'injection'});
+        }).then(function (paginationResult) {
+            paginationResult.page.should.equal(2);
+            paginationResult.limit.should.equal(15);
+            paginationResult.posts.length.should.equal(9);
+            paginationResult.pages.should.equal(2);
+            paginationResult.aspect.tag.name.should.equal('injection');
+            paginationResult.aspect.tag.slug.should.equal('injection');
 
             done();
         }).then(null, done);

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -143,6 +143,120 @@ describe('Frontend Controller', function () {
         });
     });
 
+    describe('tag redirects', function () {
+        var res;
+
+        beforeEach(function () {
+            res = {
+                redirect: sandbox.spy(),
+                render: sandbox.spy()
+            };
+
+            sandbox.stub(api.posts, 'browse', function () {
+                return when({posts: {}, pages: 3});
+            });
+
+            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            apiSettingsStub.withArgs('postsPerPage').returns(when({
+                'key': 'postsPerPage',
+                'value': 6
+            }));
+        });
+
+        it('Redirects to base tag page if page number is -1', function () {
+            var req = {params: {page: -1, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/tag/pumpkin/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to base tag page if page number is 0', function () {
+            var req = {params: {page: 0, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/tag/pumpkin/').should.be.true;
+            res.render.called.should.be.false;
+
+        });
+
+        it('Redirects to base tag page if page number is 1', function () {
+            var req = {params: {page: 1, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/tag/pumpkin/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to base tag page if page number is 0 with subdirectory', function () {
+            frontend.__set__('config', function() {
+                return {
+                    paths: {subdir: '/blog'}
+                };
+            });
+
+            var req = {params: {page: 0, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/tag/pumpkin/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to base tag page if page number is 1 with subdirectory', function () {
+            frontend.__set__('config', function() {
+                return {
+                    paths: {subdir: '/blog'}
+                };
+            });
+
+            var req = {params: {page: 1, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, null);
+
+            res.redirect.called.should.be.true;
+            res.redirect.calledWith('/blog/tag/pumpkin/').should.be.true;
+            res.render.called.should.be.false;
+        });
+
+        it('Redirects to last page if page number too big', function (done) {
+            var req = {params: {page: 4, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, done).then(function () {
+                res.redirect.called.should.be.true;
+                res.redirect.calledWith('/tag/pumpkin/page/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+        });
+
+        it('Redirects to last page if page number too big with subdirectory', function (done) {
+            frontend.__set__('config', function() {
+                return {
+                    paths: {subdir: '/blog'}
+                };
+            });
+
+            var req = {params: {page: 4, slug: 'pumpkin'}};
+
+            frontend.tag(req, res, done).then(function () {
+                res.redirect.calledOnce.should.be.true;
+                res.redirect.calledWith('/blog/tag/pumpkin/page/3/').should.be.true;
+                res.render.called.should.be.false;
+                done();
+            });
+
+        });
+    });
+
     describe('single', function () {
         var mockStaticPost = {
                 'status': 'published',

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -486,6 +486,29 @@ describe('Core Helpers', function () {
             helpers.pageUrl(2).should.equal('/blog/page/2/');
             helpers.pageUrl(50).should.equal('/blog/page/50/');
         });
+
+        it('can return a valid url for tag pages', function () {
+            var tagContext = {
+                tagSlug: 'pumpkin'
+            };
+            helpers.pageUrl.call(tagContext, 1).should.equal('/tag/pumpkin/');
+            helpers.pageUrl.call(tagContext, 2).should.equal('/tag/pumpkin/page/2/');
+            helpers.pageUrl.call(tagContext, 50).should.equal('/tag/pumpkin/page/50/');
+        });
+
+        it('can return a valid url for tag pages with subdirectory', function () {
+            helpers.__set__('config', function() {
+                return {
+                    paths: {'subdir': '/blog'}
+                };
+            });
+            var tagContext = {
+                tagSlug: 'pumpkin'
+            };
+            helpers.pageUrl.call(tagContext, 1).should.equal('/blog/tag/pumpkin/');
+            helpers.pageUrl.call(tagContext, 2).should.equal('/blog/tag/pumpkin/page/2/');
+            helpers.pageUrl.call(tagContext, 50).should.equal('/blog/tag/pumpkin/page/50/');
+        });
     });
 
     describe("Pagination helper", function () {

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -62,6 +62,10 @@ DataGenerator.Content = {
         {
             name: "pollo",
             slug: "pollo"
+        },
+        {
+            name: "injection",
+            slug: "injection"
         }
     ],
 
@@ -174,6 +178,13 @@ DataGenerator.forKnex = (function () {
         };
     }
 
+    function createPostsTags(postId, tagId) {
+        return {
+            post_id: postId,
+            tag_id: tagId
+        };
+    }
+
     posts = [
         createPost(DataGenerator.Content.posts[0]),
         createPost(DataGenerator.Content.posts[1]),
@@ -188,12 +199,14 @@ DataGenerator.forKnex = (function () {
         createTag(DataGenerator.Content.tags[0]),
         createTag(DataGenerator.Content.tags[1]),
         createTag(DataGenerator.Content.tags[2]),
-        createTag(DataGenerator.Content.tags[3])
+        createTag(DataGenerator.Content.tags[3]),
+        createTag(DataGenerator.Content.tags[4])
     ];
 
     posts_tags = [
         { post_id: 2, tag_id: 2 },
         { post_id: 2, tag_id: 3 },
+        { post_id: 3, tag_id: 2 },
         { post_id: 3, tag_id: 3 },
         { post_id: 4, tag_id: 4 },
         { post_id: 5, tag_id: 5 }
@@ -206,6 +219,7 @@ DataGenerator.forKnex = (function () {
         createUser: createUser,
         createGenericUser: createGenericUser,
         createUserRole: createUserRole,
+        createPostsTags: createPostsTags,
 
         posts: posts,
         tags: tags,


### PR DESCRIPTION
fixes #2111
- modified Post model to support a tag query
  param that will filter the desired post collection
  to only include posts that contain the requested tag
- in the updated Post model it includes the Tag model
  under a nested object called 'aspects'
- added tests for updated Post model, updating
  test utils to add more posts_tags relations 
- adds two new routes to frontend,
  one for initial tag page,
  another to page that tag page
- for tag pages the array of posts
  is exposed to the view similarly
  to the homepeage
- on the tag view page the information
  for the tag is also accessible
  for further theme usage
- the tag view page supports a hierarchy of
  views, it'll first attempt to use a tag.hbs
  file if it exists, otherwise fall back
  to the default index.hbs file
- modified pageUrl and pagination helper
  to have it be compatible with tag paging
- added unit tests for frontend controller
- added unit tests for handlebar helper modifications
- add functional tests for new tag routes
