### PR TITLE
Autofocus on input fields after routing

### DIFF
--- a/core/client/templates/forgotten.hbs
+++ b/core/client/templates/forgotten.hbs
@@ -1,7 +1,8 @@
 <section class="forgotten-box js-forgotten-box fade-in">
     <form id="forgotten" class="forgotten-form" method="post" novalidate="novalidate">
         <div class="email-wrap">
-            {{input value=email class="email" type="email" placeholder="Email Address" name="email" autofocus="autofocus" autocapitalize="off" autocorrect="off"}}
+            {{gh-trim-focus-input value=email class="email" type="email" placeholder="Email Address" name="email" 
+            autofocus="autofocus" autocapitalize="off" autocorrect="off"}}
         </div>
         <button class="button-save" type="submit" {{action "submit"}} {{bind-attr disabled=submitting}}>Send new password</button>
     </form>

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -1,7 +1,8 @@
 <section class="login-box js-login-box fade-in">
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
-            {{input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" autocapitalize="off" autocorrect="off" value=identification}}
+            {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" 
+            autocapitalize="off" autocorrect="off" value=identification}}
         </div>
         <div class="password-wrap">
             {{input class="password" type="password" placeholder="Password" name="password" value=password}}

--- a/core/client/templates/signup.hbs
+++ b/core/client/templates/signup.hbs
@@ -17,7 +17,7 @@
             </div>
             <div class="form-group">
                 <label for="name">Full Name</label>
-                {{input type="text" name="name" autofocus="autofocus" autocorrect="off" value=name }}
+                {{gh-trim-focus-input type="text" name="name" autofocus="autofocus" autocorrect="off" value=name }}
                 <p>The name that you will sign your posts with</p>
             </div>
             <div class="form-group">


### PR DESCRIPTION
closes #3538
- The “autofocus” property isn’t considered by browsers if the element
  is created after the page has been loaded. The Ember cookbook
  recommends extending the input type with a manually triggered
  autofocus, which I included here.
- This introduces the new helper “gh-focus-input”, an input field
  gaining focus even when routing occurs.
