### PR TITLE
Revert post status on failed save.

### DIFF
--- a/core/client/controllers/editor/new.js
+++ b/core/client/controllers/editor/new.js
@@ -11,9 +11,6 @@ var EditorNewController = Ember.ObjectController.extend(EditorControllerMixin, {
                 if (model.get('id')) {
                     self.transitionToRoute('editor.edit', model);
                 }
-            }).catch(function () {
-                // Publishing failed
-                self.set('status', 'draft');
             });
         }
     }

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -211,6 +211,9 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
                 return model;
             }).catch(function (errors) {
                 self.showErrorNotification(prevStatus, self.get('status'), errors);
+
+                self.set('status', prevStatus);
+
                 return Ember.RSVP.reject(errors);
             });
         },

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -375,8 +375,6 @@ CasperTest.begin('Post settings menu', 30, function suite(test) {
         });
         test.assert(!checked, 'Turned page into post.');
     });
-        
-
 
     // Test Delete Post Modal
     casper.thenClick('.post-settings-menu button.delete');
@@ -554,6 +552,102 @@ CasperTest.begin('Publish menu - existing post', 21, function suite(test) {
     });
 });
 
+CasperTest.begin('Publish menu - new post status is correct after failed save', 4, function suite(test) {
+    casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
+    });
+
+    // Fill title and content
+    casper.then(function writePost() {
+        casper.sendKeys('#entry-title', Array(160).join('x'));
+        casper.writeContentToCodeMirror('body content');
+    });
+
+    casper.then(function switchMenuToPublish() {
+       // Open the publish options menu;
+        casper.thenClick('.js-publish-splitbutton .options.up');
+
+        casper.waitForOpaque('.js-publish-splitbutton .open');
+
+        // Select the publish post button
+        casper.thenClick('.js-publish-splitbutton li:first-child a');
+    });
+
+    // attempt to save
+    casper.thenClick('.js-publish-button');
+
+    // ... check status, label, class
+    casper.waitForSelector('.notification-error', function onSuccess() {
+        test.assertExists('.js-publish-button.button-save', 'Update button should have .button-save');
+        // wait for button to settle
+        casper.wait(500);
+        test.assertSelectorHasText('.js-publish-button', 'Save Draft');
+    }, function onTimeout() {
+        test.assert(false, 'Saving post with invalid title should trigger an error');
+    });
+
+    casper.thenClick('li.content a');
+
+    casper.waitUntilVisible('.modal-content', function onSuccess() {
+        casper.thenClick('.button-delete');
+    }, function onTimeout() {
+        test.assert(false, 'Are you sure you want to leave modal did not appear.');
+    });
+});
+
+CasperTest.begin('Publish menu - existing post status is correct after failed save', 6, function suite(test) {
+    casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
+        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
+    });
+
+    // Fill title and content
+    casper.then(function writePost() {
+        casper.sendKeys('#entry-title', 'a valid title');
+        casper.writeContentToCodeMirror('body content');
+    });
+
+    // save
+    casper.thenClick('.js-publish-button');
+
+    casper.waitForSelector('.notification-success');
+
+    casper.then(function updateTitle() {
+        casper.sendKeys('#entry-title', Array(160).join('y'));
+    });
+
+    casper.then(function switchMenuToPublish() {
+        // Open the publish options menu;
+        casper.thenClick('.js-publish-splitbutton .options.up');
+
+        casper.waitForOpaque('.js-publish-splitbutton .open');
+
+        // Select the publish post button
+        casper.thenClick('.js-publish-splitbutton li:first-child a');
+
+        // ... check status, label, class
+        casper.waitForSelector('.js-publish-splitbutton.splitbutton-delete', function onSuccess() {
+            test.assertExists('.js-publish-button.button-delete', 'Publish button should have .button-delete');
+            test.assertSelectorHasText('.js-publish-button', 'Publish Now');
+        }, function onTimeout() {
+            test.assert(false, 'Publish split button should have .splitbutton-delete');
+        });
+    });
+
+    // attempt to save
+    casper.thenClick('.js-publish-button');
+
+    // ... check status, label, class
+    casper.waitForSelector('.notification-error', function onSuccess() {
+        test.assertExists('.js-publish-button.button-save', 'Update button should have .button-save');
+        // wait for button to settle
+        casper.wait(500);
+        test.assertSelectorHasText('.js-publish-button', 'Save Draft');
+    }, function onTimeout() {
+        test.assert(false, 'Saving post with invalid title should trigger an error');
+    });
+});
 
 // test the markdown help modal
 CasperTest.begin('Markdown help modal', 5, function suite(test) {


### PR DESCRIPTION
Refs #3667, Refs #3776
- If saving a post fails, revert its status back to the
  pre-save value.
- Added tests to check post status after failed save attempt
  on both new and existing posts.
