### PR TITLE
Expose blog URL to client app

### DIFF
--- a/core/client/helpers/gh-blog-url.js
+++ b/core/client/helpers/gh-blog-url.js
@@ -1,0 +1,6 @@
+var blogUrl = Ember.Handlebars.makeBoundHelper(function () {
+
+    return new Ember.Handlebars.SafeString(this.get('config.blogUrl'));
+});
+
+export default blogUrl;

--- a/core/client/initializers/ghost-config.js
+++ b/core/client/initializers/ghost-config.js
@@ -3,9 +3,12 @@ var ConfigInitializer = {
 
     initialize: function (container, application) {
         var apps = $('body').data('apps'),
-            fileStorage = $('body').data('filestorage');
+            fileStorage = $('body').data('filestorage'),
+            blogUrl = $('body').data('blogurl');
 
-        application.register('ghost:config', {apps: apps, fileStorage: fileStorage}, {instantiate: false});
+        application.register(
+            'ghost:config', {apps: apps, fileStorage: fileStorage, blogUrl: blogUrl}, {instantiate: false}
+        );
 
         application.inject('route', 'config', 'ghost:config');
         application.inject('controller', 'config', 'ghost:config');

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -36,7 +36,7 @@
 
     {{/if}}
 
-    <section class="object-list">
+    <section class="object-list active-users">
 
         <h4 class="object-list-title">Active users</h4>
 

--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -62,7 +62,7 @@
                 <label for="user-slug">Slug</label>
                 {{!-- {{input value=user.slug id="user-slug" placeholder="Slug" autocorrect="off"}} --}}
                 {{gh-blur-input class="user-name" id="user-slug" value=slugValue name="user" action="updateSlug" placeholder="Slug" selectOnClick="true" autocorrect="off"}}
-                <p>http://blog-url.com/author/{{slugValue}}</p>
+                <p>{{gh-blog-url}}/author/{{slugValue}}</p>
             </div>
 
             <div class="form-group">

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -227,7 +227,6 @@ users = {
                         return dataProvider.User.edit(
                             {status: 'invited'}, _.extend({}, options, {id: user.id})
                         ).then(function (editedUser) {
-                            console.log('user to return 2', user);
                             user = editedUser.toJSON();
                         });
                     }

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -374,6 +374,17 @@ coreHelpers.apps = function (context, options) {
     return 'false';
 };
 
+// ### Blog Url helper
+//
+// *Usage example:*
+// `{{blog_url}}`
+//
+// Returns the config value for url.
+coreHelpers.blog_url = function (context, options) {
+    /*jshint unused:false*/
+    return config.theme().url.toString();
+};
+
 coreHelpers.ghost_script_tags = function () {
     var scriptList = isProduction ? scriptFiles.production : scriptFiles.development;
 
@@ -874,6 +885,8 @@ registerHelpers = function (adminHbs, assetHash) {
     registerAdminHelper('apps', coreHelpers.apps);
 
     registerAdminHelper('file_storage', coreHelpers.file_storage);
+
+    registerAdminHelper('blog_url', coreHelpers.blog_url);
 };
 
 module.exports = coreHelpers;

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -31,7 +31,7 @@
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />
     <link rel="stylesheet" href="{{asset "css/ghost-ui.min.css" ghost="true"}}" />
 </head>
-<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}">
+<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-blogurl="{{blog_url}}">
 
     {{{ghost_script_tags}}}
 

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -203,13 +203,22 @@ CasperTest.begin('Users screen is correct', 9, function suite(test) {
                 i = 0;
             for (; i < options.length; i++) {
                 if (options[i].selected) {
-                    return options[i].text === "Author"
+                    return options[i].text === "Author";
                 }
             }
             return false;
         }, 'The "Author" role is selected by default when adding a new user');
     });
 });
+
+CasperTest.begin('User profile screen is correct', 1, function suite(test) {
+    casper.thenOpenAndWaitForPageLoad('settings.users');
+    casper.thenClick('.active-users .object-list-item-body');
+    casper.waitForSelector('.user-details-bottom', function then() {
+        test.assertSelectorHasText('.user-details-bottom .form-group p', 'http://127.0.0.1:2369/author/test-user');
+    });
+});
+
 // ### User settings tests
 // Please uncomment and fix these as the functionality is implemented
 

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -732,12 +732,17 @@ describe('Core Helpers', function () {
     });
 
     describe('url Helper', function () {
+        var configUrl = config.url;
 
         beforeEach(function () {
             apiStub.restore();
             apiStub = sandbox.stub(api.settings, 'read', function () {
                 return when({ settings: [{ value: '/:slug/' }] });
             });
+        });
+
+        afterEach(function () {
+            configUpdate({url: configUrl});
         });
 
         it('has loaded url helper', function () {
@@ -1773,10 +1778,31 @@ describe('Core Helpers', function () {
                 apps: setting
             });
 
+
             apps = helpers.apps();
 
             should.exist(apps);
             apps.should.equal(setting);
+        });
+    });
+
+    describe('blog_url helper', function () {
+        var configUrl = config.url;
+
+        afterEach(function () {
+            configUpdate({url: configUrl});
+        });
+
+        it('is loaded', function () {
+            should.exist(helpers.blog_url);
+        });
+
+        it('should return the test url by default', function () {
+            var blog_url = helpers.blog_url();
+
+            should.exist(blog_url);
+            // this is set in another test == bad!
+            blog_url.should.equal('http://testurl.com');
         });
     });
 });


### PR DESCRIPTION
 fixes #3724
- provide config.url to the ember client app via a data attribute
- create server and client side helpers to output the URL
- wire up the client side helper
- add a class for testing, and add tests for both the server and client side
