### PR TITLE
Shorter notifications

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -139,12 +139,12 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         errors: {
             post: {
                 published: {
-                    'published': 'Your post could not be updated.',
-                    'draft': 'Your post could not be saved as a draft.'
+                    'published': 'Update failed.',
+                    'draft': 'Saving failed.'
                 },
                 draft: {
-                    'published': 'Your post could not be published.',
-                    'draft': 'Your post could not be saved as a draft.'
+                    'published': 'Publish failed.',
+                    'draft': 'Saving failed.'
                 }
 
             }
@@ -153,12 +153,12 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         success: {
             post: {
                 published: {
-                    'published': 'Your post has been updated.',
-                    'draft': 'Your post has been saved as a draft.'
+                    'published': 'Updated.',
+                    'draft': 'Saved.'
                 },
                 draft: {
-                    'published': 'Your post has been published.',
-                    'draft': 'Your post has been saved as a draft.'
+                    'published': 'Published!',
+                    'draft': 'Saved.'
                 }
             }
         }

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -282,7 +282,7 @@ CasperTest.begin('Post settings menu', 30, function suite(test) {
 
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');
-        test.assertSelectorHasText('.notification-success', 'Your post has been saved as a draft.');
+        test.assertSelectorHasText('.notification-success', 'Saved.');
         casper.click('.notification-success a.close');
     }, function onTimeout() {
         test.assert(false, 'No success notification');


### PR DESCRIPTION
Basic notifications are unnecessarily verbose and, in some instances, even cause line-wrapping to occur. This change shortens them to short, concsise statements to indicate what action has taken place.
