### PR TITLE
Fix modal positioning

### DIFF
--- a/core/client/assets/sass/components/modals.scss
+++ b/core/client/assets/sass/components/modals.scss
@@ -69,6 +69,10 @@
     }
 }
 
+.modal {
+    @extend %modal;
+}
+
 .modal-action {
     @extend %modal;
     padding: 60px 0 30px;


### PR DESCRIPTION
Closes #4008
- Adds a `.modal` class which extends `%modal` - it disappeared with the migration to Libsass
