### PR TITLE
Disable autocomplete for setup & signup screens

### DIFF
--- a/core/client/templates/setup.hbs
+++ b/core/client/templates/setup.hbs
@@ -1,6 +1,11 @@
 <section class="setup-box js-setup-box fade-in">
     <div class="vertical">
         <form id="setup" class="setup-form" method="post" novalidate="novalidate">
+
+            {{!-- Horrible hack to prevent Chrome from incorrectly auto-filling inputs --}}
+            <input style="display:none;" type="text" name="fakeusernameremembered"/>
+            <input style="display:none;" type="password" name="fakepasswordremembered"/>
+
             <header>
                 <h1>Welcome to your new Ghost blog</h1>
                 <h2>Let's get a few things set up so you can get started.</h2>

--- a/core/client/templates/signup.hbs
+++ b/core/client/templates/signup.hbs
@@ -1,6 +1,11 @@
 <section class="setup-box js-signup-box fade-in">
     <div class="vertical">
         <form id="signup" class="setup-form" method="post" novalidate="novalidate">
+
+            {{!-- Horrible hack to prevent Chrome from incorrectly auto-filling inputs --}}
+            <input style="display:none;" type="text" name="fakeusernameremembered"/>
+            <input style="display:none;" type="password" name="fakepasswordremembered"/>
+
             <header>
                 <h1>Welcome to Ghost</h1>
                 <h2>Create your account to start publishing</h2>


### PR DESCRIPTION
No issue
- Adds 2 hidden inputs at the top start of the form that trick chrome into filling those, leaving out the rest.
