### PR TITLE
Return to invite new user; invite multiple users in one go

### DIFF
--- a/core/client/controllers/modals/invite-new-user.js
+++ b/core/client/controllers/modals/invite-new-user.js
@@ -6,6 +6,7 @@ var InviteNewUserController = Ember.Controller.extend({
             var authorRole = roles.findBy('name', 'Author');
             //Initialize role as well.
             self.set('role', authorRole);
+            self.set('authorRole', authorRole);
             return authorRole;
         });
     }),
@@ -51,10 +52,14 @@ var InviteNewUserController = Ember.Controller.extend({
                 newUser.deleteRecord();
                 self.notifications.closePassive();
                 self.notifications.showErrors(errors);
+            }).finally(function () {
+                //Reset
+                self.set('email', '');
+                self.set('role', self.get('authorRole'));
+                //Make sure the modal closes on confirm, no matter the
+                //method used to close it (enter in input vs Confirm click)
+                self.send('closeModal');
             });
-
-            self.set('email', null);
-            self.set('role', null);
         },
 
         confirmReject: function () {

--- a/core/client/templates/modals/invite-new-user.hbs
+++ b/core/client/templates/modals/invite-new-user.hbs
@@ -4,7 +4,7 @@
         <fieldset>
             <div class="form-group">
                 <label for="new-user-email">Email Address</label>
-                {{input class="email" id="new-user-email" type="email" placeholder="Email Address" name="email" autofocus="autofocus"
+                {{input action="confirmAccept" class="email" id="new-user-email" type="email" placeholder="Email Address" name="email" autofocus="autofocus"
                 autocapitalize="off" autocorrect="off" value=email}}
             </div>
 

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -2,7 +2,7 @@
     {{#link-to 'settings' class='button-back button'}}Back{{/link-to}}
     <h2 class="title">Users</h2>
     <section class="page-actions">
-        <button class="button-add" {{action "openModal" "invite-new-user" this}} >New&nbsp;User</button>
+        <button class="button-add" {{action "openModal" "invite-new-user"}} >New&nbsp;User</button>
     </section>
 </header>
 


### PR DESCRIPTION
Closes #3533, Closes #3547, Closes #3531 
- invite-new-user always resets role to author now, allowing for multiple invites on one load
- Added confirm action when hitting return in INUModal's email input
- Don't pass users as the model to invite-new-user-modal
- Move invite-new-user reset to a `finally` clause
- invite-new-user always closes on a confirm
