### PR TITLE
Output useful error if Node modules are missing

### DIFF
--- a/core/server/errors/moduleerror.js
+++ b/core/server/errors/moduleerror.js
@@ -1,0 +1,8 @@
+function ModuleError(e) {
+    console.error('\033[31mERROR: One or more Node modules required by Ghost could not be found. \n\n' +
+                  '\x1B[32mPlease run \'npm install --production\' and try starting Ghost again. \n' +
+                  '\x1B[32mMore information and help can be found at http://support.ghost.org. \n\n' +
+                  '\x1B[39mThe output was: \n' + e);
+}
+
+module.exports = ModuleError;

--- a/index.js
+++ b/index.js
@@ -2,11 +2,18 @@
 // Orchestrates the loading of Ghost
 // When run from command line.
 
-var ghost = require('./core'),
-    errors = require('./core/server/errors');
+try {
+    var ghost = require('./core'),
+        errors = require('./core/server/errors');
 
-ghost().then(function (app) {
-    app.start();
-}).catch(function (err) {
-    errors.logErrorAndExit(err, err.context, err.help);
-});
+    ghost().then(function (app) {
+        app.start();
+    }).catch(function (err) {
+        errors.logErrorAndExit(err, err.context, err.help);
+    });
+} catch (e) {
+    if (e && e.code === 'MODULE_NOT_FOUND') {
+        var moduleError = require('./core/server/errors/moduleerror');
+        moduleError(e);
+    }
+}


### PR DESCRIPTION
See #3864
- Catches ‘MODULE_NOT_FOUND’ at the highest level, allowing for a
  useful message to be displayed to the user.
- Message: (In red) One or more Node modules required by Ghost could
  not be found. (Not read, line break) Please run 'npm install
  --production' and try starting Ghost again. More information and help
  can be found at http://support.ghost.org.
