### PR TITLE
Correct behavior on updating user slug.

### DIFF
--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -60,9 +60,8 @@
 
             <div class="form-group">
                 <label for="user-slug">Slug</label>
-                {{!-- {{input value=user.slug id="user-slug" placeholder="Slug" autocorrect="off"}} --}}
-                {{gh-blur-input class="user-name" id="user-slug" value=user.slug name="user" action="updateSlug" placeholder="Slug" selectOnClick="true" autocorrect="off"}}
-                <p>{{gh-blog-url}}/author/{{user.slug}}</p>
+                {{gh-blur-input class="user-name" id="user-slug" value=slugValue name="user" action="updateSlug" placeholder="Slug" selectOnClick="true" autocorrect="off"}}
+                <p>{{gh-blog-url}}/author/{{slugValue}}</p>
             </div>
 
             <div class="form-group">

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -293,6 +293,57 @@ CasperTest.begin('Can save settings', 7, function suite(test) {
     });
 });
 
+CasperTest.begin('User settings screen resets all whitespace slug to original value', 3, function suite(test) {
+    var slug;
+
+    casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertUrlMatch(/ghost\/settings\/users\/test-user\/$/, 'Ghost doesn\'t require login this time');
+    });
+
+    casper.then(function setSlugToAllWhitespace() {
+        slug = casper.getElementInfo('#user-slug').attributes.value;
+
+        casper.fillSelectors('.user-profile', {
+            '#user-slug': '   '
+        }, false);
+    });
+
+    casper.thenClick('.content.settings-user');
+
+    casper.then(function checkSlugInputValue() {
+        casper.wait(250);
+        test.assertField('user', slug);
+    });
+});
+
+CasperTest.begin('User settings screen change slug handles duplicate slug', 4, function suite(test) {
+    var slug;
+
+    casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertUrlMatch(/ghost\/settings\/users\/test-user\/$/, 'Ghost doesn\'t require login this time');
+    });
+
+    casper.then(function changeSlug() {
+        slug = casper.getElementInfo('#user-slug').attributes.value;
+
+        casper.fillSelectors('.user-profile', {
+            '#user-slug': slug + '!'
+        }, false);
+    });
+
+    casper.thenClick('.content.settings-user');
+
+    casper.waitForResource(/\/slugs\/user\//, function testGoodResponse(resource) {
+        test.assert(400 > resource.status);
+    });
+
+    casper.then(function checkSlugInputValue() {
+        test.assertField('user', slug);
+    });
+});
+
 CasperTest.begin('User settings screen validates email', 6, function suite(test) {
     var email, brokenEmail;
 


### PR DESCRIPTION
No Issue
- Defer save until after slug is checked.
- If new slug is empty or all whitespace, reset to previous value.
- If new slug is the same as existing slug except for an increment
  value (e.g. ghost-user-2), use the original slug.
- If the slug has changed, change the URL path to reflect the
  change so that the browser refresh and back button still work.
