### PR TITLE
Display error for invalid email on user invite

### DIFF
--- a/core/client/mixins/validation-engine.js
+++ b/core/client/mixins/validation-engine.js
@@ -9,6 +9,7 @@ import ForgotValidator from 'ghost/validators/forgotten';
 import SettingValidator from 'ghost/validators/setting';
 import ResetValidator from 'ghost/validators/reset';
 import UserValidator from 'ghost/validators/user';
+import InviteValidator from 'ghost/validators/invite';
 
 // our extensions to the validator library
 ValidatorExtensions.init();
@@ -72,7 +73,8 @@ var ValidationEngine = Ember.Mixin.create({
         forgotten: ForgotValidator,
         setting: SettingValidator,
         reset: ResetValidator,
-        user: UserValidator
+        user: UserValidator,
+        invite: InviteValidator
     },
 
     /**

--- a/core/client/validators/invite.js
+++ b/core/client/validators/invite.js
@@ -1,0 +1,16 @@
+var InviteValidator = Ember.Object.create({
+    check: function (model) {
+        var data = model.getProperties('email'),
+            validationErrors = [];
+
+        if (!validator.isEmail(data.email)) {
+            validationErrors.push({
+                message: 'Invalid email address'
+            });
+        }
+
+        return validationErrors;
+    }
+});
+
+export default InviteValidator;


### PR DESCRIPTION
closes #3531
- Created invite validator checking for valid email format
- Included said validator in "invite new user" modal, checking the email
  before the user record is created
