### PR TITLE
Close post settings popover menu after delete post

### DIFF
--- a/core/client/controllers/modals/delete-post.js
+++ b/core/client/controllers/modals/delete-post.js
@@ -1,10 +1,10 @@
 var DeletePostController = Ember.Controller.extend({
-    needs: 'posts/post',
     actions: {
         confirmAccept: function () {
             var self = this;
 
             this.get('model').destroyRecord().then(function () {
+                self.get('popover').closePopovers();
                 self.notifications.showSuccess('Your post has been deleted.');
                 self.transitionToRoute('posts.index');
             }, function () {

--- a/core/client/initializers/popover.js
+++ b/core/client/initializers/popover.js
@@ -21,5 +21,6 @@ export default {
 
         application.inject('component:gh-popover', 'popover', 'popover:service');
         application.inject('component:gh-popover-button', 'popover', 'popover:service');
+        application.inject('controller:modals.delete-post', 'popover', 'popover:service');
     }
 };


### PR DESCRIPTION
No issue
-inject popover:service into modal component delete post
 controller so popover close can be triggered as part of
 the delete action
-remove unnecessary 'needs' from the delete post controller
