### PR TITLE
Update Users API to handle role objects or ids

### DIFF
--- a/core/client/controllers/modals/upload.js
+++ b/core/client/controllers/modals/upload.js
@@ -8,7 +8,9 @@ var UploadController = Ember.Controller.extend({
             this.get('model').save().then(function (model) {
                 self.notifications.showSuccess('Saved');
                 return model;
-            }).catch(this.notifications.showErrors);
+            }).catch(function (err) {
+                self.notifications.showErrors(err);
+            });
         },
 
         confirmReject: function () {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -316,9 +316,8 @@ User = ghostBookshelf.Model.extend({
                 if (data.roles.length > 1) {
                     return when.reject(new errors.ValidationError('Only one role per user is supported at the moment.'));
                 }
-
-                return Role.findOne({id: data.roles[0]}).then(function (role) {
-                    if (role.get('name') === 'Owner') {
+                return Role.findOne({id: data.roles[0].id || data.roles[0]}).then(function (role) {
+                    if (role && role.get('name') === 'Owner') {
                         // Get admin and owner role
                         return Role.findOne({name: 'Administrator'}).then(function (result) {
                             adminRole = result;
@@ -340,7 +339,7 @@ User = ghostBookshelf.Model.extend({
                         });
                     } else {
                         // assign all other roles
-                        return user.roles().updatePivot({role_id: data.roles[0]});
+                        return user.roles().updatePivot({role_id: data.roles[0].id || data.roles[0]});
                     }
                 }).then(function () {
                     return self.findOne(user, options);


### PR DESCRIPTION
 Closes #3357
- API method User#edit now handles User objects that have either
  an array of Role ids or objects.
- Fixed error handler notification on upload modal controller.
