### PR TITLE
Ignore tables with pg_ prefix in pg getTables.

### DIFF
--- a/core/server/data/utils/clients/pg.js
+++ b/core/server/data/utils/clients/pg.js
@@ -18,7 +18,7 @@ doRawFlattenAndPluck = function doRaw(query, name) {
 
 getTables = function getTables() {
     return doRawFlattenAndPluck(
-        'SELECT table_name FROM information_schema.tables WHERE table_schema = \'public\'', 'table_name'
+        'SELECT table_name FROM information_schema.tables WHERE table_schema = \'public\' and table_name not like \'pg_%\'', 'table_name'
     );
 };
 


### PR DESCRIPTION
Closes #3825
- Fixes an issue where a PostgreSQL extension may create
  a public table and it gets caught up in the migration process.

Tested this against pg 9.3 with the pg_stat_statements extension turned on.

`FORCE_MIGRATION=true npm start` runs as expected.
