### PR TITLE
core: add theme helpers for site owner, and site email

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -10,6 +10,12 @@ config = {
     // When running Ghost in the wild, use the production environment
     // Configure your URL and mail settings here
     production: {
+        // The website owner's name
+        owner: "Ghost Owner",
+
+        // The website owner's email
+        email: "ghost_owner@ghostmail.com",
+
         url: 'http://my-ghost-blog.com',
         mail: {},
         database: {
@@ -29,6 +35,12 @@ config = {
 
     // ### Development **(default)**
     development: {
+        // The website owner's name
+        owner: "Ghost Owner",
+
+        // The website owner's email
+        email: "ghost_owner@ghostmail.com",
+
         // The url to use when providing links to the site, E.g. in RSS and email.
         // Change this to your Ghost blogs published URL.
         url: 'http://localhost:2368',

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -775,6 +775,26 @@ coreHelpers.plural = function (context, options) {
     }
 };
 
+// ### Site Owner helper
+//
+// *Usage example:*
+// `{{site_owner}}`
+//
+// Returns the owner of the site.
+coreHelpers.site_owner = function (context, block) {
+	return config.owner;
+};
+
+// ### Site Email helper
+//
+// *Usage example:*
+// `{{site_email}}`
+//
+// Returns the email ID of the site.
+coreHelpers.site_email = function (context, block) {
+	return config.email;
+};
+
 coreHelpers.helperMissing = function (arg) {
     if (arguments.length === 2) {
         return undefined;
@@ -859,6 +879,10 @@ registerHelpers = function (adminHbs, assetHash) {
     registerThemeHelper('tags', coreHelpers.tags);
 
     registerThemeHelper('plural', coreHelpers.plural);
+
+    registerThemeHelper('site_owner', coreHelpers.site_owner);
+
+    registerThemeHelper('site_email', coreHelpers.site_email);
 
     registerAsyncThemeHelper('body_class', coreHelpers.body_class);
 


### PR DESCRIPTION
This adds two members to the theme:
{{site_email}} && {{site_owner}}

site_owner is used to denote the owner of the website
and site_email; the contact mail address for the same.

This should be useful in blogs where a no. of authors
contribute but can't all claim copyright, or, the blog
is not a company yet.
