### PR TITLE
Ensure Owner's role isn't downgraded

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -162,8 +162,14 @@ users = {
                                 parseInt(options.id, 10) === parseInt(options.context.user, 10)) {
                             return when.reject(new errors.NoPermissionError('You cannot change your own role.'));
                         } else if (roleId !== contextRoleId) {
-                            return canThis(options.context).assign.role(role).then(function () {
-                                return editOperation();
+                            return dataProvider.User.findOne({role: 'Owner'}).then(function (result) {
+                                if (parseInt(result.id, 10) !== parseInt(options.id, 10)) {
+                                    return canThis(options.context).assign.role(role).then(function () {
+                                        return editOperation();
+                                    });
+                                } else {
+                                    return when.reject(new errors.NoPermissionError('There has to be one owner.'));
+                                }
                             });
                         }
 

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -852,6 +852,26 @@ describe('Users API', function () {
                         }).catch(done);
                 });
             });
+
+            it('CANNOT downgrade owner', function (done) {
+                var options = _.extend({}, context.admin, {id: userIdFor.owner}, {include: 'roles'});
+                UserAPI.read(options).then(function (response) {
+                    response.users[0].id.should.equal(userIdFor.owner);
+                    response.users[0].roles[0].name.should.equal('Owner');
+
+                    return UserAPI.edit(
+                        {users: [
+                            {name: newName, roles: [roleIdFor.author]}
+                        ]},
+                        options
+                    ).then(function (response) {
+                        done(new Error('Author should not be able to downgrade owner'));
+                    }).catch(function (error) {
+                        error.type.should.eql('NoPermissionError');
+                        done();
+                    });
+                });
+            });
         });
 
         describe('Editor', function () {


### PR DESCRIPTION
closes #3765
- Simple API check to ensure that the owner isn’t downgraded to a
  different role (analog to the ’can’t change your own role’ check)
