### PR TITLE
Hide settings/apps unless apps:true is in config.js

### DIFF
--- a/core/client/controllers/settings.js
+++ b/core/client/controllers/settings.js
@@ -1,0 +1,5 @@
+var SettingsController = Ember.Controller.extend({
+    showApps: Ember.computed.bool('config.apps')
+});
+
+export default SettingsController;

--- a/core/client/initializers/ghost-config.js
+++ b/core/client/initializers/ghost-config.js
@@ -1,0 +1,12 @@
+var ConfigInitializer = {
+    name: 'config',
+
+    initialize: function (container, application) {
+        application.register('ghost:config', application.get('config'), {instantiate: false});
+
+        application.inject('route', 'config', 'ghost:config');
+        application.inject('controller', 'config', 'ghost:config');
+    }
+};
+
+export default ConfigInitializer;

--- a/core/client/routes/settings/apps.js
+++ b/core/client/routes/settings/apps.js
@@ -1,6 +1,11 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 
 var AppsRoute = AuthenticatedRoute.extend({
+    beforeModel: function () {
+        if (!this.get('config.apps')) {
+            this.transitionTo('settings.general');
+        }
+    },
     model: function () {
         return this.store.find('app');
     }

--- a/core/client/templates/settings.hbs
+++ b/core/client/templates/settings.hbs
@@ -8,14 +8,16 @@
                 {{#view "item-view" tagName="li" class="general"}}
                     {{#link-to "settings.general"}}General{{/link-to}}
                 {{/view}}
-                
+
                 {{#view "item-view" tagName="li" class="users"}}
                     {{#link-to "settings.user"}}User{{/link-to}}
                 {{/view}}
-                
-                {{#view "item-view" tagName="li" class="apps"}}
-                    {{#link-to "settings.apps"}}Apps{{/link-to}}
-                {{/view}}
+
+                {{#if showApps}}
+                    {{#view "item-view" tagName="li" class="apps"}}
+                        {{#link-to "settings.apps"}}Apps{{/link-to}}
+                    {{/view}}
+                {{/if}}
             </ul>
         </nav>
     </aside>

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -42,15 +42,21 @@ function setSelected(list, name) {
 
 adminControllers = {
     'index': function (req, res) {
+
         /*jslint unparam:true*/
-        var userData;
+        var userData,
+            // config we need on the frontend
+            frontConfig = {
+                apps: config().apps
+            };
 
         if (req.session && req.session.userData) {
             userData = JSON.stringify(req.session.userData);
         }
 
         res.render('default-ember', {
-            user: userData
+            user: userData,
+            config: JSON.stringify(frontConfig)
         });
     },
     // Route: index

--- a/core/server/views/default-ember.hbs
+++ b/core/server/views/default-ember.hbs
@@ -41,9 +41,8 @@
 
     <script>
     window.ENV = {
-        {{#user}}
-        user: {{{this}}}
-        {{/user}}
+        {{#user}}user: {{{this}}},{{/user}}
+        config: {{{config}}}
     };
     window.App = require('ghost/app')['default'].create(window.ENV);
     </script>

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -20,7 +20,7 @@ CasperTest.emberBegin('Settings screen is correct', 17, function suite(test) {
         test.assertExists('.settings-menu', 'Settings menu is present');
         test.assertExists('.settings-menu .general', 'General tab is present');
         test.assertExists('.settings-menu .users', 'Users tab is present');
-        test.assertExists('.settings-menu .apps', 'Apps is present');
+        test.assertNotExists('.settings-menu .apps', 'Apps is present');
         test.assertExists('.wrapper', 'Settings main view is present');
         test.assertExists('.settings-content', 'Settings content view is present');
         test.assertExists('.settings-menu .general.active', 'General tab is marked active');


### PR DESCRIPTION
fixes #3031
- Adds an initializer for passing config to the frontend, it's not pretty but it works
- Forwards the apps route and hides the apps menu item if apps:true is not present in config.js
