### PR TITLE
Custom template files for custom tags

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -189,7 +189,7 @@ frontendControllers = {
             // Render the page of posts
             filters.doFilter('prePostsRender', page.posts).then(function (posts) {
                 getActiveThemePaths().then(function (paths) {
-                    var view = paths.hasOwnProperty('tag.hbs') ? 'tag' : 'index',
+                    var view = template.getThemeViewForTag(paths, options.tag),
 
                         // Format data for template
                         result = _.extend(formatPageResponse(posts, page), {

--- a/core/server/helpers/template.js
+++ b/core/server/helpers/template.js
@@ -45,4 +45,25 @@ templates.getThemeViewForPost = function (themePaths, post) {
     return view;
 };
 
+// Given a theme object and a tag slug this will return
+// which theme template page should be used.
+// If no default or custom tag template exists then 'index'
+// will be returned
+// If no custom tag template exists but a default does then
+// 'tag' will be returned
+// If given a tag slug and a custom tag template
+// exits it will return that view.
+templates.getThemeViewForTag = function (themePaths, tag) {
+    var customTagView = 'tag-' + tag,
+        view = 'tag';
+
+    if (themePaths.hasOwnProperty(customTagView + '.hbs')) {
+        view = customTagView;
+    } else if (!themePaths.hasOwnProperty('tag.hbs')) {
+        view = 'index';
+    }
+
+    return view;
+};
+
 module.exports = templates;

--- a/core/test/unit/server_helpers_template_spec.js
+++ b/core/test/unit/server_helpers_template_spec.js
@@ -52,4 +52,36 @@ describe('Helpers Template', function () {
         });
 
     });
+
+    describe('getThemeViewForTag', function () {
+        var themePathsWithTagViews = {
+                'assets': null,
+                'default.hbs': '/content/themes/casper/default.hbs',
+                'index.hbs': '/content/themes/casper/index.hbs',
+                'tag.hbs': '/content/themes/casper/tag.hbs',
+                'tag-design.hbs': '/content/themes/casper/tag-about.hbs'
+            },
+            themePaths = {
+                'assets': null,
+                'default.hbs': '/content/themes/casper/default.hbs',
+                'index.hbs': '/content/themes/casper/index.hbs'
+            },
+            TAG_CUSTOM_EXISTS = 'design',
+            TAG_DEFAULT = 'development';
+
+        it('will return correct view for a tag', function () {
+            var view = template.getThemeViewForTag(themePathsWithTagViews, TAG_CUSTOM_EXISTS);
+            view.should.exist;
+            view.should.eql('tag-design');
+
+            view = template.getThemeViewForTag(themePathsWithTagViews, TAG_DEFAULT);
+            view.should.exist;
+            view.should.eql('tag');
+
+            view = template.getThemeViewForTag(themePaths, TAG_DEFAULT);
+            view.should.exist;
+            view.should.eql('index');
+        });
+
+    });
 });


### PR DESCRIPTION
In a similar fashion to being able to have a custom template files for page's depending on the page slug I have a similar use case for custom templates depending on the tag used. 

This will open even more doors to the power of tags for organising and displaying content.

Tried to follow the code style/structure which exists already, first contribution though so let me know if I've missed anything! :)
