### PR TITLE
Fix removeObserver for title property

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -122,7 +122,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 self.set('slug', serverSlug);
 
                 if (self.hasObserverFor('title')) {
-                    self.removeObserver('title', this, 'titleObserver');
+                    self.removeObserver('title', self, 'titleObserver');
                 }
 
                 // If this is a new post.  Don't save the model.  Defer the save


### PR DESCRIPTION
Just corrects a this/self bug causing the observer to not be removed.
