### PR TITLE
Adding helper for invite status

### DIFF
--- a/core/client/controllers/modals/invite-new-user.js
+++ b/core/client/controllers/modals/invite-new-user.js
@@ -37,7 +37,12 @@ var InviteNewUserController = Ember.Controller.extend({
 
                 self.notifications.showSuccess(notificationText, false);
             }).catch(function (errors) {
-                newUser.deleteRecord();
+                if (errors[0].message.indexOf('Email Error:') === -1) {
+                    newUser.deleteRecord();
+                } else {
+                    newUser.set('status', 'invited-pending');
+                }
+
                 self.notifications.closePassive();
                 self.notifications.showErrors(errors);
             });

--- a/core/client/controllers/settings/users/index.js
+++ b/core/client/controllers/settings/users/index.js
@@ -1,9 +1,9 @@
 var UsersIndexController = Ember.ArrayController.extend({
     users: Ember.computed.alias('model'),
 
-    activeUsers: Ember.computed.filterBy('users', 'status', 'active'),
+    activeUsers: Ember.computed.filterBy('users', 'active', true).property('users'),
 
-    invitedUsers: Ember.computed.filterBy('users', 'status', 'invited')
+    invitedUsers: Ember.computed.filterBy('users', 'invited', true).property('users')
 });
 
 export default UsersIndexController;

--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -63,6 +63,7 @@ var SettingsUserController = Ember.ObjectController.extend({
             var self = this;
 
             this.get('model').resendInvite().then(function () {
+                self.get('model').set('status', 'invited');
                 var notificationText = 'Invitation resent! (' + self.get('email') + ')';
                 self.notifications.showSuccess(notificationText, false);
             }).catch(function (error) {

--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -64,8 +64,14 @@ var User = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
         return validationErrors;
     }.property('password', 'newPassword', 'ne2Password'),
 
-    isPasswordValid: Ember.computed.empty('passwordValidationErrors.[]')
-
+    isPasswordValid: Ember.computed.empty('passwordValidationErrors.[]'),
+    active: function () {
+        return _.contains(['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'], this.get('status'));
+    }.property('status'),
+    invited: function () {
+        return _.contains(['invited', 'invited-pending'], this.get('status'));
+    }.property('status'),
+    pending: Ember.computed.equal('status', 'invited-pending').property('status')
 });
 
 export default User;

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -19,7 +19,11 @@
 
                     <div class="object-list-item-body">
                         <span class="name">{{email}}</span><br>
-                        <span class="description">Invitation sent: {{created_at}}</span>
+                            {{#if pending}}
+                                <span class="red">Invitation not sent - please try again</span>
+                            {{else}}
+                                <span class="description">Invitation sent: {{created_at}}</span>
+                            {{/if}}
                     </div>
                     <aside class="object-list-item-aside">
                         <a class="object-list-action" href="#" {{action "revoke"}}>Revoke</a>

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -234,7 +234,7 @@ users = {
                 return when.reject(new errors.ValidationError(error.message));
             });
         });
-    },
+    }
 
 };
 


### PR DESCRIPTION
Adding helper for invite status
closes #3309, closes #3229
- adds different message depending on status
- doesn't delete the new user if the problem was an email error
- filters the 2 lists based on all statuses
