### PR TITLE
Implement featured post / page

### DIFF
--- a/core/client/controllers/posts/post.js
+++ b/core/client/controllers/posts/post.js
@@ -11,7 +11,7 @@ var PostController = Ember.ObjectController.extend({
 
             this.get('model').save().then(function () {
                 self.notifications.showSuccess('Post successfully marked as ' + (featured ? 'featured' : 'not featured') + '.');
-            }, function() {
+            }, function () {
                 self.notifications.showError('An error occured while saving the post.');
             });
         }

--- a/core/client/controllers/posts/post.js
+++ b/core/client/controllers/posts/post.js
@@ -1,11 +1,19 @@
 var PostController = Ember.ObjectController.extend({
     isPublished: Ember.computed.equal('status', 'published'),
+    classNameBindings: ['featured'],
 
     actions: {
         toggleFeatured: function () {
-            this.set('featured', !this.get('featured'));
+            var featured = !this.get('featured'),
+                self = this;
 
-            this.get('model').save();
+            this.set('featured', featured);
+
+            this.get('model').save().then(function () {
+                self.notifications.showSuccess('Post successfully marked as ' + (featured ? 'featured' : 'not featured') + '.');
+            }, function() {
+                self.notifications.showError('An error occured while saving the post.');
+            });
         }
     }
 });

--- a/core/client/templates/posts.hbs
+++ b/core/client/templates/posts.hbs
@@ -9,7 +9,6 @@
         {{#view "content-list-content-view" tagName="section"}}
             <ol class="posts-list">
                 {{#each itemController="posts/post" itemView="post-item-view" itemTagName="li"}}
-                    {{!-- @TODO: Restore functionality where 'featured' and 'page' classes are added for proper posts --}}
                     {{#link-to "posts.post" this class="permalink" title="Edit this post"}}
                         <h3 class="entry-title">{{title}}</h3>
                         <section class="entry-meta">

--- a/core/client/views/post-item-view.js
+++ b/core/client/views/post-item-view.js
@@ -1,6 +1,14 @@
 import itemView from 'ghost/views/item-view';
 
 var PostItemView = itemView.extend({
+    classNameBindings: ['isFeatured'],
+
+    isFeatured: function () {
+        if (this.get('controller.model.featured')) {
+            return 'featured';
+        }
+    }.property('controller.model.featured'),
+
     openEditor: function () {
         this.get('controller').send('openEditor', this.get('controller.model'));  // send action to handle transition to editor route
     }.on('doubleClick')

--- a/core/client/views/post-item-view.js
+++ b/core/client/views/post-item-view.js
@@ -1,13 +1,19 @@
 import itemView from 'ghost/views/item-view';
 
 var PostItemView = itemView.extend({
-    classNameBindings: ['isFeatured'],
+    classNameBindings: ['isFeatured', 'isPage'],
 
     isFeatured: function () {
         if (this.get('controller.model.featured')) {
             return 'featured';
         }
     }.property('controller.model.featured'),
+
+    isPage: function () {
+        if (this.get('controller.model.page')) {
+            return 'page';
+        }
+    }.property('controller.model.page'),
 
     openEditor: function () {
         this.get('controller').send('openEditor', this.get('controller.model'));  // send action to handle transition to editor route


### PR DESCRIPTION
These two commits implement the featured posts functionality in the ember content view and page toggling.

@PaulAdamDavis: I think the `page` class needs to be adjusted in Ghost-UI as it now appears on the `li` instead of the `a` element (which works for `featured` but not for `page`)
