### PR TITLE
Fix sign up not setting user on session

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -260,7 +260,9 @@ adminControllers = {
                 password: password
             }];
 
-        api.users.register({users: users}).then(function (user) {
+        api.users.register({users: users}).then(function (apiResp) {
+            var user = apiResp.users[0];
+
             api.settings.edit.call({user: 1}, 'email', email).then(function () {
                 var message = {
                         to: email,


### PR DESCRIPTION
No issue found
- Grab `user` out of api response from `users[0]`

When signing up, the user was being redirected immediately to the signin page because the `req.session.user` was undefined.  Now the user is logged in properly after signup without having to login again.

To reproduce on master, delete your database and sign up as a new user.
