### PR TITLE
Rebuild Post Settings Menu

### DIFF
--- a/core/client/components/gh-blur-input.js
+++ b/core/client/components/gh-blur-input.js
@@ -1,4 +1,4 @@
-var BlurTextField = Ember.TextField.extend({
+var BlurInput = Ember.TextField.extend({
     selectOnClick: false,
     click: function (event) {
         if (this.get('selectOnClick')) {
@@ -10,4 +10,4 @@ var BlurTextField = Ember.TextField.extend({
     }
 });
 
-export default BlurTextField;
+export default BlurInput;

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -1,9 +1,6 @@
 /* global console */
 
 var EditorControllerMixin = Ember.Mixin.create({
-    //## Computed post properties
-    isPublished: Ember.computed.equal('status', 'published'),
-    isDraft: Ember.computed.equal('status', 'draft'),
     /**
      * By default, a post will not change its publish state.
      * Only with a user-set value (via setSaveType action)

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -19,21 +19,10 @@ var Post = DS.Model.extend({
     published_at: DS.attr('moment-date'),
     published_by: DS.belongsTo('user', { async: true }),
     tags: DS.hasMany('tag', { async: true }),
-
-    generateSlug: function () {
-        var title = this.get('title'),
-            url;
-
-        if (!title) {
-            return;
-        }
-
-        url = this.get('ghostPaths').apiUrl('slugs', 'post', encodeURIComponent(title));
-
-        return ic.ajax.request(url, {
-                type: 'GET'
-            });
-    },
+    
+    //## Computed post properties
+    isPublished: Ember.computed.equal('status', 'published'),
+    isDraft: Ember.computed.equal('status', 'draft'),
 
     validate: function () {
         var validationErrors = [];

--- a/core/client/models/slug-generator.js
+++ b/core/client/models/slug-generator.js
@@ -1,0 +1,27 @@
+var SlugGenerator = Ember.Object.extend({
+    ghostPaths: null,
+    value: null,
+    toString: function () {
+        return this.get('value');
+    },
+    generateSlug: function (textToSlugify) {
+        var self = this,
+            url;
+
+        if (!textToSlugify) {
+            return Ember.RSVP.resolve('');
+        }
+
+        url = this.get('ghostPaths').apiUrl('slugs', 'post', encodeURIComponent(textToSlugify));
+
+        return ic.ajax.request(url, {
+            type: 'GET'
+        }).then(function (response) {
+            var slug = response.slugs[0].slug;
+            self.set('value', slug);
+            return slug;
+        });
+    }
+});
+
+export default SlugGenerator;

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -17,7 +17,6 @@
                     {{/if}}
                     <span class="name">{{user.name}}</span>
                 {{/gh-popover-button}}
-                {{!-- @TODO: add functionality to allow for dropdown to work --}}
                 {{#gh-popover tagName="ul" classNames="overlay" name="user-menu" closeOnClick="true"}}
                         <li class="usermenu-profile">{{#link-to "settings.user"}}Your Profile{{/link-to}}</li>
                         <li class="divider"></li>

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -6,7 +6,7 @@
                     <label for="url">URL</label>
                 </td>
                 <td class="post-setting-field">
-                    {{gh-blur-text-field class="post-setting-slug" id="url" value=newSlug action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
+                    {{gh-blur-input class="post-setting-slug" id="url" value=slugValue action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
                 </td>
             </tr>
             <tr class="post-setting">
@@ -14,7 +14,7 @@
                     <label for="pub-date">Pub Date</label>
                 </td>
                 <td class="post-setting-field">
-                    {{gh-blur-text-field class="post-setting-date" value=view.publishedAt action="updatePublishedAt" placeholder=view.datePlaceholder}}
+                    {{gh-blur-input class="post-setting-date" value=publishedAtValue action="setPublishedAt" placeholder=publishedAtPlaceholder}}
                 </td>
             </tr>
             <tr class="post-setting">

--- a/core/client/utils/date-formatting.js
+++ b/core/client/utils/date-formatting.js
@@ -1,21 +1,31 @@
 /* global moment */
-var parseDateFormats = ['DD MMM YY HH:mm',
-                        'DD MMM YYYY HH:mm',
-                        'DD/MM/YY HH:mm',
-                        'DD/MM/YYYY HH:mm',
-                        'DD-MM-YY HH:mm',
-                        'DD-MM-YYYY HH:mm',
-                        'YYYY-MM-DD HH:mm'],
+var parseDateFormats = ['DD MMM YY @ HH:mm', 'DD MMM YY HH:mm',
+                        'DD MMM YYYY @ HH:mm', 'DD MMM YYYY HH:mm',
+                        'DD/MM/YY @ HH:mm', 'DD/MM/YY HH:mm',
+                        'DD/MM/YYYY @ HH:mm', 'DD/MM/YYYY HH:mm',
+                        'DD-MM-YY @ HH:mm', 'DD-MM-YY HH:mm',
+                        'DD-MM-YYYY @ HH:mm', 'DD-MM-YYYY HH:mm',
+                        'YYYY-MM-DD @ HH:mm', 'YYYY-MM-DD HH:mm'],
     displayDateFormat = 'DD MMM YY @ HH:mm';
+
+/**
+ * Add missing timestamps
+ */
+var verifyTimeStamp = function (dateString) {
+    if (dateString && !dateString.slice(-5).match(/\d+:\d\d/)) {
+        dateString += ' 12:00';
+    }
+    return dateString;
+};
 
 //Parses a string to a Moment
 var parseDateString = function (value) {
-    return value ? moment(value, parseDateFormats) : '';
+    return value ? moment(verifyTimeStamp(value), parseDateFormats, true) : undefined;
 };
 
 //Formats a Date or Moment
 var formatDate = function (value) {
-    return value ? moment(value).format(displayDateFormat) : '';
+    return verifyTimeStamp(value ? moment(value).format(displayDateFormat) : '');
 };
 
 export {parseDateString, formatDate};


### PR DESCRIPTION
Closes #2845.
Ref #1351.
- Refactored `PostSettingsMenuController` to appropriately set and display
  slug and publish date and their placeholders.
- Removed api spam on title change by putting `slugPlaceholder` generation
  inside of an `Ember.run.debounce` call.
- Renamed `gh-blur-text-field` to `gh-blur-input`
- Created `SlugGenerator` class to abstract slug generation.
- Added `timestampVerification` function to `utils/date-formatting`
- `utils/date-formatting` now uses `strict` parsing of dates
- Added more acceptable date formats to accommodate strict parsing
- Moved `isDraft` and `isPublished` computed properties from
  `EditorController` to `PostModel`
