### PR TITLE
Fix active theme selector.  Add validation to API.

### DIFF
--- a/core/client/controllers/settings/general.js
+++ b/core/client/controllers/settings/general.js
@@ -24,7 +24,7 @@ var SettingsGeneralController = Ember.ObjectController.extend({
 
             return themes;
         }, []);
-    }.property('availableThemes').readOnly(),
+    }.property().readOnly(),
 
     actions: {
         save: function () {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -48,9 +48,19 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     validate: function () {
-        var self = this;
-        return validation.validateSchema(self.tableName, self.toJSON()).then(function () {
+        var self = this,
+            setting = this.toJSON();
+
+        return validation.validateSchema(self.tableName, setting).then(function () {
             return validation.validateSettings(getDefaultSettings(), self);
+        }).then(function () {
+            var themeName = setting.value || '';
+
+            if (setting.key !== 'activeTheme') {
+                return when.resolve();
+            }
+
+            return validation.validateActiveTheme(themeName);
         });
     },
 

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -208,4 +208,17 @@ describe('Settings API', function () {
             done();
         }).catch(done);
     });
+
+    it('does not allow an active theme which is not installed', function (done) {
+        return callApiWithContext(defaultContext, 'edit', 'activeTheme', { settings: [{ key: 'activeTheme', value: 'rasper' }] })
+            .then(function (response) {
+                done(new Error('Allowed to set an active theme which is not installed'));
+            }).catch(function (err) {
+                should.exist(err);
+
+                err.type.should.eql('ValidationError');
+
+                done();
+            }).catch(done);
+    });
 });

--- a/core/test/integration/api/api_themes_spec.js
+++ b/core/test/integration/api/api_themes_spec.js
@@ -87,15 +87,15 @@ describe('Themes API', function () {
         _.extend(configStub, config);
         ThemeAPI.__set__('config', configStub);
 
-        ThemeAPI.edit({themes: [{uuid: 'rasper', active: true }]}, {context: {user: 1}}).then(function (result) {
+        ThemeAPI.edit({themes: [{uuid: 'casper', active: true }]}, {context: {user: 1}}).then(function (result) {
             should.exist(result);
             should.exist(result.themes);
             result.themes.length.should.be.above(0);
             testUtils.API.checkResponse(result.themes[0], 'theme');
-            result.themes[0].uuid.should.equal('rasper');
+            result.themes[0].uuid.should.equal('casper');
             done();
         }).catch(function (error) {
             done(new Error(JSON.stringify(error)));
         }).catch(done);
-    })
+    });
 });


### PR DESCRIPTION
Closes #3226
- Remove dependent property from the computed content property
  that is used to build the active theme selector.
- Add validation to the Settings model so that it rejects
  attempts to set an activeTheme that is not installed.
