### PR TITLE
Removing erroneous placeholder text from user profile

### DIFF
--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -86,7 +86,7 @@
 
             <div class="form-group">
                 <label for="user-website">Website</label>
-                {{input type="url" value=user.website id="user-website" placeholder="http://www.ghost.org/" autocapitalize="off" autocorrect="off"}}
+                {{input type="url" value=user.website id="user-website" autocapitalize="off" autocorrect="off"}}
                 <p>Have a website or blog other than this one? Link it!</p>
             </div>
 


### PR DESCRIPTION
Reverting the placeholder that was introduced in #2734 to fix #1623. We should handle this intelligently by automatically interpretting the input and using validation if we can't. The user should not have to know or care about what http is.

Regardless off any of the above, we should not be introducing user-facing text like this without proper consideration. A placeholder of "http://www.ghost.org" is far more confusing than no placeholder at all. It also looks like a cheap promotional tactic on our part. We don't use the "www" subdomain, so it's actually not even semantically correct.
