### PR TITLE
Prevent settings page from rendering same page twice

### DIFF
--- a/core/client/views/settings.js
+++ b/core/client/views/settings.js
@@ -61,7 +61,7 @@
 
             Ghost.router.navigate('/settings/' + id + '/');
             Ghost.trigger('urlchange');
-            if (this.pane && id === this.pane.el.id) {
+            if (this.pane && id === this.pane.id) {
                 return;
             }
             _.result(this.pane, 'destroy');


### PR DESCRIPTION
Closes #2316
- There was a check to prevent rerendering of same content pane but it wasn't working
- Fixed the check for this
