### PR TITLE
correct settings.edit call signature for installedApps

### DIFF
--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -28,7 +28,7 @@ function saveInstalledApps(installedApps) {
     return getInstalledApps().then(function (currentInstalledApps) {
         var updatedAppsInstalled = _.uniq(installedApps.concat(currentInstalledApps));
 
-        return api.settings.edit({context: {internal: true}, key: 'installedApps'}, updatedAppsInstalled);
+        return api.settings.edit({settings: [{key: 'installedApps', value: updatedAppsInstalled}]}, {context: {internal: true}});
     });
 }
 


### PR DESCRIPTION
This is an alternative fix for the error on startup - the signature of the edit call was refactored incorrectly, this should resolve it such that the DB is successfully updated

closes #2773
- this is left over from my refactoring work
