### PR TITLE
Add classes to settings headers

### DIFF
--- a/core/client/templates/settings/apps.hbs
+++ b/core/client/templates/settings/apps.hbs
@@ -1,4 +1,4 @@
-<header>
+<header class="settings-content-header">
     {{#link-to 'settings' class='button-back button'}}Back{{/link-to}}
     <h2 class="title">Apps</h2>
 </header>

--- a/core/client/templates/settings/general.hbs
+++ b/core/client/templates/settings/general.hbs
@@ -1,4 +1,4 @@
-<header>
+<header class="settings-content-header">
     <h2 class="title">General</h2>
 
     <div class="settings-header-inner">

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -1,4 +1,4 @@
-<header>
+<header class="settings-content-header">
     {{#link-to 'settings' class='button-back button'}}Back{{/link-to}}
     <h2 class="title">Users</h2>
     <section class="page-actions">

--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -1,4 +1,4 @@
-<header class="user-settings-header">
+<header class="settings-content-header user-settings-header">
 
     <h2 class="hidden">Your Profile</h2>
 


### PR DESCRIPTION
No issue

Refs https://github.com/TryGhost/Ghost-UI/issues/91
Related styles: https://github.com/TryGhost/Ghost-UI/commit/5249f1cc66bf52e1f7ec466b23a6ac34eaae92e0
- Adds a class to settings page headers, for cleaner CSS selectors
