### PR TITLE
Icon wrapper around signing inputs

### DIFF
--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -1,11 +1,15 @@
 <section class="login-box js-login-box fade-in">
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
-            {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" 
-            autocapitalize="off" autocorrect="off" value=identification}}
+            <span class="input-icon icon-mail">
+                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" 
+                autocapitalize="off" autocorrect="off" value=identification}}
+            </span>
         </div>
         <div class="password-wrap">
-            {{input class="password" type="password" placeholder="Password" name="password" value=password}}
+            <span class="input-icon icon-lock">
+                {{input class="password" type="password" placeholder="Password" name="password" value=password}}
+            </span>
         </div>
         <button class="btn btn-blue" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
         <section class="meta">


### PR DESCRIPTION
No issue

References https://github.com/TryGhost/Ghost-UI/commit/379a630e1bc1
- Adds `<span class="input-icon icon-mail">` around signin inputs to help match markup used elsewhere
