### PR TITLE
Tiny CSS bug fixes

### DIFF
--- a/core/client/assets/sass/components/modals.scss
+++ b/core/client/assets/sass/components/modals.scss
@@ -142,3 +142,10 @@
 .modal-style-centered {
     text-align: center;
 }
+
+// Fixes for specific modals
+.invite-new-user {
+    .btn-green {
+        width: 100%;
+    }
+}

--- a/core/client/assets/sass/helpers/icons.scss
+++ b/core/client/assets/sass/helpers/icons.scss
@@ -30,6 +30,7 @@
         speak: none;
         line-height: 1;
         -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
 
         //Function
         content: '#{$char}';
@@ -62,6 +63,7 @@
         speak: none;
         line-height: 1;
         -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
 
         // Function
         content: '#{$char}';
@@ -186,6 +188,11 @@ $i-code:            \e03e;
 //
 // Icon Classes
 // --------------------------------------------------
+
+[class*='icon-'] {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
 
 .icon-ghost:before {
     content: '#{$i-ghost}';

--- a/core/client/assets/sass/layouts/users.scss
+++ b/core/client/assets/sass/layouts/users.scss
@@ -75,7 +75,7 @@ a.object-list-item {
     display: block;
     border: 1px solid #979797;
     border-radius: 100%;
-    background-size: cover;
+    background-size: 105%;
     background-position: center center;
 } // .object-list-item-figure
 

--- a/core/client/assets/sass/patterns/forms.scss
+++ b/core/client/assets/sass/patterns/forms.scss
@@ -325,5 +325,8 @@ textarea {
         select {
             padding: 7px 10px 7px 8px;
         }
+        &:focus {
+            border-color: $brown;
+        }
     }
 } // @-moz-document

--- a/core/client/components/gh-select.js
+++ b/core/client/components/gh-select.js
@@ -16,6 +16,9 @@
 var GhostSelect = Ember.Component.extend({
     tagName: 'span',
     classNames: ['gh-select'],
+    attributeBindings: ['tabindex'],
+
+    tabindex: '0', // 0 must be a string, or else it's interpreted as false
 
     options: null,
     initialValue: null,

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -25,7 +25,7 @@
             <div class="form-group for-select">
                 <label for="activeTheme">Author</label>
                 <span class="input-icon icon-user">
-                    <span class="gh-select">
+                    <span class="gh-select" tabindex="0">
                     {{view Ember.Select
                         name="post-setting-author"
                         content=authors

--- a/core/client/templates/settings/general.hbs
+++ b/core/client/templates/settings/general.hbs
@@ -71,7 +71,7 @@
 
             <div class="form-group for-select">
                 <label for="activeTheme">Theme</label>
-                <span class="gh-select" {{bind-attr data-select-text=selectedTheme.label}}>
+                <span class="gh-select" {{bind-attr data-select-text=selectedTheme.label}} tabindex="0">
                    {{view Ember.Select
                        id="activeTheme"
                        name="general[activeTheme]"


### PR DESCRIPTION
Closes #4050
- Full-width invite user modal button
- `<select>` can be focused in Firefox
- Increase size of background images for avatars
- Add `-moz-osx-font-smoothing: grayscale;` to icons
