### PR TITLE
Fix unhandled rejected promises when using admin

### DIFF
--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -144,10 +144,10 @@ function updateCheckRequest() {
 function updateCheckResponse(response) {
     var ops = [];
 
-    ops.push(api.settings.edit.call({user: 1}, 'nextUpdateCheck', response.next_check)
+    ops.push(api.settings.edit.call({internal: true}, 'nextUpdateCheck', response.next_check)
         .otherwise(errors.rejectError));
 
-    ops.push(api.settings.edit.call({user: 1}, 'displayUpdateNotification', response.version)
+    ops.push(api.settings.edit.call({internal: true}, 'displayUpdateNotification', response.version)
                 .otherwise(errors.rejectError));
 
     return when.settle(ops).then(function (descriptors) {


### PR DESCRIPTION
closes #2707
- adjust call to api.settings.edit now that canThis is in use
