### PR TITLE
Another adjustment to handle timing issue on tests

### DIFF
--- a/core/test/functional/admin/settings_test.js
+++ b/core/test/functional/admin/settings_test.js
@@ -159,7 +159,7 @@ CasperTest.begin('Ensure image upload modals display correctly', 6, function sui
         this.click('#general .js-modal-logo');
     }, casper.failOnTimeout(test, 'waitForOpaque #general timed out'));
 
-    casper.waitForSelector('#modal-container .modal-content .js-drop-zone', assertImageUploaderModalThenClose,
+    casper.waitForSelector('#modal-container .modal-content .js-drop-zone .description', assertImageUploaderModalThenClose,
         casper.failOnTimeout(test, 'No upload logo modal container appeared'));
 
     // Test Blog Cover Upload Button
@@ -167,7 +167,7 @@ CasperTest.begin('Ensure image upload modals display correctly', 6, function sui
         this.click('#general .js-modal-cover');
     });
 
-    casper.waitForSelector('#modal-container .modal-content .js-drop-zone', assertImageUploaderModalThenClose,
+    casper.waitForSelector('#modal-container .modal-content .js-drop-zone .description', assertImageUploaderModalThenClose,
         casper.failOnTimeout(test, 'No upload cover modal container appeared'));
 });
 


### PR DESCRIPTION
I'm sorry, in #2729 I ended up testing for something else (`.description`) that depending on timing may not be there yet.

I revised the test to now wait until `.description` is present and then test that `.description` has the correct test ("Add image").  There shouldn't be any timing issues with that.
