### PR TITLE
URL replacement in RSS feed mucks with content

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -14,6 +14,7 @@ var moment      = require('moment'),
     filters     = require('../../server/filters'),
     template    = require('../helpers/template'),
     errors      = require('../errors'),
+    cheerio     = require('cheerio'),
 
     frontendControllers,
     staticPostPermalink,
@@ -485,23 +486,21 @@ frontendControllers = {
                                 categories: _.pluck(post.tags, 'name'),
                                 author: post.author ? post.author.name : null
                             },
-                            content = post.html;
+                            htmlContent = cheerio.load(post.html, { decodeEntities: false });
 
-                        //set img src to absolute url
-                        content = content.replace(/src=["|'|\s]?([\w\/\?\$\.\+\-;%:@&=,_]+)["|'|\s]?/gi, function (match, p1) {
-                            /*jslint unparam:true*/
-                            p1 = url.resolve(siteUrl, p1);
-                            return "src='" + p1 + "' ";
+                        // convert relative resource urls to absolute
+                        ['href', 'src'].forEach(function (attributeName) {
+                            htmlContent('[' + attributeName + ']').each(function (ix, el) {
+                                el = htmlContent(el);
+
+                                var attributeValue = el.attr(attributeName);
+                                attributeValue = url.resolve(siteUrl, attributeValue);
+
+                                el.attr(attributeName, attributeValue);
+                            });
                         });
 
-                        //set a href to absolute url
-                        content = content.replace(/href=["|'|\s]?([\w\/\?\$\.\+\-;%:@&=,_]+)["|'|\s]?/gi, function (match, p1) {
-                            /*jslint unparam:true*/
-                            p1 = url.resolve(siteUrl, p1);
-                            return "href='" + p1 + "' ";
-                        });
-
-                        item.description = content;
+                        item.description = htmlContent.html();
                         feed.item(item);
                     });
                 }).then(function () {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "body-parser": "1.6.3",
         "bookshelf": "0.7.6",
         "busboy": "0.2.3",
+        "cheerio": "0.17.0",
         "colors": "0.6.2",
         "compression": "^1.0.2",
         "connect": "3.0.0-rc.1",


### PR DESCRIPTION
fixes #3983

Updated pull request: dependency moved to right place.

Used cheerio to parse the content and then modify 'href' and 'src' attributes. 
This way the plain text content that contains href=' or src=' will never be selected.
