### PR TITLE
Editor: Warn if title change is unsaved

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -88,10 +88,16 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
         var model = this.get('model'),
             markdown = this.get('markdown'),
+            title = this.get('title'),
+            titleScratch = this.get('titleScratch'),
             scratch = this.getMarkdown().withoutMarkers,
             changedAttributes;
 
         if (!this.tagNamesEqual()) {
+            return true;
+        }
+
+        if (titleScratch !== title) {
             return true;
         }
 


### PR DESCRIPTION
closes #3643
- TitleScratch is compared with Title; if there’s a difference, we have
  unsaved changes and open up the modal.
