### PR TITLE
Ignore unknown setting keys on import

### DIFF
--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -265,7 +265,10 @@ utils = {
         });
 
         ops.push(models.Settings.edit(tableData, _.extend(internal, {transacting: transaction})).catch(function (error) {
-            return Promise.reject({raw: error, model: 'setting', data: tableData});
+            // Ignore NotFound errors
+            if (!(error instanceof errors.NotFoundError)) {
+                return Promise.reject({raw: error, model: 'setting', data: tableData});
+            }
         }));
 
         return Promise.settle(ops);


### PR DESCRIPTION
fixes #4059
- Ignore NotFound setting keys

---

We currently have no way to let the importer output warnings on the client-side. I think the value of `Warning: Settings key 'foobar' was ignored during import` is very limited - there's no action that the user can take to change it and an unknown setting is of no value to the blog the import was executed on.
