### PR TITLE
Display 404 page if tag does not exist.

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -133,6 +133,10 @@ frontendControllers = {
                             tag: page.meta.filters.tags ? page.meta.filters.tags[0] : ''
                         });
 
+                    // If the resulting tag is '' then 404.
+                    if (!result.tag) {
+                        return next();
+                    }
                     res.render(view, result);
                 });
             });

--- a/core/test/functional/frontend/error_test.js
+++ b/core/test/functional/frontend/error_test.js
@@ -15,3 +15,10 @@ CasperTest.begin('Check frontend route not found (404)', 2, function suite(test)
 		test.assertSelectorHasText('.error-code', '404');
     });
 }, true);
+
+CasperTest.begin('Check frontend tag route not found (404)', 2, function suite(test) {
+    casper.thenOpen(url + 'tag/asdf/', function (response) {
+        test.assertEqual(response.status, 404, 'Response status should be 404.');
+    test.assertSelectorHasText('.error-code', '404');
+    });
+}, true);


### PR DESCRIPTION
closes #2667
- if tag result is '' 404 instead of rendering an empty page
- added test for /tag/asdf should 404
