### PR TITLE
Clean up routes. Use new slug endpoint in admin.

### DIFF
--- a/core/clientold/views/post-settings.js
+++ b/core/clientold/views/post-settings.js
@@ -76,7 +76,7 @@
             // and then update the placeholder value.
             if (title) {
                 $.ajax({
-                    url: Ghost.paths.apiRoot + '/posts/slug/' + encodeURIComponent(title) + '/',
+                    url: Ghost.paths.apiRoot + '/slugs/post/' + encodeURIComponent(title) + '/',
                     success: function (result) {
                         $postSettingSlugEl.attr('placeholder', result);
                     }

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -11,7 +11,6 @@ apiRoutes = function (server) {
     server.get('/ghost/api/v0.1/posts/:slug([a-z-]+)', api.http(api.posts.read));
     server.put('/ghost/api/v0.1/posts/:id', api.http(api.posts.edit));
     server.del('/ghost/api/v0.1/posts/:id', api.http(api.posts.destroy));
-    server.get('/ghost/api/v0.1/posts/slug/:title', api.http(api.posts.generateSlug));
     // ## Settings
     server.get('/ghost/api/v0.1/settings/', api.http(api.settings.browse));
     server.get('/ghost/api/v0.1/settings/:key/', api.http(api.settings.read));
@@ -26,8 +25,6 @@ apiRoutes = function (server) {
     server.get('/ghost/api/v0.1/themes/', api.http(api.themes.browse));
     server.put('/ghost/api/v0.1/themes/:name', api.http(api.themes.edit));
     // ## Notifications
-    server.del('/ghost/api/v0.1/notifications/:id', api.http(api.notifications.destroy));
-    server.post('/ghost/api/v0.1/notifications/', api.http(api.notifications.add));
     server.get('/ghost/api/v0.1/notifications/', api.http(api.notifications.browse));
     server.post('/ghost/api/v0.1/notifications/', api.http(api.notifications.add));
     server.del('/ghost/api/v0.1/notifications/:id', api.http(api.notifications.destroy));


### PR DESCRIPTION
refs #2814
-removed route /posts/slug/:title due to API change
-changed admin to use new slug endpoint
-removed duplicate notifications routes
