### PR TITLE
Remove email address from frontend

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -59,10 +59,27 @@ function getPostPage(options) {
 }
 
 function formatPageResponse(posts, page) {
+    // Delete email from author for frontend output
+    // TODO: do this on API level if no context is available
+    posts = _.each(posts, function (post) {
+        if (post.author) {
+            delete post.author.email;
+        }
+        return post;
+    });
     return {
         posts: posts,
         pagination: page.meta.pagination
     };
+}
+
+function formatResponse(post) {
+    // Delete email from author for frontend output
+    // TODO: do this on API level if no context is available
+    if (post.author) {
+        delete post.author.email;
+    }
+    return {post: post};
 }
 
 function handleError(next) {
@@ -291,7 +308,7 @@ frontendControllers = {
                             paths = config.paths.availableThemes[activeTheme.value],
                             view = template.getThemeViewForPost(paths, post);
 
-                        res.render(view, {post: post});
+                        res.render(view, formatResponse(post));
                     });
                 });
             }

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -152,7 +152,12 @@ describe('Frontend Controller', function () {
                 'slug': 'test-static-page',
                 'markdown': 'Test static page content',
                 'page': 1,
-                'published_at': new Date('2013/12/30').getTime()
+                'published_at': new Date('2013/12/30').getTime(),
+                'author': {
+                    'id': 1,
+                    'name': 'Test User',
+                    'email': 'test@ghost.org'
+                }
             }, {
                 'status': 'published',
                 'id': 2,
@@ -160,7 +165,12 @@ describe('Frontend Controller', function () {
                 'slug': 'test-normal-post',
                 'markdown': 'The test normal post content',
                 'page': 0,
-                'published_at': new Date('2014/1/2').getTime()
+                'published_at': new Date('2014/1/2').getTime(),
+                'author': {
+                    'id': 1,
+                    'name': 'Test User',
+                    'email': 'test@ghost.org'
+                }
             }],
             mockTags = [{
                 'name': 'video',
@@ -248,6 +258,7 @@ describe('Frontend Controller', function () {
                         render: function (view, context) {
                             assert.equal(view, 'tag');
                             assert.equal(context.tag, mockTags[0]);
+                            assert.equal(context.posts[0].author.email, undefined)
                             done();
                         }
                     };
@@ -376,7 +387,12 @@ describe('Frontend Controller', function () {
                     'slug': 'test-static-page',
                     'markdown': 'Test static page content',
                     'page': 1,
-                    'published_at': new Date('2013/12/30').getTime()
+                    'published_at': new Date('2013/12/30').getTime(),
+                    'author': {
+                        'id': 1,
+                        'name': 'Test User',
+                        'email': 'test@ghost.org'
+                    }
                 }]
             }, {
                 'posts': [{
@@ -386,7 +402,12 @@ describe('Frontend Controller', function () {
                     'slug': 'test-normal-post',
                     'markdown': 'The test normal post content',
                     'page': 0,
-                    'published_at': new Date('2014/1/2').getTime()
+                    'published_at': new Date('2014/1/2').getTime(),
+                    'author': {
+                        'id': 1,
+                        'name': 'Test User',
+                        'email': 'test@ghost.org'
+                    }
                 }]
             }, {
                 'posts': [{
@@ -396,7 +417,12 @@ describe('Frontend Controller', function () {
                     'slug': 'about',
                     'markdown': 'This is the about page content',
                     'page': 1,
-                    'published_at': new Date('2014/1/30').getTime()
+                    'published_at': new Date('2014/1/30').getTime(),
+                    'author': {
+                        'id': 1,
+                        'name': 'Test User',
+                        'email': 'test@ghost.org'
+                    }
                 }]
             }],
             // Helper function to prevent unit tests
@@ -460,6 +486,7 @@ describe('Frontend Controller', function () {
                             render: function (view, context) {
                                 assert.equal(view, 'page-' + mockPosts[2].posts[0].slug);
                                 assert.equal(context.post, mockPosts[2].posts[0]);
+                                assert.equal(context.post.author.email, undefined);
                                 done();
                             }
                         };
@@ -484,6 +511,7 @@ describe('Frontend Controller', function () {
                             render: function (view, context) {
                                 assert.equal(view, 'page');
                                 assert.equal(context.post, mockPosts[0].posts[0]);
+                                assert.equal(context.post.author.email, undefined);
                                 done();
                             }
                         };
@@ -629,6 +657,7 @@ describe('Frontend Controller', function () {
                                 assert.equal(view, 'post');
                                 assert(context.post, 'Context object has post attribute');
                                 assert.equal(context.post, mockPosts[1].posts[0]);
+                                assert.equal(context.post.author.email, undefined);
                                 done();
                             }
                         };
@@ -703,6 +732,7 @@ describe('Frontend Controller', function () {
                                 assert.equal(view, 'post');
                                 assert(context.post, 'Context object has post attribute');
                                 assert.equal(context.post, mockPosts[1].posts[0]);
+                                assert.equal(context.post.author.email, undefined);
                                 done();
                             }
                         };
@@ -793,6 +823,7 @@ describe('Frontend Controller', function () {
                                 assert.equal(view, 'post');
                                 assert(context.post, 'Context object has post attribute');
                                 assert.equal(context.post, mockPosts[1].posts[0]);
+                                assert.equal(context.post.author.email, undefined);
                                 done();
                             }
                         };


### PR DESCRIPTION
closes #2330
- added email address deletion from post.author in front end
- updated tests
- with some refactoring this could be done on API level
