### PR TITLE
Fix promise rejection during validation

### DIFF
--- a/core/client/controllers/modals/leave-editor.js
+++ b/core/client/controllers/modals/leave-editor.js
@@ -14,8 +14,8 @@ var LeaveEditorController = Ember.Controller.extend({
                 model = editorController.get('model');
             }
 
-            // @TODO: throw some kind of error here? return true will send it upward?
             if (!transition || !editorController) {
+                this.notifications.showError('Sorry, there was an error in the application. Please let the Ghost team know what happened.');
                 return true;
             }
 

--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -23,8 +23,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 self.notifications.showSuccess('Successfully converted to ' + (val ? 'static page' : 'post'));
 
                 return self.get('page');
-            }, function (errors) {
+            }).catch(function (errors) {
                 self.notifications.showErrors(errors);
+                return Ember.RSVP.reject(errors);
             });
         }
 
@@ -137,8 +138,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return self.get('model').save().then(function () {
                     self.notifications.showSuccess('Permalink successfully changed to <strong>' +
                         self.get('slug') + '</strong>.');
-                }, function (errors) {
+                }).catch(function (errors) {
                     self.notifications.showErrors(errors);
+                    return Ember.RSVP.reject(errors);
                 });
             });
         },
@@ -190,8 +192,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             this.get('model').save().then(function () {
                 self.notifications.showSuccess('Publish date successfully changed to <strong>' +
                     formatDate(self.get('published_at')) + '</strong>.');
-            }, function (errors) {
+            }).catch(function (errors) {
                 self.notifications.showErrors(errors);
+                return Ember.RSVP.reject(errors);
             });
         }
     }

--- a/core/client/controllers/posts/post.js
+++ b/core/client/controllers/posts/post.js
@@ -11,6 +11,7 @@ var PostController = Ember.ObjectController.extend({
                 self.notifications.showSuccess('Post successfully marked as ' + (featured ? 'featured' : 'not featured') + '.');
             }).catch(function (errors) {
                 self.notifications.showErrors(errors);
+                return Ember.RSVP.reject(errors);
             });
         }
     }

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -109,7 +109,6 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
     actions: {
         save: function () {
             var status = this.get('willPublish') ? 'published' : 'draft',
-                model = this.get('model'),
                 self = this;
 
             // set markdown equal to what's in the editor, minus the image markers.
@@ -117,7 +116,7 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
             this.set('status', status);
 
-            return model.save().then(function () {
+            return this.get('model').save().then(function (model) {
                 model.updateTags();
                 // `updateTags` triggers `isDirty => true`.
                 // for a saved model it would otherwise be false.
@@ -126,8 +125,9 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
                 self.notifications.showSuccess('Post status saved as <strong>' +
                                                 model.get('status') + '</strong>.');
                 return model;
-            }, function (errors) {
+            }).catch(function (errors) {
                 self.notifications.showErrors(errors);
+                return Ember.RSVP.reject(errors);
             });
         },
 


### PR DESCRIPTION
fixes #3013
- bubble promise rejection on post model validation/save error so that it doesn't bubble as resolved
- prefer `.catch()` for promise handlers as per recommendations
- check if `.save()` is being called from `model.destroyRecord()` and forgo validation if so
- normalize output for both `.validate()` and `.save()`
