### PR TITLE
Fix Ghost icon is not clickable

### DIFF
--- a/core/client/views/posts.js
+++ b/core/client/views/posts.js
@@ -28,6 +28,7 @@ var PostsView = Ember.View.extend({
                     self.send('hideContentPreview');
                 });
             });
+            $('[data-off-canvas]').attr('href', this.get('controller.ghostPaths.blogRoot'));
         });
     }.on('didInsertElement'),
 });


### PR DESCRIPTION
closes #3623
- Initialization of the link was done on login page where the ‚burger‘ did not exist.
- initialization in application.js needs to be done to make it work on refresh
