### PR TITLE
Post Settings: No 'Author' selection for 'author'

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -15,10 +15,12 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
     },
 
     selectedAuthor: null,
+    userIsAuthor: null,
     initializeSelectedAuthor: Ember.observer('model', function () {
         var self = this;
 
         return this.get('author').then(function (author) {
+            self.set('userIsAuthor', author.get('isAuthor'));
             self.set('selectedAuthor', author);
             return author;
         });

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -17,24 +17,26 @@
 					{{gh-blur-input class="post-setting-date" value=publishedAtValue name="post-setting-date" action="setPublishedAt" placeholder=publishedAtPlaceholder stopEnterKeyDownPropagation="true"}}
 				</td>
 			</tr>
+			{{#unless userIsAuthor}}
 			<tr class="post-setting">
 				<td class="post-setting-label">
-			<label for="post-setting-author">Author</label>
-		</td>
-		<td class="post-setting-field">
-			<span class="gh-select">
-				{{view Ember.Select
-					name="post-setting-author"
-					content=authors
-					optionValuePath="content.id"
-					optionLabelPath="content.name"
-					selection=selectedAuthor}}
-			</span>
-		</td>
-		</tr>
-		<tr class="post-setting">
-		<td class="post-setting-label">
-					<label class="label" for="static-page">Static Page</label>
+					<label for="post-setting-author">Author</label>
+				</td>
+				<td class="post-setting-field">
+					<span class="gh-select">
+						{{view Ember.Select
+							name="post-setting-author"
+							content=authors
+							optionValuePath="content.id"
+							optionLabelPath="content.name"
+							selection=selectedAuthor}}
+					</span>
+				</td>
+			</tr>
+			{{/unless}}
+			<tr class="post-setting">
+				<td class="post-setting-label">
+							<label class="label" for="static-page">Static Page</label>
 				</td>
 				<td class="post-setting-item">
 					{{input type="checkbox" name="static-page" id="static-page" class="post-setting-static-page" checked=page}}


### PR DESCRIPTION
closes #3756
- The post settings menu’s option to change the post’s author isn’t
  displayed if the user has the ‘author’ role.
- Also fixed some incorrect intendation in the template (no actual
  code change)
