### PR TITLE
canThis() handle no user and internal requests

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -14,7 +14,6 @@ posts = {
         options = options || {};
 
         // **returns:** a promise for a page of posts in a json object
-
         return dataProvider.Post.findPage(options).then(function (result) {
             var i = 0,
                 omitted = result;
@@ -32,7 +31,6 @@ posts = {
     // **takes:** an identifier (id or slug?)
     read: function read(args) {
         // **returns:** a promise for a single post in a json object
-
         return dataProvider.Post.findOne(args).then(function (result) {
             var omitted;
 
@@ -61,11 +59,7 @@ posts = {
     // **takes:** a json object with all the properties which should be updated
     edit: function edit(postData) {
         // **returns:** a promise for the resulting post in a json object
-        if (!this.user) {
-            return when.reject({code: 403, message: 'You do not have permission to edit this post.'});
-        }
-        var self = this;
-        return canThis(self.user).edit.post(postData.id).then(function () {
+        return canThis(this.user).edit.post(postData.id).then(function () {
             return dataProvider.Post.edit(postData).then(function (result) {
                 if (result) {
                     var omitted = result.toJSON();
@@ -92,10 +86,6 @@ posts = {
     // **takes:** a json object representing a post,
     add: function add(postData) {
         // **returns:** a promise for the resulting post in a json object
-        if (!this.user) {
-            return when.reject({code: 403, message: 'You do not have permission to add posts.'});
-        }
-
         return canThis(this.user).create.post().then(function () {
             return dataProvider.Post.add(postData);
         }, function () {
@@ -108,10 +98,6 @@ posts = {
     // **takes:** an identifier (id or slug?)
     destroy: function destroy(args) {
         // **returns:** a promise for a json response with the id of the deleted post
-        if (!this.user) {
-            return when.reject({code: 403, message: 'You do not have permission to remove posts.'});
-        }
-
         return canThis(this.user).remove.post(args.id).then(function () {
             return when(posts.read({id : args.id, status: 'all'})).then(function (result) {
                 return dataProvider.Post.destroy(args.id).then(function () {

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -310,7 +310,7 @@ describe('Permissions', function () {
             })
             .otherwise(function () {
                 permissableStub.restore();
-                permissableStub.calledWith(123, { user: testUser.id, app: null }, 'edit').should.equal(true);
+                permissableStub.calledWith(123, { user: testUser.id, app: null, internal: false }, 'edit').should.equal(true);
                 done();
             });
     });
@@ -336,6 +336,7 @@ describe('Permissions', function () {
             })
             .otherwise(done);
     });
+
     it('does not allow an app to edit a post without permission', function (done) {
         // Change the author of the post so the author override doesn't affect the test
         PostProvider.edit({id: 1, 'author_id': 2})
@@ -386,6 +387,7 @@ describe('Permissions', function () {
                     });
             }).otherwise(done);
     });
+
     it('allows an app to edit a post with permission', function (done) {
         permissions.canThis({ app: 'Kudos', user: 1 })
             .edit
@@ -395,6 +397,44 @@ describe('Permissions', function () {
             })
             .otherwise(function () {
                 done(new Error("Allowed an edit of post 1"));
+            });
+    });
+
+    it('checks for null context passed and rejects', function (done) {
+        permissions.canThis(undefined)
+            .edit
+            .post(1)
+            .then(function () {
+                done(new Error("Should not allow editing post"));
+            })
+            .otherwise(function () {
+                done();
+            });
+    });
+
+    it('allows \'internal\' to be passed for internal requests', function (done) {
+        // Using tag here because post implements the custom permissable interface
+        permissions.canThis('internal')
+            .edit
+            .tag(1)
+            .then(function () {
+                done();
+            })
+            .otherwise(function () {
+                done(new Error("Should allow editing post with 'internal'"));
+            });
+    });
+
+    it('allows { internal: true } to be passed for internal requests', function (done) {
+        // Using tag here because post implements the custom permissable interface
+        permissions.canThis({ internal: true })
+            .edit
+            .tag(1)
+            .then(function () {
+                done();
+            })
+            .otherwise(function () {
+                done(new Error("Should allow editing post with { internal: true }"));
             });
     });
 });


### PR DESCRIPTION
Closes #2434
- Handle passing undefined user to canThis
  - Add existence check to parseContext if statement
  - Add unit test that passes undefined to canThis
- Allow internal canThis() checks
  - Allow passing 'internal' or { internal: true } as context
  - Do not lookup user permissions unless context.user found
  - If context.internal, resolve immediately
  - Add unit tests for passing 'internal' and { internal: true }
