### PR TITLE
Prevent duplicate slug request on saving new post

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -45,7 +45,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         });
     },
     titleObserver: function () {
-        if (this.get('isNew')) {
+        if (this.get('isNew') && !this.get('title')) {
             Ember.run.debounce(this, 'generateSlugPlaceholder', 700);
         }
     },


### PR DESCRIPTION
No Issue
- Do not run generateSlugPlaceholder if save has been initiated
  and the title has already been set on the post. At that stage
  a slug has already been generated and another API call is not
  necessary.
