### PR TITLE
Prevent editor title from being overwritten

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -5,7 +5,7 @@ import boundOneWay from 'ghost/utils/bound-one-way';
 
 // this array will hold properties we need to watch
 // to know if the model has been changed (`controller.isDirty`)
-var watchedProps = ['scratch', 'model.isDirty'];
+var watchedProps = ['scratch', 'titleScratch', 'model.isDirty'];
 
 Ember.get(PostModel, 'attributes').forEach(function (name) {
     watchedProps.push('model.' + name);
@@ -76,7 +76,14 @@ var EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
         // `updateTags` triggers `isDirty => true`.
         // for a saved model it would otherwise be false.
-        this.set('isDirty', false);
+
+        // if the two "scratch" properties (title and content) match the model, then
+        // it's ok to set isDirty to false
+        if (this.get('titleScratch') === model.get('title') &&
+            this.get('scratch') === model.get('markdown')) {
+
+            this.set('isDirty', false);
+        }
     },
 
     // an ugly hack, but necessary to watch all the model's properties

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -1,5 +1,4 @@
 import ValidationEngine from 'ghost/mixins/validation-engine';
-import boundOneWay from 'ghost/utils/bound-one-way';
 import NProgressSaveMixin from 'ghost/mixins/nprogress-save';
 
 var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
@@ -23,7 +22,6 @@ var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     published_at: DS.attr('moment-date'),
     published_by: DS.belongsTo('user', { async: true }),
     tags: DS.hasMany('tag', { embedded: 'always' }),
-    titleScratch: boundOneWay('title'),
     //## Computed post properties
     isPublished: Ember.computed.equal('status', 'published'),
     isDraft: Ember.computed.equal('status', 'draft'),

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -55,7 +55,11 @@ var EditorEditRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, bas
 
     setupController: function (controller, model) {
         this._super(controller, model);
+
         controller.set('scratch', model.get('markdown'));
+
+        controller.set('titleScratch', model.get('title'));
+
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', model.get('tags').mapBy('name'));
 


### PR DESCRIPTION
Closes #3955
- Change titleScratch from being bound to the title to being
  set when entering the editor so it is not overwritten on a
  model refresh.
- Ensure that the "unsaved content" dialog is shown when there are
  changes to the "scratch" fields after a post-settings-menu change.
- Add tests to prevent regression.
