### PR TITLE
prevent revoking invite for already active users

### DIFF
--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -63,13 +63,23 @@ var SettingsUserController = Ember.ObjectController.extend({
         },
         revoke: function () {
             var self = this,
+                model = this.get('model'),
                 email = this.get('email');
 
-            this.get('model').destroyRecord().then(function () {
-                var notificationText = 'Invitation revoked. (' + email + ')';
-                self.notifications.showSuccess(notificationText, false);
-            }).catch(function (error) {
-                self.notifications.showAPIError(error);
+            //reload the model to get the most up-to-date user information
+            model.reload().then(function () {
+                if (self.get('invited')) {
+                    model.destroyRecord().then(function () {
+                        var notificationText = 'Invitation revoked. (' + email + ')';
+                        self.notifications.showSuccess(notificationText, false);
+                    }).catch(function (error) {
+                        self.notifications.showAPIError(error);
+                    });
+                } else {
+                    //if the user is no longer marked as "invited", then show a warning and reload the route
+                    self.get('target').send('reload');
+                    self.notifications.showError('This user has already accepted the invitation.', {delayed: 500});
+                }
             });
         },
 

--- a/core/client/routes/settings/users/index.js
+++ b/core/client/routes/settings/users/index.js
@@ -26,6 +26,12 @@ var UsersIndexRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Pag
                 return true;
             });
         });
+    },
+
+    actions: {
+        reload: function () {
+            this.refresh();
+        }
     }
 });
 


### PR DESCRIPTION
closes #3563
- before attempting to revoke an invitation, get updated model info
- reload route and show warning if user info has changed
