### PR TITLE
Indirect post title in editor

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -10,7 +10,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         // when creating a new post we want to observe the title
         // to generate the post's slug
         if (this.get('isNew')) {
-            this.addObserver('title', this, 'titleObserver');
+            this.addObserver('titleScratch', this, 'titleObserver');
         }
     },
     /**
@@ -36,13 +36,14 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     //Requests slug from title
     generateSlugPlaceholder: function () {
         var self = this,
-            title = this.get('title');
+            title = this.get('titleScratch');
+        
         this.get('slugGenerator').generateSlug(title).then(function (slug) {
             self.set('slugPlaceholder', slug);
         });
     },
     titleObserver: function () {
-        if (this.get('isNew') && this.get('model').changedAttributes().hasOwnProperty('title')) {
+        if (this.get('isNew')) {
             Ember.run.debounce(this, 'generateSlugPlaceholder', 700);
         }
     },
@@ -60,7 +61,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             return value;
         }
         //The title will stand in until the actual slug has been generated
-        return this.get('title');
+        return this.get('titleScratch');
     }.property(),
 
     showErrors: function (errors) {
@@ -97,7 +98,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         updateSlug: function (newSlug) {
             var slug = this.get('slug'),
                 self = this;
-
+            
             newSlug = newSlug || slug;
 
             newSlug = newSlug.trim();
@@ -134,8 +135,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
 
                 self.set('slug', serverSlug);
 
-                if (self.hasObserverFor('title')) {
-                    self.removeObserver('title', self, 'titleObserver');
+                if (self.hasObserverFor('titleScratch')) {
+                    self.removeObserver('titleScratch', self, 'titleObserver');
                 }
 
                 // If this is a new post.  Don't save the model.  Defer the save

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -192,8 +192,10 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             // ensure an incomplete tag is finalised before save
             this.get('controllers.post-tags-input').send('addNewTag');
 
+            // Set the properties that are indirected
             // set markdown equal to what's in the editor, minus the image markers.
             this.set('markdown', this.getMarkdown().withoutMarkers);
+            this.set('title', this.get('titleScratch'));
             this.set('status', status);
 
             return this.get('model').save().then(function (model) {

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -1,4 +1,5 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
+import boundOneWay from 'ghost/utils/bound-one-way';
 
 var Post = DS.Model.extend(ValidationEngine, {
     validationType: 'post',
@@ -23,7 +24,7 @@ var Post = DS.Model.extend(ValidationEngine, {
     published_at: DS.attr('moment-date'),
     published_by: DS.belongsTo('user', { async: true }),
     tags: DS.hasMany('tag', { embedded: 'always' }),
-
+    titleScratch: boundOneWay('title'),
     //## Computed post properties
     isPublished: Ember.computed.equal('status', 'published'),
     isDraft: Ember.computed.equal('status', 'draft'),

--- a/core/client/templates/editor/edit.hbs
+++ b/core/client/templates/editor/edit.hbs
@@ -1,6 +1,6 @@
 <header>
     <section class="box entry-title">
-        {{gh-trim-focus-input type="text" id="entry-title" placeholder="Your Post Title" value=title tabindex="1"}}
+        {{gh-trim-focus-input type="text" id="entry-title" placeholder="Your Post Title" value=titleScratch tabindex="1"}}
     </section>
 </header>
 


### PR DESCRIPTION
Closes #3179
- Add `titleScratch` property to `PostModel`.
- Changed references to `title` to `titleScratch`
