### PR TITLE
Redirect authors and editors away from debug page

### DIFF
--- a/core/client/routes/debug.js
+++ b/core/client/routes/debug.js
@@ -4,11 +4,21 @@ import loadingIndicator from 'ghost/mixins/loading-indicator';
 var DebugRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin, styleBody, loadingIndicator, {
     classNames: ['settings'],
 
+    beforeModel: function () {
+        var self = this;
+        this.store.find('user', 'me').then(function (user) {
+            if (user.get('isAuthor') || user.get('isEditor')) {
+                self.transitionTo('posts');
+            }
+        });
+    },
+
     model: function () {
         return this.store.find('setting', { type: 'blog,theme' }).then(function (records) {
             return records.get('firstObject');
         });
     }
+
 });
 
 export default DebugRoute;


### PR DESCRIPTION
A signed in user with role author or editor will be redirected back to
/ghost.

closes #3292
