### PR TITLE
Label 'for' attribute value literal have no delimiter.

### DIFF
--- a/core/client/templates/settings/user.hbs
+++ b/core/client/templates/settings/user.hbs
@@ -34,7 +34,7 @@
         <fieldset class="user-details-bottom">
 
             <div class="form-group">
-                <label for"user-email">Email</label>
+                <label for="user-email">Email</label>
                 {{input type="email" value=user.email id="user-email" placeholder="Email Address" autocapitalize="off" autocorrect="off"}}
                 <p>Used for notifications</p>
             </div>

--- a/core/clientold/tpl/settings/user-profile.hbs
+++ b/core/clientold/tpl/settings/user-profile.hbs
@@ -34,7 +34,7 @@
         <fieldset class="user-details-bottom">
 
             <div class="form-group">
-                <label for"user-email">Email</label>
+                <label for="user-email">Email</label>
                 <input type="email" value="{{email}}" id="user-email" placeholder="Email Address" autocapitalize="off" autocorrect="off" />
                 <p>Used for notifications</p>
             </div>


### PR DESCRIPTION
Added equals delimiter between 'for' and attribute value literal.

Closes #2954
