### PR TITLE
Fix notification position when PSM is open

### DIFF
--- a/core/client/assets/sass/components/notifications.scss
+++ b/core/client/assets/sass/components/notifications.scss
@@ -11,8 +11,9 @@
         left: 0;
         z-index: 980;
         width: 300px;
+        transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
         body.right-outlet-expanded & {
-            transform: translate3d(360px, 0px, 0px);
+            transform: translate3d(350px, 0px, 0px);
         }
     }
 
@@ -22,7 +23,8 @@
         left: 0;
         right: 0;
         z-index: 9999;
-        body.right-outlet-expanded & {
+        transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
+        body.right-outlet-expanded & {    
             transform: translate3d(100%, 0px, 0px);
         }
     }


### PR DESCRIPTION
Closes #4006
- Adds a transition to the notification containers
- Adjusts the position of bottom notifications when PSM is open
