### PR TITLE
Installation as root fails on bower

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -233,7 +233,7 @@ var path           = require('path'),
                 // Used as part of `grunt init`. See the section on [Building Assets](#building%20assets) for more
                 // information.
                 ghost_ui: {
-                    command: path.resolve(cwd  + '/node_modules/.bin/bower update ghost-ui'),
+                    command: path.resolve(cwd  + '/node_modules/.bin/bower update ghost-ui --allow-root'),
                     options: {
                         stdout: true
                     }


### PR DESCRIPTION
### Issue Summary

Same problem as #3232, but in the new version (v0.5.0) there is a new bower task `ghost_ui` missing the same flag.

```
Running "shell:ghost_ui" (shell) task
bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option
Warning: Command failed: bower ESUDO         Cannot be run with sudo

Additional error details:
Since bower is a user command, there is no need to execute it with superuser permissions.
If you're having permission errors when using bower without sudo, please spend a few minutes learning more about how your system should work and make any necessary repairs.

http://www.joyent.com/blog/installing-node-and-npm
https://gist.github.com/isaacs/579814

You can however run a command with sudo using --allow-root option
 Use --force to continue.
```
### Steps to Reproduce
- `sudo su`
- Clone the repo
- `npm install`
- `grunt init`
### Technical details

Ghost Version: v0.5.0
Client OS: Mac OS X 10.9.4
Node Version: v0.10.28
Browser: Chrome 36.0.1985.125
Database: MySQL 5.6.19
