### PR TITLE
Stay on posts.index route when no posts exist

### DIFF
--- a/core/client/routes/posts/index.js
+++ b/core/client/routes/posts/index.js
@@ -2,7 +2,7 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var PostsIndexRoute = AuthenticatedRoute.extend(loadingIndicator, {
-    // redirect to first post subroute
+    // redirect to first post subroute unless no posts exist
     beforeModel: function () {
         var self = this;
 
@@ -11,7 +11,10 @@ var PostsIndexRoute = AuthenticatedRoute.extend(loadingIndicator, {
             staticPages: 'all'
         }).then(function (records) {
             var post = records.get('firstObject');
-            return self.transitionTo('posts.post', post);
+
+            if (post) {
+                return self.transitionTo('posts.post', post);
+            }
         });
     }
 });

--- a/core/client/templates/posts/index.hbs
+++ b/core/client/templates/posts/index.hbs
@@ -1,0 +1,6 @@
+<div class="no-posts-box">
+    <div class="no-posts">
+        <h3>You Haven't Written Any Posts Yet!</h3>
+        {{#link-to "editor.new"}}<button class="button-add large" title="New Post">Write a new Post</button>{{/link-to}}
+    </div>
+</div>

--- a/core/client/templates/posts/post.hbs
+++ b/core/client/templates/posts/post.hbs
@@ -1,21 +1,8 @@
-{{#if title}}
+{{partial "floating-header"}}
 
-    {{partial "floating-header"}}
-
-    {{#view "content-preview-content-view" tagName="section"}}
-        <div class="wrapper">
-            <h1>{{{title}}}</h1>
-            {{{html}}}
-        </div>
-    {{/view}}
-
-{{else}}
-
-    <div class="no-posts-box">
-        <div class="no-posts">
-            <h3>You Haven't Written Any Posts Yet!</h3>
-            {{#link-to "editor.new"}}<button class="button-add large" title="New Post">Write a new Post</button>{{/link-to}}
-        </div>
+{{#view "content-preview-content-view" tagName="section"}}
+    <div class="wrapper">
+        <h1>{{{title}}}</h1>
+        {{{html}}}
     </div>
-
-{{/if}}
+{{/view}}


### PR DESCRIPTION
Currently, if there are no posts in the database, navigating to the Content screen results a URL of `/ghost/ember/undefined` as shown below.

This changes the behavior to stay on the posts.index route instead of transitioning to posts.post with an undefined model.

Current:
![undefined](https://cloud.githubusercontent.com/assets/214142/3386832/f6f9e5d4-fc77-11e3-9a7b-f47be73b12f0.png)

Proposed:
![fixed](https://cloud.githubusercontent.com/assets/214142/3386911/af2fa4ae-fc78-11e3-8a60-7ca9c19da9a9.png)
