### PR TITLE
Stop event propagation when hitting "enter" in the gh-blur-input component

### DIFF
--- a/core/client/components/gh-blur-input.js
+++ b/core/client/components/gh-blur-input.js
@@ -1,5 +1,6 @@
 var BlurInput = Ember.TextField.extend({
     selectOnClick: false,
+    stopEnterKeyDownPropagation: false,
     click: function (event) {
         if (this.get('selectOnClick')) {
             event.currentTarget.select();
@@ -7,6 +8,15 @@ var BlurInput = Ember.TextField.extend({
     },
     focusOut: function () {
         this.sendAction('action', this.get('value'));
+    },
+    keyDown: function (event) {
+        // stop event propagation when pressing "enter"
+        // most useful in the case when undesired (global) keyboard shortcuts are getting triggered while interacting
+        // with this particular input element.
+        if (this.get('stopEnterKeyDownPropagation') && event.keyCode === 13) {
+            event.stopPropagation();
+            return true;
+        }
     }
 });
 

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -6,7 +6,7 @@
 					<label for="url">URL</label>
 				</td>
 				<td class="post-setting-field">
-					{{gh-blur-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" action="updateSlug" placeholder=slugPlaceholder selectOnClick="true"}}
+					{{gh-blur-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" action="updateSlug" placeholder=slugPlaceholder selectOnClick="true" stopEnterKeyDownPropagation="true"}}
 				</td>
 			</tr>
 			<tr class="post-setting">
@@ -14,7 +14,7 @@
 					<label for="pub-date">Pub Date</label>
 				</td>
 				<td class="post-setting-field">
-					{{gh-blur-input class="post-setting-date" value=publishedAtValue name="post-setting-date" action="setPublishedAt" placeholder=publishedAtPlaceholder}}
+					{{gh-blur-input class="post-setting-date" value=publishedAtValue name="post-setting-date" action="setPublishedAt" placeholder=publishedAtPlaceholder stopEnterKeyDownPropagation="true"}}
 				</td>
 			</tr>
 			<tr class="post-setting">


### PR DESCRIPTION
fixes #3516
- new behavior is disabled by default
- added new stopEnterKeyDownPropagation property enable new behavior
