### PR TITLE
adding config flags to control all items mentioned in PRIVACY.md

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -19,6 +19,7 @@ config = {
             },
             debug: false
         },
+
         server: {
             // Host to be passed to node's `net.Server#listen()`
             host: '127.0.0.1',

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -290,6 +290,43 @@ ConfigManager.prototype.validate = function () {
     return Promise.resolve(config);
 };
 
+/**
+ * Helper method for checking the state of a particular privacy flag
+ * @param privacyFlag The flag to check
+ * @returns {boolean}
+ */
+ConfigManager.prototype.isPrivacyDisabled = function (privacyFlag) {
+    if (!this.privacy) {
+        return false;
+    }
+
+    if (this.privacy.useTinfoil === true) {
+        return true;
+    }
+
+    return this.privacy[privacyFlag] === false;
+};
+
+/**
+ * Check if any of the currently set config items are deprecated, and issues a warning.
+ */
+ConfigManager.prototype.checkDeprecated = function () {
+    var deprecatedItems = ['updateCheck'],
+        self = this;
+
+    _.each(deprecatedItems, function (item) {
+        if (self.hasOwnProperty(item)) {
+            var errorText = 'The configuration property [' + item.toString().bold + '] has been deprecated.',
+                explinationText =  'This will be removed in a future version, please update your config.js file.',
+                helpText = 'Please check http://support.ghost.org/config for the most up-to-date example.';
+
+            errors.logWarn(errorText, explinationText, helpText);
+        }
+
+    });
+};
+
+
 if (testingEnvs.indexOf(process.env.NODE_ENV) > -1) {
     defaultConfig  = require('../../../config.example')[process.env.NODE_ENV];
 }

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -2,6 +2,7 @@ var _             = require('lodash'),
     api           = require('../api'),
     errors        = require('../errors'),
     updateCheck   = require('../update-check'),
+    config        = require('../config'),
     adminControllers;
 
 adminControllers = {
@@ -12,7 +13,9 @@ adminControllers = {
         /*jslint unparam:true*/
 
         function renderIndex() {
-            res.render('default');
+            res.render('default', {
+                skip_google_fonts: config.isPrivacyDisabled('useGoogleFonts')
+            });
         }
 
         updateCheck().then(function () {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -142,6 +142,8 @@ function init(options) {
 
     // Load our config.js file from the local file system.
     return config.load(options.config).then(function () {
+        return config.checkDeprecated();
+    }).then(function () {
         // Make sure javascript files have been built via grunt concat
         return builtFilesExist();
     }).then(function () {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -7,6 +7,7 @@ var _              = require('lodash'),
     crypto         = require('crypto'),
     validator      = require('validator'),
     validation     = require('../data/validation'),
+    config         = require('../config'),
 
     bcryptGenSalt  = Promise.promisify(bcrypt.genSalt),
     bcryptHash     = Promise.promisify(bcrypt.hash),
@@ -844,6 +845,10 @@ User = ghostBookshelf.Model.extend({
                 '?d=404&s=250';
 
         return new Promise(function (resolve) {
+            if (config.isPrivacyDisabled('useGravatar')) {
+                resolve(userData);
+            }
+
             http.get('http:' + gravatarUrl, function (res) {
                 if (res.statusCode !== 404) {
                     userData.image = gravatarUrl;

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -168,7 +168,8 @@ function updateCheck() {
     // 1. updateCheck is defined as false in config.js
     // 2. we've already done a check this session
     // 3. we're not in production or development mode
-    if (config.updateCheck === false || _.indexOf(allowedCheckEnvironments, process.env.NODE_ENV) === -1) {
+    //TODO: need to remove config.updateCheck in favor of config.privacy.updateCheck in future version (it is now deprecated)
+    if (config.updateCheck === false || config.isPrivacyDisabled('useUpdateCheck') || _.indexOf(allowedCheckEnvironments, process.env.NODE_ENV) === -1) {
         // No update check
         return Promise.resolve();
     } else {

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -29,7 +29,9 @@
     <meta name="msapplication-square150x150logo" content="{{asset "img/medium.png" ghost="true"}}" />
     <meta name="msapplication-square310x310logo" content="{{asset "img/large.png" ghost="true"}}" />
 
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />
+    {{#unless skip_google_fonts}}
+        <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />
+    {{/unless}}
     <link rel="stylesheet" href="{{asset "css/ghost.min.css" ghost="true"}}" />
 </head>
 <body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-blogurl="{{blog_url}}">

--- a/core/server/xmlrpc.js
+++ b/core/server/xmlrpc.js
@@ -17,7 +17,7 @@ function ping(post) {
         title = post.title;
 
     // Only ping when in production and not a page
-    if (process.env.NODE_ENV !== 'production' || post.page) {
+    if (process.env.NODE_ENV !== 'production' || post.page || config.isPrivacyDisabled('useRpcPing')) {
         return;
     }
 


### PR DESCRIPTION
closes #3241
- in config.js, the `privacy` attribute holds all privacy-related flags
- `privacy.useTinfoil: true` disables everything (equivalent to setting all flags to false)
- added helper function to core/server/config/index.js to checking privacy flags
- added helper function to core/server/config/index.js to show warning about deprecated items

Once this is merged in, http://support.ghost.org/config needs to be updated with the new config options as well as a link placed in `PRIVACY.md` to indicate how things can be disabled. Below is a sample writeup of how to use the new privacy flags (a potential for the documentation site?)

> Flags to better privacy controls and usage of 3rd party services - see https://github.com/TryGhost/Ghost/blob/master/PRIVACY.md for more details.
> Setting an individual privacy flag to `false` indicates that that particular 3rd party feature should not be utilized.
> If a particular flag is not present, then than it will be assumed to be `true`.
> There is also a special privacy flag called `useTinfoil`, which if set to `true` then Ghost will ignore all other privacy flags and disable the use of all 3rd party services as well as automatic updates (this is equivalent to setting each privacy flag to `false`).
> 
> ```
> privacy: {
>     useTinfoil: true,
>     useUpdateCheck: true,
>     useGoogleFonts: true,
>     useGravatar: true,
>     useRpcPing: true
> }
> ```
