### PR TITLE
Uncapitalise middleware should not affect tokens

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -154,9 +154,16 @@ function redirectToSetup(req, res, next) {
 
 // Detect uppercase in req.path
 function uncapitalise(req, res, next) {
-    if (/[A-Z]/.test(req.path)) {
+    var pathToTest = req.path,
+        isSignupOrReset = req.path.match(/(\/ghost\/(signup|reset)\/)/i);
+
+    if (isSignupOrReset) {
+        pathToTest = isSignupOrReset[1];
+    }
+
+    if (/[A-Z]/.test(pathToTest)) {
         res.set('Cache-Control', 'public, max-age=' + utils.ONE_YEAR_S);
-        res.redirect(301, req.url.replace(req.path, req.path.toLowerCase()));
+        res.redirect(301, req.url.replace(pathToTest, pathToTest.toLowerCase()));
     } else {
         next();
     }


### PR DESCRIPTION
no issue
- Whilst testing on next, I noticed trying to signup didn't prepopulate email addresses any more, and this is why

Anyone think of anything else this ought not to touch? It doesn't touch query params, just paths and now it doesn't touch reset or signup tokens.
