### PR TITLE
Focus title in editor when opening page.

### DIFF
--- a/core/client/components/gh-focus-input.js
+++ b/core/client/components/gh-focus-input.js
@@ -1,0 +1,7 @@
+var FocusInput = Ember.TextField.extend({
+    becomeFocused: function () {
+        this.$().val(this.$().val()).focus();
+    }.on('didInsertElement')
+});
+
+export default FocusInput;

--- a/core/client/templates/editor/edit.hbs
+++ b/core/client/templates/editor/edit.hbs
@@ -1,6 +1,6 @@
 <header>
     <section class="box entry-title">
-        {{input type="text" id="entry-title" placeholder="Your Post Title" value=title tabindex="1"}}
+        {{gh-focus-input type="text" id="entry-title" placeholder="Your Post Title" value=title tabindex="1"}}
     </section>
 </header>
 


### PR DESCRIPTION
closes #3038
- Adds new gh-focus-input component
- Uses new component in editor
