### PR TITLE
User Settings: Display cog based on rights

### DIFF
--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -12,13 +12,15 @@
 
         <section class="page-actions">
 
-            {{#gh-popover-button popoverName="user-actions-menu" tagName="a" classNames="button only-has-icon user-actions-cog" title="User Actions"}}
-                <i class="icon-settings"></i>
-                <span class="hidden">User Settings</span>
-            {{/gh-popover-button}}
-            {{#gh-popover name="user-actions-menu" classNames="user-actions-menu menu-drop-right"}}
-                {{render "user-actions-menu" model}}
-            {{/gh-popover}}
+            {{#if view.userActionsAreVisible}}
+                {{#gh-popover-button popoverName="user-actions-menu" tagName="a" classNames="button only-has-icon user-actions-cog" title="User Actions"}}
+                    <i class="icon-settings"></i>
+                    <span class="hidden">User Settings</span>
+                {{/gh-popover-button}}
+                {{#gh-popover name="user-actions-menu" classNames="user-actions-menu menu-drop-right"}}
+                    {{render "user-actions-menu"}}
+                {{/gh-popover}}
+            {{/if}}
 
             <button class="button-save" {{action "save"}}>Save</button>
         </section>

--- a/core/client/templates/user-actions-menu.hbs
+++ b/core/client/templates/user-actions-menu.hbs
@@ -1,2 +1,6 @@
+{{#if view.parentView.rolesDropdownIsVisible}}
 <a href="javascript:void(0);" {{action "openModal" "transfer-owner" this}}>Make Owner</a>
+{{/if}}
+{{#if view.parentView.deleteUserActionIsVisible}}
 <a href="javascript:void(0);" class="delete">Delete User</a>
+{{/if}}

--- a/core/client/views/settings/users/user.js
+++ b/core/client/views/settings/users/user.js
@@ -7,7 +7,18 @@ var SettingsUserView = Ember.View.extend({
     
     canAssignRoles: Ember.computed.or('currentUser.isAdmin', 'currentUser.isOwner'),
     
-    rolesDropdownIsVisible: Ember.computed.and('isNotOwnProfile', 'canAssignRoles')
+    rolesDropdownIsVisible: Ember.computed.and('isNotOwnProfile', 'canAssignRoles'),
+
+    deleteUserActionIsVisible: Ember.computed('currentUser', 'canAssignRoles', 'controller.user', function () {
+        if ((this.get('canAssignRoles') && this.get('isNotOwnProfile') && !this.get('controller.user.isOwner')) ||
+            (this.get('currentUser.isEditor') && (!this.get('isNotOwnProfile') ||
+            this.get('controller.user.isAuthor')))) {
+            return true;
+        }
+    }),
+
+    userActionsAreVisible: Ember.computed.or('deleteUserActionIsVisible', 'rolesDropdownIsVisible')
+
 });
 
 export default SettingsUserView;


### PR DESCRIPTION
closes #3400
- The user view has been extended to have properties indicating whether
  the user has rights to make the displayed user an owner or delete
  him/her
- Handlebar conditionals decide whether or not to display the cog
