### PR TITLE
Change casperjs helper used to get RSS page content.

### DIFF
--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -5,7 +5,7 @@
 CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('off');
     casper.thenOpen(url + 'rss/', function (response) {
-        var content = this.getPageContent(),
+        var content = this.getHTML(),
             siteTitle = '<title><![CDATA[Test Blog]]></title>',
             siteDescription = '<description><![CDATA[Thoughts, stories and ideas by Test User]]></description>',
             siteUrl = '<link>http://127.0.0.1:2369/</link>',
@@ -32,7 +32,7 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
 CasperTest.begin('Ensure that author element is not included. Only dc:creator', 3, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('off');
     casper.thenOpen(url + 'rss/', function (response) {
-        var content = this.getPageContent(),
+        var content = this.getHTML(),
             author = '<author>',
             postCreator = '<dc:creator><![CDATA[Test User]]>';
 
@@ -45,7 +45,7 @@ CasperTest.begin('Ensure that author element is not included. Only dc:creator', 
 CasperTest.begin('Ensures dated permalinks works with RSS', 2, function suite(test) {
     CasperTest.Routines.togglePermalinks.run('on');
     casper.thenOpen(url + 'rss/', function (response) {
-        var content = this.getPageContent(),
+        var content = this.getHTML(),
             today = new Date(),
             dd = ("0" + today.getDate()).slice(-2),
             mm = ("0" + (today.getMonth() + 1)).slice(-2),


### PR DESCRIPTION
closes #3431
- change feed_test.js to call casperjs getHTML() instead of
  getPageContent(), because the latter now strips markup

Alternative fix would be to use .page.frameContent directly
instead of using a casperjs wrapper.

Change runs cleanly on Travis (old casperjs tag) and locally
in the Ghost-Vagrant setup with both the old casperjs tag
and the current HEAD SHA (29bbd03f7cdc9fc1e70f0fe1400635dd7d3537ad)
