### PR TITLE
Have /ghost use its own express instance

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -132,6 +132,7 @@ function initNotifications() {
 function init(options) {
     // Get reference to an express app instance.
     var server = options.app ? options.app : express(),
+        adminExpress = express(),
         // create a hash for cache busting assets
         assetHash = (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10);
 
@@ -191,13 +192,14 @@ function init(options) {
         server.set('view engine', 'hbs');
 
         // Create a hbs instance for admin and init view engine
-        server.set('admin view engine', adminHbs.express3({}));
+        adminExpress.set('view engine', 'hbs');
+        adminExpress.engine('hbs', adminHbs.express3({}));
 
         // Load helpers
         helpers.loadCoreHelpers(adminHbs, assetHash);
 
         // ## Middleware and Routing
-        middleware(server, dbHash);
+        middleware(server, adminExpress);
 
         // Log all theme errors and warnings
         _.each(config.paths.availableThemes._messages.errors, function (error) {

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -50,31 +50,29 @@ middleware = {
             return a;
         });
 
-        if (res.isAdmin) {
-            if (subPath.indexOf('/ghost/api/') === 0
-                && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
-                return passport.authenticate('bearer', {session: false, failWithError: true},
-                    function (err, user, info) {
-                        if (err) {
-                            return next(err); // will generate a 500 error
-                        }
-                        // Generate a JSON response reflecting authentication status
-                        if (!user) {
-                            var msg = {
-                                type: 'error',
-                                message: 'Please Sign In',
-                                status: 'passive'
-                            };
-                            res.status(401);
-                            return res.send(msg);
-                        }
-                        // TODO: figure out, why user & authInfo is lost
-                        req.authInfo = info;
-                        req.user = user;
-                        return next(null, user, info);
+        if (subPath.indexOf('/ghost/api/') === 0
+            && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
+            return passport.authenticate('bearer', {session: false, failWithError: true},
+                function (err, user, info) {
+                    if (err) {
+                        return next(err); // will generate a 500 error
                     }
-                )(req, res, next);
-            }
+                    // Generate a JSON response reflecting authentication status
+                    if (!user) {
+                        var msg = {
+                            type: 'error',
+                            message: 'Please Sign In',
+                            status: 'passive'
+                        };
+                        res.status(401);
+                        return res.send(msg);
+                    }
+                    // TODO: figure out, why user & authInfo is lost
+                    req.authInfo = info;
+                    req.user = user;
+                    return next(null, user, info);
+                }
+            )(req, res, next);
         }
         next();
     },

--- a/core/server/routes/admin.js
+++ b/core/server/routes/admin.js
@@ -1,33 +1,12 @@
 var admin       = require('../controllers/admin'),
-    config      = require('../config'),
     express     = require('express'),
-    utils       = require('../utils'),
 
     adminRoutes;
 
-adminRoutes = function (middleware) {
-    var router = express.Router(),
-        subdir = config.paths.subdir;
+adminRoutes = function () {
+    var router = express.Router();
 
-    // ### Admin routes
-    router.get(/^\/(logout|signout)\/$/, function redirect(req, res) {
-        /*jslint unparam:true*/
-        res.set({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S});
-        res.redirect(301, subdir + '/ghost/signout/');
-    });
-    router.get(/^\/signup\/$/, function redirect(req, res) {
-        /*jslint unparam:true*/
-        res.set({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S});
-        res.redirect(301, subdir + '/ghost/signup/');
-    });
-
-    // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
-    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) {
-        /*jslint unparam:true*/
-        res.redirect(subdir + '/ghost/');
-    });
-
-    router.get(/^\/ghost\//, middleware.redirectToSetup, admin.index);
+    router.get('*', admin.index);
 
     return router;
 };

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -9,6 +9,24 @@ frontendRoutes = function () {
     var router = express.Router(),
         subdir = config.paths.subdir;
 
+    // ### Admin routes
+    router.get(/^\/(logout|signout)\/$/, function redirect(req, res) {
+        /*jslint unparam:true*/
+        res.set({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S});
+        res.redirect(301, subdir + '/ghost/signout/');
+    });
+    router.get(/^\/signup\/$/, function redirect(req, res) {
+        /*jslint unparam:true*/
+        res.set({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S});
+        res.redirect(301, subdir + '/ghost/signup/');
+    });
+
+    // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
+    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) {
+        /*jslint unparam:true*/
+        res.redirect(subdir + '/ghost/');
+    });
+
     // ### Frontend routes
     router.get('/rss/', frontend.rss);
     router.get('/rss/:page/', frontend.rss);


### PR DESCRIPTION
closes #1961
- Refactor admin to use its own express instance
- Refactor middlewares to work with /ghost mounted admin express instance

---

**Notes:** 
1. This is a solution to #1961. 
2. Having /ghost use its own express instance is a good start, but the server side code should definitely be refactored in the near future. (/cc @hswolff)
3. This change does not seem to have an impact on overall memory usage. I tested both current master and my changes and there's no noticeable effect on the memory footprint.
