### PR TITLE
Blog post titles will now be properly escaped in rss (xml) feeds.

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -301,7 +301,7 @@ frontendControllers = {
                     posts.forEach(function (post) {
                         var deferred = when.defer(),
                             item = {
-                                title:  _.escape(post.title),
+                                title: post.title,
                                 guid: post.uuid,
                                 url: config.urlFor('post', {post: post, permalinks: permalinks}, true),
                                 date: post.published_at,


### PR DESCRIPTION
closes #2313
