### PR TITLE
Fix input:focus border issues from #2088

### DIFF
--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -221,7 +221,8 @@
         }
 
         &:focus { 
-           background: lighten($darkgrey, 15%); 
+            border: none;
+            background: lighten($darkgrey, 15%); 
         }
 
     }
@@ -306,7 +307,8 @@
             max-width: 244px;
         }
         
-        &:focus { 
+        &:focus {
+            border: none;
             background: lighten($darkgrey, 15%); 
         }
 


### PR DESCRIPTION
Removes borders from the forgotten password, signup and reset password forms.

Fixes #2088
- Just added `border: none;` which isn't the cleanest approach, but works for now.
- Without delving too deeply, this PR is a sign a refactor is in order.
