### PR TITLE
Add relationships to client models

### DIFF
--- a/core/client/models/tag.js
+++ b/core/client/models/tag.js
@@ -1,15 +1,15 @@
 var Tag = DS.Model.extend({
-	uuid: DS.attr('string'),
-	name: DS.attr('string'),
-	slug: DS.attr('string'),
-	description: DS.attr('string'),
-	parent_id: DS.attr('number'),
-	meta_title: DS.attr('string'),
-	meta_description: DS.attr('string'),
-	created_at: DS.attr('date'),
-	created_by: DS.attr('number'),
-	updated_at: DS.attr('date'),
-	updated_by: DS.attr('number')
+    uuid: DS.attr('string'),
+    name: DS.attr('string'),
+    slug: DS.attr('string'),
+    description: DS.attr('string'),
+    parent_id: DS.attr('number'),
+    meta_title: DS.attr('string'),
+    meta_description: DS.attr('string'),
+    created_at: DS.attr('moment-date'),
+    created_by: DS.belongsTo('user', {async: true}),
+    updated_at: DS.attr('moment-date'),
+    updated_by: DS.belongsTo('user', {async: true})
 });
 
 export default Tag;

--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -20,9 +20,9 @@ var User = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     meta_description: DS.attr('string'),
     last_login: DS.attr('moment-date'),
     created_at: DS.attr('moment-date'),
-    created_by: DS.attr('number'),
+    created_by: DS.belongsTo('user', { async: true }),
     updated_at: DS.attr('moment-date'),
-    updated_by: DS.attr('number'),
+    updated_by: DS.belongsTo('user', { async: true }),
 
     saveNewPassword: function () {
         var url = this.get('ghostPaths.url').api('users', 'password');

--- a/core/client/routes/settings/index.js
+++ b/core/client/routes/settings/index.js
@@ -1,9 +1,6 @@
 import {mobileQuery} from 'ghost/utils/mobile';
 
 var SettingsIndexRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, {
-    activate: function () {
-        this._super();
-    },
     // redirect to general tab, unless on a mobile phone
     beforeModel: function () {
         if (!mobileQuery.matches) {


### PR DESCRIPTION
No issue
- Removed tabs from tag.js (why didn't jshint catch this?)
- Removed superfluous `activate` in SettingsIndexRoute
- updated `UserModel` and `TagModel` to have `created_by, updated_by` be references to `user` objects.
- updated `UserModel` to use `moment-date` instead of `date`
