### PR TITLE
[Feature request] Add delete post shortcut to content screen

### DIFF
--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -55,11 +55,15 @@ var PostsPostRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, load
     },
 
     shortcuts: {
-        'enter': 'openEditor'
+        'enter': 'openEditor',
+        'command+backspace, ctrl+backspace': 'deletePost'
     },
     actions: {
         openEditor: function () {
             this.transitionTo('editor.edit', this.get('controller.model'));
+        },
+        deletePost: function () {
+            this.send('openModal', 'delete-post', this.get('controller.model'));
         }
     }
 });


### PR DESCRIPTION
Proposal :: No issue
- cmd/ctrl+backspace deletes a post on the content screen

I wanted to raise an issue for this, but as it was three lines of code, I thought I'd both raise the issue _and_ create a working demo of it.

I recently wanted to delete a large number of posts, and with the new PSM, that required five clicks
1. click the post
2. click edit
3. click psm cog
4. click delete button
5. click yes

It hurt me inside. 

As a person who loves never touching his mouse, this solution popped into my head. Would love any sort of feedback, and if it gets closed and thrown away, ah well
