### PR TITLE
Improve spam prevention

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -82,8 +82,6 @@ config = {
             host: '127.0.0.1',
             port: '2369'
         },
-        ratePeriod: 1,
-        spamTimeout: 5,
         logging: false
     },
 
@@ -105,8 +103,6 @@ config = {
             host: '127.0.0.1',
             port: '2369'
         },
-        ratePeriod: 1,
-        spamTimeout: 5,
         logging: false
     },
 
@@ -124,8 +120,6 @@ config = {
                 charset  : 'utf8'
             }
         },
-        ratePeriod: 1,
-        spamTimeout: 5,
         server: {
             host: '127.0.0.1',
             port: '2369'

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -232,7 +232,7 @@ setupMiddleware = function (server) {
     expressServer = server;
     middleware.cacheServer(expressServer);
     middleware.cacheOauthServer(oauthServer);
-    oauth.init(oauthServer);
+    oauth.init(oauthServer, middleware.resetSpamCounter);
 
     // Make sure 'req.secure' is valid for proxied requests
     // (X-Forwarded-Proto header will be checked, if present)

--- a/core/server/middleware/oauth.js
+++ b/core/server/middleware/oauth.js
@@ -7,7 +7,7 @@ var oauth2orize = require('oauth2orize'),
 
 oauth = {
 
-    init: function (oauthServer) {
+    init: function (oauthServer, resetSpamCounter) {
 
         // remove all expired accesstokens on startup
         models.Accesstoken.destroyAllExpired();
@@ -39,6 +39,7 @@ oauth = {
                     return models.Accesstoken.add({token: accessToken, user_id: user.id, client_id: client.id, expires: accessExpires}).then(function () {
                         return models.Refreshtoken.add({token: refreshToken, user_id: user.id, client_id: client.id, expires: refreshExpires});
                     }).then(function () {
+                        resetSpamCounter(username);
                         return done(null, accessToken, refreshToken, {expires_in: utils.ONE_HOUR_S});
                     }).catch(function () {
                         return done(null, false);

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -72,7 +72,7 @@ apiRoutes = function (middleware) {
 
     // ## Authentication
     router.post('/authentication/passwordreset',
-        middleware.spamPrevention,
+        middleware.spamForgottenPrevention,
         api.http(api.authentication.generateResetToken)
     );
     router.put('/authentication/passwordreset', api.http(api.authentication.resetPassword));
@@ -80,7 +80,7 @@ apiRoutes = function (middleware) {
     router.post('/authentication/setup', api.http(api.authentication.setup));
     router.get('/authentication/setup', api.http(api.authentication.isSetup));
     router.post('/authentication/token',
-        middleware.spamPrevention,
+        middleware.spamSigninPrevention,
         middleware.addClientSecret,
         middleware.authenticateClient,
         middleware.generateAccessToken

--- a/core/test/functional/client/signin_test.js
+++ b/core/test/functional/client/signin_test.js
@@ -30,43 +30,6 @@ CasperTest.begin('Redirects login to signin', 2, function suite(test) {
     });
 }, true);
 
-// CasperTest.begin('Can\'t spam it', 4, function suite(test) {
-//     CasperTest.Routines.signout.run(test);
-
-//     casper.thenOpenAndWaitForPageLoad('signin', function testTitle() {
-//         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
-//         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
-//     });
-
-//     casper.waitForOpaque('.login-box',
-//         function then() {
-//             this.fillAndSave('#login', falseUser);
-//         },
-//         function onTimeout() {
-//             test.fail('Sign in form didn\'t fade in.');
-//         });
-
-
-//     casper.captureScreenshot('login_spam_test.png');
-
-//     casper.waitForText('attempts remaining!', function then() {
-//         this.fillAndSave('#login', falseUser);
-//     });
-
-//     casper.captureScreenshot('login_spam_test2.png');
-
-//     casper.waitForText('Slow down, there are way too many login attempts!', function onSuccess() {
-//         test.assert(true, 'Spamming the login did result in an error notification');
-//         test.assertSelectorDoesntHaveText('.notification-error', '[object Object]');
-//     }, function onTimeout() {
-//         test.assert(false, 'Spamming the login did not result in an error notification');
-//     });
-
-//     // This test causes the spam notification
-//     // add a wait to ensure future tests don't get tripped up by this.
-//     casper.wait(2000);
-// }, true);
-
 CasperTest.begin('Login limit is in place', 4, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
@@ -93,9 +56,6 @@ CasperTest.begin('Login limit is in place', 4, function suite(test) {
     }, function onTimeout() {
         test.assert(false, 'We did not trip the login limit.');
     });
-    // This test used login, add a wait to
-    // ensure future tests don't get tripped up by this.
-    casper.wait(2000);
 }, true);
 
 CasperTest.begin('Can login to Ghost', 5, function suite(test) {

--- a/core/test/functional/routes/api/db_test.js
+++ b/core/test/functional/routes/api/db_test.js
@@ -16,7 +16,6 @@ describe('DB API', function () {
 
     before(function (done) {
         var app = express();
-            app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/notifications_test.js
+++ b/core/test/functional/routes/api/notifications_test.js
@@ -15,7 +15,6 @@ describe('Notifications API', function () {
 
     before(function (done) {
         var app = express();
-            app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -17,7 +17,6 @@ describe('Post API', function () {
 
     before(function (done) {
         var app = express();
-            app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/settings_test.js
+++ b/core/test/functional/routes/api/settings_test.js
@@ -15,7 +15,6 @@ describe('Settings API', function () {
 
     before(function (done) {
         var app = express();
-        app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/slugs_test.js
+++ b/core/test/functional/routes/api/slugs_test.js
@@ -15,7 +15,6 @@ describe('Slug API', function () {
 
     before(function (done) {
         var app = express();
-        app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/tags_test.js
+++ b/core/test/functional/routes/api/tags_test.js
@@ -15,7 +15,6 @@ describe('Tag API', function () {
 
     before(function (done) {
         var app = express();
-        app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -15,7 +15,6 @@ describe('User API', function () {
 
     before(function (done) {
         var app = express();
-        app.set('disableLoginLimiter', true);
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves


### PR DESCRIPTION
closes #3544
- limit forgotten password requests to five requests per IP per hour
  for different email addresses
- limit forgotten password requests to five requests per email address
- limit signin requests to ten failed requests per IP per hour
- removed special treatment for tests
