### PR TITLE
Working CopyHTML shortcut

### DIFF
--- a/core/client/controllers/modals/copy-html.js
+++ b/core/client/controllers/modals/copy-html.js
@@ -1,0 +1,7 @@
+var CopyHTMLController = Ember.Controller.extend({
+
+    generatedHTML: Ember.computed.alias('model.generatedHTML')
+
+});
+
+export default CopyHTMLController;

--- a/core/client/templates/editor/edit.hbs
+++ b/core/client/templates/editor/edit.hbs
@@ -10,7 +10,7 @@
         <a class="markdown-help" href="" {{action "openModal" "markdown"}}><span class="hidden">What is Markdown?</span></a>
     </header>
     <section id="entry-markdown-content" class="entry-markdown-content">
-        {{gh-codemirror value=scratch scrollInfo=view.markdownScrollInfo setCodeMirror="setCodeMirror"}}
+        {{gh-codemirror value=scratch scrollInfo=view.markdownScrollInfo setCodeMirror="setCodeMirror" openModal="openModal"}}
     </section>
 </section>
 

--- a/core/client/templates/modals/copy-html.hbs
+++ b/core/client/templates/modals/copy-html.hbs
@@ -1,0 +1,6 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" animation="fade"
+    title="Generated HTML" confirm=confirm class="copy-html"}}
+
+    {{textarea value=generatedHTML rows="6"}}
+
+{{/gh-modal-dialog}}

--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -1,4 +1,4 @@
-/* global CodeMirror, moment */
+/* global CodeMirror, moment, Showdown */
 /** Set up a shortcut function to be called via router actions.
  *  See editor-route-base
  */
@@ -23,7 +23,9 @@ function init() {
             line = this.getLine(cursor.line),
             fromLineStart = {line: cursor.line, ch: 0},
             toLineEnd = {line: cursor.line, ch: line.length},
-            md, letterCount, textIndex, position;
+            md, letterCount, textIndex, position, converter,
+            generatedHTML;
+
         switch (type) {
         case 'h1':
             line = line.replace(/^#* /, '');
@@ -98,18 +100,19 @@ function init() {
         case 'titlecase':
             md = titleize(text);
             break;
-        /** @TODO
         case 'copyHTML':
             converter = new Showdown.converter();
+
             if (text) {
-                md = converter.makeHtml(text);
+                generatedHTML = converter.makeHtml(text);
             } else {
-                md = converter.makeHtml(this.getValue());
+                generatedHTML = converter.makeHtml(this.getValue());
             }
 
-            $(".modal-copyToHTML-content").text(md).selectText();
+            // Talk to Ember
+            this.component.sendAction('openModal', 'copy-html', { generatedHTML: generatedHTML });
+            
             break;
-        */
         default:
             if (this.simpleShortcutSyntax[type]) {
                 md = this.simpleShortcutSyntax[type].replace('$1', text);

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -20,6 +20,7 @@ shortcuts[ctrlOrCmd + '+i'] = {action: 'codeMirrorShortcut', options: {type: 'it
 shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
 shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
 shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
+shortcuts[ctrlOrCmd + '+shift+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
 
 //Headings
 shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
@@ -38,11 +39,5 @@ shortcuts['ctrl+shift+1'] = {action: 'codeMirrorShortcut', options: {type: 'curr
 shortcuts[ctrlOrCmd + '+k'] = {action: 'codeMirrorShortcut', options: {type: 'link'}};
 shortcuts[ctrlOrCmd + '+shift+i'] = {action: 'codeMirrorShortcut', options: {type: 'image'}};
 shortcuts[ctrlOrCmd + '+shift+k'] = {action: 'codeMirrorShortcut', options: {type: 'code'}};
-
-//Currently broken CodeMirror Markdown shortcuts.
-// Some may be broken due to a conflict with CodeMirror commands.
-// (see http://codemirror.net/doc/manual.html#commands)
-//
-//shortcuts[ctrlOrCmd + '+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
 
 export default shortcuts;


### PR DESCRIPTION
closes #3481
- Pressing Ctrl/CMD+Shift+C in the editor will open up a modal that
  contains the generated HTML for either the selected text or the whole
  post
