### PR TITLE
The page refresh when oauth token has expired was broken.

### DIFF
--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -42,10 +42,6 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
             this.notifications.showError(error.message);
         },
 
-        sessionInvalidationSucceeded: function () {
-            this.notifications.showSuccess('You were successfully signed out.', true);
-        },
-
         openModal: function (modalName, model, type) {
             modalName = 'modals/' + modalName;
             // We don't always require a modal to have a controller


### PR DESCRIPTION
Ember simple-auth action "sessionInvalidationSucceeded" was overriden to display a meaningless message.
