### PR TITLE
Fix ::selection bug

### DIFF
--- a/core/client/assets/sass/patterns/global.scss
+++ b/core/client/assets/sass/patterns/global.scss
@@ -20,15 +20,11 @@ body {
 }
 
 ::-moz-selection {
-    color: $darkgrey;
     background: lighten($blue, 20%);
-    text-shadow: none;
 }
 
 ::selection {
-    color: $darkgrey;
     background: lighten($blue, 20%);
-    text-shadow: none;
 }
 
 h1, h2, h3,


### PR DESCRIPTION
No issue

Fixes a weird issue where text would overlap other text by removing text shadow and font colour.

> @PaulAdamDavis Yea it’s an OpenType / selection bug. You can only change background-color in ::selection with font-feature-settings enabled.

From [@designbyjake](https://twitter.com/designbyjake/status/510772571886075904)

![selection](https://cloud.githubusercontent.com/assets/390392/4260750/19416000-3b4c-11e4-9e3c-cd34d82a01c2.gif)
