### PR TITLE
Build correct path on image upload when config has custom content path

### DIFF
--- a/core/server/storage/localfilesystem.js
+++ b/core/server/storage/localfilesystem.js
@@ -33,7 +33,7 @@ localFileStore = _.extend(baseStore, {
         }).then(function () {
             // The src for the image must be in URI format, not a file system path, which in Windows uses \
             // For local file system storage can use relative path so add a slash
-            var fullUrl = (config().paths.subdir + '/' + path.relative(config().paths.appRoot, targetFilename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
+            var fullUrl = (config().paths.subdir + '/' + config().paths.imagesRelPath + '/' + path.relative(config().paths.imagesPath, targetFilename)).replace(new RegExp('\\' + path.sep, 'g'), '/');
             return saved.resolve(fullUrl);
         }).otherwise(function (e) {
             errors.logError(e);

--- a/core/test/unit/storage_localfilesystem_spec.js
+++ b/core/test/unit/storage_localfilesystem_spec.js
@@ -2,6 +2,7 @@
 var fs = require('fs-extra'),
     path = require('path'),
     should = require('should'),
+    config = require('../../server/config'),
     sinon = require('sinon'),
     when = require('when'),
     localfilesystem = require('../../server/storage/localfilesystem');
@@ -122,6 +123,27 @@ describe('Local File System Storage', function () {
         }).then(null, done);
     });
 
+    describe('when a custom content path is used', function () {
+        var origContentPath = config().paths.contentPath;
+        var origImagesPath = config().paths.imagesPath;
+
+        beforeEach(function () {
+            config().paths.contentPath = config().paths.appRoot + '/var/ghostcms';
+            config().paths.imagesPath = config().paths.appRoot + '/var/ghostcms/' + config().paths.imagesRelPath;
+        });
+
+        afterEach(function () {
+            config().paths.contentPath = origContentPath;
+            config().paths.imagesPath = origImagesPath;
+        });
+
+        it('should send the correct path to image', function (done) {
+            localfilesystem.save(image).then(function (url) {
+                url.should.equal('/content/images/2013/Sep/IMAGE.jpg');
+                return done();
+            }).then(null, done);
+        });
+    });
 
     describe('on Windows', function () {
         var truePathSep = path.sep;
@@ -139,7 +161,15 @@ describe('Local File System Storage', function () {
             path.sep = '\\';
             path.join.returns('content\\images\\2013\\Sep\\IMAGE.jpg');
             localfilesystem.save(image).then(function (url) {
-                url.should.equal('/content/images/2013/Sep/IMAGE.jpg');
+                if (truePathSep === '\\') {
+                    url.should.equal('/content/images/2013/Sep/IMAGE.jpg');
+                } else {
+                    // if this unit test is run on an OS that uses forward slash separators,
+                    // localfilesystem.save() will use a path.relative() call on 
+                    // one path with backslash separators and one path with forward
+                    // slashes and it returns a path that needs to be normalized
+                    path.normalize(url).should.equal('/content/images/2013/Sep/IMAGE.jpg');
+                }
                 return done();
             }).then(null, done);
         });


### PR DESCRIPTION
closes #2563
- build path relative to imagesPath (which contains the custom content path)
  instead of appRoot
- added test for custom content path
- added logic to tests for Windows url building to handle cases where Windows
  functionality is being tested on a unix operating system
