### PR TITLE
Refactor navbar to eliminate nested {{link-to}}.

### DIFF
--- a/core/client/app.js
+++ b/core/client/app.js
@@ -1,6 +1,7 @@
 import Resolver from 'ember/resolver';
 import initFixtures from 'ghost/fixtures/init';
 import {currentUser, injectCurrentUser} from 'ghost/initializers/current-user';
+import 'ghost/utils/link-view';
 
 var App = Ember.Application.extend({
     /**

--- a/core/client/components/activating-list-item.js
+++ b/core/client/components/activating-list-item.js
@@ -1,0 +1,5 @@
+export default Ember.Component.extend({
+    tagName: 'li',
+    classNameBindings: ['active'],
+    active: false
+});

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -4,17 +4,9 @@
     </a>
     <nav id="global-nav" role="navigation">
         <ul id="main-menu" >
-            {{!-- @TODO: don't nest link-to attributes
-                currently required to get proper class styling --}}
-            {{#link-to "posts" class="content" tagName="li" disabled=true}}
-                {{#link-to "posts"}}Content{{/link-to}}
-            {{/link-to}}
-            {{#link-to "new" class="editor" tagName="li" disabled=true}}
-                {{#link-to "new"}}New post{{/link-to}}
-            {{/link-to}}
-            {{#link-to "settings" class="settings" tagName="li" disabled=true}}
-                {{#link-to "settings"}}Settings{{/link-to}}
-            {{/link-to}}
+            {{activating-list-item route="posts" title="Content" classNames="content"}}
+            {{activating-list-item route="new" title="New post" classNames="content"}}
+            {{activating-list-item route="settings" title="Settings" classNames="content"}}
 
             <li id="usermenu" class="usermenu subnav">
                 <a href="#" class="dropdown">

--- a/core/client/templates/components/activating-list-item.hbs
+++ b/core/client/templates/components/activating-list-item.hbs
@@ -1,0 +1,1 @@
+{{#link-to route alternateActive=active}}{{title}}{{yield}}{{/link-to}}

--- a/core/client/utils/link-view.js
+++ b/core/client/utils/link-view.js
@@ -1,0 +1,9 @@
+Ember.LinkView.reopen({
+    active: Ember.computed('resolvedParams', 'routeArgs', function () {
+        var isActive = this._super();
+
+        Ember.set(this, 'alternateActive', isActive);
+
+        return isActive;
+    })
+});


### PR DESCRIPTION
This is essentially setting up a binding from the `LinkView`'s `active` status and whatever is set as `alternativeActive` in the `{{link-to}}` (in our case the `activating-list-item` component.

Here is a sample [JSBin](http://emberjs.jsbin.com/navew/2/edit) demoing the technique.

Screenshots showing that the proper CSS classes are given:

![screenshot](http://monosnap.com/image/tzOH6n82rIVGNEFAUWVOLN52QuASQ4.png)

![screenshot](http://monosnap.com/image/5gmcwJcj0kgEXt8lnET4OKgIZ8KRpH.png)

![screenshot](http://monosnap.com/image/UCVNukTXLMNfVneLhzwVyhkrVlGSBt.png)
