### PR TITLE
Replace spaces in uploaded filenames with hyphens

### DIFF
--- a/core/server/storage/base.js
+++ b/core/server/storage/base.js
@@ -41,7 +41,7 @@ baseStore = {
     'getUniqueFileName': function (store, image, targetDir) {
         var done = when.defer(),
             ext = path.extname(image.name),
-            name = path.basename(image.name, ext).replace(/[\W]/gi, '_');
+            name = path.basename(image.name, ext).replace(/[\W]/gi, '-');
 
         this.generateUnique(store, targetDir, name, ext, 0, done);
 

--- a/core/test/unit/storage_localfilesystem_spec.js
+++ b/core/test/unit/storage_localfilesystem_spec.js
@@ -44,7 +44,7 @@ describe('Local File System Storage', function () {
     it('should send correct path to image when original file has spaces', function (done) {
         image.name = 'AN IMAGE.jpg';
         localfilesystem.save(image).then(function (url) {
-            url.should.equal('/content/images/2013/Sep/AN_IMAGE.jpg');
+            url.should.equal('/content/images/2013/Sep/AN-IMAGE.jpg');
             return done();
         }).then(null, done);
     });


### PR DESCRIPTION
closes #2485
- use hyphens instead of underscores when santising filenames
- updated tests
