### PR TITLE
Change `posts`, `post`, and `signout` routes to be `AuthenticatedRoute`s

### DIFF
--- a/core/client/routes/posts/index.js
+++ b/core/client/routes/posts/index.js
@@ -1,4 +1,6 @@
-var PostsIndexRoute = Ember.Route.extend({
+import AuthenticatedRoute from 'ghost/routes/authenticated';
+
+var PostsIndexRoute = AuthenticatedRoute.extend({
     // redirect to first post subroute
     redirect: function () {
         var firstPost = (this.modelFor('posts') || []).get('firstObject');

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -1,4 +1,6 @@
-var PostsPostRoute = Ember.Route.extend({
+import AuthenticatedRoute from 'ghost/routes/authenticated';
+
+var PostsPostRoute = AuthenticatedRoute.extend({
     model: function (params) {
         var post = this.modelFor('posts').findBy('id', params.post_id);
 

--- a/core/client/routes/signout.js
+++ b/core/client/routes/signout.js
@@ -1,7 +1,8 @@
 import ajax from 'ghost/utils/ajax';
 import styleBody from 'ghost/mixins/style-body';
+import AuthenticatedRoute from 'ghost/routes/authenticated';
 
-var SignoutRoute = Ember.Route.extend(styleBody, {
+var SignoutRoute = AuthenticatedRoute.extend(styleBody, {
     classNames: ['ghost-signout'],
 
     beforeModel: function () {


### PR DESCRIPTION
No issue.
The following is a list of routes which are _not_ authenticated after this PR
- placeholder routes: `editor` and `content`
- `application`
- password routes: `forgotten`, `reset`, `signin`, `signup`
