### PR TITLE
Enable uppercase, lowercase, titlecase shortcuts.

### DIFF
--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -3,6 +3,8 @@
  *  See editor-route-base
  */
 
+import titleize from 'ghost/utils/titleize';
+
 function init() {
     //Used for simple, noncomputational replace-and-go! shortcuts.
     //  See default case in shortcut function below.
@@ -20,30 +22,37 @@ function init() {
             cursor = this.getCursor(),
             line = this.getLine(cursor.line),
             fromLineStart = {line: cursor.line, ch: 0},
+            toLineEnd = {line: cursor.line, ch: line.length},
             md, letterCount, textIndex, position;
         switch (type) {
         case 'h1':
-            this.replaceRange('# ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('# ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 2);
             return;
         case 'h2':
-            this.replaceRange('## ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('## ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 3);
             return;
         case 'h3':
-            this.replaceRange('### ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('### ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 4);
             return;
         case 'h4':
-            this.replaceRange('#### ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('#### ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 5);
             return;
         case 'h5':
-            this.replaceRange('##### ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('##### ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 6);
             return;
         case 'h6':
-            this.replaceRange('###### ' + line, fromLineStart);
+            line = line.replace(/^#* /, '');
+            this.replaceRange('###### ' + line, fromLineStart, toLineEnd);
             this.setCursor(cursor.line, cursor.ch + 7);
             return;
         case 'link':
@@ -80,7 +89,6 @@ function init() {
             md = moment(new Date()).format('D MMMM YYYY');
             this.replaceSelection(md, 'end');
             return;
-        /** @TODO
         case 'uppercase':
             md = text.toLocaleUpperCase();
             break;
@@ -88,8 +96,9 @@ function init() {
             md = text.toLocaleLowerCase();
             break;
         case 'titlecase':
-            md = text.toTitleCase();
+            md = titleize(text);
             break;
+        /** @TODO
         case 'copyHTML':
             converter = new Showdown.converter();
             if (text) {

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -17,6 +17,11 @@ shortcuts['ctrl+alt+u'] = {action: 'codeMirrorShortcut', options: {type: 'strike
 shortcuts[ctrlOrCmd + '+b'] = {action: 'codeMirrorShortcut', options: {type: 'bold'}};
 shortcuts[ctrlOrCmd + '+i'] = {action: 'codeMirrorShortcut', options: {type: 'italic'}};
 
+shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
+shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
+shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
+
+
 //Headings
 shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
 shortcuts['ctrl+alt+2'] = {action: 'codeMirrorShortcut', options: {type: 'h2'}};
@@ -38,9 +43,6 @@ shortcuts[ctrlOrCmd + '+shift+i'] = {action: 'codeMirrorShortcut', options: {typ
 // Some may be broken due to a conflict with CodeMirror commands.
 // (see http://codemirror.net/doc/manual.html#commands)
 //
-//shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
-//shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
-//shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
 //shortcuts[ctrlOrCmd + '+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
 
 export default shortcuts;

--- a/core/client/utils/titleize.js
+++ b/core/client/utils/titleize.js
@@ -1,0 +1,17 @@
+var lowerWords = ['of', 'a', 'the', 'and', 'an', 'or', 'nor', 'but', 'is', 'if',
+                  'then', 'else', 'when', 'at', 'from', 'by', 'on', 'off', 'for',
+                  'in', 'out', 'over', 'to', 'into', 'with'];
+
+function titleize(input) {
+    var words = input.split(' ').map(function (word, index) {
+        if (index === 0 || lowerWords.indexOf(word) === -1) {
+            word = Ember.String.capitalize(word);
+        }
+
+        return word;
+    });
+
+    return words.join(' ');
+}
+
+export default titleize;


### PR DESCRIPTION
Addresses #3469.
Addresses #3019.
- Add titleize utility function.
  - Capitalizes first word.
  - Capitalizes all words not contained in simple article/conjunction
    list.
- Enable shortcuts for `uppercase`, `lowercase`, and `titlecase`.
- Fix header shortcuts
  - Ensure that header shortcuts do not duplicate text.
  - Make headers idempotent (pressing `ctrl+alt+1` then `ctrl+alt+2` does not make `# # # blah`.

---

Will somewhat conflict with the changes in #3471 (will just need minor copy/pasta changes) so one or the other will need to be rebased after the first is merged.
