### PR TITLE
[dist] update sqlite version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "https://github.com/ErisDS/showdown/archive/v0.3.2-ghost.tar.gz",
-        "sqlite3": "2.2.0",
+        "sqlite3": "2.2.3",
         "unidecode": "0.1.3",
         "validator": "3.4.0",
         "when": "2.7.0",


### PR DESCRIPTION
Current version os sqlite does not compile on smartos/sunos flavors. This will enable it to do so

See [here](https://github.com/mapbox/node-sqlite3/issues/290#issuecomment-42370551)
