### PR TITLE
Add missing model to template render.

### DIFF
--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -18,7 +18,7 @@
                     <span class="hidden">User Settings</span>
                 {{/gh-popover-button}}
                 {{#gh-popover name="user-actions-menu" classNames="user-actions-menu menu-drop-right"}}
-                    {{render "user-actions-menu"}}
+                    {{render "user-actions-menu" model}}
                 {{/gh-popover}}
             {{/if}}
 


### PR DESCRIPTION
Closes #3530, Refs #3474
- Cleanup from #3474 which stopped passing the model into
  the render template call.
