### PR TITLE
Changed default slug from placeholder to value

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -68,7 +68,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             title = this.get('titleScratch');
 
         this.get('slugGenerator').generateSlug(title).then(function (slug) {
-            self.set('slugPlaceholder', slug);
+            self.set('slugValue', slug);
         });
     },
     titleObserver: function () {

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -6,7 +6,7 @@
 					<label for="url">URL</label>
 				</td>
 				<td class="post-setting-field">
-					{{gh-blur-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
+					{{gh-blur-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" action="updateSlug" selectOnClick="true"}}
 				</td>
 			</tr>
 			<tr class="post-setting">


### PR DESCRIPTION
The default slug couldn’t be selected because it was a placeholder rather than a value attribute which seems to have confused people. I've changed this to value.
