### PR TITLE
Less 'developery' error for login throttling

### DIFF
--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -208,7 +208,7 @@ var middleware = {
         }
 
         if (deniedRateLimit) {
-            return next(new errors.UnauthorizedError('Only ' + rateForgottenAttempts + ' tries per IP address every ' + rateForgottenPeriod + ' seconds.'));
+            return next(new errors.UnauthorizedError('There have been too many login attempts from your IP!'));
         }
 
         next();


### PR DESCRIPTION
closes #3589
- Error message for login throttling is now always ‘There have been too
  many login attempts from your IP’, even if there’s a set attempts/time
  limit.
