### PR TITLE
Add a notify action to the notifications component

### DIFF
--- a/core/client/components/gh-notifications.js
+++ b/core/client/components/gh-notifications.js
@@ -14,7 +14,11 @@ var NotificationsComponent = Ember.Component.extend({
             notification.get('location') : notification.location;
 
         return this.get('location') === displayLocation;
-    })
+    }),
+
+    messageCountObserver: function () {
+        this.sendAction('notify', this.get('messages').length);
+    }.observes('messages.[]')
 });
 
 export default NotificationsComponent;

--- a/core/client/controllers/application.js
+++ b/core/client/controllers/application.js
@@ -1,9 +1,15 @@
 var ApplicationController = Ember.Controller.extend({
     hideNav: Ember.computed.match('currentPath', /(signin|signup|setup|forgotten|reset)/),
 
+    topNotificationCount: 0,
+
     actions: {
         toggleMenu: function () {
             this.toggleProperty('showMenu');
+        },
+
+        topNotificationChange: function (count) {
+            this.set('topNotificationCount', count);
         }
     }
 });

--- a/core/client/templates/application.hbs
+++ b/core/client/templates/application.hbs
@@ -2,8 +2,8 @@
     {{partial "navbar"}}
 {{/unless}}
 
-<main role="main" id="main">
-    {{gh-notifications location="top"}}
+<main role="main" id="main" {{bind-attr data-notification-count=topNotificationCount}}>
+    {{gh-notifications location="top" notify="topNotificationChange"}}
     {{gh-notifications location="bottom"}}
 
     {{outlet}}


### PR DESCRIPTION
Refs #3160
- gh-notifications component now takes an optional notify
  parameter.  If present it will be invoked as an action
  when a notification is added or removed.
- Add a data-notification-count attribute to the main container
  that tracks the number of "top" notification messages that
  are currently being shown.
