### PR TITLE
Force apps flag to be boolean in config API

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -11,7 +11,7 @@ var _                  = require('lodash'),
 function getValidKeys() {
     var validKeys = {
             'fileStorage': config.fileStorage === false ? false : true,
-            'apps': config.apps || false,
+            'apps': config.apps === true ? true : false,
             'version': false,
             'environment': process.env.NODE_ENV,
             'database': config.database.client,


### PR DESCRIPTION
ref #3969
- it shouldn't be possible to set keys via this flag
