### PR TITLE
Working delete user modal & button

### DIFF
--- a/core/client/controllers/modals/delete-user.js
+++ b/core/client/controllers/modals/delete-user.js
@@ -1,0 +1,33 @@
+var DeleteUserController = Ember.Controller.extend({
+    actions: {
+        confirmAccept: function () {
+            var self = this,
+                user = this.get('model');
+
+            user.destroyRecord().then(function () {
+                self.store.unloadAll('post');
+                self.transitionToRoute('settings.users');
+                self.notifications.showSuccess('The user has been deleted.', { delayed: true });
+            }, function () {
+                self.notifications.showError('The user could not be deleted. Please try again.');
+            });
+
+        },
+
+        confirmReject: function () {
+            return false;
+        }
+    },
+    confirm: {
+        accept: {
+            text: 'Delete User',
+            buttonClass: 'button-delete'
+        },
+        reject: {
+            text: 'Cancel',
+            buttonClass: 'button'
+        }
+    }
+});
+
+export default DeleteUserController;

--- a/core/client/templates/modals/delete-user.hbs
+++ b/core/client/templates/modals/delete-user.hbs
@@ -1,0 +1,7 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+    title="Are you sure you want to delete this user?" confirm=confirm}}
+
+    <p>All posts and associated data will also be deleted. There is no way to recover this data.
+    </p>
+
+{{/gh-modal-dialog}}

--- a/core/client/templates/user-actions-menu.hbs
+++ b/core/client/templates/user-actions-menu.hbs
@@ -2,5 +2,5 @@
 <a href="javascript:void(0);" {{action "openModal" "transfer-owner" this}}>Make Owner</a>
 {{/if}}
 {{#if view.parentView.deleteUserActionIsVisible}}
-<a href="javascript:void(0);" class="delete">Delete User</a>
+<a href="javascript:void(0);" {{action "openModal" "delete-user" this}} class="delete">Delete User</a>
 {{/if}}


### PR DESCRIPTION
closes #3529
- Created ‘delete user’ modal & controller (similar to the ‘delete post’ modal) with @JohnONolan's text
- Modal will be opened if ‘Delete User’ is selected in the user
  setting cog menu
