### PR TITLE
Move inline templates to standalone template file

### DIFF
--- a/core/client/templates/post-tags-input.hbs
+++ b/core/client/templates/post-tags-input.hbs
@@ -1,13 +1,17 @@
 <label class="tag-label" for="tags" title="Tags"><span class="hidden">Tags</span></label>
 <div class="tags">
 {{#each tags}}
-    {{view view.tagView tag=this}}
+    {{#view view.tagView tag=this}}
+        {{view.tag.name}}
+    {{/view}}
 {{/each}}
 </div>
 <input type="hidden" class="tags-holder" id="tags-holder">
 {{view view.tagInputView class="tag-input" id="tags" value=newTagText}}
 <ul class="suggestions overlay" {{bind-attr style=view.overlayStyles}}>
   {{#each suggestions}}
-    {{view view.suggestionView suggestion=this}}
+    {{#view view.suggestionView suggestion=this}}
+        <a href="javascript:void(0);">{{view.suggestion.highlightedName}}</a>
+    {{/view}}
   {{/each}}
 </ul>

--- a/core/client/views/post-tags-input.js
+++ b/core/client/views/post-tags-input.js
@@ -111,7 +111,6 @@ var PostTagsInputView = Ember.View.extend({
 
     tagView: Ember.View.extend({
         tagName: 'span',
-        template: Ember.Handlebars.compile('{{view.tag.name}}'),
         classNames: 'tag',
 
         tag: null,
@@ -124,7 +123,6 @@ var PostTagsInputView = Ember.View.extend({
 
     suggestionView: Ember.View.extend({
         tagName: 'li',
-        template: Ember.Handlebars.compile('<a href="javascript:void(0);">{{view.suggestion.highlightedName}}</a>'),
         classNameBindings: 'suggestion.selected',
 
         suggestion: null,


### PR DESCRIPTION
Refs #3161
- Move two inline template snippets from the post tags input
  component into the .hbs template file so they can be
  pre-compiled.  Needed when shipping only the handlebars runtime
  in production mode.
