### PR TITLE
Fix default user cover on ember settings pane

### DIFF
--- a/core/client/controllers/settings/user.js
+++ b/core/client/controllers/settings/user.js
@@ -1,10 +1,14 @@
 /*global alert */
-
 var SettingsUserController = Ember.Controller.extend({
+    coverDefault: '/shared/img/user-cover.png',
     cover: function () {
         // @TODO: add {{asset}} subdir path
-        return this.user.getWithDefault('cover', '/shared/img/user-cover.png');
-    }.property('user.cover'),
+        var cover = this.user.get('cover');
+        if (typeof cover !== 'string') {
+            cover = this.get('coverDefault');
+        }
+        return cover;
+    }.property('user.cover', 'coverDefault'),
 
     coverTitle: function () {
         return this.get('user.name') + '\'s Cover Image';


### PR DESCRIPTION
Closes #2806
- Ensures that the user's cover property is a string, otherwise uses the
  default cover.
