### PR TITLE
Add permalink customization.

### DIFF
--- a/core/client/controllers/settings/general.js
+++ b/core/client/controllers/settings/general.js
@@ -1,16 +1,4 @@
 var SettingsGeneralController = Ember.ObjectController.extend({
-    isDatedPermalinks: Ember.computed('permalinks', function (key, value) {
-        // setter
-        if (arguments.length > 1) {
-            this.set('permalinks', value ? '/:year/:month/:day/:slug/' : '/:slug/');
-        }
-
-        // getter
-        var slugForm = this.get('permalinks');
-
-        return slugForm !== '/:slug/';
-    }),
-
     themes: Ember.computed(function () {
         return this.get('availableThemes').reduce(function (themes, t) {
             var theme = {};
@@ -43,6 +31,25 @@ var SettingsGeneralController = Ember.ObjectController.extend({
             if (this.get('postsPerPage') < 1 || this.get('postsPerPage') > 1000 || isNaN(this.get('postsPerPage'))) {
                 this.set('postsPerPage', 5);
             }
+        },
+
+        checkPermalinks: function () {
+            var permalinks = this.get('permalinks');
+            if (! permalinks) {
+                permalinks = '/:slug/';
+            }
+
+            // ensure leading slash
+            if (! /^\//.test(permalinks)) {
+                permalinks = '/' + permalinks;
+            }
+
+            // ensure trailing slash
+            if (! /\/$/.test(permalinks)) {
+                permalinks = permalinks + '/';
+            }
+
+            this.set('permalinks', permalinks);
         }
     }
 });

--- a/core/client/templates/settings/general.hbs
+++ b/core/client/templates/settings/general.hbs
@@ -60,13 +60,10 @@
                 <p>How many posts should be displayed on each page</p>
             </div>
 
-            <div class="form-group for-checkbox">
-                <label for="permalinks">Dated Permalinks</label>
-                <label class="checkbox" for="permalinks">
-                    {{input id="permalinks" name="general[permalinks]" type="checkbox" checked=isDatedPermalinks}}
-                    <span class="input-toggle-component"></span>
-                    <p>Include the date in your post URLs</p>
-                </label>
+            <div class="form-group">
+                <label for="permalinks">Permalink format</label>
+                {{input id="permalinks" name="general[permalinks]" focus-out="checkPermalinks" value=permalinks type="text"}}
+                <p>Customize permalinks. :id, :slug, :year, :month, and :day will be replaced with the post's values</p>
             </div>
 
             <div class="form-group for-select">

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -57,8 +57,7 @@
         "permalinks": {
             "defaultValue": "/:slug/",
             "validations": {
-                "matches": "^(\/:?[a-z0-9_-]+){1,5}\/$",
-                "matches": "(:id|:slug|:year|:month|:day)",
+                "matches": "^(\/([a-z-0-9_-]+|:id|:slug|:year|:month|:day))+\/$",
                 "notContains": "/ghost/"
             }
         }

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -427,11 +427,20 @@ CasperTest.Routines = (function () {
     // This will need switching over to ember once settings general is working properly.
     function togglePermalinks(state) {
         casper.thenOpenAndWaitForPageLoad('settings.general', function then() {
+            // convert from off/on API, to values used to
+            // select the correct button.
+            if (state === 'off') {
+                state = '/:slug/';
+            } else if (state === 'on') {
+                state = '/:year/:month/:day/:slug/';
+            }
+
             var currentState = this.evaluate(function () {
-                return document.querySelector('#permalinks') && document.querySelector('#permalinks').checked ? 'on' : 'off';
+                return document.querySelector('#permalinks') && document.querySelector('#permalinks').value;
             });
+
             if (currentState !== state) {
-                casper.thenClick('#permalinks');
+                casper.sendKeys('#permalinks', state, { reset: true })
                 casper.thenClick('.btn-blue');
 
                 casper.captureScreenshot('saving.png');


### PR DESCRIPTION
- Change the permalink input element to type text.
- URLs can be any combination of `^(\/([a-z-0-9_-]+|:id|:slug|:year|:month|:day))+\/` to allow for URLs like `/way_to-customize/:id/:slug/another-customization/`
- Checking is not very strict, could be made more so.
- Permalink toggling test code is updated to handle new format.

Open Questions:
- Should a URL be required to contain, at a minimum, either `:id`, or `:slug`?
- Should all functional tests that make use of `togglePermalinks` be updated to specify the permalink format instead of `off`|`on`?

fixes #1631
