### PR TITLE
Installation as root fails mysteriously

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -219,7 +219,7 @@ var path           = require('path'),
                 // Used as part of `grunt init`. See the section on [Building Assets](#building%20assets) for more
                 // information.
                 bower: {
-                    command: path.resolve(__dirname.replace(' ', '\\ ') + '/node_modules/.bin/bower install'),
+                    command: path.resolve(__dirname.replace(' ', '\\ ') + '/node_modules/.bin/bower --allow-root install'),
                     options: {
                         stdout: true
                     }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "grunt-es6-module-transpiler": "~0.6.0",
         "grunt-express-server": "~0.4.11",
         "grunt-mocha-cli": "~1.4.0",
-        "grunt-shell": "~0.6.1",
+        "grunt-shell": "~0.7.0",
         "grunt-update-submodules": "~0.4.0",
         "matchdep": "~0.3.0",
         "mocha": "~1.15.1",


### PR DESCRIPTION
### Issue Summary

If you try to install Ghost as root you'll have a very frustrating time of it!

Mostly because grunt-shell < 0.7.0 doesn't pass errors upstream by default - so `grunt init` appears to succeed (even though the bower shell task will have failed), `npm start` works and you'll make it to the landing page but visiting /ghost yields a blank screen.

The actual reason things break is because bower can't run as root.

Opinion time: Ghost itself places no restrictions on running as root (indeed neither do node, npm, grunt-cli or pretty much any other program I've heard of) so why does bower get to be an exception?

This patch addresses both issues. If you disagree with my opinion I still recommend updating grunt-shell to 0.7.0 so that at least blame for failure can be properly placed on bower's insubordination.
### Steps to Reproduce
1. be root
2. clone the repo
3. `git checkout stable`
4. `npm install`
5. `grunt init`
6. `npm start`
7. visit in browser and experience broken things
### Technical details
- Ghost Version: stable - latest commit:  4e664f0e1c55c11b46a89448f14cc9b059fcad06
- Client OS: Mac OS X 10.9.4
- Server OS: Arch Linux lxc container
- Node Version: 0.10.29
- Browser: Chrome 35.0.1916.153
- Database: SQLite
