### PR TITLE
Fix direct access to settings/user using session.user CP

### DIFF
--- a/core/client/controllers/settings/user.js
+++ b/core/client/controllers/settings/user.js
@@ -1,9 +1,12 @@
 /*global alert */
-var SettingsUserController = Ember.Controller.extend({
+var SettingsUserController = Ember.ObjectController.extend({
+
+    user: Ember.computed.alias('model'),
+
     coverDefault: '/shared/img/user-cover.png',
     cover: function () {
         // @TODO: add {{asset}} subdir path
-        var cover = this.user.get('cover');
+        var cover = this.get('user.cover');
         if (typeof cover !== 'string') {
             cover = this.get('coverDefault');
         }
@@ -16,35 +19,36 @@ var SettingsUserController = Ember.Controller.extend({
 
     image: function () {
         // @TODO: add {{asset}} subdir path
-        return 'background-image: url(' + this.user.getWithDefault('image', '/shared/img/user-image.png') + ')';
+        return 'background-image: url(' + this.getWithDefault('user.image', '/shared/img/user-image.png') + ')';
     }.property('user.image'),
 
     actions: {
         save: function () {
-            var self = this;
+            var user = this.get('user'),
+                self = this;
 
             self.notifications.closePassive();
 
             alert('@TODO: Saving user...');
 
-            if (this.user.validate().get('isValid')) {
-                this.user.save().then(function (response) {
-
+            if (user.validate().get('isValid')) {
+                user.save().then(function (response) {
                     alert('Done saving' + JSON.stringify(response));
                 }, function () {
                     alert('Error saving.');
                 });
             } else {
-                alert('Errors found! ' + JSON.stringify(this.user.get('errors')));
+                alert('Errors found! ' + JSON.stringify(user.get('errors')));
             }
         },
 
         password: function () {
             alert('@TODO: Changing password...');
-            var passwordProperties = this.getProperties('password', 'newPassword', 'ne2Password');
+            var user = this.get('user'),
+                passwordProperties = this.getProperties('password', 'newPassword', 'ne2Password');
 
-            if (this.user.validatePassword(passwordProperties).get('passwordIsValid')) {
-                this.user.saveNewPassword(passwordProperties).then(function () {
+            if (user.validatePassword(passwordProperties).get('passwordIsValid')) {
+                user.saveNewPassword(passwordProperties).then(function () {
                     alert('Success!');
                     // Clear properties from view
                     this.setProperties({
@@ -56,7 +60,7 @@ var SettingsUserController = Ember.Controller.extend({
                     alert('Errors ' + JSON.stringify(errors));
                 });
             } else {
-                alert('Errors found! ' + JSON.stringify(this.user.get('passwordErrors')));
+                alert('Errors found! ' + JSON.stringify(user.get('passwordErrors')));
             }
         }
     }

--- a/core/client/controllers/setup.js
+++ b/core/client/controllers/setup.js
@@ -28,11 +28,8 @@ var SetupController = Ember.ObjectController.extend(ValidationEngine, {
                         identification: self.get('email'),
                         password: self.get('password')
                     }).then(function () {
-                        self.store.find('user', 'me').then(function (user) {
-                            self.send('signedIn', user);
-                            self.notifications.clear();
-                            self.transitionToRoute(Ember.SimpleAuth.routeAfterAuthentication);
-                        });
+                        self.send('signedIn');
+                        self.transitionToRoute(Ember.SimpleAuth.routeAfterAuthentication);
                     });
                 }, function (resp) {
                     self.toggleProperty('submitting');

--- a/core/client/controllers/signup.js
+++ b/core/client/controllers/signup.js
@@ -27,11 +27,8 @@ var SignupController = Ember.ObjectController.extend(ValidationEngine, {
                         identification: self.get('email'),
                         password: self.get('password')
                     }).then(function () {
-                        self.store.find('user', 'me').then(function (user) {
-                            self.send('signedIn', user);
-                            self.notifications.clear();
-                            self.transitionToRoute(Ember.SimpleAuth.routeAfterAuthentication);
-                        });
+                        self.send('signedIn');
+                        self.transitionToRoute(Ember.SimpleAuth.routeAfterAuthentication);
                     });
                 }, function (resp) {
                     self.toggleProperty('submitting');

--- a/core/client/initializers/authentication.js
+++ b/core/client/initializers/authentication.js
@@ -4,6 +4,11 @@ var AuthenticationInitializer = {
     after: 'registerTrailingLocationHistory',
 
     initialize: function (container, application) {
+        Ember.SimpleAuth.Session.reopen({
+            user: function () {
+                return container.lookup('store:main').find('user', 'me');
+            }.property()
+        });
         Ember.SimpleAuth.Authenticators.OAuth2.reopen({
             serverTokenEndpoint: '/ghost/api/v0.1/authentication/token',
             refreshAccessTokens: true,

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -6,20 +6,6 @@ var ApplicationRoute = Ember.Route.extend(Ember.SimpleAuth.ApplicationRouteMixin
     shortcuts: {
         'esc': 'closePopups'
     },
-    beforeModel: function () {
-        var self = this;
-        if (this.get('session').isAuthenticated) {
-            this.store.find('user', 'me').then(function (user) {
-                // Update the user on all routes and controllers
-                self.container.unregister('user:current');
-                self.container.register('user:current', user, { instantiate: false });
-
-                self.container.injection('route', 'user', 'user:current');
-                self.container.injection('controller', 'user', 'user:current');
-
-            });
-        }
-    },
     mobileInteractions: function () {
         var responsiveAction = mobileUtils.responsiveAction;
 
@@ -47,30 +33,8 @@ var ApplicationRoute = Ember.Route.extend(Ember.SimpleAuth.ApplicationRouteMixin
             this.send('closeModal');
         },
 
-        signedIn: function (user) {
-            // Update the user on all routes and controllers
-            this.container.unregister('user:current');
-            this.container.register('user:current', user, { instantiate: false });
-
-            this.container.injection('route', 'user', 'user:current');
-            this.container.injection('controller', 'user', 'user:current');
-
-            this.set('user', user);
-            this.set('controller.user', user);
-
+        signedIn: function () {
             this.send('loadServerNotifications', true);
-        },
-
-        signedOut: function () {
-            // Nullify the user on all routes and controllers
-            this.container.unregister('user:current');
-            this.container.register('user:current', null, { instantiate: false });
-
-            this.container.injection('route', 'user', 'user:current');
-            this.container.injection('controller', 'user', 'user:current');
-
-            this.set('user', null);
-            this.set('controller.user', null);
         },
 
         openModal: function (modalName, model, type) {

--- a/core/client/routes/settings/user.js
+++ b/core/client/routes/settings/user.js
@@ -1,0 +1,21 @@
+var SettingsUserRoute = Ember.Route.extend({
+    model: function () {
+        return this.session.get('user').then(function (user) {
+            user.reload();
+            return user;
+        });
+    },
+
+    deactivate: function () {
+        this._super();
+
+        // we want to revert any unsaved changes on exit
+        this.session.get('user').then(function (user) {
+            if (user.get('isDirty')) {
+                user.rollback();
+            }
+        });
+    }
+});
+
+export default SettingsUserRoute;

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -10,12 +10,12 @@
 
             <li id="usermenu" class="usermenu subnav">
                 {{#gh-popover-button popoverName="user-menu" tagName="a" href="#" classNames="dropdown"}}
-                    {{#if user.image}}
-                    <img class="avatar" {{bind-attr src="user.image"}} alt="Avatar" />
+                    {{#if session.user.image}}
+                    <img class="avatar" {{bind-attr src="session.user.image"}} alt="Avatar" />
                     {{else}}
                     <img class="avatar" src="/shared/img/user-image.png" alt="Avatar" />
                     {{/if}}
-                    <span class="name">{{user.name}}</span>
+                    <span class="name">{{session.user.name}}</span>
                 {{/gh-popover-button}}
                 {{#gh-popover tagName="ul" classNames="overlay" name="user-menu" closeOnClick="true"}}
                         <li class="usermenu-profile">{{#link-to "settings.user"}}Your Profile{{/link-to}}</li>


### PR DESCRIPTION
closes #3162
- removes injection of user object in application route's beforeModel
- removes injection/cleanup of user object in signedIn/signedOut actions
- removes loading of user and passing to signedIn action in signup/setup controllers
- adds 'user' property to session object
- updates header nav to reference session.user
- sets model of settings/user route to session.user and forces reload
- on leaving settings/user, rollback any unsaved changes
