### PR TITLE
Add fileStorage config to frontend

### DIFF
--- a/core/client/components/gh-markdown.js
+++ b/core/client/components/gh-markdown.js
@@ -22,7 +22,7 @@ var Markdown = Ember.Component.extend({
 
             uploader.call(dropzones, {
                 editor: true,
-                filestorage: false
+                fileStorage: this.get('config.fileStorage')
             });
 
             dropzones.on('uploadstart', _.bind(this.sendAction, this, 'uploadStarted'));

--- a/core/client/components/gh-upload-modal.js
+++ b/core/client/components/gh-upload-modal.js
@@ -6,8 +6,7 @@ var UploadModal = ModalDialog.extend({
 
     didInsertElement: function () {
         this._super();
-        var filestorage = $('#general').data('filestorage');
-        upload.call(this.$('.js-drop-zone'), {fileStorage: filestorage});
+        upload.call(this.$('.js-drop-zone'), {fileStorage: this.get('config.fileStorage')});
     },
     confirm: {
         reject: {

--- a/core/client/initializers/ghost-config.js
+++ b/core/client/initializers/ghost-config.js
@@ -6,6 +6,7 @@ var ConfigInitializer = {
 
         application.inject('route', 'config', 'ghost:config');
         application.inject('controller', 'config', 'ghost:config');
+        application.inject('component', 'config', 'ghost:config');
     }
 };
 

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -47,6 +47,7 @@ adminControllers = {
         var userData,
             // config we need on the frontend
             frontConfig = {
+                fileStorage: config().fileStorage,
                 apps: config().apps
             };
 


### PR DESCRIPTION
closes #2956
- adds fileStorage to config passed to ember, and then grabs it in the relevant places.
