### PR TITLE
[WIP] Post Filter Menu

### DIFF
--- a/core/client/assets/sass/layouts/content.scss
+++ b/core/client/assets/sass/layouts/content.scss
@@ -14,6 +14,20 @@
     }
 }
 
+.post-filter-button {
+    text-transform: uppercase;
+    .icon-chevron-down {
+        display: inline-block;
+        margin-left: 2px;
+    }
+}
+.post-filter-list {
+    .dropdown-menu {
+        top: calc(100% + 4px);
+        min-width: 0;
+    }
+}
+
 .content-list {
     width: 33%;
     padding: 15px;
@@ -97,14 +111,14 @@
         };
     }
 
-    ol {
+    .posts-list {
         list-style: none;
         padding: 0;
         margin: 0;
         border-top: $lightbrown 1px solid;
     }
 
-    li {
+    .posts-list {
         margin: 0;
         padding: 0;
         border-bottom: $lightbrown 1px solid;

--- a/core/client/controllers/posts.js
+++ b/core/client/controllers/posts.js
@@ -24,6 +24,29 @@ var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
     // this will cause the list to re-sort when any of these properties change on any of the models
     sortProperties: ['status', 'published_at', 'updated_at'],
 
+    queryParams: ['status', 'featured', 'staticPages'],
+    status: 'all',
+    featured: null,
+    staticPages: 'all',
+
+    filter: 'all',
+    activeFilterName: Ember.computed('filter', function () {
+        switch (this.filter) {
+            case 'all':
+                return 'All Posts';
+            case 'featured':
+                return 'Featured';
+            case 'published':
+                return 'Published';
+            case 'pages':
+                return 'Pages';
+            case 'draft':
+                return 'Drafts';
+            default:
+                return 'All Posts';
+        }
+    }),
+
     // override Ember.SortableMixin
     //
     // this function will keep the posts list sorted when loading individual/bulk
@@ -71,6 +94,46 @@ var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
         //let the PaginationControllerMixin know what type of model we will be paginating
         //this is necesariy because we do not have access to the model inside the Controller::init method
         this._super({'modelType': 'post'});
+    },
+
+    setFilter: function (filterName) {
+        this.set('filter', filterName);
+        switch (filterName) {
+            case 'all':
+                this.setProperties({'status': 'all', 'featured': null, 'staticPages': 'all'});
+                break;
+            case 'featured':
+                this.setProperties({'status': 'all', 'featured': true, 'staticPages': 'all'});
+                break;
+            case 'published':
+                this.setProperties({'status': 'published', 'featured': null, 'staticPages': 'all'});
+                break;
+            case 'pages':
+                this.setProperties({'status': 'all', 'featured': null, 'staticPages': true});
+                break;
+            case 'draft':
+                this.setProperties({'status': 'draft', 'featured': null, 'staticPages': 'all'});
+                break;
+            default:
+                break;
+        }
+    },
+
+    actions: {
+        resetContentPreview: function () {
+            $('.js-content-list').removeAttr('style');
+            $('.js-content-preview').removeAttr('style');
+        },
+
+        showContentPreview: function () {
+            $('.js-content-list').animate({right: '100%', left: '-100%', 'margin-right': '15px'}, 300);
+            $('.js-content-preview').animate({right: '0', left: '0', 'margin-left': '0'}, 300);
+        },
+
+        hideContentPreview: function () {
+            $('.js-content-list').animate({right: '0', left: '0', 'margin-right': '0'}, 300);
+            $('.js-content-preview').animate({right: '-100%', left: '100%', 'margin-left': '15px'}, 300);
+        },
     }
 });
 

--- a/core/client/initializers/trailing-history.js
+++ b/core/client/initializers/trailing-history.js
@@ -2,7 +2,23 @@
 
 var trailingHistory = Ember.HistoryLocation.extend({
     formatURL: function () {
-        return this._super.apply(this, arguments).replace(/\/?$/, '/');
+        var path = this._super.apply(this, arguments),
+            reQuery = /[\?\&]+/,
+            paths;
+
+        paths = path.split(reQuery);
+
+        if (paths[0].slice(-1) !== '/') {
+            path = paths[0] + '/';
+        } else {
+            path = paths[0];
+        }
+
+        if (paths.length > 1) {
+            path += '?' + paths[1];
+        }
+
+        return path;
     }
 });
 

--- a/core/client/templates/posts.hbs
+++ b/core/client/templates/posts.hbs
@@ -7,7 +7,18 @@
     <section class="content-list js-content-list">
         <header class="floatingheader">
             <section class="content-filter">
-                <small>All Posts</small>
+                {{#gh-popover-button popoverName="post-filter" classNames="post-filter-button" title="Post Filter"}}
+                <small>{{activeFilterName}}</small> <i class="icon-chevron-down"></i>
+                {{/gh-popover-button}}
+                {{#gh-popover name="post-filter" classNames="dropdown post-filter-list" closeOnClick="true"}}
+                <ul class="dropdown-menu dropdown-triangle-top" role="menu">
+                    <li role="presentation"><button class="dropdown-item" {{action 'filterPosts' 'all'}}>All Posts</button></li>
+                    <li role="presentation"><button class="dropdown-item" {{action 'filterPosts' 'draft'}}>Drafts</button></li>
+                    <li role="presentation"><button class="dropdown-item" {{action 'filterPosts' 'published'}}>Published</button></li>
+                    <li role="presentation"><button class="dropdown-item" {{action 'filterPosts' 'pages'}}>Pages</button></li>
+                    <li role="presentation"><button class="dropdown-item" {{action 'filterPosts' 'featured'}}>Featured</button></li>
+                </ul>
+                {{/gh-popover}}
             </section>
             {{#link-to "editor.new" class="btn btn-green" title="New Post"}}<span class="hidden">New Post</span>{{/link-to}}
         </header>

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -44,7 +44,7 @@ posts = {
      * Can return posts for a particular tag by passing a tag slug in
      *
      * @public
-     * @param {{context, page, limit, status, staticPages, tag}} options (optional)
+     * @param {{context, page, limit, status, staticPages, featured, tag}} options (optional)
      * @returns {Promise(Posts)} Posts Collection with Meta
      */
     browse: function browse(options) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -210,7 +210,7 @@ Post = ghostBookshelf.Model.extend({
             validOptions = {
                 findAll: ['withRelated'],
                 findOne: ['importing', 'withRelated'],
-                findPage: ['page', 'limit', 'status', 'staticPages'],
+                findPage: ['page', 'limit', 'status', 'staticPages', 'featured'],
                 add: ['importing']
             };
 
@@ -304,6 +304,14 @@ Post = ghostBookshelf.Model.extend({
                 options.staticPages = options.staticPages === 'true' || options.staticPages === '1' ? true : false;
             }
             options.where.page = options.staticPages;
+        }
+
+        if (options.featured) {
+            // convert string true/false to boolean
+            if (!_.isBoolean(options.featured)) {
+                options.featured = options.featured === 'true' || options.featured === '1' ? true : false;
+            }
+            options.where.featured = true;
         }
 
         // Unless `all` is passed as an option, filter on


### PR DESCRIPTION
closes #2640
- Adds post filter
- Adds gh-popup to show filter menu
- Implements more filters on posts.api

---

This PR implements the post filter menu. A live example can be seen in the screencast below (styles would need adjusting - they are inherited from `class='content-list'`). There's a bug with URL handling so that when you refresh the page with a query param active, it will append a trailing slash and screw up a ton of stuff. Not sure if it's us doing the trailing slash or queryParams not handling the our trailing slash correctly. I haven't yet looked into proper pagination, but it should be fairly simple to resolve.

![post-menu](https://cloud.githubusercontent.com/assets/176576/4173659/1f69bf32-3560-11e4-84a2-00ffba881254.gif)

I realise the issue is in the 0.6 milestone - no hard feelings if this isn't going to get merged, this can easily serve as a PoC. Working on this helped me get a better understanding in the whole Ember magic.
