### PR TITLE
Tag API: Primary Document Format

### DIFF
--- a/core/client/models/tag.js
+++ b/core/client/models/tag.js
@@ -3,6 +3,10 @@
     'use strict';
 
     Ghost.Collections.Tags = Ghost.ProgressCollection.extend({
-        url: Ghost.paths.apiRoot + '/tags/'
+        url: Ghost.paths.apiRoot + '/tags/',
+
+        parse: function (resp) {
+            return resp.tags;
+        }
     });
 }());

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -4,12 +4,11 @@ var dataProvider = require('../models'),
 
 tags = {
     // #### Browse
-
     // **takes:** Nothing yet
     browse: function browse() {
         // **returns:** a promise for all tags which have previously been used in a json object
         return dataProvider.Tag.findAll().then(function (result) {
-            return result.toJSON();
+            return { tags: result.toJSON() };
         });
     }
 };

--- a/core/test/functional/routes/api/tags_test.js
+++ b/core/test/functional/routes/api/tags_test.js
@@ -93,8 +93,9 @@ describe('Tag API', function () {
                 res.should.be.json;
                 var jsonResponse = res.body;
                 jsonResponse.should.exist;
-                jsonResponse.should.have.length(6);
-                testUtils.API.checkResponse(jsonResponse[0], 'tag');
+                jsonResponse.tags.should.exist;
+                jsonResponse.tags.should.have.length(6);
+                testUtils.API.checkResponse(jsonResponse.tags[0], 'tag');
                 done();
             });
     });

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -33,8 +33,9 @@ describe('Tags API', function () {
     it('can browse', function (done) {
         TagsAPI.browse().then(function (results) {
             should.exist(results);
-            results.length.should.be.above(0);
-            testUtils.API.checkResponse(results[0], 'tag');
+            should.exist(results.tags);
+            results.tags.length.should.be.above(0);
+            testUtils.API.checkResponse(results.tags[0], 'tag');
             done();
         }).then(null, done);
     });


### PR DESCRIPTION
Closes #2605
- Change tags browse() response to { tags: [...] }
- Update client side collection to use nested tags document
- Update test references to use response.tags

Added some basic [Tags API Docs](https://github.com/TryGhost/Ghost/wiki/%5BWIP%5D-API-Documentation#tag) as well.
# easywin #beginner4lyfe
