### PR TITLE
Signin error notifications kept from stacking

### DIFF
--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -10,6 +10,7 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     },
     actions: {
         sessionAuthenticationFailed: function (error) {
+            this.notifications.closePassive();
             this.notifications.showError(error.message);
         },
         sessionAuthenticationSucceeded: function () {
@@ -26,6 +27,7 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
             });
         },
         sessionInvalidationFailed: function (error) {
+            this.notifications.closePassive();
             this.notifications.showError(error.message);
         },
         sessionInvalidationSucceeded: function () {


### PR DESCRIPTION
closes #3375
- Prior to showing error notifications, the signin route now calls
  closePassive().
