### PR TITLE
Fix content preview actions and add tests

### DIFF
--- a/core/clientold/views/blog.js
+++ b/core/clientold/views/blog.js
@@ -260,6 +260,8 @@
         templateName: "preview",
 
         render: function () {
+            var self = this;
+
             this.model = this.collection.get(this.activeId);
             this.$el.html(this.template(this.templateData()));
 
@@ -269,13 +271,14 @@
             });
 
             if (this.model !== undefined) {
-                this.addSubview(new Ghost.View.PostSettings({el: $('.post-controls'), model: this.model})).render();
+                this.model.fetch({ data: { status: 'all', include: 'tags,author' } }).then(function () {
+                    self.addSubview(new Ghost.View.PostSettings({ el: $('.post-controls'), model: self.model })).render();
+                });
             }
 
             Ghost.temporary.initToggles(this.$el);
             return this;
         }
-
     });
 
 }());

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -53,14 +53,13 @@ Post = ghostBookshelf.Model.extend({
         this.myTags = [];
 
         _.each(tagsToCheck, function (item) {
-            if (_.isObject(self.myTags)) {
-                for (i = 0; i < self.myTags.length; i = i + 1) {
-                    if (self.myTags[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
-                        return;
-                    }
+            for (i = 0; i < self.myTags.length; i = i + 1) {
+                if (self.myTags[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
+                    return;
                 }
-                self.myTags.push(item);
             }
+
+            self.myTags.push(item);
         });
 
         ghostBookshelf.Model.prototype.saving.call(this, newPage, attr, options);

--- a/core/test/functional/admin/content_test.js
+++ b/core/test/functional/admin/content_test.js
@@ -313,6 +313,408 @@ CasperTest.begin("Posts can be marked as featured", 12, function suite(test) {
     });
 });
 
+CasperTest.begin("Posts with tags can be marked as featured", 12, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+
+        casper.sendKeys('#entry-tags input.tag-input', 'TestTag');
+        casper.sendKeys('#entry-tags input.tag-input', casper.page.event.key.Enter);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + "ghost/content/", function testTitleAndUrl() {
+        test.assertTitle("Ghost Admin", "Ghost admin has no title");
+    });
+
+    // Mark as featured
+    casper.waitForSelector('.content-preview .unfeatured', function () {
+        this.click('.content-preview .unfeatured');
+    }, function onTimeOut() {
+        test.assert(false, 'The first post can\'t be marked as featured');
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Post successfully marked as featured.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    casper.waitForSelector('.content-list-content li:first-child .featured', function () {
+        test.assertExists('.content-preview .featured');
+        test.assert(true, 'got a featured star');
+        this.click('.notification-success .close');
+    }, function onTimeout() {
+        test.assert(false, 'No featured star appeared in the left pane');
+    });
+
+    // Mark as not featured
+    casper.waitWhileSelector('.notification-success', function waitForNoSuccess() {
+        this.click('.content-preview .featured');
+    }, function onTimeout() {
+        test.assert(false, 'Success notification wont go away:(');
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Post successfully marked as not featured.');
+        test.assertDoesntExist('.content-preview .featured');
+        test.assertDoesntExist('.content-list-content li:first-child .featured');
+    }, function onTimeout() {
+        test.assert(false, 'Success notification wont go away:(');
+    });
+});
+
+CasperTest.begin('Post url can be changed', 9, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change permalink
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#url': 'new-url'
+        }, false);
+
+        this.click('a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Permalink successfully changed to new-url.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success', function () {
+        test.assert(true, 'notification cleared.');
+        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    });
+});
+
+CasperTest.begin('Post url can be changed on Posts with tags', 9, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+
+        casper.sendKeys('#entry-tags input.tag-input', 'TestTag');
+        casper.sendKeys('#entry-tags input.tag-input', casper.page.event.key.Enter);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change permalink
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#url': 'new-url-with-tags'
+        }, false);
+
+        this.click('a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Permalink successfully changed to new-url-with-tags.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success', function () {
+        test.assert(true, 'notification cleared.');
+        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    });
+});
+
+CasperTest.begin('Post published date can be changed', 9, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change published date
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#pub-date': '22 May 14 @ 23:39'
+        }, false);
+
+        this.click('a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Publish date successfully changed to 22 May 14 @ 23:39.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success', function () {
+        test.assert(true, 'notification cleared.');
+        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    });
+});
+
+CasperTest.begin('Post published date can be changed on Posts with tags', 9, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+
+        casper.sendKeys('#entry-tags input.tag-input', 'TestTag');
+        casper.sendKeys('#entry-tags input.tag-input', casper.page.event.key.Enter);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change published date
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#pub-date': '21 May 14 @ 23:39'
+        }, false);
+
+        this.click('a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Publish date successfully changed to 21 May 14 @ 23:39.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success', function () {
+        test.assert(true, 'notification cleared.');
+        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    });
+});
+
+CasperTest.begin('Post can be changed to static page', 8, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change to static page
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    casper.thenClick('.post-settings-menu #static-page');
+
+    var staticPageConversionText = "Successfully converted to static page.";
+    casper.waitForText(staticPageConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            '.notification-success', staticPageConversionText, 'correct static page conversion notification appears');
+    });
+
+    casper.thenClick('.post-settings-menu #static-page');
+
+    var postConversionText = 'Successfully converted to post.';
+    casper.waitForText(postConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            '.notification-success', postConversionText, 'correct post conversion notification appears');
+    });
+});
+
+CasperTest.begin('Post with tags can be changed to static page', 8, function suite(test) {
+    // Create a sample post
+    casper.thenOpen(url + 'ghost/editor/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.then(function createTestPost() {
+        casper.sendKeys('#entry-title', testPost.title);
+        casper.writeContentToCodeMirror(testPost.html);
+
+        casper.sendKeys('#entry-tags input.tag-input', 'TestTag');
+        casper.sendKeys('#entry-tags input.tag-input', casper.page.event.key.Enter);
+    });
+
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification :(');
+    });
+
+    // Begin test
+    casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+    });
+
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    // Test change to static page
+    casper.thenClick('a.post-settings');
+
+    casper.waitUntilVisible('.post-settings-menu', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    casper.thenClick('.post-settings-menu #static-page');
+
+    var staticPageConversionText = "Successfully converted to static page.";
+    casper.waitForText(staticPageConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            '.notification-success', staticPageConversionText, 'correct static page conversion notification appears');
+    });
+
+    casper.thenClick('.post-settings-menu #static-page');
+
+    var postConversionText = 'Successfully converted to post.';
+    casper.waitForText(postConversionText, function onSuccess() {
+        test.assertSelectorHasText(
+            '.notification-success', postConversionText, 'correct post conversion notification appears');
+    });
+});
+
 CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
     casper.thenOpen(url + 'ghost/content/', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');

--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -233,7 +233,7 @@ CasperTest.begin("Tag editor", 6, function suite(test) {
     });
 });
 
-CasperTest.begin("Post settings menu", 18, function suite(test) {
+CasperTest.begin("Post settings menu", 28, function suite(test) {
     casper.thenOpen(url + "ghost/editor/", function testTitleAndUrl() {
         test.assertTitle("Ghost Admin", "Ghost admin has no title");
     });
@@ -267,6 +267,16 @@ CasperTest.begin("Post settings menu", 18, function suite(test) {
         casper.thenClick(".js-publish-button");
     });
 
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success');
+
     casper.thenClick("#publish-bar a.post-settings");
 
     casper.waitUntilVisible("#publish-bar .post-settings-menu", function onSuccess() {
@@ -277,7 +287,60 @@ CasperTest.begin("Post settings menu", 18, function suite(test) {
         test.assert(true, "delete post button should be visible for saved drafts");
     });
 
+    // Test change permalink
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#url': 'new-url-editor'
+        }, false);
+
+        this.click('#publish-bar a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Permalink successfully changed to new-url-editor.');
+        casper.click('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success', function () {
+        test.assert(true, 'notification cleared.');
+        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    });
+
+    // Test change pub date
+    casper.thenClick('#publish-bar a.post-settings');
+
+    casper.waitUntilVisible('#publish-bar .post-settings-menu #pub-date', function onSuccess() {
+        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    });
+
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#pub-date': '10 May 14 @ 00:17'
+        }, false);
+
+        this.click('#publish-bar a.post-settings')
+    });
+
+    casper.waitForSelector('.notification-success', function waitForSuccess() {
+        test.assert(true, 'got success notification');
+        test.assertSelectorHasText('.notification-success', 'Publish date successfully changed to 10 May 14 @ 00:17.');
+        casper.thenClick('.notification-success a.close');
+    }, function onTimeout() {
+        test.assert(false, 'No success notification');
+    });
+
+    casper.waitWhileSelector('.notification-success');
+
     // Test Static Page conversion
+    casper.thenClick("#publish-bar a.post-settings");
+
+    casper.waitUntilVisible("#publish-bar .post-settings-menu", function onSuccess() {
+        test.assert(true, "post settings menu should be visible after clicking post-settings icon");
+    });
+
     casper.thenClick(".post-settings-menu #static-page");
 
     var staticPageConversionText = "Successfully converted to static page.";


### PR DESCRIPTION
Closes #2798
-fetch full model for active post in Backbone content preview view
-remove unnecessary type check in Models.Post.saving
-add functional tests for all post settings menu actions in editor screen
-add functional tests for all post actions in content preview
 screen for posts with and without tags
