### PR TITLE
Fix incomplete tags sticking between post edits

### DIFF
--- a/core/client/views/post-tags-input.js
+++ b/core/client/views/post-tags-input.js
@@ -22,6 +22,10 @@ var PostTagsInputView = Ember.View.extend({
         this.get('controller').send('loadAllTags');
     },
 
+    willDestroyElement: function () {
+        this.get('controller').send('reset');
+    },
+
     overlayStyles: function () {
         var styles = [],
             leftPos;


### PR DESCRIPTION
closes #3065
- send 'reset' action to PostTagsInputController when associated view is destroyed
