### PR TITLE
Error modifying "author" attribute before post record has been created

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -24,6 +24,12 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             return;
         }
         model.set('author', selectedAuthor);
+
+        //if this is a new post (never been saved before), don't try to save it
+        if (this.get('isNew')) {
+            return;
+        }
+
         model.save(this.get('saveOptions')).catch(function (errors) {
             self.showErrors(errors);
             self.set('selectedAuthor', author);


### PR DESCRIPTION
fixes #3523
- when changing the author, added a check to NOT trigger a save if the post has not been created/saved as yet
