### PR TITLE
Preserve order of tags as entered by the user.

### DIFF
--- a/core/client/templates/post-tags-input.hbs
+++ b/core/client/templates/post-tags-input.hbs
@@ -1,6 +1,6 @@
 <label class="tag-label" for="tags" title="Tags"><span class="hidden">Tags</span></label>
 <div class="tags">
-{{#each tags}}
+{{#each controller.tags}}
     {{#view view.tagView tag=this}}
         {{view.tag.name}}
     {{/view}}


### PR DESCRIPTION
Closes #3133
- Implement an ordered set for the tags property of the tag
  input controller.  Set order is by order added to the post.
