### PR TITLE
Nocache404

### DIFF
--- a/core/server/errorHandling.js
+++ b/core/server/errorHandling.js
@@ -10,9 +10,7 @@ var _           = require('lodash'),
     // Paths for views
     defaultErrorTemplatePath = path.resolve(config().paths.adminViews, 'user-error.hbs'),
     userErrorTemplatePath    = path.resolve(config().paths.themePath, 'error.hbs'),
-    userErrorTemplateExists   = false,
-
-    ONE_HOUR_S  = 60 * 60;
+    userErrorTemplateExists   = false;
 
 // This is not useful but required for jshint
 colors.setTheme({silly: 'rainbow'});
@@ -201,8 +199,8 @@ errors = {
     error404: function (req, res, next) {
         var message = res.isAdmin && req.session.user ? "No Ghost Found" : "Page Not Found";
 
-        // 404 errors should be briefly cached
-        res.set({'Cache-Control': 'public, max-age=' + ONE_HOUR_S});
+        // do not cache 404 error
+        res.set({'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'});
         if (req.method === 'GET') {
             this.renderErrorPage(404, message, req, res, next);
         } else {

--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -131,7 +131,7 @@ describe('Admin Routing', function () {
 
         it('should respond 404 for /ghost/reset/', function (done) {
             request.get('/ghost/reset/')
-                .expect('Cache-Control', cacheRules.hour)
+                .expect('Cache-Control', cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -89,7 +89,7 @@ describe('Frontend Routing', function () {
             var date  = moment().format("YYYY/MM/DD");
 
             request.get('/' + date + '/welcome-to-ghost/')
-                .expect('Cache-Control', cacheRules.hour)
+                //.expect('Cache-Control', cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));
@@ -97,7 +97,7 @@ describe('Frontend Routing', function () {
 
         it('should 404 for unknown post', function (done) {
             request.get('/spectacular/')
-                .expect('Cache-Control', cacheRules.hour)
+                .expect('Cache-Control', cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));

--- a/core/test/unit/errorHandling_spec.js
+++ b/core/test/unit/errorHandling_spec.js
@@ -253,7 +253,7 @@ describe("Error handling", function () {
                 this.statusCode.should.equal(404);
 
                 // Test that the headers are correct
-                this._headers['cache-control'].should.equal('public, max-age=' + ONE_HOUR_S);
+                this._headers['cache-control'].should.equal('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
 
                 done();
             });
@@ -280,7 +280,7 @@ describe("Error handling", function () {
                 this.statusCode.should.equal(404);
 
                 // Test that the headers are correct
-                this._headers['cache-control'].should.equal('public, max-age=' + ONE_HOUR_S);
+                this._headers['cache-control'].should.equal('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
 
                 done();
             });


### PR DESCRIPTION
Remove the caching of 404 pages instead of caching them for an hour.
