### PR TITLE
Filestorage helper returns string true if config is object

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -355,7 +355,7 @@ coreHelpers.excerpt = function (options) {
 coreHelpers.file_storage = function (context, options) {
     /*jshint unused:false*/
     if (config.hasOwnProperty('fileStorage')) {
-        return config.fileStorage.toString();
+        return _.isObject(config.fileStorage) ? 'true' : config.fileStorage.toString();
     }
     return 'true';
 };

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -1754,6 +1754,21 @@ describe('Core Helpers', function () {
             should.exist(fileStorage);
             fileStorage.should.equal(setting);
         });
+
+        it('should just return true if config.fileStorage is an object', function () {
+            var setting = {someKey: 'someValue'},
+                cfg = helpers.__get__('config'),
+                fileStorage;
+
+            _.extend(cfg, {
+                fileStorage: setting
+            });
+
+            fileStorage = helpers.file_storage();
+
+            should.exist(fileStorage);
+            fileStorage.should.equal('true');
+        });
     });
 
     describe('apps helper', function () {


### PR DESCRIPTION
no issue
- else admin client gets [object Object] which is weird
