### PR TITLE
Show concise casper logs in Travis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -609,7 +609,7 @@ var path           = require('path'),
                 options = ['host', 'noPort', 'port', 'email', 'password'],
                 args = ['test']
                     .concat(grunt.option('target') || ['admin/', 'frontend/'])
-                    .concat(['--includes=base.js', '--verbose', '--log-level=debug', '--port=2369']);
+                    .concat(['--includes=base.js', '--log-level=debug', '--port=2369']);
 
             // Forward parameters from grunt to casperjs
             _.each(options, function processOption(option) {
@@ -622,8 +622,11 @@ var path           = require('path'),
                 args.push('--fail-fast');
             }
 
-            if (grunt.option('concise')) {
+            // Show concise logs in Travis as ours are getting too long
+            if (grunt.option('concise') || process.env.TRAVIS) {
                 args.push('--concise');
+            } else {
+                args.push('--verbose');
             }
 
             grunt.util.spawn({

--- a/core/test/functional/admin/login_test.js
+++ b/core/test/functional/admin/login_test.js
@@ -20,10 +20,10 @@ CasperTest.begin('Ensure a User is Registered', 2, function suite(test) {
     casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
         test.assertSelectorHasText('.notification-error', 'already registered');
         // If the previous assert succeeds, then we should skip the next check and just pass.
-        casper.echo('Already registered!');
+        casper.echoConcise('Already registered!');
     }, function onTimeout() {
         test.assertUrlMatch(/\/ghost\/$/, 'If we\'re not already registered, we should be logged in.');
-        casper.echo('Successfully registered.');
+        casper.echoConcise('Successfully registered.');
     }, 2000);
 
     casper.thenOpen(url + 'logout/', function then() {
@@ -41,7 +41,7 @@ CasperTest.begin("Ghost admin will load login page", 3, function suite(test) {
                 return document.querySelector(selector).getAttribute('href');
             }, '.forgotten-password');
 
-            casper.echo('LINK' + link);
+            casper.echoConcise('LINK' + link);
             test.assert(link === '/ghost/forgotten/', 'Has correct forgotten password link');
         });
     });

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -83,18 +83,24 @@ casper.failOnTimeout = function (test, message) {
     };
 };
 
+casper.echoConcise = function (message, style) {
+    if (!casper.cli.options.concise) {
+        casper.echo(message, style);
+    }
+}
+
 // ## Debugging
 // output all errors to the console
 casper.on('remote.message', function (msg) {
-    casper.echo('GOT CONSOLE LOG: ' + msg);
+    casper.echoConcise('GOT CONSOLE LOG: ' + msg);
 });
 
 casper.on('error', function (msg) {
-    casper.echo('GOT ERROR, ' + msg);
+    casper.echoConcise('GOT ERROR, ' + msg);
 });
 
 casper.on("page.error", function (msg) {
-    this.echo("GOT PAGE ERROR: " + msg, "ERROR");
+    casper.echoConcise("GOT PAGE ERROR: " + msg, "ERROR");
 });
 
 casper.captureScreenshot = function (filename, debugOnly) {
@@ -202,9 +208,9 @@ CasperTest.Routines = (function () {
             var errorText = casper.evaluate(function () {
                 return document.querySelector('.notification-error').innerText;
             });
-            this.echo('It appears as though a user is already registered. Error text: ' + errorText);
+            casper.echoConcise('It appears as though a user is already registered. Error text: ' + errorText);
         }, function onTimeout() {
-            this.echo('It appears as though a user was not already registered.');
+            casper.echoConcise('It appears as though a user was not already registered.');
         }, 2000);
     }
 


### PR DESCRIPTION
- Casper logs have gotten too long and no longer display completely
- Implements custom casper.echoConcise which takes account of the concise flag
