### PR TITLE
Adding support for disabling or setting custom x-powered-by header.

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -240,7 +240,8 @@ function init(server) {
         );
     }).then(function () {
         var adminHbs = hbs.create(),
-            deferred = when.defer();
+            deferred = when.defer(),
+            customPoweredBy = config().customPoweredBy;
 
         // Output necessary notifications on init
         initNotifications();
@@ -252,6 +253,21 @@ function init(server) {
         // enabled gzip compression by default
         if (config().server.compress !== false) {
             server.use(compress());
+        }
+
+        // set a custom x-powered-by header
+        if (customPoweredBy !== undefined) {
+            if (customPoweredBy === false) {
+                server.disable('x-powered-by');
+            } else {
+                server.use(function (req, res, next) {
+                    if (customPoweredBy === true) {
+                        customPoweredBy = 'Ghost';
+                    }
+                    res.header('x-powered-by', customPoweredBy);
+                    next();
+                });
+            }
         }
 
         // ## View engine


### PR DESCRIPTION
- If config property customPoweredBy is false, disables the x-powered-by header.
- If property customPoweredBy is true, sets the value to 'Ghost'.
- If property is undefied, does nothing and lets express set the header.
- If property is any other value, sets the value to config value.
