### PR TITLE
Update Ghost-UI version to ~0.8.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",
     "ember-simple-auth": "git://github.com/simplabs/ember-simple-auth-component.git#0.5.3",
     "fastclick": "1.0.0",
-    "ghost-ui": "0.8.3",
+    "ghost-ui": "~0.8.0",
     "handlebars": "1.3.0",
     "ic-ajax": "1.0.1",
     "jquery": "1.11.0",


### PR DESCRIPTION
No issue
- Changes Ghost-UI version to look for any version from 0.8.0 onwards.
