### PR TITLE
Fix user cover images

### DIFF
--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -23,7 +23,7 @@ var SettingsUserController = Ember.ObjectController.extend({
         if (Ember.isBlank(cover)) {
             cover = this.get('coverDefault');
         }
-        return cover;
+        return 'background-image: url(' + cover + ')';
     }),
 
     coverTitle: Ember.computed('user.name', function () {


### PR DESCRIPTION
No issue

The cover image method in the settings/user controller returned the correct asset URL, but not the corresponding CSS which is needed to show it correctly.
