### PR TITLE
[docs] absolute=true will add options.hash

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -134,7 +134,7 @@ coreHelpers.pageUrl = function (context, block) {
 //
 // *Usage example:*
 // `{{url}}`
-// `{{url absolute}}`
+// `{{url absolute=true}}`
 //
 // Returns the URL for the current object context
 // i.e. If inside a post context will return post permalink

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -134,7 +134,7 @@ coreHelpers.pageUrl = function (context, block) {
 //
 // *Usage example:*
 // `{{url}}`
-// `{{url absolute=true}}`
+// `{{url absolute="true"}}`
 //
 // Returns the URL for the current object context
 // i.e. If inside a post context will return post permalink


### PR DESCRIPTION
Ran into this will calling the helper from a theme, tried to get the absolute url, but just providing {{url absolute}} wasn't enough. After explicitly adding `=true` it worked.
