### PR TITLE
Makes the Ghost application more express middleware friendly. 

### DIFF
--- a/core/server/GhostServer.js
+++ b/core/server/GhostServer.js
@@ -9,6 +9,9 @@ function GhostServer(app) {
     this.httpServer = null;
     this.connections = [];
     this.upgradeWarning = setTimeout(this.logUpgradeWarning.bind(this), 5000);
+
+    // Expose config module for use externally.
+    this.config = config;
 }
 
 GhostServer.prototype.connection = function (socket) {
@@ -86,9 +89,16 @@ GhostServer.prototype.logUpgradeWarning = function () {
     console.log('Warning: Ghost will no longer start automatically when using it as an npm module. Please see the docs(http://tinyurl.com/npm-upgrade) for information on how to update your code.'.red);
 };
 
-// Starts the ghost server listening on the configured port
-GhostServer.prototype.start = function () {
-    var self = this;
+/**
+ * Starts the ghost server listening on the configured port.
+ * Alternatively you can pass in your own express instance and let Ghost
+ * start lisetning for you.
+ * @param  {Object=} externalApp Optional express app instance.
+ * @return {Promise}
+ */
+GhostServer.prototype.start = function (externalApp) {
+    var self = this,
+        app = externalApp ? externalApp : self.app;
 
     // ## Start Ghost App
     return new Promise(function (resolve) {
@@ -100,14 +110,14 @@ GhostServer.prototype.start = function () {
                 // We can ignore this.
             }
 
-            self.httpServer = self.app.listen(
+            self.httpServer = app.listen(
                 config.getSocket()
             );
 
             fs.chmod(config.getSocket(), '0660');
 
         } else {
-            self.httpServer = self.app.listen(
+            self.httpServer = app.listen(
                 config.server.port,
                 config.server.host
             );

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -43,7 +43,7 @@ var middleware = {
 
         // SubPath is the url path starting after any default subdirectories
         // it is stripped of anything after the two levels `/ghost/.*?/` as the reset link has an argument
-        path = req.path.substring(config.paths.subdir.length);
+        path = req.path;
         /*jslint regexp:true, unparam:true*/
         subPath = path.replace(/^(\/.*?\/.*?\/)(.*)?/, function (match, a) {
             return a;

--- a/index.js
+++ b/index.js
@@ -2,11 +2,19 @@
 // Orchestrates the loading of Ghost
 // When run from command line.
 
-var ghost = require('./core'),
-    errors = require('./core/server/errors');
+var express = require('express'),
+    ghost   = require('./core'),
+    errors  = require('./core/server/errors');
 
-ghost().then(function (app) {
-    app.start();
+// Create our parent express app instance.
+var server = express();
+
+ghost().then(function (instance) {
+    // Mount our ghost instance on our desired subdirectory path if it exists.
+    server.use(instance.config.paths.subdir, instance.app);
+
+    // Let ghost handle starting our server instance.
+    instance.start(server);
 }).catch(function (err) {
     errors.logErrorAndExit(err, err.context, err.help);
 });


### PR DESCRIPTION
refs #827
- Moves ./index to use Ghost in a similar manner to how someone uses
  Ghost as an npm module.
- Allows Ghost to be cleanly mounted on another express application
  on any arbitrary endpoint, all you need to customize is the mount path.

I built this on top of my #3866 pull request, hence the second commit.

In `./index`, instead of starting ghost by doing:

```
instance.start(server);
```

You can swap it to:

```
server.listen('2368')
```

Voila. 
