### PR TITLE
Prevent transition to signup on invalid invitation

### DIFF
--- a/core/client/controllers/signup.js
+++ b/core/client/controllers/signup.js
@@ -2,10 +2,6 @@ import ajax from 'ghost/utils/ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
 var SignupController = Ember.ObjectController.extend(ValidationEngine, {
-    name: null,
-    email: null,
-    password: null,
-    token: null,
     submitting: false,
 
     // ValidationEngine settings

--- a/core/client/routes/signup.js
+++ b/core/client/routes/signup.js
@@ -1,4 +1,3 @@
-import ajax from 'ghost/utils/ajax';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
@@ -10,24 +9,29 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
             this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
         }
     },
-    setupController: function (controller, params) {
+
+    model: function (params) {
         var self = this,
             tokenText,
             email,
+            model = {},
             re = /^(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/;
-        if (re.test(params.token)) {
-            try {
-                tokenText = atob(params.token);
-                email = tokenText.split('|')[1];
-                controller.token = params.token;
-                controller.email = email;
-            } catch (e) {
-                this.transitionTo('signin');
-                this.notifications.showError('Invalid token.', {delayed: true});
+
+        return new Ember.RSVP.Promise(function (resolve) {
+            if (!re.test(params.token)) {
+                self.notifications.showError('Invalid token.', { delayed: true });
+
+                return resolve(self.transitionTo('signin'));
             }
 
-            ajax({
-                url: this.get('ghostPaths.url').api('authentication', 'invitation'),
+            tokenText = atob(params.token);
+            email = tokenText.split('|')[1];
+
+            model.email = email;
+            model.token = params.token;
+
+            return ic.ajax.request({
+                url: self.get('ghostPaths.url').api('authentication', 'invitation'),
                 type: 'GET',
                 dataType: 'json',
                 data: {
@@ -35,17 +39,23 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
                 }
             }).then(function (response) {
                 if (response && response.invitation && response.invitation[0].valid === false) {
-                    self.transitionTo('signin');
-                    self.notifications.showError('The invitation does not exist or is no longer valid.', {delayed: true});
-                }
-            }).catch(function (error) {
-                self.notifications.showAPIError(error);
-            });
+                    self.notifications.showError('The invitation does not exist or is no longer valid.', { delayed: true });
 
-        } else {
-            this.transitionTo('signin');
-            this.notifications.showError('Invalid token.', {delayed: true});
-        }
+                    return resolve(self.transitionTo('signin'));
+                }
+
+                resolve(model);
+            }).catch(function () {
+                resolve(model);
+            });
+        });
+    },
+
+    deactivate: function () {
+        this._super();
+
+        // clear the properties that hold the sensitive data from the controller
+        this.controllerFor('signup').setProperties({ email: '', password: '', token: '' });
     }
 });
 

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -155,10 +155,6 @@ authentication = {
      * @returns {Promise(Invitation}} An invitation status
      */
     isInvitation: function (options) {
-        if (!options.email) {
-            return Promise.reject(new errors.NoPermissionError('The server did not receive a valid email'));
-        }
-
         return authentication.isSetup().then(function (result) {
             var setup = result.setup[0].status;
 
@@ -174,6 +170,8 @@ authentication = {
                         return {invitation: [{valid: false}]};
                     }
                 });
+            } else {
+                return Promise.reject(new errors.BadRequestError('The server did not receive a valid email'));
             }
         });
     },


### PR DESCRIPTION
Refs #3876
- Prevent signup page from flashing when an invalid invitation
  token is used.
- Clear sensitive information from signup controller.
- Make isInvitation API behavior consistent with other auth
  related APIs.

Example:
![signup](https://cloud.githubusercontent.com/assets/214142/4330916/e1057862-3fb9-11e4-8a9a-0ae91c888b1a.gif)
