### PR TITLE
Fix the author context block

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -202,11 +202,15 @@ coreHelpers.asset = function (context, options) {
 // Returns the full name of the author of a given post, or a blank string
 // if the author could not be determined.
 //
-coreHelpers.author = function (options) {
-    options = options || {};
-    options.hash = options.hash || {};
+coreHelpers.author = function (context, options) {
+    if (_.isUndefined(options)) {
+        options = context;
+    }
 
-    /*jshint unused:false*/
+    if (options.fn) {
+        return hbs.handlebars.helpers['with'].call(this, this.author, options);
+    }
+
     var autolink = _.isString(options.hash.autolink) && options.hash.autolink === 'false' ? false : true,
         output = '';
 

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -209,7 +209,7 @@ describe('Core Helpers', function () {
 
         it('Returns the link to the author from the context', function () {
             var data = {'author': {'name': 'abc 123', slug: 'abc123', bio: '', website: '', status: '', location: ''}},
-                result = helpers.author.call(data);
+                result = helpers.author.call(data, {hash: {}});
 
             String(result).should.equal('<a href="/author/abc123/">abc 123</a>');
         });
@@ -224,12 +224,21 @@ describe('Core Helpers', function () {
 
         it('Returns a blank string where author data is missing', function () {
             var data = {'author': null},
-                result = helpers.author.call(data);
+                result = helpers.author.call(data, {hash: {}});
 
             String(result).should.equal('');
         });
 
+        it('Functions as block helper if called with #', function () {
+            var data = {'author': {'name': 'abc 123', slug: 'abc123'}},
+                // including fn emulates the #
+                result = helpers.author.call(data, {hash: {}, fn: function () { return 'FN'; }});
+
+            // It outputs the result of fn
+            String(result).should.equal('FN');
+        });
     });
+
 
     describe('encode Helper', function () {
 
@@ -246,8 +255,6 @@ describe('Core Helpers', function () {
             String(escaped).should.equal(expected);
         });
     });
-
-
 
     describe('Plural Helper', function () {
 


### PR DESCRIPTION
fixes #3599
- If the author helper is called as a block (i.e. fn is present) then
  treat it as a with call
