### PR TITLE
Added basic sitemap functionality

### DIFF
--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -19,6 +19,7 @@ utils = {
     /**
      * Timespans in seconds and milliseconds for better readability
      */
+    ONE_MINUTE_MS: 60000,
     ONE_HOUR_S: 3600,
     ONE_DAY_S: 86400,
     ONE_YEAR_S: 31536000,

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -466,6 +466,13 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
+        it('should retrieve sitemap.xml', function (done) {
+            request.get('/sitemap.xml')
+                .expect('Content-Type', 'application/xml')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
         // at the moment there is no image fixture to test
         // it('should retrieve image assets', function (done) {
         // request.get('/content/images/some.jpg')

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "rss": "0.2.1",
         "semver": "2.2.1",
         "showdown": "https://github.com/ErisDS/showdown/archive/v0.3.2-ghost.tar.gz",
+        "sitemap": "^0.7.3",
         "sqlite3": "2.2.7",
         "static-favicon": "1.0.2",
         "unidecode": "0.1.3",


### PR DESCRIPTION
I have used a timer to invalidate the cache instead of relying on changes to posts due to the fact that this could be run in a scale-out scenario. If run on multiple servers, without a central cache all servers can share, one server would correctly clear the cache on post update, but others would not. This would mean different servers would serve different versions of the sitemap. 

I added the functionality to the middleware in order to get around the trailing slash issue which normal routes are subject to. Any thoughts on the implementation?
