### PR TITLE
Revert "update CodeMirror 4.5.0"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ghost",
   "dependencies": {
-    "codemirror": "4.5.0",
+    "codemirror": "4.0.1",
     "Countable": "2.0.2",
     "device": "git://github.com/matthewhudson/device.js#5347a275b66020a0d4dfe9aad81a488f8cce448d",
     "ember": "1.7.0",


### PR DESCRIPTION
closes #4047 and reverts TryGhost/Ghost#4022
- This is necessary due to odd behaviour being experienced, we didn't have those reports on the old version, so lets revert this for now and revisit post-release.
