### PR TITLE
Sanity check page parameter used in findPage

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -283,7 +283,11 @@ Post = ghostBookshelf.Model.extend({
             authorInstance = options.author !== undefined ? User.forge({slug: options.author}) : false;
 
         if (options.limit) {
-            options.limit = parseInt(options.limit) || 15;
+            options.limit = parseInt(options.limit, 10) || 15;
+        }
+
+        if (options.page) {
+            options.page = parseInt(options.page, 10) || 1;
         }
 
         options = this.filterOptions(options, 'findPage');
@@ -400,7 +404,7 @@ Post = ghostBookshelf.Model.extend({
                     meta = {},
                     data = {};
 
-                pagination.page = parseInt(options.page, 10);
+                pagination.page = options.page;
                 pagination.limit = options.limit;
                 pagination.pages = calcPages === 0 ? 1 : calcPages;
                 pagination.total = totalPosts;

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -164,7 +164,11 @@ User = ghostBookshelf.Model.extend({
             roleInstance = options.role !== undefined ? Role.forge({name: options.role}) : false;
 
         if (options.limit && options.limit !== 'all') {
-            options.limit = parseInt(options.limit) || 15;
+            options.limit = parseInt(options.limit, 10) || 15;
+        }
+
+        if (options.page) {
+            options.page = parseInt(options.page, 10) || 1;
         }
 
         options = this.filterOptions(options, 'findPage');
@@ -268,7 +272,7 @@ User = ghostBookshelf.Model.extend({
                     meta = {},
                     data = {};
 
-                pagination.page = parseInt(options.page, 10);
+                pagination.page = options.page;
                 pagination.limit = options.limit;
                 pagination.pages = calcPages === 0 ? 1 : calcPages;
                 pagination.total = totalUsers;

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -105,7 +105,6 @@ describe('Post Model', function () {
                 }).catch(done);
         });
 
-
         it('can findOne', function (done) {
             var firstPost;
 
@@ -156,7 +155,6 @@ describe('Post Model', function () {
                 done();
             }).catch(done);
         });
-
 
         it('can add, defaults are all correct', function (done) {
             var createdPostUpdatedDate,
@@ -395,7 +393,6 @@ describe('Post Model', function () {
             }).catch(done);
         });
 
-
         it('can findPage, with various options', function (done) {
             testUtils.fixtures.insertMorePosts().then(function () {
 
@@ -445,6 +442,7 @@ describe('Post Model', function () {
                 done();
             }).catch(done);
         });
+
         it('can findPage for tag, with various options', function (done) {
             testUtils.fixtures.insertMorePosts().then(function () {
 
@@ -489,6 +487,17 @@ describe('Post Model', function () {
 
                 done();
             }).catch(done);
+        });
+
+        it('can NOT findPage for a page that overflows the datatype', function (done) {
+            PostModel.findPage({ page: 5700000000055345439587894375457849375284932759842375894372589243758947325894375894275894275894725897432859724309 })
+                .then(function (paginationResult) {
+                    should.exist(paginationResult.meta);
+
+                    paginationResult.meta.pagination.page.should.be.a.Number;
+
+                    done();
+                }).catch(done);
         });
     });
 

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -215,6 +215,16 @@ describe('User Model', function run() {
             }).catch(done);
         });
 
+        it('can NOT findPage for a page that overflows the datatype', function (done) {
+            UserModel.findPage({ page: 5700000000055345439587894375457849375284932759842375894372589243758947325894375894275894275894725897432859724309 })
+                .then(function (paginationResult) {
+                    should.exist(paginationResult.meta);
+
+                    paginationResult.meta.pagination.page.should.be.a.Number;
+                    
+                    done();
+                }).catch(done);
+        });
 
         it('can findOne', function (done) {
             var firstUser;


### PR DESCRIPTION
Closes #3510
- Make sure the page parameter is does not overflow the
  integer data type.
