### PR TITLE
Cleanup naming & order in admin controller

### DIFF
--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -26,24 +26,24 @@ module.exports = function (server) {
         res.redirect(301, subdir + '/ghost/signin/');
     });
 
-    server.get('/ghost/signout/', admin.logout);
-    server.get('/ghost/signin/', middleware.redirectToSignup, middleware.redirectToDashboard, admin.login);
+    server.get('/ghost/signout/', admin.signout);
+    server.get('/ghost/signin/', middleware.redirectToSignup, middleware.redirectToDashboard, admin.signin);
+    server.post('/ghost/signin/', admin.doSignin);
     server.get('/ghost/signup/', middleware.redirectToDashboard, admin.signup);
+    server.post('/ghost/signup/', admin.doSignup);
     server.get('/ghost/forgotten/', middleware.redirectToDashboard, admin.forgotten);
-    server.post('/ghost/forgotten/', admin.generateResetToken);
+    server.post('/ghost/forgotten/', admin.doForgotten);
     server.get('/ghost/reset/:token', admin.reset);
-    server.post('/ghost/reset/:token', admin.resetPassword);
-    server.post('/ghost/signin/', admin.auth);
-    server.post('/ghost/signup/', admin.doRegister);
+    server.post('/ghost/reset/:token', admin.doReset);
+    server.post('/ghost/changepw/', admin.doChangePassword);
 
-    server.post('/ghost/changepw/', admin.changepw);
     server.get('/ghost/editor(/:id)/', admin.editor);
     server.get('/ghost/editor/', admin.editor);
     server.get('/ghost/content/', admin.content);
     server.get('/ghost/settings*', admin.settings);
     server.get('/ghost/debug/', admin.debug.index);
 
-    server.post('/ghost/upload/', middleware.busboy, admin.uploader);
+    server.post('/ghost/upload/', middleware.busboy, admin.upload);
 
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
     server.get(/\/((ghost-admin|admin|wp-admin|dashboard|signin)\/?)$/, function (req, res) {

--- a/core/test/unit/admin_spec.js
+++ b/core/test/unit/admin_spec.js
@@ -9,7 +9,7 @@ var fs      = require('fs-extra'),
     admin = require('../../server/controllers/admin');
 
 describe('Admin Controller', function () {
-    describe('uploader', function () {
+    describe('upload', function () {
 
         var req, res, store;
 
@@ -43,7 +43,7 @@ describe('Admin Controller', function () {
                 res.send = sinon.stub();
                 req.files.uploadimage.name = 'INVALID.FILE';
                 req.files.uploadimage.type = 'application/octet-stream';
-                admin.uploader(req, res);
+                admin.upload(req, res);
                 res.send.calledOnce.should.be.true;
                 res.send.args[0][0].should.equal(415);
                 res.send.args[0][1].should.equal('Unsupported Media Type');
@@ -55,7 +55,7 @@ describe('Admin Controller', function () {
                 res.send = sinon.stub();
                 req.files.uploadimage.name = 'INVALID.jpg';
                 req.files.uploadimage.type = 'application/octet-stream';
-                admin.uploader(req, res);
+                admin.upload(req, res);
                 res.send.calledOnce.should.be.true;
                 res.send.args[0][0].should.equal(415);
                 res.send.args[0][1].should.equal('Unsupported Media Type');
@@ -80,7 +80,7 @@ describe('Admin Controller', function () {
                     return done();
                 });
 
-                admin.uploader(req, res);
+                admin.upload(req, res);
             });
 
             it('cannot upload jpg with incorrect extension', function (done) {
@@ -90,7 +90,7 @@ describe('Admin Controller', function () {
                     return done();
                 });
 
-                admin.uploader(req, res);
+                admin.upload(req, res);
             });
 
             it('can upload png', function (done) {
@@ -101,7 +101,7 @@ describe('Admin Controller', function () {
                     return done();
                 });
 
-                admin.uploader(req, res);
+                admin.upload(req, res);
             });
 
             it('can upload gif', function (done) {
@@ -112,7 +112,7 @@ describe('Admin Controller', function () {
                     return done();
                 });
 
-                admin.uploader(req, res);
+                admin.upload(req, res);
             });
 
             it('should send correct url', function (done) {
@@ -121,7 +121,7 @@ describe('Admin Controller', function () {
                     return done();
                 });
 
-                admin.uploader(req, res);
+                admin.upload(req, res);
             });
         });
     });


### PR DESCRIPTION
I imagine that a lot of the admin routes need to either disappear into 1-page-app-wonderland, or be moved onto the API, but at least this makes it easier to see what we're working with.

I know this might conflict with other PRs so prob won't merge straight away.

 There seemed to be no convention or order to the functions in the admin controller, so I have:
- organised them
- reordered them
- added a small doc-block
- reordered some routes
- updated tests accordingly
