### PR TITLE
Fix check for using default cover image

### DIFF
--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -14,7 +14,7 @@ var SettingsUserController = Ember.ObjectController.extend({
 
     cover: function () {
         var cover = this.get('user.cover');
-        if (typeof cover !== 'string') {
+        if (Ember.isBlank(cover)) {
             cover = this.get('coverDefault');
         }
         return cover;


### PR DESCRIPTION
Closes #3348
- Cover attribute is a string so its typeof will always return
  string. Switch check to Ember.isBlank.
