### PR TITLE
Introduce new PRIVACY.md document

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,42 @@
+# Privacy
+
+This is a plain English summary of all of the components within Ghost which may affect your privacy in some way. Please keep in mind that if you use third party Themes or Apps with Ghost, there may be additional things not listed here.
+
+
+## Official Services
+
+Some official services for Ghost are enabled by default. These services connect to Ghost.org and are managed by the Ghost Foundation: the Non-Profit organisation which runs the Ghost project.
+
+
+### Automatic Update Checks
+
+When a new session is started, Ghost pings a Ghost.org endpoint to check if the current version of Ghost is the latest version of Ghost. If an update is available, a notification appears inside Ghost to let you know. Ghost.org collects basic anonymised usage statistics from update check requests.
+
+This service can be disabled at any time. All of the information and code related to this service is available in the [update-check.js](https://github.com/TryGhost/Ghost/blob/master/core/server/update-check.js) file.
+
+
+## Third Party Services
+
+Ghost uses a number of third party services for specific functionality within Ghost. 
+
+
+### Google Fonts
+
+Ghost makes use of the Open Sans and Inconsolata [Google Fonts](https://www.google.com/fonts). These are loaded into the Ghost admin area to provide a typographically stimulating experience.
+
+### Gravatar
+
+To automatically populate your profile picture, Ghost pings [Gravatar](http://gravatar.com) to see if your email address is associated with a profile there. If it is, we pull in your profile picture. If not: nothing happens.
+
+### RPC Pings
+
+When you publish a new post, Ghost sends out an RPC ping to let third party services know that new content is available on your blog. This enables search engines and other services to discover and index content on your blog more quickly. At present Ghost sends an RPC ping to the following services when you publish a new post:
+
+- http://blogsearch.google.com
+- http://rpc.pingomatic.com
+
+RPC pings only happen when Ghost is running in the `production` environment.
+
+### Sharing Buttons
+
+The default theme which comes with Ghost contains three sharing buttons to [Twitter](http://twitter.com), [Facebook](http://facebook.com), and [Google Plus](http://plus.google.com). No resources are loaded from any services, however the buttons do allow visitors to your blog to share your content publicly on these respective networks.


### PR DESCRIPTION
A few days ago a discussion took place in IRC around whether or not we should consider adding Open Graph meta tags by default to be output on the front-end of a Ghost blog. The argument centered around privacy. While the OG tags would provide be of use and value to a large majority of users, there would also be privacy-concerned users who would not realise that this functionality was switched on by default.

The key point -- which was a good one -- was that unless you happen to view the correct source code at the correct time, it's impossible to know if and when things like this are occurring. Which kind of sucks.

Last year, a small movement started in the Open Source community which is slowly evolving into a standard practice: The inclusion of a SECURITY.md file in every repository - outlining the security policy for the project.

So, my idea is this: 

**PRIVACY.md - A plain English summary of all components within a repository which may affect user privacy. A single, standardised location to find out what's going on under the hood.** 

This PR is speculative and open to discussion - Have a look at the attached changeset for an example of what this might look like in the context of Ghost.

While we already have a flag to disable Ghost update-checks, I would suggest that a nice followup to this would be if there was a config flag for _every item_ in PRIVACY.md to allow it to be disabled, if so desired. Along with a blanket rule flag, to disable absolutely everything. (Perhaps `tinfoil: true`)
