### PR TITLE
Ensure that the character set is UTF-8 for RSS feed

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -344,7 +344,7 @@ frontendControllers = {
                 });
 
                 when.all(feedItems).then(function () {
-                    res.set('Content-Type', 'text/xml');
+                    res.set('Content-Type', 'text/xml; charset=UTF-8');
                     res.send(feed.xml());
                 });
             });

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -57,3 +57,11 @@ CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(te
     });
     CasperTest.Routines.togglePermalinks.run('off');
 }, false);
+
+CasperTest.begin('Ensure that character set is UTF-8 for RSS feed', 1, function suite(test) {
+    CasperTest.Routines.togglePermalinks.run('off');
+    casper.thenOpen(url + 'rss/', function (response) {
+        test.assertEqual(response.headers.get('Content-Type'), 'text/xml; charset=UTF-8', 'Content type should include UTF-8 character set encoding.');
+    });
+}, false);
+


### PR DESCRIPTION
When setting the Content-Type header for the RSS feeds, the character set is omitted. However, when running the feed through the [Feed Validator](http://feedvalidator.org), it became apparent that there was a problem as the encoding defaults to US-ASCII. See [RFC 3023](http://www.ietf.org/rfc/rfc3023.txt) for further information on the default XML charset over HTTP.

I have added a test and simple update to the 'Content-Type' header.
