### PR TITLE
Don't fade out notifications when the mouse is over

### DIFF
--- a/core/client/assets/sass/modules/global.scss
+++ b/core/client/assets/sass/modules/global.scss
@@ -1007,6 +1007,10 @@ nav {
         @include animation-iteration-count(1);
         @include animation-fill-mode(forwards);
     }
+    
+    &.notification-passive:hover {
+        @include animation(fade-in 1s linear);
+    }
 }
 
 .notification-error {


### PR DESCRIPTION
closes #993
- fade the notification back in if the mouse enters whilst it is fading out
- also stops the notification starting to fade if the mouse is over
