### PR TITLE
[Apps] Added friendly handling for nonexistent apps

### DIFF
--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -58,10 +58,17 @@ module.exports = {
                     return when.resolve(loadedApp);
                 },
                 loadPromises = _.map(appsToLoad, function (app) {
+
                     // If already installed, just activate the app
                     if (_.contains(installedApps, app)) {
                         return loader.activateAppByName(app).then(function (loadedApp) {
                             return recordLoadedApp(app, loadedApp);
+                        }).otherwise(function (err) {
+                            errors.logError(
+                                err.message || err,
+                                'The app will not be loaded',
+                                'Check with the app creator, or read the app documentation for more details on app requirements'
+                            );
                         });
                     }
 
@@ -70,6 +77,12 @@ module.exports = {
                         return loader.activateAppByName(app);
                     }).then(function (loadedApp) {
                         return recordLoadedApp(app, loadedApp);
+                    }).otherwise(function (err) {
+                        errors.logError(
+                            err.message || err,
+                            'The app will not be loaded',
+                            'Check with the app creator, or read the app documentation for more details on app requirements'
+                        );
                     });
                 });
 

--- a/core/server/apps/loader.js
+++ b/core/server/apps/loader.js
@@ -30,8 +30,15 @@ function loadApp(appPath) {
 
 function getAppByName(name) {
     // Grab the app class to instantiate
-    var AppClass = loadApp(getAppRelativePath(name)),
+    var AppClass,
         app;
+
+    // Attempt to load the app and error if it does not exist
+    try {
+        AppClass = loadApp(getAppRelativePath(name));
+    } catch (e) {
+        throw new Error("Error loading app " + name + "; app directory (/content/apps/" + name + ") does not exist.");
+    }
 
     // Check for an actual class, otherwise just use whatever was returned
     if (_.isFunction(AppClass)) {
@@ -50,7 +57,13 @@ loader = {
         // Install the apps dependendencies first
         var deps = new AppDependencies(getAppAbsolutePath(name));
         return deps.install().then(function () {
-            var app = getAppByName(name);
+            var app;
+
+            try {
+                app = getAppByName(name);
+            } catch (e) {
+                return when.reject(e);
+            }
 
             // Check for an install() method on the app.
             if (!_.isFunction(app.install)) {
@@ -68,7 +81,13 @@ loader = {
 
     // Activate a app and return it
     activateAppByName: function (name) {
-        var app = getAppByName(name);
+        var app;
+
+        try {
+            app = getAppByName(name);
+        } catch (e) {
+            return when.reject(e);
+        }
 
         // Check for an activate() method on the app.
         if (!_.isFunction(app.activate)) {

--- a/core/test/unit/apps_spec.js
+++ b/core/test/unit/apps_spec.js
@@ -9,6 +9,7 @@ var fs           = require('fs'),
     filters      = require('../../server/filters'),
 
     // Stuff we are testing
+    loader     = require('../../server/apps/loader'),
     appProxy   = require('../../server/apps/proxy'),
     AppSandbox = require('../../server/apps/sandbox'),
     AppDependencies = require('../../server/apps/dependencies');
@@ -47,6 +48,7 @@ describe('Apps', function () {
                 add: sandbox.stub()
             }
         };
+
     });
 
     afterEach(function () {
@@ -84,6 +86,7 @@ describe('Apps', function () {
     });
 
     describe('Sandbox', function () {
+
         it('loads apps in a sandbox', function () {
             var appBox = new AppSandbox(),
                 appPath = path.resolve(__dirname, '..', 'utils', 'fixtures', 'app', 'good.js'),
@@ -154,6 +157,30 @@ describe('Apps', function () {
                 };
 
             loadApp.should.throw(/^Unsafe App require[\w\W]*example$/);
+        });
+
+        it('throws a friendly error for a nonexistent app being activated', function () {
+            var appName = 'doesnotexist';
+
+            loader.activateAppByName(appName).then(function (msg) {
+                done(new Error('Activation of nonexistent app did not fail'));
+            }).otherwise(function (err) {
+                err.should.equal('Error loading app ' + appName + '; app directory (/content/apps/' + appName + ') does not exist.');
+                done();
+            });
+
+        });
+
+        it('throws a friendly error for a nonexistent app being installed', function () {
+            var appName = 'doesnotexist';
+
+            loader.installAppByName(appName).then(function (msg) {
+                done(new Error('Installation of nonexistent app did not fail'));
+            }).otherwise(function (err) {
+                err.should.equal('Error loading app ' + appName + '; app directory (/content/apps/' + appName + ') does not exist.');
+                done();
+            });
+
         });
     });
 


### PR DESCRIPTION
Fixes #1829
- Added try-catch block in core/server/apps/loader.js to catch and reject with an error when getAppByName fails (meaning app loading failed, meaning the app directory doesn't exist). Error message as follows:
  
  > Error loading app named <name>; app directory (/content/apps/<name>) does not exist."
- Added .otherwise blocks with error logs to core/server/apps/index.js to catch the new rejections and log error message to console
