### PR TITLE
[WIP] Integration with  downsize ContextualTags API.

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -202,21 +202,41 @@ coreHelpers.tags = function (options) {
 // **returns** SafeString content html, complete or truncated.
 //
 coreHelpers.content = function (options) {
-    var truncateOptions = (options || {}).hash || {};
-    truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
-    _.keys(truncateOptions).map(function (key) {
-        truncateOptions[key] = parseInt(truncateOptions[key], 10);
+    var inputOptions = (options || {}).hash || {},
+        numericTruncateOptions,
+        stringTruncateOptions,
+        downsizeOptions;
+
+    numericTruncateOptions = _.pick(inputOptions, ['words', 'characters']);
+    _.keys(numericTruncateOptions).map(function (key) {
+        numericTruncateOptions[key] = parseInt(numericTruncateOptions[key], 10);
     });
 
-    if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
+    stringTruncateOptions = _.pick(inputOptions, ['context']);
+    _.keys(stringTruncateOptions).map(function (key) {
+        stringTruncateOptions[key] = (String(stringTruncateOptions[key]) || '').trim().toLowerCase();
+    });
+
+    if (numericTruncateOptions.hasOwnProperty('words') || numericTruncateOptions.hasOwnProperty('characters')) {
+        // Copy over fully API matching numeric object
+        downsizeOptions = numericTruncateOptions;
+
         // Due to weirdness in downsize the 'words' option
         // must be passed as a string. refer to #1796
         // TODO: when downsize fixes this quirk remove this hack.
-        if (truncateOptions.hasOwnProperty('words')) {
-            truncateOptions.words = truncateOptions.words.toString();
+        if (downsizeOptions.hasOwnProperty('words')) {
+            downsizeOptions.words = downsizeOptions.words.toString();
         }
+
+        if (stringTruncateOptions.context === 'true') {
+            // We're trying to keep context.
+            // Since we know our html is markdown sourced, we pass the important
+            // contextual markdown tags. Content in these tags will not be cleaved.
+            downsizeOptions.contextualTags = ['p', 'ul', 'ol', 'pre', 'blockquote'];
+        }
+
         return new hbs.handlebars.SafeString(
-            downsize(this.html, truncateOptions)
+            downsize(this.html, downsizeOptions)
         );
     }
 

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -151,6 +151,77 @@ describe('Core Helpers', function () {
             should.exist(rendered);
             rendered.string.should.equal("<p>Hello <strong>Wo</strong></p>");
         });
+
+        it('can defer truncating html until the end of a matching <p> tag when context=\"true\" is specified.', function () {
+            var html = "<p>I am a first paragraph. I am longer than 2 words.</p><p>I am a second paragraph.</p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": 2, "context": "true"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<p>I am a first paragraph. I am longer than 2 words.</p>");
+        });
+
+        it('can defer truncating html until the end of a matching <pre> tag when context=\"true\" is specified.', function () {
+            var html = "<pre>I am a first pre. I am longer than 2 words.</pre><p>I am a second contextful element.</p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": 2, "context": "true"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<pre>I am a first pre. I am longer than 2 words.</pre>");
+        });
+
+        it('can defer truncating html until the end of a matching <blockquote> tag when context=\"true\" is specified.', function () {
+            var html = "<blockquote>I am a first blockquote. I am longer than 2 words.</blockquote><p>I am a second contextful element.</p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": 2, "context": "true"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<blockquote>I am a first blockquote. I am longer than 2 words.</blockquote>");
+        });
+
+        it('can defer truncating html until the end of a matching <ul> tag when context=\"true\" is specified.', function () {
+            var html = "<ul><li>I am a first ul.</li><li>I am longer than 2 words.</li></ul><p>I am a second contextful element.</p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": 2, "context": "true"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<ul><li>I am a first ul.</li><li>I am longer than 2 words.</li></ul>");
+        });
+
+        it('can defer truncating html until the end of a matching <ol> tag when context=\"true\" is specified.', function () {
+            var html = "<ol><li>I am a first ol.</li><li>I am longer than 2 words.</li></ol><p>I am a second contextful element.</p>",
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {"hash": {"words": 2, "context": "true"}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal("<ol><li>I am a first ol.</li><li>I am longer than 2 words.</li></ol>");
+        });
+
     });
 
     describe('Author Helper', function () {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "busboy": "0.0.12",
         "colors": "0.6.2",
         "connect-slashes": "1.2.0",
-        "downsize": "0.0.5",
+        "downsize": "0.0.6",
         "express": "3.4.6",
         "express-hbs": "0.7.9",
         "fs-extra": "0.8.1",


### PR DESCRIPTION
This commit is an initial attempt to integrate with the downsize contextual tags API ([commit](https://github.com/cgiffard/Downsize/commit/00f9fd88f6a0d0a7261f4d037dedd119e8d899ef)).

This implementation would allow you to pass context="true" to {{content}}, and not get your 'core' markdown generated elements clipped. i.e. the elements p, ol, ul, pre, and blockquote would all not be clipped. Instead, whatever element the character limit or word limit was hit inside of would be finished before the html is clipped.

I've tried to adhere to code and API conventions, please let me know if there's anything you'd like me to change! (This is my first ghost PR, so I'd love feedback :))

Relates to:
- https://github.com/TryGhost/Ghost/issues/2206
- https://github.com/TryGhost/Ghost/issues/2166

Best regards,

-adam
## commit message:

Introduces the context="true" API to {{content}}.
Currently defaults to false.
