### PR TITLE
Remove "Delete This Post" option from New Post publish bar menu items

### DIFF
--- a/core/client/templates/-publish-bar.hbs
+++ b/core/client/templates/-publish-bar.hbs
@@ -4,7 +4,7 @@
 
         <div class="right">
 
-            <section id="entry-controls">
+            <section id="entry-controls" {{bind-attr class="isNew:unsaved"}}>
                 {{#gh-popover-button popoverName="post-settings-menu" tagName="a" href="#" classNames="post-settings" title="Post Settings"}}
                     <span class="hidden">Post Settings</span>
                 {{/gh-popover-button}}


### PR DESCRIPTION
closes #3025
- adds 'unsaved' class to entry-controls when the post model/controller isNew evaluates to true
