### PR TITLE
Adjust morgan call to avoid deprecation warning

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -256,9 +256,9 @@ setupMiddleware = function (server, adminExpress) {
     // Logging configuration
     if (logging !== false) {
         if (expressServer.get('env') !== 'development') {
-            expressServer.use(logger(logging || {}));
+            expressServer.use(logger('combined', logging));
         } else {
-            expressServer.use(logger(logging || 'dev'));
+            expressServer.use(logger('dev', logging));
         }
     }
 


### PR DESCRIPTION
No Issue
- Change the invocation of the morgan logging package to
  conform to the new function signature introduced in
  morgan 1.2.0.

Example:
![screen shot 2014-09-19 at 11 12 15 am](https://cloud.githubusercontent.com/assets/214142/4338594/dbf38c86-401a-11e4-9753-7acbd35f7adc.png)
