### PR TITLE
Update validation to match server error.

### DIFF
--- a/core/client/validators/forgotten.js
+++ b/core/client/validators/forgotten.js
@@ -5,7 +5,7 @@ var ForgotValidator = Ember.Object.create({
 
         if (!validator.isEmail(data.email)) {
             validationErrors.push({
-                message: 'Invalid Email'
+                message: 'Invalid email address'
             });
         }
 


### PR DESCRIPTION
When a using the forgottenRoute if you enter an incorrectly formatted email address you would see the error message 'Invalid Email', however if you entered an email address that was correctly formatted but missing the error message would be 'Invalid email address'.

This fixes the discrepancy.

See https://github.com/TryGhost/Ghost/blob/master/core/server/api/authentication.js#L75 for server side error.
