### PR TITLE
Use current user in models

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -47,7 +47,7 @@ requestHandler = function (apiMethod) {
     return function (req, res) {
         var options = _.extend(req.body, req.files, req.query, req.params),
             apiContext = {
-                user: req.session && req.session.user
+                user: (req.session && req.session.user) ? req.session.user : null
             };
 
         return apiMethod.call(apiContext, options).then(function (result) {

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -59,8 +59,10 @@ posts = {
     // **takes:** a json object with all the properties which should be updated
     edit: function edit(postData) {
         // **returns:** a promise for the resulting post in a json object
-        return canThis(this.user).edit.post(postData.id).then(function () {
-            return dataProvider.Post.edit(postData).then(function (result) {
+        var self = this;
+
+        return canThis(self.user).edit.post(postData.id).then(function () {
+            return dataProvider.Post.edit(postData, {user: self.user}).then(function (result) {
                 if (result) {
                     var omitted = result.toJSON();
                     omitted.author = _.omit(omitted.author, filteredUserAttributes);
@@ -85,9 +87,10 @@ posts = {
 
     // **takes:** a json object representing a post,
     add: function add(postData) {
+        var self = this;
         // **returns:** a promise for the resulting post in a json object
         return canThis(this.user).create.post().then(function () {
-            return dataProvider.Post.add(postData);
+            return dataProvider.Post.add(postData, {user: self.user});
         }, function () {
             return when.reject({code: 403, message: 'You do not have permission to add posts.'});
         });

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -181,16 +181,19 @@ settings = {
 
      // **takes:** either a json object representing a collection of settings, or a key and value pair
     edit: function edit(key, value) {
+        var self = this,
+            type;
+
         // Check for passing a collection of settings first
         if (_.isObject(key)) {
             //clean data
-            var type = key.type;
+            type = key.type;
             delete key.type;
             delete key.availableThemes;
             delete key.availableApps;
 
             key = settingsCollection(key);
-            return dataProvider.Settings.edit(key).then(function (result) {
+            return dataProvider.Settings.edit(key, {user: self.user}).then(function (result) {
                 result.models = result;
                 return when(readSettingsResult(result)).then(function (settings) {
                     updateSettingsCache(settings);
@@ -216,7 +219,7 @@ settings = {
                 value = JSON.stringify(value);
             }
             setting.set('value', value);
-            return dataProvider.Settings.edit(setting).then(function (result) {
+            return dataProvider.Settings.edit(setting, {user: self.user}).then(function (result) {
                 settingsCache[_.first(result).attributes.key].value = _.first(result).attributes.value;
             }).then(function () {
                 return config.theme.update(settings, config().url).then(function () {

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -53,7 +53,7 @@ users = {
     edit: function edit(userData) {
         // **returns:** a promise for the resulting user in a json object
         userData.id = this.user;
-        return dataProvider.User.edit(userData).then(function (result) {
+        return dataProvider.User.edit(userData, {user: this.user}).then(function (result) {
             if (result) {
                 var omitted = _.omit(result.toJSON(), filteredAttributes);
                 return omitted;
@@ -67,7 +67,15 @@ users = {
     add: function add(userData) {
 
         // **returns:** a promise for the resulting user in a json object
-        return dataProvider.User.add(userData);
+        return dataProvider.User.add(userData, {user: this.user});
+    },
+
+    // #### Register
+    // **takes:** a json object representing a user
+    register: function register(userData) {
+        // TODO: if we want to prevent users from being created with the signup form
+        // this is the right place to do it
+        return users.add.call({user: 1}, userData);
     },
 
     // #### Check

--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -26,7 +26,7 @@ function saveInstalledApps(installedApps) {
     return getInstalledApps().then(function (currentInstalledApps) {
         var updatedAppsInstalled = _.uniq(installedApps.concat(currentInstalledApps));
 
-        return api.settings.edit('installedApps', updatedAppsInstalled);
+        return api.settings.edit.call({user: 1}, 'installedApps', updatedAppsInstalled);
     });
 }
 

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -244,12 +244,12 @@ adminControllers = {
             email = req.body.email,
             password = req.body.password;
 
-        api.users.add({
+        api.users.register({
             name: name,
             email: email,
             password: password
         }).then(function (user) {
-            api.settings.edit('email', email).then(function () {
+            api.settings.edit.call({user: 1}, 'email', email).then(function () {
                 var message = {
                     to: email,
                     subject: 'Your New Ghost Blog',

--- a/core/server/data/fixtures/index.js
+++ b/core/server/data/fixtures/index.js
@@ -128,29 +128,28 @@ var fixtures = {
     ]
 };
 
-
 populateFixtures = function () {
     var ops = [],
         relations = [];
 
     _.each(fixtures.posts, function (post) {
-        ops.push(function () {return Post.add(post); });
+        ops.push(function () {return Post.add(post, {user: 1}); });
     });
 
     _.each(fixtures.tags, function (tag) {
-        ops.push(function () {return Tag.add(tag); });
+        ops.push(function () {return Tag.add(tag, {user: 1}); });
     });
 
     _.each(fixtures.roles, function (role) {
-        ops.push(function () {return Role.add(role); });
+        ops.push(function () {return Role.add(role, {user: 1}); });
     });
 
     _.each(fixtures.permissions, function (permission) {
-        ops.push(function () {return Permission.add(permission); });
+        ops.push(function () {return Permission.add(permission, {user: 1}); });
     });
 
     _.each(fixtures.permissions003, function (permission) {
-        ops.push(function () {return Permission.add(permission); });
+        ops.push(function () {return Permission.add(permission, {user: 1}); });
     });
 
     // add the tag to the post
@@ -222,7 +221,7 @@ updateFixtures = function () {
         relations = [];
 
     _.each(fixtures.permissions003, function (permission) {
-        ops.push(function () {return Permission.add(permission); });
+        ops.push(function () {return Permission.add(permission, {user: 1}); });
     });
 
     relations.push(function () {

--- a/core/server/data/import/000.js
+++ b/core/server/data/import/000.js
@@ -84,7 +84,7 @@ function importTags(ops, tableData, transaction) {
     _.each(tableData, function (tag) {
         ops.push(models.Tag.findOne({name: tag.name}, {transacting: transaction}).then(function (_tag) {
             if (!_tag) {
-                return models.Tag.add(tag, {transacting: transaction})
+                return models.Tag.add(tag, {user: 1, transacting: transaction})
                     // add pass-through error handling so that bluebird doesn't think we've dropped it
                     .otherwise(function (error) { return when.reject(error); });
             }
@@ -96,7 +96,7 @@ function importTags(ops, tableData, transaction) {
 function importPosts(ops, tableData, transaction) {
     tableData = stripProperties(['id'], tableData);
     _.each(tableData, function (post) {
-        ops.push(models.Post.add(post, {transacting: transaction, importing: true})
+        ops.push(models.Post.add(post, {user: 1, transacting: transaction, importing: true})
             // add pass-through error handling so that bluebird doesn't think we've dropped it
             .otherwise(function (error) { return when.reject(error); }));
     });
@@ -106,7 +106,7 @@ function importUsers(ops, tableData, transaction) {
     // don't override the users credentials
     tableData = stripProperties(['id', 'email', 'password'], tableData);
     tableData[0].id = 1;
-    ops.push(models.User.edit(tableData[0], {transacting: transaction})
+    ops.push(models.User.edit(tableData[0], {user: 1, transacting: transaction})
         // add pass-through error handling so that bluebird doesn't think we've dropped it
         .otherwise(function (error) { return when.reject(error); }));
 }
@@ -121,8 +121,7 @@ function importSettings(ops, tableData, transaction) {
     tableData = _.filter(tableData, function (data) {
         return blackList.indexOf(data.type) === -1;
     });
-
-    ops.push(models.Settings.edit(tableData, transaction)
+    ops.push(models.Settings.edit(tableData, {user: 1, transacting: transaction})
          // add pass-through error handling so that bluebird doesn't think we've dropped it
          .otherwise(function (error) { return when.reject(error); }));
 }
@@ -234,10 +233,10 @@ Importer000.prototype.basicImport = function (data) {
                     rej = true;
                 }
             });
-            if (rej) {
-                t.rollback(error);
-            } else {
+            if (!rej) {
                 t.commit();
+            } else {
+                t.rollback(error);
             }
         });
     }).then(function () {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -59,7 +59,7 @@ function initDbHashAndFirstRun() {
 
         if (dbHash === null) {
             var initHash = uuid.v4();
-            return when(api.settings.edit('dbHash', initHash)).then(function (settings) {
+            return when(api.settings.edit.call({user: 1}, 'dbHash', initHash)).then(function (settings) {
                 dbHash = settings.dbHash;
                 return dbHash;
             }).then(doFirstRun);

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -47,20 +47,16 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         validation.validateSchema(this.tableName, this.toJSON());
     },
 
-    creating: function () {
+    creating: function (newObj, attr, options) {
         if (!this.get('created_by')) {
-            this.set('created_by', 1);
+            this.set('created_by', options.user);
         }
     },
 
-    saving: function () {
-         // Remove any properties which don't belong on the model
+    saving: function (newObj, attr, options) {
+        // Remove any properties which don't belong on the model
         this.attributes = this.pick(this.permittedAttributes());
-
-        // sessions do not have 'updated_by' column
-        if (this.tableName !== 'sessions') {
-            this.set('updated_by', 1);
-        }
+        this.set('updated_by', options.user);
     },
 
     // Base prototype properties will go here

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -53,6 +53,7 @@ Post = ghostBookshelf.Model.extend({
             tagsToCheck,
             i;
 
+        options = options || {};
         // keep tags for 'saved' event and deduplicate upper/lowercase tags
         tagsToCheck = this.get('tags');
         this.myTags = [];
@@ -65,7 +66,7 @@ Post = ghostBookshelf.Model.extend({
             self.myTags.push(item);
         });
 
-        ghostBookshelf.Model.prototype.saving.call(this);
+        ghostBookshelf.Model.prototype.saving.call(this, newPage, attr, options);
 
         this.set('html', converter.makeHtml(this.get('markdown')));
 
@@ -78,7 +79,7 @@ Post = ghostBookshelf.Model.extend({
                 this.set('published_at', new Date());
             }
             // This will need to go elsewhere in the API layer.
-            this.set('published_by', 1);
+            this.set('published_by', options.user);
         }
 
         if (this.hasChanged('slug') || !this.get('slug')) {
@@ -94,13 +95,14 @@ Post = ghostBookshelf.Model.extend({
 
     creating: function (newPage, attr, options) {
         /*jshint unused:false*/
+        options = options || {};
 
         // set any dynamic default properties
         if (!this.get('author_id')) {
-            this.set('author_id', 1);
+            this.set('author_id', options.user);
         }
 
-        ghostBookshelf.Model.prototype.creating.call(this);
+        ghostBookshelf.Model.prototype.creating.call(this, newPage, attr, options);
     },
 
     updateTags: function (newPost, attr, options) {
@@ -128,7 +130,9 @@ Post = ghostBookshelf.Model.extend({
             });
 
             if (tagsToDetach.length > 0) {
-                tagOperations.push(newPost.tags().detach(tagsToDetach, options));
+                // _.omit(options, 'query') is a fix for using bookshelf 0.6.8
+                // (https://github.com/tgriesser/bookshelf/issues/294)
+                tagOperations.push(newPost.tags().detach(tagsToDetach, _.omit(options, 'query')));
             }
 
             // Next check if new tags are all exactly the same as what is set on the model
@@ -142,7 +146,9 @@ Post = ghostBookshelf.Model.extend({
             if (!_.isEmpty(tagsToAttach)) {
                 return Tags.forge().query('whereIn', 'name', _.pluck(tagsToAttach, 'name')).fetch(options).then(function (matchingTags) {
                     _.each(matchingTags.toJSON(), function (matchingTag) {
-                        tagOperations.push(newPost.tags().attach(matchingTag.id, options));
+                        // _.omit(options, 'query') is a fix for using bookshelf 0.6.8
+                        // (https://github.com/tgriesser/bookshelf/issues/294)
+                        tagOperations.push(newPost.tags().attach(matchingTag.id, _.omit(options, 'query')));
                         tagsToAttach = _.reject(tagsToAttach, function (tagToAttach) {
                             return tagToAttach.name === matchingTag.name;
                         });
@@ -171,7 +177,9 @@ Post = ghostBookshelf.Model.extend({
 
                                 // Attach each newly created tag
                                 _.each(createdTagsToAttach, function (tagToAttach) {
-                                    newPost.tags().attach(tagToAttach.id, tagToAttach.name, options);
+                                    // _.omit(options, 'query') is a fix for using bookshelf 0.6.8
+                                    // (https://github.com/tgriesser/bookshelf/issues/294)
+                                    newPost.tags().attach(tagToAttach.id, tagToAttach.name, _.omit(options, 'query'));
                                 });
 
                             }
@@ -446,6 +454,7 @@ Post = ghostBookshelf.Model.extend({
     },
     add: function (newPostData, options) {
         var self = this;
+        options = options || {};
 
         return ghostBookshelf.Model.add.call(this, newPostData, options).then(function (post) {
             return self.findOne({status: 'all', id: post.id}, options);
@@ -453,6 +462,7 @@ Post = ghostBookshelf.Model.extend({
     },
     edit: function (editedPost, options) {
         var self = this;
+        options = options || {};
 
         return ghostBookshelf.Model.edit.call(this, editedPost, options).then(function (post) {
             return self.findOne({status: 'all', id: post.id}, options);
@@ -460,6 +470,7 @@ Post = ghostBookshelf.Model.extend({
     },
     destroy: function (_identifier, options) {
         options = options || {};
+
         return this.forge({id: _identifier}).fetch({withRelated: ['tags']}).then(function destroyTags(post) {
             var tagIds = _.pluck(post.related('tags').toJSON(), 'id');
             if (tagIds) {

--- a/core/server/models/session.js
+++ b/core/server/models/session.js
@@ -5,7 +5,21 @@ var ghostBookshelf = require('./base'),
 
 Session = ghostBookshelf.Model.extend({
 
-    tableName: 'sessions'
+    tableName: 'sessions',
+
+    // override for base function since we don't have
+    // a created_by field for sessions
+    creating: function (newObj, attr, options) {
+        /*jshint unused:false*/
+    },
+
+    // override for base function since we don't have
+    // a updated_by field for sessions
+    saving: function (newObj, attr, options) {
+        /*jshint unused:false*/
+        // Remove any properties which don't belong on the model
+        this.attributes = this.pick(this.permittedAttributes());
+    },
 
 }, {
     destroyAll:  function (options) {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -48,7 +48,6 @@ Settings = ghostBookshelf.Model.extend({
 
 
     saving: function () {
-
          // disabling sanitization until we can implement a better version
          // All blog setting keys that need their values to be escaped.
          // if (this.get('type') === 'blog' && _.contains(['title', 'description', 'email'], this.get('key'))) {
@@ -69,20 +68,22 @@ Settings = ghostBookshelf.Model.extend({
         });
     },
 
-    edit: function (_data, t) {
-        var settings = this;
+    edit: function (_data, options) {
+
         if (!Array.isArray(_data)) {
             _data = [_data];
         }
+
         return when.map(_data, function (item) {
             // Accept an array of models as input
             if (item.toJSON) { item = item.toJSON(); }
-            return settings.forge({ key: item.key }).fetch({transacting: t}).then(function (setting) {
+            return Settings.forge({ key: item.key }).fetch(options).then(function (setting) {
 
                 if (setting) {
-                    return setting.set('value', item.value).save(null, {transacting: t});
+                    return setting.save({value: item.value}, options);
                 }
-                return settings.forge({ key: item.key, value: item.value }).save(null, {transacting: t});
+
+                return Settings.forge({ key: item.key, value: item.value }).save(null, options);
 
             }, errors.logAndThrowError);
         });
@@ -101,7 +102,7 @@ Settings = ghostBookshelf.Model.extend({
                 }
                 if (isMissingFromDB) {
                     defaultSetting.value = defaultSetting.defaultValue;
-                    insertOperations.push(Settings.forge(defaultSetting).save());
+                    insertOperations.push(Settings.forge(defaultSetting).save(null, {user: 1}));
                 }
             });
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -81,7 +81,7 @@ User = ghostBookshelf.Model.extend({
      *
      * Hashes the password provided before saving to the database.
      */
-    add: function (_user) {
+    add: function (_user, options) {
 
         var self = this,
             // Clone the _user so we don't expose the hashed password unnecessarily
@@ -108,7 +108,7 @@ User = ghostBookshelf.Model.extend({
             return self.gravatarLookup(userData);
         }).then(function (userData) {
             // Save the user with the hashed password
-            return ghostBookshelf.Model.add.call(self, userData);
+            return ghostBookshelf.Model.add.call(self, userData, options);
         }).then(function (addedUser) {
             // Assign the userData to our created user so we can pass it back
             userData = addedUser;

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -143,10 +143,10 @@ function updateCheckRequest() {
 function updateCheckResponse(response) {
     var ops = [];
 
-    ops.push(api.settings.edit('nextUpdateCheck', response.next_check)
+    ops.push(api.settings.edit.call({user: 1}, 'nextUpdateCheck', response.next_check)
         .otherwise(errors.rejectError));
 
-    ops.push(api.settings.edit('displayUpdateNotification', response.version)
+    ops.push(api.settings.edit.call({user: 1}, 'displayUpdateNotification', response.version)
                 .otherwise(errors.rejectError));
 
     return when.settle(ops).then(function (descriptors) {

--- a/core/test/integration/model/model_permissions_spec.js
+++ b/core/test/integration/model/model_permissions_spec.js
@@ -71,7 +71,7 @@ describe("Permission Model", function () {
             action_type: 'test'
         };
 
-        PermissionModel.add(newPerm).then(function (createdPerm) {
+        PermissionModel.add(newPerm, {user: 1}).then(function (createdPerm) {
             should.exist(createdPerm);
 
             createdPerm.attributes.name.should.equal(newPerm.name);

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -124,7 +124,7 @@ describe('Post Model', function () {
             newPost = testUtils.DataGenerator.forModel.posts[2],
             newPostDB = testUtils.DataGenerator.Content.posts[2];
 
-        PostModel.add(newPost).then(function (createdPost) {
+        PostModel.add(newPost, {user: 1}).then(function (createdPost) {
             return new PostModel({id: createdPost.id}).fetch();
         }).then(function (createdPost) {
             should.exist(createdPost);
@@ -155,7 +155,7 @@ describe('Post Model', function () {
             createdPostUpdatedDate = createdPost.get('updated_at');
 
             // Set the status to published to check that `published_at` is set.
-            return createdPost.save({status: 'published'});
+            return createdPost.save({status: 'published'}, {user: 1});
         }).then(function (publishedPost) {
             publishedPost.get('published_at').should.be.instanceOf(Date);
             publishedPost.get('published_by').should.equal(1);
@@ -176,7 +176,7 @@ describe('Post Model', function () {
             published_at: previousPublishedAtDate,
             title: 'published_at test',
             markdown: 'This is some content'
-        }).then(function (newPost) {
+        }, {user: 1}).then(function (newPost) {
 
             should.exist(newPost);
             new Date(newPost.get('published_at')).getTime().should.equal(previousPublishedAtDate.getTime());
@@ -194,7 +194,7 @@ describe('Post Model', function () {
                 markdown: 'Test Content'
             };
 
-        PostModel.add(newPost).then(function (createdPost) {
+        PostModel.add(newPost, {user: 1}).then(function (createdPost) {
             return new PostModel({ id: createdPost.id }).fetch();
         }).then(function (createdPost) {
             should.exist(createdPost);
@@ -220,7 +220,7 @@ describe('Post Model', function () {
                 return PostModel.add({
                     title: 'Test Title',
                     markdown: 'Test Content ' + (i+1)
-                });
+                }, {user: 1});
             };
         })).then(function (createdPosts) {
             // Should have created 12 posts
@@ -250,7 +250,7 @@ describe('Post Model', function () {
             markdown: 'Test Content 1'
         };
 
-        PostModel.add(newPost).then(function (createdPost) {
+        PostModel.add(newPost, {user: 1}).then(function (createdPost) {
 
             createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
 
@@ -264,7 +264,7 @@ describe('Post Model', function () {
             markdown: 'Test Content 1'
         };
 
-        PostModel.add(newPost).then(function (createdPost) {
+        PostModel.add(newPost, {user: 1}).then(function (createdPost) {
             createdPost.get('slug').should.not.equal('rss');
             done();
         });
@@ -276,7 +276,7 @@ describe('Post Model', function () {
             markdown: 'Test Content 1'
         };
 
-        PostModel.add(newPost).then(function (createdPost) {
+        PostModel.add(newPost, {user: 1}).then(function (createdPost) {
             createdPost.get('slug').should.equal('bhute-dhddkii-bhrvnnaaraa-aahet');
             done();
         });
@@ -293,13 +293,13 @@ describe('Post Model', function () {
             };
 
         // Create the first post
-        PostModel.add(firstPost)
+        PostModel.add(firstPost, {user: 1})
             .then(function (createdFirstPost) {
                 // Store the slug for later
                 firstPost.slug = createdFirstPost.get('slug');
 
                 // Create the second post
-                return PostModel.add(secondPost);
+                return PostModel.add(secondPost, {user: 1});
             }).then(function (createdSecondPost) {
                 // Store the slug for comparison later
                 secondPost.slug = createdSecondPost.get('slug');

--- a/core/test/integration/model/model_roles_spec.js
+++ b/core/test/integration/model/model_roles_spec.js
@@ -70,7 +70,7 @@ describe("Role Model", function () {
             description: "test1 description"
         };
 
-        RoleModel.add(newRole).then(function (createdRole) {
+        RoleModel.add(newRole, {user: 1}).then(function (createdRole) {
             should.exist(createdRole);
 
             createdRole.attributes.name.should.equal(newRole.name);

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -141,7 +141,7 @@ describe('Settings Model', function () {
                 value: 'Test Content 1'
             };
 
-            SettingsModel.add(newSetting).then(function (createdSetting) {
+            SettingsModel.add(newSetting, {user: 1}).then(function (createdSetting) {
 
                 should.exist(createdSetting);
                 createdSetting.has('uuid').should.equal(true);
@@ -218,7 +218,7 @@ describe('Settings Model', function () {
         });
 
         it('doesn\'t overwrite any existing settings', function (done) {
-            SettingsModel.edit({key: 'description', value: 'Adam\'s Blog'}).then(function () {
+            SettingsModel.edit({key: 'description', value: 'Adam\'s Blog'}, {user: 1}).then(function () {
                 return SettingsModel.populateDefaults();
             }).then(function () {
                 return SettingsModel.read('description');

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -40,8 +40,8 @@ describe('Tag Model', function () {
                 createdPostID;
 
             when.all([
-                PostModel.add(newPost),
-                TagModel.add(newTag)
+                PostModel.add(newPost, {user: 1}),
+                TagModel.add(newTag, {user: 1})
             ]).then(function (models) {
                 var createdPost = models[0],
                     createdTag = models[1];
@@ -67,8 +67,8 @@ describe('Tag Model', function () {
                 createdPostID;
 
             when.all([
-                PostModel.add(newPost),
-                TagModel.add(newTag)
+                PostModel.add(newPost, {user: 1}),
+                TagModel.add(newTag, {user: 1})
             ]).then(function (models) {
                 var createdPost = models[0],
                     createdTag = models[1];
@@ -95,10 +95,10 @@ describe('Tag Model', function () {
 
             function seedTags(tagNames) {
                 var createOperations = [
-                    PostModel.add(testUtils.DataGenerator.forModel.posts[0])
+                    PostModel.add(testUtils.DataGenerator.forModel.posts[0], {user: 1})
                 ];
 
-                var tagModels = tagNames.map(function (tagName) { return TagModel.add({name: tagName}); });
+                var tagModels = tagNames.map(function (tagName) { return TagModel.add({name: tagName}, {user: 1}); });
                 createOperations = createOperations.concat(tagModels);
 
                 return when.all(createOperations).then(function (models) {
@@ -165,7 +165,7 @@ describe('Tag Model', function () {
 
                 seedTags(seededTagNames).then(function (_postModel) {
                     postModel = _postModel;
-                    return TagModel.add({name: 'tag3'});
+                    return TagModel.add({name: 'tag3'}, {user: 1});
                 }).then(function () {
                     // the tag API expects tags to be provided like {id: 1, name: 'draft'}
                     var tagData = seededTagNames.map(function (tagName, i) { return {id: i + 1, name: tagName}; });
@@ -198,7 +198,7 @@ describe('Tag Model', function () {
 
                     // add the additional tag, and save
                     tagData.push({id: null, name: 'tag3'});
-                    return postModel.set('tags', tagData).save();
+                    return postModel.set('tags', tagData).save(null, {user: 1});
                 }).then(function (postModel) {
                     return PostModel.read({id: postModel.id, status: 'all'}, { withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -219,7 +219,7 @@ describe('Tag Model', function () {
                     // add the additional tags, and save
                     tagData.push({id: null, name: 'tag2'});
                     tagData.push({id: null, name: 'tag3'});
-                    return postModel.set('tags', tagData).save();
+                    return postModel.set('tags', tagData).save(null, {user: 1});
                 }).then(function (postModel) {
                     return PostModel.read({id: postModel.id, status: 'all'}, { withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -236,7 +236,7 @@ describe('Tag Model', function () {
 
                 seedTags(seededTagNames).then(function (_postModel) {
                     postModel = _postModel;
-                    return TagModel.add({name: 'tag2'});
+                    return TagModel.add({name: 'tag2'}, {user: 1});
                 }).then(function () {
                     // the tag API expects tags to be provided like {id: 1, name: 'draft'}
                     var tagData = seededTagNames.map(function (tagName, i) { return {id: i + 1, name: tagName}; });
@@ -247,7 +247,7 @@ describe('Tag Model', function () {
                     // Add the tag that doesn't exist in the database
                     tagData.push({id: 3, name: 'tag3'});
 
-                    return postModel.set('tags', tagData).save();
+                    return postModel.set('tags', tagData).save(null, {user: 1});
                 }).then(function () {
                     return PostModel.read({id: postModel.id, status: 'all'}, { withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -271,7 +271,7 @@ describe('Tag Model', function () {
 
                 seedTags(seededTagNames).then(function (_postModel) {
                     postModel = _postModel;
-                    return TagModel.add({name: 'tag2'});
+                    return TagModel.add({name: 'tag2'}, {user: 1});
                 }).then(function () {
                     // the tag API expects tags to be provided like {id: 1, name: 'draft'}
                     var tagData = seededTagNames.map(function (tagName, i) { return {id: i + 1, name: tagName}; });
@@ -283,7 +283,7 @@ describe('Tag Model', function () {
                     tagData.push({id: 3, name: 'tag3'});
                     tagData.push({id: 4, name: 'tag4'});
 
-                    return postModel.set('tags', tagData).save();
+                    return postModel.set('tags', tagData).save(null, {user: 1});
                 }).then(function () {
                     return PostModel.read({id: postModel.id, status: 'all'}, { withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -304,7 +304,7 @@ describe('Tag Model', function () {
             it('can add a tag to a post on creation', function (done) {
                 var newPost = _.extend(testUtils.DataGenerator.forModel.posts[0], {tags: [{name: 'test_tag_1'}]})
 
-                PostModel.add(newPost).then(function (createdPost) {
+                PostModel.add(newPost, {user: 1}).then(function (createdPost) {
                     return PostModel.read({id: createdPost.id, status: 'all'}, { withRelated: ['tags']});
                 }).then(function (postWithTag) {
                     postWithTag.related('tags').length.should.equal(1);

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -39,7 +39,7 @@ describe('User Model', function run() {
                     return when.resolve(userData);
                 });
 
-            UserModel.add(userData).then(function (createdUser) {
+            UserModel.add(userData, {user: 1}).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
                 createdUser.attributes.password.should.not.equal(userData.password, "password was hashed");
@@ -55,7 +55,7 @@ describe('User Model', function run() {
                     return when.resolve(userData);
                 });
 
-            UserModel.add(userData).then(function (createdUser) {
+            UserModel.add(userData, {user: 1}).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
                 createdUser.attributes.email.should.eql(userData.email, "email address correct");
@@ -71,7 +71,7 @@ describe('User Model', function run() {
                     return when.resolve(userData);
                 });
 
-            UserModel.add(userData).then(function (createdUser) {
+            UserModel.add(userData, {user: 1}).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
                 createdUser.attributes.image.should.eql('http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404', 'Gravatar found');
@@ -86,7 +86,7 @@ describe('User Model', function run() {
                     return when.resolve(userData);
                 });
 
-            UserModel.add(userData).then(function (createdUser) {
+            UserModel.add(userData, {user: 1}).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
                 should.not.exist(createdUser.image);
@@ -99,7 +99,7 @@ describe('User Model', function run() {
             var userData = testUtils.DataGenerator.forModel.users[2],
                 email = testUtils.DataGenerator.forModel.users[2].email;
 
-            UserModel.add(userData).then(function () {
+            UserModel.add(userData, {user: 1}).then(function () {
                 // Test same case
                 return UserModel.getByEmail(email).then(function (user) {
                     should.exist(user);
@@ -144,7 +144,7 @@ describe('User Model', function run() {
         it('can\'t add second', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[1];
 
-            return UserModel.add(userData).then(done, function (failure) {
+            return UserModel.add(userData, {user: 1}).then(done, function (failure) {
                 failure.message.should.eql('A user is already registered. Only one user for now!');
                 done();
             }).then(null, done);

--- a/core/test/unit/import_spec.js
+++ b/core/test/unit/import_spec.js
@@ -164,8 +164,6 @@ describe("Import", function () {
         beforeEach(function (done) {
             // migrate to current version
             migration.migrateUpFreshDb().then(function () {
-                // Load the fixtures
-            }).then(function () {
                 return testUtils.insertDefaultUser();
             }).then(function () {
                 done();

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -87,7 +87,7 @@ describe('Permissions', function () {
                 object_type: obj
             };
 
-            return PermissionsProvider.add(newPerm);
+            return PermissionsProvider.add(newPerm, {user: 1});
         },
         createTestPermissions = function () {
             var createActions = _.map(testPerms, function (testPerm) {
@@ -127,7 +127,7 @@ describe('Permissions', function () {
 
             existingUserRoles = foundUser.related('roles').length;
 
-            return testRole.save().then(function () {
+            return testRole.save(null, {user: 1}).then(function () {
                 return foundUser.roles().attach(testRole);
             });
         }).then(function () {
@@ -151,7 +151,7 @@ describe('Permissions', function () {
 
             testUser.related('permissions').length.should.equal(0);
 
-            return testPermission.save().then(function () {
+            return testPermission.save(null, {user: 1}).then(function () {
                 return testUser.permissions().attach(testPermission);
             });
         }).then(function () {
@@ -171,7 +171,7 @@ describe('Permissions', function () {
             description: "test2 description"
         });
 
-        testRole.save()
+        testRole.save(null, {user: 1})
             .then(function () {
                 return testRole.load('permissions');
             })
@@ -184,7 +184,7 @@ describe('Permissions', function () {
 
                 testRole.related('permissions').length.should.equal(0);
 
-                return rolePermission.save().then(function () {
+                return rolePermission.save(null, {user: 1}).then(function () {
                     return testRole.permissions().attach(rolePermission);
                 });
             })
@@ -240,7 +240,7 @@ describe('Permissions', function () {
                     object_type: "post"
                 });
 
-                return newPerm.save().then(function () {
+                return newPerm.save(null, {user: 1}).then(function () {
                     return foundUser.permissions().attach(newPerm);
                 });
             })
@@ -350,7 +350,7 @@ describe('Permissions', function () {
                             object_type: "post"
                         });
 
-                        return newPerm.save().then(function () {
+                        return newPerm.save(null, {user: 1}).then(function () {
                             return foundUser.permissions().attach(newPerm).then(function () {
                                 return when.all([updatedPost, foundUser]);
                             });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "engineStrict": true,
     "dependencies": {
         "bcryptjs": "0.7.10",
-        "bookshelf": "0.6.1",
+        "bookshelf": "0.6.8",
         "busboy": "0.0.12",
         "colors": "0.6.2",
         "connect-slashes": "1.2.0",


### PR DESCRIPTION
closes #2058
- fixed apiContext as suggested in the issue
- added user to options object for models
- added api.users.register() for public registration
- changed models to use options.user for created_by, updated_by,
  author_id and published_by
- added override to session model to avoid created_by and updated_by
  values
- added user (id: 1) to tests
- added user (id: 1) for registration
- added user (id: 1) for import, fixtures and default settings
- added user (id: 1) for user update
- added user (id: 1) for settings update (dbHash, installedApps, update
  check)
- updated bookshelf to version 0.6.8
