### PR TITLE
Fetch actual user in settings/users/user

### DIFF
--- a/core/client/routes/settings/users/user.js
+++ b/core/client/routes/settings/users/user.js
@@ -1,20 +1,23 @@
 var SettingsUserRoute = Ember.Route.extend({
-    model: function () {
-        return this.session.get('user').then(function (user) {
-            user.reload();
-            return user;
+    model: function (params) {
+        // TODO: Make custom user adapter that uses /api/users/:slug endpoint
+        // return this.store.find('user', { slug: params.slug });
+
+        // Instead, get all the users and then find by slug
+        return this.store.find('user').then(function (result) {
+            return result.findBy('slug', params.slug);
         });
     },
 
     deactivate: function () {
-        this._super();
+        var model = this.modelFor('settings.users.user');
 
         // we want to revert any unsaved changes on exit
-        this.session.get('user').then(function (user) {
-            if (user.get('isDirty')) {
-                user.rollback();
-            }
-        });
+        if (model && model.get('isDirty')) {
+            model.rollback();
+        }
+
+        this._super();
     }
 });
 

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -37,7 +37,7 @@
         <h4 class="object-list-title">Active users</h4>
 
         {{#each activeUsers itemController="settings/users/user"}}
-            {{#link-to 'settings.users.user' slug class="object-list-item" }}
+            {{#link-to 'settings.users.user' this class="object-list-item" }}
                 <img class="object-list-item-figure"
                      src="{{unbound imageUrl}}"
                      alt="Photo of {{unbound name}}" />


### PR DESCRIPTION
Closes #3279
- Switch from `this.session.get('user')` to `this.store.find('user')` and
  some further limiting until a custom user adapter is created
- Switch the deactivate logic to rollback the used model
