### PR TITLE
Redirect uppercase routes to lowercase version

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -152,6 +152,16 @@ function redirectToSetup(req, res, next) {
     });
 }
 
+// Detect uppercase in req.path
+function uncapitalise(req, res, next) {
+    if (/[A-Z]/.test(req.path)) {
+        res.set('Cache-Control', 'public, max-age=' + utils.ONE_YEAR_S);
+        res.redirect(301, req.url.replace(req.path, req.path.toLowerCase()));
+    } else {
+        next();
+    }
+}
+
 function isSSLrequired(isAdmin) {
     var forceSSL = url.parse(config.url).protocol === 'https:' ? true : false,
         forceAdminSSL = (isAdmin && config.forceAdminSSL);
@@ -280,8 +290,9 @@ setupMiddleware = function (server) {
     // Serve robots.txt if not found in theme
     expressServer.use(robots());
 
-    // Add in all trailing slashes
+    // Handle trailing slashes and capitalization of routes
     expressServer.use(slashes(true, {headers: {'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}}));
+    expressServer.use(uncapitalise);
 
     // Body parsing
     expressServer.use(bodyParser.json());

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -27,7 +27,7 @@ adminRoutes = function (middleware) {
         res.redirect(subdir + '/ghost/');
     });
 
-    router.get('/ghost/*', middleware.redirectToSetup, admin.index);
+    router.get(/^\/ghost\//, middleware.redirectToSetup, admin.index);
 
     return router;
 };

--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -114,7 +114,13 @@ describe('Admin Routing', function () {
                 .expect(302)
                 .end(doEndNoAuth(done));
         });
-        // there are more of these... but we get the point
+
+        it('should redirect /GHOST/ to /ghost/', function (done) {
+            request.get('/GHOST/')
+                .expect('Location', '/ghost/')
+                .expect(301)
+                .end(doEndNoAuth(done));
+        });
     });
 
     // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -88,7 +88,14 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-        it('should respond with html', function (done) {
+        it('should redirect uppercase', function (done) {
+            request.get('/Welcome-To-Ghost/')
+                .expect('Location', '/welcome-to-ghost/')
+                .expect(301)
+                .end(doEnd(done));
+        });
+
+        it('should respond with html for valid url', function (done) {
             request.get('/welcome-to-ghost/')
                 .expect('Content-Type', /html/)
                 .expect('Cache-Control', cacheRules['public'])


### PR DESCRIPTION
fixes #3857
- add express-uncapitalize, so that mistyped uppercase urls always redirect to
  their lowercase equivalents
- change the ghost route to a regex, just so it's consistent with other
  routes in the file
