### PR TITLE
Revert staticPage setting on validation or server error

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -22,8 +22,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             return this.get('model').save().then(function () {
                 self.notifications.showSuccess('Successfully converted to ' + (val ? 'static page' : 'post'));
 
-                return self.get('page');
             }).catch(function (errors) {
+                self.toggleProperty('page');
                 self.notifications.showErrors(errors);
                 return Ember.RSVP.reject(errors);
             });


### PR DESCRIPTION
closes #3134
- reset `page` property in PSM if errors occur after un/setting static page in editor
