### PR TITLE
Change signout link to button

### DIFF
--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -24,7 +24,7 @@
                         <li class="divider"></li>
                         <li class="usermenu-help"><a href="http://support.ghost.org/">Help / Support</a></li>
                         <li class="divider"></li>
-                        <li class="usermenu-signout"><a {{ action 'invalidateSession' }}>Sign Out</a></li>
+                        <li class="usermenu-signout"><button {{action 'invalidateSession'}}>Sign Out</button></li>
                 {{/gh-popover}}
             </li>
         </ul>

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -95,7 +95,7 @@ screens = {
    },
    'signout': {
        url: 'ghost/signout/',
-       linkSelector: '#user-menu li.usermenu-signout a',
+       linkSelector: '#user-menu li.usermenu-signout button',
        // When no user exists we get redirected to setup which has button-add
        selector: '.button-save, .button-add'
    },

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -47,7 +47,7 @@ CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
     casper.waitForSelector('#usermenu ul.overlay.open', function then() {
         var profileHref = this.getElementAttribute('#usermenu li.usermenu-profile a', 'href'),
             helpHref = this.getElementAttribute('#usermenu li.usermenu-help a', 'href'),
-            signoutHref = this.getElementAttribute('#usermenu li.usermenu-signout a', 'href');
+            signoutHref = this.getElementAttribute('#usermenu li.usermenu-signout button', 'href');
 
         test.assertVisible('#usermenu ul.overlay', 'User menu should be visible');
 
@@ -60,8 +60,8 @@ CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
         test.assertSelectorHasText('#usermenu li.usermenu-help a', 'Help / Support', 'Help menu item has correct text');
         test.assertEquals(helpHref, 'http://support.ghost.org/', 'Help href is correct');
 
-        test.assertExists('#usermenu li.usermenu-signout a', 'Sign Out menu item exists');
-        test.assertSelectorHasText('#usermenu li.usermenu-signout a', 'Sign Out', 'Signout menu item has correct text');
+        test.assertExists('#usermenu li.usermenu-signout button', 'Sign Out menu item exists');
+        test.assertSelectorHasText('#usermenu li.usermenu-signout button', 'Sign Out', 'Signout menu item has correct text');
         // test.assertEquals(signoutHref, '/ghost/signout/', 'Sign Out href is correct');
     }, casper.failOnTimeout(test, 'WaitForSelector #usermenu ul.overlay failed'));
 });

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -21,8 +21,8 @@ CasperTest.begin('Ghost signout works correctly', 3, function suite(test) {
 
     casper.captureScreenshot('user-menu-open.png');
 
-    casper.waitForSelector('.usermenu-signout a');
-    casper.thenClick('.usermenu-signout a');
+    casper.waitForSelector('.usermenu-signout button');
+    casper.thenClick('.usermenu-signout button');
 
     casper.waitForSelector('#login').then(function assertSuccess() {
         test.assert(true, 'Got login screen');


### PR DESCRIPTION
References https://github.com/TryGhost/Ghost-UI/issues/65
- Swap signout link from an `<a>` tag to `<button>`
- Changed tests to match new element
