### PR TITLE
add a transparent border around inputs

### DIFF
--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -207,7 +207,7 @@
         width: 280px;
         padding: 8px 10px;
         position: relative;
-        border: none;
+        border: solid 1px transparent;
         color: #fff;
         font-size: 1.1em;
         font-weight: 200;


### PR DESCRIPTION
this prevents the visual jump that happens on initial input focus.
## before

![out](https://f.cloud.github.com/assets/883126/2175415/fcbd999a-95be-11e3-8897-2873105c3cd8.gif)
## after

![out](https://f.cloud.github.com/assets/883126/2175422/0b1d3ee6-95bf-11e3-9a26-d175726bb501.gif)
