### PR TITLE
Catch user validation errors on login

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -84,15 +84,20 @@ errors = {
     },
 
     logError: function (err, context, help) {
+        var self = this,
+            origArgs = _.toArray(arguments).slice(1),
+            stack,
+            msgs;
+
         if (_.isArray(err)) {
             _.each(err, function (e) {
-                errors.logError(e);
+                var newArgs = [e].concat(origArgs);
+                errors.logError.apply(self, newArgs);
             });
             return;
         }
 
-        var stack = err ? err.stack : null,
-            msgs;
+        stack = err ? err.stack : null;
 
         err = _.isString(err) ? err : (_.isObject(err) ? err.message : 'An unknown error occurred.');
 


### PR DESCRIPTION
This is one of two PRs I have for this issue. This PR catches errors from the 'update user' events that happen during the login to update the user's status and last_login.

The errors will still occur, but will be handled nicely and not prevent login.

The problem with this is the values won't be updated in these cases - not sure if this presents a security risk, or is just lame. See my follow up PR for more info.

fixes #3658
- Catch any errors from user.save() events during login
- Fixes a problem I introduced with errors which are arrays in logError
