### PR TITLE
Add /content redirect to Ember admin.

### DIFF
--- a/core/client/router.js
+++ b/core/client/router.js
@@ -25,6 +25,8 @@ Router.map(function () {
         this.route('apps');
     });
     this.route('debug');
+    //Redirect legacy content to posts
+    this.route('content');
 });
 
 export default Router;

--- a/core/client/routes/content.js
+++ b/core/client/routes/content.js
@@ -1,0 +1,7 @@
+var ContentRoute = Ember.Route.extend({
+    beforeModel: function () {
+        this.transitionTo('posts');
+    }
+});
+
+export default ContentRoute;


### PR DESCRIPTION
Closes #2746
- Adds content route to router
- Content route transitions to posts route in the beforeModel hook.
