### PR TITLE
Switching the tests to use ember admin by default

### DIFF
--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -279,13 +279,13 @@ var CasperTest = (function () {
     casper.test.tearDown(function (done) {
         casper.then(_beforeDoneHandler);
 
-        CasperTest.Routines.emberSignout.run();
+        CasperTest.Routines.signout.run();
 
         casper.run(done);
     });
 
     // Wrapper around `casper.test.begin`
-    function begin(testName, expect, suite, doNotAutoLogin) {
+    function oldBegin(testName, expect, suite, doNotAutoLogin) {
         _beforeDoneHandler = _noop;
 
         var runTest = function (test) {
@@ -296,16 +296,16 @@ var CasperTest = (function () {
             if (!doNotAutoLogin) {
                 // Only call register once for the lifetime of Mindless
                 if (!_isUserRegistered) {
-                    CasperTest.Routines.logout.run(test);
-                    CasperTest.Routines.register.run(test);
+                    CasperTest.Routines.oldLogout.run(test);
+                    CasperTest.Routines.oldRegister.run(test);
 
                     _isUserRegistered = true;
                 }
 
                 /* Ensure we're logged out at the start of every test or we may get
                    unexpected failures. */
-                CasperTest.Routines.logout.run(test);
-                CasperTest.Routines.login.run(test);
+                CasperTest.Routines.oldLogout.run(test);
+                CasperTest.Routines.oldLogin.run(test);
             }
 
             suite.call(casper, test);
@@ -325,7 +325,7 @@ var CasperTest = (function () {
         }
     }
 
-    function emberBegin(testName, expect, suite, doNotAutoLogin) {
+    function begin(testName, expect, suite, doNotAutoLogin) {
         _beforeDoneHandler = _noop;
 
         var runTest = function (test) {
@@ -337,16 +337,16 @@ var CasperTest = (function () {
                 // Only call register once for the lifetime of CasperTest
                 if (!_isUserRegistered) {
 
-                    CasperTest.Routines.emberSignout.run();
-                    CasperTest.Routines.emberSetup.run();
+                    CasperTest.Routines.signout.run();
+                    CasperTest.Routines.setup.run();
 
                     _isUserRegistered = true;
                 }
 
                 /* Ensure we're logged out at the start of every test or we may get
                  unexpected failures. */
-                CasperTest.Routines.emberSignout.run();
-                CasperTest.Routines.emberSignin.run();
+                CasperTest.Routines.signout.run();
+                CasperTest.Routines.signin.run();
             }
 
             suite.call(casper, test);
@@ -377,8 +377,8 @@ var CasperTest = (function () {
     }
 
     return {
+        oldBegin: oldBegin,
         begin: begin,
-        emberBegin: emberBegin,
         beforeDone: beforeDone
     };
 
@@ -386,7 +386,7 @@ var CasperTest = (function () {
 
 CasperTest.Routines = (function () {
 
-    function register(test) {
+    function oldRegister(test) {
         casper.thenOpen(url + 'ghost/signup/');
 
         casper.waitForOpaque('.signup-box', function then() {
@@ -403,15 +403,15 @@ CasperTest.Routines = (function () {
         }, 2000);
     }
 
-    function emberSetup() {
+    function setup() {
         casper.thenOpenAndWaitForPageLoad('setup', function then() {
-            casper.captureScreenshot('ember_signing_up1.png');
+            casper.captureScreenshot('ember_setting_up1.png');
 
             casper.waitForOpaque('.setup-box', function then() {
                 this.fillAndAdd('#setup', newSetup);
             });
 
-            casper.captureScreenshot('ember_signing_up2.png');
+            casper.captureScreenshot('ember_setting_up2.png');
 
             casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
                 var errorText = casper.evaluate(function () {
@@ -422,12 +422,12 @@ CasperTest.Routines = (function () {
                 casper.echoConcise('It appears as though a user was not already registered.');
             }, 2000);
 
-            casper.captureScreenshot('ember_signing_up3.png');
+            casper.captureScreenshot('ember_setting_up3.png');
 
         });
     }
 
-    function login(test) {
+    function oldLogin(test) {
         casper.thenOpen(url + 'ghost/signin/');
 
         casper.waitForResource(/ghost\/signin/);
@@ -447,7 +447,7 @@ CasperTest.Routines = (function () {
         });
     }
 
-    function emberSignin() {
+    function signin() {
         casper.thenOpenAndWaitForPageLoad('signin', function then() {
 
             casper.waitForOpaque('.login-box', function then() {
@@ -464,7 +464,7 @@ CasperTest.Routines = (function () {
         });
     }
 
-    function logout(test) {
+    function oldLogout(test) {
         casper.thenOpen(url + 'ghost/signout/');
 
         casper.captureScreenshot('logging_out.png');
@@ -473,7 +473,7 @@ CasperTest.Routines = (function () {
         casper.waitForResource(/ghost\/sign/);
     }
 
-    function emberSignout() {
+    function signout() {
         casper.thenOpenAndWaitForPageLoad('signout', function then() {
             casper.captureScreenshot('ember_signing_out.png');
         });
@@ -481,12 +481,7 @@ CasperTest.Routines = (function () {
 
     // This will need switching over to ember once settings general is working properly.
     function togglePermalinks(state) {
-        casper.thenOpen(url + 'ghost/settings/general');
-
-        casper.waitForResource(/ghost\/settings\/general/);
-
-        casper.waitForSelector('#general');
-        casper.waitForOpaque('#general', function then() {
+        casper.thenOpenAndWaitForPageLoad('settings.general', function then() {
             var currentState = this.evaluate(function () {
                 return document.querySelector('#permalinks') && document.querySelector('#permalinks').checked ? 'on' : 'off';
             });
@@ -548,13 +543,13 @@ CasperTest.Routines = (function () {
     }
 
     return {
-        register: _createRunner(register),
-        login: _createRunner(login),
-        logout: _createRunner(logout),
+        oldRegister: _createRunner(oldRegister),
+        oldLogin: _createRunner(oldLogin),
+        oldLogout: _createRunner(oldLogout),
         togglePermalinks: _createRunner(togglePermalinks),
-        emberSetup: _createRunner(emberSetup),
-        emberSignin: _createRunner(emberSignin),
-        emberSignout: _createRunner(emberSignout),
+        setup: _createRunner(setup),
+        signin: _createRunner(signin),
+        signout: _createRunner(signout),
         createTestPost: _createRunner(createTestPost)
     };
 

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -3,7 +3,7 @@
 
 /*globals CasperTest, casper */
 
-CasperTest.emberBegin('Admin navigation bar is correct', 28, function suite(test) {
+CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('root', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/\d+\/$/, 'Landed on the correct URL');

--- a/core/test/functional/client/content_test.js
+++ b/core/test/functional/client/content_test.js
@@ -3,7 +3,7 @@
 
 /*globals CasperTest, casper, testPost, newUser */
 
-CasperTest.emberBegin('Content screen is correct', 17, function suite(test) {
+CasperTest.begin('Content screen is correct', 17, function suite(test) {
     // First, create a sample post for testing (this should probably be a routine)
     CasperTest.Routines.createTestPost.run(false);
 
@@ -67,7 +67,7 @@ CasperTest.emberBegin('Content screen is correct', 17, function suite(test) {
 //    });
 });
 
-CasperTest.emberBegin('Content list shows correct post status', 7, function testStaticPageStatus(test) {
+CasperTest.begin('Content list shows correct post status', 7, function testStaticPageStatus(test) {
     CasperTest.Routines.createTestPost.run(true);
 
     // Begin test
@@ -111,7 +111,7 @@ CasperTest.emberBegin('Content list shows correct post status', 7, function test
     });
 });
 
-CasperTest.emberBegin('Delete post modal', 7, function testDeleteModal(test) {
+CasperTest.begin('Delete post modal', 7, function testDeleteModal(test) {
     // Create a post that can be deleted
     CasperTest.Routines.createTestPost.run(false);
 
@@ -159,7 +159,7 @@ CasperTest.emberBegin('Delete post modal', 7, function testDeleteModal(test) {
 });
 
 // TODO: Implement this test... much needed!
-//CasperTest.emberBegin('Infinite scrolling', 2, function suite(test) {
+//CasperTest.begin('Infinite scrolling', 2, function suite(test) {
 //    // Placeholder for infinite scrolling/pagination tests (will need to setup 16+ posts).
 //
 //    casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
@@ -168,7 +168,7 @@ CasperTest.emberBegin('Delete post modal', 7, function testDeleteModal(test) {
 //    });
 //});
 
-CasperTest.emberBegin('Posts can be marked as featured', 10, function suite(test) {
+CasperTest.begin('Posts can be marked as featured', 10, function suite(test) {
     // Create a sample post
     CasperTest.Routines.createTestPost.run(false);
 
@@ -217,7 +217,7 @@ CasperTest.emberBegin('Posts can be marked as featured', 10, function suite(test
     });
 });
 
-CasperTest.emberBegin('Post url can be changed', 7, function suite(test) {
+CasperTest.begin('Post url can be changed', 7, function suite(test) {
     // Create a sample post
     CasperTest.Routines.createTestPost.run(false);
 
@@ -256,7 +256,7 @@ CasperTest.emberBegin('Post url can be changed', 7, function suite(test) {
     });
 });
 
-CasperTest.emberBegin('Post published date can be changed', 7, function suite(test) {
+CasperTest.begin('Post published date can be changed', 7, function suite(test) {
     // Create a sample post
       CasperTest.Routines.createTestPost.run(false);
 
@@ -295,7 +295,7 @@ CasperTest.emberBegin('Post published date can be changed', 7, function suite(te
     });
 });
 
-CasperTest.emberBegin('Post can be changed to static page', 7, function suite(test) {
+CasperTest.begin('Post can be changed to static page', 7, function suite(test) {
     // Create a sample post
     CasperTest.Routines.createTestPost.run(false);
 

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -2,7 +2,7 @@
 // Test the editor screen works as expected
 
 /*globals CasperTest, casper, testPost, $ */
-CasperTest.emberBegin('Ghost editor functions correctly', 19, function suite(test) {
+CasperTest.begin('Ghost editor functions correctly', 19, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -115,7 +115,7 @@ CasperTest.emberBegin('Ghost editor functions correctly', 19, function suite(tes
 });
 
 // TODO: Expand markdown tests to cover more markdown, and keyboard shortcuts
-CasperTest.emberBegin('Markdown in editor works', 4, function suite(test) {
+CasperTest.begin('Markdown in editor works', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -138,7 +138,7 @@ CasperTest.emberBegin('Markdown in editor works', 4, function suite(test) {
     });
 });
 
-CasperTest.emberBegin('Image Uploads', 17, function suite(test) {
+CasperTest.begin('Image Uploads', 17, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -215,7 +215,7 @@ CasperTest.emberBegin('Image Uploads', 17, function suite(test) {
     });
 });
 
-CasperTest.emberBegin('Tag editor', 7, function suite(test) {
+CasperTest.begin('Tag editor', 7, function suite(test) {
 casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
     test.assertTitle('Ghost Admin', 'Ghost admin has no title');
     test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -243,7 +243,7 @@ casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
     });
 });
 
-CasperTest.emberBegin('Post settings menu', 30, function suite(test) {
+CasperTest.begin('Post settings menu', 30, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -406,7 +406,7 @@ CasperTest.emberBegin('Post settings menu', 30, function suite(test) {
     });
 });
 
-CasperTest.emberBegin('Publish menu - new post', 11, function suite(test) {
+CasperTest.begin('Publish menu - new post', 11, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');
@@ -451,7 +451,7 @@ CasperTest.emberBegin('Publish menu - new post', 11, function suite(test) {
     });
 });
 
-CasperTest.emberBegin('Publish menu - existing post', 21, function suite(test) {
+CasperTest.begin('Publish menu - existing post', 21, function suite(test) {
     // Create a post, save it and test refreshed editor
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
@@ -550,7 +550,7 @@ CasperTest.emberBegin('Publish menu - existing post', 21, function suite(test) {
 
 
 // test the markdown help modal
-CasperTest.emberBegin('Markdown help modal', 5, function suite(test) {
+CasperTest.begin('Markdown help modal', 5, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/editor\/$/, 'Landed on the correct URL');

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -7,8 +7,8 @@
 // These are used to check that a switch to a tab is complete, or that we are on the right tab.
 var generalTabDetector = '.settings-content form#settings-general',
     userTabDetector = '.settings-content form.user-profile';
-//
-CasperTest.emberBegin('Settings screen is correct', 17, function suite(test) {
+
+CasperTest.begin('Settings screen is correct', 17, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/settings\/general\/$/, 'Landed on the correct URL');
@@ -46,7 +46,7 @@ CasperTest.emberBegin('Settings screen is correct', 17, function suite(test) {
 });
 
 // ## General settings tests
-CasperTest.emberBegin('General settings pane is correct', 8, function suite(test) {
+CasperTest.begin('General settings pane is correct', 8, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.general', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/settings\/general\/$/, 'Landed on the correct URL');
@@ -110,70 +110,70 @@ CasperTest.emberBegin('General settings pane is correct', 8, function suite(test
 });
 
 //// ## General settings validations tests
-CasperTest.emberBegin('General settings validation is correct', 7, function suite(test) {
-   casper.thenOpenAndWaitForPageLoad('settings.general', function testTitleAndUrl() {
-       test.assertTitle('Ghost Admin', 'Ghost admin has no title');
-       test.assertUrlMatch(/ghost\/ember\/settings\/general\/$/, 'Landed on the correct URL');
-   });
+CasperTest.begin('General settings validation is correct', 7, function suite(test) {
+    casper.thenOpenAndWaitForPageLoad('settings.general', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertUrlMatch(/ghost\/ember\/settings\/general\/$/, 'Landed on the correct URL');
+    });
 
-   // Ensure general blog title field length validation
-   casper.fillAndSave('form#settings-general', {
-       'general[title]': new Array(152).join('a')
-   });
+    // Ensure general blog title field length validation
+    casper.fillAndSave('form#settings-general', {
+        'general[title]': new Array(152).join('a')
+    });
 
-   casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-       test.assertSelectorHasText('.notification-error', 'too long');
-   }, casper.failOnTimeout(test, 'Blog title length error did not appear'), 2000);
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'too long');
+    }, casper.failOnTimeout(test, 'Blog title length error did not appear'), 2000);
 
-   casper.thenClick('.js-bb-notification .close');
+    casper.thenClick('.js-bb-notification .close');
 
-   // Ensure general blog description field length validation
-   casper.fillAndSave('form#settings-general', {
-       'general[description]': new Array(202).join('a')
-   });
+    // Ensure general blog description field length validation
+    casper.fillAndSave('form#settings-general', {
+        'general[description]': new Array(202).join('a')
+    });
 
-   casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-       test.assertSelectorHasText('.notification-error', 'too long');
-   }, casper.failOnTimeout(test, 'Blog description length error did not appear'));
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'too long');
+    }, casper.failOnTimeout(test, 'Blog description length error did not appear'));
 
-   casper.thenClick('.js-bb-notification .close');
+    casper.thenClick('.js-bb-notification .close');
 
-   // Ensure postsPerPage number field form validation
-   casper.fillAndSave('form#settings-general', {
-       'general[postsPerPage]': 'notaninteger'
-   });
+    // Ensure postsPerPage number field form validation
+    casper.fillAndSave('form#settings-general', {
+        'general[postsPerPage]': 'notaninteger'
+    });
 
-   casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-       test.assertSelectorHasText('.notification-error', 'use a number');
-   }, casper.failOnTimeout(test, 'postsPerPage error did not appear'), 2000);
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'use a number');
+    }, casper.failOnTimeout(test, 'postsPerPage error did not appear'), 2000);
 
-   casper.thenClick('.js-bb-notification .close');
+    casper.thenClick('.js-bb-notification .close');
 
-   // Ensure postsPerPage max of 1000
-   casper.fillAndSave('form#settings-general', {
-       'general[postsPerPage]': '1001'
-   });
+    // Ensure postsPerPage max of 1000
+    casper.fillAndSave('form#settings-general', {
+        'general[postsPerPage]': '1001'
+    });
 
-   casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-       test.assertSelectorHasText('.notification-error', 'use a number less than 1000');
-   }, casper.failOnTimeout(test, 'postsPerPage max error did not appear', 2000));
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'use a number less than 1000');
+    }, casper.failOnTimeout(test, 'postsPerPage max error did not appear', 2000));
 
-   casper.thenClick('.js-bb-notification .close');
+    casper.thenClick('.js-bb-notification .close');
 
-   // Ensure postsPerPage min of 0
-   casper.fillAndSave('form#settings-general', {
-       'general[postsPerPage]': '-1'
-   });
+    // Ensure postsPerPage min of 0
+    casper.fillAndSave('form#settings-general', {
+        'general[postsPerPage]': '-1'
+    });
 
-   casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
-       test.assertSelectorHasText('.notification-error', 'use a number greater than 0');
-   }, casper.failOnTimeout(test, 'postsPerPage min error did not appear', 2000));
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'use a number greater than 0');
+    }, casper.failOnTimeout(test, 'postsPerPage min error did not appear', 2000));
 });
 
 // ### User settings tests
 // Please uncomment and fix these as the functionality is implemented
 
-//CasperTest.emberBegin('Can save settings', 6, function suite(test) {
+//CasperTest.begin('Can save settings', 6, function suite(test) {
 //    casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
 //        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
 //        test.assertUrlMatch(/ghost\/ember\/settings\/user\/$/, 'Landed on the correct URL');
@@ -244,7 +244,7 @@ CasperTest.emberBegin('General settings validation is correct', 7, function suit
 
 
 //
-//CasperTest.emberBegin('User settings screen validates email', 6, function suite(test) {
+//CasperTest.begin('User settings screen validates email', 6, function suite(test) {
 //    var email, brokenEmail;
 //
 //    casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
@@ -287,7 +287,7 @@ CasperTest.emberBegin('General settings validation is correct', 7, function suit
 //});
 //
 //
-CasperTest.emberBegin('User settings screen shows remaining characters for Bio properly', 4, function suite(test) {
+CasperTest.begin('User settings screen shows remaining characters for Bio properly', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/settings\/user\/$/, 'Ghost doesn\'t require login this time');
@@ -312,7 +312,7 @@ CasperTest.emberBegin('User settings screen shows remaining characters for Bio p
     });
 });
 
-//CasperTest.emberBegin('Ensure user bio field length validation', 3, function suite(test) {
+//CasperTest.begin('Ensure user bio field length validation', 3, function suite(test) {
 //    casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
 //        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
 //        test.assertUrlMatch(/ghost\/settings\/user\/$/, 'Ghost doesn\'t require login this time');
@@ -331,7 +331,7 @@ CasperTest.emberBegin('User settings screen shows remaining characters for Bio p
 //    }, casper.failOnTimeout(test, 'Bio field length error did not appear', 2000));
 //});
 //
-//CasperTest.emberBegin('Ensure user url field validation', 3, function suite(test) {
+//CasperTest.begin('Ensure user url field validation', 3, function suite(test) {
 //    casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
 //        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
 //        test.assertUrlMatch(/ghost\/settings\/user\/$/, 'Ghost doesn\'t require login this time');
@@ -350,7 +350,7 @@ CasperTest.emberBegin('User settings screen shows remaining characters for Bio p
 //    }, casper.failOnTimeout(test, 'Url validation error did not appear', 2000));
 //});
 //
-//CasperTest.emberBegin('Ensure user location field length validation', 3, function suite(test) {
+//CasperTest.begin('Ensure user location field length validation', 3, function suite(test) {
 //    casper.thenOpenAndWaitForPageLoad('settings.user', function testTitleAndUrl() {
 //        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
 //        test.assertUrlMatch(/ghost\/settings\/user\/$/, 'Ghost doesn\'t require login this time');

--- a/core/test/functional/client/setup_test.js
+++ b/core/test/functional/client/setup_test.js
@@ -3,7 +3,7 @@
 
 /*global CasperTest, casper, email */
 
-CasperTest.emberBegin('Ghost setup fails properly', 5, function suite(test) {
+CasperTest.begin('Ghost setup fails properly', 5, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('setup', function then() {
         test.assertUrlMatch(/ghost\/ember\/setup\/$/, 'Landed on the correct URL');
     });

--- a/core/test/functional/client/signin_test.js
+++ b/core/test/functional/client/signin_test.js
@@ -3,7 +3,7 @@
 
 /*globals CasperTest, casper, url, newUser, user, falseUser */
 
-CasperTest.emberBegin('Ensure a User is Registered', 3, function suite(test) {
+CasperTest.begin('Ensure a User is Registered', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signup', function checkUrl() {
         test.assertUrlMatch(/ghost\/ember\/signup\/$/, 'Landed on the correct URL');
     });
@@ -33,7 +33,7 @@ CasperTest.emberBegin('Ensure a User is Registered', 3, function suite(test) {
     });
 }, true);
 
-CasperTest.emberBegin('Ghost admin will load login page', 3, function suite(test) {
+CasperTest.begin('Ghost admin will load login page', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/signin\/$/, 'We should be presented with the signin page.');
@@ -51,14 +51,14 @@ CasperTest.emberBegin('Ghost admin will load login page', 3, function suite(test
 
 // Note, this test applies to a global redirect, which sends us to the standard admin.
 // Once Ember becomes the standard admin, this test should still pass.
-CasperTest.emberBegin('Redirects login to signin', 2, function suite(test) {
+CasperTest.begin('Redirects login to signin', 2, function suite(test) {
     casper.start(url + 'ghost/login/', function testRedirect(response) {
         test.assertEqual(response.status, 200, 'Response status should be 200.');
         test.assertUrlMatch(/ghost\/signin\//, 'Should be redirected to /signin/.');
     });
 }, true);
 
-CasperTest.emberBegin('Can\'t spam it', 4, function suite(test) {
+CasperTest.begin('Can\'t spam it', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitle() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/signin\/$/, 'Landed on the correct URL');
@@ -94,7 +94,7 @@ CasperTest.emberBegin('Can\'t spam it', 4, function suite(test) {
 }, true);
 
 
-CasperTest.emberBegin('Login limit is in place', 4, function suite(test) {
+CasperTest.begin('Login limit is in place', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/signin\/$/, 'Landed on the correct URL');
@@ -123,7 +123,7 @@ CasperTest.emberBegin('Login limit is in place', 4, function suite(test) {
     casper.wait(2000);
 }, true);
 
-CasperTest.emberBegin('Can login to Ghost', 5, function suite(test) {
+CasperTest.begin('Can login to Ghost', 5, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/signin\/$/, 'Landed on the correct URL');
@@ -144,7 +144,7 @@ CasperTest.emberBegin('Can login to Ghost', 5, function suite(test) {
     });
 }, true);
 
-CasperTest.emberBegin('Ensure email field form validation', 3, function suite(test) {
+CasperTest.begin('Ensure email field form validation', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/ember\/signin\/$/, 'Landed on the correct URL');

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -2,10 +2,10 @@
 // Test that signout works correctly
 
 /*globals CasperTest, casper */
-CasperTest.emberBegin('Ghost signout works correctly', 4, function suite(test) {
-    CasperTest.Routines.register.run(test);
-    CasperTest.Routines.logout.run(test);
-    CasperTest.Routines.login.run(test);
+CasperTest.begin('Ghost signout works correctly', 4, function suite(test) {
+    CasperTest.Routines.setup.run(test);
+    CasperTest.Routines.signout.run(test);
+    CasperTest.Routines.signin.run(test);
 
     casper.thenOpenAndWaitForPageLoad('root', function then() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');

--- a/core/test/functional/client/signup_test.js
+++ b/core/test/functional/client/signup_test.js
@@ -4,7 +4,7 @@
 /*global CasperTest, casper, email */
 
 
-CasperTest.emberBegin('Ghost signup fails properly', 0, function suite(test) {
+CasperTest.begin('Ghost signup fails properly', 0, function suite(test) {
 /*
     casper.thenOpenAndWaitForPageLoad('signup', function then() {
         test.assertUrlMatch(/ghost\/ember\/signup\/$/, 'Landed on the correct URL');

--- a/core/test/functional/clientold/logout_test.js
+++ b/core/test/functional/clientold/logout_test.js
@@ -4,9 +4,9 @@
 
 /*globals casper, __utils__, url, testPost, falseUser, email */
 CasperTest.begin("Ghost logout works correctly", 2, function suite(test) {
-    CasperTest.Routines.register.run(test);
-    CasperTest.Routines.logout.run(test);
-    CasperTest.Routines.login.run(test);
+    CasperTest.Routines.oldRegister.run(test);
+    CasperTest.Routines.oldLogout.run(test);
+    CasperTest.Routines.oldLogin.run(test);
 
     casper.thenOpen(url + "ghost/", function then() {
         test.assertEquals(casper.getCurrentUrl(), url + "ghost/", "Ghost doesn't require login this time");


### PR DESCRIPTION
ref #3060
- Some of our tests use the old signin/signout as part of the setup/teardown process. The old stuff is going away, so this PR switches everything over to use the new admin by default.
- There wil be a further PR to remove the old stuff completely soon.
