### PR TITLE
Stop validation error notification stack

### DIFF
--- a/core/client/controllers/forgotten.js
+++ b/core/client/controllers/forgotten.js
@@ -30,10 +30,12 @@ var ForgottenController = Ember.Controller.extend(ValidationEngine, {
                     self.transitionToRoute('signin');
                 }).catch(function (resp) {
                     self.toggleProperty('submitting');
+                    self.notifications.closePassive();
                     self.notifications.showAPIError(resp, 'There was a problem logging in, please try again.');
                 });
             }).catch(function (errors) {
                 self.toggleProperty('submitting');
+                self.notifications.closePassive();
                 self.notifications.showErrors(errors);
             });
         }


### PR DESCRIPTION
closes #3383
- Calls closePassive() if a new validation error is thrown to display
  only the latest validation error
