### PR TITLE
Add Gmail-style shortcuts

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "jquery-file-upload": "9.5.6",
     "jquery-hammerjs": "1.0.1",
     "jquery-ui": "1.10.4",
-    "keymaster": "git://github.com/madrobby/keymaster#0f09fc1b7e66c2b7e07afe89a419366dcf2d1cd8",
+    "keymaster": "git://github.com/madrobby/keymaster#564ea42e07de40da8113a571f17ceae8802672ff",
     "loader.js": "git://github.com/stefanpenner/loader.js#1.0.0",
     "lodash": "2.4.1",
     "moment": "2.4.0",

--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -56,10 +56,14 @@ var PostsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, Shortcut
     },
 
     shortcuts: {
-        'up': 'moveUp',
-        'down': 'moveDown'
+        'up, k': 'moveUp',
+        'down, j': 'moveDown',
+        'c': 'newPost'
     },
     actions: {
+        newPost: function () {
+            this.transitionTo('editor.new');
+        },
         moveUp: function () {
             this.stepThroughPosts(-1);
         },

--- a/core/client/routes/posts/post.js
+++ b/core/client/routes/posts/post.js
@@ -55,7 +55,7 @@ var PostsPostRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, load
     },
 
     shortcuts: {
-        'enter': 'openEditor',
+        'enter, o': 'openEditor',
         'command+backspace, ctrl+backspace': 'deletePost'
     },
     actions: {


### PR DESCRIPTION
Ref #3940
- add `j`/`k` for navigating posts down / up
- `c` for opening a new post
-  `o` to open the selected post
- update keymaster dep to allow for multiple key unbinds (`key.unbind('up, j')`)
