### PR TITLE
remove legacy CSS class from markup

### DIFF
--- a/core/client/templates/settings.hbs
+++ b/core/client/templates/settings.hbs
@@ -21,6 +21,6 @@
     </nav>
 </aside>
 
-<section class="settings-content active">
+<section class="settings-content">
     {{outlet}}
 </section>


### PR DESCRIPTION
fixes #3254
