### PR TITLE
delete posts from post settings menu

### DIFF
--- a/core/client/adapters/application.js
+++ b/core/client/adapters/application.js
@@ -18,5 +18,19 @@ export default DS.RESTAdapter.extend({
         }
 
         return url;
+    },
+
+    // Override deleteRecord to disregard the response body on 2xx responses.
+    // This is currently needed because the API is returning status 200 along
+    // with the JSON object for the deleted entity and Ember expects an empty
+    // response body for successful DELETEs.
+    // Non-2xx (failure) responses will still work correctly as Ember will turn
+    // them into rejected promises.
+    deleteRecord: function () {
+        var response = this._super.apply(this, arguments);
+
+        return response.then(function () {
+            return null;
+        });
     }
 });

--- a/core/client/components/gh-modal-dialog.js
+++ b/core/client/components/gh-modal-dialog.js
@@ -18,15 +18,15 @@ var ModalDialog = Ember.Component.extend({
         return this._super();
     },
 
+    confirmaccept: 'confirmAccept',
+    confirmreject: 'confirmReject',
+
     actions: {
         closeModal: function () {
             this.sendAction();
         },
         confirm: function (type) {
-            var func = this.get('confirm.' + type + '.func');
-            if (typeof func === 'function') {
-                func();
-            }
+            this.sendAction('confirm' + type);
             this.sendAction();
         }
     },

--- a/core/client/controllers/modals/delete-all.js
+++ b/core/client/controllers/modals/delete-all.js
@@ -1,51 +1,24 @@
 /*global alert */
 
 var DeleteAllController = Ember.Controller.extend({
+    actions: {
+        confirmAccept: function () {
+            alert('Deleting everything!');
+
+            this.notifications.showSuccess('Everything has been deleted.');
+        },
+
+        confirmReject: function () {
+            return true;
+        }
+    },
+
     confirm: {
         accept: {
-            func: function () {
-                // @TODO make the below real :)
-                alert('Deleting everything!');
-                // $.ajax({
-                //     url: Ghost.paths.apiRoot + '/db/',
-                //     type: 'DELETE',
-                //     headers: {
-                //         'X-CSRF-Token': $("meta[name='csrf-param']").attr('content')
-                //     },
-                //     success: function onSuccess(response) {
-                //         if (!response) {
-                //             throw new Error('No response received from server.');
-                //         }
-                //         if (!response.message) {
-                //             throw new Error(response.detail || 'Unknown error');
-                //         }
-
-                //         Ghost.notifications.addItem({
-                //             type: 'success',
-                //             message: response.message,
-                //             status: 'passive'
-                //         });
-
-                //     },
-                //     error: function onError(response) {
-                //         var responseText = JSON.parse(response.responseText),
-                //             message = responseText && responseText.error ? responseText.error : 'unknown';
-                //         Ghost.notifications.addItem({
-                //             type: 'error',
-                //             message: ['A problem was encountered while deleting content from your blog. Error: ', message].join(''),
-                //             status: 'passive'
-                //         });
-
-                //     }
-                // });
-            },
             text: 'Delete',
             buttonClass: 'button-delete'
         },
         reject: {
-            func: function () {
-                return true;
-            },
             text: 'Cancel',
             buttonClass: 'button'
         }

--- a/core/client/controllers/modals/delete-post.js
+++ b/core/client/controllers/modals/delete-post.js
@@ -1,38 +1,28 @@
-/*global alert */
-
 var DeletePostController = Ember.Controller.extend({
+    needs: 'posts/post',
+    actions: {
+        confirmAccept: function () {
+            var self = this;
+
+            this.get('model').destroyRecord().then(function () {
+                self.notifications.showSuccess('Your post has been deleted.');
+                self.transitionToRoute('posts.index');
+            }, function () {
+                self.notifications.showError('Your post could not be deleted. Please try again.');
+            });
+
+        },
+
+        confirmReject: function () {
+            return false;
+        }
+    },
     confirm: {
         accept: {
-            func: function () {
-                // @TODO: make this real
-                alert('Deleting post');
-                // self.model.destroy({
-                //     wait: true
-                // }).then(function () {
-                //     // Redirect to content screen if deleting post from editor.
-                //     if (window.location.pathname.indexOf('editor') > -1) {
-                //         window.location = Ghost.paths.subdir + '/ghost/content/';
-                //     }
-                //     Ghost.notifications.addItem({
-                //         type: 'success',
-                //         message: 'Your post has been deleted.',
-                //         status: 'passive'
-                //     });
-                // }, function () {
-                //     Ghost.notifications.addItem({
-                //         type: 'error',
-                //         message: 'Your post could not be deleted. Please try again.',
-                //         status: 'passive'
-                //     });
-                // });
-            },
             text: 'Delete',
             buttonClass: 'button-delete'
         },
         reject: {
-            func: function () {
-                return true;
-            },
             text: 'Cancel',
             buttonClass: 'button'
         }

--- a/core/client/controllers/modals/upload.js
+++ b/core/client/controllers/modals/upload.js
@@ -1,10 +1,13 @@
 
 var UploadController = Ember.Controller.extend({
+    actions: {
+        confirmReject: function () {
+            return true;
+        }
+    },
+
     confirm: {
         reject: {
-            func: function () { // The function called on rejection
-                return true;
-            },
             buttonClass: true,
             text: 'Cancel' // The reject button text
         }

--- a/core/client/templates/editor-save-button.hbs
+++ b/core/client/templates/editor-save-button.hbs
@@ -4,7 +4,7 @@
 {{#gh-popover-button popoverName="post-save-menu" classNameBindings="open:active :options :up" title="Post Settings"}}
     <span class="hidden">Post Settings</span>
 {{/gh-popover-button}} 
-{{#gh-popover name="post-save-menu" closeOnClick="true" tagName="ul" classNames="editor-options overlay" publishTextBinding=view.publish-text draftTextBinding=view.draft-text}}
+{{#gh-popover name="post-save-menu" closeOnClick="true" tagName="ul" classNames="editor-options overlay" publishTextBinding="view.publish-text" draftTextBinding="view.draft-text"}}
     <li {{bind-attr class="controller.willPublish:active" }}>
         <a {{action "setSaveType" "publish"}} href="#">{{view.publishText}}</a>
     </li>

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -29,4 +29,4 @@
         </tbody>
     </table>
 </form>
-<a class="delete" {{action "openModal" "delete-post" post}}>Delete This Post</a>
+<a class="delete" {{action "openModal" "delete-post" this}}>Delete This Post</a>

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -223,6 +223,7 @@ http = function (apiMethod) {
                                 'Content-Disposition': contentDispositionHeader()
                             });
                         }
+
                         // #### Success
                         // Send a properly formatting HTTP response containing the data with correct headers
                         res.json(result || {});


### PR DESCRIPTION
WIP to show the behavior on deleting posts and receiving a `200` response + the object body.

Deleting a post works fine from the Content screen but if you open a post in the editor and try to delete it, it gets deleted but Ember throws an exception about calling `.set()` on an object that's already been destroyed.

(refs #2849)
