### PR TITLE
About ghost page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,9 @@ config.js
 # Built asset files
 /core/built
 /core/client/assets/css
+/core/client/assets/img/contributors/
 /core/client/docs/dist/css
+/core/client/templates/-contributors.hbs
 
 # Coverage reports
 coverage.html

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -33,6 +33,7 @@ Router.map(function () {
         this.resource('settings.users', { path: '/users' }, function () {
             this.route('user', { path: '/:slug' });
         });
+        this.route('about');
     });
     this.route('debug');
     //Redirect legacy content to posts

--- a/core/client/routes/settings/about.js
+++ b/core/client/routes/settings/about.js
@@ -1,0 +1,25 @@
+import loadingIndicator from 'ghost/mixins/loading-indicator';
+
+var SettingsAboutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, {
+    cachedConfig: false,
+    model: function () {
+        var cachedConfig = this.get('cachedConfig'),
+            self = this;
+        if (cachedConfig) {
+            return cachedConfig;
+        }
+
+        return ic.ajax.request(this.get('ghostPaths.url').api('configuration'))
+            .then(function (configurationResponse) {
+                var configKeyValues = configurationResponse.configuration;
+                cachedConfig = {};
+                configKeyValues.forEach(function (configKeyValue) {
+                    cachedConfig[configKeyValue.key] = configKeyValue.value;
+                });
+                self.set('cachedConfig', cachedConfig);
+                return cachedConfig;
+            });
+    }
+});
+
+export default SettingsAboutRoute;

--- a/core/client/templates/settings.hbs
+++ b/core/client/templates/settings.hbs
@@ -14,6 +14,8 @@
                 {{gh-activating-list-item route="settings.users" title="Users" classNames="settings-menu-users"}}
 
             {{/unless}}
+
+            {{gh-activating-list-item route="settings.about" title="About" classNames="settings-menu-about"}}
         </ul>
     </nav>
 

--- a/core/client/templates/settings/about.hbs
+++ b/core/client/templates/settings/about.hbs
@@ -1,0 +1,55 @@
+<header class="settings-view-header">
+    <h2 class="page-title">About</h2>
+    <div class="settings-header-inner">
+        {{#link-to 'settings' class='btn btn-default btn-back'}}Back{{/link-to}}
+    </div>
+</header>
+
+<section class="content settings-about">
+    <section class="about-ghost-intro">
+        <h1>
+            <span class="ghost_logo">
+                <span class="hidden">Ghost</span>
+            </span>
+            <span class="version blue">v{{version}}</span>
+        </h1>
+        <p>A free, open, simple publishing platform</p>
+
+        <div class="about-environment-help clearfix">
+            <div class="about-environment">
+                <dl>
+                    <dt>Version:</dt>
+                    <dd class="about-environment-detail">{{version}}</dd>
+                    <dt>Environment:</dt>
+                    <dd class="about-environment-detail">{{environment}}</dd>
+                    <dt>Database:</dt>
+                    <dd class="about-environment-detail">{{database}}</dd>
+                    <dt>Mail:</dt>
+                    <dd class="about-environment-detail">{{#if mail}}{{mail}}{{else}}Native{{/if}}</dd>
+                </dl>
+            </div>
+            <div class="about-help">
+                <a href="http://support.ghost.org" class="btn">User Documentation</a>
+                <a href="https://ghost.org/forum/" class="btn">Get Help With Ghost</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="about-credits">
+        <h1>The People Who Made it Possible</h1>
+
+        <ul class="top-contributors clearfix">
+            {{partial "contributors"}}
+        </ul>
+
+        <p class="about-contributors-info">Ghost is built by an incredible group of contributors from all over the world. Here are just a few of the people who helped create the version you’re using right now.</p>
+
+        <a href="https://github.com/TryGhost/Ghost/blob/master/CONTRIBUTING.md" class="about-get-involved btn-blue btn-lg btn">Find out how you can get involved</a>
+
+        <p class="about-copyright">
+            Copyright 2013 - 2014 Ghost Foundation, released under the <a href="https://github.com/TryGhost/Ghost/blob/master/LICENSE">MIT license</a>.
+            <br>
+            <a href="https://ghost.org/">Ghost</a> is a trademark of the <a href="https://ghost.org/about/">Ghost Foundation</a>.
+        </p>
+    </section>
+</section>

--- a/core/client/utils/ghost-paths.js
+++ b/core/client/utils/ghost-paths.js
@@ -25,7 +25,7 @@ function ghostPaths() {
         blogRoot: subdir + '/',
         adminRoot: adminRoot,
         apiRoot: apiRoot,
-        userImage: assetUrl('/assets/img/user-image.png'),
+        contributorsDir: assetUrl('/ghost/img/contributors'),
         errorImageSrc: assetUrl('/ghost/img/404-ghost@2x.png'),
         errorImageSrcSet: assetUrl('/ghost/img/404-ghost.png') + ' 1x, ' +
             assetUrl('/ghost/img/404-ghost@2x.png') + ' 2x',

--- a/core/client/views/settings/about.js
+++ b/core/client/views/settings/about.js
@@ -1,0 +1,5 @@
+import BaseView from 'ghost/views/settings/content-base';
+
+var SettingsAboutView = BaseView.extend();
+
+export default SettingsAboutView;

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
         "require-dir": "~0.1.0",
         "should": "~2.1.1",
         "sinon": "~1.7.3",
-        "supertest": "~0.8.2"
+        "supertest": "~0.8.2",
+        "top-gh-contribs": "0.0.1"
     }
 }


### PR DESCRIPTION
Closes #3568
- Deleted html placeholders in client
- Added new grunt task, buildAboutPage, which 1)creates -contributors.hbs partial and 2) downloads contributor avatars
- buildAboutPage is called by anything that does an emberTemplates task
- Removed unused code from ghostpaths

---
1. [x] query GH API for top contributors between releases ([via](/novaugust/top-gh-contribs))
2. [x] Create hbs partial for user list from 1 @ `core/client/templates/-contributors.hbs`
3. [x] Download avatar for each user, and move to `client/assets/img/contributors/<name>`
4. [x] Insert ghost config (DB, Version, Environment, Mail
