### PR TITLE
Expose configuration API to apps

### DIFF
--- a/core/server/apps/proxy.js
+++ b/core/server/apps/proxy.js
@@ -74,6 +74,9 @@ var generateProxyFunctions = function (name, permissions) {
             ),
             settings: passThruAppContextToApi('settings',
                 _.pick(api.settings, 'browse', 'read', 'edit')
+            ),
+            configuration: passThruAppContextToApi('configuration',
+                _.pick(api.configuration, 'browse', 'read')
             )
         }
     };


### PR DESCRIPTION
This change allows your Ghost app to read your site's configuration. This is useful for when your app needs to be configurable, e.g. providing a Disqus or Google Tag Manager ID.
