### PR TITLE
Better handling of validation errors + more documentation

### DIFF
--- a/core/client/controllers/posts.js
+++ b/core/client/controllers/posts.js
@@ -92,7 +92,7 @@ var PostsController = Ember.ArrayController.extend({
 
         if (response) {
             // Get message from response
-            message += ': ' + getRequestErrorMessage(response);
+            message += ': ' + getRequestErrorMessage(response, true);
         } else {
             message += '.';
         }

--- a/core/client/utils/ajax.js
+++ b/core/client/utils/ajax.js
@@ -6,7 +6,7 @@ var ajax = window.ajax = function () {
 
 // Used in API request fail handlers to parse a standard api error
 // response json for the message to display
-var getRequestErrorMessage = function (request) {
+var getRequestErrorMessage = function (request, performConcat) {
     var message,
         msgDetail;
 
@@ -26,7 +26,7 @@ var getRequestErrorMessage = function (request) {
 
                 message = request.responseJSON.errors.map(function (errorItem) {
                     return errorItem.message;
-                }).join('<br />');
+                });
             } else {
                 message =  request.responseJSON.error || 'Unknown Error';
             }
@@ -34,6 +34,15 @@ var getRequestErrorMessage = function (request) {
             msgDetail = request.status ? request.status + ' - ' + request.statusText : 'Server was not available';
             message = 'The server returned an error (' + msgDetail + ').';
         }
+    }
+
+    if (performConcat && Ember.isArray(message)) {
+        message = message.join('<br />');
+    }
+
+    // return an array of errors by default
+    if (!performConcat && typeof message === 'string') {
+        message = [message];
     }
 
     return message;

--- a/core/client/validators/forgotten.js
+++ b/core/client/validators/forgotten.js
@@ -1,5 +1,5 @@
 var ForgotValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var data = model.getProperties('email'),
             validationErrors = [];
 

--- a/core/client/validators/post.js
+++ b/core/client/validators/post.js
@@ -1,5 +1,5 @@
 var PostValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var validationErrors = [],
 
             title = model.get('title');

--- a/core/client/validators/reset.js
+++ b/core/client/validators/reset.js
@@ -1,5 +1,5 @@
 var ResetValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
 
         var data = model.getProperties('passwords'),
             p1 = data.passwords.newPassword,

--- a/core/client/validators/setting.js
+++ b/core/client/validators/setting.js
@@ -1,5 +1,5 @@
 var SettingValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var validationErrors = [],
             title = model.get('title'),
             description = model.get('description'),

--- a/core/client/validators/setup.js
+++ b/core/client/validators/setup.js
@@ -1,5 +1,5 @@
 var SetupValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var data = model.getProperties('blogTitle', 'name', 'email', 'password'),
             validationErrors = [];
 
@@ -8,7 +8,7 @@ var SetupValidator = Ember.Object.create({
                 message: 'Please enter a blog title.'
             });
         }
-        
+
         if (!validator.isLength(data.name || '', 1)) {
             validationErrors.push({
                 message: 'Please enter a name.'

--- a/core/client/validators/signin.js
+++ b/core/client/validators/signin.js
@@ -1,5 +1,5 @@
 var SigninValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var data = model.getProperties('identification', 'password'),
             validationErrors = [];
 

--- a/core/client/validators/signup.js
+++ b/core/client/validators/signup.js
@@ -1,8 +1,8 @@
 var SignupValidator = Ember.Object.create({
-    validate: function (model) {
+    check: function (model) {
         var data = model.getProperties('name', 'email', 'password'),
             validationErrors = [];
-        
+
         if (!validator.isLength(data.name || '', 1)) {
             validationErrors.push({
                 message: 'Please enter a name.'


### PR DESCRIPTION
closes #3153
- this is all about the validation engine
- add a option, `opts.model`, to use a passed-in model directly if needed
- handle validators that return an array of strings, array of objects, or both
- ajax util returns either an array of errors or a single concat'd string
- remove formatErrors function from the mixin and make it private
- allow validation options to be passed into `.save()` since ember-data doesn't take params on `.save()` anyway
- streamline control flow

The validation engine needs to be updated to handle different error types (array of objects vs. array of strings or a mix of both), as well as handle more passed-in options depending on what's needed. Also, needs more docs. :)

As I update the PR for this, it'd be great to hear pain points, feature requests, and thoughts of the new features added.
