### PR TITLE
Set year and time defaults for post pubdate

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -176,7 +176,7 @@
             // Check for missing time stamp on new data
             // If no time specified, add a 12:00
             if (newPubDate && !newPubDate.slice(-5).match(/\d+:\d\d/)) {
-                newPubDate += " 12:00";
+                newPubDate += " " + moment().format('YYYY') + " 12:00";
             }
 
             newPubDateMoment = moment(newPubDate, parseDateFormats);
@@ -186,7 +186,7 @@
                  // Check for missing time stamp on current model
                 // If no time specified, add a 12:00
                 if (!pubDate.slice(-5).match(/\d+:\d\d/)) {
-                    pubDate += " 12:00";
+                    newPubDate += " " + moment().format('YYYY') + " 12:00";
                 }
 
                 pubDateMoment = moment(pubDate, parseDateFormats);


### PR DESCRIPTION
closes #2331
- Appended year to newPubDate
- This has the effect of defaulting the pubdate year to the current year
- And pubdate time to 12:00
