### PR TITLE
Check the end of notification fade-out animation

### DIFF
--- a/core/client/components/gh-notification.js
+++ b/core/client/components/gh-notification.js
@@ -31,7 +31,9 @@ var NotificationComponent = Ember.Component.extend({
 
         self.$().on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', function (event) {
             /* jshint unused: false */
-            self.notifications.removeObject(self.get('message'));
+            if (event.originalEvent.animationName === 'fade-out') {
+                self.notifications.removeObject(self.get('message'));
+            }
         });
     },
 


### PR DESCRIPTION
Closes #3166
- Checks the name of the animation that just ended, so the notification is only removed when the `fade-out` is removed

Related styles (but not needed for this to work) are https://github.com/TryGhost/Ghost-UI/commit/220414b1b2c9f3711737dab9e38496ef9483c07a
