### PR TITLE
Fix naming of export file during migration

### DIFF
--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -44,10 +44,12 @@ backupDatabase = function backupDatabase() {
     logInfo('Creating database backup');
     return dataExport().then(function (exportedData) {
         // Save the exported data to the file system for download
-        var fileName = path.resolve(config.paths.contentPath + '/data/' + dataExport.fileName());
+        return dataExport.fileName().then(function (fileName) {
+            fileName = path.resolve(config.paths.contentPath + '/data/' + fileName);
 
-        return nodefn.call(fs.writeFile, fileName, JSON.stringify(exportedData)).then(function () {
-            logInfo('Database backup written to: ' + fileName);
+            return nodefn.call(fs.writeFile, fileName, JSON.stringify(exportedData)).then(function () {
+                logInfo('Database backup written to: ' + fileName);
+            });
         });
     });
 };


### PR DESCRIPTION
No Issue
- The method that generates a filename for the export during
  a migration returns a promise, not the filename directly,
  so the export file was being named [object Object].
