### PR TITLE
Use bookshelf's model registry plugin

### DIFF
--- a/core/server/models/accesstoken.js
+++ b/core/server/models/accesstoken.js
@@ -1,6 +1,4 @@
 var ghostBookshelf = require('./base'),
-    User           = require('./user'),
-    Client         = require('./client'),
 
     Accesstoken,
     Accesstokens;
@@ -10,11 +8,11 @@ Accesstoken = ghostBookshelf.Model.extend({
     tableName: 'accesstokens',
 
     user: function () {
-        return this.belongsTo(User);
+        return this.belongsTo('User');
     },
 
     client: function () {
-        return this.belongsTo(Client);
+        return this.belongsTo('Client');
     },
 
     // override for base function since we don't have
@@ -48,6 +46,6 @@ Accesstokens = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Accesstoken: Accesstoken,
-    Accesstokens: Accesstokens
+    Accesstoken: ghostBookshelf.model('Accesstoken', Accesstoken),
+    Accesstokens: ghostBookshelf.collection('Accesstokens', Accesstokens)
 };

--- a/core/server/models/app.js
+++ b/core/server/models/app.js
@@ -1,7 +1,8 @@
 var ghostBookshelf = require('./base'),
-    AppSetting     = require('./appSetting'),
     App,
     Apps;
+
+
 
 App = ghostBookshelf.Model.extend({
     tableName: 'apps',
@@ -24,11 +25,11 @@ App = ghostBookshelf.Model.extend({
 
     permissions: function () {
         // Have to use the require here because of circular dependencies
-        return this.belongsToMany(require('./permission').Permission, 'permissions_apps');
+        return this.belongsToMany('Permission', 'permissions_apps');
     },
 
     settings: function () {
-        return this.belongsToMany(AppSetting, 'app_settings');
+        return this.belongsToMany('AppSetting', 'app_settings');
     }
 }, {
     /**
@@ -58,6 +59,6 @@ Apps = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    App: App,
-    Apps: Apps
+    App: ghostBookshelf.model('App', App),
+    Apps: ghostBookshelf.collection('Apps', Apps)
 };

--- a/core/server/models/appField.js
+++ b/core/server/models/appField.js
@@ -1,5 +1,4 @@
 var ghostBookshelf = require('./base'),
-    Post = require('./post').Post,
     AppField,
     AppFields;
 
@@ -7,7 +6,7 @@ AppField = ghostBookshelf.Model.extend({
     tableName: 'app_fields',
 
     post: function () {
-        return this.morphOne(Post, 'relatable');
+        return this.morphOne('Post', 'relatable');
     }
 });
 
@@ -16,6 +15,6 @@ AppFields = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    AppField: AppField,
-    AppFields: AppFields
+    AppField: ghostBookshelf.model('AppField', AppField),
+    AppFields: ghostBookshelf.collection('AppFields', AppFields)
 };

--- a/core/server/models/appSetting.js
+++ b/core/server/models/appSetting.js
@@ -1,5 +1,4 @@
 var ghostBookshelf = require('./base'),
-    App = require('./app'),
     AppSetting,
     AppSettings;
 
@@ -7,7 +6,7 @@ AppSetting = ghostBookshelf.Model.extend({
     tableName: 'app_settings',
 
     app: function () {
-        return this.belongsTo(App);
+        return this.belongsTo('App');
     }
 });
 
@@ -16,6 +15,6 @@ AppSettings = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    AppSetting: AppSetting,
-    AppSettings: AppSettings
+    AppSetting: ghostBookshelf.model('AppSetting', AppSetting),
+    AppSettings: ghostBookshelf.collection('AppSettings', AppSettings)
 };

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -21,6 +21,8 @@ var bookshelf  = require('bookshelf'),
 // ### ghostBookshelf
 // Initializes a new Bookshelf instance called ghostBookshelf, for reference elsewhere in Ghost.
 ghostBookshelf = bookshelf(config().database.knex);
+// Load the registry plugin, which helps us avoid circular dependencies
+ghostBookshelf.plugin('registry');
 
 // ### ghostBookshelf.Model
 // The Base Model which other Ghost objects will inherit from,

--- a/core/server/models/client.js
+++ b/core/server/models/client.js
@@ -3,6 +3,7 @@ var ghostBookshelf = require('./base'),
     Client,
     Clients;
 
+
 Client = ghostBookshelf.Model.extend({
 
     tableName: 'clients'
@@ -14,6 +15,6 @@ Clients = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Client: Client,
-    Clients: Clients
+    Client: ghostBookshelf.model('Client', Client),
+    Clients: ghostBookshelf.collection('Clients', Clients)
 };

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -1,7 +1,8 @@
-var _          = require('lodash'),
-    when   = require('when');
+var _      = require('lodash'),
+    when   = require('when'),
+    models;
 
-module.exports = {
+models = {
     Post: require('./post').Post,
     User: require('./user').User,
     Role: require('./role').Role,
@@ -39,3 +40,5 @@ module.exports = {
         });
     }
 };
+
+module.exports = models;

--- a/core/server/models/permission.js
+++ b/core/server/models/permission.js
@@ -1,7 +1,4 @@
 var ghostBookshelf = require('./base'),
-    User           = require('./user').User,
-    Role           = require('./role').Role,
-    App            = require('./app').App,
 
     Permission,
     Permissions;
@@ -11,15 +8,15 @@ Permission = ghostBookshelf.Model.extend({
     tableName: 'permissions',
 
     roles: function () {
-        return this.belongsToMany(Role);
+        return this.belongsToMany('Role');
     },
 
     users: function () {
-        return this.belongsToMany(User);
+        return this.belongsToMany('User');
     },
 
     apps: function () {
-        return this.belongsToMany(App);
+        return this.belongsToMany('App');
     }
 }, {
     /**
@@ -41,7 +38,7 @@ Permission = ghostBookshelf.Model.extend({
         }
 
         return options;
-    },
+    }
 });
 
 Permissions = ghostBookshelf.Collection.extend({
@@ -49,6 +46,6 @@ Permissions = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Permission: Permission,
-    Permissions: Permissions
+    Permission: ghostBookshelf.model('Permission', Permission),
+    Permissions: ghostBookshelf.collection('Permissions', Permissions)
 };

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -6,9 +6,7 @@ var _              = require('lodash'),
     Showdown       = require('showdown'),
     ghostgfm       = require('../../shared/lib/showdown/extensions/ghostgfm'),
     converter      = new Showdown.converter({extensions: [ghostgfm]}),
-    AppField       = require('./appField').AppField,
-    User           = require('./user').User,
-    Tag            = require('./tag').Tag,
+    Tag           = require('./tag').Tag,
     Tags           = require('./tag').Tags,
     ghostBookshelf = require('./base'),
     xmlrpc         = require('../xmlrpc'),
@@ -169,19 +167,19 @@ Post = ghostBookshelf.Model.extend({
 
     // Relations
     author_id: function () {
-        return this.belongsTo(User, 'author_id');
+        return this.belongsTo('User', 'author_id');
     },
 
     created_by: function () {
-        return this.belongsTo(User, 'created_by');
+        return this.belongsTo('User', 'created_by');
     },
 
     updated_by: function () {
-        return this.belongsTo(User, 'updated_by');
+        return this.belongsTo('User', 'updated_by');
     },
 
     published_by: function () {
-        return this.belongsTo(User, 'published_by');
+        return this.belongsTo('User', 'published_by');
     },
 
     tags: function () {
@@ -189,7 +187,7 @@ Post = ghostBookshelf.Model.extend({
     },
 
     fields: function () {
-        return this.morphMany(AppField, 'relatable');
+        return this.morphMany('AppField', 'relatable');
     },
 
     toJSON: function (options) {
@@ -536,12 +534,10 @@ Post = ghostBookshelf.Model.extend({
 });
 
 Posts = ghostBookshelf.Collection.extend({
-
     model: Post
-
 });
 
 module.exports = {
-    Post: Post,
-    Posts: Posts
+    Post: ghostBookshelf.model('Post', Post),
+    Posts: ghostBookshelf.collection('Posts', Posts)
 };

--- a/core/server/models/refreshtoken.js
+++ b/core/server/models/refreshtoken.js
@@ -1,6 +1,4 @@
 var ghostBookshelf = require('./base'),
-    User           = require('./user'),
-    Client         = require('./client'),
 
     Refreshtoken,
     Refreshtokens;
@@ -10,11 +8,11 @@ Refreshtoken = ghostBookshelf.Model.extend({
     tableName: 'refreshtokens',
 
     user: function () {
-        return this.belongsTo(User);
+        return this.belongsTo('User');
     },
 
     client: function () {
-        return this.belongsTo(Client);
+        return this.belongsTo('Client');
     },
 
     // override for base function since we don't have
@@ -48,6 +46,6 @@ Refreshtokens = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Refreshtoken: Refreshtoken,
-    Refreshtokens: Refreshtokens
+    Refreshtoken: ghostBookshelf.model('Refreshtoken', Refreshtoken),
+    Refreshtokens: ghostBookshelf.collection('Refreshtokens', Refreshtokens)
 };

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -1,6 +1,4 @@
-var User           = require('./user').User,
-    Permission     = require('./permission').Permission,
-    ghostBookshelf = require('./base'),
+var ghostBookshelf = require('./base'),
 
     Role,
     Roles;
@@ -10,11 +8,11 @@ Role = ghostBookshelf.Model.extend({
     tableName: 'roles',
 
     users: function () {
-        return this.belongsToMany(User);
+        return this.belongsToMany('User');
     },
 
     permissions: function () {
-        return this.belongsToMany(Permission);
+        return this.belongsToMany('Permission');
     }
 }, {
     /**
@@ -45,6 +43,6 @@ Roles = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Role: Role,
-    Roles: Roles
+    Role: ghostBookshelf.model('Role', Role),
+    Roles: ghostBookshelf.collection('Roles', Roles)
 };

--- a/core/server/models/session.js
+++ b/core/server/models/session.js
@@ -36,6 +36,6 @@ Sessions = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    Session: Session,
-    Sessions: Sessions
+    Session: ghostBookshelf.model('Session', Session),
+    Sessions: ghostBookshelf.collection('Sessions', Sessions)
 };

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -177,5 +177,5 @@ Settings = ghostBookshelf.Model.extend({
 });
 
 module.exports = {
-    Settings: Settings
+    Settings: ghostBookshelf.model('Settings', Settings)
 };

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -1,5 +1,4 @@
-var Posts          = require('./post').Posts,
-    ghostBookshelf = require('./base'),
+var ghostBookshelf = require('./base'),
 
     Tag,
     Tags;
@@ -26,7 +25,7 @@ Tag = ghostBookshelf.Model.extend({
     },
 
     posts: function () {
-        return this.belongsToMany(Posts);
+        return this.belongsToMany('Post');
     },
 
     toJSON: function (options) {
@@ -61,12 +60,10 @@ Tag = ghostBookshelf.Model.extend({
 });
 
 Tags = ghostBookshelf.Collection.extend({
-
     model: Tag
-
 });
 
 module.exports = {
-    Tag: Tag,
-    Tags: Tags
+    Tag: ghostBookshelf.model('Tag', Tag),
+    Tags: ghostBookshelf.collection('Tags', Tags)
 };

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -3,10 +3,7 @@ var _              = require('lodash'),
     errors         = require('../errors'),
     nodefn         = require('when/node'),
     bcrypt         = require('bcryptjs'),
-    Posts          = require('./post').Posts,
     ghostBookshelf = require('./base'),
-    Role           = require('./role').Role,
-    Permission     = require('./permission').Permission,
     http           = require('http'),
     crypto         = require('crypto'),
     validator      = require('validator'),
@@ -70,15 +67,15 @@ User = ghostBookshelf.Model.extend({
     },
 
     posts: function () {
-        return this.hasMany(Posts, 'created_by');
+        return this.hasMany('Posts', 'created_by');
     },
 
     roles: function () {
-        return this.belongsToMany(Role);
+        return this.belongsToMany('Role');
     },
 
     permissions: function () {
-        return this.belongsToMany(Permission);
+        return this.belongsToMany('Permission');
     }
 
 }, {
@@ -482,6 +479,6 @@ Users = ghostBookshelf.Collection.extend({
 });
 
 module.exports = {
-    User: User,
-    Users: Users
+    User: ghostBookshelf.model('User', User),
+    Users: ghostBookshelf.collection('Users', Users)
 };


### PR DESCRIPTION
Refs #2170

This removes the circular dependency problem from our models
- add the registry plugin
- switch all models and collections to be registered
- switch relationships to be defined using a string, which calls from the registry
