### PR TITLE
Lock accounts based on IP & Username

### DIFF
--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -145,6 +145,10 @@ var middleware = {
             rateSigninAttempts = config.rateSigninAttempts || 10;
 
         if (req.body.username && req.body.grant_type === 'password') {
+            // remove entries with the same username
+            loginSecurity = _.filter(loginSecurity, function (logUser) {
+                return (logUser.email !== req.body.username);
+            });
             loginSecurity.push({ip: remoteAddress, time: currentTime, email: req.body.username});
         } else if (req.body.grant_type === 'refresh_token') {
             return next();


### PR DESCRIPTION
closes #3545
- Repeated login tries by one user are only counted once, keeping a
  single user from locking out a whole IP range (implementation according
  to @sebgie).
