### PR TITLE
Custom Page Templates

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -15,6 +15,7 @@ var moment      = require('moment'),
     config      = require('../config'),
     errors      = require('../errorHandling'),
     filters     = require('../../server/filters'),
+    template    = require('../helpers/template'),
 
     frontendControllers,
     // Cache static post permalink regex
@@ -186,7 +187,8 @@ frontendControllers = {
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {
                         var paths = config().paths.availableThemes[activeTheme.value],
-                            view = post.page && paths.hasOwnProperty('page.hbs') ? 'page' : 'post';
+                            view = template.getThemeViewForPost(paths, post);
+
                         res.render(view, {post: post});
                     });
                 });

--- a/core/server/helpers/template.js
+++ b/core/server/helpers/template.js
@@ -23,4 +23,26 @@ templates.execute = function (name, context) {
     return new hbs.handlebars.SafeString(partial(context));
 };
 
+// Given a theme object and a post object this will return
+// which theme template page should be used.
+// If given a post object that is a regular post
+// it will return 'post'.
+// If given a static post object it will return 'page'.
+// If given a static post object and a custom page template
+// exits it will return that page.
+templates.getThemeViewForPost = function (themePaths, post) {
+    var customPageView = 'page-' + post.slug,
+        view = 'post';
+
+    if (post.page) {
+        if (themePaths.hasOwnProperty(customPageView + '.hbs')) {
+            view = customPageView;
+        } else if (themePaths.hasOwnProperty('page.hbs')) {
+            view = 'page';
+        }
+    }
+
+    return view;
+};
+
 module.exports = templates;

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -20,6 +20,7 @@ describe('Core Helpers', function () {
 
     var sandbox,
         apiStub,
+        configStub,
         overrideConfig = function (newConfig) {
             helpers.__set__('config', function() {
                 return newConfig;
@@ -35,13 +36,28 @@ describe('Core Helpers', function () {
         });
 
         config = helpers.__get__('config');
-        config.theme = sandbox.stub(config, 'theme', function () {
-            return {
-                title: 'Ghost',
-                description: 'Just a blogging platform.',
-                url: 'http://testurl.com'
-            };
+        configStub = sandbox.stub().returns({
+            'paths': {
+                'subdir': '',
+                'availableThemes': {
+                    'casper': {
+                        'assets': null,
+                        'default.hbs': '/content/themes/casper/default.hbs',
+                        'index.hbs': '/content/themes/casper/index.hbs',
+                        'page.hbs': '/content/themes/casper/page.hbs',
+                        'page-about.hbs': '/content/themes/casper/page-about.hbs',
+                        'post.hbs': '/content/themes/casper/post.hbs'
+                    }
+                }
+            }
         });
+        _.extend(configStub, config);
+        configStub.theme = sandbox.stub().returns({
+            title: 'Ghost',
+            description: 'Just a blogging platform.',
+            url: 'http://testurl.com'
+        });
+        helpers.__set__('config', configStub);
 
         helpers.loadCoreHelpers(adminHbs);
         // Load template helpers in handlebars
@@ -306,6 +322,22 @@ describe('Core Helpers', function () {
             }).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.equal('home-template page');
+
+                done();
+            }).then(null, done);
+        });
+
+        it('can render class for static page with custom template', function (done) {
+            helpers.body_class.call({
+                relativeUrl: '/about',
+                post: {
+                    page: true,
+                    slug: 'about'
+
+                }
+            }).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.equal('post-template page page-template-about');
 
                 done();
             }).then(null, done);

--- a/core/test/unit/server_helpers_template_spec.js
+++ b/core/test/unit/server_helpers_template_spec.js
@@ -22,4 +22,40 @@ describe('Helpers Template', function () {
         should.exist(safeString);
         safeString.should.have.property('string').and.equal('<h1>Hello world</h1>');
     });
+
+    describe('getThemeViewForPost', function () {
+        var themePaths = {
+                'assets': null,
+                'default.hbs': '/content/themes/casper/default.hbs',
+                'index.hbs': '/content/themes/casper/index.hbs',
+                'page.hbs': '/content/themes/casper/page.hbs',
+                'page-about.hbs': '/content/themes/casper/page-about.hbs',
+                'post.hbs': '/content/themes/casper/post.hbs'
+            },
+            posts = [{
+                page: 1,
+                slug: 'about'
+            }, {
+                page: 1,
+                slug: 'contact'
+            }, {
+                page: 0,
+                slug: 'test-post'
+            }];
+
+        it('will return correct view for a post', function () {
+            var view = template.getThemeViewForPost(themePaths, posts[0]);
+            view.should.exist;
+            view.should.eql('page-about');
+
+            view = template.getThemeViewForPost(themePaths, posts[1]);
+            view.should.exist;
+            view.should.eql('page');
+
+            view = template.getThemeViewForPost(themePaths, posts[2]);
+            view.should.exist;
+            view.should.eql('post');
+        });
+
+    });
 });


### PR DESCRIPTION
fixes #1969
- creates new ./server/helpers/tempalte.js method
  which returns the correct view to use when rendering
- updates fronted controller to check if a custom page template
  exists and if so then uses that to render the static page
- adds additional class name to body_class helper when
  a custom page template is being rendered
- adds tests to address all new features
