### PR TITLE
Turn off user validation on login

### DIFF
--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -61,6 +61,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     validate: function () {
+        if (arguments[1].hasOwnProperty('validate') && arguments[1].validate === false) {
+            return;
+        }
         return validation.validateSchema(this.tableName, this.toJSON());
     },
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -561,7 +561,7 @@ User = ghostBookshelf.Model.extend({
         return when.reject();
     },
 
-    setWarning: function (user) {
+    setWarning: function (user, options) {
         var status = user.get('status'),
             regexp = /warn-(\d+)/i,
             level;
@@ -577,7 +577,7 @@ User = ghostBookshelf.Model.extend({
                 user.set('status', 'warn-' + level);
             }
         }
-        return when(user.save()).then(function () {
+        return when(user.save(options)).then(function () {
             return 5 - level;
         });
     },
@@ -598,16 +598,17 @@ User = ghostBookshelf.Model.extend({
             if (user.get('status') !== 'locked') {
                 return nodefn.call(bcrypt.compare, object.password, user.get('password')).then(function (matched) {
                     if (!matched) {
-                        return when(self.setWarning(user)).then(function (remaining) {
+                        return when(self.setWarning(user, {validate: false})).then(function (remaining) {
                             s = (remaining > 1) ? 's' : '';
                             return when.reject(new errors.UnauthorizedError('Your password is incorrect.<br>' +
                                 remaining + ' attempt' + s + ' remaining!'));
                         });
                     }
 
-                    return when(user.set({status : 'active', last_login : new Date()}).save()).then(function (user) {
-                        return user;
-                    });
+                    return when(user.set({status : 'active', last_login : new Date()}).save({validate: false}))
+                        .then(function (user) {
+                            return user;
+                        });
                 }, errors.logAndThrowError);
             }
             return when.reject(new errors.NoPermissionError('Your account is locked due to too many ' +


### PR DESCRIPTION
A follow up PR to #3688, this is a bit more heavy-duty, as it disables validation during the login check entirely.
This means the values are saved, but has the potential to save invalid values.  However, in both of these cases, we are setting explicit properties. 

In future we'll want to update our validation to only validate the values that are actually passed. This will be a necessary part of adding PATCH support, but I think is too much for 0.5.

I wanted to present this as a separate PR, to determine whether #3688 alone is the right fix for 0.5, or if we decide both are necessary, I'll squash the two things.

issue #3658
- prevent validation from occuring when we're only logging in
