### PR TITLE
Change user menu link to a button

### DIFF
--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -7,11 +7,11 @@
             {{gh-activating-list-item route="posts" title="Content" classNames="content js-close-sidebar"}}
             {{gh-activating-list-item route="editor.new" title="New Post" classNames="editor js-close-sidebar"}}
             {{#unless session.user.isAuthor}}
-              {{gh-activating-list-item route="settings" title="Settings" classNames="settings js-close-sidebar"}}
+                {{gh-activating-list-item route="settings" title="Settings" classNames="settings js-close-sidebar"}}
             {{/unless}}
 
             <li id="usermenu" class="usermenu subnav">
-                {{#gh-popover-button popoverName="user-menu" tagName="a" href="#" classNames="dropdown"}}
+                {{#gh-popover-button popoverName="user-menu" classNames="dropdown"}}
                     {{#if session.user.image}}
                     <img class="avatar" {{bind-attr src="session.user.image"}} alt="Avatar" />
                     {{else}}

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -43,7 +43,7 @@ CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
         test.assertNotExists('#usermenu ul.overlay.open', 'User menu should not be visible');
     });
 
-    casper.thenClick('#usermenu a');
+    casper.thenClick('#usermenu button');
     casper.waitForSelector('#usermenu ul.overlay.open', function then() {
         var profileHref = this.getElementAttribute('#usermenu li.usermenu-profile a', 'href'),
             helpHref = this.getElementAttribute('#usermenu li.usermenu-help a', 'href'),

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -11,7 +11,7 @@ CasperTest.begin('Ghost signout works correctly', 3, function suite(test) {
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL without signing in');
     });
 
-    casper.thenClick('#usermenu a').waitFor(function checkOpaque() {
+    casper.thenClick('#usermenu button').waitFor(function checkOpaque() {
         return this.evaluate(function () {
             var menu = document.querySelector('#usermenu .overlay.open');
             return window.getComputedStyle(menu).getPropertyValue('display') === 'block' &&


### PR DESCRIPTION
Closes #3546
- Change user menu popover toggle from an `<a>` to a `<button>`
- Change tests accordingly
