### PR TITLE
Show role label next to authors

### DIFF
--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -54,11 +54,9 @@
                     <span class="description">Last seen: {{unbound last_login}}</span>
                 </div>
                 <aside class="object-list-item-aside">
-                    {{#unless isAuthor}}
-                        {{#each roles}}
-                            <span class="role-label {{unbound lowerCaseName}}">{{name}}</span>
-                        {{/each}}
-                    {{/unless}}
+                    {{#each roles}}
+                        <span class="role-label {{unbound lowerCaseName}}">{{name}}</span>
+                    {{/each}}
                 </aside>
             {{/link-to}}
         {{/each}}

--- a/core/client/views/settings/users/users-list-view.js
+++ b/core/client/views/settings/users/users-list-view.js
@@ -1,4 +1,3 @@
-//import setScrollClassName from 'ghost/utils/set-scroll-classname';
 import PaginationViewMixin from 'ghost/mixins/pagination-view-infinite-scroll';
 
 var UsersListView = Ember.View.extend(PaginationViewMixin, {


### PR DESCRIPTION
closes #3711
- Shows role label next to users with author role
- Also, death to weird commented out stuff
