### PR TITLE
Transition user to original destination on login

### DIFF
--- a/core/client/routes/authenticated.js
+++ b/core/client/routes/authenticated.js
@@ -1,18 +1,22 @@
 var AuthenticatedRoute = Ember.Route.extend({
-    beforeModel: function () {
+    beforeModel: function (transition) {
         var user = this.container.lookup('user:current');
 
         if (!user || !user.get('isSignedIn')) {
-            this.notifications.showError('Please sign in');
-
-            this.transitionTo('signin');
+            this.redirectToSignin(transition);
         }
     },
-
+    redirectToSignin: function (transition) {
+        this.notifications.showError('Please sign in');
+        if (transition) {
+            this.controllerFor('application').set('loginTransition', transition);
+        }
+        this.transitionTo('signin');
+    },
     actions: {
         error: function (error) {
             if (error.jqXHR && error.jqXHR.status === 401) {
-                this.transitionTo('signin');
+                this.redirectToSignin();
             }
         }
     }


### PR DESCRIPTION
Closes #2943
- `AuthenticatedRoute` now stores the user's original destination on the
  `ApplicationController`.
- The `SignIn` route's `login` action checks if the
  `originalUserDestination` property is set on the
  `ApplicationController`, and if so, retries that transition after a
  successful login.

I definitely jshint'd this before PRing. Go me.
