### PR TITLE
Fix problems from importing 0.4.0 file

### DIFF
--- a/core/server/data/import/000.js
+++ b/core/server/data/import/000.js
@@ -112,13 +112,13 @@ function importUsers(ops, tableData, transaction) {
 
 function importSettings(ops, tableData, transaction) {
     // for settings we need to update individual settings, and insert any missing ones
-    // settings we MUST NOT update are the databaseVersion, dbHash, and activeTheme
+    // settings we MUST NOT update are 'core' and 'theme' settings
     // as all of these will cause side effects which don't make sense for an import
+    var blackList = ['core', 'theme'];
 
-    var blackList = ['databaseVersion', 'dbHash', 'activeTheme'];
     tableData = stripProperties(['id'], tableData);
     tableData = _.filter(tableData, function (data) {
-        return blackList.indexOf(data.key) === -1;
+        return blackList.indexOf(data.type) === -1;
     });
 
     ops.push(models.Settings.edit(tableData, transaction)

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -192,7 +192,7 @@ function showUpdateNotification() {
         // Version 0.4 used boolean to indicate the need for an update. This special case is
         // translated to the version string.
         // TODO: remove in future version.
-        if (display.value === 'false' || display.value === 'true') {
+        if (display.value === 'false' || display.value === 'true' || display.value === '1' || display.value === '0') {
             display.value = '0.4.0';
         }
 


### PR DESCRIPTION
fixes #2244
- added mysql ‚true’/‚false‘ values as ‚0‘/‚1‘
- removed all core settings from import
