### PR TITLE
Use the ghost-paths consistently.

### DIFF
--- a/core/client/assets/lib/uploader.js
+++ b/core/client/assets/lib/uploader.js
@@ -63,7 +63,7 @@ UploadUi = function ($dropzone, settings) {
             var self = this;
 
             $dropzone.find('.js-fileupload').fileupload().fileupload('option', {
-                url: Ghost.subdir + '/ghost/api/v0.1/uploads/',
+                url: Ghost.apiRoot + '/uploads/',
                 add: function (e, data) {
                     /*jshint unused:false*/
                     $('.js-button-accept').prop('disabled', true);

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -6,7 +6,7 @@ var Router = Ember.Router.extend();
 
 Router.reopen({
     location: 'trailing-history', // use HTML5 History API instead of hash-tag based URLs
-    rootURL: ghostPaths().subdir + '/ghost/', // admin interface lives under sub-directory /ghost
+    rootURL: ghostPaths().adminRoot, // admin interface lives under sub-directory /ghost
 
     clearNotifications: function () {
         this.notifications.closePassive();


### PR DESCRIPTION
No issue.

Always using the utility function ensures that we have the ability to update/change/etc these paths without scouring the codebase.

For example, if we ever decide to bump the API version it would be nice if there was only one location it needed to be updated at.
