### PR TITLE
Fix handling of async db calls in fixtures

### DIFF
--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -43,13 +43,13 @@ describe('DB API', function () {
             result.db.should.be.instanceof(Array);
             result.db.should.be.empty;
         }).then(function () {
-            TagsAPI.browse().then(function (results) {
+            return TagsAPI.browse().then(function (results) {
                 should.exist(results);
                 should.exist(results.tags);
                 results.tags.length.should.equal(0);
             });
         }).then(function () {
-            PostAPI.browse().then(function (results) {
+            return PostAPI.browse().then(function (results) {
                 should.exist(results);
                 results.posts.length.should.equal(0);
                 done();

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -186,7 +186,7 @@ function insertAppWithFields() {
 
 function insertDefaultFixtures() {
     return insertDefaultUser().then(function () {
-        return insertPosts()
+        return insertPosts();
     }).then(function () {
         return insertApps();
     });


### PR DESCRIPTION
Closes #3167
- Change fixture loading methods to keep track of promises
  returned from async database calls so that aggregators function
  correctly.
