### PR TITLE
Return leading image for {{content words="0"}}

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -9,6 +9,7 @@ var downsize        = require('downsize'),
     filters         = require('../filters'),
     template        = require('./template'),
     schema          = require('../data/schema').checks,
+    downzero        = require('../utils/downzero'),
 
     assetTemplate   = _.template('<%= source %>?v=<%= version %>'),
     linkTemplate    = _.template('<a href="<%= url %>"><%= text %></a>'),
@@ -290,6 +291,14 @@ coreHelpers.content = function (options) {
     });
 
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
+        
+        // Legacy function: {{content words="0"}} should return leading tags.
+        if (truncateOptions.hasOwnProperty('words') && truncateOptions.words === 0) {
+            return new hbs.handlebars.SafeString(
+                downzero(this.html)
+            );
+        }
+
         // Due to weirdness in downsize the 'words' option
         // must be passed as a string. refer to #1796
         // TODO: when downsize fixes this quirk remove this hack.

--- a/core/server/utils/downzero.js
+++ b/core/server/utils/downzero.js
@@ -1,0 +1,111 @@
+// Functions to imitate the behavior of Downsize@0.0.5 with 'words: "0"' (heavily based on Downsize)
+
+var stack, tagName, tagBuffer, truncatedText, parseState, pointer,
+    states = {unitialized: 0, tag_commenced: 1, tag_string: -1, tag_string_single: -2, comment: -3 },
+    voidElements = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 'input',
+                    'keygen', 'link', 'meta', 'param', 'source', 'track', 'wbr'];
+
+function getTagName(tag) {
+    var tagName = (tag || "").match(/<\/*([a-z0-9\:\-\_]+)/i);
+    return tagName ? tagName[1] : null;
+}
+
+function closeTag(openingTag) {
+    var tagName = (getTagName(openingTag)) ? "</" + getTagName(openingTag) + ">" : "";
+    return tagName;
+}
+
+function downzero(text) {
+
+    stack = [];
+    tagName = '';
+    tagBuffer = '';
+    truncatedText = "";
+    parseState = 0;
+    pointer = 0;
+
+    for (; pointer < text.length; pointer += 1) {
+
+        if (parseState !== states.unitialized) {
+            tagBuffer += text[pointer];
+        }
+
+        switch (text[pointer]) {
+            case "<":
+                if (parseState === states.unitialized && text[pointer + 1].match(/[a-z0-9\-\_\/\!]/)) {
+                    parseState = states.tag_commenced;
+                    tagBuffer += text[pointer];
+                }
+
+                break;
+            case "!":
+                if (parseState === states.tag_commenced && text[pointer - 1] === "<") {
+                    parseState = states.comment;
+                }
+
+                break;
+            case "\"":
+                if (parseState === states.tag_string) {
+                    parseState = states.tag_commenced;
+                } else if (parseState === states.tag_string_single) {
+                    // if double quote is found in a single quote string, ignore it and let the string finish
+                    break;
+                } else if (parseState !== states.unitialized) {
+                    parseState = states.tag_string;
+                }
+
+                break;
+            case "'":
+                if (parseState === states.tag_string_single) {
+                    parseState = states.tag_commenced;
+                } else if (parseState === states.tag_string) {
+                    break;
+                } else if (parseState !== states.unitialized) {
+                    parseState = states.tag_string_single;
+                }
+
+                break;
+            case ">":
+                if (parseState === states.tag_commenced) {
+                    parseState = states.unitialized;
+                    truncatedText += tagBuffer;
+                    tagName = getTagName(tagBuffer);
+
+                    if (tagBuffer.match(/<\s*\//) && getTagName(stack[stack.length - 1]) === tagName) {
+                        stack.pop();
+                    } else if (voidElements.indexOf(tagName) < 0 && !tagBuffer.match(/\/\s*>$/)) {
+                        stack.push(tagBuffer);
+                    }
+                    tagBuffer = "";
+
+                    continue;
+                }
+
+                if (parseState === states.comment && text.substring(pointer - 2, pointer) === "--") {
+                    parseState = states.unitialized;
+                    truncatedText += tagBuffer;
+                    tagBuffer = "";
+
+                    continue;
+                }
+
+                break;
+            case "-":
+                break;
+        }
+
+        if (!parseState) {
+            break;
+        }
+    }
+
+    truncatedText += tagBuffer;
+
+    while (stack.length) {
+        truncatedText += closeTag(stack.pop());
+    }
+
+    return truncatedText;
+}
+
+module.exports = downzero;

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -124,13 +124,27 @@ describe('Core Helpers', function () {
             rendered.string.should.equal('<p><img src="example.jpg" /></p>');
         });
 
+        it('can truncate html to 0 words, leaving image tag with attributes', function () {
+            var html = '<p><img src="example.png" alt="Alternative" title="Title"></p>',
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html},
+                            {'hash': {'words': '0'}}
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal('<p><img src="example.png" alt="Alternative" title="Title"></p>');
+        });
+
         it('can truncate html to 0 words, leaving first image tag & if alt text has a single quote', function () {
             var html = '<p><img src="example.jpg" alt="It\'s me!" />Hello <strong>World! It\'s me!</strong></p>',
                 rendered = (
                     helpers.content
                         .call(
-                            { html: html },
-                            { 'hash': { 'words': '0' } }
+                            {html: html},
+                            {'hash': { 'words': '0' } }
                         )
                 );
 
@@ -144,13 +158,69 @@ describe('Core Helpers', function () {
                 rendered = (
                     helpers.content
                         .call(
-                            { html: html },
-                            { 'hash': { 'words': '0' } }
+                            {html: html },
+                            {'hash': { 'words': '0' } }
                         )
                 );
 
             should.exist(rendered);
             rendered.string.should.equal('<p><img src="example.jpg" alt="A double quote is \'" /></p>');
+        });
+
+        it('can truncate html to 0 words, leaving first image tag if it contains > & <', function () {
+            var html = '<p><img src="examp>><><>le.png"></p>',
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html },
+                            {'hash': { 'words': '0' } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal('<p><img src="examp>><><>le.png"></p>');
+        });
+
+        it('can truncate html to 0 words, leaving first two image tags', function () {
+            var html = '<p><img src="example.png"><img src="example.png">Hi<img src="example.png"></p>',
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html },
+                            {'hash': { 'words': '0' } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal('<p><img src="example.png"><img src="example.png"></p>');
+        });
+
+        it('can truncate html to 0 words, removing image if text comes first', function () {
+            var html = '<p><a>Bli<a><a><img src="example.png"></a></a>Blob</a></p>',
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html },
+                            {'hash': { 'words': '0' } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal('<p><a></a></p>');
+        });
+
+        it('can truncate html to 0 words, leaving video tag', function () {
+            var html = '<p><video><source src="movie.mp4"><source src="movie.ogg"></video></p>',
+                rendered = (
+                    helpers.content
+                        .call(
+                            {html: html },
+                            {'hash': { 'words': '0' } }
+                        )
+                );
+
+            should.exist(rendered);
+            rendered.string.should.equal('<p><video><source src="movie.mp4"><source src="movie.ogg"></video></p>');
         });
 
         it('can truncate html by character', function () {


### PR DESCRIPTION
Closes #3884
- The custom parsing first checks for a leading markdown image. If none
  is found, it will check for a leading `<img>` tag (or a `<img>`  inside a
  leading `<p>`).
- A leading Markdown image tag will be parsed and the resulting HTML
  returned. A leading HTML image tag will be extracted and returned.
- Before/After-Behavior is identical.
- The tests have been updated to also submit markdown and to test img
  tags the way they are currently being returned by Showdown.
