### PR TITLE
[WIP] Send 204 response status on api delete requests

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -223,7 +223,14 @@ http = function (apiMethod) {
                                 'Content-Disposition': contentDispositionHeader()
                             });
                         }
+                        
                         // #### Success
+
+                        // Send a status of 204 and an empty response body on DELETEs
+                        if (req.method === 'DELETE') {
+                            res.send(204);
+                        }
+
                         // Send a properly formatting HTTP response containing the data with correct headers
                         res.json(result || {});
                     });

--- a/core/test/functional/routes/api/notifications_test.js
+++ b/core/test/functional/routes/api/notifications_test.js
@@ -139,19 +139,13 @@ describe('Notifications API', function () {
                     // begin delete test
                     request.del(location)
                         .set('X-CSRF-Token', csrfToken)
-                        .expect(200)
+                        .expect(204)
                         .end(function (err, res) {
                             if (err) {
                                 return done(err);
                             }
 
-                            // a delete returns a JSON object containing the notification
-                            // we just deleted.
-                            var deleteResponse = res.body;
-                            deleteResponse.notifications.should.exist;
-                            deleteResponse.notifications[0].type.should.equal(newNotification.type);
-                            deleteResponse.notifications[0].message.should.equal(newNotification.message);
-                            deleteResponse.notifications[0].status.should.equal(newNotification.status);
+                            res.body.should.be.empty;
 
                             done();
                         });

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -669,19 +669,15 @@ describe('Post API', function () {
             var deletePostId = 1;
             request.del(testUtils.API.getApiQuery('posts/' + deletePostId + '/'))
                 .set('X-CSRF-Token', csrfToken)
-                .expect(200)
+                .expect(204)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
                     }
 
-                    res.should.be.json;
-                    var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
-                    res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /' + jsonResponse.posts[0].slug + '/');
-                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-                    jsonResponse.posts[0].id.should.eql(deletePostId);
+                    res.headers['x-cache-invalidate'].should.eql('/, /page/*, /rss/, /rss/*, /tag/*, /welcome-to-ghost/');
+                    res.body.should.be.empty;
+
                     done();
                 });
         });
@@ -729,17 +725,14 @@ describe('Post API', function () {
 
                     request.del(testUtils.API.getApiQuery('posts/' + draftPost.posts[0].id + '/'))
                         .set('X-CSRF-Token', csrfToken)
-                        .expect(200)
+                        .expect(204)
                         .end(function (err, res) {
                             if (err) {
                                 return done(err);
                             }
 
-                            res.should.be.json;
-                            var jsonResponse = res.body
-                            jsonResponse.should.exist;
-                            jsonResponse.posts.should.exist;
-                            testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                            res.body.should.be.empty;
+
                             done();
                         });
                 });


### PR DESCRIPTION
Closes #2871
-send a 204 response code and an empty response body for
 HTTP API delete requests
-changes API tests to expect a 204 on deletes
