### PR TITLE
Removed 2 sec pause

### DIFF
--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -43,7 +43,7 @@ describe('Post API', function () {
                             pattern_meta.should.exist;
                             csrfToken = res.text.match(pattern_meta)[1];
 
-                            setTimeout(function () {
+                            process.nextTick(function() {
                                 request.post('/ghost/signin/')
                                     .set('X-CSRF-Token', csrfToken)
                                     .send({email: user.email, password: user.password})
@@ -67,7 +67,7 @@ describe('Post API', function () {
                                             });
                                     });
 
-                            }, 2000);
+                            });
 
                         });
                 }, done);

--- a/core/test/functional/routes/api/settings_test.js
+++ b/core/test/functional/routes/api/settings_test.js
@@ -43,7 +43,7 @@ describe('Settings API', function () {
                             pattern_meta.should.exist;
                             csrfToken = res.text.match(pattern_meta)[1];
 
-                            setTimeout(function () {
+                            process.nextTick(function() {
                                 request.post('/ghost/signin/')
                                     .set('X-CSRF-Token', csrfToken)
                                     .send({email: user.email, password: user.password})
@@ -67,7 +67,7 @@ describe('Settings API', function () {
                                             });
                                     });
 
-                            }, 2000);
+                            });
 
                         });
                 }, done);

--- a/core/test/functional/routes/api/tags_test.js
+++ b/core/test/functional/routes/api/tags_test.js
@@ -43,7 +43,7 @@ describe('Tag API', function () {
                             pattern_meta.should.exist;
                             csrfToken = res.text.match(pattern_meta)[1];
 
-                            setTimeout(function () {
+                            process.nextTick(function() {
                                 request.post('/ghost/signin/')
                                     .set('X-CSRF-Token', csrfToken)
                                     .send({email: user.email, password: user.password})
@@ -67,8 +67,7 @@ describe('Tag API', function () {
                                             });
                                     });
 
-                            }, 2000);
-
+                            });
                         });
                 }, done);
         }).otherwise(function (e) {

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -44,7 +44,7 @@ describe('User API', function () {
                             pattern_meta.should.exist;
                             csrfToken = res.text.match(pattern_meta)[1];
 
-                            setTimeout(function () {
+                            process.nextTick(function() {
                                 request.post('/ghost/signin/')
                                     .set('X-CSRF-Token', csrfToken)
                                     .send({email: user.email, password: user.password})
@@ -67,7 +67,7 @@ describe('User API', function () {
                                             });
                                     });
 
-                            }, 2000);
+                            });
 
                         });
                 }, done);


### PR DESCRIPTION
refs #2660
- removed timeout from routes tests (since Ghost is used as module it
  is restarted before logging in)
- Casper.js does only one login and the existing waits are executed
  after testing login limiters
- gain: 8 sec :-/
