### PR TITLE
Fix word count in ember.

### DIFF
--- a/core/client/utils/word-count.js
+++ b/core/client/utils/word-count.js
@@ -1,6 +1,7 @@
 export default function (s) {
     s = s.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
     s = s.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
-    s = s.replace(/\n /, '\n'); // exclude newline with a start spacing
-    return s.split(' ').length;
+    s = s.replace(/\n /gi, '\n'); // exclude newline with a start spacing
+    s = s.replace(/\n+/gi, '\n');
+    return s.split(/ |\n/).length;
 }


### PR DESCRIPTION
The word count in ember is currently incorrect as it ignored new lines.

When entering the following text the word count shows 3 instead of 4:

```
foo bar
baz rasper
```

No issue. Sorry @ErisDS :v: 
