### PR TITLE
Fixed check for a theme's custom error.hbs

### DIFF
--- a/core/server/errorHandling.js
+++ b/core/server/errorHandling.js
@@ -9,7 +9,6 @@ var _           = require('lodash'),
 
     // Paths for views
     defaultErrorTemplatePath = path.resolve(config().paths.adminViews, 'user-error.hbs'),
-    userErrorTemplatePath    = path.resolve(config().paths.themePath, 'error.hbs'),
     userErrorTemplateExists   = false;
 
 // This is not useful but required for jshint
@@ -19,9 +18,8 @@ colors.setTheme({silly: 'rainbow'});
  * Basic error handling helpers
  */
 errors = {
-    updateActiveTheme: function (activeTheme, hasErrorTemplate) {
-        userErrorTemplatePath = path.resolve(config().paths.themePath, activeTheme, 'error.hbs');
-        userErrorTemplateExists = hasErrorTemplate;
+    updateActiveTheme: function (activeTheme) {
+        userErrorTemplateExists = config().paths.availableThemes[activeTheme].hasOwnProperty('error.hbs');
     },
 
     throwError: function (err) {

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -118,7 +118,7 @@ function activateTheme(activeTheme) {
     expressServer.set('theme view engine', hbs.express3(hbsOptions));
 
     // Update user error template
-    errors.updateActiveTheme(activeTheme, config().paths.availableThemes[activeTheme].hasOwnProperty('error'));
+    errors.updateActiveTheme(activeTheme);
 }
 
  // ### ManageAdminAndTheme Middleware


### PR DESCRIPTION
Checks if the active theme has the property 'error.hbs' rather than just 'error'. 
Fix for #2513

Apologies for double PR. Learned the hard way the value of working issues on branches.
