### PR TITLE
Reset slug input text box after invalid input.

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -152,6 +152,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
 
             // Ignore unchanged slugs or candidate slugs that are empty
             if (!newSlug || slug === newSlug) {
+                // reset the input to its previous state
+                this.set('slugValue', slug);
+
                 return;
             }
 
@@ -176,6 +179,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 // for the incrementor then the existing slug should be used
                 if (_.isNumber(check) && check > 0) {
                     if (slug === slugTokens.join('-') && serverSlug !== newSlug) {
+                        self.set('slugValue', slug);
+
                         return;
                     }
                 }
@@ -193,9 +198,11 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 }
 
                 return self.get('model').save(self.get('saveOptions'));
-            }).then(function () {
-                self.showSuccess('Permalink successfully changed to <strong>' +
+            }).then(function (changed) {
+                if (changed) {
+                    self.showSuccess('Permalink successfully changed to <strong>' +
                     self.get('slug') + '</strong>.');
+                }
             }).catch(function (errors) {
                 self.showErrors(errors);
                 self.get('model').rollback();

--- a/core/test/functional/client/psm_test.js
+++ b/core/test/functional/client/psm_test.js
@@ -154,6 +154,45 @@ CasperTest.begin('Post url can be changed', 4, function suite(test) {
     });
 });
 
+CasperTest.begin('Post url input is reset from all whitespace back to original value', 3, function suite(test) {
+    // Create a sample post
+    CasperTest.Routines.createTestPost.run(false);
+
+    // Begin test
+    casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
+    });
+
+    casper.thenClick('.post-settings');
+
+    casper.waitForOpaque('.post-settings-menu.open');
+
+    var originalSlug;
+    casper.then(function () {
+        originalSlug = casper.evaluate(function () {
+            return __utils__.getFieldValue('post-setting-slug');
+        });
+    });
+
+    // Test change permalink
+    casper.then(function () {
+        this.fillSelectors('.post-settings-menu form', {
+            '#url': '    '
+        }, false);
+
+        this.click('.post-settings');
+    });
+
+    casper.then(function checkValueMatches() {
+        //using assertField(name) checks the htmls initial "value" attribute, so have to hack around it.
+        var slugVal = this.evaluate(function () {
+            return __utils__.getFieldValue('post-setting-slug');
+        });
+        test.assertEqual(slugVal, originalSlug);
+    });
+});
+
 CasperTest.begin('Post published date can be changed', 4, function suite(test) {
     // Create a sample post
     CasperTest.Routines.createTestPost.run(false);


### PR DESCRIPTION
No Issue
- When an invalid, all whitespace slug is entered into the
  slug input in the post settings menu, it's rejected but
  the input's value still remains the same.  This resets the
  input back to its original value.
- Added test for the above behavior.
- Only show success notification if slug was actually changed.
- Convert whitespace from tabs to spaces in post-settings-menu.hbs
