### PR TITLE
fix most recent post stolen by the last logged in user AND only show active users in post-settings-menu drop-down

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -13,7 +13,13 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             this.addObserver('titleScratch', this, 'titleObserver');
         }
     },
-    selectedAuthor: Ember.computed.oneWay('author'),
+    selectedAuthor: Ember.computed(function () {
+        var self = this;
+        return this.get('author').then(function (author) {
+            self.set('selectedAuthor', author);
+            return author;
+        });
+    }),
     changeAuthor: function () {
         var author = this.get('author'),
             selectedAuthor = this.get('selectedAuthor'),
@@ -32,15 +38,14 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     }.observes('selectedAuthor'),
     authors: function () {
         //Loaded asynchronously, so must use promise proxies.
-        var deferred = {},
-            self = this;
+        var deferred = {};
 
         deferred.promise = this.store.find('user').then(function (users) {
             return users.rejectBy('id', 'me');
         }).then(function (users) {
-            self.set('selectedAuthor', users.get('firstObject'));
-
-            return users;
+            return users.filter(function (user) {
+                return user.get('active');
+            });
         });
 
         return Ember.ArrayProxy


### PR DESCRIPTION
2 bugs in 1
- most recent post stolen by the last logged in user
- only show active users in post-settings-menu drop-down

fixes #3549 fixes #3528
- instead of grabbing and setting the author after fetching the list of users, get the author info from the models "author" property and set it when that value returns. (3549)
- added filter to the PSM's "authors" attribute to only display active users (3528)
