### PR TITLE
Do not clear password until after leaving signin

### DIFF
--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -1,11 +1,17 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var SigninController = Ember.Controller.extend(SimpleAuth.LoginControllerMixin, ValidationEngine, {
+var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControllerMixin, ValidationEngine, {
     authenticator: 'simple-auth-authenticator:oauth2-password-grant',
 
     validationType: 'signin',
 
     actions: {
+        authenticate: function () {
+            var data = this.getProperties('identification', 'password');
+
+            return this._super(data);
+        },
+
         validateAndAuthenticate: function () {
             var self = this;
 

--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -8,6 +8,16 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
             this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
         }
     },
+
+    // the deactivate hook is called after a route has been exited.
+    deactivate: function () {
+        this._super();
+
+        // clear the password property from the controller when we're no longer
+        // on the signin screen
+        this.controllerFor('signin').set('password', '');
+    },
+
     actions: {
         sessionAuthenticationFailed: function (error) {
             this.notifications.closePassive();


### PR DESCRIPTION
Closes #3399
- Provide our own authenticate action handler which does not
  clear the password input.
- Use the Signin route's deactivate hook to clear the password
  property on the controller after the user has transitioned
  away from the signin page.
