### PR TITLE
Prevent stacking notifications during rapid toggle

### DIFF
--- a/core/client/controllers/editor/new.js
+++ b/core/client/controllers/editor/new.js
@@ -11,7 +11,6 @@ var EditorNewController = Ember.ObjectController.extend(EditorControllerMixin, {
                 if (model.get('id')) {
                     self.transitionToRoute('editor.edit', model);
                 }
-                return model;
             });
         }
     }

--- a/core/client/controllers/posts/post.js
+++ b/core/client/controllers/posts/post.js
@@ -7,13 +7,12 @@ var PostController = Ember.ObjectController.extend({
             var featured = this.toggleProperty('featured'),
                 self = this;
 
-            self.notifications.closePassive();
-
             this.get('model').save().then(function () {
+                self.notifications.closePassive();
                 self.notifications.showSuccess('Post successfully marked as ' + (featured ? 'featured' : 'not featured') + '.');
             }).catch(function (errors) {
+                self.notifications.closePassive();
                 self.notifications.showErrors(errors);
-                return Ember.RSVP.reject(errors);
             });
         }
     }

--- a/core/client/controllers/settings/general.js
+++ b/core/client/controllers/settings/general.js
@@ -30,16 +30,14 @@ var SettingsGeneralController = Ember.ObjectController.extend({
         save: function () {
             var self = this;
 
-            self.notifications.closePassive();
-
             return this.get('model').save().then(function (model) {
+                self.notifications.closePassive();
                 self.notifications.showSuccess('Settings successfully saved.');
 
                 return model;
             }).catch(function (errors) {
+                self.notifications.closePassive();
                 self.notifications.showErrors(errors);
-
-                return Ember.RSVP.reject(errors);
             });
         },
     }

--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -12,6 +12,7 @@ var SigninController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerM
             this.validate({ format: false }).then(function () {
                 self.send('authenticate');
             }).catch(function (errors) {
+                self.notifications.closePassive();
                 self.notifications.showErrors(errors);
             });
         }


### PR DESCRIPTION
This covers the following:
- It's still possible to get multiple stacked notifications for the same event on UI elements that you can toggle very rapidly (featured/not featured, general settings save button, sign in button, etc.).  This calls `notifications.closePassive()` after both the successful or rejected promise resolution.  Otherwise what can happen is that notifications get cleared, save gets called async, the user toggles the item again and notifications get cleared again before the original async save is finished--eventually you end up with a bunch of notifications when the saves catch up.
- We discovered earlier today that re-rejecting promises in `.catch` handlers of controller actions can result in Ember throwing unhandled rejection errors.  This removes the occurrences of this behavior where it shouldn't be that aren't covered by #3180.
