### PR TITLE
Fixes sass:compress

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -311,10 +311,10 @@ var _              = require('lodash'),
                         style: 'compressed',
                         sourceMap: true
                     },
-                    files: {
-                        'core/client/assets/css/<%= pkg.name %>.min.css': 'core/client/assets/sass/screen.scss',
-                        'core/client/docs/dist/css/<%= pkg.name %>.min.css': 'core/client/assets/sass/screen.scss'
-                    }
+                    files: [
+                        {dest: path.resolve('core/client/assets/css/<%= pkg.name %>.min.css'), src: path.resolve('core/client/assets/sass/screen.scss')},
+                        {dest: path.resolve('core/client/docs/dist/css/<%= pkg.name %>.min.css'), src: path.resolve('core/client/assets/sass/screen.scss')}
+                    ]
                 }
             },
 


### PR DESCRIPTION
no ref
- Use absolute path for compress/sourceMap

---

Fixes error reported in IRC by @hswolff (http://107.20.237.151:8081/logs/%23ghost/20140921#pm92637) and https://github.com/sass/node-sass/issues/425
