### PR TITLE
Fix serializing/deserializing Tags on save from the Editor

### DIFF
--- a/core/client/serializers/post.js
+++ b/core/client/serializers/post.js
@@ -1,0 +1,17 @@
+import ApplicationSerializer from 'ghost/serializers/application';
+
+var PostSerializer = ApplicationSerializer.extend({
+    serializeHasMany: function (record, json, relationship) {
+        var key = relationship.key;
+
+        if (key === 'tags') {
+            json[key] = Ember.get(record, key).map(function (tag) {
+                return tag.serialize({ includeId: true });
+            });
+        } else {
+            this._super.apply(this, arguments);
+        }
+    }
+});
+
+export default PostSerializer;


### PR DESCRIPTION
closes #2947
- make a PostSerializer to embed the tags objects in the posts POST/PUT request
- on editor save, clear out tags from the post and data store that have `id: null`

There's no easy or obvious way in Ember Data to update the client-generated tags once they return from the server with the id. I tried for hours with a Tag serializer before giving up. Instead, on return from the server, I allow the saved tags to attach themselves to the post, and delete the otherwise identical client-generated tags. The Editor PR will also delete unsaved client-generated tasks on transition away from the editor.
