### PR TITLE
Sanitize models' attributes/options before passing to bookshelf/knex

### DIFF
--- a/core/server/models/app.js
+++ b/core/server/models/app.js
@@ -14,6 +14,27 @@ App = ghostBookshelf.Model.extend({
     settings: function () {
         return this.belongsToMany(AppSetting, 'app_settings');
     }
+}, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                findOne: ['withRelated']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    }
 });
 
 Apps = ghostBookshelf.Collection.extend({

--- a/core/server/models/permission.js
+++ b/core/server/models/permission.js
@@ -21,6 +21,27 @@ Permission = ghostBookshelf.Model.extend({
     apps: function () {
         return this.belongsToMany(App);
     }
+}, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                add: ['user']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    },
 });
 
 Permissions = ghostBookshelf.Collection.extend({

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -16,6 +16,28 @@ Role = ghostBookshelf.Model.extend({
     permissions: function () {
         return this.belongsToMany(Permission);
     }
+}, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                findOne: ['withRelated'],
+                add: ['user']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    },
 });
 
 Roles = ghostBookshelf.Collection.extend({

--- a/core/server/models/session.js
+++ b/core/server/models/session.js
@@ -23,7 +23,7 @@ Session = ghostBookshelf.Model.extend({
 
 }, {
     destroyAll:  function (options) {
-        options = options || {};
+        options = this.filterOptions(options, 'destroyAll');
         return ghostBookshelf.Collection.forge([], {model: this}).fetch()
             .then(function (collection) {
                 collection.invokeThen('destroy', options);

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -58,6 +58,28 @@ Settings = ghostBookshelf.Model.extend({
     }
 
 }, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                add: ['user'],
+                edit: ['user']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    },
+
     findOne: function (_key) {
         // Allow for just passing the key instead of attributes
         if (!_.isObject(_key)) {
@@ -67,6 +89,8 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     edit: function (_data, options) {
+        var self = this;
+        options = this.filterOptions(options, 'edit');
 
         if (!Array.isArray(_data)) {
             _data = [_data];
@@ -78,6 +102,9 @@ Settings = ghostBookshelf.Model.extend({
             if (!(_.isString(item.key) && item.key.length > 0)) {
                 return when.reject({type: 'ValidationError', message: 'Setting key cannot be empty.'});
             }
+
+            item = self.filterData(item);
+
             return Settings.forge({ key: item.key }).fetch(options).then(function (setting) {
 
                 if (setting) {

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -37,6 +37,27 @@ Tag = ghostBookshelf.Model.extend({
 
         return attrs;
     }
+}, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                add: ['user']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    },
 });
 
 Tags = ghostBookshelf.Collection.extend({

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -65,7 +65,7 @@ User = ghostBookshelf.Model.extend({
         var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
         // remove password hash for security reasons
         delete attrs.password;
-        
+
         return attrs;
     },
 
@@ -82,6 +82,28 @@ User = ghostBookshelf.Model.extend({
     }
 
 }, {
+    /**
+    * Returns an array of keys permitted in a method's `options` hash, depending on the current method.
+    * @param {String} methodName The name of the method to check valid options for.
+    * @return {Array} Keys allowed in the `options` hash of the model's method.
+    */
+    permittedOptions: function (methodName) {
+        var options = ghostBookshelf.Model.permittedOptions(),
+
+            // whitelists for the `options` hash argument on methods, by method name.
+            // these are the only options that can be passed to Bookshelf / Knex.
+            validOptions = {
+                findOne: ['withRelated'],
+                add: ['user'],
+                edit: ['user']
+            };
+
+        if (validOptions[methodName]) {
+            options = options.concat(validOptions[methodName]);
+        }
+
+        return options;
+    },
 
     /**
      * Naive user add
@@ -93,7 +115,10 @@ User = ghostBookshelf.Model.extend({
 
         var self = this,
             // Clone the _user so we don't expose the hashed password unnecessarily
-            userData = _.extend({}, _user);
+            userData = this.filterData(_user);
+
+        options = this.filterOptions(options, 'add');
+
         /**
          * This only allows one user to be added to the database, otherwise fails.
          * @param {object} user
@@ -314,7 +339,7 @@ User = ghostBookshelf.Model.extend({
             var diff = 0,
                 i;
 
-            // check if the token lenght is correct
+            // check if the token length is correct
             if (token.length !== generatedToken.length) {
                 diff = 1;
             }


### PR DESCRIPTION
closes #2653 

This isn't necessarily ready-to-merge right away. I took Hannah's advice and kept BaseModel as strict as possible, by porting methods from Base over to each model where it made logical sense to me. The only place where Base accepts an option is in `base#findOne` since many models use `transacting` as an option. In some cases I had to remove calls to the Base parent methods and copy such functionality in order to keep Base clean.

I added a class method `base#permittedAttributes` that pulls the schema attributes from a method of the same name on its prototype, in order to filter them where I saw it was needed. I recreated this function on the PostModel as it seems `tags` is a necessary attribute for at least one test, but it's not listed in the schema. It's manually added to the whitelist in that case.

Please let me know if you see any issues with this PR. I wanted to add tests, but thought I'd leave it up to discussion how I might best accomplish it. In many cases trying to use certain options that are necessary but not yet whitelisted causes tests to timeout without any indication that the whitelist is the issue.
