### PR TITLE
Handle invalid post ids in editor route

### DIFF
--- a/core/client/routes/editor.js
+++ b/core/client/routes/editor.js
@@ -5,16 +5,32 @@ var EditorRoute = AuthenticatedRoute.extend(styleBody, {
     classNames: ['editor'],
 
     model: function (params) {
-        var post = this.store.getById('post', params.post_id);
+        var self = this,
+            post,
+            postId;
+
+        postId = Number(params.post_id);
+
+        if (!Number.isInteger(postId) || !Number.isFinite(postId) || postId <= 0) {
+            this.transitionTo('posts.index');
+        }
+
+        post = this.store.getById('post', postId);
 
         if (post) {
             return post;
         }
 
         return this.store.filter('post', { status: 'all', staticPages: 'all' }, function (post) {
-            return post.get('id') === params.post_id;
+            return post.get('id') === postId;
         }).then(function (records) {
-            return records.get('firstObject');
+            var post = records.get('firstObject');
+
+            if (post) {
+                return post;
+            }
+
+            return self.transitionTo('posts.index');
         });
     }
 });


### PR DESCRIPTION
This does two things:
1. Fail fast on requests to the `editor` route for post ids that are clearly invalid.  Doing this prevents making a network request and pulling down all posts for no reason.
2. Transitions back to the `posts.index` route for post ids that do not exist instead of returning an invalid model.
