### PR TITLE
Convert support links from forum to new support site

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are **two** main ways to get started with Ghost, take care to use the meth
 
 If you just want to get a Ghost blog running in the fastest time possible, this method is for you.
 
-For detailed instructions for various platforms visit the [Ghost Installation Guide](http://docs.ghost.org/installation/). If you get stuck, help is available on [our forum](http://ghost.org/forum/).
+For detailed instructions for various platforms visit the [Ghost Installation Guide](http://docs.ghost.org/installation/). If you get stuck, help is available on [our support site](http://support.ghost.org/).
 
 1. Install [Node.js](http://nodejs.org) - Ghost requires **Node v0.10.x**
 1. Download the latest Ghost package from [Ghost.org](http://ghost.org/download). 

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -21,7 +21,7 @@
                 {{#gh-popover tagName="ul" classNames="overlay" name="user-menu" closeOnClick="true"}}
                         <li class="usermenu-profile">{{#link-to "settings.user"}}Your Profile{{/link-to}}</li>
                         <li class="divider"></li>
-                        <li class="usermenu-help"><a href="http://ghost.org/forum/">Help / Support</a></li>
+                        <li class="usermenu-help"><a href="http://support.ghost.org/">Help / Support</a></li>
                         <li class="divider"></li>
                         <li class="usermenu-signout">{{#link-to 'signout'}}Sign Out{{/link-to}}</li>
                 {{/gh-popover}}

--- a/core/server/views/partials/navbar.hbs
+++ b/core/server/views/partials/navbar.hbs
@@ -16,7 +16,7 @@
                 <ul class="overlay">
                     <li class="usermenu-profile"><a href="{{admin_url}}/settings/user/">Your Profile</a></li>
                     <li class="divider"></li>
-                    <li class="usermenu-help"><a href="http://ghost.org/forum/">Help / Support</a></li>
+                    <li class="usermenu-help"><a href="http://support.ghost.org/">Help / Support</a></li>
                     <li class="divider"></li>
                     <li class="usermenu-signout"><a href="{{admin_url}}/signout/">Sign Out</a></li>
                 </ul>

--- a/core/test/functional/admin/content_test.js
+++ b/core/test/functional/admin/content_test.js
@@ -762,7 +762,7 @@ CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
 
         test.assertExists('#usermenu li.usermenu-help a', 'Help menu item exists');
         test.assertSelectorHasText('#usermenu li.usermenu-help a', 'Help / Support', 'Help menu item has correct text');
-        test.assertEquals(this.getElementAttribute('li.usermenu-help a', 'href'), 'http://ghost.org/forum/', 'Help href is correct');
+        test.assertEquals(this.getElementAttribute('li.usermenu-help a', 'href'), 'http://support.ghost.org/', 'Help href is correct');
 
         test.assertExists('#usermenu li.usermenu-signout a', 'Sign Out menu item exists');
         test.assertSelectorHasText('#usermenu li.usermenu-signout a', 'Sign Out', 'Sign Out menu item has correct text');

--- a/core/test/functional/admin/editor_test.js
+++ b/core/test/functional/admin/editor_test.js
@@ -562,7 +562,7 @@ CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
 
         test.assertExists('#usermenu li.usermenu-help a', 'Help menu item exists');
         test.assertSelectorHasText('#usermenu li.usermenu-help a', 'Help / Support', 'Help menu item has correct text');
-        test.assertEquals(this.getElementAttribute('#usermenu li.usermenu-help a', 'href'), 'http://ghost.org/forum/', 'Help href is correct');
+        test.assertEquals(this.getElementAttribute('#usermenu li.usermenu-help a', 'href'), 'http://support.ghost.org/', 'Help href is correct');
 
         test.assertExists('#usermenu li.usermenu-signout a', 'Sign Out menu item exists');
         test.assertSelectorHasText('#usermenu li.usermenu-signout a', 'Sign Out', 'Sign Out menu item has correct text');

--- a/core/test/functional/admin/settings_test.js
+++ b/core/test/functional/admin/settings_test.js
@@ -406,7 +406,7 @@ CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
 
         test.assertExists('#usermenu li.usermenu-help a', 'Help menu item exists');
         test.assertSelectorHasText('#usermenu li.usermenu-help a', 'Help / Support', 'Help menu item has correct text');
-        test.assertEquals(this.getElementAttribute('#usermenu li.usermenu-help a', 'href'), 'http://ghost.org/forum/',
+        test.assertEquals(this.getElementAttribute('#usermenu li.usermenu-help a', 'href'), 'http://support.ghost.org/',
             'Help href is correct');
 
         test.assertExists('#usermenu li.usermenu-signout a', 'Sign Out menu item exists');


### PR DESCRIPTION
Since we've launched support.ghost.org - people should go there as a starting point for any assistance rather than directly to the forum.
