### PR TITLE
Update Ember to latest stable (1.7.0).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "codemirror": "4.0.1",
     "Countable": "2.0.2",
     "device": "git://github.com/matthewhudson/device.js#5347a275b66020a0d4dfe9aad81a488f8cce448d",
-    "ember": "1.6.1",
+    "ember": "1.7.0",
     "ember-data": "~1.0.0-beta.8",
     "ember-load-initializers": "git://github.com/stefanpenner/ember-load-initializers.git#0.0.1",
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",


### PR DESCRIPTION
No issue.

This updates Ember to the latest stable version which includes many bugfixes and performance tweaks.  Changelog can be reviewed here:

https://github.com/emberjs/ember.js/blob/v1.7.0/CHANGELOG.md
