### PR TITLE
Add plugin icons to Apps menu item in Ghost settings

### DIFF
--- a/core/client/assets/sass/layouts/settings.scss
+++ b/core/client/assets/sass/layouts/settings.scss
@@ -162,7 +162,7 @@
         .services a { @include icon($i-services) }
         .users a { @include icon($i-users) }
         .appearance a { @include icon($i-appearance) }
-        .plugins a { @include icon($i-plugins) }
+        .apps a { @include icon($i-plugins) }
 
     }//.settings-menu
 


### PR DESCRIPTION
closes #2290
- added css entry in settings.scss for to display plugin icon for apps menu item
