### PR TITLE
Detect images in lists

### DIFF
--- a/core/shared/lib/showdown/extensions/ghostimagepreview.js
+++ b/core/shared/lib/showdown/extensions/ghostimagepreview.js
@@ -15,7 +15,7 @@ var Ghost = Ghost || {};
             {
                 type: 'lang',
                 filter: function (text) {
-                    var imageMarkdownRegex = /^(?:\{<(.*?)>\})?!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?$/gim,
+                    var imageMarkdownRegex = /(?:\{<(.*?)>\})?!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?/gi,
                         /* regex from isURL in node-validator. Yum! */
                         uriRegex = /^(?!mailto:)(?:(?:https?|ftp):\/\/)?(?:\S+(?::\S*)?@)?(?:(?:(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[0-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]+-?)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))|localhost)(?::\d{2,5})?(?:\/[^\s]*)?$/i,
                         pathRegex = /^(\/)?([^\/\0]+(\/)?)+$/i;


### PR DESCRIPTION
closes #3577
-Removes ^ and $ from the image markdown regex so that it can be used anywhere
