### PR TITLE
Don't send HTML on post save.

### DIFF
--- a/core/client/serializers/post.js
+++ b/core/client/serializers/post.js
@@ -54,6 +54,8 @@ var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
 
         // Don't ever pass uuid's
         delete data.uuid;
+        // Don't send HTML
+        delete data.html;
 
         hash[root] = [data];
     }


### PR DESCRIPTION
fixes #3956
- adjusts post serialiser to not send HTML content
