### PR TITLE
Transition to signin with error message on invalid token not 500 error

### DIFF
--- a/core/client/controllers/application.js
+++ b/core/client/controllers/application.js
@@ -1,5 +1,5 @@
 var ApplicationController = Ember.Controller.extend({
-    hideNav: Ember.computed.match('currentPath', /(signin|signup|setup|forgotten|reset)/),
+    hideNav: Ember.computed.match('currentPath', /(error|signin|signup|setup|forgotten|reset)/),
 
     topNotificationCount: 0,
 

--- a/core/client/routes/signup.js
+++ b/core/client/routes/signup.js
@@ -10,10 +10,23 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
         }
     },
     setupController: function (controller, params) {
-        var tokenText = atob(params.token),
-            email = tokenText.split('|')[1];
-        controller.token = params.token;
-        controller.email = email;
+        var tokenText,
+            email,
+            re = /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/;
+        if (re.test(params.token)) {
+            try {
+                tokenText = atob(params.token);
+                email = tokenText.split('|')[1];
+                controller.token = params.token;
+                controller.email = email;
+            } catch (e) {
+                this.transitionTo('signin');
+                this.notifications.showError('Invalid token.', {delayed: true});
+            }
+        } else {
+            this.transitionTo('signin');
+            this.notifications.showError('Invalid token.', {delayed: true});
+        }
     }
 });
 


### PR DESCRIPTION
closes #3548
- Add error to hidenav, removes menubar from error screen.
- Wrap atob() in a try/catch
- Added regex to try and validate if params.token at least looks like base64
