### PR TITLE
Adjust setup and teardown of route tests.

### DIFF
--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -12,7 +12,6 @@ var request    = require('supertest'),
 
     testUtils  = require('../../utils'),
     ghost      = require('../../../../core'),
-    ghostServer,
     agent      = request.agent,
 
     cacheRules = {
@@ -52,24 +51,21 @@ describe('Admin Routing', function () {
     before(function (done) {
         var app = express();
 
-        ghost({app: app}).then(function (_ghostServer) {
+        ghost({app: app}).then(function () {
             // Setup the request object with the ghost express app
-            ghostServer = _ghostServer;
             request = request(app);
-            testUtils.clearData().then(function () {
-                // we initialise data, but not a user. No user should be required for navigating the frontend
-                return testUtils.initData();
-            }).then(function () {
-                done();
-            }).catch(done);
+
+            done();
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
             console.log(e.stack);
         });
     });
 
-    after(function () {
-        ghostServer.stop();
+    after(function (done) {
+        testUtils.clearData().then(function () {
+            done();
+        }).catch(done);
     });
 
     describe('Legacy Redirects', function () {

--- a/core/test/functional/routes/api/authentication_test.js
+++ b/core/test/functional/routes/api/authentication_test.js
@@ -6,7 +6,6 @@ var supertest     = require('supertest'),
     testUtils     = require('../../../utils'),
     user          = testUtils.DataGenerator.forModel.users[0],
     ghost         = require('../../../../../core'),
-    ghostServer,
     request;
 
 
@@ -18,8 +17,7 @@ describe('Authentication API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
         }).then(function () {
             return testUtils.doAuth(request);
@@ -34,9 +32,8 @@ describe('Authentication API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     it('can authenticate', function (done) {

--- a/core/test/functional/routes/api/db_test.js
+++ b/core/test/functional/routes/api/db_test.js
@@ -4,10 +4,7 @@ var supertest     = require('supertest'),
     express       = require('express'),
     should        = require('should'),
     testUtils     = require('../../../utils'),
-
     ghost         = require('../../../../../core'),
-
-    ghostServer,
     request;
 
 
@@ -19,10 +16,8 @@ describe('DB API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -36,9 +31,8 @@ describe('DB API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     it('attaches the Content-Disposition header on export', function (done) {

--- a/core/test/functional/routes/api/error_test.js
+++ b/core/test/functional/routes/api/error_test.js
@@ -12,8 +12,6 @@ var supertest     = require('supertest'),
     testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
-
-    ghostServer,
     request,
     agent;
 
@@ -22,22 +20,17 @@ describe('Unauthorized', function () {
     before(function (done) {
         var app = express();
 
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
-            // request = supertest(app);
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-            testUtils.clearData().then(function () {
-                // we initialise data, but not a user.
-                return testUtils.initData();
-            }).then(function () {
-                done();
-            }).catch(done);
-        });
 
+            done();
+        });
     });
 
-    after(function () {
-        ghostServer.stop();
+    after(function (done) {
+        testUtils.clearData().then(function () {
+            done();
+        }).catch(done);
     });
 
 

--- a/core/test/functional/routes/api/notifications_test.js
+++ b/core/test/functional/routes/api/notifications_test.js
@@ -7,7 +7,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 describe('Notifications API', function () {
@@ -18,8 +17,7 @@ describe('Notifications API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
 
         }).then(function () {
@@ -33,8 +31,10 @@ describe('Notifications API', function () {
         });
     });
 
-    after(function () {
-        ghostServer.stop();
+    after(function (done) {
+        testUtils.clearData().then(function () {
+            done();
+        }).catch(done);
     });
 
     describe('Add', function () {

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -8,7 +8,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 
@@ -20,8 +19,7 @@ describe('Post API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
 
         }).then(function () {
@@ -37,9 +35,8 @@ describe('Post API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     describe('Browse', function () {

--- a/core/test/functional/routes/api/settings_test.js
+++ b/core/test/functional/routes/api/settings_test.js
@@ -7,7 +7,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 describe('Settings API', function () {
@@ -18,10 +17,8 @@ describe('Settings API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -35,9 +32,8 @@ describe('Settings API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     // TODO: currently includes values of type=core

--- a/core/test/functional/routes/api/slugs_test.js
+++ b/core/test/functional/routes/api/slugs_test.js
@@ -7,7 +7,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 describe('Slug API', function () {
@@ -18,10 +17,8 @@ describe('Slug API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -35,9 +32,8 @@ describe('Slug API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     it('should be able to get a post slug', function (done) {

--- a/core/test/functional/routes/api/tags_test.js
+++ b/core/test/functional/routes/api/tags_test.js
@@ -7,7 +7,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 describe('Tag API', function () {
@@ -18,10 +17,8 @@ describe('Tag API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-
         }).then(function () {
             return testUtils.doAuth(request, 'posts');
         }).then(function (token) {
@@ -35,9 +32,8 @@ describe('Tag API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     it('can retrieve all tags', function (done) {

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -7,7 +7,6 @@ var testUtils     = require('../../../utils'),
 
     ghost         = require('../../../../../core'),
 
-    ghostServer,
     request;
 
 describe('User API', function () {
@@ -18,10 +17,8 @@ describe('User API', function () {
 
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost({app: app}).then(function (_ghostServer) {
-            ghostServer = _ghostServer;
+        ghost({app: app}).then(function () {
             request = supertest.agent(app);
-
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -35,9 +32,8 @@ describe('User API', function () {
 
     after(function (done) {
         testUtils.clearData().then(function () {
-            ghostServer.stop();
             done();
-        });
+        }).catch(done);
     });
 
     describe('Browse', function () {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -13,7 +13,6 @@ var request    = require('supertest'),
 
     testUtils  = require('../../utils'),
     ghost      = require('../../../../core'),
-    ghostServer,
 
     cacheRules = {
         'public': 'public, max-age=0',
@@ -41,24 +40,21 @@ describe('Frontend Routing', function () {
     before(function (done) {
         var app = express();
 
-        ghost({app: app}).then(function (_ghostServer) {
+        ghost({app: app}).then(function () {
             // Setup the request object with the ghost express app
-            ghostServer = _ghostServer;
             request = request(app);
-            testUtils.clearData().then(function () {
-                // we initialise data, but not a user. No user should be required for navigating the frontend
-                return testUtils.initData();
-            }).then(function () {
-                done();
-            }).catch(done);
+
+            done();
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
             console.log(e.stack);
         });
     });
 
-    after(function () {
-        ghostServer.stop();
+    after(function (done) {
+       testUtils.clearData().then(function () {
+            done();
+        }).catch(done);
     });
 
     describe('Home', function () {


### PR DESCRIPTION
**Changes to tests only**

Closes #3856
- No longer call clearData and initData in test setup because
  migration.init is run during Ghost startup.  The unhandled
  error was a result of clearData removing all the tables while
  Ghost was running--there was a timing issue with the oauth middleware
  checking the refreshtokens table when it had just been deleted.
