### PR TITLE
Enable cycling header levels with ctrl+h.

### DIFF
--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -6,6 +6,9 @@
 import titleize from 'ghost/utils/titleize';
 
 function init() {
+    // remove predefined `ctrl+h` shortcut
+    delete CodeMirror.keyMap.emacsy['Ctrl-H'];
+
     //Used for simple, noncomputational replace-and-go! shortcuts.
     //  See default case in shortcut function below.
     CodeMirror.prototype.simpleShortcutSyntax = {
@@ -23,38 +26,26 @@ function init() {
             line = this.getLine(cursor.line),
             fromLineStart = {line: cursor.line, ch: 0},
             toLineEnd = {line: cursor.line, ch: line.length},
-            md, letterCount, textIndex, position;
+            md, letterCount, textIndex, position, match,
+            currentHeaderLevel, hashPrefix, replacementLine;
         switch (type) {
-        case 'h1':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('# ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 2);
-            return;
-        case 'h2':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('## ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 3);
-            return;
-        case 'h3':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('### ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 4);
-            return;
-        case 'h4':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('#### ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 5);
-            return;
-        case 'h5':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('##### ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 6);
-            return;
-        case 'h6':
-            line = line.replace(/^#* /, '');
-            this.replaceRange('###### ' + line, fromLineStart, toLineEnd);
-            this.setCursor(cursor.line, cursor.ch + 7);
-            return;
+        case 'cycleHeaderLevel':
+            match = line.match(/^#+/);
+
+            if (!match) {
+                currentHeaderLevel = 1;
+            } else {
+                currentHeaderLevel = match[0].length;
+            }
+
+            if (currentHeaderLevel > 5) { currentHeaderLevel = 0; }
+
+            hashPrefix = new Array(currentHeaderLevel + 2).join('#');
+            replacementLine = hashPrefix + ' ' + line.replace(/^#* /, '');
+
+            this.replaceRange(replacementLine, fromLineStart, toLineEnd);
+            this.setCursor(cursor.line, cursor.ch +  replacementLine.length - line.length);
+            break;
         case 'link':
             md = this.simpleShortcutSyntax.link.replace('$1', text);
             this.replaceSelection(md, 'end');

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -21,14 +21,7 @@ shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'
 shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
 shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
 
-
-//Headings
-shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
-shortcuts['ctrl+alt+2'] = {action: 'codeMirrorShortcut', options: {type: 'h2'}};
-shortcuts['ctrl+alt+3'] = {action: 'codeMirrorShortcut', options: {type: 'h3'}};
-shortcuts['ctrl+alt+4'] = {action: 'codeMirrorShortcut', options: {type: 'h4'}};
-shortcuts['ctrl+alt+5'] = {action: 'codeMirrorShortcut', options: {type: 'h5'}};
-shortcuts['ctrl+alt+6'] = {action: 'codeMirrorShortcut', options: {type: 'h6'}};
+shortcuts['ctrl+h'] = {action: 'codeMirrorShortcut', options: {type: 'cycleHeaderLevel'}};
 
 //Formatting
 shortcuts['ctrl+q'] = {action: 'codeMirrorShortcut', options: {type: 'blockquote'}};


### PR DESCRIPTION
Addresses #3469.
Addresses #3019.
- Remove preexisting `ctrl+h` keymap.
- Add logic to cycle the header level.
  - Loops around after h6.
  - Maintains cursor position.
  - Set initial level to h2.
- Remove `ctrl+alt+${NUM}` keymaps (as they do not work
  internationally).
