### PR TITLE
Update markdown help modal

### DIFF
--- a/core/client/templates/modals/markdown.hbs
+++ b/core/client/templates/modals/markdown.hbs
@@ -13,27 +13,32 @@
             <tr>
                 <td><strong>Bold</strong></td>
                 <td>**text**</td>
-                <td>Ctrl / Cmd + B</td>
+                <td>Ctrl/⌘ + B </td>
             </tr>
             <tr>
                 <td><em>Emphasize</em></td>
                 <td>*text*</td>
-                <td>Ctrl / Cmd + I</td>
+                <td>Ctrl/⌘ + I</td>
             </tr>
             <tr>
-                <td>Strike-through</td>
+                <td><del>Strike-through</del></td>
                 <td>~~text~~</td>
                 <td>Ctrl + Alt + U</td>
             </tr>
             <tr>
                 <td><a href="#">Link</a></td>
                 <td>[title](http://)</td>
-                <td>Ctrl + Shift + L</td>
+                <td>Ctrl/⌘ + K</td>
+            </tr>
+            <tr>
+                <td><code>Inline Code</code></td>
+                <td>`code`</td>
+                <td>Ctrl/⌘ + Shift + K</td>
             </tr>
             <tr>
                 <td>Image</td>
                 <td>![alt](http://)</td>
-                <td>Ctrl + Shift + I</td>
+                <td>Ctrl/⌘ + Shift + I</td>
             </tr>
             <tr>
                 <td>List</td>
@@ -59,11 +64,6 @@
                 <td>H3</td>
                 <td>### Heading</td>
                 <td>Ctrl + Alt + 3</td>
-            </tr>
-            <tr>
-                <td><code>Inline Code</code></td>
-                <td>`code`</td>
-                <td>Cmd + K / Ctrl + Shift + K</td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Closes #3499
- Swapped out "Cmd" for the symbol. We're all UTF8, right?
- Removed hint for "Inline Code" until we readd its shortcut
