### PR TITLE
Fix package.json scripts to be more in line with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ matrix:
   allow_failures:
     - env: DB=pg
 before_install:
-  - rvm use 1.9.3
   - gem install bundler
-  - npm install -g grunt-cli
   - git clone git://github.com/n1k0/casperjs.git ~/casperjs
   - cd ~/casperjs
   - git checkout tags/1.1-beta3
@@ -22,3 +20,4 @@ before_install:
 before_script:
   - phantomjs --version
   - casperjs --version
+  - grunt init

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,14 +194,13 @@ developing Ghost.
 1. cd into the project folder
 1. Run `npm install -g grunt-cli`
 1. Run `npm install`.
-	* If the install fails with errors to do with "node-gyp rebuild" or "SQLite3", follow the SQLite3 install 
+	* If the install fails with errors to do with "node-gyp rebuild" or "SQLite3", follow the SQLite3 install
 instructions below this list
     * Usually if you're within vagrant, and have installed the guest plugins and updated that, this will not happen
-1. Run `grunt init` from the root - this generates the Bourbon directory, compiles SASS and compiles Handlebars 
-templates
+1. Run `grunt init` from the root - this runs bundler, generates the Bourbon directory, compiles SASS and compiles Handlebars templates
 1. Run `npm start` from the root to start the server.
 
-If something goes wrong, please see the 
+If something goes wrong, please see the
 [troubleshooting tips](https://github.com/TryGhost/Ghost/blob/master/CONTRIBUTING.md#troubleshooting--faq) below.
 
 ### Developer Tips

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,7 +49,7 @@ var path           = require('path'),
     configureGrunt = function (grunt) {
 
         // load all grunt tasks
-        require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+        require('matchdep').filterDev(['grunt-*', '!grunt-cli']).forEach(grunt.loadNpmTasks);
 
         var cfg = {
             // Common paths to be used by tasks
@@ -277,6 +277,10 @@ var path           = require('path'),
             // ### config for grunt-shell
             // command line tools
             shell: {
+                // run bundle
+                bundle: {
+                    command: 'bundle install'
+                },
                 // install bourbon
                 bourbon: {
                     command: 'bourbon install --path <%= paths.adminAssets %>/sass/modules/'
@@ -847,7 +851,7 @@ var path           = require('path'),
 
         // ### Tools for building assets
 
-        grunt.registerTask('init', 'Prepare the project for development', ['shell:bourbon', 'default']);
+        grunt.registerTask('init', 'Prepare the project for development', ['shell:bundle', 'shell:bourbon', 'default']);
 
         // Before running in production mode
         grunt.registerTask('prod', 'Build CSS, JS & templates for production', ['sass:compress', 'handlebars', 'concat', 'uglify']);

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "main": "./core/index",
     "scripts": {
         "start": "node index",
-        "test": "./node_modules/.bin/grunt validate --verbose",
-        "install": "bundle install && grunt init"
+        "test": "./node_modules/.bin/grunt validate --verbose"
     },
     "engines": {
         "node": "~0.10.0"


### PR DESCRIPTION
expected behavior of npm packages

fixes #1053
- updates travis config to be more in line with
  current dev steps
- fix `grunt-cli` warning from appearing when
  running grunt

I tried adding the `prepublish` script to `package.json` however it seems that script is run at two points:

From [npm-scripts](https://www.npmjs.org/doc/misc/npm-scripts.html):

> prepublish: Run BEFORE the package is published. (Also run on local npm install without any arguments.)

So when you go to `npm install` anything in `prepublish` is ran as well unfortunately.

This is proving much more squirrelly than first blush :).
