### PR TITLE
Additional objects

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -30,14 +30,6 @@ function getPostPage(options) {
         }
         options.include = 'author,tags,fields';
         return api.posts.browse(options);
-    }).then(function (page) {
-
-        // A bit of a hack for situations with no content.
-        if (page.meta.pagination.pages === 0) {
-            page.meta.pagination.pages = 1;
-        }
-
-        return page;
     });
 }
 
@@ -121,7 +113,7 @@ frontendControllers = {
 
                         // Format data for template
                         response = _.extend(formatPageResponse(posts, page), {
-                            tag: page.aspect.tag
+                            tag: page.meta.filters.tags ? page.meta.filters.tags[0] : ''
                         });
 
                     res.render(view, response);
@@ -286,8 +278,10 @@ frontendControllers = {
                     feed;
 
                 if (tagParam) {
-                    title = page.aspect.tag.name + ' - ' + title;
-                    feedUrl = feedUrl + 'tag/' + page.aspect.tag.slug + '/';
+                    if (page.meta.filters.tags) {
+                        title = page.meta.filters.tags[0].name + ' - ' + title;
+                        feedUrl = feedUrl + 'tag/' + page.meta.filters.tags[0].slug + '/';
+                    }
                 }
 
                 feed = new RSS({
@@ -298,13 +292,6 @@ frontendControllers = {
                     site_url: siteUrl,
                     ttl: '60'
                 });
-
-
-                // A bit of a hack for situations with no content.
-                if (maxPage === 0) {
-                    maxPage = 1;
-                    page.meta.pagination.pages = 1;
-                }
 
                 // If page is greater than number of pages we have, redirect to last page
                 if (pageParam > maxPage) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -380,13 +380,14 @@ Post = ghostBookshelf.Model.extend({
             // Format response of data
             .then(function (resp) {
                 var totalPosts = parseInt(resp[0].aggregate, 10),
+                    calcPages = Math.ceil(totalPosts / opts.limit),
                     pagination = {},
                     meta = {},
                     data = {};
 
                 pagination['page'] = parseInt(opts.page, 10);
                 pagination['limit'] = opts.limit;
-                pagination['pages'] = Math.ceil(totalPosts / opts.limit);
+                pagination['pages'] = calcPages === 0 ? 1 : calcPages;
                 pagination['total'] = totalPosts;
                 pagination['next'] = null;
                 pagination['prev'] = null;
@@ -413,9 +414,10 @@ Post = ghostBookshelf.Model.extend({
                 }
 
                 if (tagInstance) {
-                    data.aspect = {
-                        tag: tagInstance.toJSON()
-                    };
+                    meta['filters'] = {};
+                    if (!tagInstance.isNew()) {
+                        meta.filters['tags'] = [tagInstance.toJSON()];
+                    }
                 }
 
                 return data;

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -395,8 +395,8 @@ describe('Post Model', function () {
             paginationResult.meta.pagination.page.should.equal(1);
             paginationResult.meta.pagination.limit.should.equal(15);
             paginationResult.meta.pagination.pages.should.equal(1);
-            paginationResult.aspect.tag.name.should.equal('bacon');
-            paginationResult.aspect.tag.slug.should.equal('bacon');
+            paginationResult.meta.filters.tags[0].name.should.equal('bacon');
+            paginationResult.meta.filters.tags[0].slug.should.equal('bacon');
             paginationResult.posts.length.should.equal(2);
 
             return PostModel.findPage({page: 1, tag: 'kitchen-sink'});
@@ -404,8 +404,8 @@ describe('Post Model', function () {
             paginationResult.meta.pagination.page.should.equal(1);
             paginationResult.meta.pagination.limit.should.equal(15);
             paginationResult.meta.pagination.pages.should.equal(1);
-            paginationResult.aspect.tag.name.should.equal('kitchen sink');
-            paginationResult.aspect.tag.slug.should.equal('kitchen-sink');
+            paginationResult.meta.filters.tags[0].name.should.equal('kitchen sink');
+            paginationResult.meta.filters.tags[0].slug.should.equal('kitchen-sink');
             paginationResult.posts.length.should.equal(2);
 
             return PostModel.findPage({page: 1, tag: 'injection'});
@@ -413,8 +413,8 @@ describe('Post Model', function () {
             paginationResult.meta.pagination.page.should.equal(1);
             paginationResult.meta.pagination.limit.should.equal(15);
             paginationResult.meta.pagination.pages.should.equal(2);
-            paginationResult.aspect.tag.name.should.equal('injection');
-            paginationResult.aspect.tag.slug.should.equal('injection');
+            paginationResult.meta.filters.tags[0].name.should.equal('injection');
+            paginationResult.meta.filters.tags[0].slug.should.equal('injection');
             paginationResult.posts.length.should.equal(15);
 
             return PostModel.findPage({page: 2, tag: 'injection'});
@@ -422,8 +422,8 @@ describe('Post Model', function () {
             paginationResult.meta.pagination.page.should.equal(2);
             paginationResult.meta.pagination.limit.should.equal(15);
             paginationResult.meta.pagination.pages.should.equal(2);
-            paginationResult.aspect.tag.name.should.equal('injection');
-            paginationResult.aspect.tag.slug.should.equal('injection');
+            paginationResult.meta.filters.tags[0].name.should.equal('injection');
+            paginationResult.meta.filters.tags[0].slug.should.equal('injection');
             paginationResult.posts.length.should.equal(11);
 
             done();

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -189,8 +189,10 @@ describe('Frontend Controller', function () {
                             page: 1,
                             pages: 1,
                         },
+                        filters: {
+                            tags: [mockTags[0]]
+                        }
                     },
-                    aspect: {tag: mockTags[0]}
                 });
             });
  


### PR DESCRIPTION
closes #2620
- moved aspect -> filters
- updated tests
- fixed inconsistency in pagination object
- changed filter object to `filters: {tags:[{id: 1, ...}]}`
