### PR TITLE
fixes #1838

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -184,8 +184,9 @@ adminControllers = {
         var email = req.body.email;
 
         api.users.generateResetToken(email).then(function (token) {
-            var siteLink = '<a href="' + config().url + '">' + config().url + '</a>',
-                resetUrl = config().url.replace(/\/$/, '') +  '/ghost/reset/' + token + '/',
+            var baseUrl = config().forceAdminSSL ? (config().urlSSL || config().url) : config().url,
+                siteLink = '<a href="' + baseUrl + '">' + baseUrl + '</a>',
+                resetUrl = baseUrl.replace(/\/$/, '') +  '/ghost/reset/' + token + '/',
                 resetLink = '<a href="' + resetUrl + '">' + resetUrl + '</a>',
                 message = {
                     to: email,

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -71,19 +71,34 @@ function ghostLocals(req, res, next) {
     }
 }
 
+function initThemeData(secure) {
+    var themeConfig = config.theme();
+    if (secure && config().urlSSL) {
+        // For secure requests override .url property with the SSL version
+        themeConfig = _.clone(themeConfig);
+        themeConfig.url = config().urlSSL.replace(/\/$/, '');
+    }
+    return themeConfig;
+}
+
 // ### InitViews Middleware
 // Initialise Theme or Admin Views
 function initViews(req, res, next) {
     /*jslint unparam:true*/
 
     if (!res.isAdmin) {
-        hbs.updateTemplateOptions({ data: {blog: config.theme()} });
+        var themeData = initThemeData(req.secure);
+        hbs.updateTemplateOptions({ data: {blog: themeData} });
         expressServer.engine('hbs', expressServer.get('theme view engine'));
         expressServer.set('views', path.join(config().paths.themePath, expressServer.get('activeTheme')));
     } else {
         expressServer.engine('hbs', expressServer.get('admin view engine'));
         expressServer.set('views', config().paths.adminViews);
     }
+
+    // Pass 'secure' flag to the view engine
+    // so that templates can choose 'url' vs 'urlSSL'
+    res.locals.secure = req.secure;
 
     next();
 }
@@ -184,9 +199,20 @@ function isSSLrequired(isAdmin) {
 function checkSSL(req, res, next) {
     if (isSSLrequired(res.isAdmin)) {
         if (!req.secure) {
+            var forceAdminSSL = config().forceAdminSSL,
+                redirectUrl;
+
+            // Check if forceAdminSSL: { redirect: false } is set, which means
+            // we should just deny non-SSL access rather than redirect
+            if (forceAdminSSL && forceAdminSSL.redirect !== undefined && !forceAdminSSL.redirect) {
+                return res.send(403);
+            }
+
+            redirectUrl = url.parse(config().urlSSL || config().url);
             return res.redirect(301, url.format({
                 protocol: 'https:',
-                hostname: url.parse(config().url).hostname,
+                hostname: redirectUrl.hostname,
+                port: redirectUrl.port,
                 pathname: req.path,
                 query: req.query
             }));

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -1,0 +1,128 @@
+var cp         = require('child_process'),
+    _          = require('lodash'),
+    fs         = require('fs'),
+    url        = require('url'),
+    net        = require('net'),
+    when       = require('when'),
+    path       = require('path'),
+    config     = require('../../server/config');
+    
+function findFreePort(port) {
+    var deferred = when.defer();
+
+    if (typeof port === 'string') port = parseInt(port);
+    if (typeof port !== 'number') port = 2368;
+    port = port + 1;
+
+    var server = net.createServer();
+    server.on('error', function(e) {
+        if (e.code === 'EADDRINUSE') {
+            when.chain(findFreePort(port), deferred);
+        } else {
+            deferred.reject(e);
+        }
+    });
+    server.listen(port, function() {
+        var listenPort = server.address().port;
+        server.close(function() {
+            deferred.resolve(listenPort);
+        });
+    });
+    
+    return deferred.promise;
+}
+
+// Get a copy of current config object from file, to be modified before
+// passing to forkGhost() method
+function forkConfig() {
+    // require caches values, and we want to read it fresh from the file
+    delete require.cache[config().paths.config];
+    return _.cloneDeep(require(config().paths.config)[process.env.NODE_ENV]);
+}
+
+// Creates a new fork of Ghost process with a given config
+// Useful for tests that want to verify certain config options
+function forkGhost(newConfig, envName) {
+    var deferred = when.defer();
+    envName = envName || 'forked';
+    findFreePort(newConfig.server ? newConfig.server.port : undefined)
+        .then(function(port) {
+            newConfig.server = newConfig.server || {};
+            newConfig.server.port = port;
+            newConfig.url = url.format(_.extend(url.parse(newConfig.url), {port: port, host: null}));
+            
+            var newConfigFile = path.join(config().paths.appRoot, 'config.test' + port + '.js');
+            fs.writeFile(newConfigFile, 'module.exports = {' + envName + ': ' + JSON.stringify(newConfig) + '}', function(err) {
+                if (err) throw err;
+                
+                // setup process environment for the forked Ghost to use the new config file
+                var env = _.clone(process.env);
+                env['GHOST_CONFIG'] = newConfigFile;
+                env['NODE_ENV'] = envName;
+                var child = cp.fork(path.join(config().paths.appRoot, 'index.js'), {env: env});
+                
+                var pingTries = 0;
+                var pingCheck;
+                var pingStop = function() {
+                    if (pingCheck) {
+                        clearInterval(pingCheck);
+                        pingCheck = undefined;
+                        return true;
+                    }
+                    return false;
+                };
+                // periodic check until forked Ghost is running and is listening on the port
+                pingCheck = setInterval(function() {
+                    var socket = net.connect(port);
+                    socket.on('connect', function() {
+                        socket.end();
+                        if (pingStop()) {
+                            deferred.resolve(child);
+                        }
+                    });
+                    socket.on('error', function(err) {
+                        // continue checking
+                        if (++pingTries >= 20 && pingStop()) {
+                            deferred.reject(new Error("Timed out waiting for child process"));
+                        }
+                    });
+                }, 200);
+        
+                child.on('exit', function(code, signal) {
+                    child.exited = true;
+                    if (pingStop()) {
+                        deferred.reject(new Error("Child process exit code: " + code));
+                    }
+                    // cleanup the temporary config file
+                    fs.unlink(newConfigFile);
+                });
+                
+                // override kill() to have an async callback
+                var baseKill = child.kill;
+                child.kill = function(signal, cb) {
+                    if (typeof signal === 'function') {
+                        cb = signal;
+                        signal = undefined;
+                    }
+                    
+                    if (cb) {
+                        child.on('exit', function() {
+                            cb();
+                        });
+                    }
+
+                    if (child.exited) {
+                        process.nextTick(cb);
+                    } else {
+                        baseKill.apply(child, [signal]);
+                    }
+                };
+            });
+        })
+        .otherwise(deferred.reject);
+
+    return deferred.promise;
+}
+
+module.exports.ghost = forkGhost;
+module.exports.config = forkConfig;

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -7,7 +7,8 @@ var knex          = require('../../server/models/base').knex,
     migration     = require("../../server/data/migration/"),
     Settings      = require('../../server/models/settings').Settings,
     DataGenerator = require('./fixtures/data-generator'),
-    API           = require('./api');
+    API           = require('./api'),
+    fork          = require('./fork');
 
 function initData() {
     return migration.init();
@@ -126,5 +127,7 @@ module.exports = {
     loadExportFixture: loadExportFixture,
 
     DataGenerator: DataGenerator,
-    API: API
+    API: API,
+    
+    fork: fork
 };


### PR DESCRIPTION
- adding `forceAdminSSL: {redirect: true/false}` option to allow 403 over non-SSL rather than redirect
- adding `urlSSL` option to specify SSL variant of `url`
- using `urlSSL` when redirecting to SSL (forceAdminSSL), if specified
- dynamically patching `.url` property for view engine templates to use SSL variant over HTTPS connections (pass `.secure` property as view engine data)
- using `urlSSL` in a "reset password" email, if specified
- adding unit tests to test `forceAdminSSL` and `urlSSL` options
- created a unit test utility function to dynamically fork a new instance of Ghost during the test, with different configuration options
