### PR TITLE
Fixed role sort order in the invite a new user drop down list

### DIFF
--- a/core/client/controllers/modals/invite-new-user.js
+++ b/core/client/controllers/modals/invite-new-user.js
@@ -14,7 +14,7 @@ var InviteNewUserController = Ember.Controller.extend({
             self = this;
 
         roles.promise = this.store.find('role', { permissions: 'assign' }).then(function (roles) {
-            return roles.rejectBy('name', 'Owner').sortBy('name');
+            return roles.rejectBy('name', 'Owner').sortBy('id');
         }).then(function (roles) {
             // After the promise containing the roles has been resolved and the array
             // has been sorted, explicitly set the selectedRole for the Ember.Select.


### PR DESCRIPTION
The "Invite a new user" popup, "Role" drop down is now sorted by permission level. Fixes #3391

I simply removed the sortBy function so they are sorted by their default order which happens to be the correct order. I can create a new "order" field to sort by if you would prefer this to be more explicit. Let me know.
