### PR TITLE
Helper updates for Tag Pages

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -114,6 +114,8 @@ function urlFor(context, data, absolute) {
         // trying to create a url for an object
         if (context === 'post' && data.post && data.permalinks) {
             urlPath = urlPathForPost(data.post, data.permalinks);
+        } else if (context === 'tag' && data.tag) {
+            urlPath = '/tag/' + data.tag.slug + '/';
         }
         // other objects are recognised but not yet supported
     } else if (_.isString(context) && _.indexOf(_.keys(knownPaths), context) !== -1) {

--- a/core/server/data/schema.js
+++ b/core/server/data/schema.js
@@ -123,7 +123,13 @@ function isPost(jsonData) {
         && jsonData.hasOwnProperty('title') && jsonData.hasOwnProperty('slug');
 }
 
+function isTag(jsonData) {
+    return jsonData.hasOwnProperty('name') && jsonData.hasOwnProperty('slug')
+        && jsonData.hasOwnProperty('description') && jsonData.hasOwnProperty('parent_id');
+}
+
 module.exports.tables = db;
 module.exports.checks = {
-    isPost: isPost
+    isPost: isPost,
+    isTag: isTag
 };

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -235,6 +235,19 @@ describe('Config', function () {
             config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog' + postLink);
         });
 
+        it('should return url for a tag when asked for', function () {
+            var testContext = 'tag',
+                testData = {tag: testUtils.DataGenerator.Content.tags[0]};
+
+            configUpdate({url: 'http://my-ghost-blog.com'});
+            config.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
+            config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
+
+            configUpdate({url: 'http://my-ghost-blog.com/blog'});
+            config.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
+            config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
+        });
+
     });
 
     describe('urlForPost', function () {

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -449,7 +449,14 @@ describe('Core Helpers', function () {
             });
         });
 
-        it('should return empty string if not a post', function () {
+        it('should return the slug with a prefixed /tag/ if the context is a tag', function () {
+            helpers.url.call({name: 'the tag', slug: "the-tag", description: null, parent_id: null}).then(function (rendered) {
+                should.exist(rendered);
+                rendered.should.equal('/tag/the-tag/');
+            });
+        });
+
+        it('should return empty string if not a post or tag', function () {
             helpers.url.call({markdown: "ff", title: "title", slug: "slug"}).then(function (rendered) {
                 rendered.should.equal('');
             });
@@ -585,7 +592,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'foo'}, {name: 'bar'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {}}
+                    {"hash": {autolink: 'false'}}
                 );
             should.exist(rendered);
 
@@ -596,7 +603,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {separator: '|'}}
+                    {"hash": {separator: '|', autolink: 'false'}}
                 );
 
             should.exist(rendered);
@@ -608,7 +615,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {prefix: 'on '}}
+                    {"hash": {prefix: 'on ', autolink: 'false'}}
                 );
 
             should.exist(rendered);
@@ -620,7 +627,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {suffix: ' forever'}}
+                    {"hash": {suffix: ' forever', autolink: 'false'}}
                 );
 
             should.exist(rendered);
@@ -632,7 +639,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {suffix: ' forever', prefix: 'on '}}
+                    {"hash": {suffix: ' forever', prefix: 'on ', autolink: 'false'}}
                 );
 
             should.exist(rendered);
@@ -644,7 +651,7 @@ describe('Core Helpers', function () {
             var tags = [{name: 'haunted'}, {name: 'ghost'}],
                 rendered = handlebars.helpers.tags.call(
                     {tags: tags},
-                    {"hash": {suffix: ' &bull;', prefix: '&hellip; '}}
+                    {"hash": {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}}
                 );
 
             should.exist(rendered);
@@ -655,12 +662,23 @@ describe('Core Helpers', function () {
         it('does not add prefix or suffix if no tags exist', function () {
             var rendered = handlebars.helpers.tags.call(
                     {},
-                    {"hash": {prefix: 'on ', suffix: ' forever'}}
+                    {"hash": {prefix: 'on ', suffix: ' forever', autolink: 'false'}}
                 );
 
             should.exist(rendered);
 
             String(rendered).should.equal('');
+        });
+
+        it('can autolink tags to tag pages', function () {
+            var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
+                rendered = handlebars.helpers.tags.call(
+                    {tags: tags},
+                    {"hash": {}}
+                );
+            should.exist(rendered);
+
+            String(rendered).should.equal('<a href="/tag/foo-bar/">foo</a>, <a href="/tag/bar/">bar</a>');
         });
     });
 


### PR DESCRIPTION
fixes #2112
refs #1833
- modified config.urlFor to handle tag pages
- modified {{#tags}} handlebars helper to autolink to
  tag pages. Additional autolink="false" parameter can
  be used to deactivate autolinking
- modified url handlebars helper to handle tags
- added isTag function to schema
- added unit test for additional urlFor functionality
- added unit test for {{#tags}} helper modifications
- added unit test for url handlebards helper
