### PR TITLE
Fix for missing author when switching posts

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -32,10 +32,17 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     }.observes('selectedAuthor'),
     authors: function () {
         //Loaded asynchronously, so must use promise proxies.
-        var deferred = {};
+        var deferred = {},
+            self = this;
+
         deferred.promise = this.store.find('user').then(function (users) {
             return users.rejectBy('id', 'me');
+        }).then(function (users) {
+            self.set('selectedAuthor', users.get('firstObject'));
+
+            return users;
         });
+
         return Ember.ArrayProxy
             .extend(Ember.PromiseProxyMixin)
             .create(deferred);


### PR DESCRIPTION
No Issue
- Fixes the case where the authors dropdown in the
  post settings menu has no author selected after
  switching between posts.
