### PR TITLE
fix mirrored scrolling in markdown editor

### DIFF
--- a/core/client/components/-markdown.js
+++ b/core/client/components/-markdown.js
@@ -1,6 +1,6 @@
 var Markdown = Ember.Component.extend({
     adjustScrollPosition: function () {
-        var scrollWrapper = this.$('.entry-preview-content').get(0),
+        var scrollWrapper = this.$().closest('.entry-preview-content').get(0),
         // calculate absolute scroll position from percentage
             scrollPixel = scrollWrapper.scrollHeight * this.get('scrollPosition');
 


### PR DESCRIPTION
issue #2426
- ember markdown component now looks for preview element as a DOM ancestor rather than a descendent
