### PR TITLE
Ensure editor awareness if publishing fails

### DIFF
--- a/core/client/controllers/editor/new.js
+++ b/core/client/controllers/editor/new.js
@@ -11,6 +11,9 @@ var EditorNewController = Ember.ObjectController.extend(EditorControllerMixin, {
                 if (model.get('id')) {
                     self.transitionToRoute('editor.edit', model);
                 }
+            }).catch(function () {
+                // Publishing failed
+                self.set('status', 'draft');
             });
         }
     }

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -421,6 +421,12 @@ CasperTest.begin('Publish menu - new post', 11, function suite(test) {
         test.assertSelectorHasText('.js-publish-button', 'Save Draft');
     });
 
+    // Fill headline and content
+    casper.then(function fillContent() {
+        casper.sendKeys('#entry-title', 'Headline');
+        casper.writeContentToCodeMirror('Just a bit of testtext');
+    })
+
     casper.then(function switchMenuToPublish() {
        // Open the publish options menu;
         casper.thenClick('.js-publish-splitbutton .options.up');


### PR DESCRIPTION
closes #3667
- If the ‘save’ function on a new post fails, the local Ember model
  still beliefs that the status is ‘published’, resulting in wrong
  buttons. A simple catch fixes that.
