### PR TITLE
Only load posts once on navigating to content tab

### DIFF
--- a/core/client/routes/posts/index.js
+++ b/core/client/routes/posts/index.js
@@ -1,20 +1,16 @@
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var PostsIndexRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, {
-    // redirect to first post subroute unless no posts exist
+    // This route's only function is to determine whether or not a post
+    // exists to be used for the content preview.  It has a parent resource (Posts)
+    // that is responsible for populating the store.
     beforeModel: function () {
-        var self = this;
+        // the store has been populated so we can work with the local copy
+        var post = this.store.all('post').get('firstObject');
 
-        return this.store.find('post', {
-            status: 'all',
-            staticPages: 'all',
-        }).then(function (records) {
-            var post = records.get('firstObject');
-
-            if (post) {
-                return self.transitionTo('posts.post', post);
-            }
-        });
+        if (post) {
+            return this.transitionTo('posts.post', post);
+        }
     }
 });
 


### PR DESCRIPTION
No Issue
- Loading posts from the API should not be necessary in PostsIndexRoute
  because its parent resource (PostsRoute) pre-loads the store.
  Changing the store.find to store.all gets rid of a duplicate
  network request to load all posts.
