### PR TITLE
Show settings-cog and back button

### DIFF
--- a/core/client/templates/-user-actions-menu.hbs
+++ b/core/client/templates/-user-actions-menu.hbs
@@ -1,6 +1,6 @@
-{{#if view.parentView.canMakeOwner}}
+{{#if view.canMakeOwner}}
 <li><button {{action "openModal" "transfer-owner" this}}>Make Owner</button></li>
 {{/if}}
-{{#if view.parentView.deleteUserActionIsVisible}}
+{{#if view.deleteUserActionIsVisible}}
 <li><button {{action "openModal" "delete-user" this}} class="delete">Delete User</button></li>
 {{/if}}

--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -1,17 +1,17 @@
 <header class="settings-subview-header">
     {{#unless session.user.isAuthor}}
-        {{#link-to "settings.users" class="button has-icon users-back" tagName="button"}}<i class="icon-chevron-left"></i>Users{{/link-to}}
+        {{#link-to "settings.users" class="btn btn-default btn-back" tagName="button"}}<i class="icon-chevron-left"></i>Users{{/link-to}}
     {{/unless}}
     <h2 class="page-title">{{user.name}}</h2>
     <section class="page-actions">
         {{#if view.userActionsAreVisible}}
             <span class="dropdown">
-                {{#gh-popover-button popoverName="user-actions-menu" classNames="button only-has-icon user-actions-cog" title="User Actions"}}
+                {{#gh-popover-button popoverName="user-actions-menu" classNames="btn btn-default only-has-icon user-actions-cog" title="User Actions"}}
                     <i class="icon-settings"></i>
                     <span class="hidden">User Settings</span>
                 {{/gh-popover-button}}
                 {{#gh-popover name="user-actions-menu" tagName="ul" classNames="user-actions-menu dropdown-menu dropdown-triangle-top-right"}}
-                    {{render "user-actions-menu" model}}
+                    {{partial "user-actions-menu"}}
                 {{/gh-popover}}
             </span>
         {{/if}}


### PR DESCRIPTION
closes #3925
- Make user-settings-cog reappear
- Show [< Users] back button

@PaulAdamDavis For some reason the user-settings-cog hides behind the cover image. Which class do I need to apply here?

![screen shot 2014-09-02 at 23 52 11](https://cloud.githubusercontent.com/assets/176576/4126401/c56c0812-32eb-11e4-8c4d-840aef3f2207.png)
