### PR TITLE
Rename getSlug to slug

### DIFF
--- a/core/client/views/post-settings.js
+++ b/core/client/views/post-settings.js
@@ -76,7 +76,7 @@
             // and then update the placeholder value.
             if (title) {
                 $.ajax({
-                    url: Ghost.paths.apiRoot + '/posts/getSlug/' + encodeURIComponent(title) + '/',
+                    url: Ghost.paths.apiRoot + '/posts/slug/' + encodeURIComponent(title) + '/',
                     success: function (result) {
                         $postSettingSlugEl.attr('placeholder', result);
                     }

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -47,7 +47,7 @@ posts = {
         });
     },
 
-    getSlug: function getSlug(args) {
+    generateSlug: function getSlug(args) {
         return dataProvider.Base.Model.generateSlug(dataProvider.Post, args.title, {status: 'all'}).then(function (slug) {
             if (slug) {
                 return slug;

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -9,7 +9,7 @@ module.exports = function (server) {
     server.get('/ghost/api/v0.1/posts/:id', api.requestHandler(api.posts.read));
     server.put('/ghost/api/v0.1/posts/:id', api.requestHandler(api.posts.edit));
     server.del('/ghost/api/v0.1/posts/:id', api.requestHandler(api.posts.destroy));
-    server.get('/ghost/api/v0.1/posts/getSlug/:title', middleware.authAPI, api.requestHandler(api.posts.getSlug));
+    server.get('/ghost/api/v0.1/posts/slug/:title', middleware.authAPI, api.requestHandler(api.posts.generateSlug));
     // #### Settings
     server.get('/ghost/api/v0.1/settings/', api.requestHandler(api.settings.browse));
     server.get('/ghost/api/v0.1/settings/:key/', api.requestHandler(api.settings.read));


### PR DESCRIPTION
another 2 % of #2124
- renamed `/ghost/api/v0.1/posts/getSlug/ to
  `/ghost/api/v0.1/posts/slug/`
- renamed method getSlug to generateSlug
