### PR TITLE
Fixing typo in allowedSections for allowed pages under settings

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -89,7 +89,7 @@ adminControllers = {
     // Method: GET
     'settings': function (req, res, next) {
         // TODO: Centralise list/enumeration of settings panes, so we don't run into trouble in future.
-        var allowedSections = ['', 'general', 'user', 'app'],
+        var allowedSections = ['', 'general', 'user', 'apps'],
             section = req.url.replace(/(^\/ghost\/settings[\/]*|\/$)/ig, '');
 
         if (allowedSections.indexOf(section) < 0) {


### PR DESCRIPTION
To repeat the problem first go to the apps settings page then hit reload in your browser. You'll get a 404 since apps isn't in the allowed sections.

This solves this. It seemed like the problem is in allowedSections and not the other way around so I solved it by editing allowedSections rather then rewriting apps to app.
