### PR TITLE
Change Ghost logo link back to an anchor

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",
     "ember-simple-auth": "0.6.4",
     "fastclick": "1.0.0",
-    "ghost-ui": "0.8.12",
+    "ghost-ui": "0.8.13",
     "handlebars": "1.3.0",
     "ic-ajax": "1.0.1",
     "jquery": "1.11.0",

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -1,7 +1,12 @@
 <header id="global-header" class="navbar">
-    <button {{action "toggleSidebarOrGoHome" target="view"}} class="ghost-logo">
+    
+    <button {{action "toggleSidebarOrGoHome" target="view"}} class="ghost-logo ghost-logo-button">
         <span class="hidden">Ghost</span>
     </button>
+    <a class="ghost-logo ghost-logo-link">
+        <span class="hidden">Ghost</span>
+    </a>
+
     <nav id="global-nav" role="navigation">
         <ul id="main-menu" >
             {{gh-activating-list-item route="posts" title="Content" classNames="content js-close-sidebar"}}

--- a/core/client/views/application.js
+++ b/core/client/views/application.js
@@ -1,9 +1,15 @@
 var ApplicationView = Ember.View.extend({
+
     setupCloseSidebar: function () {
+
         // #### Navigating within the sidebar closes it.
         $(document).on('click', '.js-close-sidebar', function () {
             $('body').removeClass('off-canvas');
         });
+
+        // #### Add the blog URL to the <a> version of the ghost logo
+        $('.ghost-logo-link').attr('href', this.get('controller.ghostPaths').blogRoot);
+
     }.on('didInsertElement'),
     
     actions: {

--- a/core/client/views/posts.js
+++ b/core/client/views/posts.js
@@ -15,6 +15,9 @@ var PostsView = Ember.View.extend({
                 }
             });
 
+            // ### Add the blog URL to the <a> version of the ghost logo
+            $('.ghost-logo-link').attr('href', this.get('controller.ghostPaths').blogRoot);
+
             // ### Show content preview when swiping left on content list
             $('.manage').on('click', '.content-list ol li', function (event) {
                 responsiveAction(event, '(max-width: 800px)', function () {

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -3,19 +3,22 @@
 
 /*globals CasperTest, casper */
 
-CasperTest.begin('Admin navigation bar is correct', 27, function suite(test) {
+CasperTest.begin('Admin navigation bar is correct', 29, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('root', function testTitleAndUrl() {
         test.assertTitle('Ghost Admin', 'Ghost admin has no title');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
     casper.then(function testNavItems() {
-        var contentHref = this.getElementAttribute('#main-menu li.content a', 'href'),
+        var logoHref = this.getElementAttribute('.ghost-logo-link', 'href'),
+            contentHref = this.getElementAttribute('#main-menu li.content a', 'href'),
             editorHref = this.getElementAttribute('#main-menu li.editor a', 'href'),
             settingsHref = this.getElementAttribute('#main-menu li.settings a', 'href');
 
         // Logo
-        test.assertExists('button.ghost-logo', 'Ghost logo home page button exists');
+        test.assertExists('.ghost-logo-button', 'Ghost logo home page button exists');
+        test.assertExists('.ghost-logo-link', 'Ghost logo home page link exists');
+        test.assertEquals(logoHref, '/', 'Ghost logo link href is correct');
 
         // Content
         test.assertExists('#main-menu li.content a', 'Content nav item exists');


### PR DESCRIPTION
Amends #3736, references #3623

With `button.ghost-logo`, there's no `href`, so cannot be opened in a new window. This adds an anchor and appends the blog URL to a href attribute. :doughnut: 

Related styles: https://github.com/TryGhost/Ghost-UI/commit/e6c24979d1672e2e31e93aaed5e0d74a778db229
