### PR TITLE
Remove active class from button styles

### DIFF
--- a/core/client/assets/sass/patterns/buttons.scss
+++ b/core/client/assets/sass/patterns/buttons.scss
@@ -26,11 +26,8 @@
     @include user-select(none);
 
     &,
-    &:active,
-    &.active {
-        &:focus {
-            @include tab-focus();
-        }
+    &:active {
+        @include tab-focus();
     }
 
     &:hover,
@@ -39,8 +36,7 @@
         text-decoration: none;
     }
 
-    &:active,
-    &.active {
+    &:active {
         outline: 0;
         background-image: none;
         box-shadow: inset 0 2px 2px rgba(0,0,0,.125);
@@ -72,14 +68,12 @@
     &:hover,
     &:focus,
     &:active,
-    &.active,
     .open > &.dropdown-toggle {
         color: $color;
         background-color: darken($background, 10%);
         border-color: darken($border, 12%);
     }
     &:active,
-    &.active,
     .open > &.dropdown-toggle {
         background-image: none;
     }
@@ -89,8 +83,7 @@
         &,
         &:hover,
         &:focus,
-        &:active,
-        &.active {
+        &:active {
             background-color: $background;
             border-color: $border;
         }


### PR DESCRIPTION
No issue

Removes any styling related to buttons with an `.active` class.
This prevent buttons having active styling when we don't want it, such as the [< Users] button in user settings

![screen shot 2014-09-09 at 10 48 03](https://cloud.githubusercontent.com/assets/390392/4199508/6ade9188-3806-11e4-89f7-a00f212264ed.png)
