### PR TITLE
Hide Access Token

### DIFF
--- a/core/client/controllers/debug.js
+++ b/core/client/controllers/debug.js
@@ -1,11 +1,6 @@
 var DebugController = Ember.Controller.extend(Ember.Evented, {
     uploadButtonText: 'Import',
 
-    exportPath: function () {
-        return this.get('ghostPaths.url').api('db') +
-            '?access_token=' + this.get('session.access_token');
-    }.property(),
-
     actions: {
         onUpload: function (file) {
             var self = this,
@@ -33,15 +28,15 @@ var DebugController = Ember.Controller.extend(Ember.Evented, {
         },
 
         exportData: function () {
-            var self = this;
+            var iframe = $('#iframeDownload'),
+                downloadURL = this.get('ghostPaths.url').api('db') +
+                    '?access_token=' + this.get('session.access_token');
 
-            ic.ajax.request(this.get('ghostPaths.url').api('db'), {
-                type: 'GET'
-            }).then(function () {
-                self.notifications.showSuccess('Data exported successfully.');
-            }).catch(function (response) {
-                self.notifications.showErrors(response);
-            });
+            if (iframe.length === 0) {
+                iframe = $('<iframe>', { id: 'iframeDownload' }).hide().appendTo('body');
+            }
+
+            iframe.attr('src', downloadURL);
         },
 
         sendTestEmail: function () {

--- a/core/client/templates/debug.hbs
+++ b/core/client/templates/debug.hbs
@@ -19,7 +19,7 @@
                 <fieldset>
                     <div class="form-group">
                         <label>Export</label>
-                        <a class="button-save" {{bind-attr href=exportPath}}>Export</a>
+                        <a class="button-save" {{action "exportData"}}>Export</a>
                         <p>Export the blog settings and data.</p>
                     </div>
                 </fieldset>


### PR DESCRIPTION
closes #3177
- uses an iFrame to initiate the download to hide the access token

The access token is hidden in the admin logic if this PR is merged. If we would like to
completely hide the token it is possible to remove the access token and
use signed requests instead, but I think the effort isn’t worth the
benefit in this case.
