### PR TITLE
Lazy load default settings

### DIFF
--- a/core/server/data/versioning/index.js
+++ b/core/server/data/versioning/index.js
@@ -13,9 +13,7 @@ var _               = require('lodash'),
 function getDefaultDatabaseVersion() {
     if (!defaultDatabaseVersion) {
         // This be the current version according to the software
-        defaultDatabaseVersion = _.find(defaultSettings.core, function (setting) {
-            return setting.key === 'databaseVersion';
-        }).defaultValue;
+        defaultDatabaseVersion = defaultSettings.core.databaseVersion.defaultValue;
     }
 
     return defaultDatabaseVersion;

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -216,9 +216,6 @@ function init(server) {
         // Initialise the models
         return models.init();
     }).then(function () {
-        // Populate any missing default settings
-        return models.Settings.populateDefaults();
-    }).then(function () {
         // Initialize the settings cache
         return api.init();
     }).then(function () {


### PR DESCRIPTION
Closes #2061
- Lazy load the defaultSettings value in Settings model
- Populate individual defaults before read/edit
- Populate all defaults before first browse call
- Remove populateDefaults calls from init code
