### PR TITLE
Remove minor notifications; Close persistent notifications even on error

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -77,19 +77,16 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     },
     actions: {
         togglePage: function () {
-            var value = this.toggleProperty('page'),
-                self = this;
+            var self = this;
 
+            this.toggleProperty('page');
             // If this is a new post.  Don't save the model.  Defer the save
             // to the user pressing the save button
             if (this.get('isNew')) {
                 return;
             }
-            
-            return this.get('model').save(this.get('saveOptions')).then(function () {
-                self.showSuccess('Successfully converted to ' + (value ? 'static page' : 'post'));
-                return value;
-            }).catch(function (errors) {
+
+            this.get('model').save(this.get('saveOptions')).catch(function (errors) {
                 self.showErrors(errors);
                 self.get('model').rollback();
             });
@@ -205,10 +202,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return;
             }
 
-            this.get('model').save(this.get('saveOptions')).then(function () {
-                self.showSuccess('Publish date successfully changed to <strong>' +
-                    formatDate(self.get('published_at')) + '</strong>.');
-            }).catch(function (errors) {
+            this.get('model').save(this.get('saveOptions')).catch(function (errors) {
                 self.showErrors(errors);
                 self.get('model').rollback();
             });

--- a/core/client/controllers/posts/post.js
+++ b/core/client/controllers/posts/post.js
@@ -4,13 +4,11 @@ var PostController = Ember.ObjectController.extend({
 
     actions: {
         toggleFeatured: function () {
-            var featured = this.toggleProperty('featured'),
+            var options = {disableNProgress: true},
                 self = this;
 
-            this.get('model').save().then(function () {
-                self.notifications.closePassive();
-                self.notifications.showSuccess('Post successfully marked as ' + (featured ? 'featured' : 'not featured') + '.');
-            }).catch(function (errors) {
+            this.toggleProperty('featured');
+            this.get('model').save(options).catch(function (errors) {
                 self.notifications.closePassive();
                 self.notifications.showErrors(errors);
             });

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -6,7 +6,7 @@
                     <label for="url">URL</label>
                 </td>
                 <td class="post-setting-field">
-                    {{gh-blur-input class="post-setting-slug" id="url" value=slugValue action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
+                    {{gh-blur-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
                 </td>
             </tr>
             <tr class="post-setting">
@@ -14,7 +14,7 @@
                     <label for="pub-date">Pub Date</label>
                 </td>
                 <td class="post-setting-field">
-                    {{gh-blur-input class="post-setting-date" value=publishedAtValue action="setPublishedAt" placeholder=publishedAtPlaceholder}}
+                    {{gh-blur-input class="post-setting-date" value=publishedAtValue name="post-setting-date" action="setPublishedAt" placeholder=publishedAtPlaceholder}}
                 </td>
             </tr>
             <tr class="post-setting">

--- a/core/client/utils/notifications.js
+++ b/core/client/utils/notifications.js
@@ -68,6 +68,7 @@ var Notifications = Ember.ArrayProxy.extend({
             message: message
         }, delayed);
     },
+    // @Todo this function isn't referenced anywhere. Should it be removed?
     showWarn: function (message, delayed) {
         this.handleNotification({
             type: 'warn',
@@ -87,7 +88,7 @@ var Notifications = Ember.ArrayProxy.extend({
 
         if (notification instanceof Notification) {
             notification.deleteRecord();
-            notification.save().then(function () {
+            notification.save().finally(function () {
                 self.removeObject(notification);
             });
         } else {

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -243,7 +243,7 @@ casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
     });
 });
 
-CasperTest.begin('Post settings menu', 31, function suite(test) {
+CasperTest.begin('Post settings menu', 30, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
@@ -337,45 +337,46 @@ CasperTest.begin('Post settings menu', 31, function suite(test) {
         this.click('#publish-bar a.post-settings');
     });
 
-    casper.waitForSelector('.notification-success', function waitForSuccess() {
-        test.assert(true, 'got success notification');
-        test.assertSelectorHasText('.notification-success', 'Publish date successfully changed to 10 May 14 @ 00:17.');
-        casper.thenClick('.notification-success a.close');
-    }, function onTimeout() {
-        test.assert(false, 'No success notification');
+    casper.waitForResource(/\/posts\/\d+\/\?include=tags/, function testGoodResponse(resource) {
+        test.assert(400 > resource.status);
     });
 
-    casper.waitWhileSelector('.notification-success');
-
-    // Test Static Page conversion
-    casper.thenClick('#publish-bar a.post-settings');
-
-    casper.waitUntilVisible('#publish-bar .post-settings-menu', function onSuccess() {
-        test.assert(true, 'post settings menu should be visible after clicking post-settings icon');
+    casper.then(function checkValueMatches() {
+        //using assertField(name) checks the htmls initial "value" attribute, so have to hack around it.
+        var dateVal = this.evaluate(function () {
+            return __utils__.getFieldValue('post-setting-date');
+        });
+        test.assertEqual(dateVal, '10 May 14 @ 00:17');
     });
-
+    
+    // Test static page toggling
     casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
-    casper.waitForSelector('.notification-success', function waitForSuccess() {
-        test.assert(true, 'got success notification');
-        casper.click('.notification-success a.close');
-    }, function onTimeout() {
-        test.assert(false, 'No success notification');
+    casper.waitForResource(/\/posts\/\d+\/\?include=tags/, function testGoodResponse(resource) {
+        test.assert(400 > resource.status);
     });
-
-    casper.waitWhileSelector('.notification-success', function () {
-        test.assert(true, 'notification cleared.');
-        test.assertNotVisible('.notification-success', 'success notification should not still exist');
+    
+    casper.then(function staticPageIsCheckedTest() {
+        var checked = casper.evaluate(function evalCheckedProp() {
+            return document.querySelector('.post-setting-static-page').checked
+        });
+        test.assert(checked, 'Turned post into static page.');
     });
-
+    
     casper.thenClick('.post-settings-menu .post-setting-static-page + label');
 
-    casper.waitForSelector('.notification-success', function waitForSuccess() {
-        test.assert(true, 'got success notification');
-        casper.click('.notification-success a.close');
-    }, function onTimeout() {
-        test.assert(false, 'No success notification');
+    casper.waitForResource(/\/posts\/\d+\/\?include=tags/, function testGoodResponse(resource) {
+        test.assert(400 > resource.status);
     });
+    
+    casper.then(function staticPageIsCheckedTest() {
+        var checked = casper.evaluate(function evalCheckedProp() {
+            return document.querySelector('.post-setting-static-page').checked
+        });
+        test.assert(!checked, 'Turned page into post.');
+    });
+        
+
 
     // Test Delete Post Modal
     casper.thenClick('.post-settings-menu a.delete');


### PR DESCRIPTION
Closes #3105, Closes #3175
- Removed notification on successful post's `page` status change
- Removed notification on successful post `featured` status change
- Added `closePassive()` notifications on error in the post-settings-menu
- Persistent notifications will close whether their `DELETE` request was  successful or not.
