### PR TITLE
Use new slug endpoint in ember admin

### DIFF
--- a/core/client/fixtures/init.js
+++ b/core/client/fixtures/init.js
@@ -41,7 +41,7 @@ var defineFixtures = function (status) {
     ic.ajax.defineFixture('/ghost/api/v0.1/posts/2', post(2, status));
     ic.ajax.defineFixture('/ghost/api/v0.1/posts/3', post(3, status));
     ic.ajax.defineFixture('/ghost/api/v0.1/posts/4', post(4, status));
-    ic.ajax.defineFixture('/ghost/api/v0.1/posts/slug/test%20title/', response('generated-slug', status));
+    ic.ajax.defineFixture('/ghost/api/v0.1/slugs/post/test%20title/', response('generated-slug', status));
 
     ic.ajax.defineFixture('/ghost/api/v0.1/users/me/', user(status));
     ic.ajax.defineFixture('/ghost/changepw/', response({

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -22,7 +22,13 @@ var Post = DS.Model.extend({
 
     generateSlug: function () {
         var title = this.get('title'),
-            url = this.get('ghostPaths').apiUrl('posts', 'slug', encodeURIComponent(title));
+            url;
+
+        if (!title) {
+            return;
+        }
+
+        url = this.get('ghostPaths').apiUrl('slugs', 'post', encodeURIComponent(title));
 
         return ic.ajax.request(url, {
                 type: 'GET'


### PR DESCRIPTION
Closes #2831
-use new slug endpoint in fixture
-use new slug endpoint in post model
-do not try to generate slug for zero length titles
