### PR TITLE
Close mobile nav sidebar on navigation

### DIFF
--- a/core/client/components/gh-popover.js
+++ b/core/client/components/gh-popover.js
@@ -4,6 +4,7 @@ var GhostPopover = Ember.Component.extend(PopoverMixin, {
     classNames: 'ghost-popover fade-in',
     name: null,
     closeOnClick: false,
+    closeMobileSidebar: false,
     //Helps track the user re-opening the menu while it's fading out.
     closing: false,
 
@@ -48,6 +49,9 @@ var GhostPopover = Ember.Component.extend(PopoverMixin, {
 
     click: function (event) {
         this._super(event);
+        if (this.get('closeMobileSidebar')) {
+            $('body').removeClass('off-canvas');
+        }
         if (this.get('closeOnClick')) {
             return this.close();
         }

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -24,7 +24,7 @@
                     {{/if}}
                     <span class="name">{{session.user.name}}</span>
                 {{/gh-popover-button}}
-                {{#gh-popover tagName="ul" classNames="overlay" name="user-menu" closeOnClick="true"}}
+                {{#gh-popover tagName="ul" classNames="overlay" name="user-menu" closeOnClick="true" closeMobileSidebar="true"}}
                         <li class="usermenu-profile">{{#link-to "settings.users.user" session.user.slug}}Your Profile{{/link-to}}</li>
                         <li class="divider"></li>
                         <li class="usermenu-help"><a href="http://support.ghost.org/" target="_blank">Help / Support</a></li>


### PR DESCRIPTION
closes #3759
- I believe that giving the gh-popover a `closeMobileSidebar`
  property is the least invasive way without compromising anything else,
  otherwise we’ll have to either change the way popovers capture click
  events or the way we close the main menu.
