### PR TITLE
Five posts per page

### DIFF
--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -40,7 +40,7 @@
             }
         },
         "postsPerPage": {
-            "defaultValue": "6",
+            "defaultValue": "5",
             "validations": {
                 "isNull": false,
                 "isInt": true,

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -223,12 +223,12 @@ describe('Frontend Routing', function () {
 
     describe('Archive pages', function () {
 
-        // Add enough posts to trigger pages for both the archive (6 pp) and rss (15 pp)
+        // Add enough posts to trigger pages for both the archive (5 pp) and rss (15 pp)
         // insertPosts adds 5 published posts, 1 draft post, 1 published static page and one draft page
         // we then insert with max 11 which ensures we have 16 published posts
         before(function (done) {
             testUtils.insertPosts().then(function () {
-                return testUtils.insertMorePosts(11);
+                return testUtils.insertMorePosts(9);
             }).then(function () {
                 done();
             }).catch(done);
@@ -277,6 +277,13 @@ describe('Frontend Routing', function () {
     });
 
     describe('RSS pages', function () {
+        before(function (done) {
+            testUtils.insertPosts().then(function () {
+                return testUtils.insertMorePosts(2);
+            }).then(function () {
+                done();
+            }).catch(done);
+        });
         it('should redirect without slash', function (done) {
             request.get('/rss/2')
                 .expect('Location', '/rss/2/')

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -50,7 +50,7 @@ describe('Frontend Controller', function () {
             apiSettingsStub.withArgs('postsPerPage').returns(when({
                 settings: [{
                     'key': 'postsPerPage',
-                    'value': 6
+                    'value': 5
                 }]
             }));
         });
@@ -279,7 +279,7 @@ describe('Frontend Controller', function () {
             apiSettingsStub.withArgs('postsPerPage').returns(when({
                 settings: [{
                     'key': 'postsPerPage',
-                    'value': 6
+                    'value': 5
                 }]
             }));
         });


### PR DESCRIPTION
Since Casper has evolved typographically and with more meta data, the default value for posts per page (6) is starting to feel a little long. This adjusts the default value to 5, which I think makes more sense all round.
