### PR TITLE
Prevent loading setup screen if already setup

### DIFF
--- a/core/client/routes/setup.js
+++ b/core/client/routes/setup.js
@@ -3,10 +3,29 @@ import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SetupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     classNames: ['ghost-setup'],
+
+    // use the beforeModel hook to check to see whether or not setup has been
+    // previously completed.  If it has, stop the transition into the setup page.
+
     beforeModel: function () {
+        var self = this;
+
+        // If user is logged in, setup has already been completed.
         if (this.get('session').isAuthenticated) {
             this.transitionTo(Ember.SimpleAuth.routeAfterAuthentication);
+            return;
         }
+
+        // If user is not logged in, check the state of the setup process via the API
+        return ic.ajax.request(this.get('ghostPaths.url').api('authentication/setup'), {
+            type: 'GET'
+        }).then(function (result) {
+            var setup = result.setup[0].status;
+
+            if (setup) {
+                return self.transitionTo('signin');
+            }
+        });
     }
 });
 

--- a/core/client/templates/error.hbs
+++ b/core/client/templates/error.hbs
@@ -16,13 +16,13 @@
         <h3>Stack Trace</h3>
         <p><strong>{{message}}</strong></p>
         <ul class="error-stack-list">
-            {{#foreach stack}}
+            {{#each stack}}
                 <li>
                     at
                     {{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
                     <span class="error-stack-file">({{at}})</span>
                 </li>
-            {{/foreach}}
+            {{/each}}
         </ul>
     </section>
 {{/if}}

--- a/core/client/validators/setup.js
+++ b/core/client/validators/setup.js
@@ -3,13 +3,13 @@ var SetupValidator = Ember.Object.create({
         var data = model.getProperties('blogTitle', 'name', 'email', 'password'),
             validationErrors = [];
 
-        if (!validator.isLength(data.blogTitle || '', 1)) {
+        if (!validator.isLength(data.blogTitle, 1)) {
             validationErrors.push({
                 message: 'Please enter a blog title.'
             });
         }
 
-        if (!validator.isLength(data.name || '', 1)) {
+        if (!validator.isLength(data.name, 1)) {
             validationErrors.push({
                 message: 'Please enter a name.'
             });
@@ -21,9 +21,9 @@ var SetupValidator = Ember.Object.create({
             });
         }
 
-        if (!validator.isLength(data.password || '', 1)) {
+        if (!validator.isLength(data.password, 8)) {
             validationErrors.push({
-                message: 'Please enter a password.'
+                message: 'Password must be at least 8 characters long.'
             });
         }
 

--- a/core/client/validators/signup.js
+++ b/core/client/validators/signup.js
@@ -3,7 +3,7 @@ var SignupValidator = Ember.Object.create({
         var data = model.getProperties('name', 'email', 'password'),
             validationErrors = [];
 
-        if (!validator.isLength(data.name || '', 1)) {
+        if (!validator.isLength(data.name, 1)) {
             validationErrors.push({
                 message: 'Please enter a name.'
             });
@@ -15,9 +15,9 @@ var SignupValidator = Ember.Object.create({
             });
         }
 
-        if (!validator.isLength(data.password || '', 1)) {
+        if (!validator.isLength(data.password, 8)) {
             validationErrors.push({
-                message: 'Please enter a password.'
+                message: 'Password must be at least 8 characters long.'
             });
         }
 

--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -41,13 +41,13 @@
           <h3>Stack Trace</h3>
           <p><strong>{{message}}</strong></p>
           <ul class="error-stack-list">
-            {{#foreach stack}}
+            {{#each stack}}
               <li>
                 at
                 {{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
                 <span class="error-stack-file">({{at}})</span>
               </li>
-            {{/foreach}}
+            {{/each}}
           </ul>
         </section>
       {{/if}}

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -91,7 +91,7 @@ screens = {
    'signin-authenticated': {
        url: 'ghost/signin/',
        //signin with authenticated user redirects to posts
-       selector: '#main-menu .content.active'
+       selector: '#main-menu .content .active'
    },
    'signout': {
        url: 'ghost/signout/',
@@ -109,7 +109,7 @@ screens = {
    },
    'setup-authenticated': {
        url: 'ghost/setup/',
-       selector: '#main-menu .content.active'
+       selector: '#main-menu .content a.active'
    }
 };
 
@@ -386,9 +386,9 @@ CasperTest.Routines = (function () {
                 var errorText = casper.evaluate(function () {
                     return document.querySelector('.notification-error').innerText;
                 });
-                casper.echoConcise('It appears as though a user is already registered. Error text: ' + errorText);
+                casper.echoConcise('Setup failed. Error text: ' + errorText);
             }, function onTimeout() {
-                casper.echoConcise('It appears as though a user was not already registered.');
+                casper.echoConcise('Setup completed.');
             }, 2000);
 
             casper.captureScreenshot('setting_up3.png');

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -3,7 +3,6 @@
 
 /*globals CasperTest, casper */
 CasperTest.begin('Ghost signout works correctly', 3, function suite(test) {
-    CasperTest.Routines.setup.run(test);
     CasperTest.Routines.signout.run(test);
     CasperTest.Routines.signin.run(test);
 

--- a/core/test/functional/setup/setup_test.js
+++ b/core/test/functional/setup/setup_test.js
@@ -3,33 +3,35 @@
 
 /*global CasperTest, casper, email */
 
-CasperTest.begin('Ghost setup fails properly', 5, function suite(test) {
+CasperTest.begin('Ghost setup fails properly', 6, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('setup', function then() {
         test.assertUrlMatch(/ghost\/setup\/$/, 'Landed on the correct URL');
     });
 
     casper.then(function setupWithShortPassword() {
-        casper.fillAndAdd('#setup', {email: email, password: 'test'});
+        casper.fillAndAdd('#setup', { 'blog-title': 'ghost', name: 'slimer', email: email, password: 'short' });
     });
 
     // should now throw a short password error
     casper.waitForSelector('.notification-error', function onSuccess() {
         test.assert(true, 'Got error notification');
-        test.assertSelectorDoesntHaveText('.notification-error', '[object Object]');
+        test.assertSelectorHasText('.notification-error', 'Password must be at least 8 characters long');
     }, function onTimeout() {
         test.assert(false, 'No error notification :(');
     });
 
     casper.then(function setupWithLongPassword() {
-        casper.fillAndAdd('#setup', {email: email, password: 'testing1234'});
+        casper.fillAndAdd('#setup', { 'blog-title': 'ghost', name: 'slimer', email: email, password: password });
     });
 
-    // should now throw a 1 user only error
-    casper.waitForSelector('.notification-error', function onSuccess() {
-        test.assert(true, 'Got error notification');
-        test.assertSelectorDoesntHaveText('.notification-error', '[object Object]');
-    }, function onTimeout() {
-        test.assert(false, 'No error notification :(');
+    casper.wait(2000);
+
+    casper.waitForResource(/\d+/, function testForDashboard() {
+        test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
+        test.assertExists('#global-header', 'Global admin header is present');
+        test.assertExists('.manage', 'We\'re now on content');
+    }, function onTimeOut() {
+        test.fail('Failed to signin');
     });
 }, true);
 
@@ -39,13 +41,13 @@ CasperTest.begin('Authenticated user is redirected', 8, function suite(test) {
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 
-    casper.waitForOpaque('.login-box', function then() {
+     casper.waitForOpaque('.login-box', function then() {
         this.fillAndSave('#login', user);
     });
 
     casper.wait(2000);
 
-    casper.waitForResource(/posts/, function testForDashboard() {
+    casper.waitForResource(/\d+/, function testForDashboard() {
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
         test.assertExists('#global-header', 'Global admin header is present');
         test.assertExists('.manage', 'We\'re now on content');


### PR DESCRIPTION
Closes #3145
- Prevent navigation to the setup screen if Ghost setup
  has previously been completed.
- Fix templates that were incorrectly using foreach instead of each.
- Add validation for minimum password length.
- Fix up functional tests and split out tests for setup to a separate
  instance of casper because setup requires a new database.
