### PR TITLE
Wiring up "resend" and "revoke" button on user management screen

### DIFF
--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -40,11 +40,28 @@ var SettingsUserController = Ember.ObjectController.extend({
 
     actions: {
         revoke: function () {
-            alert('@TODO: revoke users invitation');
+            var self = this,
+                email = this.get('email');
+
+            this.get('model').destroyRecord().then(function () {
+                var notificationText = 'Invitation revoked. (' + email + ')';
+                self.notifications.showSuccess(notificationText, false);
+            }).catch(function (error) {
+                self.notifications.closePassive();
+                self.notifications.showAPIError(error);
+            });
         },
 
         resend: function () {
-            alert('@TODO: resend users invitation');
+            var self = this;
+
+            this.get('model').resendInvite().then(function () {
+                var notificationText = 'Invitation resent! (' + self.get('email') + ')';
+                self.notifications.showSuccess(notificationText, false);
+            }).catch(function (error) {
+                self.notifications.closePassive();
+                self.notifications.showAPIError(error);
+            });
         },
 
         save: function () {

--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -57,6 +57,18 @@ var User = DS.Model.extend({
         });
     },
 
+    resendInvite: function () {
+        var userData = {};
+
+        userData.email = this.get('email');
+
+        return ic.ajax.request(this.get('ghostPaths').apiUrl('users'), {
+            type: 'POST',
+            data: JSON.stringify({users: [userData]}),
+            contentType: 'application/json'
+        });
+    },
+
     passwordValidationErrors: function (password) {
         var validationErrors = [];
 


### PR DESCRIPTION
fixes #3214
- new `User::resendInvite` method on the User model encapsulates all logic
- only sending users email address when re-inviting, since the user already exists on the back-end
- `SettingsUserController::revoke` calls DELETE on `/ghost/api/v0.1/users/:user_id`
