### PR TITLE
Fix deletion of Post Model in Editor and Content screens

### DIFF
--- a/core/client/controllers/modals/delete-post.js
+++ b/core/client/controllers/modals/delete-post.js
@@ -1,9 +1,13 @@
 var DeletePostController = Ember.Controller.extend({
     actions: {
         confirmAccept: function () {
-            var self = this;
+            var self = this,
+                model = this.get('model');
 
-            this.get('model').destroyRecord().then(function () {
+            // definitely want to clear the data store and post of any unsaved, client-generated tags
+            model.updateTags();
+
+            model.destroyRecord().then(function () {
                 self.get('popover').closePopovers();
                 self.notifications.showSuccess('Your post has been deleted.');
                 self.transitionToRoute('posts.index');

--- a/core/client/controllers/modals/leave-editor.js
+++ b/core/client/controllers/modals/leave-editor.js
@@ -20,7 +20,7 @@ var LeaveEditorController = Ember.Controller.extend({
             }
 
             // definitely want to clear the data store and post of any unsaved, client-generated tags
-            editorController.updateTags();
+            model.updateTags();
 
             if (model.get('isNew')) {
                 // the user doesn't want to save the new, unsaved post, so delete it.

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -106,16 +106,6 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             '==============================';
     },
 
-    // remove client-generated tags, which have `id: null`.
-    // Ember Data won't recognize/update them automatically
-    // when returned from the server with ids.
-    updateTags: function () {
-        var tags = this.get('model.tags'),
-            oldTags = tags.filterBy('id', null);
-
-        tags.removeObjects(oldTags);
-        oldTags.invoke('deleteRecord');
-    },
     actions: {
         save: function () {
             var status = this.get('willPublish') ? 'published' : 'draft',
@@ -126,7 +116,7 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
             this.set('status', status);
             return this.get('model').save().then(function (model) {
-                self.updateTags();
+                model.updateTags();
                 // `updateTags` triggers `isDirty => true`.
                 // for a saved model it would otherwise be false.
                 self.set('isDirty', false);

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -34,7 +34,18 @@ var Post = DS.Model.extend({
         }
 
         return validationErrors;
-    }.property('title')
+    }.property('title'),
+
+    // remove client-generated tags, which have `id: null`.
+    // Ember Data won't recognize/update them automatically
+    // when returned from the server with ids.
+    updateTags: function () {
+        var tags = this.get('tags'),
+        oldTags = tags.filterBy('id', null);
+
+        tags.removeObjects(oldTags);
+        oldTags.invoke('deleteRecord');
+    }
 });
 
 export default Post;

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -30,8 +30,11 @@ var ApplicationRoute = Ember.Route.extend({
             // so we're skipping asserting if one exists
             if (this.controllerFor(modalName, true)) {
                 this.controllerFor(modalName).set('model', model);
-                this.controllerFor(modalName).set('imageType', type);
-                this.controllerFor(modalName).set('src', model.get(type));
+
+                if (type) {
+                    this.controllerFor(modalName).set('imageType', type);
+                    this.controllerFor(modalName).set('src', model.get(type));
+                }
             }
             return this.render(modalName, {
                 into: 'application',

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -57,12 +57,17 @@ var EditorEditRoute = AuthenticatedRoute.extend(styleBody, {
 
                 model = controller.get('model'),
                 isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted');
+                isDeleted = model.get('isDeleted'),
+                modelIsDirty = model.get('isDirty');
 
             // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. in that case  we can probably just transition
-            // now and have the server return the record, thereby updating it
-            if (!(isDeleted && isSaving) && isDirty) {
+            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
+            // the record has already been deleted and the deletion persisted.
+            //
+            // in either case  we can probably just transition now.
+            // in the former case the server will return the record, thereby updating it.
+            // @TODO: this will break if the model fails server-side validation.
+            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
                 transition.abort();
                 this.send('openModal', 'leave-editor', [controller, transition]);
                 return;

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -24,12 +24,17 @@ var EditorNewRoute = AuthenticatedRoute.extend(styleBody, {
                 model = controller.get('model'),
                 isNew = model.get('isNew'),
                 isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted');
+                isDeleted = model.get('isDeleted'),
+                modelIsDirty = model.get('isDirty');
 
             // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. in that case  we can probably just transition
-            // now and have the server return the record, thereby updating it
-            if (!(isDeleted && isSaving) && isDirty) {
+            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
+            // the record has already been deleted and the deletion persisted.
+            //
+            // in either case  we can probably just transition now.
+            // in the former case the server will return the record, thereby updating it.
+            // @TODO: this will break if the model fails server-side validation.
+            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
                 transition.abort();
                 this.send('openModal', 'leave-editor', [controller, transition]);
                 return;


### PR DESCRIPTION
fixes #2999
- handle undefined argument in openModal function
- catch whether a model is deleted in Editor routes to aid transition
- move updateTags function to the PostModel
- add call to updateTags in delete-post modal
