### PR TITLE
Let Ghost serve favicon instead of using dependency

### DIFF
--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -15,6 +15,7 @@ var request    = require('supertest'),
 
     cacheRules = {
         public: 'public, max-age=0',
+        day: 'public, max-age=' + testUtils.ONE_DAY_S,
         hour:  'public, max-age=' + testUtils.ONE_HOUR_S,
         year:  'public, max-age=' + testUtils.ONE_YEAR_S,
         private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
@@ -463,6 +464,15 @@ describe('Frontend Routing', function () {
         it('should retrieve default robots.txt', function (done) {
             request.get('/robots.txt')
                 .expect('Cache-Control', cacheRules.year)
+                .expect('ETag', /[0-9a-f]{32}/i)
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('should retrieve default favicon.ico', function (done) {
+            request.get('/favicon.ico')
+                .expect('Cache-Control', cacheRules.day)
+                .expect('ETag', /[0-9a-f]{32}/i)
                 .expect(200)
                 .end(doEnd(done));
         });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -539,5 +539,6 @@ module.exports = {
         }
     },
     ONE_HOUR_S: 3600,
+    ONE_DAY_S: 86400,
     ONE_YEAR_S: 31536000
 };

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "semver": "2.2.1",
         "showdown": "https://github.com/ErisDS/showdown/archive/v0.3.2-ghost.tar.gz",
         "sqlite3": "2.2.7",
-        "static-favicon": "1.0.2",
         "unidecode": "0.1.3",
         "validator": "3.4.0",
         "xml": "0.0.12"


### PR DESCRIPTION
no ref
- Remove static-favicon dependency
- Refactor robots.txt middleware to also serve favicon
