### PR TITLE
Lock accounts based on IP & Username

### DIFF
--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -141,7 +141,7 @@ var middleware = {
             deniedRateLimit = '',
             ipCount = '',
             rateSigninPeriod = config.rateSigninPeriod || 3600,
-            rateSigninAttempts = config.rateSigninAttempts || 10;
+            rateSigninAttempts = config.rateSigninAttempts || 5;
 
         if (req.body.username) {
             loginSecurity.push({ip: remoteAddress, time: currentTime, email: req.body.username});
@@ -151,7 +151,7 @@ var middleware = {
 
         // filter entries that are older than rateSigninPeriod
         loginSecurity = _.filter(loginSecurity, function (logTime) {
-            return (logTime.time + rateSigninPeriod > currentTime);
+            return (logTime.time + rateSigninPeriod > currentTime && logTime.email === req.body.username);
         });
 
         // check number of tries per IP address


### PR DESCRIPTION
closes #3545
- Adds username as a condition in the rate limiter, thus preventing one
  user to lock out a whole range of users with the same IP.
- Changed default rate limit to 5 (per @sebgie's comment)
