### PR TITLE
Add tabindex to CodeMirror

### DIFF
--- a/core/client/components/gh-codemirror.js
+++ b/core/client/components/gh-codemirror.js
@@ -19,7 +19,8 @@ var Codemirror = Ember.TextArea.extend({
     initCodemirror: function () {
         // create codemirror
         this.codemirror = CodeMirror.fromTextArea(this.get('element'), {
-            lineWrapping: true
+            lineWrapping: true,
+            tabindex: 2
         });
         this.codemirror.component = this; // save reference to this
 


### PR DESCRIPTION
Closes #2913
- CodeMirror gets a tabindex of 2, meaning it will be the second choice after the title.
