### PR TITLE
AppProxy with permissions checks and app context

### DIFF
--- a/core/server/apps/loader.js
+++ b/core/server/apps/loader.js
@@ -2,7 +2,7 @@
 var path = require('path'),
     _    = require('lodash'),
     when = require('when'),
-    appProxy = require('./proxy'),
+    AppProxy = require('./proxy'),
     config = require('../config'),
     AppSandbox = require('./sandbox'),
     AppDependencies = require('./dependencies'),
@@ -29,9 +29,13 @@ function loadApp(appPath) {
     return sandbox.loadApp(appPath);
 }
 
-function getAppByName(name) {
+function getAppByName(name, permissions) {
     // Grab the app class to instantiate
     var AppClass = loadApp(getAppRelativePath(name)),
+        appProxy = new AppProxy({
+            name: name,
+            permissions: permissions
+        }),
         app;
 
     // Check for an actual class, otherwise just use whatever was returned
@@ -41,7 +45,10 @@ function getAppByName(name) {
         app = AppClass;
     }
 
-    return app;
+    return {
+        app: app,
+        proxy: appProxy
+    };
 }
 
 // The loader is responsible for loading apps
@@ -63,7 +70,9 @@ loader = {
                 });
             })
             .then(function (appPerms) {
-                var app = getAppByName(name, appPerms);
+                var appInfo = getAppByName(name, appPerms),
+                    app = appInfo.app,
+                    appProxy = appInfo.proxy;
 
                 // Check for an install() method on the app.
                 if (!_.isFunction(app.install)) {
@@ -84,7 +93,9 @@ loader = {
         var perms = new AppPermissions(getAppAbsolutePath(name));
 
         return perms.read().then(function (appPerms) {
-            var app = getAppByName(name, appPerms);
+            var appInfo = getAppByName(name, appPerms),
+                app = appInfo.app,
+                appProxy = appInfo.proxy;
 
             // Check for an activate() method on the app.
             if (!_.isFunction(app.activate)) {

--- a/core/server/apps/proxy.js
+++ b/core/server/apps/proxy.js
@@ -3,22 +3,81 @@ var _           = require('lodash'),
     helpers     = require('../helpers'),
     filters     = require('../filters');
 
-var proxy = {
+var generateProxyFunctions = function (name, permissions) {
+    var getPermission = function (perm) {
+            return permissions[perm];
+        },
+        getPermissionToMethod = function (perm, method) {
+            var perms = getPermission(perm);
 
-    filters: {
-        register: filters.registerFilter.bind(filters),
-        deregister: filters.deregisterFilter.bind(filters)
-    },
-    helpers: {
-        register: helpers.registerThemeHelper.bind(helpers),
-        registerAsync: helpers.registerAsyncThemeHelper.bind(helpers)
-    },
-    api: {
-        posts: _.pick(api.posts, 'browse', 'read'),
-        tags: _.pick(api.tags, 'browse'),
-        notifications: _.pick(api.notifications, 'add'),
-        settings: _.pick(api.settings, 'read')
-    }
+            if (!perms) {
+                return false;
+            }
+
+            return _.find(perms, function (name) {
+                return name === method;
+            });
+        },
+        runIfPermissionToMethod = function (perm, method, wrappedFunc, context, args) {
+            var permValue = getPermissionToMethod(perm, method);
+
+            if (!permValue) {
+                throw new Error('The App "' + name + '" attempted to perform an action or access a resource (' + perm + '.' + method + ') without permission.');
+            }
+
+            return wrappedFunc.apply(context, args);
+        },
+        checkRegisterPermissions = function (perm, registerMethod) {
+            return _.wrap(registerMethod, function (origRegister, name) {
+                return runIfPermissionToMethod(perm, name, origRegister, this, _.toArray(arguments).slice(1));
+            });
+        },
+        passThruAppContextToApi = function (perm, apiMethods) {
+            var appContext = {
+                    app: name
+                };
+
+            return _.reduce(apiMethods, function (memo, apiMethod, methodName) {
+                memo[methodName] = function () {
+                    return apiMethod.apply(_.clone(appContext), _.toArray(arguments));
+                };
+
+                return memo;
+            }, {});
+        },
+        proxy;
+
+    proxy = {
+        filters: {
+            register: checkRegisterPermissions('filters', filters.registerFilter.bind(filters)),
+            deregister: checkRegisterPermissions('filters', filters.deregisterFilter.bind(filters))
+        },
+        helpers: {
+            register: checkRegisterPermissions('helpers', helpers.registerThemeHelper.bind(helpers)),
+            registerAsync: checkRegisterPermissions('helpers', helpers.registerAsyncThemeHelper.bind(helpers))
+        },
+        api: {
+            posts: passThruAppContextToApi('posts', _.pick(api.posts, 'browse', 'read', 'edit', 'add', 'destroy')),
+            tags: passThruAppContextToApi('tags', _.pick(api.tags, 'browse')),
+            notifications: passThruAppContextToApi('notifications', _.pick(api.notifications, 'browse', 'add', 'destroy')),
+            settings: passThruAppContextToApi('settings', _.pick(api.settings, 'browse', 'read', 'edit'))
+        }
+    };
+
+    return proxy;
 };
 
-module.exports = proxy;
+function AppProxy(options) {
+
+    if (!options.name) {
+        throw new Error('Must provide an app name for api context');
+    }
+
+    if (!options.permissions) {
+        throw new Error('Must provide app permissions');
+    }
+
+    _.extend(this, generateProxyFunctions(options.name, options.permissions));
+}
+
+module.exports = AppProxy;


### PR DESCRIPTION
Ref #2059 (ACL for Apps)
- Refactor appProxy into class that is instantiated per App
- Check for permissions before doing proxied method calls
- Unit tests for most of the situations I could think of

I know that the API is going to be running their own `canThis({ app: '...' })` checks, but I was already doing a kind of wrapped permission check with filters and helpers so I threw in another quick gated check for method access in this PR.  If you think it's gonna cause harm somewhere down the line, I'll take it out and just do a straight pass thru while running with the `{ app: '...' }` context.

I also made an assumption about requiring filter permissions by name of filter because I didn't hear back after my last comment about someone potentially registering a `prePostsRender` filter for an app that's permissions didn't allow read access to posts.  I figure being explicit will be better for us in the long run, and at least this way a user knows when an app is requesting access to a filter that potentially could give them access to post content, user content, etc.
