### PR TITLE
Add option to specify reporter and output file via grunt.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -171,8 +171,9 @@ var _              = require('lodash'),
             mochacli: {
                 options: {
                     ui: 'bdd',
-                    reporter: 'spec',
-                    timeout: '15000'
+                    reporter: grunt.option('reporter') || 'spec',
+                    timeout: '15000',
+                    save: grunt.option('reporter-output')
                 },
 
                 // #### All Unit tests


### PR DESCRIPTION
Fixes #4038.
- This allows continuous integration platforms like Jenkins to retrieve
  and parse tests results easily.
- It uses tap-file as a Mocha reporter to output unit tests results to a
  file. A FILE_TAP environment variable needs to be set in order to
  specify the file path where the tests results will be stored.
- It uses casperjs' --xunit command line switch to output functional
  tests results to a file.
- phantomjs and casperjs are added to devDependencies so that the
  continuous integration platform doesn't have to setup these
  dependencies itself.
- Currently, phantomjs dependency is set to version 1.9.1-7 because
  that's the only version working on SmartOS, and I need it to work on
  SmartOS. However, if that's an issue, I can work around that on my
  side.
- Node engine has been set to >= 0.10.0 so that Ghost can be tested
  against Node 0.11.x-pre versions (and later).
