### PR TITLE
Fire NProgress on User, Post, and Settings save

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -13,6 +13,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             this.addObserver('titleScratch', this, 'titleObserver');
         }
     },
+    //Changes in the PSM are too minor to warrant NProgress firing
+    saveOptions: {disableNProgress: true},
     /**
      * The placeholder is the published date of the post,
      * or the current date if the pubdate has not been set.
@@ -83,8 +85,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             if (this.get('isNew')) {
                 return;
             }
-
-            return this.get('model').save().then(function () {
+            
+            return this.get('model').save(this.get('saveOptions')).then(function () {
                 self.showSuccess('Successfully converted to ' + (value ? 'static page' : 'post'));
                 return value;
             }).catch(function (errors) {
@@ -145,8 +147,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                     return;
                 }
 
-                // Save post model properties excluding any changes to the post body
-                return self.get('model').save();
+                return self.get('model').save(self.get('saveOptions'));
             }).then(function () {
                 self.showSuccess('Permalink successfully changed to <strong>' +
                     self.get('slug') + '</strong>.');
@@ -204,7 +205,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return;
             }
 
-            this.get('model').save().then(function () {
+            this.get('model').save(this.get('saveOptions')).then(function () {
                 self.showSuccess('Publish date successfully changed to <strong>' +
                     formatDate(self.get('published_at')) + '</strong>.');
             }).catch(function (errors) {

--- a/core/client/mixins/nprogress-save.js
+++ b/core/client/mixins/nprogress-save.js
@@ -1,0 +1,18 @@
+var NProgressSaveMixin = Ember.Mixin.create({
+    save: function (options) {
+        if (options && options.disableNProgress) {
+            return this._super(options);
+        }
+        
+        NProgress.start();
+        return this._super(options).then(function (value) {
+            NProgress.done();
+            return value;
+        }).catch(function (error) {
+            NProgress.done();
+            return Ember.RSVP.reject(error);
+        });
+    }
+});
+
+export default NProgressSaveMixin;

--- a/core/client/mixins/validation-engine.js
+++ b/core/client/mixins/validation-engine.js
@@ -121,14 +121,14 @@ var ValidationEngine = Ember.Mixin.create({
     * This allows us to run validation before actually trying to save the model to the server.
     * You can supply options to be passed into the `validate` method, since the ED `save` method takes no options.
     */
-    save: function (validationOpts) {
+    save: function (options) {
         var self = this,
             // this is a hack, but needed for async _super calls.
             // ref: https://github.com/emberjs/ember.js/pull/4301
             _super = this.__nextSuper;
 
-        validationOpts = validationOpts || {};
-        validationOpts.wasSave = true;
+        options = options || {};
+        options.wasSave = true;
 
         // model.destroyRecord() calls model.save() behind the scenes.
         // in that case, we don't need validation checks or error propagation,
@@ -139,14 +139,14 @@ var ValidationEngine = Ember.Mixin.create({
 
         // If validation fails, reject with validation errors.
         // If save to the server fails, reject with server response.
-        return this.validate(validationOpts).then(function () {
-            return _super.call(self);
+        return this.validate(options).then(function () {
+            return _super.call(self, options);
         }).catch(function (result) {
             // server save failed - validate() would have given back an array
             if (! Ember.isArray(result)) {
-                if (validationOpts.format !== false) {
+                if (options.format !== false) {
                     // concatenate all errors into an array with a single object: [{ message: 'concatted message' }]
-                    result = formatErrors(result, validationOpts);
+                    result = formatErrors(result, options);
                 } else {
                     // return the array of errors from the server
                     result = getRequestErrorMessage(result);

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -1,7 +1,8 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
 import boundOneWay from 'ghost/utils/bound-one-way';
+import NProgressSaveMixin from 'ghost/mixins/nprogress-save';
 
-var Post = DS.Model.extend(ValidationEngine, {
+var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     validationType: 'post',
 
     uuid: DS.attr('string'),

--- a/core/client/models/setting.js
+++ b/core/client/models/setting.js
@@ -1,6 +1,7 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
+import NProgressSaveMixin from 'ghost/mixins/nprogress-save';
 
-var Setting = DS.Model.extend(ValidationEngine, {
+var Setting = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     validationType: 'setting',
 
     title: DS.attr('string'),

--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -1,8 +1,8 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
+import NProgressSaveMixin from 'ghost/mixins/nprogress-save';
 
-var User = DS.Model.extend(ValidationEngine, {
+var User = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     validationType: 'user',
-
     uuid: DS.attr('string'),
     name: DS.attr('string'),
     slug: DS.attr('string'),


### PR DESCRIPTION
Closes #3037
- Created `NProgressSaveMixin`, which extends the `save` method of a model to fire NProgress.
- Extended `UserModel`, `PostModel`, and `SettingModel` with the new mixin.
- NProgress can be disabled by passing an options hash to the save function with the `{disableNProgress:true}`
- Now that the ValidationEngine isn't the only thing playing with options inside of `model#save`, refactored it to pass the options down the super chain.
