### PR TITLE
Post API response to use author not author_id

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -211,6 +211,15 @@ Post = ghostBookshelf.Model.extend({
 
     fields: function () {
         return this.morphMany(AppField, 'relatable');
+    },
+
+    toJSON: function (options) {
+        var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
+
+        attrs.author = attrs.author || attrs.author_id;
+        delete attrs.author_id;
+        
+        return attrs;
     }
 
 }, {

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -73,6 +73,7 @@ describe('Post Model', function () {
             results.length.should.be.above(0);
             firstPost = results.models[0].toJSON();
 
+            should.not.exist(firstPost.author_id);
             firstPost.author.should.be.an.Object;
             firstPost.fields.should.be.an.Array;
             firstPost.author.name.should.equal(DataGenerator.Content.users[0].name);
@@ -89,6 +90,7 @@ describe('Post Model', function () {
             should.exist(result);
             firstPost = result.toJSON();
 
+            should.not.exist(firstPost.author_id);
             firstPost.author.should.be.an.Object;
             firstPost.fields.should.be.an.Array;
             firstPost.author.name.should.equal(testUtils.DataGenerator.Content.users[0].name);
@@ -142,6 +144,7 @@ describe('Post Model', function () {
             createdPost.get('created_at').should.be.above(new Date(0).getTime());
             createdPost.get('created_by').should.equal(1);
             createdPost.get('author_id').should.equal(1);
+            createdPost.has('author').should.equal(false);
             createdPost.get('created_by').should.equal(createdPost.get('author_id'));
             createdPost.get('updated_at').should.be.above(new Date(0).getTime());
             createdPost.get('updated_by').should.equal(1);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
         posts: ['posts', 'meta'],
         pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
         post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
-            'featured', 'image', 'status', 'language', 'author_id', 'created_at', 'created_by', 'updated_at',
+            'featured', 'image', 'status', 'language', 'created_at', 'created_by', 'updated_at',
             'updated_by', 'published_at', 'published_by', 'page', 'author', 'tags', 'fields'],
         // TODO: remove databaseVersion, dbHash
         settings: ['databaseVersion', 'dbHash', 'title', 'description', 'email', 'logo', 'cover', 'defaultLang',


### PR DESCRIPTION
Closes #2608
- added toJSON method override for post model
- in the event no expanded author relation is present the id will be used
- removed author_id from expected response JSON for posts.
- updated integration tests to check for existence or not of author and author_id
