### PR TITLE
Avoids duplicate notification / transition

### DIFF
--- a/core/client/controllers/setup.js
+++ b/core/client/controllers/setup.js
@@ -35,9 +35,6 @@ var SetupController = Ember.ObjectController.extend(ValidationEngine, {
                     self.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', {
                         identification: self.get('email'),
                         password: self.get('password')
-                    }).then(function () {
-                        self.send('signedIn');
-                        self.transitionToRoute(SimpleAuth.Configuration.routeAfterAuthentication);
                     });
                 }, function (resp) {
                     self.toggleProperty('submitting');

--- a/core/client/controllers/signup.js
+++ b/core/client/controllers/signup.js
@@ -36,9 +36,6 @@ var SignupController = Ember.ObjectController.extend(ValidationEngine, {
                     self.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', {
                         identification: self.get('email'),
                         password: self.get('password')
-                    }).then(function () {
-                        self.send('signedIn');
-                        self.transitionToRoute(SimpleAuth.Configuration.routeAfterAuthentication);
                     });
                 }, function (resp) {
                     self.toggleProperty('submitting');

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -6,12 +6,6 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
         'esc': 'closePopups'
     },
 
-    setupController: function () {
-        Ember.run.next(this, function () {
-            this.send('loadServerNotifications');
-        });
-    },
-
     actions: {
         closePopups: function () {
             this.get('popover').closePopovers();


### PR DESCRIPTION
no ref
- Let application.js handle transition after setup
- Remove duplicate loading of server notifications

---

After signup the email notification was shown twice because of a duplicate trigger for the signedIn action. This PR removed triggering the `signedIn` action twice and lets application.js handle the transition after signup.
