### PR TITLE
Tag archive body_class

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -364,12 +364,17 @@ coreHelpers.body_class = function (options) {
         tags = this.post && this.post.tags ? this.post.tags : this.tags || [],
         page = this.post && this.post.page ? this.post.page : this.page || false;
 
-    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page|tag)/)) {
+    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page\/\d)/)) {
         classes.push('archive-template');
     } else if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
         classes.push('home-template');
-    } else {
+    } else if (post) {
         classes.push('post-template');
+    }
+
+    if (this.tag !== undefined) {
+        classes.push('tag-template');
+        classes.push('tag-' + this.tag.slug);
     }
 
     if (tags) {

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -296,18 +296,24 @@ describe('Core Helpers', function () {
         it('can render class string for context', function (done) {
             when.all([
                 helpers.body_class.call({relativeUrl: '/'}),
-                helpers.body_class.call({relativeUrl: '/a-post-title'}),
-                helpers.body_class.call({relativeUrl: '/page/4'})
+                helpers.body_class.call({relativeUrl: '/a-post-title', post: {}}),
+                helpers.body_class.call({relativeUrl: '/page/4'}),
+                helpers.body_class.call({relativeUrl: '/tag/foo', tag: { slug: 'foo'}}),
+                helpers.body_class.call({relativeUrl: '/tag/foo/page/2', tag: { slug: 'foo'}})
             ]).then(function (rendered) {
-                rendered.length.should.equal(3);
+                rendered.length.should.equal(5);
 
                 should.exist(rendered[0]);
                 should.exist(rendered[1]);
                 should.exist(rendered[2]);
+                should.exist(rendered[3]);
+                should.exist(rendered[4]);
 
                 rendered[0].string.should.equal('home-template');
                 rendered[1].string.should.equal('post-template');
                 rendered[2].string.should.equal('archive-template');
+                rendered[3].string.should.equal('tag-template tag-foo');
+                rendered[4].string.should.equal('archive-template tag-template tag-foo');
 
                 done();
             }).then(null, done);


### PR DESCRIPTION
closes #2473
- Show tag-template class on tag pages
- Show tag-{{name}} class on tag pages
- Show archive-template only on second page of tag pages
