### PR TITLE
Show posts authored by current user.

### DIFF
--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -35,7 +35,7 @@ var PostsPostRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, load
             return self.store.find('post', paginationSettings).then(function (records) {
                 var post = records.get('firstObject');
 
-                if (user.get('isAuthor') && post.isAuthoredByUser(user)) {
+                if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
                     // do not show the post if they are an author but not this posts author
                     post = null;
                 }


### PR DESCRIPTION
The current logic allows showing of all EXCEPT the current users posts
(when the current user is an author).

This fixes that.
