### PR TITLE
refreshless user logout

### DIFF
--- a/core/client/router.js
+++ b/core/client/router.js
@@ -10,6 +10,7 @@ Router.reopen({
 
 Router.map(function () {
     this.route('signin');
+    this.route('signout');
     this.route('signup');
     this.route('forgotten');
     this.route('reset', { path: '/reset/:token' });

--- a/core/client/routes/signout.js
+++ b/core/client/routes/signout.js
@@ -1,0 +1,27 @@
+import ajax from 'ghost/utils/ajax';
+import styleBody from 'ghost/mixins/style-body';
+
+var SignoutRoute = Ember.Route.extend(styleBody, {
+    classNames: ['ghost-signout'],
+
+    beforeModel: function () {
+        var self = this;
+
+        ajax({
+            url: this.get('ghostPaths').adminUrl('signout'),
+            type: 'POST',
+            headers: {
+                'X-CSRF-Token': this.get('csrf')
+            }
+        }).then(function () {
+
+            // @TODO: new CSRF token to enable logging back in w/o refreshing - see issue #2861 for details
+            self.transitionTo('signin');
+        }, function (resp) {
+            self.notifications.showAPIError(resp, 'There was a problem logging out, please try again.');
+            self.transitionTo('posts');
+        });
+    }
+});
+
+export default SignoutRoute;

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -23,7 +23,7 @@
                         <li class="divider"></li>
                         <li class="usermenu-help"><a href="http://ghost.org/forum/">Help / Support</a></li>
                         <li class="divider"></li>
-                        <li class="usermenu-signout"><a href="#">Sign Out</a></li>
+                        <li class="usermenu-signout">{{#link-to 'signout'}}Sign Out{{/link-to}}</li>
                 {{/gh-popover}}
             </li>
         </ul>

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -194,6 +194,37 @@ adminControllers = {
             res.redirect(config().paths.subdir + '/ghost/signin/');
         });
     },
+    // Route: doSignout
+    // Path: /ghost/signout/
+    // Method: POST
+    'doSignout': function (req, res) {
+        req.session.destroy();
+
+        var statusCode,
+            redirectUrl,
+            errorMessage,
+            notification = {
+            type: 'success',
+            message: 'You were successfully signed out.',
+            status: 'passive'
+        };
+
+        if (_.isUndefined(req.session)) {
+            statusCode = 200;
+            redirectUrl = config().paths.subdir + '/ghost/signin/';
+        } else {
+            notification.type = 'error';
+            notification.message = 'Unable to sign out.';
+
+            statusCode = 500;
+            errorMessage = 'There was a problem logging out. Please try again.';
+        }
+
+        return api.notifications.add(notification).then(function () {
+            res.json(statusCode, {error: errorMessage, redirect: redirectUrl});
+        });
+
+    },
     // Route: signin
     // Path: /ghost/signin/
     // Method: GET

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -36,6 +36,7 @@ adminRoutes = function (server) {
     });
 
     server.get('/ghost/signout/', admin.signout);
+    server.post('/ghost/signout/', admin.doSignout);
     server.get('/ghost/signin/', middleware.redirectToSignup, middleware.redirectToDashboard, admin.signin);
     server.post('/ghost/signin/', admin.doSignin);
     server.get('/ghost/signup/', middleware.redirectToDashboard, admin.signup);


### PR DESCRIPTION
fixes #2842
- new Ember route for signout
- new API route to allow async signout

Something worth noting is that after logging out a user won't be able to immediately log back in yet because of the issue described in #2861.
