### PR TITLE
GhostGFM honours escaped tildes

### DIFF
--- a/core/shared/lib/showdown/extensions/ghostgfm.js
+++ b/core/shared/lib/showdown/extensions/ghostgfm.js
@@ -22,6 +22,15 @@
                 }
             },
             {
+                // Escaped tildes
+                // NOTE: showdown already replaced "~" with "~T", and this char doesn't get escaped properly.
+                type    : 'lang',
+                regex   : '\\\\(~T)',
+                replace : function (match,  content) {
+                    return content;
+                }
+            },
+            {
                 // GFM newline and underscore modifications, happen BEFORE showdown
                 type    : 'lang',
                 filter  : function (text) {

--- a/core/test/unit/showdown_client_integrated_spec.js
+++ b/core/test/unit/showdown_client_integrated_spec.js
@@ -29,6 +29,14 @@ describe('Showdown client side converter', function () {
         processedMarkup.should.match(testPhrase.output);
     });
 
+    it('should honour escaped tildes', function () {
+        var testPhrase = {input: '\\~\\~foo_bar\\~\\~', output: /^<p>~~foo_bar~~<\/p>$/},
+            processedMarkup = converter.makeHtml(testPhrase.input);
+
+        // The image is the entire markup, so the image box should be too
+        processedMarkup.should.match(testPhrase.output);
+    });
+
     it('should not touch single underscores inside words', function () {
         var testPhrase = {input: 'foo_bar', output: /^<p>foo_bar<\/p>$/},
             processedMarkup = converter.makeHtml(testPhrase.input);

--- a/core/test/unit/showdown_ghostGFM_spec.js
+++ b/core/test/unit/showdown_ghostGFM_spec.js
@@ -50,6 +50,16 @@ describe('Ghost GFM showdown extension', function () {
         processedMarkup.should.match(testPhrase.output);
     });
 
+    it('should honour escaped tildes', function () {
+        /*jshint -W044 */
+        var testPhrase = {input: '\\~T\\~Tfoo_bar\\~T\\~T', output: /~T~Tfoo_bar~T~T/},
+        /*jshint +W044 */
+            processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        // The image is the entire markup, so the image box should be too
+        processedMarkup.should.match(testPhrase.output);
+    });
+
     it('should allow 4 underscores', function () {
         var testPhrase = {input: 'Ghost ____', output: /Ghost\s(?:&#95;){4}$/},
             processedMarkup = _ConvertPhrase(testPhrase.input);


### PR DESCRIPTION
For the majority of editor bugs, I'm just closing them against #1294 but this one struck me as worth a quick look as it'd be either super easy or difficult enough to justify closing.
Turns out it was easy.

fixes #2703
- adds an extra rule to remove the slash if a tilde is escaped as showdown
  won't do this.
