### PR TITLE
Properly align word-count

### DIFF
--- a/core/client/assets/sass/layouts/settings.scss
+++ b/core/client/assets/sass/layouts/settings.scss
@@ -164,6 +164,10 @@
         }
     } // .content
 
+    .word-count {
+        float: right;
+        font-weight: bold;
+    }
 } // .settings-content
 
 // This is the header for /ghost/settings/view/


### PR DESCRIPTION
no ref
- Re-adds word-count styles

Somehow got lost (settings screen, text areas)
