### PR TITLE
Grunt warning on local grunt-cli module

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "sqlite3": "2.2.0",
         "unidecode": "0.1.3",
         "validator": "1.4.0",
+        "grunt-cli": "~0.1.13",
         "when": "2.7.0"
     },
     "optionalDependencies": {
@@ -62,7 +63,6 @@
     "devDependencies": {
         "blanket": "~1.1.5",
         "grunt": "~0.4.1",
-        "grunt-cli": "~0.1.13",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-compress": "~0.5.2",
         "grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
- fixes #2191
- moves grunt-cli module into peerDependencies
