### PR TITLE
User managment screen

### DIFF
--- a/core/client/controllers/posts.js
+++ b/core/client/controllers/posts.js
@@ -1,6 +1,7 @@
 import { getRequestErrorMessage } from 'ghost/utils/ajax';
+import PaginationControllerMixin from 'ghost/mixins/pagination-controller';
 
-var PostsController = Ember.ArrayController.extend({
+var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
     // this will cause the list to re-sort when any of these properties change on any of the models
     sortProperties: ['status', 'published_at', 'updated_at'],
 
@@ -66,20 +67,10 @@ var PostsController = Ember.ArrayController.extend({
         return statusResult;
     },
 
-    // set from PostsRoute
-    paginationSettings: null,
-
-    // holds the next page to load during infinite scroll
-    nextPage: null,
-
-    // indicates whether we're currently loading the next page
-    isLoading: null,
-
     init: function () {
-        this._super();
-
-        var metadata = this.store.metadataFor('post');
-        this.set('nextPage', metadata.pagination.next);
+        //let the PaginationControllerMixin know what type of model we will be paginating
+        //this is necesariy because we do not have access to the model inside the Controller::init method
+        this._super({'modelType': 'post'});
     },
 
     /**
@@ -98,32 +89,6 @@ var PostsController = Ember.ArrayController.extend({
         }
 
         this.notifications.showError(message);
-    },
-
-    actions: {
-        /**
-        * Loads the next paginated page of posts into the ember-data store. Will cause the posts list UI to update.
-        * @return
-        */
-        loadNextPage: function () {
-            var self = this,
-                store = this.get('store'),
-                nextPage = this.get('nextPage'),
-                paginationSettings = this.get('paginationSettings');
-
-            if (nextPage) {
-                this.set('isLoading', true);
-                this.set('paginationSettings.page', nextPage);
-                store.find('post', paginationSettings).then(function () {
-                    var metadata = store.metadataFor('post');
-
-                    self.set('nextPage', metadata.pagination.next);
-                    self.set('isLoading', false);
-                }, function (response) {
-                    self.reportLoadError(response);
-                });
-            }
-        }
     }
 });
 

--- a/core/client/controllers/settings/users/index.js
+++ b/core/client/controllers/settings/users/index.js
@@ -1,4 +1,13 @@
-var UsersIndexController = Ember.ArrayController.extend({
+import PaginationControllerMixin from 'ghost/mixins/pagination-controller';
+
+var UsersIndexController = Ember.ArrayController.extend(PaginationControllerMixin, {
+
+    init: function () {
+        //let the PaginationControllerMixin know what type of model we will be paginating
+        //this is necesariy because we do not have access to the model inside the Controller::init method
+        this._super({'modelType': 'user'});
+    },
+
     users: Ember.computed.alias('model'),
 
     activeUsers: Ember.computed.filterBy('users', 'status', 'active'),

--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -12,6 +12,8 @@ var SettingsUserController = Ember.ObjectController.extend({
         return this.get('ghostPaths.url').asset('/shared/img/user-image.png');
     }.property('ghostPaths'),
 
+    roles: Ember.computed.readOnly('user.roles'),
+
     cover: function () {
         var cover = this.get('user.cover');
         if (typeof cover !== 'string') {

--- a/core/client/mixins/pagination-controller.js
+++ b/core/client/mixins/pagination-controller.js
@@ -1,0 +1,55 @@
+var PaginationControllerMixin = Ember.Mixin.create({
+
+    // set from PostsRoute
+    paginationSettings: null,
+
+    // holds the next page to load during infinite scroll
+    nextPage: null,
+
+    // indicates whether we're currently loading the next page
+    isLoading: null,
+
+    /**
+     *
+     * @param options: {
+     *                      modelType: <String> name of the model that will be paginated
+     *                  }
+     */
+    init: function (options) {
+        this._super();
+
+        var metadata = this.store.metadataFor(options.modelType);
+        this.set('nextPage', metadata.pagination.next);
+    },
+
+    actions: {
+        /**
+         * Loads the next paginated page of posts into the ember-data store. Will cause the posts list UI to update.
+         * @return
+         */
+        loadNextPage: function () {
+
+            var self = this,
+                store = this.get('store'),
+                recordType = this.get('model').get('type'),
+                nextPage = this.get('nextPage'),
+                paginationSettings = this.get('paginationSettings');
+
+            if (nextPage) {
+                this.set('isLoading', true);
+                this.set('paginationSettings.page', nextPage);
+                store.find(recordType, paginationSettings).then(function () {
+                    var metadata = store.metadataFor(recordType);
+
+                    self.set('nextPage', metadata.pagination.next);
+                    self.set('isLoading', false);
+                }, function (response) {
+                    self.reportLoadError(response);
+                });
+            }
+        }
+    }
+
+});
+
+export default PaginationControllerMixin;

--- a/core/client/mixins/pagination-route.js
+++ b/core/client/mixins/pagination-route.js
@@ -1,0 +1,23 @@
+var defaultPaginationSettings = {
+    page: 1,
+    limit: 15
+};
+
+var PaginationRoute = Ember.Mixin.create({
+
+    /**
+     * Sets up pagination details
+     * @param {settings}: object that specifies additional pagination details
+     */
+    setupPagination: function (settings) {
+
+        settings = settings || {};
+        settings = _.defaults(settings, defaultPaginationSettings);
+
+        this.set('paginationSettings', settings);
+        this.controller.set('paginationSettings', settings);
+    }
+
+});
+
+export default PaginationRoute;

--- a/core/client/mixins/pagination-view.js
+++ b/core/client/mixins/pagination-view.js
@@ -1,0 +1,39 @@
+var PaginationViewMixin = Ember.Mixin.create({
+
+    /**
+     * Determines if we are past a scroll point where we need to fetch the next page
+     * @param event The scroll event
+     */
+    checkScroll: function (event) {
+        var element = event.target,
+            triggerPoint = 100,
+            controller = this.get('controller'),
+            isLoading = controller.get('isLoading');
+
+        // If we haven't passed our threshold or we are already fetching content, exit
+        if (isLoading || (element.scrollTop + element.clientHeight + triggerPoint <= element.scrollHeight)) {
+            return;
+        }
+
+        controller.send('loadNextPage');
+    },
+
+    /**
+     * Bind to the scroll event once the element is in the DOM
+     */
+    didInsertElement: function () {
+        var el = this.$();
+
+        el.on('scroll', Ember.run.bind(this, this.checkScroll));
+    },
+
+    /**
+     * Unbind from the scroll event when the element is no longer in the DOM
+     */
+    willDestroyElement: function () {
+        var el = this.$();
+        el.off('scroll');
+    }
+});
+
+export default PaginationViewMixin;

--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -23,6 +23,7 @@ var User = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     created_by: DS.attr('number'),
     updated_at: DS.attr('moment-date'),
     updated_by: DS.attr('number'),
+    roles: DS.attr(),
 
     saveNewPassword: function () {
         var url = this.get('ghostPaths.url').api('users', 'password');

--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -1,6 +1,7 @@
 import styleBody from 'ghost/mixins/style-body';
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
+import PaginationRouteMixin from 'ghost/mixins/pagination-route';
 
 var paginationSettings = {
     status: 'all',
@@ -9,7 +10,7 @@ var paginationSettings = {
     page: 1
 };
 
-var PostsRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, ShortcutsRoute, styleBody, loadingIndicator, {
+var PostsRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, ShortcutsRoute, styleBody, loadingIndicator, PaginationRouteMixin, {
     classNames: ['manage'],
 
     model: function () {
@@ -22,7 +23,7 @@ var PostsRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, Sh
 
     setupController: function (controller, model) {
         this._super(controller, model);
-        controller.set('paginationSettings', paginationSettings);
+        this.setupPagination(paginationSettings);
     },
 
     shortcuts: {

--- a/core/client/routes/settings/users/index.js
+++ b/core/client/routes/settings/users/index.js
@@ -1,7 +1,35 @@
-var UsersIndexRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, {
+import PaginationRouteMixin from 'ghost/mixins/pagination-route';
+
+var activeUsersPaginationSettings = {
+    include: 'roles',
+    page: 1,
+    limit: 20
+};
+
+var invitedUsersPaginationSettings = {
+    include: 'roles',
+    where: {'status': 'invited'}
+};
+
+var UsersIndexRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, PaginationRouteMixin, {
+
+    setupController: function (controller, model) {
+        this._super(controller, model.active);
+        this.setupPagination(activeUsersPaginationSettings);
+
+    },
 
     model: function () {
-        return this.store.find('user');
+        // using `.filter` allows the template to auto-update when new models are pulled in from the server.
+        // we just need to 'return true' to allow all models by default.
+        return Ember.RSVP.hash({
+            inactive: this.store.filter('user', invitedUsersPaginationSettings, function () {
+                return true;
+            }),
+            active: this.store.filter('user', activeUsersPaginationSettings, function () {
+                return true;
+            })
+        });
     }
 });
 

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -6,7 +6,7 @@
     </section>
 </header>
 
-<section class="content settings-users">
+{{#view "settings/users/users-list-view" tagName="section" class="content settings-users" }}
     {{#if invitedUsers}}
 
         <section class="object-list invited-users">
@@ -51,11 +51,13 @@
                 </div>
                 <!-- @TODO: replace these with real access level once API and data model are updated -->
                 <aside class="object-list-item-aside">
-                    <span class="role-label editor">Editor</span>
-                    <span class="role-label owner">Owner</span>
+                    {{#each roles}}
+                        <span class="role-label owner">{{name}}</span>
+                    {{/each}}
+
                 </aside>
             {{/link-to}}
         {{/each}}
 
     </section>
-</section>
+{{/view}}

--- a/core/client/views/content-list-content-view.js
+++ b/core/client/views/content-list-content-view.js
@@ -1,34 +1,16 @@
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
+import PaginationViewMixin from 'ghost/mixins/pagination-view';
 
-var PostsListView = Ember.View.extend({
+var PostsListView = Ember.View.extend(PaginationViewMixin, {
     classNames: ['content-list-content'],
 
-    checkScroll: function (event) {
-        var element = event.target,
-            triggerPoint = 100,
-            controller = this.get('controller'),
-            isLoading = controller.get('isLoading');
-
-        // If we haven't passed our threshold, exit
-        if (isLoading || (element.scrollTop + element.clientHeight + triggerPoint <= element.scrollHeight)) {
-            return;
-        }
-
-        controller.send('loadNextPage');
-    },
-
     didInsertElement: function () {
+        this._super();
         var el = this.$();
-        el.on('scroll', Ember.run.bind(this, this.checkScroll));
         el.on('scroll', Ember.run.bind(el, setScrollClassName, {
             target: el.closest('.content-list'),
             offset: 10
         }));
-    },
-
-    willDestroyElement: function () {
-        var el = this.$();
-        el.off('scroll');
     }
 });
 

--- a/core/client/views/settings/users/users-list-view.js
+++ b/core/client/views/settings/users/users-list-view.js
@@ -1,0 +1,8 @@
+//import setScrollClassName from 'ghost/utils/set-scroll-classname';
+import PaginationViewMixin from 'ghost/mixins/pagination-view';
+
+var UsersListView = Ember.View.extend(PaginationViewMixin, {
+    classNames: ['settings-users']
+});
+
+export default UsersListView;

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -42,9 +42,7 @@ users = {
             if (options.include) {
                 options.include = prepareInclude(options.include);
             }
-            return dataProvider.User.findAll(options).then(function (result) {
-                return { users: result.toJSON() };
-            });
+            return dataProvider.User.findPage(options);
         }, function () {
             return when.reject(new errors.NoPermissionError('You do not have permission to browse users.'));
         });
@@ -67,6 +65,12 @@ users = {
 
         if (data.id === 'me' && options.context && options.context.user) {
             data.id = options.context.user;
+
+            //always include the the role when getting info about currently authenticated user
+            options.include = options.include || [];
+            if (options.include.indexOf('roles') === -1) {
+                options.include.push('roles');
+            }
         }
 
         return dataProvider.User.findOne(data, options).then(function (result) {

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -186,7 +186,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     permittedOptions: function () {
         // terms to whitelist for all methods.
-        return ['context', 'include', 'transacting'];
+        return ['context', 'include', 'transacting', 'limit', 'page', 'where'];
     },
 
     /**
@@ -214,7 +214,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return filteredOptions;
     },
 
-     // ## Model Data Functions
+    // ## Model Data Functions
 
     /**
      * ### Find All
@@ -299,7 +299,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     /**
-    * ### Generate Slug
+     * ### Generate Slug
      * Create a string to act as the permalink for an object.
      * @param {ghostBookshelf.Model} Model Model type to generate a slug for
      * @param {String} base The string for which to generate a slug, usually a title or name

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -117,7 +117,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -138,7 +137,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -159,7 +157,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -180,7 +177,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -201,7 +197,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -223,7 +218,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
@@ -247,7 +241,6 @@ describe('User API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
                     jsonResponse.users.should.exist;
-                    testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -39,7 +39,7 @@ describe('Users API', function () {
                 'password': 'password'
             }]}).then(function (results) {
                 should.exist(results);
-                testUtils.API.checkResponse(results, 'users');
+                results.users.should.exist;
                 should.exist(results.users);
                 results.users.should.have.length(1);
                 testUtils.API.checkResponse(results.users[0], 'user', ['roles']);
@@ -129,7 +129,7 @@ describe('Users API', function () {
         it('admin can read', function (done) {
             UsersAPI.read({id: 1, context: {user: 1}}).then(function (results) {
                 should.exist(results);
-                testUtils.API.checkResponse(results, 'users');
+                results.users.should.exist;
                 results.users[0].id.should.eql(1);
                 testUtils.API.checkResponse(results.users[0], 'user', ['roles']);
 
@@ -142,7 +142,7 @@ describe('Users API', function () {
         it('editor can read', function (done) {
             UsersAPI.read({id: 1, context: {user: 2}}).then(function (results) {
                 should.exist(results);
-                testUtils.API.checkResponse(results, 'users');
+                results.users.should.exist;
                 results.users[0].id.should.eql(1);
                 testUtils.API.checkResponse(results.users[0], 'user', ['roles']);
                 done();
@@ -152,7 +152,7 @@ describe('Users API', function () {
         it('author can read', function (done) {
             UsersAPI.read({id: 1, context: {user: 3}}).then(function (results) {
                 should.exist(results);
-                testUtils.API.checkResponse(results, 'users');
+                results.users.should.exist;
                 results.users[0].id.should.eql(1);
                 testUtils.API.checkResponse(results.users[0], 'user', ['roles']);
                 done();
@@ -162,7 +162,7 @@ describe('Users API', function () {
         it('no-auth can read', function (done) {
             UsersAPI.read({id: 1}).then(function (results) {
                 should.exist(results);
-                testUtils.API.checkResponse(results, 'users');
+                results.users.should.exist;
                 results.users[0].id.should.eql(1);
                 testUtils.API.checkResponse(results.users[0], 'user', ['roles']);
                 done();
@@ -172,7 +172,7 @@ describe('Users API', function () {
         it('admin can edit', function (done) {
             UsersAPI.edit({users: [{name: 'Joe Blogger'}]}, {id: 1, context: {user: 1}}).then(function (response) {
                 should.exist(response);
-                testUtils.API.checkResponse(response, 'users');
+                response.users.should.exist;
                 response.users.should.have.length(1);
                 testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
                 response.users[0].name.should.equal('Joe Blogger');
@@ -184,7 +184,7 @@ describe('Users API', function () {
         it('editor can edit', function (done) {
             UsersAPI.edit({users: [{name: 'Joe Blogger'}]}, {id: 1, context: {user: 2}}).then(function (response) {
                 should.exist(response);
-                testUtils.API.checkResponse(response, 'users');
+                response.users.should.exist;
                 response.users.should.have.length(1);
                 testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
                 response.users[0].name.should.eql('Joe Blogger');
@@ -204,7 +204,7 @@ describe('Users API', function () {
                 return UsersAPI.edit({users: [{name: 'Timothy Bogendath'}]}, {id: 3, context: {user: 3}})
                     .then(function (response) {
                         should.exist(response);
-                        testUtils.API.checkResponse(response, 'users');
+                        response.users.should.exist;
                         response.users.should.have.length(1);
                         testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
                         response.users[0].name.should.eql('Timothy Bogendath');

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -6,7 +6,7 @@ var url = require('url'),
     schema = 'http://',
     expectedProperties = {
         posts: ['posts', 'meta'],
-        users: ['users'],
+        users: ['users', 'meta'],
         pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
         post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
             'featured', 'image', 'status', 'language', 'created_at', 'created_by', 'updated_at',


### PR DESCRIPTION
closes #3222, closes #3287, closes #3085 
- /users/me API  now returns roles by default
- displaying a users roles on the Users Management screen
- creating 3 new mixins (route, controller and view) to encapsulate pagination functionality
- updating route, controller and view for Posts to use new mixing
- implementing server-side pagination for /users API
- implementing infinite scrolling on the Users Management screen (using new mixins)
- Users Management screen now displays all invited users, but paginates active users
