### PR TITLE
Switch Ember initializers to public API methods

### DIFF
--- a/core/client/initializers/csrf-token.js
+++ b/core/client/initializers/csrf-token.js
@@ -1,12 +1,12 @@
 var CSRFTokenInitializer = {
     name: 'csrf-token',
 
-    initialize: function (container) {
-        container.register('csrf:token', $('meta[name="csrf-param"]').attr('content'), { instantiate: false });
+    initialize: function (container, application) {
+        application.register('csrf:token', $('meta[name="csrf-param"]').attr('content'), { instantiate: false });
 
-        container.injection('route', 'csrf', 'csrf:token');
-        container.injection('model', 'csrf', 'csrf:token');
-        container.injection('controller', 'csrf', 'csrf:token');
+        application.inject('route', 'csrf', 'csrf:token');
+        application.inject('model', 'csrf', 'csrf:token');
+        application.inject('controller', 'csrf', 'csrf:token');
     }
 };
 

--- a/core/client/initializers/csrf.js
+++ b/core/client/initializers/csrf.js
@@ -1,11 +1,11 @@
 var CSRFInitializer = {
     name: 'csrf',
 
-    initialize: function (container) {
-        container.register('csrf:current', $('meta[name="csrf-param"]').attr('content'), { instantiate: false });
+    initialize: function (container, application) {
+        application.register('csrf:current', $('meta[name="csrf-param"]').attr('content'), { instantiate: false });
 
-        container.injection('route', 'csrf', 'csrf:current');
-        container.injection('controller', 'csrf', 'csrf:current');
+        application.inject('route', 'csrf', 'csrf:current');
+        application.inject('controller', 'csrf', 'csrf:current');
     }
 };
 

--- a/core/client/initializers/current-user.js
+++ b/core/client/initializers/current-user.js
@@ -22,11 +22,11 @@ var currentUserInitializer = {
         // Find the user (which should be fast since we just preloaded it in the store)
         store.find('user', preloadedUser.id).then(function (user) {
             // Register the value for injection
-            container.register('user:current', user, { instantiate: false });
+            application.register('user:current', user, { instantiate: false });
 
             // Inject into the routes and controllers as the user property.
-            container.injection('route', 'user', 'user:current');
-            container.injection('controller', 'user', 'user:current');
+            application.inject('route', 'user', 'user:current');
+            application.inject('controller', 'user', 'user:current');
 
             application.advanceReadiness();
         });

--- a/core/client/initializers/ghost-paths.js
+++ b/core/client/initializers/ghost-paths.js
@@ -4,12 +4,12 @@ var ghostPathsInitializer = {
     name: 'ghost-paths',
     after: 'store',
 
-    initialize: function (container) {
-        container.register('ghost:paths', ghostPaths(), {instantiate: false});
+    initialize: function (container, application) {
+        application.register('ghost:paths', ghostPaths(), { instantiate: false });
 
-        container.injection('route', 'ghostPaths', 'ghost:paths');
-        container.injection('model', 'ghostPaths', 'ghost:paths');
-        container.injection('controller', 'ghostPaths', 'ghost:paths');
+        application.inject('route', 'ghostPaths', 'ghost:paths');
+        application.inject('model', 'ghostPaths', 'ghost:paths');
+        application.inject('controller', 'ghostPaths', 'ghost:paths');
     }
 };
 


### PR DESCRIPTION
According to https://github.com/emberjs/ember.js/blob/master/packages/container/lib/container.js the public API for registering and injection services should be the methods on the `Application` object.

Currently some of the initializers are using `Application` and some are using `Container`.  This just switches all of them over to using `Application#register` and `Application#inject`.
