### PR TITLE
Sends test email to the person who clicked on the button

### DIFF
--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -58,19 +58,23 @@ mail = {
      * @param {Object} required property 'to' which contains the recipient address
      * @returns {Promise}
      */
-    sendTest: function (object, options) {
+    sendTest: function (options) {
+        var user = require('../models/user').User;
 
-        return mail.generateContent({template: 'test'}).then(function (emailContent) {
-            var payload = {mail: [{
-                message: {
-                    to: object.to,
-                    subject: 'Test Ghost Email',
-                    html: emailContent.html,
-                    text: emailContent.text
-                }
-            }]};
-
-            return mail.send(payload, options);
+        return user.findOne({id: options.context.user}).then(function (result) {
+            return mail.generateContent({template: 'test'}).then(function (emailContent) {
+                var payload = {mail: [{
+                    message: {
+                        to: result.get('email'),
+                        subject: 'Test Ghost Email',
+                        html: emailContent.html,
+                        text: emailContent.text
+                    }
+                }]};
+                return mail.send(payload, options);
+            });
+        }, function () {
+            return when.reject(new errors.NotFoundError('Could not find the current user'));
         });
     },
 

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -58,15 +58,7 @@ apiRoutes = function (middleware) {
     // ## Mail
     router.post('/mail', api.http(api.mail.send));
     router.post('/mail/test', function (req, res) {
-        api.settings.read('email').then(function (result) {
-            // attach the to: address to the request body so that it is available
-            // to the http api handler
-            req.body = { to: result.settings[0].value };
-
-            api.http(api.mail.sendTest)(req, res);
-        }).catch(function () {
-            api.http(api.mail.sendTest)(req, res);
-        });
+        api.http(api.mail.sendTest)(req, res);
     });
 
 


### PR DESCRIPTION
Closes #3649
- Small refactor of the api route for email test. We no longer need to look up the email in the settings
- Added a user model lookup based on context to the test email method.
