### PR TITLE
Fix intermittent image upload modal failures

### DIFF
--- a/core/test/functional/admin/settings_test.js
+++ b/core/test/functional/admin/settings_test.js
@@ -163,9 +163,9 @@ CasperTest.begin('Ensure image upload modals display correctly', 6, function sui
         casper.failOnTimeout(test, 'No upload logo modal container appeared'));
 
     // Test Blog Cover Upload Button
-    casper.then(function () {
-        this.click('#general .js-modal-cover');
-    });
+    casper.waitForOpaque('#general', function then() {
+                this.click('#general .js-modal-cover');
+    }, casper.failOnTimeout(test, 'waitForOpaque #general timed out'));
 
     casper.waitForSelector('#modal-container .modal-content .js-drop-zone', assertImageUploaderModalThenClose,
         casper.failOnTimeout(test, 'No upload cover modal container appeared'));


### PR DESCRIPTION
Okay, I think I've finally nailed this down.  Along with the changes made in #2729 it looks like the errors for the image upload modals are no longer occurring.  I ran it through travis on my fork 20 or so times (thanks @halfdan) without a single failure.

The last piece of the puzzle appears to have been the timing between testing for the logo image modal and then the cover image modal.  I did some digging and realized that although it's sometimes both tests that fail, it's usually the test for the cover image modal, which happens to be tested after the logo image modal...

I think you can reproduce what's happening in the tests by opening a dev tools console on `/ghost/settings/general/` and running the following:  
`$('a.js-modal-logo').click(); $('#modal-container .js-button-accept').click(); $('a.js-modal-cover').click()`

If that last button click occurs while the previous modal is still being torn down, it just gets swallowed up in it and never appears.  So in the tests, waiting for the previous modal to completely disappear seems to do the trick.
