### PR TITLE
Fix trailing slashes output app-wide

### DIFF
--- a/core/client/initializers/trailing-history.js
+++ b/core/client/initializers/trailing-history.js
@@ -1,14 +1,8 @@
 /*global Ember */
 
 var trailingHistory = Ember.HistoryLocation.extend({
-    setURL: function (path) {
-        var state = this.getState();
-        path = this.formatURL(path);
-        path = path.replace(/\/?$/, '/');
-
-        if (state && state.path !== path) {
-            this.pushState(path);
-        }
+    formatURL: function () {
+        return this._super.apply(this, arguments).replace(/\/?$/, '/');
     }
 });
 


### PR DESCRIPTION
closes #2963, closes #2964
- override Ember's `HistoryLocation.formatURL`
- remove overridden `HistoryLocation.setURL`

all thanks to @jgwhite for the `formatURL` Ember code reference.
