### PR TITLE
[WIP] Handle session expiration gracefully

### DIFF
--- a/core/client/controllers/modals/signin.js
+++ b/core/client/controllers/modals/signin.js
@@ -1,0 +1,12 @@
+import SigninController from '../signin';
+
+export default SigninController.extend({
+    actions: {
+        authenticate: function (data) {
+            var self = this;
+            this._super(data).then(function () {
+                self.send('closeModal');
+            });
+        },
+    }
+});

--- a/core/client/initializers/authentication.js
+++ b/core/client/initializers/authentication.js
@@ -16,9 +16,9 @@ var AuthenticationInitializer = {
             authorizer: 'simple-auth-authorizer:oauth2-bearer'
         };
         SimpleAuth.Session.reopen({
-            user: Ember.computed(function () {
+            user: function () {
                 return container.lookup('store:main').find('user', 'me');
-            })
+            }.property()
         });
         SimpleAuth.Authenticators.OAuth2.reopen({
             serverTokenEndpoint: Ghost.apiRoot + '/authentication/token',

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -13,18 +13,6 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
     },
 
     actions: {
-        authorizationFailed: function () {
-            var currentRoute = this.get('controller').get('currentRouteName');
-
-            if (currentRoute.split('.')[0] === 'editor') {
-                this.send('openModal', 'auth-failed-unsaved', this.controllerFor(currentRoute));
-
-                return;
-            }
-
-            this._super();
-        },
-
         closePopups: function () {
             this.get('popover').closePopovers();
             this.get('notifications').closeAll();

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -91,7 +91,11 @@ var EditorEditRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, bas
 
             // remove model-related listeners created in editor-route-base
             this.detachModelHooks(controller, model);
-        }
+        },
+
+        authorizationFailed: function () {
+            this.send('openModal', 'signin');
+        },
     }
 });
 

--- a/core/client/templates/modals/signin.hbs
+++ b/core/client/templates/modals/signin.hbs
@@ -1,0 +1,14 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+    title="Please login again" confirm=confirm}}
+
+        <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
+            <div class="email-wrap">
+                {{input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" autocapitalize="off" autocorrect="off" value=identification}}
+            </div>
+            <div class="password-wrap">
+                {{input class="password" type="password" placeholder="Password" name="password" value=password}}
+            </div>
+            <button class="button-save" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
+       </form>
+
+{{/gh-modal-dialog}}

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -2,7 +2,7 @@
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
             <span class="input-icon icon-mail">
-                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" 
+                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus"
                 autocapitalize="off" autocorrect="off" value=identification}}
             </span>
         </div>


### PR DESCRIPTION
This will eventually fix #2092, however it's currently missing correct handling of some edge cases, tests etc. Whenever a 401 response is detected (which most likely means that the session is expired), a modal signin window is opened that lets the user sign in again to retry the action that triggered the 401 response.

That, together with Ember Simple Auth's automatic token refresh should resolve all problems with expired sessions and lost data.

Missing:
- tests
- when 401 is triggered by a transition the modal is opened before the redirect to the signing page which looks ugly
- the modal itself needs to be styled
