### PR TITLE
Force preview to scroll to the end

### DIFF
--- a/core/client/assets/lib/editor/markdownEditor.js
+++ b/core/client/assets/lib/editor/markdownEditor.js
@@ -81,6 +81,9 @@
                     $(document).trigger('markdownEditorChange');
                 });
             },
+            isCursorAtEnd: function () {
+                return codemirror.getCursor('end').line > codemirror.lineCount() - 5;
+            },
             value: function () {
                 return codemirror.getValue();
             }

--- a/core/client/assets/lib/editor/scrollHandler.js
+++ b/core/client/assets/lib/editor/scrollHandler.js
@@ -21,6 +21,10 @@
                 ratio = previewHeight / markdownHeight,
                 previewPosition = $markdownViewPort.scrollTop() * ratio;
 
+            if (markdown.isCursorAtEnd()) {
+                previewPosition = previewHeight + 30;
+            }
+
             // apply new scroll
             $previewViewPort.scrollTop(previewPosition);
         }, 10);


### PR DESCRIPTION
This one has been bugging me for a while!

fixes #958 and fixes #535

Except, it seems it can still get a bit stuck if the last thing you have in your editor is an image, and the image is slightly off screen.
- If the cursor is within the last 5 lines, then scroll to the end of the preview window, rather than using a ratio
