### PR TITLE
Implements User Role Label

### DIFF
--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -53,10 +53,10 @@
                     <br>
                     <span class="description">Last seen: {{unbound last_login}}</span>
                 </div>
-                <!-- @TODO: replace these with real access level once API and data model are updated -->
                 <aside class="object-list-item-aside">
-                    <span class="role-label editor">Editor</span>
-                    <span class="role-label owner">Owner</span>
+                    {{#each roles}}
+                       <span class="role-label {{unbound lowerCaseName}}">{{name}}</span>
+                    {{/each}}
                 </aside>
             {{/link-to}}
         {{/each}}


### PR DESCRIPTION
Closes #3287. Role label now displays correctly for each user, instead of being hard coded.
