### PR TITLE
Change class for editor PSM closing transparent div

### DIFF
--- a/core/client/assets/sass/components/navigation.scss
+++ b/core/client/assets/sass/components/navigation.scss
@@ -162,23 +162,6 @@
 
 }//.user-menu
 
-body.right-outlet-expanded & {
-    .global-nav {
-        z-index: 700;
-    }
-
-    .nav-cover {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        z-index: 700;
-        transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
-        transform: translate3d(-350px, 0px, 0px);
-    }
-}
-
 
 //
 // Mobile

--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -669,6 +669,20 @@ body.zen {
 // Post Settings Menu
 // --------------------------------------------------
 
+ body.right-outlet-expanded {
+
+    .editor-cover {
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 600;
+        transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
+        transform: translate3d(-350px, 0px, 0px); // Not off the screen, to give a parallax effect
+    }//.editor-cover
+}//body.right-outlet-expanded
+
 .post-settings {
     @include icon($i-settings, 14px);
     display: inline-block;

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -1,4 +1,4 @@
-<div class="nav-cover" {{action "closePostSettings"}}></div>
+<div class="editor-cover" {{action "closePostSettings"}}></div>
 <div id="entry-controls" {{bind-attr class=":right-outlet isNew:unsaved"}}>
     <div class="post-settings-menu outlet-pane outlet-pane-in">
         <div class="post-settings-header">


### PR DESCRIPTION
No issue
- Changes the class used by the transparent div used to close the PSM

Without this change, when in the editor and the nav is open, the transparent div here is above the div the nav is looking for. So, the div for the PSM is clicked, rather than the nav div.
