### PR TITLE
Change validation for posts 'page' attribute

### DIFF
--- a/core/server/data/schema.js
+++ b/core/server/data/schema.js
@@ -8,7 +8,7 @@ var db = {
             html: {type: 'text', maxlength: 16777215, fieldtype: 'medium', nullable: true},
             image: {type: 'text', maxlength: 2000, nullable: true},
             featured: {type: 'bool', nullable: false, defaultTo: false},
-            page: {type: 'bool', nullable: false, defaultTo: false, validations: {'isIn': [['true', 'false']]}},
+            page: {type: 'bool', nullable: false, defaultTo: false, validations: {'isIn': [['0', '1']]}},
             status: {type: 'string', maxlength: 150, nullable: false, defaultTo: 'draft'},
             language: {type: 'string', maxlength: 6, nullable: false, defaultTo: 'en_US'},
             meta_title: {type: 'string', maxlength: 150, nullable: true},

--- a/core/test/functional/api/posts_test.js
+++ b/core/test/functional/api/posts_test.js
@@ -248,6 +248,52 @@ describe('Post API', function () {
             });
         });
 
+        it('can change a post to a static page', function (done) {
+            request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
+                var jsonResponse = JSON.parse(body),
+                    changedValue = true;
+                jsonResponse.should.exist;
+		jsonResponse.page.should.eql(0);
+                jsonResponse.page = changedValue;
+
+                request.put({uri: testUtils.API.getApiURL('posts/1/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse}, function (error, response, putBody) {
+                    response.should.have.status(200);
+                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + putBody.slug + '/');
+                    response.should.be.json;
+                    putBody.should.exist;
+                    putBody.page.should.eql(changedValue);
+
+                    testUtils.API.checkResponse(putBody, 'post');
+                    done();
+                });
+            });
+        });
+
+        it('can change a static page to a post', function (done) {
+            request.get(testUtils.API.getApiURL('posts/7/'), function (error, response, body) {
+                var jsonResponse = JSON.parse(body),
+                    changedValue = false;
+                jsonResponse.should.exist;
+		jsonResponse.page.should.eql(1);
+                jsonResponse.page = changedValue;
+
+                request.put({uri: testUtils.API.getApiURL('posts/1/'),
+                    headers: {'X-CSRF-Token': csrfToken},
+                    json: jsonResponse}, function (error, response, putBody) {
+                    response.should.have.status(200);
+                    response.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /' + putBody.slug + '/');
+                    response.should.be.json;
+                    putBody.should.exist;
+                    putBody.page.should.eql(changedValue);
+
+                    testUtils.API.checkResponse(putBody, 'post');
+                    done();
+                });
+            });
+        });
+
         it('can\'t edit a post with invalid CSRF token', function (done) {
             request.get(testUtils.API.getApiURL('posts/1/'), function (error, response, body) {
                 var jsonResponse = JSON.parse(body);


### PR DESCRIPTION
Change validation for the posts 'page' attribute to expect 0 or 1, rather than "true" or "false"

closes #2305
