### PR TITLE
PostSettingsMenu: Don't save new posts, reset values on failure

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -13,24 +13,6 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             this.addObserver('title', this, 'titleObserver');
         }
     },
-    isStaticPage: function (key, val) {
-        var self = this;
-
-        if (arguments.length > 1) {
-            this.set('page', val);
-
-            return this.get('model').save().then(function () {
-                self.notifications.showSuccess('Successfully converted to ' + (val ? 'static page' : 'post'));
-
-                return self.get('page');
-            }).catch(function (errors) {
-                self.notifications.showErrors(errors);
-                return Ember.RSVP.reject(errors);
-            });
-        }
-
-        return this.get('page');
-    }.property('page'),
     /**
      * The placeholder is the published date of the post,
      * or the current date if the pubdate has not been set.
@@ -47,14 +29,15 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     slugValue: boundOneWay('slug'),
     //Lazy load the slug generator for slugPlaceholder
     slugGenerator: Ember.computed(function () {
-        return SlugGenerator.create({ghostPaths: this.get('ghostPaths')});
+        return SlugGenerator.create({
+            ghostPaths: this.get('ghostPaths')
+        });
     }),
     //Requests slug from title
     generateSlugPlaceholder: function () {
         var self = this,
-            slugGenerator = this.get('slugGenerator'),
             title = this.get('title');
-        slugGenerator.generateSlug(title).then(function (slug) {
+        this.get('slugGenerator').generateSlug(title).then(function (slug) {
             self.set('slugPlaceholder', slug);
         });
     },
@@ -80,7 +63,34 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         return this.get('title');
     }.property(),
 
+    showErrors: function (errors) {
+        errors = Ember.isArray(errors) ? errors : [errors];
+        this.notifications.closePassive();
+        this.notifications.showErrors(errors);
+    },
+    showSuccess: function (message) {
+        this.notifications.closePassive();
+        this.notifications.showSuccess(message);
+    },
     actions: {
+        togglePage: function () {
+            var value = this.toggleProperty('page'),
+                self = this;
+
+            // If this is a new post.  Don't save the model.  Defer the save
+            // to the user pressing the save button
+            if (this.get('isNew')) {
+                return;
+            }
+
+            return this.get('model').save().then(function () {
+                self.showSuccess('Successfully converted to ' + (value ? 'static page' : 'post'));
+                return value;
+            }).catch(function (errors) {
+                self.showErrors(errors);
+                self.get('model').rollback();
+            });
+        },
         /**
          * triggered by user manually changing slug
          */
@@ -135,13 +145,13 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 }
 
                 // Save post model properties excluding any changes to the post body
-                return self.get('model').save().then(function () {
-                    self.notifications.showSuccess('Permalink successfully changed to <strong>' +
-                        self.get('slug') + '</strong>.');
-                }).catch(function (errors) {
-                    self.notifications.showErrors(errors);
-                    return Ember.RSVP.reject(errors);
-                });
+                return self.get('model').save();
+            }).then(function () {
+                self.showSuccess('Permalink successfully changed to <strong>' +
+                    self.get('slug') + '</strong>.');
+            }).catch(function (errors) {
+                self.showErrors(errors);
+                self.get('model').rollback();
             });
         },
 
@@ -164,37 +174,41 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return;
             }
 
-            // Do nothing if the user didn't actually change the date
-            if (publishedAt && publishedAt.isSame(newPublishedAt)) {
-                return;
-            }
-
             // Validate new Published date
             if (!newPublishedAt.isValid()) {
                 errMessage = 'Published Date must be a valid date with format: ' +
                     'DD MMM YY @ HH:mm (e.g. 6 Dec 14 @ 15:00)';
             }
-
-            //Can't publish in the future yet
             if (newPublishedAt.diff(new Date(), 'h') > 0) {
                 errMessage = 'Published Date cannot currently be in the future.';
             }
 
             //If errors, notify and exit.
             if (errMessage) {
-                this.notifications.showError(errMessage);
+                this.showErrors(errMessage);
+                return;
+            }
+
+            // Do nothing if the user didn't actually change the date
+            if (publishedAt && publishedAt.isSame(newPublishedAt)) {
                 return;
             }
 
             //Validation complete
             this.set('published_at', newPublishedAt);
 
+            // If this is a new post.  Don't save the model.  Defer the save
+            // to the user pressing the save button
+            if (this.get('isNew')) {
+                return;
+            }
+
             this.get('model').save().then(function () {
-                self.notifications.showSuccess('Publish date successfully changed to <strong>' +
+                self.showSuccess('Publish date successfully changed to <strong>' +
                     formatDate(self.get('published_at')) + '</strong>.');
             }).catch(function (errors) {
-                self.notifications.showErrors(errors);
-                return Ember.RSVP.reject(errors);
+                self.showErrors(errors);
+                self.get('model').rollback();
             });
         }
     }

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -22,8 +22,8 @@
                     <label class="label" for="static-page">Static Page</label>
                 </td>
                 <td class="post-setting-item">
-                    {{input type="checkbox" name="static-page" id="static-page" class="post-setting-static-page" checked=isStaticPage}}
-                    <label class="checkbox" for="static-page"></label>
+                    {{input type="checkbox" name="static-page" id="static-page" class="post-setting-static-page" checked=page}}
+                    <label class="checkbox" for="static-page" {{action 'togglePage' bubbles="false"}}></label>
                 </td>
             </tr>
         </tbody>

--- a/core/test/functional/client/content_test.js
+++ b/core/test/functional/client/content_test.js
@@ -101,7 +101,7 @@ CasperTest.begin('Content list shows correct post status', 7, function testStati
         test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
     });
 
-    casper.thenClick('.post-settings-menu .post-setting-static-page');
+    casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
     casper.waitForSelector('.content-list-content li .entry-meta .status .page', function waitForSuccess() {
         test.assertSelectorHasText('.content-list-content li .entry-meta .status .page', 'Page', 'status is Page');
@@ -310,7 +310,7 @@ CasperTest.begin('Post can be changed to static page', 7, function suite(test) {
         test.assert(true, 'post settings should be visible after clicking post-settings icon');
     });
 
-    casper.thenClick('.post-settings-menu .post-setting-static-page');
+    casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');
@@ -324,7 +324,7 @@ CasperTest.begin('Post can be changed to static page', 7, function suite(test) {
         test.assertNotVisible('.notification-success', 'success notification should not still exist');
     });
 
-    casper.thenClick('.post-settings-menu .post-setting-static-page');
+    casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -354,7 +354,7 @@ CasperTest.begin('Post settings menu', 31, function suite(test) {
         test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
     });
 
-    casper.thenClick('.post-settings-menu .post-setting-static-page');
+    casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');
@@ -368,7 +368,7 @@ CasperTest.begin('Post settings menu', 31, function suite(test) {
         test.assertNotVisible('.notification-success', 'success notification should not still exist');
     });
 
-    casper.thenClick('.post-settings-menu .post-setting-static-page');
+    casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');


### PR DESCRIPTION
Closes #3158, Closes #3143, Closes #3134
- Added `togglePage` action to indirect the setting of `page`. togglePage resets page back to its original value in the case of an error saving.
- Removed `isStaticPage` property in favor of `togglePage` action
- `updateSlug` and `updatePublishedAt` similarly reset their respective properties on failure
- moved `updateSlug` error catching to outer promise (slugGenerator promise)
-  modifying the `page` and `published_at` properties will no longer cause a new post to save
- Close passive notifications on published date parse fail
- Removed promise creation in catch statements
