### PR TITLE
Run import run operations in order.

### DIFF
--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -30,10 +30,12 @@ cleanError = function cleanError(error) {
             offendingProperty = temp.length === 2 ? temp[1] : error.model;
             temp = offendingProperty.split('.');
             value = temp.length === 2 ? error.data[temp[1]] : 'unknown';
+        } else if (error.raw.detail) {
+            value = error.raw.detail;
+            offendingProperty = error.model;
         }
         message = 'Duplicate entry found. Multiple values of "' + value + '" found for ' + offendingProperty + '.';
     }
-
 
     offendingProperty = offendingProperty || error.model;
     value = value || 'unknown';

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -144,7 +144,7 @@ Post = ghostBookshelf.Model.extend({
                         createdTag = createdTag.toJSON();
                         // _.omit(options, 'query') is a fix for using bookshelf 0.6.8
                         // (https://github.com/tgriesser/bookshelf/issues/294)
-                        return post.tags().attach(createdTag.id, createdTag.name, _.omit(options, 'query'));
+                        return post.tags().attach(createdTag.id, _.omit(options, 'query'));
                     });
 
                     tagOps.push(createAndAttachOperation);


### PR DESCRIPTION
Closes #1977, Refs #3473
- Ensure that import operations are run in sequence.
  Previously the operations were started in order but subsequent
  ops were allowed to begin before the previous finished, which would
  result in out-of-order execution.
- Fix bug in attach() where a model property was being passed in
  instead of a transaction object.  If the call was made when a
  transaction was in process, it could cause bookshelf/knex to
  hang and never finish the transaction.
