### PR TITLE
Swap notification close link for a button

### DIFF
--- a/core/client/templates/components/gh-notification.hbs
+++ b/core/client/templates/components/gh-notification.hbs
@@ -2,5 +2,5 @@
     <span class="notification-message">
         {{{message.message}}}
     </span>
-    <a class="close" {{action "closeNotification"}}><span class="hidden">Close</span></a>
+    <button class="close" {{action "closeNotification"}}><span class="hidden">Close</span></button>
 </section>

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -283,7 +283,7 @@ CasperTest.begin('Post settings menu', 30, function suite(test) {
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');
         test.assertSelectorHasText('.notification-success', 'Saved.');
-        casper.click('.notification-success a.close');
+        casper.click('.notification-success .close');
     }, function onTimeout() {
         test.assert(false, 'No success notification');
     });
@@ -312,7 +312,7 @@ CasperTest.begin('Post settings menu', 30, function suite(test) {
     casper.waitForSelector('.notification-success', function waitForSuccess() {
         test.assert(true, 'got success notification');
         test.assertSelectorHasText('.notification-success', 'Permalink successfully changed to new-url-editor.');
-        casper.click('.notification-success a.close');
+        casper.click('.notification-success .close');
     }, function onTimeout() {
         test.assert(false, 'No success notification');
     });


### PR DESCRIPTION
No issue
- Swap out notification <a> close link for <button> (we gain a native hover state)
- Remove element selector from tests, to is only looks for the class now

No style changes are needed, but https://github.com/TryGhost/Ghost-UI/commit/087868c1c99b84e0c5b9701202418ce7b477b18c was done in tandem
