### PR TITLE
Fix csrfSecret handling

### DIFF
--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -23,6 +23,14 @@ var SigninRoute = Ember.Route.extend(styleBody, {
                     headers: {'X-CSRF-Token': this.get('csrf')},
                     data: data
                 }).then(function (response) {
+                    // once the email and password are pulled from the controller
+                    // they need to be cleared, or they will reappear next time the signin
+                    // page is visited
+                    controller.setProperties({
+                        email: '',
+                        password: ''
+                    });
+
                     self.store.pushPayload({users: [response.userData]});
                     return self.store.find('user', response.userData.id);
                 }).then(function (user) {

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -254,11 +254,11 @@ adminControllers = {
             loginSecurity.push({ip: remoteAddress, time: currentTime});
             api.users.check({email: req.body.email, pw: req.body.password}).then(function (user) {
                 // Carry over the csrf secret
-                var existingSecret = req.session._csrfSecret;
+                var existingSecret = req.session.csrfSecret;
 
                 req.session.regenerate(function (err) {
                     if (!err) {
-                        req.session._csrfSecret = existingSecret;
+                        req.session.csrfSecret = existingSecret;
 
                         req.session.user = user.id;
                         req.session.userData = user.attributes;
@@ -339,13 +339,13 @@ adminControllers = {
                 });
 
                 // Carry over the csrf secret
-                existingSecret = req.session._csrfSecret;
+                existingSecret = req.session.csrfSecret;
                 req.session.regenerate(function (err) {
                     if (err) {
                         return next(err);
                     }
 
-                    req.session._csrfSecret = existingSecret;
+                    req.session.csrfSecret = existingSecret;
 
                     if (req.session.user === undefined) {
                         req.session.user = user.id;


### PR DESCRIPTION
Closes #2974
-use req.session.csrfSecret instead of _csrfSecret.
-clear username and password properties from the signin controller.
