### PR TITLE
Fixes race conditions in functional test introduced in PR#2395

### DIFF
--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -228,13 +228,12 @@ CasperTest.begin("Tag editor", 6, function suite(test) {
 
     casper.thenClick(createdTagSelector);
 
-    casper.then(function () {
-        test.assertDoesntExist(createdTagSelector, "clicking the tag should delete the tag");
+    casper.waitWhileSelector(createdTagSelector, function onSuccess() {
+        test.assert(true, "clicking the tag should delete the tag");
     });
-
 });
 
-CasperTest.begin("Post settings menu", 17, function suite(test) {
+CasperTest.begin("Post settings menu", 18, function suite(test) {
     casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
     });
@@ -271,7 +270,11 @@ CasperTest.begin("Post settings menu", 17, function suite(test) {
     casper.thenClick("#publish-bar a.post-settings");
 
     casper.waitUntilVisible("#publish-bar .post-settings-menu", function onSuccess() {
-        test.assertVisible(".post-settings-menu a.delete", "delete post button should be visible for saved drafts");
+        test.assert(true, "post settings menu should be visible after clicking post-settings icon");
+    });
+
+    casper.waitUntilVisible(".post-settings-menu a.delete", function onSuccess() {
+        test.assert(true, "delete post button should be visible for saved drafts");
     });
 
     // Test Static Page conversion
@@ -310,7 +313,9 @@ CasperTest.begin("Post settings menu", 17, function suite(test) {
 
     casper.thenClick("#publish-bar a.post-settings");
     casper.thenClick(".post-settings-menu a.delete");
-    casper.thenClick("#modal-container .js-button-accept");
+    casper.waitUntilVisible("#modal-container", function onSuccess() {
+        casper.thenClick("#modal-container .js-button-accept");
+    });
 
     casper.waitForUrl(/ghost\/content\/$/, function onSuccess() {
         test.assert(true, "clicking the delete post button should bring us to the content page");


### PR DESCRIPTION
Fixes race conditions in functional test introduced in [PR#2395](https://github.com/TryGhost/Ghost/pull/2395)

fixes [PR#2395](https://github.com/TryGhost/Ghost/pull/2395)
- in editor_test.js line 272, I wait until the post settings menu appears, and THEN also wait until the delete post button appears, rather than just waiting for the first condition, this can result in a race condition which has been seen.
- in editor_test.js line 229, I click on the tag, then wait until it disappears, rather than asserting the tag doesn't exist immediately.  This could potentially result in a race condition, but I have not seen it yet.
- in editr_test.js line 315, I click on the delete post button, and now wait for the modal container to appear before clicking the accept button.  This could result in a race condition, but I have not seen it yet.
