### PR TITLE
Error handling for require-tree

### DIFF
--- a/core/server/require-tree.js
+++ b/core/server/require-tree.js
@@ -120,6 +120,8 @@ var _        = require('lodash'),
             }
             paths._messages = messages;
             return paths;
+        }).otherwise(function () {
+            return {'_messages': messages};
         });
     };
 


### PR DESCRIPTION
fixes #2507
- ideally we would create an apps directory if one isn't present, but we can deal with that in later versions
