### PR TITLE
Ensure keyboard navigation matches custom post sorting.

### DIFF
--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -38,7 +38,7 @@ var PostsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Shortcut
 
     stepThroughPosts: function (step) {
         var currentPost = this.get('controller.currentPost'),
-            posts = this.get('controller.model'),
+            posts = this.get('controller.arrangedContent'),
             length = posts.get('length'),
             newPosition;
 


### PR DESCRIPTION
No issue.

Since we are using a custom sort order for our post listing, we need to use that sort order when determining the next post (for up and down keyboard shortcuts).
