### PR TITLE
Handle EADDRINUSE

### DIFF
--- a/core/server/GhostServer.js
+++ b/core/server/GhostServer.js
@@ -123,6 +123,17 @@ GhostServer.prototype.start = function (externalApp) {
             );
         }
 
+        self.httpServer.on('error', function (error) {
+            if (error.errno === 'EADDRINUSE') {
+                console.log('ERROR: Cannot start Ghost. Another program is already using this port (is another Ghost instance already running?)'.red);
+            } else {
+                console.log(
+                    'ERROR: There was an error starting your server. '.red,
+                    ('(Code: ' + error.errno + ')').red
+                );
+            }
+            process.exit(-1);
+        });
         self.httpServer.on('connection', self.connection.bind(self));
         self.httpServer.on('listening', function () {
             self.logStartMessages();


### PR DESCRIPTION
no ref
- Show a human readable message on EADDRINUSE

---

Prevents the all too common stacktrace below and shows a nice message instead.

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: listen EADDRINUSE
    at errnoException (net.js:901:11)
    at Server._listen2 (net.js:1039:14)
    at listen (net.js:1061:10)
    at net.js:1143:9
    at dns.js:72:18
    at process._tickDomainCallback (node.js:459:13)
    at process._tickFromSpinner (node.js:390:15)
npm ERR! weird error 8
npm WARN This failure might be due to the use of legacy binary "node"
npm WARN For further explanations, please read
/usr/share/doc/nodejs/README.Debian
```
