### PR TITLE
Remove useless regex for redirecting /ghost -> /ghost/

### DIFF
--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -50,7 +50,7 @@ module.exports = function (server) {
         /*jslint unparam:true*/
         res.redirect(subdir + '/ghost/');
     });
-    server.get(/\/(ghost$\/?)/, function (req, res) {
+    server.get(/\/ghost$/, function (req, res) {
         /*jslint unparam:true*/
         res.redirect(subdir + '/ghost/');
     });


### PR DESCRIPTION
The `\/?` is useless in the regex `/\/(ghost$\/?)/`. Since `$` must match, and since it represents the end of the string, it means `\/?` will never be used, and thus the regex is equivalent to `/\/(ghost$)/`, which is equivalent to `/\/ghost$/`.

This change makes that more obvious in the code, as it may not be immediately obvious what `/\/(ghost$\/?)/` means.
