### PR TITLE
Fix up route parameter validation

### DIFF
--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -10,8 +10,8 @@ var EditorEditRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixi
 
         postId = Number(params.post_id);
 
-        if (!Number.isInteger(postId) || !Number.isFinite(postId) || postId <= 0) {
-            this.transitionTo('error404', 'editor/' + params.post_id);
+        if (!_.isNumber(postId) || !_.isFinite(postId) || postId % 1 !== 0 || postId <= 0) {
+            return this.transitionTo('error404', 'editor/' + params.post_id);
         }
 
         post = this.store.getById('post', postId);

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -9,8 +9,9 @@ var PostsPostRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin
 
         postId = Number(params.post_id);
 
-        if (!Number.isInteger(postId) || !Number.isFinite(postId) || postId <= 0) {
-            this.transitionTo('error404', params.post_id);
+        if (!_.isNumber(postId) || !_.isFinite(postId) || postId % 1 !== 0 || postId <= 0)
+        {
+            return this.transitionTo('error404', params.post_id);
         }
 
         post = this.store.getById('post', postId);


### PR DESCRIPTION
Closes #3169
-Replace javascript methods that are not available on all
 supported browsers with lodash methods.
-Add returns to transitionTo calls in cases where the model
 hook should stop executing immediately.
