### PR TITLE
Invalidate cache header only for published posts

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -56,6 +56,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     saving: function (newObj, attr, options) {
         // Remove any properties which don't belong on the model
         this.attributes = this.pick(this.permittedAttributes());
+        // Store the previous attributes so we can tell what was updated later
+        this._updatedAttributes = newObj.previousAttributes();
+
         this.set('updated_by', options.user);
     },
 
@@ -106,6 +109,16 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
     sanitize: function (attr) {
         return sanitize(this.get(attr)).xss();
+    },
+
+    // Get attributes that have been updated (values before a .save() call)
+    updatedAttributes: function () {
+        return this._updatedAttributes || {};
+    },
+
+    // Get a specific updated attribute value
+    updated: function (attr) {
+        return this.updatedAttributes()[attr];
     }
 
 }, {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -444,7 +444,12 @@ Post = ghostBookshelf.Model.extend({
 
         return ghostBookshelf.Model.edit.call(this, editedPost, options).then(function (post) {
             if (post) {
-                return self.findOne({status: 'all', id: post.id}, options);
+                return self.findOne({status: 'all', id: post.id}, options)
+                    .then(function (found) {
+                        // Pass along the updated attributes for checking status changes
+                        found._updatedAttributes = post._updatedAttributes;
+                        return found;
+                    });
             }
         });
     },

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -316,6 +316,7 @@ describe('Post API', function () {
                             }
 
                             var publishedPost = res.body;
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(true);
                             res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + publishedPost.posts[0].slug + '/');
                             res.should.be.json;
                             publishedPost.should.exist;
@@ -334,7 +335,7 @@ describe('Post API', function () {
                                     }
 
                                     var updatedPost = res.body;
-                                    res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + updatedPost.posts[0].slug + '/');
+                                    _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                                     res.should.be.json;
                                     updatedPost.should.exist;
                                     updatedPost.posts.should.exist;
@@ -373,7 +374,7 @@ describe('Post API', function () {
                             }
 
                             var putBody = res.body;
-                            res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + putBody.posts[0].slug + '/');
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             putBody.should.exist;
                             putBody.posts[0].title.should.eql(changedValue);
@@ -407,7 +408,7 @@ describe('Post API', function () {
                             }
 
                             var putBody = res.body;
-                            res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + putBody.posts[0].slug + '/');
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             putBody.should.exist;
                             putBody.posts[0].page.should.eql(changedValue);
@@ -442,7 +443,7 @@ describe('Post API', function () {
                             }
 
                             var putBody = res.body;
-                            res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + putBody.posts[0].slug + '/');
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             putBody.should.exist;
                             putBody.posts[0].page.should.eql(changedValue);
@@ -498,7 +499,7 @@ describe('Post API', function () {
                             }
 
                             var putBody = res.body;
-                            res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + putBody.posts[0].slug + '/');
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             putBody.should.exist;
                             putBody.posts.should.exist;
@@ -539,7 +540,7 @@ describe('Post API', function () {
                             }
 
                             var putBody = res.body;
-                            should.not.exist(res.headers['x-cache-invalidate']);
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             testUtils.API.checkResponseValue(putBody, ['error']);
                             done();
@@ -724,7 +725,7 @@ describe('Post API', function () {
                                 yyyy = today.getFullYear(),
                                 postLink = '/' + yyyy + '/' + mm + '/' + dd + '/' + putBody.posts[0].slug + '/';
 
-                            res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, ' + postLink);
+                            _.has(res.headers, 'x-cache-invalidate').should.equal(false);
                             res.should.be.json;
                             putBody.should.exist;
                             putBody.posts[0].title.should.eql(changedValue);


### PR DESCRIPTION
Closes #1563
- ~~Add check for post.status === 'published'~~
- Add new updatedAttributes() functionality to base models
- Update Post.edit(...) to pass along _updatedAttributes values
- Update Post.delete to set statusChanged to true
- Add checking for statusChanged to cacheInvalidationHeader()
- Update route tests that check for cache invalidation header

I have a couple open questions about whether I'm even solving the right problem described in #1563, but just in case this is all that is necessary I'm gonna put it up here.
