### PR TITLE
Show warning dialog if session has ended in editor

### DIFF
--- a/core/client/controllers/modals/auth-failed-unsaved.js
+++ b/core/client/controllers/modals/auth-failed-unsaved.js
@@ -1,0 +1,34 @@
+var AuthFailedUnsavedController = Ember.Controller.extend({
+    editorController: Ember.computed.alias('model'),
+
+    actions: {
+        confirmAccept: function () {
+            var editorController = this.get('editorController');
+
+            if (editorController) {
+                editorController.get('model').rollback();
+            }
+
+            window.onbeforeunload = null;
+
+            window.location = this.get('ghostPaths').adminRoot + '/signin/';
+        },
+
+        confirmReject: function () {
+
+        }
+    },
+
+    confirm: {
+        accept: {
+            text: 'Leave',
+            buttonClass: 'btn btn-red'
+        },
+        reject: {
+            text: 'Stay',
+            buttonClass: 'btn btn-default btn-minor'
+        }
+    }
+});
+
+export default AuthFailedUnsavedController;

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -13,6 +13,18 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
     },
 
     actions: {
+        authorizationFailed: function () {
+            var currentRoute = this.get('controller').get('currentRouteName');
+
+            if (currentRoute.split('.')[0] === 'editor') {
+                this.send('openModal', 'auth-failed-unsaved', this.controllerFor(currentRoute));
+
+                return;
+            }
+
+            this._super();
+        },
+
         closePopups: function () {
             this.get('popover').closePopovers();
             this.get('notifications').closeAll();

--- a/core/client/templates/modals/auth-failed-unsaved.hbs
+++ b/core/client/templates/modals/auth-failed-unsaved.hbs
@@ -1,0 +1,8 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+    title="Post NOT saved." confirm=confirm}}
+
+    <p>Hey there! Something has gone wrong and you have been logged out.  It looks like you have unsaved content that will be lost if you leave this page.</p>
+
+    <p>Copy your content somewhere safe before you go!</p>
+
+{{/gh-modal-dialog}}


### PR DESCRIPTION
Closes #3839
- Display a warning modal in the editor routes if the user
  is logged out due to re-authorization problems.  This provides
  a chance to copy any unsaved content before being sent to the
  signin page to log back in.

![publish-button](https://cloud.githubusercontent.com/assets/214142/4024349/e83ad824-2bc4-11e4-8b68-edfb71bf1523.gif)
