### PR TITLE
Ember editor save and publish button functionality

### DIFF
--- a/core/client/routes/new.js
+++ b/core/client/routes/new.js
@@ -1,11 +1,17 @@
-import styleBody from 'ghost/mixins/style-body';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
+import styleBody from 'ghost/mixins/style-body';
+import Post from 'ghost/models/post';
 
 var NewRoute = AuthenticatedRoute.extend(styleBody, {
+    controllerName: 'posts/post',
     classNames: ['editor'],
 
     renderTemplate: function () {
         this.render('editor');
+    },
+
+    model: function () {
+        return Post.create();
     }
 });
 

--- a/core/client/templates/-publish-bar.hbs
+++ b/core/client/templates/-publish-bar.hbs
@@ -15,15 +15,7 @@
                 {{view "post-settings-menu-view"}}
             </section>
 
-            <section id="entry-actions" class="js-publish-splitbutton splitbutton-save">
-                <button type="button" class="js-publish-button button-save">Save Draft</button>
-                <a class="options up" data-toggle="ul" href="#" title="Post Settings"><span class="hidden">Post Settings</span></a>
-                {{!-- @TODO: implement popover --}}
-                <ul class="editor-options overlay" style="display:none">
-                    <li data-set-status="published"><a href="#"></a></li>
-                    <li data-set-status="draft"><a href="#"></a></li>
-                </ul>
-            </section>
+            {{view "editor-save-button" id="entry-actions"}}
         </div>
     </nav>
 </footer>

--- a/core/client/templates/editor-save-button.hbs
+++ b/core/client/templates/editor-save-button.hbs
@@ -1,0 +1,12 @@
+<button type="button" {{action "save"}} {{bind-attr class="view.isDangerous:button-delete:button-save :js-publish-button" }}>{{view.save-text}}</button>
+<button {{action 'viewSaveTypes'}} {{bind-attr class="controller.isViewingSaveTypes:active :options :up" }} title="Post Settings"><span class="hidden">Post Settings</span>
+</button>
+{{!-- @TODO: implement popover --}}
+<ul {{bind-attr class="controller.isViewingSaveTypes::hidden :editor-options :overlay" }}>
+    <li {{bind-attr class="controller.willPublish:active"}}>
+        <a {{action "setSaveType" "publish"}} href="#">{{view.publish-text}}</a>
+    </li>
+    <li {{bind-attr class="controller.willPublish::active"}}>
+        <a {{action "setSaveType" "draft"}} href="#">{{view.draft-text}}</a>
+    </li>
+</ul>

--- a/core/client/views/editor-save-button.js
+++ b/core/client/views/editor-save-button.js
@@ -1,0 +1,23 @@
+export default Ember.View.extend({
+    templateName: 'editor-save-button',
+    tagName: 'section',
+    classNames: ['js-publish-splitbutton'],
+    classNameBindings: ['isDangerous:splitbutton-delete:splitbutton-save'],
+
+    //Tracks whether we're going to change the state of the post on save
+    isDangerous: function () {
+        return this.get('controller.isPublished') !== this.get('controller.willPublish');
+    }.property('controller.isPublished', 'controller.willPublish'),
+
+    'save-text': function () {
+        return this.get('controller.willPublish') ? this.get('publish-text') : this.get('draft-text');
+    }.property('controller.willPublish'),
+
+    'publish-text': function () {
+        return this.get('controller.isPublished') ? 'Update Post' : 'Publish Now';
+    }.property('controller.isPublished'),
+
+    'draft-text': function () {
+        return this.get('controller.isPublished') ? 'Unpublish' : 'Save Draft';
+    }.property('controller.isPublished')
+});


### PR DESCRIPTION
Closes #2747
- Added new 'editor-save-button' view and template.
- Added save action to post controller.

It's important to say what I didn't do: this will need ghost-popover (#2418) for full popover behavior, and the post's save action will need work once ember data is in.

PS: Ember felt so nice for this.
