### PR TITLE
Fix ghost-ui reference

### DIFF
--- a/core/server/views/user-error.hbs
+++ b/core/server/views/user-error.hbs
@@ -17,7 +17,7 @@
     <meta http-equiv="cleartype" content="on">
 
     <link rel="stylesheet" type='text/css' href='//fonts.googleapis.com/css?family=Open+Sans:400,300,700'>
-    <link rel="stylesheet" href="{{asset "css/ghost-ui.min.css" ghost="true"}}">
+    <link rel="stylesheet" href="{{asset "css/ghost.min.css" ghost="true"}}">
   </head>
   <body class="{{bodyClass}}">
     <main role="main" id="main">


### PR DESCRIPTION
fixes #4072
- Correct reference to ghost.min.css
