### PR TITLE
Stop packagePath variable from being undefined

### DIFF
--- a/core/server/apps/permissions.js
+++ b/core/server/apps/permissions.js
@@ -33,9 +33,11 @@ AppPermissions.prototype.read = function () {
 };
 
 AppPermissions.prototype.checkPackageContentsExists = function () {
+    var self = this;
+
     // Mostly just broken out for stubbing in unit tests
     return new Promise(function (resolve) {
-        fs.exists(this.packagePath, function (exists) {
+        fs.exists(self.packagePath, function (exists) {
             resolve(exists);
         });
     });


### PR DESCRIPTION
Ghost currently fails at trying to load apps. This small change addresses that issue by doing that scoping thing that you need to do occasionally when working with, like, embedded functions.
