### PR TITLE
clears notifications on clicking featured icon

### DIFF
--- a/core/client/views/blog.js
+++ b/core/client/views/blog.js
@@ -239,6 +239,7 @@
             }, {
                 success : function () {
                     featuredEl.removeClass("featured unfeatured").addClass(featured ? "featured" : "unfeatured");
+                    Ghost.notifications.clearEverything();
                     Ghost.notifications.addItem({
                         type: 'success',
                         message: "Post successfully marked as " + (featured ? "featured" : "not featured") + ".",


### PR DESCRIPTION
closes #2479
- adds a cleareverything command to toggleFeatured in blog.js to stop stacking of notifications on multiple clicks of featured icon
