### PR TITLE
Add class to invited users container

### DIFF
--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -9,7 +9,7 @@
 <section class="content settings-users">
     {{#if invitedUsers}}
 
-        <section class="object-list">
+        <section class="object-list invited-users">
 
             <h4 class="object-list-title">Invited users</h4>
 


### PR DESCRIPTION
No issue
- Relates to https://github.com/TryGhost/Ghost-UI/commit/447c7d77ec9e532930d1f251bb42f626bebeef87#diff-acda43902fe5a16fa255b16e7b32e6d0R14
- Adds class to the invited users container, used only for spacing right now
