### PR TITLE
Add the new body classes

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -408,13 +408,6 @@ coreHelpers.body_class = function (options) {
         tags = this.post && this.post.tags ? this.post.tags : this.tags || [],
         page = this.post && this.post.page ? this.post.page : this.page || false;
 
-    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page\/\d)/)) {
-        classes.push('archive-template');
-    } else if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
-        classes.push('home-template');
-    } else if (post) {
-        classes.push('post-template');
-    }
 
     if (this.tag !== undefined) {
         classes.push('tag-template');
@@ -426,12 +419,27 @@ coreHelpers.body_class = function (options) {
         classes.push('author-' + this.author.slug);
     }
 
-    if (tags) {
-        classes = classes.concat(tags.map(function (tag) { return 'tag-' + tag.slug; }));
+    if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page\/\d)/)) {
+        classes.push('paged');
+        // To be removed from pages by #2597 when we're ready to deprecate this
+        classes.push('archive-template');
+
+    } else if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
+        classes.push('home-template');
+    } else if (post) {
+        // To be removed from pages by #2597 when we're ready to deprecate this
+        // i.e. this should be if (post && !page) { ... }
+        classes.push('post-template');
     }
 
     if (page) {
+        classes.push('page-template');
+        // To be removed by #2597 when we're ready to deprecate this
         classes.push('page');
+    }
+
+    if (tags) {
+        classes = classes.concat(tags.map(function (tag) { return 'tag-' + tag.slug; }));
     }
 
     return api.settings.read({context: {internal: true}, key: 'activeTheme'}).then(function (response) {
@@ -439,13 +447,12 @@ coreHelpers.body_class = function (options) {
             paths = config.paths.availableThemes[activeTheme.value],
             view;
 
-        if (post) {
+        if (post && page) {
             view = template.getThemeViewForPost(paths, post).split('-');
 
-            // If this is a page and we have a custom page template
-            // then we need to modify the class name we inject
-            // e.g. 'page-contact' is outputted as 'page-template-contact'
             if (view[0] === 'page' && view.length > 1) {
+                classes.push(view.join('-'));
+                // To be removed by #2597 when we're ready to deprecate this
                 view.splice(1, 0, 'template');
                 classes.push(view.join('-'));
             }

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -414,11 +414,11 @@ describe('Core Helpers', function () {
 
                 rendered[0].string.should.equal('home-template');
                 rendered[1].string.should.equal('post-template');
-                rendered[2].string.should.equal('archive-template');
+                rendered[2].string.should.equal('paged archive-template');
                 rendered[3].string.should.equal('tag-template tag-foo');
-                rendered[4].string.should.equal('archive-template tag-template tag-foo');
+                rendered[4].string.should.equal('tag-template tag-foo paged archive-template');
                 rendered[5].string.should.equal('author-template author-bar');
-                rendered[6].string.should.equal('archive-template author-template author-bar');
+                rendered[6].string.should.equal('author-template author-bar paged archive-template');
 
                 done();
             }).catch(done);
@@ -432,7 +432,7 @@ describe('Core Helpers', function () {
                 }
             }).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.equal('home-template page');
+                rendered.string.should.equal('home-template page-template page');
 
                 done();
             }).catch(done);
@@ -448,7 +448,7 @@ describe('Core Helpers', function () {
                 }
             }).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.equal('post-template page page-template-about');
+                rendered.string.should.equal('post-template page-template page page-about page-template-about');
 
                 done();
             }).catch(done);


### PR DESCRIPTION
This is the first step towards implementing the final outcome from the massive discussion on #1967. It adds all the new body classes we need in order to make them match the 'proposed' column in the [context table](https://github.com/TryGhost/Ghost/wiki/Context-aware-Filters-and-Helpers).  The table shows the full details of what would be output in each case.

It will require #2597 to be completed in the future to remove the old classes after we've given theme developers a chance to update. 

The changes are as follows.
- adds `paged` to eventually replace `archive-template`
- adds `page-template`to eventually replace `page` (and `post-template` on pages)
- changes custom page template class to be `page-slug` instead of `page-template-slug`

@JohnONolan I have one remaining concern with this, which is that a post and a page will not share a body class at all posts get `post-template`, and pages get `page-template`. Is this definitely ok?
