### PR TITLE
Add transition to editor/:id upon saving new post

### DIFF
--- a/core/client/controllers/editor/new.js
+++ b/core/client/controllers/editor/new.js
@@ -1,5 +1,20 @@
 import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
 
-var EditorNewController = Ember.ObjectController.extend(EditorControllerMixin);
+var EditorNewController = Ember.ObjectController.extend(EditorControllerMixin, {
+    actions: {
+        /**
+          * Redirect to editor after the first save
+          */
+        save: function () {
+            var self = this;
+            this._super().then(function (model) {
+                if (model.get('id')) {
+                    self.transitionTo('editor.edit', model);
+                }
+                return model;
+            });
+        }
+    }
+});
 
 export default EditorNewController;

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -22,10 +22,10 @@ var EditorControllerMixin = Ember.Mixin.create({
                 self = this;
 
             this.set('status', status);
-            this.get('model').save().then(function () {
-                console.log('saved');
+            return this.get('model').save().then(function (model) {
                 self.notifications.showSuccess('Post status saved as <strong>' +
-                    self.get('status') + '</strong>.');
+                    model.get('status') + '</strong>.');
+                return model;
             }, this.notifications.showErrors);
         },
 


### PR DESCRIPTION
Closes #2860
- Editor save action's promise now returns the model after saving it
- NewController will transition to EditorController upon first successful
  save
