### PR TITLE
Fix earlier commit for grunt watch.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,14 +63,21 @@ var path           = require('path'),
                     ],
                     tasks: ['concat']
                 },
+                'ghost-ui': {
+                    files: [
+                        // Ghost UI CSS
+                        'bower_components/ghost-ui/dist/css/*.css'
+                    ],
+                    tasks: ['copy:dev']
+                },
                 livereload: {
                     files: [
                         // Theme CSS
                         'content/themes/casper/css/*.css',
-                        // Ghost UI CSS
-                        'bower_components/ghost-ui/dist/css/*.css',
                         // Theme JS
                         'content/themes/casper/js/*.js',
+                        // Client CSS
+                        'core/client/assets/css/*.css',
                         // Admin JS
                         'core/built/scripts/*.js'
                     ],
@@ -555,7 +562,6 @@ var path           = require('path'),
         };
 
         grunt.initConfig(cfg);
-
 
         // ## Custom Tasks
 


### PR DESCRIPTION
refs TryGhost/Ghost-UI#18
- Trigger livereload when files in core/client/assets/css/ change
- Copy over new ghost-ui files when changed

This fixes my earlier commit where `grunt watch` was triggered but didn't update ghost-ui files.

**Note:** It would be great if someone could look over this. The `'ghost-ui'` subtask is triggered twice when a change in ghost-ui occurs. This is due to two files being changes. There is a `debounceDelay` option which however doesn't seem to prevent triggering the task twice. I looked into `_.debounce` options, but those are overly complex for the simple use case we have here. 

TL;DR;: This PR fixes the issue from the earlier commit but triggers the copy:dev task twice.
