### PR TITLE
Update dependency sqlite3@2.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "https://github.com/ErisDS/showdown/archive/v0.3.2-ghost.tar.gz",
-        "sqlite3": "2.2.3",
+        "sqlite3": "2.2.7",
         "static-favicon": "1.0.2",
         "unidecode": "0.1.3",
         "validator": "3.4.0",


### PR DESCRIPTION
No Issue
- sqlite3 2.2.7 supports building on node v0.11.13.
