### PR TITLE
Ghost Logo navigation responds correctly to mobile

### DIFF
--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -1,5 +1,5 @@
 <header id="global-header" class="navbar">
-    <a class="ghost-logo" {{bind-attr href=ghostPaths.blogRoot title=ghostPaths.blogRoot}} data-off-canvas="left">
+    <a class="ghost-logo" data-off-canvas="left">
         <span class="hidden">Ghost</span>
     </a>
     <nav id="global-nav" role="navigation">

--- a/core/client/views/application.js
+++ b/core/client/views/application.js
@@ -10,6 +10,7 @@ var ApplicationView = Ember.View.extend({
                 body.toggleClass('off-canvas');
             });
         });
+        $('[data-off-canvas]').attr('href', this.get('controller.ghostPaths.blogRoot'));
         // #### Navigating within the sidebar closes it.
         $('.js-close-sidebar').on('click', function () {
             body.removeClass('off-canvas');


### PR DESCRIPTION
closes #3522 
- Previously, the logo had a href attribute which was manually kept
  from executing on mobile. Slow mobile devices that didn’t fully load
  the JS would therefore navigate “desktop style”
- The href attribute is now set after the event handler has been 
  loaded, ensuring correct navigation behaviour.
