### PR TITLE
Set postgres version to 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   directories:
     - node_modules
     - bower_components
+addons:
+  postgresql: "9.3"
 env:
   - DB=sqlite3 NODE_ENV=testing
   - DB=mysql NODE_ENV=testing-mysql


### PR DESCRIPTION
refs #2499

Just talked to @josh-k in IRC:

```
12:00 AM <halfdan> heya - we've been experiencing some weird issues with postgresql 
12:00 AM <halfdan> https://travis-ci.org/TryGhost/Ghost/jobs/31375123#L135
12:00 AM <halfdan> sometimes the psql server just doesn't seem to run
12:00 AM <halfdan> josh-k: ^
12:02 AM <@josh-k> hi halfdan
12:02 AM <halfdan> heya
12:03 AM <@josh-k> hmmm, this is not the first report of this problem
12:03 AM <@josh-k> can you try using:
12:03 AM <@josh-k> addons:
12:03 AM <@josh-k>   postgresql: 9.3 (or which ever version you need)
12:03 AM <@josh-k> for now
12:03 AM <halfdan> definitely
```
