### PR TITLE
Fix floating header gradient in FF and settings images

### DIFF
--- a/core/client/assets/sass/layouts/settings.scss
+++ b/core/client/assets/sass/layouts/settings.scss
@@ -145,6 +145,7 @@
     .settings-general img {
         max-width: 100%;
         max-height: 400px;
+        display: block;
     }
 
     .content {

--- a/core/client/assets/sass/patterns/_shame.scss
+++ b/core/client/assets/sass/patterns/_shame.scss
@@ -45,7 +45,7 @@
     text-transform: uppercase;
     color: $brown;
     //Transparent gradient to make bg fade out as it goes out the top.
-    background: linear-gradient(top, white 0%, white 25%, rgba(255,255,255,0.9) 100%);
+    background: linear-gradient(to bottom, white 0%, white 25%, rgba(255,255,255,0.9) 100%);
 
     // button,
     .button {

--- a/core/client/assets/sass/patterns/global.scss
+++ b/core/client/assets/sass/patterns/global.scss
@@ -218,6 +218,7 @@ button {
     border: none;
     outline: none;
     box-shadow: none;
+    padding: 0;
 }
 
 


### PR DESCRIPTION
No issue
- Corrects the syntax used for the floating header gradient so it now gets prefixed correctly for Firefox
- Remove padding from the cover & profile images in settings, when inside a button
