### PR TITLE
Fix mail test send endpoint

### DIFF
--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -1,6 +1,6 @@
 // # Mail API
 // API for sending Mail
-var when       = require("when"),
+var when       = require('when'),
     config     = require('../config'),
     errors     = require('../errors'),
     mail;
@@ -39,14 +39,16 @@ mail = {
                 return when.reject(new errors.EmailError(error.message));
             });
     },
+
     /**
      * ### SendTest
      * Send a test email
      *
      * @public
+     * @param {Object} required property 'to' which contains the recipient address
      * @returns {Promise}
      */
-    sendTest: function () {
+    sendTest: function (object) {
         var html = '<p><strong>Hello there!</strong></p>' +
             '<p>Excellent!' +
             ' You\'ve successfully setup your email config for your Ghost blog over on ' + config().url + '</p>' +
@@ -57,6 +59,7 @@ mail = {
 
             payload = {mail: [{
                 message: {
+                    to: object.to,
                     subject: 'Test Ghost Email',
                     html: html
                 }
@@ -65,4 +68,5 @@ mail = {
         return mail.send(payload);
     }
 };
+
 module.exports = mail;

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -39,7 +39,17 @@ apiRoutes = function (middleware) {
     router['delete']('/ghost/api/v0.1/db/', api.http(api.db.deleteAllContent));
     // ## Mail
     router.post('/ghost/api/v0.1/mail', api.http(api.mail.send));
-    router.post('/ghost/api/v0.1/mail/test', api.http(api.mail.sendTest));
+    router.post('/ghost/api/v0.1/mail/test', function (req, res) {
+        api.settings.read('email').then(function (result) {
+            // attach the to: address to the request body so that it is available
+            // to the http api handler
+            req.body = { to: result.settings[0].value };
+
+            api.http(api.mail.sendTest)(req, res);
+        }).catch(function () {
+            api.http(api.mail.sendTest)(req, res);
+        });
+    });
     // ## Slugs
     router.get('/ghost/api/v0.1/slugs/:type/:name', api.http(api.slugs.generate));
     // ## Authentication


### PR DESCRIPTION
Closes #3071
-Inject a test payload into the mail api from the route
 handler.
-Remove sendTest method from the mail api.
