### PR TITLE
Add environment switcher to the config

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -5,6 +5,9 @@
 var path = require('path'),
     config;
 
+// Define which kind of environment you want to use ('development', 'production' or 'testing')
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+
 config = {
     // ### Development **(default)**
     development: {


### PR DESCRIPTION
With this addition to the config it is possible to specify the used environment without the need to use a specific command line.

I am dependent on this because I start Ghost with a user which has no real home directory.
