### PR TITLE
Remove unnecessary hard refresh on signout.

### DIFF
--- a/core/client/routes/signout.js
+++ b/core/client/routes/signout.js
@@ -1,6 +1,5 @@
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
-import ghostPaths from 'ghost/utils/ghost-paths';
 
 var SignoutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, loadingIndicator, {
     classNames: ['ghost-signout'],
@@ -13,13 +12,7 @@ var SignoutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleB
         } else {
             this.send('invalidateSession');
         }
-
-        this.hardRefresh();
     },
-
-    hardRefresh: function () {
-        window.location = ghostPaths().adminRoot + '/signin/';
-    }
 });
 
 export default SignoutRoute;


### PR DESCRIPTION
Refs #3488
- Hard refresh handled by ember-simple-auth.
