### PR TITLE
Don't xmlrpc ping for the default Welcome to Ghost post

### DIFF
--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -18,7 +18,7 @@ function hasActionsMap() {
 
     return _.any(exported.actionsMap, function (val, key) {
         /*jslint unparam:true*/
-        return Object.hasOwnProperty(key);
+        return Object.hasOwnProperty.call(exported.actionsMap, key);
     });
 }
 

--- a/core/server/xmlrpc.js
+++ b/core/server/xmlrpc.js
@@ -20,6 +20,14 @@ function ping(post) {
         return;
     }
 
+    // Don't ping for the welcome to ghost post.
+    // This also handles the case where during ghost's first run
+    // models.init() inserts this post but permissions.init() hasn't
+    // (can't) run yet.
+    if (post.slug === 'welcome-to-ghost') {
+        return;
+    }
+
     // Need to require here because of circular dependency
     return config.urlForPost(require('./api').settings, post, true).then(function (url) {
 


### PR DESCRIPTION
closes #2712
-prevents xmlrpc.ping from being run before Ghost is in a valid
state
-fix a call to Object.hasOwnProperty in permissions.hasActionsMap
