### PR TITLE
Prev & Next Links for Ghost_Head

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -490,7 +490,9 @@ coreHelpers.ghost_head = function (options) {
         blog = config.theme(),
         head = [],
         majorMinor = /^(\d+\.)?(\d+)/,
-        trimmedVersion = this.version;
+        trimmedVersion = this.version,
+        trimmedUrlpattern = /.+(?=\/page\/\d*\/)/,
+        trimmedUrl, next, prev;
 
     trimmedVersion = trimmedVersion ? trimmedVersion.match(majorMinor)[0] : '?';
 
@@ -501,6 +503,20 @@ coreHelpers.ghost_head = function (options) {
 
     return coreHelpers.url.call(self, {hash: {absolute: true}}).then(function (url) {
         head.push('<link rel="canonical" href="' + url + '" />');
+
+        if (self.pagination) {
+            trimmedUrl = self.relativeUrl.match(trimmedUrlpattern);
+            if (self.pagination.prev) {
+                prev = (self.pagination.prev > 1 ? prev = '/page/' + self.pagination.prev + '/' : prev = '/');
+                prev = (trimmedUrl) ? '/' + trimmedUrl + prev : prev;
+                head.push('<link rel="prev" href="' + config.urlFor({relativeUrl: prev}, true) + '" />');
+            }
+            if (self.pagination.next) {
+                next = '/page/' + self.pagination.next + '/';
+                next = (trimmedUrl) ? '/' + trimmedUrl + next : next;
+                head.push('<link rel="next" href="' + config.urlFor({relativeUrl: next}, true) + '" />');
+            }
+        }
 
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -551,6 +551,32 @@ describe('Core Helpers', function () {
                 done();
             }).catch(done);
         });
+
+        it('returns next & prev URL correctly for middle page', function (done) {
+            configUpdate({url: 'http://testurl.com'});
+            helpers.ghost_head.call({version: '0.3.0', relativeUrl: '/page/3/', pagination: {next: '4', prev: '2'}}).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n' +
+                    '<link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/">\n' +
+                    '<link rel="canonical" href="http://testurl.com/page/3/" />\n' +
+                    '<link rel="prev" href="http://testurl.com/page/2/" />\n' +
+                    '<link rel="next" href="http://testurl.com/page/4/" />');
+                done();
+            }).catch(done);
+        });
+
+        it('returns next & prev URL correctly for second page', function (done) {
+            configUpdate({url: 'http://testurl.com'});
+            helpers.ghost_head.call({version: '0.3.0', relativeUrl: '/page/2/', pagination: {next: '3', prev: '1'}}).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.equal('<meta name="generator" content="Ghost 0.3" />\n' +
+                    '<link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/">\n' +
+                    '<link rel="canonical" href="http://testurl.com/page/2/" />\n' +
+                    '<link rel="prev" href="http://testurl.com/" />\n' +
+                    '<link rel="next" href="http://testurl.com/page/3/" />');
+                done();
+            }).catch(done);
+        });
     });
 
     describe('ghost_foot Helper', function () {


### PR DESCRIPTION
closes #685
- Now that we have a ‘pagination’ meta object, we can implement
  SEO-friendly `next` and `prev` ref links in `<head>`.
- This implementation works uniformly for anything that supports
  pagination in the current schema (posts, tags, authors)
- Regex should make the implementation future-proof for additional
  pagination
