### PR TITLE
Reset preview scroll position when post item is clicked

### DIFF
--- a/core/client/views/content-preview-content-view.js
+++ b/core/client/views/content-preview-content-view.js
@@ -11,6 +11,10 @@ var PostContentView = Ember.View.extend({
         }));
     },
 
+    contentObserver: function () {
+        this.$().closest('.content-preview').scrollTop(0);
+    }.observes('controller.content'),
+
     willDestroyElement: function () {
         var el = this.$();
         el.off('scroll');


### PR DESCRIPTION
When scrolling through the preview of a long article, if the post was changed the scroll position of the preview would remain the same.

![ghostpreview](https://cloud.githubusercontent.com/assets/846587/3964791/7eb248d2-278d-11e4-80ce-6da126080df5.gif)
