### PR TITLE
Fix scoping issue on signup

### DIFF
--- a/core/client/views/login.js
+++ b/core/client/views/login.js
@@ -94,7 +94,8 @@
             var name = this.$('.name').val(),
                 email = this.$('.email').val(),
                 password = this.$('.password').val(),
-                validationErrors = [];
+                validationErrors = [],
+                self = this;
 
             if (!validator.isLength(name, 1)) {
                 validationErrors.push("Please enter a name.");
@@ -131,7 +132,7 @@
                         window.location.href = msg.redirect;
                     },
                     error: function (xhr) {
-                        this.submitted = "no";
+                        self.submitted = "no";
                         Ghost.notifications.clearEverything();
                         Ghost.notifications.addItem({
                             type: 'error',


### PR DESCRIPTION
The Guard added in #2049 has a scoping issue that prevents the submitted variable from changing when the signup fails. Meaning any attempts to resubmit the form wont work and the user will need to reload the page. 

Found when entering a password >1 character to pass client side validation but <8 which fails server side validation.
