### PR TITLE
Keyboard shortcuts for Mac vs All

### DIFF
--- a/core/client/mixins/editor-route-base.js
+++ b/core/client/mixins/editor-route-base.js
@@ -1,7 +1,7 @@
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
-
+import editorShortcuts from 'ghost/utils/editor-shortcuts';
 
 var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndicator, {
     actions: {
@@ -22,6 +22,8 @@ var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
         }
     },
 
+    shortcuts: editorShortcuts,
+
     attachModelHooks: function (controller, model) {
         // this will allow us to track when the model is saved and update the controller
         // so that we can be sure controller.isDirty is correct, without having to update the
@@ -40,38 +42,6 @@ var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
     detachModelHooks: function (controller, model) {
         model.off('didCreate', controller, controller.get('modelSaved'));
         model.off('didUpdate', controller, controller.get('modelSaved'));
-    },
-
-    shortcuts: {
-        //General Editor shortcuts
-        'ctrl+s, command+s': 'save',
-        'ctrl+alt+p': 'publish',
-        'alt+shift+z': 'toggleZenMode',
-        //CodeMirror Markdown Shortcuts
-        'ctrl+alt+u': {action: 'codeMirrorShortcut', options: {type: 'strike'}},
-        'ctrl+alt+1': {action: 'codeMirrorShortcut', options: {type: 'h1'}},
-        'ctrl+alt+2': {action: 'codeMirrorShortcut', options: {type: 'h2'}},
-        'ctrl+alt+3': {action: 'codeMirrorShortcut', options: {type: 'h3'}},
-        'ctrl+alt+4': {action: 'codeMirrorShortcut', options: {type: 'h4'}},
-        'ctrl+alt+5': {action: 'codeMirrorShortcut', options: {type: 'h5'}},
-        'ctrl+alt+6': {action: 'codeMirrorShortcut', options: {type: 'h6'}},
-        'ctrl+shift+i': {action: 'codeMirrorShortcut', options: {type: 'image'}},
-        'ctrl+q': {action: 'codeMirrorShortcut', options: {type: 'blockquote'}},
-        'ctrl+shift+1': {action: 'codeMirrorShortcut', options: {type: 'currentDate'}},
-        'ctrl+b, command+b': {action: 'codeMirrorShortcut', options: {type: 'bold'}},
-        'ctrl+i, command+i': {action: 'codeMirrorShortcut', options: {type: 'italic'}},
-        'ctrl+k, command+k': {action: 'codeMirrorShortcut', options: {type: 'link'}},
-        'ctrl+l': {action: 'codeMirrorShortcut', options: {type: 'list'}},
-    /** Currently broken CodeMirror Markdown shortcuts.
-      * some may be broken due to a conflict with CodeMirror commands
-      *   (see http://codemirror.net/doc/manual.html#commands)
-        'ctrl+U': {action: 'codeMirrorShortcut', options: {type: 'uppercase'}},
-        'ctrl+shift+U': {action: 'codeMirrorShortcut', options: {type: 'lowercase'}},
-        'ctrl+alt+shift+U': {action: 'codeMirrorShortcut', options: {type: 'titlecase'}}
-        'ctrl+alt+W': {action: 'codeMirrorShortcut', options: {type: 'selectword'}},
-        'ctrl+alt+c': {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}},
-        'ctrl+enter': {action: 'codeMirrorShortcut', options: {type: 'newLine'}},
-       */
     }
 });
 

--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -90,14 +90,6 @@ function init() {
         case 'titlecase':
             md = text.toTitleCase();
             break;
-        case 'selectword':
-            word = this.getTokenAt(cursor);
-            if (!/\w$/g.test(word.string)) {
-                this.setSelection({line: cursor.line, ch: word.start}, {line: cursor.line, ch: word.end - 1});
-            } else {
-                this.setSelection({line: cursor.line, ch: word.start}, {line: cursor.line, ch: word.end});
-            }
-            break;
         case 'copyHTML':
             converter = new Showdown.converter();
             if (text) {
@@ -107,11 +99,6 @@ function init() {
             }
 
             $(".modal-copyToHTML-content").text(md).selectText();
-            break;
-        case 'newLine':
-            if (line !== "") {
-                this.replaceRange(line + "\n\n", fromLineStart);
-            }
             break;
         */
         default:

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -1,0 +1,46 @@
+var shortcuts = {},
+    ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
+//
+//General editor shortcuts
+//
+
+shortcuts[ctrlOrCmd + '+s'] = 'save';
+shortcuts[ctrlOrCmd + '+alt+p'] = 'publish';
+shortcuts['alt+shift+z'] = 'toggleZenMode';
+
+//
+//CodeMirror Markdown Shortcuts
+//
+
+//Text
+shortcuts['ctrl+alt+u'] = {action: 'codeMirrorShortcut', options: {type: 'strike'}};
+shortcuts[ctrlOrCmd + '+b'] = {action: 'codeMirrorShortcut', options: {type: 'bold'}};
+shortcuts[ctrlOrCmd + '+i'] = {action: 'codeMirrorShortcut', options: {type: 'italic'}};
+
+//Headings
+shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
+shortcuts['ctrl+alt+2'] = {action: 'codeMirrorShortcut', options: {type: 'h2'}};
+shortcuts['ctrl+alt+3'] = {action: 'codeMirrorShortcut', options: {type: 'h3'}};
+shortcuts['ctrl+alt+4'] = {action: 'codeMirrorShortcut', options: {type: 'h4'}};
+shortcuts['ctrl+alt+5'] = {action: 'codeMirrorShortcut', options: {type: 'h5'}};
+shortcuts['ctrl+alt+6'] = {action: 'codeMirrorShortcut', options: {type: 'h6'}};
+
+//Formatting
+shortcuts['ctrl+q'] = {action: 'codeMirrorShortcut', options: {type: 'blockquote'}};
+shortcuts['ctrl+l'] = {action: 'codeMirrorShortcut', options: {type: 'list'}};
+
+//Insert content
+shortcuts['ctrl+shift+1'] = {action: 'codeMirrorShortcut', options: {type: 'currentDate'}};
+shortcuts[ctrlOrCmd + '+k'] = {action: 'codeMirrorShortcut', options: {type: 'link'}};
+shortcuts[ctrlOrCmd + '+shift+i'] = {action: 'codeMirrorShortcut', options: {type: 'image'}};
+
+//Currently broken CodeMirror Markdown shortcuts.
+// Some may be broken due to a conflict with CodeMirror commands.
+// (see http://codemirror.net/doc/manual.html#commands)
+//
+//shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
+//shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
+//shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
+//shortcuts[ctrlOrCmd + '+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
+
+export default shortcuts;


### PR DESCRIPTION
Closes #3029, Ref #3469,  Ref #
- Editor shortcuts are now built in a separate file, which uses `ctrlOrCmd` to correctly set OS specific shortcuts.
- Removed `newLine` and `selectWord` shortcuts.
