### PR TITLE
Update delete post button labels

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -330,13 +330,15 @@
                                         });
                                     });
                                 },
-                                text: "Yes"
+                                text: "Delete",
+                                buttonClass: "button-delete"
                             },
                             reject: {
                                 func: function () {
                                     return true;
                                 },
-                                text: "No"
+                                text: "Cancel",
+                                buttonClass: "button"
                             }
                         },
                         type: "action",


### PR DESCRIPTION
As pointed out in [an ADN post](https://alpha.app.net/isaiah/post/23202339), the prompt to delete a post is confusing.

![image_1](https://f.cloud.github.com/assets/15747/2215332/f7f64adc-99ed-11e3-935d-c49bbf50cc47.png)

This pull request changes the labels to "Delete" and "Cancel". It's still confusing that the delete button is green, but it doesn't look like there is an easy way to change that without swapping the accept and reject functions in the JS, which would be confusing.

If there is a good way to do it, I'd be happy to update the pull request.
