### PR TITLE
Removed Username From Initial Blog Description

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -202,7 +202,7 @@ authentication = {
             // Handles the additional values set by the setup screen.
             if (!_.isEmpty(setupUser.blogTitle)) {
                 userSettings.push({key: 'title', value: setupUser.blogTitle});
-                userSettings.push({key: 'description', value: 'Thoughts, stories and ideas by ' + setupUser.name});
+                userSettings.push({key: 'description', value: 'Thoughts, stories and ideas.'});
             }
             setupUser = user.toJSON();
             return settings.edit({settings: userSettings}, {context: {user: setupUser.id}});

--- a/core/test/functional/frontend/feed_test.js
+++ b/core/test/functional/frontend/feed_test.js
@@ -7,7 +7,7 @@ CasperTest.begin('Ensure that RSS is available', 11, function suite(test) {
     casper.thenOpen(url + 'rss/', function (response) {
         var content = this.getHTML(),
             siteTitle = '<title><![CDATA[Test Blog]]></title>',
-            siteDescription = '<description><![CDATA[Thoughts, stories and ideas by Test User]]></description>',
+            siteDescription = '<description><![CDATA[Thoughts, stories and ideas.]]></description>',
             siteUrl = '<link>http://127.0.0.1:2369/</link>',
             postTitle = '<![CDATA[Welcome to Ghost]]>',
             postStart = '<description><![CDATA[<p>You\'re live!',


### PR DESCRIPTION
closes #3631
- Removed the 'by + setupUser.name' from authentication.js
- Removed the 'by Test User' from feed_test.js
- Added a '.' to the end of each per issue comment example
