### PR TITLE
Fixes the first run messages

### DIFF
--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -21,11 +21,6 @@ function parseDefaultSettings() {
             setting.type = categoryName;
             setting.key = settingName;
 
-            // Special case for dbHash
-            if (setting.key === 'dbHash' && setting.defaultValue === null) {
-                setting.defaultValue = uuid.v4();
-            }
-
             defaultSettingsFlattened[settingName] = setting;
         });
     });


### PR DESCRIPTION
no issue
- Whilst testing the mail PR #3915 I noticed the first run messages aren't
  appearing because the dbHash is getting pre-populated, but there doesn't
  appear to be a reason why this is necessary
