### PR TITLE
Error notification if send test mail returns 500

### DIFF
--- a/core/client/controllers/debug.js
+++ b/core/client/controllers/debug.js
@@ -50,9 +50,13 @@ var DebugController = Ember.Controller.extend(Ember.Evented, {
             ic.ajax.request(this.get('ghostPaths.url').api('mail', 'test'), {
                 type: 'POST'
             }).then(function () {
-                self.notifications.showSuccess('Check your email for the test message:');
-            }).catch(function (response) {
-                self.notifications.showErrors(response);
+                self.notifications.showSuccess('Check your email for the test message.');
+            }).catch(function (error) {
+                if (typeof error.jqXHR !== 'undefined') {
+                    self.notifications.showAPIError(error);
+                } else {
+                    self.notifications.showErrors(error);
+                }
             });
         }
     }


### PR DESCRIPTION
closes #3728
- If the mail config is broken, the ajax call will fail with 500 and
  not return an error.
- This change catches 500 and wraps the error in a notification.
