### PR TITLE
Provide immediate error for invalid signup link

### DIFF
--- a/core/client/routes/signup.js
+++ b/core/client/routes/signup.js
@@ -1,4 +1,5 @@
 import styleBody from 'ghost/mixins/style-body';
+import ajax from 'ghost/utils/ajax';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
@@ -11,9 +12,24 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     },
     setupController: function (controller, params) {
         var tokenText = atob(params.token),
-            email = tokenText.split('|')[1];
+            email = tokenText.split('|')[1],
+            self = this;
         controller.token = params.token;
         controller.email = email;
+
+        ajax({
+            url: self.get('ghostPaths.url').api('authentication', 'invitationcheck'),
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                invitationcheck: [{
+                    email: email
+                }]
+            }
+        }).catch(function () {
+            controller.toggleProperty('submitting');
+            self.notifications.showError('This invitation link is not valid or has been revoked.', true);
+        });
     }
 });
 

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -106,6 +106,31 @@ authentication = {
     },
 
     /**
+     * ### Check for Invitation
+     * @param {invivationcheck} object containing the email to check for
+     * @returns {Promise(checkedInvitation}} message
+     */
+    checkForInvitation: function checkForInvitation(object) {
+        return authentication.isSetup().then(function (result) {
+            var setup = result.setup[0].status;
+
+            if (!setup) {
+                return when.reject(new errors.NoPermissionError('Setup must be completed before making this request.'));
+            }
+
+            return utils.checkObject(object, 'invitationcheck');
+        }).then(function (checkedObject) {
+            return dataProvider.User.getByEmail(checkedObject.invitationcheck[0].email).then(function (result) {
+                if (!result) {
+                    return when.reject(new errors.NoPermissionError('The invitation link is not valid or has been revoked.'));
+                } else {
+                    return when.resolve({checkedInvitation: [{message: 'Invitation found.'}]});
+                }
+            });
+        });
+    },
+
+    /**
      * ### Accept Invitation
      * @param {User} object the user to create
      * @returns {Promise(User}} Newly created user

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -77,6 +77,7 @@ apiRoutes = function (middleware) {
     );
     router.put('/authentication/passwordreset', api.http(api.authentication.resetPassword));
     router.post('/authentication/invitation', api.http(api.authentication.acceptInvitation));
+    router.post('/authentication/invitationcheck', api.http(api.authentication.checkForInvitation));
     router.post('/authentication/setup', api.http(api.authentication.setup));
     router.get('/authentication/setup', api.http(api.authentication.isSetup));
     router.post('/authentication/token',


### PR DESCRIPTION
closes #3565 
- Included server api able to check if a user record with the given
  email exists
- If it does, an error message is displayed on the client (also, the
  ‘submit’ button is disabled
