### PR TITLE
Allow bower install to run as root

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -332,7 +332,7 @@ var path           = require('path'),
                     command: 'bourbon install --path <%= paths.adminAssets %>/sass/modules/'
                 },
                 bower: {
-                    command: path.resolve(__dirname + '/node_modules/.bin/bower install'),
+                    command: path.resolve(__dirname + '/node_modules/.bin/bower install --allow-root'),
                     options: {
                         stdout: true
                     }


### PR DESCRIPTION
It's not uncommon for build and CI systems to run as root. Debian packages get build in a (fake)root environment, Docker images get build as root and probably most other build systems as well.

However one might think about that, it doesn't make sense to force users to run the build as non-root.
