### PR TITLE
Change config.example.js to check for PORT environment variable first

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -36,8 +36,8 @@ config = {
         server: {
             // Host to be passed to node's `net.Server#listen()`
             host: '127.0.0.1',
-            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
-            port: '2368'
+            // Port to be passed to node's `net.Server#listen()`, check environment for PORT first and if not set use default
+            port: process.env.PORT || '2368'
         },
         paths: {
             contentPath: path.join(__dirname, '/content/')
@@ -60,8 +60,8 @@ config = {
         server: {
             // Host to be passed to node's `net.Server#listen()`
             host: '127.0.0.1',
-            // Port to be passed to node's `net.Server#listen()`, for iisnode set this to `process.env.PORT`
-            port: '2368'
+            // Port to be passed to node's `net.Server#listen()`, check environment for PORT first and if not set use default
+            port: process.env.PORT || '2368'
         }
     },
 


### PR DESCRIPTION
...then use default, simplifies Ghost configuration for IISNode.

This removes a mandatory step for deploying into Azure while maintaining compatibility with other enviornments and following NodeJS best practices for listening ports.
