### PR TITLE
Hide Settings Tab if Author

### DIFF
--- a/core/client/models/user.js
+++ b/core/client/models/user.js
@@ -25,6 +25,13 @@ var User = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     updated_by: DS.belongsTo('user', { async: true }),
     roles: DS.hasMany('role', { embedded: 'always' }),
 
+
+    // TODO: Once client-side permissions are in place,
+    // remove the hard role check.
+    isAuthor: Ember.computed('roles', function () {
+        return this.get('roles').objectAt(0).get('name').toLowerCase() === 'author';
+    }),
+
     saveNewPassword: function () {
         var url = this.get('ghostPaths.url').api('users', 'password');
         return ic.ajax.request(url, {

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -6,7 +6,9 @@
         <ul id="main-menu" >
             {{gh-activating-list-item route="posts" title="Content" classNames="content js-close-sidebar"}}
             {{gh-activating-list-item route="editor.new" title="New Post" classNames="editor js-close-sidebar"}}
-            {{gh-activating-list-item route="settings" title="Settings" classNames="settings js-close-sidebar"}}
+            {{#unless session.user.isAuthor}}
+              {{gh-activating-list-item route="settings" title="Settings" classNames="settings js-close-sidebar"}}
+            {{/unless}}
 
             <li id="usermenu" class="usermenu subnav">
                 {{#gh-popover-button popoverName="user-menu" tagName="a" href="#" classNames="dropdown"}}


### PR DESCRIPTION
Implements #3293. Currently, we don’t have a permission system on the
client side, so this relies on a hardcoded “author” string.
