### PR TITLE
Added functional tests for editor: tag editor, image uploads, post settings

### DIFF
--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -91,6 +91,81 @@ CasperTest.begin("Word count and plurality", 4, function suite(test) {
     });
 });
 
+CasperTest.begin("Image Uploads", 14, function suite(test) {
+    casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    // Test standard image upload modal
+    casper.then(function () {
+        casper.writeContentToCodeMirror("![]()");
+    });
+
+    function assertEmptyImageUploaderDisplaysCorrectly() {
+        test.assertExists(".entry-preview .js-upload-target", "Upload target exists");
+        test.assertExists(".entry-preview .js-fileupload", "File upload target exists");
+        test.assertExists(".entry-preview .image-url", "Image URL button exists");
+    };
+
+    casper.waitForSelector(".entry-preview .js-drop-zone.image-uploader", assertEmptyImageUploaderDisplaysCorrectly);
+
+    // Test image URL upload modal
+    casper.thenClick(".entry-preview .image-uploader a.image-url");
+
+    casper.waitForSelector(".image-uploader-url", function onSuccess() {
+        test.assertExists(".image-uploader-url .url.js-upload-url", "Image URL uploader exists")
+        test.assertExists(".image-uploader-url .button-save.js-button-accept", "Image URL accept button exists")
+        test.assertExists(".image-uploader-url .image-upload", "Back to normal image upload style button exists")
+    });
+
+    // Test image source location
+    casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    var testFileLocation = "test/file/location";
+
+    casper.then(function () {
+        var markdownImageString = "![](" + testFileLocation + ")";
+        casper.writeContentToCodeMirror(markdownImageString);
+    });
+
+    casper.waitForSelector(".entry-preview .js-drop-zone.pre-image-uploader", function onSuccess() {
+        var imageJQuerySelector = ".entry-preview img.js-upload-target[src='" + testFileLocation + "']"
+        test.assertExists(imageJQuerySelector, "Uploaded image tag properly links to source location");
+    });
+
+    // Test cancel image button
+    casper.thenClick(".pre-image-uploader a.image-cancel.js-cancel");
+
+    casper.waitForSelector(".entry-preview .js-drop-zone.image-uploader", assertEmptyImageUploaderDisplaysCorrectly);
+
+    // Test image url source location
+    casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    casper.then(function () {
+        casper.writeContentToCodeMirror("![]()");
+    });
+
+    casper.waitForSelector(".entry-preview .js-drop-zone.image-uploader", function onSuccess() {
+        casper.thenClick(".entry-preview .image-uploader a.image-url");
+    });
+
+    var imageURL = "random.url";
+    casper.waitForSelector(".image-uploader-url", function onSuccess() {
+        casper.sendKeys(".image-uploader-url input.url.js-upload-url", imageURL);
+        casper.thenClick(".js-button-accept.button-save");
+    });
+
+    casper.waitForSelector(".entry-preview .js-drop-zone.pre-image-uploader", function onSuccess() {
+        var imageJQuerySelector = ".entry-preview img.js-upload-target[src='" + imageURL + "']"
+        test.assertExists(imageJQuerySelector, "Uploaded image tag properly links to inputted image URL");
+    });
+
+});
+
 CasperTest.begin('Required Title', 4, function suite(test) {
     casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
@@ -128,6 +203,117 @@ CasperTest.begin('Title Trimming', 2, function suite(test) {
             return $('#entry-title').val();
 
         }, trimmedTitle, 'Entry title should match expected value.');
+    });
+});
+
+CasperTest.begin("Tag editor", 6, function suite(test) {
+    casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    var tagName = "someTagName";
+
+    casper.then(function () {
+        test.assertExists("#entry-tags", "should have tag label area");
+        test.assertExists("#entry-tags .tag-label", "should have tag label icon");
+        test.assertExists("#entry-tags input.tag-input", "should have tag input area");
+        casper.sendKeys("#entry-tags input.tag-input", tagName);
+        casper.sendKeys("#entry-tags input.tag-input", casper.page.event.key.Enter);
+    });
+
+    var createdTagSelector = "#entry-tags .tags .tag";
+    casper.waitForSelector(createdTagSelector, function onSuccess() {
+        test.assertSelectorHasText(createdTagSelector, tagName, "typing enter after tag name should create tag");
+    });
+
+    casper.thenClick(createdTagSelector);
+
+    casper.then(function () {
+        test.assertDoesntExist(createdTagSelector, "clicking the tag should delete the tag");
+    });
+
+});
+
+CasperTest.begin("Post settings menu", 17, function suite(test) {
+    casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    casper.then(function () {
+        test.assertExists("#publish-bar a.post-settings", "icon toggle should exist");
+        test.assertNotVisible("#publish-bar .post-settings-menu", "popup menu should not be visible at startup");
+        test.assertExists(".post-settings-menu input#url", "url field exists");
+        test.assertExists(".post-settings-menu input#pub-date", "publication date field exists");
+        test.assertExists(".post-settings-menu input#static-page", "static page checkbox field exists");
+        test.assertExists(".post-settings-menu a.delete", "delete post button exists")
+    });
+
+    casper.thenClick("#publish-bar a.post-settings");
+
+    casper.waitUntilVisible("#publish-bar .post-settings-menu", function onSuccess() {
+        test.assert(true, "popup menu should be visible after clicking post-settings icon");
+        test.assertNotVisible(".post-settings-menu a.delete", "delete post btn shouldn't be visible on unsaved drafts");
+    });
+
+    casper.thenClick("#publish-bar a.post-settings");
+
+    casper.waitWhileVisible("#publish-bar .post-settings-menu", function onSuccess() {
+        test.assert(true, "popup menu should not be visible after clicking post-settings icon");
+    });
+
+    // Enter a title and save draft so converting to/from static post
+    // will result in notifications and 'Delete This Post' button appears
+    casper.then(function (){
+        casper.sendKeys("#entry-title", "aTitle");
+        casper.thenClick(".js-publish-button");
+    });
+
+    casper.thenClick("#publish-bar a.post-settings");
+
+    casper.waitUntilVisible("#publish-bar .post-settings-menu", function onSuccess() {
+        test.assertVisible(".post-settings-menu a.delete", "delete post button should be visible for saved drafts");
+    });
+
+    // Test Static Page conversion
+    casper.thenClick(".post-settings-menu #static-page");
+
+    var staticPageConversionText = "Successfully converted to static page.";
+    casper.waitForText(staticPageConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            ".notification-success", staticPageConversionText, "correct static page conversion notification appears");
+    })
+
+    casper.thenClick(".post-settings-menu #static-page");
+
+    var postConversionText = "Successfully converted to post.";
+    casper.waitForText(postConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            ".notification-success", postConversionText, "correct post conversion notification appears");
+    });
+
+    // Test Delete Post Modal
+    casper.thenClick(".post-settings-menu a.delete");
+
+    casper.waitUntilVisible("#modal-container", function onSuccess() {
+        test.assert(true, "delete post modal is visible after clicking delete");
+        test.assertSelectorHasText(
+            "#modal-container .modal-header",
+            "Are you sure you want to delete this post?",
+            "delete post modal header has correct text");
+    });
+
+    casper.thenClick("#modal-container .js-button-reject");
+
+    casper.waitWhileVisible("#modal-container", function onSuccess() {
+        test.assert(true, "clicking cancel should close the delete post modal");
+    });
+
+    casper.thenClick("#publish-bar a.post-settings");
+    casper.thenClick(".post-settings-menu a.delete");
+    casper.thenClick("#modal-container .js-button-accept");
+
+    casper.waitForUrl(/ghost\/content\/$/, function onSuccess() {
+        test.assert(true, "clicking the delete post button should bring us to the content page");
     });
 });
 


### PR DESCRIPTION
Added functional tests for editor: tag editor, image uploads, post settings

references #2273
- test tag creation and tag deletion
- tests image uploader appears after typing `![]()` in editor
- tests image URL matches url inside `![](url)`
- tests all input elements of post settings menu
