### PR TITLE
Ensure settings values are strings before saving

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -214,6 +214,10 @@ settings = {
                 return when.all(checks);
             };
 
+        if (!_.isString(value)) {
+            value = JSON.stringify(value);
+        }
+
         // Allow shorthand syntax
         if (_.isString(key)) {
             key = { settings: [{ key: key, value: value }]};

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -163,4 +163,16 @@ describe('Settings API', function () {
             done();
         });
     });
+
+    it('ensures values are stringified before saving to database', function (done) {
+        return callApiWithContext(defaultContext, 'edit', 'title', []).then(function (response) {
+            should.exist(response);
+            testUtils.API.checkResponse(response, 'settings');
+            response.settings.length.should.equal(1);
+            testUtils.API.checkResponse(response.settings[0], 'setting');
+            response.settings[0].value.should.equal('[]');
+
+            done();
+        }).catch(done);
+    });
 });


### PR DESCRIPTION
closes #2736
-reintroduces JSON.stringify for non-string values in
 api.settings.edit
-added a regression test
