### PR TITLE
Signin Validation

### DIFF
--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -1,5 +1,21 @@
-var SigninController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin, {
+import ValidationEngine from 'ghost/mixins/validation-engine';
+
+var SigninController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin, ValidationEngine, {
     authenticatorFactory: 'ember-simple-auth-authenticator:oauth2-password-grant',
+
+    validationType: 'signin',
+
+    actions: {
+        validateAndAuthenticate: function () {
+            var self = this;
+
+            this.validate({ format: false }).then(function () {
+                self.send('authenticate');
+            }).catch(function (errors) {
+                self.notifications.showErrors(errors);
+            });
+        }
+    }
 });
 
 export default SigninController;

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -1,12 +1,12 @@
 <section class="login-box js-login-box fade-in">
-    <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'authenticate' on='submit'}}>
+    <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
             {{input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" autocapitalize="off" autocorrect="off" value=identification}}
         </div>
         <div class="password-wrap">
             {{input class="password" type="password" placeholder="Password" name="password" value=password}}
         </div>
-        <button class="button-save" type="submit" {{action "authenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
+        <button class="button-save" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
         <section class="meta">
             {{#link-to 'forgotten' class="forgotten-password"}}Forgotten password?{{/link-to}}
         </section>


### PR DESCRIPTION
closes #3120
- create `validateAndAuthenticate` action to validate, send `authenticate` action on success, notifications on error
- signin template uses `validateAndAuthenticate` action instead of `authenticate` action
