### PR TITLE
Update user roles in store after owner transfer

### DIFF
--- a/core/client/controllers/modals/transfer-owner.js
+++ b/core/client/controllers/modals/transfer-owner.js
@@ -14,7 +14,18 @@ var TransferOwnerController = Ember.Controller.extend({
                         'id': user.get('id')
                     }]
                 }
-            }).then(function () {
+            }).then(function (response) {
+                // manually update the roles for the users that just changed roles
+                // because store.pushPayload is not working with embedded relations
+                if (response && Ember.isArray(response.users)) {
+                    response.users.forEach(function (userJSON) {
+                        var user = self.store.getById('user', userJSON.id),
+                            role = self.store.getById('role', userJSON.roles[0].id);
+
+                        user.set('role', role);
+                    });
+                }
+
                 self.notifications.closePassive();
                 self.notifications.showSuccess('Ownership successfully transferred to ' + user.get('name'));
             }).catch(function (error) {

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -296,8 +296,8 @@ users = {
             return canThis(options.context).assign.role(ownerRole);
         }).then(function () {
             return utils.checkObject(object, 'owner').then(function (checkedOwnerTransfer) {
-                return dataProvider.User.transferOwnership(checkedOwnerTransfer.owner[0], options).then(function () {
-                    return when.resolve({owner: [{message: 'Ownership transferred successfully.'}]});
+                return dataProvider.User.transferOwnership(checkedOwnerTransfer.owner[0], options).then(function (updatedUsers) {
+                    return when.resolve({ users: updatedUsers });
                 }).catch(function (error) {
                     return when.reject(new errors.ValidationError(error.message));
                 });

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -757,6 +757,12 @@ User = ghostBookshelf.Model.extend({
         }).then(function () {
             // assign owner role to a new user
             return assignUser.roles().updatePivot({role_id: ownerRole.id});
+        }).then(function () {
+            return Users.forge()
+                .query('whereIn', 'id', [contextUser.id, assignUser.id])
+                .fetch({ withRelated: ['roles'] });
+        }).then(function (users) {
+            return users.toJSON({ include: ['roles'] });
         });
     },
 

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -898,11 +898,13 @@ describe('Users API', function () {
                    {id: userIdFor.admin}
                ]}, context.owner
            ).then(function (response) {
-               should.exist(response);
-               should.exist(response.owner);
-               response.owner.should.have.length(1);
-               response.owner[0].message.should.eql('Ownership transferred successfully.');
-               done();
+                should.exist(response);
+                response.users.should.have.length(2);
+                testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
+                testUtils.API.checkResponse(response.users[1], 'user', ['roles']);
+                response.users[0].roles[0].id.should.equal(1);
+                response.users[1].roles[0].id.should.equal(4);
+                done();
            }).catch(done);
        });
 


### PR DESCRIPTION
Closes #3466
- Transferring the owner role is now done via a separate
  endpoint and not through Ember-Data.  As a result the
  user role data needs to be updated manually.
- Updated the owner endpoint to return a response body
  containing the updated user objects.
- Updated tests.
