### PR TITLE
adds code injection

### DIFF
--- a/core/client/controllers/settings/code-injection.js
+++ b/core/client/controllers/settings/code-injection.js
@@ -1,0 +1,19 @@
+var SettingsCodeInjectionController = Ember.ObjectController.extend({
+    actions: {
+        save: function () {
+            var self = this;
+
+            return this.get('model').save().then(function (model) {
+                self.notifications.closePassive();
+                self.notifications.showSuccess('Settings successfully saved.');
+
+                return model;
+            }).catch(function (errors) {
+                self.notifications.closePassive();
+                self.notifications.showErrors(errors);
+            });
+        },
+    }
+});
+
+export default SettingsCodeInjectionController;

--- a/core/client/models/setting.js
+++ b/core/client/models/setting.js
@@ -14,7 +14,9 @@ var Setting = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     forceI18n: DS.attr('boolean'),
     permalinks: DS.attr('string'),
     activeTheme: DS.attr('string'),
-    availableThemes: DS.attr()
+    availableThemes: DS.attr(),
+    ghost_head: DS.attr('string'),
+    ghost_foot: DS.attr('string')
 });
 
 export default Setting;

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -33,6 +33,7 @@ Router.map(function () {
         this.resource('settings.users', { path: '/users' }, function () {
             this.route('user', { path: '/:slug' });
         });
+        this.route('code-injection');
         this.route('apps');
     });
     this.route('debug');

--- a/core/client/routes/settings/code-injection.js
+++ b/core/client/routes/settings/code-injection.js
@@ -1,0 +1,18 @@
+import loadingIndicator from 'ghost/mixins/loading-indicator';
+import CurrentUserSettings from 'ghost/mixins/current-user-settings';
+
+var SettingsCodeInjectionRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, CurrentUserSettings, {
+    beforeModel: function () {
+        return this.currentUser()
+            .then(this.transitionAuthor())
+            .then(this.transitionEditor());
+    },
+
+    model: function () {
+        return this.store.find('setting', { type: 'blog,theme' }).then(function (records) {
+            return records.get('firstObject');
+        });
+    }
+});
+
+export default SettingsCodeInjectionRoute;

--- a/core/client/templates/settings.hbs
+++ b/core/client/templates/settings.hbs
@@ -9,6 +9,10 @@
                     {{gh-activating-list-item route="settings.general" title="General" classNames="general"}}
                 {{/unless}}
 
+                {{#unless session.user.isEditor}}
+                    {{gh-activating-list-item route="settings.code-injection" title="Code Injection" classNames="code"}}
+                {{/unless}}
+
                 {{gh-activating-list-item route="settings.users" title="Users" classNames="users"}}
 
                 {{#if showApps}}

--- a/core/client/templates/settings/code-injection.hbs
+++ b/core/client/templates/settings/code-injection.hbs
@@ -1,0 +1,35 @@
+<header>
+    <h2 class="title">Code Injection</h2>
+
+    <div class="settings-header-inner">
+	{{#link-to 'settings' class='button-back button'}}Back{{/link-to}}
+
+        <section class="page-actions">
+            <button type="button" class="button-save" {{action "save"}}>Save</button>
+        </section>
+    </div>
+</header>
+
+<section class="content settings-codeInjection">
+    <form id="settings-codeInjection" novalidate="novalidate">
+        <fieldset>
+            <div class="form-group">
+                <p>
+                    Ghost allows you to inject code into the top and bottom of your template files without editing them. This allows for quick modifications to insert useful things like tracking codes and meta data.
+                </p>
+            </div>
+
+            <div class="form-group">
+                <label for="blog-header">Blog Header</label>
+                <p>Code here will be injected to the \{{ghost_head}} helper at the top of your page</p>
+                {{textarea id="ghost-head" name="codeInjection[ghost_head]" type="text" value=ghost_head}}
+            </div>
+
+            <div class="form-group">
+                <label for="blog-header">Blog Footer</label>
+                <p>Code here will be injected to the \{{ghost_foot}} helper at the top of your page</p>
+                {{textarea id="blog-foot" name="codeInjection[ghost_foot]" type="text" value=ghost_foot}}
+            </div>
+        </fieldset>
+    </form>
+</section>

--- a/core/client/views/settings/code-injection.js
+++ b/core/client/views/settings/code-injection.js
@@ -1,0 +1,5 @@
+import BaseView from 'ghost/views/settings/content-base';
+
+var SettingsGeneralView = BaseView.extend();
+
+export default SettingsGeneralView;

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -61,6 +61,12 @@
                 "matches": "(:id|:slug|:year|:month|:day)",
                 "notContains": "/ghost/"
             }
+        },
+        "ghost_head": {
+            "defaultValue" : ""
+        },
+        "ghost_foot": {
+            "defaultValue" : ""
         }
     },
     "theme": {

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -482,7 +482,16 @@ coreHelpers.ghost_head = function (options) {
     return coreHelpers.url.call(self, {hash: {absolute: true}}).then(function (url) {
         head.push('<link rel="canonical" href="' + url + '" />');
 
-        return filters.doFilter('ghost_head', head);
+        return api.settings.read({key: 'ghost_head'}).then(function (response) {
+            for (var i = 0; i < response.settings.length; i += 1) {
+                if (response.settings[i].key === 'ghost_head') {
+                    head.push(response.settings[i].value);
+                }
+            }
+            return head;
+        }).then(function (head) {
+            return filters.doFilter('ghost_head', head);
+        });
     }).then(function (head) {
         var headString = _.reduce(head, function (memo, item) { return memo + '\n' + item; }, '');
         return new hbs.handlebars.SafeString(headString.trim());
@@ -500,6 +509,11 @@ coreHelpers.ghost_foot = function (options) {
     }));
 
     return filters.doFilter('ghost_foot', foot).then(function (foot) {
+        return api.settings.read({key: 'ghost_foot'}).then(function (response) {
+            foot.push(response.settings[0].value);
+            return foot;
+        });
+    }).then(function (foot) {
         var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');
         return new hbs.handlebars.SafeString(footString.trim());
     });


### PR DESCRIPTION
closes #1993

includes code injection for `{{ghost_head}}` and `{{ghost_foot}}`

Some steps still have to be done
- Include CodeMirror for syntax highlighting
- renaming settings "head" and "foot" to "ghost_head" and "ghost_foot" (to be on par with the handlebar helpers)
- and removing all the comments resulting from the copypasta :-)
- related: TryGhost/Ghost-UI#86

@DominikAngerer will look into CodeMirror.
