### PR TITLE
No right scroll

### DIFF
--- a/core/client/assets/sass/layouts/default.scss
+++ b/core/client/assets/sass/layouts/default.scss
@@ -162,6 +162,7 @@
     left: 0;
     background: #fff;
     overflow-y: auto;
+    overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
 
     @media (max-width: 900px) {


### PR DESCRIPTION
Closes #4000
- Adds `overflow-x: hidden;` to the content list & preview wrapper
