### PR TITLE
Ensure grunt-contrib-watch watches appropriate files for re-building ember admin when files change.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,6 +54,14 @@ var path           = require('path'),
                     files: ['core/clientold/tpl/**/*.hbs'],
                     tasks: ['handlebars']
                 },
+                'handlebars-ember': {
+                    files: ['core/client/**/*.hbs'],
+                    tasks: ['emberTemplates:dev']
+                },
+                ember: {
+                    files: ['core/client/**/*.js'],
+                    tasks: ['transpile', 'concat_sourcemap']
+                },
                 concat: {
                     files: [
                         'core/clientold/*.js',


### PR DESCRIPTION
Currently `grunt dev` doesn't actually watch for Ember file changes and thus the admin is never rebuilt.

This fixes that.
