### PR TITLE
Add keyboard navigation of posts

### DIFF
--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -24,7 +24,25 @@ var PostsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Shortcut
         this._super(controller, model);
         this.setupPagination(paginationSettings);
     },
-
+    
+    stepThroughPosts: function (step) {
+        var currentPost = this.get('controller.currentPost'),
+            posts = this.get('controller.model'),
+            length = posts.get('length'),
+            newPosition;
+        
+        newPosition = posts.indexOf(currentPost) + step;
+        
+        //Make sure we're inbounds
+        if (newPosition >= length) {
+            newPosition = 0;
+        }
+        else if (newPosition < 0) {
+            newPosition = length - 1;
+        }
+        this.transitionTo('posts.post', posts.objectAt(newPosition));
+    },
+    
     shortcuts: {
         'up': 'moveUp',
         'down': 'moveDown'
@@ -34,10 +52,10 @@ var PostsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Shortcut
             this.transitionTo('editor.edit', post);
         },
         moveUp: function () {
-            window.alert('@todo keyboard post navigation: up');
+            this.stepThroughPosts(-1);
         },
         moveDown: function () {
-            window.alert('@todo keyboard post navigation: down');
+            this.stepThroughPosts(1);
         }
     }
 });

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -34,6 +34,12 @@ var PostsPostRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, load
             return self.transitionTo('posts.index');
         });
     },
+    setupController: function (controller, model) {
+        this._super(controller, model);
+        
+        this.controllerFor('posts').set('currentPost', model);
+    },
+    
     shortcuts: {
         'enter': 'openEditor'
     },


### PR DESCRIPTION
Closes #3015, ref #3469 
- Added stepThroughPosts method to PostsRoute, takes an integer, steps that far, wraps around the array.
- PostsPostRoute notifies the PostsController of which model it currently has, to help stepThroughPosts know who's selected

![keyboardsc](https://cloud.githubusercontent.com/assets/1207005/3759349/e6c7abba-185b-11e4-9deb-c21e5c252f41.gif)
