### PR TITLE
Fix Firefox <select> height issue

### DIFF
--- a/core/client/assets/sass/modules/forms.scss
+++ b/core/client/assets/sass/modules/forms.scss
@@ -129,6 +129,12 @@ select {
         width: 100%;
     }
 }
+// 'vanilla' CSS hack to specifically target Firefox
+@-moz-document url-prefix() {
+    select {
+        height: auto;
+    }
+}
 
 .form-group {
     position: relative;


### PR DESCRIPTION
closes #1109
- Use moz-specific selector to make <select> elements use auto height

Not the _best_ solution in the world, but is as lightweight as it can be, and works.
