### PR TITLE
Fixed: #3983 URL replacement in RSS feed mucks with content

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
         "static-favicon": "1.0.2",
         "unidecode": "0.1.3",
         "validator": "3.4.0",
-        "xml": "0.0.12"
+        "xml": "0.0.12",
+        "cheerio": "0.17.0"
     },
     "optionalDependencies": {
         "mysql": "2.1.1"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "body-parser": "1.6.3",
         "bookshelf": "0.7.6",
         "busboy": "0.2.3",
+        "cheerio": "0.17.0",
         "colors": "0.6.2",
         "compression": "^1.0.2",
         "connect": "3.0.0-rc.1",


### PR DESCRIPTION
Used cheerio to parse the content and then modify 'href' and 'src' attributes. 
This way the plain text content that contains href=' or src=' will never be selected.
