### PR TITLE
Easier editor entry

### DIFF
--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -31,7 +31,7 @@ var PostsRoute = AuthenticatedRoute.extend(ShortcutsRoute, styleBody, loadingInd
     },
     actions: {
         openEditor: function (post) {
-            this.transitionTo('editor', post);
+            this.transitionTo('editor.edit', post);
         },
         moveUp: function () {
             window.alert('@todo keyboard post navigation: up');

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -1,7 +1,8 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
+import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 
-var PostsPostRoute = AuthenticatedRoute.extend(loadingIndicator, {
+var PostsPostRoute = AuthenticatedRoute.extend(loadingIndicator, ShortcutsRoute, {
     model: function (params) {
         var self = this,
             post,
@@ -33,6 +34,14 @@ var PostsPostRoute = AuthenticatedRoute.extend(loadingIndicator, {
             return self.transitionTo('posts.index');
         });
     },
+    shortcuts: {
+        'ctrl+e, command+e': 'openEditor'
+    },
+    actions: {
+        openEditor: function () {
+            this.transitionTo('editor.edit', this.get('controller.model'));
+        }
+    }
 });
 
 export default PostsPostRoute;

--- a/core/client/views/post-item-view.js
+++ b/core/client/views/post-item-view.js
@@ -6,13 +6,12 @@ var PostItemView = itemView.extend({
     isFeatured: Ember.computed.alias('controller.model.featured'),
 
     isPage: Ember.computed.alias('controller.model.page'),
-
-    // WIP for #2308
-    /*
-    openEditor: function () {
-        this.get('controller').send('openEditor', this.get('controller.model'));  // send action to handle transition to editor route
-    }.on('doubleClick')
-    */
+    
+    //Edit post on double click
+    doubleClick: function () {
+        this.get('controller').send('openEditor', this.get('controller.model'));
+    }
+    
 });
 
 export default PostItemView;


### PR DESCRIPTION
Ref #2308
- Double clicking a PostItemView on the content screen will open that post
  in the editor.
- Added `'ctrl+e, command+e': 'openEditor'` shortcut will open editor as well. Added `openEditor` action to `PostsPostController` to this end.
