### PR TITLE
UX Improvements

### DIFF
--- a/core/client/assets/sass/components/notifications.scss
+++ b/core/client/assets/sass/components/notifications.scss
@@ -70,6 +70,7 @@
         padding: 10px 43px 10px 57px;
         max-height: 253px;
         overflow: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
     .close {

--- a/core/client/assets/sass/layouts/content.scss
+++ b/core/client/assets/sass/layouts/content.scss
@@ -63,6 +63,7 @@
         bottom: 0;
         left: 0;
         overflow: auto;
+        -webkit-overflow-scrolling: touch;
         padding-top: 40px;
     }
 
@@ -176,6 +177,7 @@
     top:0;
     right:0;
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
     background: #fff;
     @media (max-width: 900px) {
         width: auto;

--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -122,6 +122,7 @@
         &.active .entry-preview-content {
             height: auto;
             overflow: auto;
+            -webkit-overflow-scrolling: touch;
         }
 
         // Restore the white bg of the currently .active tab, remove hand cursor from currently active tab
@@ -268,6 +269,7 @@
         left: 0;
         padding: 60px 40px 40px 40px;
         overflow: auto;
+        -webkit-overflow-scrolling: touch;
         word-break: break-word;
         hyphens: auto;
         @include user-select(none);

--- a/core/client/assets/sass/lib/codemirror.scss
+++ b/core/client/assets/sass/lib/codemirror.scss
@@ -11,6 +11,7 @@
 .CodeMirror-scroll {
     /* Set scrolling behaviour here */
     overflow: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 /* PADDING */

--- a/core/client/assets/sass/patterns/global.scss
+++ b/core/client/assets/sass/patterns/global.scss
@@ -9,13 +9,22 @@
 html {
     font: 62.5%/1.65 "Open Sans", sans-serif;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+    // Prevent elastic scrolling on the whole page
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
 }
 
 body {
-    width: 100%;
     color: lighten($darkgrey, 10%);
     font-size: 1.4rem;
     font-feature-settings: "kern" 1;
+
+    // Prevent elastic scrolling on the whole page
+    height: 100%;
+    width: 100%;
+    overflow: auto;
     overflow-x: hidden; // Never allow horizontal scrollbars
 }
 


### PR DESCRIPTION
No issue

This is a set of small styling fixes that I think make mobile usage better, and a couple desktop things.
I've purposefully left them as separate commits so I can remove any of them if desired. Will sqaush when ready. :grin: 

They are as follows:
- Smaller padding on content previews for smaller width screens (not the editor)
- Adds `-webkit-overflow-scrolling: touch;` everywhere we have `overflow: hidden;` for native feeling scrolling on (many) mobile devices
- Minor adjustments to `<pre>` elements so lines of code don't wrap – scroll to the side to view it all
- Prevent the whole page bouncing up and down when you get to the top of bottom of a scrollable element
