### PR TITLE
{{gh-path}} Handlebars helper, returning paths

### DIFF
--- a/core/client/helpers/gh-path.js
+++ b/core/client/helpers/gh-path.js
@@ -1,0 +1,18 @@
+// Tiny helper allowing the use of {{gh-path}} to find ghost's root
+var paths = Ember.Handlebars.makeBoundHelper(function (options) {
+    var path = window.location.pathname,
+        ghostRoot = path.substr(0, path.search('/ghost/')),
+        adminRoot = ghostRoot + '/ghost';
+    
+    switch (options) {
+        case 'ghost':
+            return new Ember.Handlebars.SafeString(ghostRoot);
+        case 'admin':
+            return new Ember.Handlebars.SafeString(adminRoot);
+        default:
+            return new Ember.Handlebars.SafeString(ghostRoot);
+    }
+
+});
+
+export default paths;


### PR DESCRIPTION
closes #3718
- Really tiny helper returning the correct subdirectories (/ghost/ vs
  /somesub/that/the/user/specified/ghost/))
- {{gh-path}} or {{gh-path ‘ghost’}} for Ghost’s root (mysubdir/)
- {{gh-path ‘admin’}} for Ghost’s admin root (/mysubdir/ghost)
