### PR TITLE
Remove .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-    "directory": "bower_components"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ results
 npm-debug.log
 node_modules
 bower_components
-
+.bowerrc
 .idea/*
 *.iml
 projectFilesBackup


### PR DESCRIPTION
If there are no further comments or suggestions for #2386 then I think it would be good to get this in. Remove .bowerrc from base repo but allows it to still be used for people with specialised dev environments by adding to .gitignore
