### PR TITLE
Respect subdirectory in authenticate middleware

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -272,8 +272,8 @@ module.exports = function (server, dbHash) {
 
     // ### Caching
     expressServer.use(middleware.cacheControl('public'));
-    expressServer.use('/api/', middleware.cacheControl('private'));
-    expressServer.use('/ghost/', middleware.cacheControl('private'));
+    expressServer.use(subdir + '/api/', middleware.cacheControl('private'));
+    expressServer.use(subdir + '/ghost/', middleware.cacheControl('private'));
 
     // enable authentication; has to be done before CSRF handling
     expressServer.use(middleware.authenticate);

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -29,17 +29,17 @@ var middleware = {
     // exceptions for signin, signout, signup, forgotten, reset only
     // api and frontend use different authentication mechanisms atm
     authenticate: function (req, res, next) {
-        if (res.isAdmin) {
-            if (req.path.indexOf("/ghost/api/") === 0) {
-                return middleware.authAPI(req, res, next);
-            }
-
-            var noAuthNeeded = [
+        var subPath = req.path.substring(config().paths.subdir.length),
+            noAuthNeeded = [
                 '/ghost/signin/', '/ghost/signout/', '/ghost/signup/',
                 '/ghost/forgotten/', '/ghost/reset/'
             ];
+        if (res.isAdmin) {
+            if (subPath.indexOf('/ghost/api/') === 0) {
+                return middleware.authAPI(req, res, next);
+            }
 
-            if (noAuthNeeded.indexOf(req.path) < 0) {
+            if (noAuthNeeded.indexOf(subPath) < 0) {
                 return middleware.auth(req, res, next);
             }
         }
@@ -51,7 +51,8 @@ var middleware = {
     // We strip /ghost/ out of the redirect parameter for neatness
     auth: function (req, res, next) {
         if (!req.session.user) {
-            var reqPath = req.path.replace(/^\/ghost\/?/gi, ''),
+            var subPath = req.path.substring(config().paths.subdir.length),
+                reqPath = subPath.replace(/^\/ghost\/?/gi, ''),
                 redirect = '',
                 msg;
 


### PR DESCRIPTION
Commit d3c641ea31 broke subdirectory support. `req.path` includes the subdirectory, thus may not necessarily start with `"/ghost"`. This strips the subdirectory from the path before the tests are done to ensure the subdirectory is respected.

I don't know if a test could be added that tests subdirectories (particularly sadistic ones that would break unsanitary regex testing) and paths like `/ghost/` and `/ghost/signin/`, but I think that would be helpful. I might look into that if I have time, but I make no promises.
