### PR TITLE
Fix HTML preview rendering on the main screen

### DIFF
--- a/core/client/templates/posts/post.hbs
+++ b/core/client/templates/posts/post.hbs
@@ -4,8 +4,8 @@
 
   <section class="content-preview-content">
       <div class="wrapper">
-          <h1>{{title}}</h1>
-          {{gh-format-markdown markdown}}
+          <h1>{{{title}}}</h1>
+          {{{html}}}
       </div>
   </section>
 


### PR DESCRIPTION
closes #2904
- The `posts/post` template now takes its HTML from the post model instead of using the editor's markdown component
