### PR TITLE
Fix tag updating on model save in editor controller

### DIFF
--- a/core/client/mixins/editor-route-base.js
+++ b/core/client/mixins/editor-route-base.js
@@ -22,6 +22,26 @@ var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
         }
     },
 
+    attachModelHooks: function (controller, model) {
+        // this will allow us to track when the model is saved and update the controller
+        // so that we can be sure controller.isDirty is correct, without having to update the
+        // controller on each instance of `model.save()`.
+        //
+        // another reason we can't do this on `model.save().then()` is because the post-settings-menu
+        // also saves the model, and passing messages is difficult because we have two
+        // types of editor controllers, and the PSM also exists on the posts.post route.
+        //
+        // The reason we can't just keep this functionality in the editor controller is
+        // because we need to remove these handlers on `willTransition` in the editor route.
+        model.on('didCreate', controller, controller.get('modelSaved'));
+        model.on('didUpdate', controller, controller.get('modelSaved'));
+    },
+
+    detachModelHooks: function (controller, model) {
+        model.off('didCreate', controller, controller.get('modelSaved'));
+        model.off('didUpdate', controller, controller.get('modelSaved'));
+    },
+
     shortcuts: {
         //General Editor shortcuts
         'ctrl+s, command+s': 'save',

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -46,6 +46,9 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
         controller.set('scratch', model.get('markdown'));
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', model.get('tags').mapBy('name'));
+
+        // attach model-related listeners created in editor-route-base
+        this.attachModelHooks(controller, model);
     },
 
     actions: {
@@ -73,6 +76,9 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
 
             // since the transition is now certain to complete..
             window.onbeforeunload = null;
+
+            // remove model-related listeners created in editor-route-base
+            this.detachModelHooks(controller, model);
         }
     }
 });

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -14,6 +14,9 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
 
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', Ember.A());
+
+        // attach model-related listeners created in editor-route-base
+        this.attachModelHooks(controller, model);
     },
 
     actions: {
@@ -46,6 +49,9 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
 
             // since the transition is now certain to complete..
             window.onbeforeunload = null;
+
+            // remove model-related listeners created in editor-route-base
+            this.detachModelHooks(controller, model);
         }
     }
 });


### PR DESCRIPTION
closes #3131
- create a hook in the editor controller that fires on a model's save events
- use this hook to perform all the things that need to happen on save, regardless of where the save originated
- remove logic from instances of model.save() that now belongs in the modelSaved hook
- detach the model event listeners on willTransition in the editor routes
