### PR TITLE
Fix Editor/:postId 404 on draft

### DIFF
--- a/core/client/routes/editor.js
+++ b/core/client/routes/editor.js
@@ -5,7 +5,17 @@ var EditorRoute = AuthenticatedRoute.extend(styleBody, {
     classNames: ['editor'],
     controllerName: 'posts.post',
     model: function (params) {
-        return this.store.find('post', params.post_id);
+        var post = this.store.getById('post', params.post_id);
+
+        if (post) {
+            return post;
+        }
+
+        return this.store.filter('post', { status: 'all' }, function (post) {
+            return post.get('id') === params.post_id;
+        }).then(function (records) {
+            return records.get('firstObject');
+        });
     }
 });
 


### PR DESCRIPTION
closes #2857
- in EditorRoute, get model from the datastore if it's there
- if page is refreshed, get model from `/posts` API with `{status: 'all'}`

This is @rjackson's fix with minor modifications.
