### PR TITLE
fixing sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "bower": "~1.3.5",
         "grunt": "~0.4.1",
         "grunt-cli": "~0.1.13",
-        "grunt-concat-sourcemap": "~0.4.0",
+        "grunt-concat-sourcemap": "~0.4.3",
         "grunt-contrib-clean": "~0.5.0",
         "grunt-contrib-compress": "~0.5.2",
         "grunt-contrib-concat": "~0.4.0",


### PR DESCRIPTION
closes #3186
bumping `grunt-concat-sourcemap` v0.4.0 -> v0.4.3
