### PR TITLE
Profanity for a cleaner content, out of the box

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,29 +1,26 @@
 {
-    "name": "ghost",
-    "dependencies": {
-        "backbone": "1.0.0",
-        "codemirror": "4.0.1",
-        "Countable": "2.0.2",
-        "ember": "1.5.0",
-        "ember-data": "~1.0.0-beta.7",
-        "ember-load-initializers": "git://github.com/stefanpenner/ember-load-initializers.git#0.0.1",
-        "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",
-        "fastclick": "1.0.0",
-        "ghost-ui": "0.1.3",
-        "handlebars": "1.3.0",
-        "ic-ajax": "1.0.1",
-        "jquery": "1.11.0",
-        "jquery-file-upload": "9.5.6",
-        "jquery-hammerjs": "1.0.1",
-        "jquery-ui": "1.10.4",
-        "lodash": "2.4.1",
-        "moment": "2.4.0",
-        "nprogress": "0.1.2",
-        "showdown": "https://github.com/ErisDS/showdown.git#v0.3.2-ghost",
-        "validator-js": "3.4.0",
-        "loader.js": "stefanpenner/loader.js#1.0.0"
-    },
-    "resolutions": {
-      "ember": "~1.4.0"
-    }
+  "name": "ghost",
+  "dependencies": {
+    "backbone": "1.0.0",
+    "codemirror": "4.0.1",
+    "Countable": "2.0.2",
+    "ember": "1.5.0",
+    "ember-data": "~1.0.0-beta.7",
+    "ember-load-initializers": "git://github.com/stefanpenner/ember-load-initializers.git#0.0.1",
+    "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",
+    "fastclick": "1.0.0",
+    "ghost-ui": "0.1.3",
+    "handlebars": "1.3.0",
+    "ic-ajax": "1.0.1",
+    "jquery": "1.11.0",
+    "jquery-file-upload": "9.5.6",
+    "jquery-hammerjs": "1.0.1",
+    "jquery-ui": "1.10.4",
+    "lodash": "2.4.1",
+    "moment": "2.4.0",
+    "nprogress": "0.1.2",
+    "showdown": "https://github.com/ErisDS/showdown.git#v0.3.2-ghost",
+    "validator-js": "3.4.0",
+    "loader.js": "stefanpenner/loader.js#1.0.0"
   }
+}

--- a/core/client/models/settings.js
+++ b/core/client/models/settings.js
@@ -14,6 +14,7 @@ var SettingsModel = BaseModel.extend({
     postsPerPage: null,
     forceI18n: null,
     permalinks: null,
+    profanity: null,
     activeTheme: null,
     activeApps: null,
     installedApps: null,

--- a/core/client/templates/settings/general.hbs
+++ b/core/client/templates/settings/general.hbs
@@ -64,6 +64,13 @@
                 <label class="checkbox" for="permalinks"></label>
                 <p>Include the date in your post URLs</p>
             </div>
+            
+            <div class="form-group">
+                <label for="permalinks">Profanity Filters</label>
+                {{input id="profanity" name="general[profanity]" type="checkbox" checked=isProfanity}}
+                <label class="checkbox" for="profanity"></label>
+                <p>Obscure foul words on each post</p>
+            </div>
 
             <div class="form-group">
                 <label for="activeTheme">Theme</label>

--- a/core/clientold/tpl/settings/general.hbs
+++ b/core/clientold/tpl/settings/general.hbs
@@ -66,6 +66,13 @@
             </div>
 
             <div class="form-group">
+                <label for="profanity">Profanity Filters</label>
+                <input id="profanity" name="general[profanity]" type="checkbox" value='profanity'/>
+                <label class="checkbox" for="profanity"></label>
+                <p>Obscure foul words on each post</p>
+            </div>
+            
+            <div class="form-group">
                 <label for="activeTheme">Theme</label>
                 <select id="activeTheme" name="general[activeTheme]">
                     {{#each availableThemes}}

--- a/core/clientold/tpl/settings/general.hbs
+++ b/core/clientold/tpl/settings/general.hbs
@@ -69,7 +69,7 @@
                 <label for="profanity">Profanity Filters</label>
                 <input id="profanity" name="general[profanity]" type="checkbox" value='profanity'/>
                 <label class="checkbox" for="profanity"></label>
-                <p>Obscure foul words on each post</p>
+                <p>Obscure foul words upon saving (will not affect old posts)</p>
             </div>
             
             <div class="form-group">

--- a/core/clientold/views/settings.js
+++ b/core/clientold/views/settings.js
@@ -160,6 +160,7 @@
                 description = this.$('#blog-description').val(),
                 email = this.$('#email-address').val(),
                 postsPerPage = this.$('#postsPerPage').val(),
+                profanity = this.$('#profanity').is(":checked"),
                 permalinks = this.$('#permalinks').is(':checked') ? '/:year/:month/:day/:slug/' : '/:slug/',
                 validationErrors = [];
 
@@ -193,7 +194,8 @@
                     email: email,
                     postsPerPage: postsPerPage,
                     activeTheme: this.$('#activeTheme').val(),
-                    permalinks: permalinks
+                    permalinks: permalinks,
+                    profanity: profanity
                 }, {
                     success: this.saveSuccess,
                     error: this.saveError

--- a/core/clientold/views/settings.js
+++ b/core/clientold/views/settings.js
@@ -240,6 +240,8 @@
             var self = this;
 
             this.$('#permalinks').prop('checked', this.model.get('permalinks') !== '/:slug/');
+            this.$('#profanity').prop('checked', this.model.get('profanity') === 'true');
+            console.log(this.model.get('profanity'));
             this.$('.js-drop-zone').upload();
 
             Countable.live(document.getElementById('blog-description'), function (counter) {

--- a/core/clientold/views/settings.js
+++ b/core/clientold/views/settings.js
@@ -241,7 +241,6 @@
 
             this.$('#permalinks').prop('checked', this.model.get('permalinks') !== '/:slug/');
             this.$('#profanity').prop('checked', this.model.get('profanity') === 'true');
-            console.log(this.model.get('profanity'));
             this.$('.js-drop-zone').upload();
 
             Countable.live(document.getElementById('blog-description'), function (counter) {

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -54,6 +54,13 @@
                 "isIn": [["true", "false"]]
             }
         },
+        "profanity": {
+            "defaultValue": "true",
+            "validations": {
+                "isNull": false,
+                "isIn": [["true", "false"]]
+            }
+        },
         "permalinks": {
             "defaultValue": "/:slug/",
             "validations": {

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -361,6 +361,9 @@ module.exports = function (server, dbHash) {
     // ToDo: Remove when ember handles passive notifications.
     expressServer.use(middleware.cleanNotifications);
 
+    //profanity
+    expressServer.use(middleware.profanity.init);
+
     // ### Routing
     // Set up API routes
     expressServer.use(subdir, routes.api(middleware));

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -227,6 +227,21 @@ function checkSSL(req, res, next) {
     next();
 }
 
+// Check to see if we should use Profanity filters
+// and modify req as needed
+function checkProfanity(req, res, next) {
+    api.settings.read({key: 'profanity'}).then(function (response) {
+        var profanity = response.settings[0];
+        if (profanity.value === 'true') {
+            middleware.profanity.init(req, res, next);
+        } else
+            next(); //no profanity to filter
+    }).otherwise(function (err) {
+        //pass on the error
+        next(err);
+    });
+}
+
 // ### Robots Middleware
 // Handle requests to robots.txt and cache file
 function robots() {
@@ -362,8 +377,8 @@ module.exports = function (server, dbHash) {
     expressServer.use(middleware.cleanNotifications);
 
     //profanity
-    expressServer.use(middleware.profanity.init);
-
+    expressServer.use(checkProfanity);
+    
     // ### Routing
     // Set up API routes
     expressServer.use(subdir, routes.api(middleware));

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -9,6 +9,7 @@ var _           = require('lodash'),
     config      = require('../config'),
     path        = require('path'),
     api         = require('../api'),
+    profanity   = require('profanity-middleware'),
 
     expressServer,
     ONE_HOUR_MS = 60 * 60 * 1000,
@@ -194,7 +195,8 @@ var middleware = {
         next();
     },
 
-    busboy: busboy
+    busboy: busboy,
+    profanity: profanity
 };
 
 module.exports = middleware;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "unidecode": "0.1.3",
         "validator": "3.4.0",
         "when": "2.7.0",
+        "profanity-middleware": "0.1.4",
         "xml": "0.0.12"
     },
     "optionalDependencies": {


### PR DESCRIPTION
Hello,

I've added a profanity filter for obscuring harsh words from posts written in the Ghost blog, to make the blog posts more cleaner.

The sole focus of Ghost is on the simplicity and the ease of composing - keeping this in mind, I've implemented a feature that makes the internet a more cleaner place to read - I've integrated the profanity-middleware NodeJS module as a default, which can be disabled in the settings.

On a technical note, the module works as a middleware, which makes it compatible with the existing Ghost architecture. Profanity is filtered upon 'save' of a post from admin (not while reading the content for display) - this is done to reduce the need for multiple parsing.

I have seen the Road Map and gone through the blogs for Ghost - and I'm aware that there will be a commenting system in Ghost at a later stage - This middleware will work seamlessly even then.

I believe this could add value to the Ghost platform. I'd love to get feedback, if any.

Cheers!

![dxq6km](https://cloud.githubusercontent.com/assets/7126758/3350932/4fc22752-f9e5-11e3-81e1-5b6f8461c2da.png)
