### PR TITLE
Do not redirect to editor if parameter does not equal edit.

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -183,8 +183,11 @@ frontendControllers = {
 
             function render() {
                 // If we're ready to render the page but the last param is 'edit' then we'll send you to the edit page.
-                if (params.edit !== undefined) {
+                if (params.edit === 'edit') {
                     return res.redirect(config().paths.subdir + '/ghost/editor/' + post.id + '/');
+                } else if (params.edit !== undefined) {
+                    // Use throw 'no match' to show 404.
+                    throw new Error('no match');
                 }
                 filters.doFilter('prePostsRender', post).then(function (post) {
                     api.settings.read('activeTheme').then(function (activeTheme) {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -117,6 +117,32 @@ describe('Frontend Routing', function () {
         });
     });
 
+    describe('Post edit', function () {
+        it('should redirect without slash', function (done) {
+            request.get('/welcome-to-ghost/edit')
+                .expect('Location', '/welcome-to-ghost/edit/')
+                .expect('Cache-Control', cacheRules.year)
+                .expect(301)
+                .end(doEnd(done));
+        });
+
+        it('should redirect to editor', function (done) {
+            request.get('/welcome-to-ghost/edit/')
+                .expect('Location', '/ghost/editor/1/')
+                .expect('Cache-Control', cacheRules['public'])
+                .expect(302)
+                .end(doEnd(done));
+        });
+
+        it('should 404 for non-edit parameter', function (done) {
+            request.get('/welcome-to-ghost/notedit/')
+                .expect('Cache-Control', cacheRules['private'])
+                .expect(404)
+                .expect(/Page Not Found/)
+                .end(doEnd(done));
+        });
+    });
+
     describe('RSS', function () {
         it('should redirect without slash', function (done) {
             request.get('/rss')


### PR DESCRIPTION
Closes #2619
- If edit parameter is 'edit' redirect to editor.
- If edit parameter is anything other then undefined redirect to 404.
- Create edit post tests.
- Test redirect without trailing slash.
- Test redirect to editor.
- Test redirect to 404.
