### PR TITLE
Do not show edit screen if any string other than '/edit' added to post URL

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -175,7 +175,6 @@ frontendControllers = {
             }
 
             function render() {
-                console.log(params);
                 // If we're ready to render the page but the last param is 'edit' then we'll send you to the edit page.
                 if (params.edit !== undefined && params.edit === 'edit') {
                     return res.redirect(config().paths.subdir + '/ghost/editor/' + post.id + '/');

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -176,9 +176,10 @@ frontendControllers = {
 
             function render() {
                 // If we're ready to render the page but the last param is 'edit' then we'll send you to the edit page.
-                if (params.edit !== undefined) {
+                if (params.edit !== undefined && params.edit === 'edit') {
                     return res.redirect(config().paths.subdir + '/ghost/editor/' + post.id + '/');
                 }
+
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {
                         var paths = config().paths.availableThemes[activeTheme.value],

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -175,9 +175,12 @@ frontendControllers = {
             }
 
             function render() {
+                console.log(params);
                 // If we're ready to render the page but the last param is 'edit' then we'll send you to the edit page.
                 if (params.edit !== undefined && params.edit === 'edit') {
                     return res.redirect(config().paths.subdir + '/ghost/editor/' + post.id + '/');
+                } else if (params.edit !== undefined) {
+                    throw new Error('no match');
                 }
 
                 filters.doFilter('prePostsRender', post).then(function (post) {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -97,6 +97,20 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
+        it('should get redirected to /ghost/editor/1 from /welcome-to-ghost/edit', function (done) {
+            request.get('/welcome-to-ghost/edit/')
+                .expect('Location', '/ghost/editor/1/')
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should not get redirected to edit screen', function (done) {
+            request.get('/welcome-to-ghost/noedit/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .end(doEnd(done));
+        });
+
         it('should not work with date permalinks', function (done) {
             // get today's date
             var date  = moment().format("YYYY/MM/DD");

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -97,19 +97,9 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-        it('should get redirected to /ghost/editor/1 from /welcome-to-ghost/edit', function (done) {
-            request.get('/welcome-to-ghost/edit/')
-                .expect('Location', '/ghost/editor/1/')
-                .expect(302)
-                .end(doEnd(done));
-        });
 
-        it('should not get redirected to edit screen', function (done) {
-            request.get('/welcome-to-ghost/noedit/')
-                .expect('Content-Type', /html/)
-                .expect(200)
-                .end(doEnd(done));
-        });
+
+    
 
         it('should not work with date permalinks', function (done) {
             // get today's date
@@ -125,6 +115,36 @@ describe('Frontend Routing', function () {
         it('should 404 for unknown post', function (done) {
             request.get('/spectacular/')
                 .expect('Cache-Control', cacheRules['private'])
+                .expect(404)
+                .expect(/Page Not Found/)
+                .end(doEnd(done));
+        });
+    });
+
+    describe('EDIT', function() {
+        it('should get redirected to /ghost/editor/1 from /welcome-to-ghost/edit', function (done) {
+            request.get('/welcome-to-ghost/edit/')
+                .expect('Location', '/ghost/editor/1/')
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should not get redirected to edit screen', function (done) {
+            request.get('/welcome-to-ghost/noedit/')
+                .expect('Content-Type', /html/)
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('should 404 on /edit/', function (done) {
+            request.get('/edit/')
+                .expect(404)
+                .expect(/Page Not Found/)
+                .end(doEnd(done));
+        });
+
+        it('should 404 on non existent post + /edit/', function (done) {
+            request.get('/thispostdoesntexist/edit/')
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -97,10 +97,6 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-
-
-    
-
         it('should not work with date permalinks', function (done) {
             // get today's date
             var date  = moment().format("YYYY/MM/DD");
@@ -129,10 +125,10 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-        it('should not get redirected to edit screen', function (done) {
+        it('should 404 on param that is not edit', function (done) {
             request.get('/welcome-to-ghost/noedit/')
-                .expect('Content-Type', /html/)
-                .expect(200)
+                .expect(404)
+                .expect(/Page Not Found/)
                 .end(doEnd(done));
         });
 

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -102,7 +102,6 @@ describe('Frontend Routing', function () {
             var date  = moment().format("YYYY/MM/DD");
 
             request.get('/' + date + '/welcome-to-ghost/')
-                //.expect('Cache-Control', cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));
@@ -117,7 +116,7 @@ describe('Frontend Routing', function () {
         });
     });
 
-    describe('EDIT', function() {
+    describe('Edit', function() {
         it('should get redirected to /ghost/editor/1 from /welcome-to-ghost/edit', function (done) {
             request.get('/welcome-to-ghost/edit/')
                 .expect('Location', '/ghost/editor/1/')


### PR DESCRIPTION
closes #2619
- added 'edit' string check for anything appended to the post URL
- this fixes redirecting to the post's edit screen if a random string is entered after the post URL
