### PR TITLE
Check for server notifications on hard refresh

### DIFF
--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -2,6 +2,12 @@ import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 
 var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, ShortcutsRoute, {
 
+    afterModel: function (model, transition) {
+        if (this.get('session').isAuthenticated) {
+            transition.send('loadServerNotifications');
+        }
+    },
+
     shortcuts: {
         'esc': 'closePopups'
     },


### PR DESCRIPTION
Closes #3612
- Trigger the loadServerNotifications event from the
  ApplicationRoute's afterModel hook, which gets called
  every time the app gets loaded.
