### PR TITLE
Replacing "touchstart" with "tap" event, provided by hammer.js

### DIFF
--- a/core/client/utils/codemirror-mobile.js
+++ b/core/client/utils/codemirror-mobile.js
@@ -29,7 +29,7 @@ init = function init() {
         $('body').addClass('touch-editor');
 
         // make editor tabs touch-to-toggle in portrait mode
-        $('.floatingheader').on('touchstart', function () {
+        $('.floatingheader').on('tap', function () {
             $('.entry-markdown').toggleClass('active');
             $('.entry-preview').toggleClass('active');
         });


### PR DESCRIPTION
fixes #3502
