### PR TITLE
Add Author dropdown to PostSettingsMenu

### DIFF
--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -4,7 +4,12 @@ var EditorNewRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin
     classNames: ['editor'],
 
     model: function () {
-        return this.store.createRecord('post');
+        var self = this;
+        return this.get('session.user').then(function (user) {
+            return self.store.createRecord('post', {
+                author: user
+            });
+        });
     },
 
     setupController: function (controller, model) {

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -19,6 +19,21 @@
             </tr>
             <tr class="post-setting">
                 <td class="post-setting-label">
+		    <label for="post-setting-author">Author</label>
+		</td>
+		<td class="post-setting-field">
+		    <span class="author-select-wrapper" {{bind-attr data-select-text=selectedAuthor.name}}>
+		       {{view Ember.Select
+			   name="post-setting-author"
+			   content=authors
+			   optionValuePath="content.id"
+			   optionLabelPath="content.name"
+			   selection=selectedAuthor}}
+		    </span>
+		</td>
+	    </tr>
+	    <tr class="post-setting">
+		<td class="post-setting-label">
                     <label class="label" for="static-page">Static Page</label>
                 </td>
                 <td class="post-setting-item">


### PR DESCRIPTION
Ref #3084
This PR does NOT hide the dropdown as required to close 3084.
- `EditorNewRoute` creates post with the author set to the current user
- added `authors` ArrayPromiseProxy (whoa, what?) to PSM
- added `changeAuthor` function that sets author and saves model when the user selects a new author
