### PR TITLE
Insert inline code shortcut for editor

### DIFF
--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -21,7 +21,6 @@ shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'
 shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
 shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
 
-
 //Headings
 shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
 shortcuts['ctrl+alt+2'] = {action: 'codeMirrorShortcut', options: {type: 'h2'}};
@@ -38,6 +37,7 @@ shortcuts['ctrl+l'] = {action: 'codeMirrorShortcut', options: {type: 'list'}};
 shortcuts['ctrl+shift+1'] = {action: 'codeMirrorShortcut', options: {type: 'currentDate'}};
 shortcuts[ctrlOrCmd + '+k'] = {action: 'codeMirrorShortcut', options: {type: 'link'}};
 shortcuts[ctrlOrCmd + '+shift+i'] = {action: 'codeMirrorShortcut', options: {type: 'image'}};
+shortcuts[ctrlOrCmd + '+shift+k'] = {action: 'codeMirrorShortcut', options: {type: 'code'}};
 
 //Currently broken CodeMirror Markdown shortcuts.
 // Some may be broken due to a conflict with CodeMirror commands.


### PR DESCRIPTION
closes #3543
- Wired up existing code shortcut in codemirror-shortcuts.js in
  editor-shortcuts.js
