### PR TITLE
{{gh-path}} Handlebars helper, returning paths

### DIFF
--- a/core/client/app.js
+++ b/core/client/app.js
@@ -3,6 +3,7 @@ import loadInitializers from 'ember/load-initializers';
 import 'ghost/utils/link-view';
 import 'ghost/utils/text-field';
 import configureApp from 'ghost/config';
+import ghostPathsHelper from 'ghost/helpers/ghostPaths';
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
@@ -15,5 +16,7 @@ var App = Ember.Application.extend({
 configureApp(App);
 
 loadInitializers(App, 'ghost');
+
+Ember.Handlebars.registerHelper('gh-path', ghostPathsHelper);
 
 export default App;

--- a/core/client/helpers/ghostPaths.js
+++ b/core/client/helpers/ghostPaths.js
@@ -1,0 +1,34 @@
+// Handlebars Helper {{gh-path}}
+// Usage: Assume 'http://www.myghostblog.org/myblog/'
+// {{gh-path}} or {{gh-path ‘blog’}} for Ghost’s root (/myblog/)
+// {{gh-path ‘admin’}} for Ghost’s admin root (/myblog/ghost/)
+// {{gh-path ‘api’}} for Ghost’s api root (/myblog/ghost/api/v0.1/)
+// {{gh-path 'admin' '/assets/hi.png'}} for resolved url (/myblog/ghost/assets/hi.png)
+import ghostPaths from 'ghost/utils/ghost-paths';
+
+export default function (path, url) {
+
+    var base;
+
+    switch (path.toString()) {
+        case 'blog':
+            base = ghostPaths().blogRoot;
+            break;
+        case 'admin':
+            base = ghostPaths().adminRoot;
+            break;
+        case 'api':
+            base = ghostPaths().apiRoot;
+            break;
+        default:
+            base = ghostPaths().blogRoot;
+            break;
+    }
+
+    if (url && url.length > 0) {
+        base = base + url;
+    }
+
+    return new Ember.Handlebars.SafeString(base);
+
+}

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -1,6 +1,6 @@
 <nav class="global-nav" role="navigation">
 
-    <a class="nav-item ghost-logo" {{bind-attr href=ghostPaths.blogRoot title=ghostPaths.blogRoot}}>
+    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="{{gh-path 'blog'}}">
         <div class="nav-label"><i class="icon-ghost"></i> <span>Visit blog</span> </div>
     </a>
     

--- a/core/client/templates/error.hbs
+++ b/core/client/templates/error.hbs
@@ -6,7 +6,7 @@
          <section class="error-message">
              <h1 class="error-code">{{code}}</h1>
              <h2 class="error-description">{{message}}</h2>
-             <a class="error-link" {{bind-attr href=ghostPaths.blogRoot}}>Go to the front page →</a>
+             <a class="error-link" href="{{gh-path 'blog'}}">Go to the front page →</a>
          </section>
     </section>
 </section>


### PR DESCRIPTION
closes #3718
- Uses utils/ghost-paths to resolve paths
- Usage: Assume 'http://www.myghostblog.org/myblog/'
- {{gh-path}} or {{gh-path ‘blog’}} for Ghost’s root (/myblog/)
- {{gh-path ‘admin’}} for Ghost’s admin root (/myblog/ghost/)
- {{gh-path ‘api’}} for Ghost’s api root (/myblog/ghost/api/v0.1/)
- {{gh-path 'admin' '/assets/hi.png'}} for resolved url (/myblog/ghost/assets/hi.png)
