### PR TITLE
Restore original display after window resizing.

### DIFF
--- a/core/client/controllers/posts.js
+++ b/core/client/controllers/posts.js
@@ -75,6 +75,11 @@ var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
     },
 
     actions: {
+        resetContentPreview: function() {
+            $('.content-list').removeAttr('style')
+            $('.content-preview').removeAttr('style')
+        },
+
         showContentPreview: function () {
             $('.content-list').animate({right: '100%', left: '-100%', 'margin-right': '15px'}, 300);
             $('.content-preview').animate({right: '0', left: '0', 'margin-left': '0'}, 300);

--- a/core/client/views/posts.js
+++ b/core/client/views/posts.js
@@ -1,4 +1,4 @@
-import {responsiveAction} from 'ghost/utils/mobile';
+import {mobileQuery, responsiveAction} from 'ghost/utils/mobile';
 
 var PostsView = Ember.View.extend({
     target: Ember.computed.alias('controller'),
@@ -8,6 +8,13 @@ var PostsView = Ember.View.extend({
     mobileInteractions: function () {
         Ember.run.scheduleOnce('afterRender', this, function () {
             var self = this;
+
+            $(window).resize(function() {
+              if (!mobileQuery.matches) {
+                self.send('resetContentPreview');
+              }
+            });
+
             // ### Show content preview when swiping left on content list
             $('.manage').on('click', '.content-list ol li', function (event) {
                 responsiveAction(event, '(max-width: 800px)', function () {


### PR DESCRIPTION
Closes #3597.

Reset's element specific styling (used during mobile views) when the window is resized (and now is greater than 800px max-width).
