### PR TITLE
[WIP] Ghost as middleware

### DIFF
--- a/core/middleware.js
+++ b/core/middleware.js
@@ -1,0 +1,26 @@
+var ghost = require('./index'),
+    errors = require('./server/errors');
+
+function ghostMiddleware(options) {
+    var app = false,
+        requestBuffer = [];
+
+    ghost(options).then(function (blog) {
+        app = blog.app;
+        while (requestBuffer.length) {
+            app.apply(app, requestBuffer.pop());
+        }
+    }).catch(function (err) {
+        errors.logErrorAndExit(err, err.context, err.help);
+    });
+
+    return function (req, res) {
+        if (app === false) {
+            requestBuffer.unshift([req, res]);
+        } else {
+            app(req, res);
+        }
+    };
+}
+
+module.exports = ghostMiddleware;


### PR DESCRIPTION
# Ghost as middleware!

Here is what I have so far for ghost middleware. This works hypothetically, but it is proving tricky to use in practice.

```
var app = require( 'express' )()
var ghost = require( 'ghost/core/middleware' )
app.use( ghost() )
app.listen( 8888 )
```
## The Good
- Running the middleware generator lazy-loads ghost in the background, and all requests are buffered until the loading is finished.
- ... it's middleware
## The Bad

If I want my blog at `www.joshwillik.com/blog`, `app.use( '/blog', ghost() )` doesn't work because express strips off the /blog from the url before passing the request on, and that confuses Ghost.

Setting the URL in a config file and `app.use( ghost({ config: __dirname + '/ghost-config.js' })` is a bit better, but that turns Ghost into a catch-all.

This might be a seperate issue, but a misconfigured config file produces very opaque errors. For example, if `database.connection.filename` is incorrectly set, SQLite complains with `cannot read property _cid of undefined`.
If `paths.contentPath` is incorrect, a cryptic `Casper not installed` error is thrown.

One possible solution to the app mounting issue is to change the middleware footprint to something this.

```
var app = require( 'express' )()
var ghost = require( 'ghost/core/middleware' )
app.use( ghost( '/blog', options ) )
app.listen( 8888 )
```

However, setting the url in both the middleware and config feels redundant, and it violates the expected behaviour of express middleware. Perhaps the URL config option could be split into two? `internalURL` for internal routing and `externalURL` for resource and path generation?

As for the config errors, I imagine they will be fairly common for Ghost as middleware, so perhaps some checks for those should be added?

What do you guys think?
