### PR TITLE
Indirectly couple editor markdown and post's actual markdown

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -1,6 +1,7 @@
 /* global moment */
 import {parseDateString, formatDate} from 'ghost/utils/date-formatting';
 import SlugGenerator from 'ghost/models/slug-generator';
+import boundOneWay from 'ghost/utils/bound-one-way';
 
 var PostSettingsMenuController = Ember.ObjectController.extend({
     isStaticPage: function (key, val) {
@@ -29,21 +30,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         }
         return formatDate(moment());
     }.property('publishedAtValue'),
+    publishedAtValue: boundOneWay('published_at', formatDate),
 
-    publishedAtValue: function (key, value) {
-        if (arguments.length > 1) {
-            return value;
-        }
-        return formatDate(this.get('published_at'));
-    }.property('published_at'),
-
-    slugValue: function (key, value) {
-        if (arguments.length > 1) {
-            return value;
-        }
-        return this.get('slug');
-    }.property('slug'),
-
+    slugValue: boundOneWay('slug'),
     //Lazy load the slug generator for slugPlaceholder
     slugGenerator: Ember.computed(function () {
         return SlugGenerator.create({ghostPaths: this.get('ghostPaths')});

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -1,4 +1,5 @@
 /* global console */
+import boundOneWay from 'ghost/utils/bound-one-way';
 
 var EditorControllerMixin = Ember.Mixin.create({
     /**
@@ -6,12 +7,8 @@ var EditorControllerMixin = Ember.Mixin.create({
      * Only with a user-set value (via setSaveType action)
      * can the post's status change.
      */
-    willPublish: function (key, value) {
-        if (arguments.length > 1) {
-            return value;
-        }
-        return this.get('isPublished');
-    }.property('isPublished'),
+    willPublish: boundOneWay('isPublished'),
+    markdown: Ember.computed.oneWay('model.markdown'),
 
     // remove client-generated tags, which have `id: null`.
     // Ember Data won't recognize/update them automatically
@@ -23,13 +20,14 @@ var EditorControllerMixin = Ember.Mixin.create({
         tags.removeObjects(oldTags);
         oldTags.invoke('deleteRecord');
     },
-
     actions: {
         save: function () {
             var status = this.get('willPublish') ? 'published' : 'draft',
                 self = this;
 
             this.set('status', status);
+            //Update with content changes
+            this.set('model.markdown', this.get('markdown'));
             return this.get('model').save().then(function (model) {
                 self.updateTags();
 

--- a/core/client/utils/bound-one-way.js
+++ b/core/client/utils/bound-one-way.js
@@ -1,0 +1,20 @@
+/**
+ * Defines a property similarly to `Ember.computed.oneway`,
+ * save that while a `oneway` loses its binding upon being set,
+ * the `BoundOneWay` will continue to listen for upstream changes.
+ *
+ * This is an ideal tool for working with values inside of {{input}}
+ * elements.
+ * @param transform: a function to transform the **upstream** value.
+ */
+var BoundOneWay = function (upstream, transform) {
+    if (typeof transform !== 'function') {
+        //default to the identity function
+        transform = function (value) { return value; };
+    }
+    return function (key, value) {
+        return arguments.length > 1 ? value : transform(this.get(upstream));
+    }.property(upstream);
+};
+
+export default BoundOneWay;


### PR DESCRIPTION
Closes #2958
- Created `boundOneWay` util to extract common pattern of having a oneWay property that doesn't break its binding after being set
- Changed `EditorControllerMixin.willPublish`,  `PostSettingsMenuController.publishedAtValue` and `.slugValue` to use the new `boundOneWay` util
- Added `markdown` property to `EditorControllerMixin`
- Updated editor's `save` action to set the model's markdown to the editor's markdown.
