### PR TITLE
Add ghostPaths util and initializer

### DIFF
--- a/core/client/app.js
+++ b/core/client/app.js
@@ -2,6 +2,7 @@ import Resolver from 'ember/resolver';
 import initFixtures from 'ghost/fixtures/init';
 import {currentUser, injectCurrentUser} from 'ghost/initializers/current-user';
 import {registerNotifications, injectNotifications} from 'ghost/initializers/notifications';
+import injectGhostPaths from 'ghost/initializers/ghost-paths';
 import 'ghost/utils/link-view';
 import 'ghost/utils/text-field';
 
@@ -22,6 +23,7 @@ initFixtures();
 
 App.initializer(currentUser);
 App.initializer(injectCurrentUser);
+App.initializer(injectGhostPaths);
 App.initializer(registerNotifications);
 App.initializer(injectNotifications);
 

--- a/core/client/initializers/ghost-paths.js
+++ b/core/client/initializers/ghost-paths.js
@@ -1,0 +1,13 @@
+import ghostPaths from 'ghost/utils/ghost-paths';
+
+export default {
+    name: 'ghost-paths',
+
+    initialize: function (container) {
+        container.register('ghost:paths', ghostPaths(), {instantiate: false});
+
+        container.injection('route', 'ghostPaths', 'ghost:paths');
+        container.injection('model', 'ghostPaths', 'ghost:paths');
+        container.injection('controller', 'ghostPaths', 'ghost:paths');
+    }
+};

--- a/core/client/models/base.js
+++ b/core/client/models/base.js
@@ -1,14 +1,4 @@
-
-function ghostPaths() {
-    var path = window.location.pathname,
-        subdir = path.substr(0, path.search('/ghost/'));
-
-    return {
-        subdir: subdir,
-        adminRoot: subdir + '/ghost',
-        apiRoot: subdir + '/ghost/api/v0.1'
-    };
-}
+import ghostPaths from 'ghost/utils/ghost-paths';
 
 var BaseModel = Ember.Object.extend({
 

--- a/core/client/utils/ghost-paths.js
+++ b/core/client/utils/ghost-paths.js
@@ -1,0 +1,29 @@
+var makeRoute = function (root, args) {
+    var parts = Array.prototype.slice.call(args, 0).join('/'),
+        route = [root, parts].join('/');
+
+    if (route.slice(-1) !== '/') {
+        route += '/';
+    }
+
+    return route;
+};
+
+export default function ghostPaths() {
+    var path = window.location.pathname,
+        subdir = path.substr(0, path.search('/ghost/'));
+
+    return {
+        subdir: subdir,
+        adminRoot: subdir + '/ghost',
+        apiRoot: subdir + '/ghost/api/v0.1',
+
+        adminUrl: function () {
+            return makeRoute(this.adminRoot, arguments);
+        },
+
+        apiUrl: function () {
+            return makeRoute(this.apiRoot, arguments);
+        }
+    };
+}


### PR DESCRIPTION
No Issue
- Move the ghostPaths from base model to utils
- Add initializer that injects it into every route, model and controller
- Add a adminUrl and apiUrl helper method

Here is some example usage you might use in a routes model function:

``` js
// /ghost/api/v0.1/posts/
var postsUrl = this.get('ghostPaths').apiUrl('posts'); 

// /ghost/api/v0.1/posts/1/
var postsUrl = this.get('ghostPaths').apiUrl('posts', params.post_id); 

// /ghost/signin/
var signInUrl = this.get('ghostPaths').adminUrl('signin');
```

I'm open to suggestion on the injected name being `ghostPaths`, it could possible be just `paths`.
