### PR TITLE
Revert "Remove limit from ember post API calls"

### DIFF
--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -4,7 +4,8 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 var paginationSettings = {
     status: 'all',
     staticPages: 'all',
-    page: 1
+    page: 1,
+    limit: 15
 };
 
 var PostsRoute = AuthenticatedRoute.extend(styleBody, {


### PR DESCRIPTION
refs #3004

However, this just removes the limit, so the initial content query returns all results, as shown below.

```
GET /ghost/api/v0.1/posts/?status=all&staticPages=all&page=1 200 43ms
GET /ghost/api/v0.1/posts/?status=all&staticPages=all&page=2 200 63ms
```

So the second page request isn't needed. The use of LIMIT being an int was fixed here: 22c05da93aff7b2975177e1e0d321ec7758c78d7

So this should be reverted back (tested in MySQL and sqlite), to obtain this.

```
GET /ghost/api/v0.1/posts/?status=all&staticPages=all&page=1&limit=15 200 43ms
GET /ghost/api/v0.1/posts/?status=all&staticPages=all&page=2&limit=15 200 63ms
```

This reverts commit 74205134ef521948b503cbc3025a98efa6f621fc.
