### PR TITLE
Adding .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "bower_components"
+}


### PR DESCRIPTION
If no .bowerrc file is found in the current folder it seems to lookup if one exists in parent folders and uses this. Thus, we need to use .bowerrc in order to avoid problems.
