### PR TITLE
 Correct link shortcut so that it inserts, selects text or moves cursor properly

### DIFF
--- a/core/client/markdown-actions.js
+++ b/core/client/markdown-actions.js
@@ -15,7 +15,7 @@
             self.replace();
         },
         replace: function () {
-            var text = this.elem.getSelection(), pass = true, cursor = this.elem.getCursor(), line = this.elem.getLine(cursor.line), md, word, letterCount, converter;
+            var text = this.elem.getSelection(), pass = true, cursor = this.elem.getCursor(), line = this.elem.getLine(cursor.line), md, word, letterCount, converter, textIndex, position;
             switch (this.style) {
             case 'h1':
                 this.elem.setLine(cursor.line, '# ' + line);
@@ -50,7 +50,13 @@
             case 'link':
                 md = this.options.syntax.link.replace('$1', text);
                 this.elem.replaceSelection(md, 'end');
-                this.elem.setSelection({line: cursor.line, ch: cursor.ch - 8}, {line: cursor.line, ch: cursor.ch - 1});
+                if (!text) {
+                    this.elem.setCursor(cursor.line, cursor.ch + 1);
+                } else {
+                    textIndex = line.indexOf(text, cursor.ch - text.length);
+                    position = textIndex + md.length - 1;
+                    this.elem.setSelection({line: cursor.line, ch: position - 7}, {line: cursor.line, ch: position});
+                }
                 pass = false;
                 break;
             case 'image':


### PR DESCRIPTION
Correct link shortcut so that it inserts, selects text or moves cursor properly

 Closes #2614
- Determine proper place for selection, or simply move the cursor.
- When no text is selected insert link markdown and move cursor to a into the [].
- When text is selected insert link markdown and move selection to http:// so URL can be pasted.
