### PR TITLE
Add .gitignores for vim, TernJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,18 @@ bower_components
 projectFilesBackup
 
 .DS_Store
+
+# vim-related
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+.vimrc
 *~
-*.swp
-*.swo
+
+# TernJS
+.tern-project
 
 # Ghost DB file
 *.db


### PR DESCRIPTION
- vim-related ignores from https://github.com/github/gitignore/blob/master/Global/vim.gitignore
- `.vimrc` and `.tern-project` ignores are my own additions
