### PR TITLE
Change fallback from address to webmaster@[blog.url]

### DIFF
--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -82,6 +82,22 @@ GhostMailer.prototype.emailDisabled = function () {
     this.transport = null;
 };
 
+GhostMailer.prototype.fromAddress = function () {
+    var from = config().mail && config().mail.fromaddress,
+        domain;
+
+    if (!from) {
+        // Extract the domain name from url set in config.js
+        domain = config().url.match(new RegExp("^https?://([^/:?#]+)(?:[/:?#]|$)", "i"));
+        domain = domain && domain[1];
+
+        // Default to webmaster@[blog.url]
+        from = 'webmaster@' + domain;
+    }
+
+    return from;
+};
+
 // Sends an e-mail message enforcing `to` (blog owner) and `from` fields
 GhostMailer.prototype.send = function (message) {
     var self = this;
@@ -94,11 +110,10 @@ GhostMailer.prototype.send = function (message) {
     }
 
     return api.settings.read('email').then(function (email) {
-        var from = (config().mail && config().mail.fromaddress) || email.value,
-            to = message.to || email.value;
+        var to = message.to || email.value;
 
         message = _.extend(message, {
-            from: from,
+            from: self.fromAddress(),
             to: to,
             generateTextFromHTML: true
         });

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -167,4 +167,26 @@ describe("Mail", function () {
             done();
         });
     });
+
+    it('should use from address as configured in config.js', function (done) {
+        overrideConfig({mail:{fromaddress: 'static@example.com'}});
+        mailer.fromAddress().should.equal('static@example.com');
+        done();
+    });
+
+    it('should fall back to webmaster@[blog.url] as from address', function (done) {
+        // Standard domain
+        overrideConfig({url: 'http://default.com', mail:{fromaddress: null}});
+        mailer.fromAddress().should.equal('webmaster@default.com');
+
+        // Trailing slash
+        overrideConfig({url: 'http://default.com/', mail:{}});
+        mailer.fromAddress().should.equal('webmaster@default.com');
+
+        // Strip Port
+        overrideConfig({url: 'http://default.com:2368/', mail:{}});
+        mailer.fromAddress().should.equal('webmaster@default.com');
+
+        done();
+    });
 });


### PR DESCRIPTION
This change is needed because the previous default of the user's email
address is too often mismatched against the site domain, triggering spam filters.

Fixes #2145
- added `fromAddress()` to GhostMailer to handle this logic
- added unit tests to `mail_spec.js`
