### PR TITLE
Support for urlSSL config option and forceAdminSSL 403 response

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -301,8 +301,9 @@ adminControllers = {
         var email = req.body.email;
 
         api.users.generateResetToken(email).then(function (token) {
-            var siteLink = '<a href="' + config().url + '">' + config().url + '</a>',
-                resetUrl = config().url.replace(/\/$/, '') +  '/ghost/reset/' + token + '/',
+            var baseUrl = config().forceAdminSSL ? (config().urlSSL || config().url) : config().url,
+                siteLink = '<a href="' + baseUrl + '">' + baseUrl + '</a>',
+                resetUrl = baseUrl.replace(/\/$/, '') +  '/ghost/reset/' + token + '/',
                 resetLink = '<a href="' + resetUrl + '">' + resetUrl + '</a>',
                 message = {
                     to: email,

--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -111,6 +111,80 @@ describe('Admin Routing', function () {
                 .end(doEndNoAuth(done));
         });
     });
+    
+    // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
+    describe('Require HTTPS - no redirect', function() {
+        var forkedGhost, request;
+        before(function (done) {
+            var configTestHttps = testUtils.fork.config();
+            configTestHttps.forceAdminSSL = {redirect: false};
+            configTestHttps.urlSSL = 'https://localhost/';
+
+            testUtils.fork.ghost(configTestHttps, 'testhttps')
+                .then(function(child) {
+                    forkedGhost = child;
+                    request = require('supertest');
+                    request = request(configTestHttps.url.replace(/\/$/, ''));
+                }, done)
+                .then(done);
+        });
+        
+        after(function (done) {
+            if (forkedGhost) {
+                forkedGhost.kill(done);
+            }
+        });
+        
+        it('should block admin access over non-HTTPS', function(done) {
+            request.get('/ghost/')
+                .expect(403)
+                .end(done);
+        });
+
+        it('should allow admin access over HTTPS', function(done) {
+            request.get('/ghost/signup/')
+                .set('X-Forwarded-Proto', 'https')
+                .expect(200)
+                .end(doEnd(done));
+        });
+    });    
+
+    describe('Require HTTPS - redirect', function() {
+        var forkedGhost, request;
+        before(function (done) {
+            var configTestHttps = testUtils.fork.config();
+            configTestHttps.forceAdminSSL = {redirect: true};
+            configTestHttps.urlSSL = 'https://localhost/';
+
+            testUtils.fork.ghost(configTestHttps, 'testhttps')
+                .then(function(child) {
+                    forkedGhost = child;
+                    request = require('supertest');
+                    request = request(configTestHttps.url.replace(/\/$/, ''));
+                }, done)
+                .then(done);
+        });
+        
+        after(function (done) {
+            if (forkedGhost) {
+                forkedGhost.kill(done);
+            }
+        });
+        
+        it('should redirect admin access over non-HTTPS', function(done) {
+            request.get('/ghost/')
+                .expect('Location', /^https:\/\/localhost\/ghost\//)
+                .expect(301)
+                .end(done);
+        });
+
+        it('should allow admin access over HTTPS', function(done) {
+            request.get('/ghost/signup/')
+                .set('X-Forwarded-Proto', 'https')
+                .expect(200)
+                .end(done);
+        });
+    });    
 
     describe('Ghost Admin Signup', function () {
         it('should have a session cookie which expires in 12 hours', function (done) {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -9,6 +9,7 @@ var request    = require('supertest'),
     express    = require('express'),
     should     = require('should'),
     moment     = require('moment'),
+    path       = require('path'),
 
     testUtils  = require('../../utils'),
     ghost      = require('../../../../core'),
@@ -139,6 +140,47 @@ describe('Frontend Routing', function () {
                 .expect('Cache-Control', cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
+                .end(doEnd(done));
+        });
+    });
+    
+    // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
+    describe('HTTPS', function() {
+        var forkedGhost, request;
+        before(function (done) {
+            var configTestHttps = testUtils.fork.config();
+            configTestHttps.forceAdminSSL = {redirect: false};
+            configTestHttps.urlSSL = 'https://localhost/';
+
+            testUtils.fork.ghost(configTestHttps, 'testhttps')
+                .then(function(child) {
+                    forkedGhost = child;
+                    request = require('supertest');
+                    request = request(configTestHttps.url.replace(/\/$/, ''));
+                }, done)
+                .then(done);
+        });
+        
+        after(function (done) {
+            if (forkedGhost) {
+                forkedGhost.kill(done);
+            }
+        });
+        
+        it('should set links to url over non-HTTPS', function(done) {
+            request.get('/')
+                .expect(200)
+                .expect(/\<link rel="canonical" href="http:\/\/127.0.0.1:2370\/" \/\>/)
+                .expect(/copyright \<a href="http:\/\/127.0.0.1:2370\/">Ghost\<\/a\>/)
+                .end(doEnd(done));
+        });
+
+        it('should set links to urlSSL over HTTPS', function(done) {
+            request.get('/')
+                .set('X-Forwarded-Proto', 'https')
+                .expect(200)
+                .expect(/\<link rel="canonical" href="https:\/\/localhost\/" \/\>/)
+                .expect(/copyright \<a href="https:\/\/localhost\/">Ghost\<\/a\>/)
                 .end(doEnd(done));
         });
     });

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -1,0 +1,128 @@
+var cp         = require('child_process'),
+    _          = require('lodash'),
+    fs         = require('fs'),
+    url        = require('url'),
+    net        = require('net'),
+    when       = require('when'),
+    path       = require('path'),
+    config     = require('../../server/config');
+    
+function findFreePort(port) {
+    var deferred = when.defer();
+
+    if (typeof port === 'string') port = parseInt(port);
+    if (typeof port !== 'number') port = 2368;
+    port = port + 1;
+
+    var server = net.createServer();
+    server.on('error', function(e) {
+        if (e.code === 'EADDRINUSE') {
+            when.chain(findFreePort(port), deferred);
+        } else {
+            deferred.reject(e);
+        }
+    });
+    server.listen(port, function() {
+        var listenPort = server.address().port;
+        server.close(function() {
+            deferred.resolve(listenPort);
+        });
+    });
+    
+    return deferred.promise;
+}
+
+// Get a copy of current config object from file, to be modified before
+// passing to forkGhost() method
+function forkConfig() {
+    // require caches values, and we want to read it fresh from the file
+    delete require.cache[config().paths.config];
+    return _.cloneDeep(require(config().paths.config)[process.env.NODE_ENV]);
+}
+
+// Creates a new fork of Ghost process with a given config
+// Useful for tests that want to verify certain config options
+function forkGhost(newConfig, envName) {
+    var deferred = when.defer();
+    envName = envName || 'forked';
+    findFreePort(newConfig.server ? newConfig.server.port : undefined)
+        .then(function(port) {
+            newConfig.server = newConfig.server || {};
+            newConfig.server.port = port;
+            newConfig.url = url.format(_.extend(url.parse(newConfig.url), {port: port, host: null}));
+            
+            var newConfigFile = path.join(config().paths.appRoot, 'config.test' + port + '.js');
+            fs.writeFile(newConfigFile, 'module.exports = {' + envName + ': ' + JSON.stringify(newConfig) + '}', function(err) {
+                if (err) throw err;
+                
+                // setup process environment for the forked Ghost to use the new config file
+                var env = _.clone(process.env);
+                env['GHOST_CONFIG'] = newConfigFile;
+                env['NODE_ENV'] = envName;
+                var child = cp.fork(path.join(config().paths.appRoot, 'index.js'), {env: env});
+                
+                var pingTries = 0;
+                var pingCheck;
+                var pingStop = function() {
+                    if (pingCheck) {
+                        clearInterval(pingCheck);
+                        pingCheck = undefined;
+                        return true;
+                    }
+                    return false;
+                };
+                // periodic check until forked Ghost is running and is listening on the port
+                pingCheck = setInterval(function() {
+                    var socket = net.connect(port);
+                    socket.on('connect', function() {
+                        socket.end();
+                        if (pingStop()) {
+                            deferred.resolve(child);
+                        }
+                    });
+                    socket.on('error', function(err) {
+                        // continue checking
+                        if (++pingTries >= 20 && pingStop()) {
+                            deferred.reject(new Error("Timed out waiting for child process"));
+                        }
+                    });
+                }, 200);
+        
+                child.on('exit', function(code, signal) {
+                    child.exited = true;
+                    if (pingStop()) {
+                        deferred.reject(new Error("Child process exit code: " + code));
+                    }
+                    // cleanup the temporary config file
+                    fs.unlink(newConfigFile);
+                });
+                
+                // override kill() to have an async callback
+                var baseKill = child.kill;
+                child.kill = function(signal, cb) {
+                    if (typeof signal === 'function') {
+                        cb = signal;
+                        signal = undefined;
+                    }
+                    
+                    if (cb) {
+                        child.on('exit', function() {
+                            cb();
+                        });
+                    }
+
+                    if (child.exited) {
+                        process.nextTick(cb);
+                    } else {
+                        baseKill.apply(child, [signal]);
+                    }
+                };
+            });
+        })
+        .otherwise(deferred.reject);
+
+    return deferred.promise;
+}
+
+module.exports.ghost = forkGhost;
+module.exports.config = forkConfig;

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -8,7 +8,8 @@ var knex          = require('../../server/models/base').knex,
     migration     = require("../../server/data/migration/"),
     Settings      = require('../../server/models/settings').Settings,
     DataGenerator = require('./fixtures/data-generator'),
-    API           = require('./api');
+    API           = require('./api'),
+    fork          = require('./fork');
 
 function initData() {
     return migration.init();
@@ -228,5 +229,7 @@ module.exports = {
     loadExportFixture: loadExportFixture,
 
     DataGenerator: DataGenerator,
-    API: API
+    API: API,
+    
+    fork: fork
 };


### PR DESCRIPTION
closes #1838
- adding `forceAdminSSL: {redirect: true/false}` option to allow 403 over non-SSL rather than redirect
- adding `urlSSL` option to specify SSL variant of `url`
- using `urlSSL` when redirecting to SSL (forceAdminSSL), if specified
- dynamically patching `.url` property for view engine templates to use SSL variant over HTTPS connections (pass `.secure` property as view engine data)
- using `urlSSL` in a "reset password" email, if specified
- adding unit tests to test `forceAdminSSL` and `urlSSL` options
- created a unit test utility function to dynamically fork a new instance of Ghost during the test, with different configuration options
