### PR TITLE
Fixup signin and signout

### DIFF
--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -16,6 +16,7 @@ var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControll
             var self = this;
 
             this.validate({ format: false }).then(function () {
+                self.notifications.closePassive();
                 self.send('authenticate');
             }).catch(function (errors) {
                 self.notifications.closePassive();

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -24,6 +24,34 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
             this.send('loadServerNotifications', true);
         },
 
+        sessionAuthenticationFailed: function (error) {
+            this.notifications.closePassive();
+            this.notifications.showError(error.message);
+        },
+
+        sessionAuthenticationSucceeded: function () {
+            var self = this;
+            this.store.find('user', 'me').then(function (user) {
+                self.send('signedIn', user);
+                var attemptedTransition = self.get('session').get('attemptedTransition');
+                if (attemptedTransition) {
+                    attemptedTransition.retry();
+                    self.get('session').set('attemptedTransition', null);
+                } else {
+                    self.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+                }
+            });
+        },
+
+        sessionInvalidationFailed: function (error) {
+            this.notifications.closePassive();
+            this.notifications.showError(error.message);
+        },
+
+        sessionInvalidationSucceeded: function () {
+            this.notifications.showSuccess('You were successfully signed out.', true);
+        },
+
         openModal: function (modalName, model, type) {
             modalName = 'modals/' + modalName;
             // We don't always require a modal to have a controller

--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -13,40 +13,10 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     deactivate: function () {
         this._super();
 
-        // clear the password property from the controller when we're no longer
-        // on the signin screen
-        this.controllerFor('signin').set('password', '');
-    },
-
-    actions: {
-        sessionAuthenticationFailed: function (error) {
-            this.notifications.closePassive();
-            this.notifications.showError(error.message);
-        },
-        sessionAuthenticationSucceeded: function () {
-            var self = this;
-            this.store.find('user', 'me').then(function (user) {
-                self.send('signedIn', user);
-                var attemptedTransition = self.get('session').get('attemptedTransition');
-                if (attemptedTransition) {
-                    attemptedTransition.retry();
-                    self.get('session').set('attemptedTransition', null);
-                } else {
-                    self.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
-                }
-            });
-        },
-        sessionInvalidationFailed: function (error) {
-            this.notifications.closePassive();
-            this.notifications.showError(error.message);
-        },
-        sessionInvalidationSucceeded: function () {
-            this.notifications.showSuccess('You were successfully signed out.', true);
-            this.send('signedOut');
-        }
+        // clear the properties that hold the credentials from the controller
+        // when we're no longer on the signin screen
+        this.controllerFor('signin').setProperties({ identification: '', password: '' });
     }
-
-
 });
 
 export default SigninRoute;

--- a/core/client/routes/signout.js
+++ b/core/client/routes/signout.js
@@ -4,13 +4,14 @@ import loadingIndicator from 'ghost/mixins/loading-indicator';
 var SignoutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, loadingIndicator, {
     classNames: ['ghost-signout'],
 
-    afterModel: function (resolvedModel, transition) {
+    afterModel: function (model, transition) {
         if (Ember.canInvoke(transition, 'send')) {
             transition.send('invalidateSession');
             transition.abort();
             this.transitionTo('signin');
         } else {
             this.send('invalidateSession');
+            this.transitionTo('signin');
         }
     }
 });

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -24,7 +24,7 @@
                         <li class="divider"></li>
                         <li class="usermenu-help"><a href="http://support.ghost.org/">Help / Support</a></li>
                         <li class="divider"></li>
-                        <li class="usermenu-signout"><button {{action 'invalidateSession'}}>Sign Out</button></li>
+                        <li class="usermenu-signout">{{#link-to "signout"}}Sign Out{{/link-to}}</li>
                 {{/gh-popover}}
             </li>
         </ul>

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -95,7 +95,7 @@ screens = {
    },
    'signout': {
        url: 'ghost/signout/',
-       linkSelector: '#user-menu li.usermenu-signout button',
+       linkSelector: '#usermenu li.usermenu-signout a',
        // When no user exists we get redirected to setup which has button-add
        selector: '.button-save, .button-add'
    },

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -3,7 +3,7 @@
 
 /*globals CasperTest, casper */
 
-CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
+CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('root', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
@@ -47,7 +47,7 @@ CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
     casper.waitForSelector('#usermenu ul.overlay.open', function then() {
         var profileHref = this.getElementAttribute('#usermenu li.usermenu-profile a', 'href'),
             helpHref = this.getElementAttribute('#usermenu li.usermenu-help a', 'href'),
-            signoutHref = this.getElementAttribute('#usermenu li.usermenu-signout button', 'href');
+            signoutHref = this.getElementAttribute('#usermenu li.usermenu-signout a', 'href');
 
         test.assertVisible('#usermenu ul.overlay', 'User menu should be visible');
 
@@ -60,9 +60,9 @@ CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
         test.assertSelectorHasText('#usermenu li.usermenu-help a', 'Help / Support', 'Help menu item has correct text');
         test.assertEquals(helpHref, 'http://support.ghost.org/', 'Help href is correct');
 
-        test.assertExists('#usermenu li.usermenu-signout button', 'Sign Out menu item exists');
-        test.assertSelectorHasText('#usermenu li.usermenu-signout button', 'Sign Out', 'Signout menu item has correct text');
-        // test.assertEquals(signoutHref, '/ghost/signout/', 'Sign Out href is correct');
+        test.assertExists('#usermenu li.usermenu-signout a', 'Sign Out menu item exists');
+        test.assertSelectorHasText('#usermenu li.usermenu-signout a', 'Sign Out', 'Signout menu item has correct text');
+        test.assertEquals(signoutHref, '/ghost/signout/', 'Sign Out href is correct');
     }, casper.failOnTimeout(test, 'WaitForSelector #usermenu ul.overlay failed'));
 });
 

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -21,8 +21,8 @@ CasperTest.begin('Ghost signout works correctly', 3, function suite(test) {
 
     casper.captureScreenshot('user-menu-open.png');
 
-    casper.waitForSelector('.usermenu-signout button');
-    casper.thenClick('.usermenu-signout button');
+    casper.waitForSelector('.usermenu-signout a');
+    casper.thenClick('.usermenu-signout a');
 
     casper.waitForSelector('#login').then(function assertSuccess() {
         test.assert(true, 'Got login screen');


### PR DESCRIPTION
No Issue
- Move authentication related handlers to the Application route.
- Switch Sign Out from a button to a link.  Use the signout route
  to handle invalidating the session and redirecting instead of
  an action from a button.
- Clear error messages on signin page when pressing log in button.
- Errors are now always shown on sign in screen and a success
  notification is shown after sign out.
- Update functional tests.
