### PR TITLE
Allow Ghost to be used as middleware within another Express app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ npm-debug.log
 node_modules
 bower_components
 .bowerrc
-.idea/*
+.idea
 *.iml
 *.sublime-*
 projectFilesBackup

--- a/as-middleware.js
+++ b/as-middleware.js
@@ -1,0 +1,51 @@
+require('./core/server/utils/startup-check').check();
+
+var express = require('express'),
+    _       = require('lodash'),
+    chalk = require('chalk'),
+    config  = require('./core/server/config'),
+    ghost   = require('./core/server');
+
+function logStartMessages() {
+    console.log(chalk.green('Ghost middleware configured and ready to serve requests'));
+    if (process.env.NODE_ENV !== 'production') {
+        console.log(chalk.grey('Ghost is running in environment "' + process.env.NODE_ENV + '"...'));
+    }
+}
+
+function buildServer(configValues) {
+    var setupResults, message,
+        promise = config.init(_.merge(configValues, {asMiddleware: true}), 'middleware'),
+        ghostPromise,
+        actualGhostInstance,
+        startupTimingWrapper;
+
+    if (promise.isRejected()) {
+        message = promise.reason();
+        promise.catch(function () {});  // silence "Possibly unhandled" warnings
+        throw message;
+    }
+
+    setupResults = ghost.setupMiddleware(promise);
+    ghostPromise = setupResults[0];
+    actualGhostInstance = setupResults[1];
+
+    ghostPromise.then(logStartMessages);
+    startupTimingWrapper = express();
+    startupTimingWrapper.use(
+        function (req, res, next) {
+            ghostPromise.then(function () {
+                // let Ghost know where it's really mounted
+                actualGhostInstance.mountpath = startupTimingWrapper.mountpath;
+                actualGhostInstance.parent = startupTimingWrapper.parent;
+
+                actualGhostInstance(req, res, next);
+            });
+        }
+    );
+
+    startupTimingWrapper.ghostPromise = ghostPromise;
+    return startupTimingWrapper;
+}
+
+module.exports = buildServer;

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -37,6 +37,9 @@ function createUrl(urlPath, absolute, secure) {
     // create base of url, always ends without a slash
     if (absolute) {
         baseUrl = (secure && ghostConfig.urlSSL) ? ghostConfig.urlSSL : ghostConfig.url;
+        if (!baseUrl) {
+            return false;
+        }
         output += baseUrl.replace(/\/$/, '');
     } else {
         output += ghostConfig.paths.subdir;

--- a/core/server/data/xml/xmlrpc.js
+++ b/core/server/data/xml/xmlrpc.js
@@ -16,9 +16,7 @@ pingList = [{
 }];
 
 function ping(post) {
-    var pingXML,
-        title = post.title,
-        url = config.urlFor('post', {post: post}, true);
+    var pingXML, url;
 
     // Only ping when in production and not a page
     if (process.env.NODE_ENV !== 'production' || post.page || config.isPrivacyDisabled('useRpcPing')) {
@@ -33,6 +31,11 @@ function ping(post) {
         return;
     }
 
+    url = config.urlFor('post', {post: post}, true);
+    if (!url) {
+        return;
+    }
+
     // Build XML object.
     pingXML = xml({
         methodCall: [{
@@ -41,7 +44,7 @@ function ping(post) {
             params: [{
                 param: [{
                     value: [{
-                        string: title
+                        string: post.title
                     }]
                 }]
             }, {

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -31,6 +31,13 @@ function getConfigModule() {
     return config;
 }
 
+function shouldLog() {
+    return process.env.NODE_ENV === 'development' ||
+        process.env.NODE_ENV === 'staging' ||
+        process.env.NODE_ENV === 'production' ||
+        process.env.ENABLE_GHOST_LOGGING === 'true';
+}
+
 /**
  * Basic error handling helpers
  */
@@ -58,17 +65,13 @@ errors = {
     },
 
     logInfo: function (component, info) {
-        if ((process.env.NODE_ENV === 'development' ||
-            process.env.NODE_ENV === 'staging' ||
-            process.env.NODE_ENV === 'production')) {
+        if (shouldLog()) {
             console.info(chalk.cyan(component + ':', info));
         }
     },
 
     logWarn: function (warn, context, help) {
-        if ((process.env.NODE_ENV === 'development' ||
-            process.env.NODE_ENV === 'staging' ||
-            process.env.NODE_ENV === 'production')) {
+        if (shouldLog()) {
             warn = warn || 'no message supplied';
             var msgs = [chalk.yellow('\nWarning:', warn), '\n'];
 
@@ -119,9 +122,7 @@ errors = {
         }
         // TODO: Logging framework hookup
         // Eventually we'll have better logging which will know about envs
-        if ((process.env.NODE_ENV === 'development' ||
-            process.env.NODE_ENV === 'staging' ||
-            process.env.NODE_ENV === 'production')) {
+        if (shouldLog()) {
             msgs = [chalk.red('\nERROR:', err), '\n'];
 
             if (context) {

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -3,8 +3,6 @@
 var Promise = require('bluebird'),
     chalk = require('chalk'),
     fs = require('fs'),
-    semver = require('semver'),
-    packageInfo = require('../../package.json'),
     errors = require('./errors'),
     config = require('./config');
 
@@ -18,7 +16,10 @@ function GhostServer(rootApp) {
     this.httpServer = null;
     this.connections = {};
     this.connectionId = 0;
-    this.upgradeWarning = setTimeout(this.logUpgradeWarning.bind(this), 5000);
+
+    if (config.server) {
+        this.upgradeWarning = setTimeout(this.logUpgradeWarning.bind(this), 5000);
+    }
 
     // Expose config module for use externally.
     this.config = config;
@@ -167,21 +168,6 @@ GhostServer.prototype.closeConnections = function () {
  * ### Log Start Messages
  */
 GhostServer.prototype.logStartMessages = function () {
-    // Tell users if their node version is not supported, and exit
-    if (!semver.satisfies(process.versions.node, packageInfo.engines.node) &&
-        !semver.satisfies(process.versions.node, packageInfo.engines.iojs)) {
-        console.log(
-            chalk.red('\nERROR: Unsupported version of Node'),
-            chalk.red('\nGhost needs Node version'),
-            chalk.yellow(packageInfo.engines.node),
-            chalk.red('you are using version'),
-            chalk.yellow(process.versions.node),
-            chalk.green('\nPlease go to http://nodejs.org to get a supported version')
-        );
-
-        process.exit(0);
-    }
-
     // Startup & Shutdown messages
     if (process.env.NODE_ENV === 'production') {
         console.log(

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -1,6 +1,6 @@
 // # Custom Middleware
 // The following custom middleware functions cannot yet be unit tested, and as such are kept separate from
-// the testable custom middleware functions in middleware.js
+// the testable custom middleware functions in ./middleware.js
 
 var api            = require('../api'),
     bodyParser     = require('body-parser'),
@@ -21,6 +21,7 @@ var api            = require('../api'),
     oauth          = require('./oauth'),
     oauth2orize    = require('oauth2orize'),
     authStrategies = require('./auth-strategies'),
+    url            = require('url'),
     utils          = require('../utils'),
     sitemapHandler = require('../data/xml/sitemap/handler'),
 
@@ -181,6 +182,46 @@ function uncapitalise(req, res, next) {
     }
 }
 
+function isSSLrequired(isAdmin) {
+    if (!config.url) {
+        return false;
+    }
+
+    var forceSSL = url.parse(config.url).protocol === 'https:' ? true : false,
+        forceAdminSSL = (isAdmin && config.forceAdminSSL);
+    if (forceSSL || forceAdminSSL) {
+        return true;
+    }
+    return false;
+}
+
+// Check to see if we should use SSL
+// and redirect if needed
+function checkSSL(req, res, next) {
+    if (isSSLrequired(res.isAdmin)) {
+        if (!req.secure) {
+            var forceAdminSSL = config.forceAdminSSL,
+                redirectUrl;
+
+            // Check if forceAdminSSL: { redirect: false } is set, which means
+            // we should just deny non-SSL access rather than redirect
+            if (forceAdminSSL && forceAdminSSL.redirect !== undefined && !forceAdminSSL.redirect) {
+                return res.sendStatus(403);
+            }
+
+            redirectUrl = url.parse(config.urlSSL || config.url);
+            return res.redirect(301, url.format({
+                protocol: 'https:',
+                hostname: redirectUrl.hostname,
+                port: redirectUrl.port,
+                pathname: req.path,
+                query: req.query
+            }));
+        }
+    }
+    next();
+}
+
 // ### ServeSharedFile Middleware
 // Handles requests to robots.txt and favicon.ico (and caches them)
 function serveSharedFile(file, type, maxAge) {
@@ -237,6 +278,10 @@ setupMiddleware = function (blogAppInstance, adminApp) {
     // Make sure 'req.secure' is valid for proxied requests
     // (X-Forwarded-Proto header will be checked, if present)
     blogApp.enable('trust proxy');
+
+    if (config.asMiddleware) {
+        blogApp.use(middleware.setPathsFromMountpath);
+    }
 
     // Logging configuration
     if (logging !== false) {
@@ -328,14 +373,20 @@ setupMiddleware = function (blogAppInstance, adminApp) {
 
     // ### Error handling
     // 404 Handler
-    blogApp.use(errors.error404);
+    if (config.generate404s !== false) {
+        blogApp.use(errors.error404);
+    }
 
     // 500 Handler
-    blogApp.use(errors.error500);
+    if (config.generate500s !== false) {
+        blogApp.use(errors.error500);
+    }
 };
 
 module.exports = setupMiddleware;
 // Export middleware functions directly
 module.exports.middleware = middleware;
+
 // Expose middleware functions in this file as well
 module.exports.middleware.redirectToSetup = redirectToSetup;
+module.exports.middleware.checkSSL = checkSSL;

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -298,6 +298,30 @@ middleware = {
         });
     },
 
+    setPathsFromMountpath: function (req, res, next) {
+        var host,
+            url,
+            path = blogApp.mountpath;
+        path = (path === '/') ? '' : path;
+        config.paths.subdir = path;
+
+        if (req.get('x-forwarded-host')) {
+            host = req.get('x-forwarded-host');
+            if (req.get('x-forwarded-port')) {
+                host += ':' + req.get('x-forwarded-port');
+            }
+        } else {
+            host = req.get('Host');
+        }
+
+        url = req.protocol + '://' + host + req.baseUrl;
+
+        config._config.url = url;
+        config.url = url;
+        config.theme.url = url;
+        next();
+    },
+
     busboy: busboy,
     cacheControl: cacheControl,
     spamPrevention: spamPrevention

--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -1,17 +1,40 @@
-var packages = require('../../../package.json'),
+var semver = require('semver'),
+    packages = require('../../../package.json'),
     path = require('path'),
+    chalk = require('chalk'),
     crypto = require('crypto'),
     fs = require('fs'),
+    errors = require('../errors'),            // jshint ignore:line
+
     mode = process.env.NODE_ENV === undefined ? 'development' : process.env.NODE_ENV,
     appRoot = path.resolve(__dirname, '../../../'),
+    packageInfo = require('../../../package.json'),
     configFilePath = process.env.GHOST_CONFIG || path.join(appRoot, 'config.js'),
     checks;
 
 checks = {
     check: function check() {
+        this.nodeVersion();
         this.packages();
         this.contentPath();
         this.sqlite();
+    },
+
+    // Tell users if their node version is not supported, and exit
+    nodeVersion: function checkNodeVersion() {
+        if (!semver.satisfies(process.versions.node, packageInfo.engines.node) &&
+            !semver.satisfies(process.versions.node, packageInfo.engines.iojs)) {
+            console.log(
+                chalk.red('\nERROR: Unsupported version of Node'),
+                chalk.red('\nGhost needs Node version'),
+                chalk.yellow(packageInfo.engines.node),
+                chalk.red('you are using version'),
+                chalk.yellow(process.versions.node),
+                chalk.green('\nPlease go to http://nodejs.org to get a supported version')
+            );
+
+            process.exit(0);
+        }
     },
 
     // Make sure package.json dependencies have been installed.

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -22,7 +22,8 @@ CasperTest.begin('Admin navigation bar is correct', 65, function suite(test) {
 
         // Logo
         test.assertExists('.gh-nav-footer-sitelink', 'Ghost home page link exists in nav footer');
-        test.assertEquals(logoHref, 'http://127.0.0.1:2369/', 'Ghost logo link href is correct');
+        test.assert((logoHref === 'http://127.0.0.1:2369/' || logoHref === 'http://localhost:2369/'),
+            'Ghost logo link href is correct');
 
         // Content
         test.assertExists('.gh-nav-main-content', 'Content nav item exists');

--- a/core/test/functional/middleware_test_app.js
+++ b/core/test/functional/middleware_test_app.js
@@ -1,0 +1,21 @@
+var express = require('express'),
+    ghostMiddleware = require('../../../as-middleware'),
+
+    ghostConfig = require('../../../config.example.js')[process.env.NODE_ENV],
+    host = ghostConfig.server.host,
+    port = ghostConfig.server.port,
+
+    app, ghost;
+
+// information Ghost should get from Express once it is mounted
+delete ghostConfig.server;
+delete ghostConfig.url;
+ghost = ghostMiddleware(ghostConfig);
+
+app = express();
+app.use('/', ghost);   // mount at root so paths in tests work for middleware and non-middleware
+
+ghost.ghostPromise.then(function () {
+    app.listen(port, host);
+    console.log('Middleware test harness listening on ' + host + ':' + port);
+});

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -433,24 +433,28 @@ describe('Frontend Routing', function () {
                     var content = res.text,
                         siteTitle = '<title><![CDATA[Ghost]]></title>',
                         siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
-                        siteUrl = '<link>http://127.0.0.1:2369/</link>',
+                        siteUrlA = '<link>http://127.0.0.1:2369/</link>',
+                        siteUrlB = '<link>http://127.0.0.1:2369/</link>',
                         postTitle = '<![CDATA[Welcome to Ghost]]>',
                         descStart = '<description><![CDATA[<p>You\'re live!',
                         postStart = '<content:encoded><![CDATA[<p>You\'re live!',
                         postEnd = 'you think :)</p>]]></content:encoded>',
-                        postLink = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
+                        postLinkA = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
+                        postLinkB = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
                         postCreator = '<dc:creator><![CDATA[Joe Bloggs]]>',
                         author = '<author>';
 
                     content.indexOf('<rss').should.be.above(0);
                     content.indexOf(siteTitle).should.be.above(0);
                     content.indexOf(siteDescription).should.be.above(0);
-                    content.indexOf(siteUrl).should.be.above(0);
+                    Math.max(content.indexOf(siteUrlA), content.indexOf(siteUrlB))
+                        .should.be.above(0);
                     content.indexOf(postTitle).should.be.above(0);
                     content.indexOf(descStart).should.be.above(0);
                     content.indexOf(postStart).should.be.above(0);
                     content.indexOf(postEnd).should.be.above(0);
-                    content.indexOf(postLink).should.be.above(0);
+                    Math.max(content.indexOf(postLinkA), content.indexOf(postLinkB))
+                        .should.be.above(0);
                     content.indexOf(postCreator).should.be.above(0);
                     content.indexOf('</rss>').should.be.above(0);
                     content.indexOf(author).should.be.below(0);
@@ -944,8 +948,8 @@ describe('Frontend Routing', function () {
         it('should set links to url over non-HTTPS', function (done) {
             request.get('/')
                 .expect(200)
-                .expect(/<link rel="canonical" href="http:\/\/127.0.0.1:2370\/" \/\>/)
-                .expect(/<a href="http:\/\/127.0.0.1:2370">Ghost<\/a\>/)
+                .expect(/<link rel="canonical" href="http:\/\/((127.0.0.1)|(localhost)):2370\/" \/\>/)
+                .expect(/<a href="http:\/\/((127.0.0.1)|(localhost)):2370">Ghost<\/a\>/)
                 .end(doEnd(done));
         });
 

--- a/core/test/unit/as_middleware_spec.js
+++ b/core/test/unit/as_middleware_spec.js
@@ -1,0 +1,201 @@
+/*globals describe, it, beforeEach, afterEach */
+/*jshint expr:true*/
+var Promise         = require('bluebird'),
+    should          = require('should'),                           // jshint ignore:line
+    sinon           = require('sinon'),
+    _               = require('lodash'),
+    rewire          = require('rewire'),
+    GhostServer     = require('../../server/ghost-server'),
+
+    // Thing we are testing
+    middleware      = rewire('../../../as-middleware');
+
+describe('Express middleware module', function () {
+    var defaultConfig = {database: {client: 'sqlite3'}};
+
+    function cleanOutConfigManager() {
+        var middlewaresConfig = middleware.__get__('config');
+        _(_.keys(middlewaresConfig._config)).each(function (key) {
+            delete middlewaresConfig[key];
+        });
+        middlewaresConfig._config = {};
+    }
+
+    function shouldBeAnInstanceOfExpress(express) {
+        // first-order duck typing for an express server
+        express.should.be.a.function;
+        express.length.should.equal(3, 'a real express server function has an arity of 3');
+        express.request.should.be.an.object;
+        express.response.should.be.an.object;
+    }
+
+    // alternatively we could stub server/index#setupFromConfigPromise or there-abouts, but
+    //   for just two tests, the performance gain doesn't seem worth the loss of coverage
+    function waitForTheConfigurationPromiseToResolve(middlewareInstance, done) {
+        var promise = middlewareInstance.ghostPromise;
+        promise.then(function () {
+            done();
+        }).catch(function (error) {
+            error.should.equal('In this test, the promise should never be rejected.');
+        });
+    }
+
+    beforeEach(function () {
+        cleanOutConfigManager();
+    });
+
+    it('returns an Express server instance when called', function (done) {
+        var middlewareInstance = middleware(defaultConfig);
+        shouldBeAnInstanceOfExpress(middlewareInstance);
+
+        waitForTheConfigurationPromiseToResolve(middlewareInstance, done);
+    });
+
+    it('extends the middleware instance to provide access to Ghost\'s initialization promise', function (done) {
+        var middlewareInstance = middleware(defaultConfig);
+        middlewareInstance.ghostPromise.should.be.an.instanceOf(Promise);
+
+        waitForTheConfigurationPromiseToResolve(middlewareInstance, done);
+    });
+
+    it('asynchronously initializes the middleware', function (done) {
+        var ghostInitializationPromise = middleware(defaultConfig).ghostPromise;
+        ghostInitializationPromise.then(function (ghostServerInstance) {
+            ghostServerInstance.should.be.an.instanceOf(GhostServer);
+            done();
+        }).catch(function (error) {
+            error.should.be.null;
+        });
+    });
+
+    it('it includes the "asMiddleware" flag in the configuration loaded', function (done) {
+        var middlewareInstance = middleware(defaultConfig);
+        middleware.__get__('config').asMiddleware.should.be.true;
+
+        waitForTheConfigurationPromiseToResolve(middlewareInstance, done);
+    });
+
+    it('fails if it is given a bad configuration', function () {
+        function createMiddlewareWithBadConfiguration() {
+            return middleware({});
+        }
+
+        createMiddlewareWithBadConfiguration.should.throw('invalid database configuration');
+    });
+
+    describe('startup timing', function () {
+        afterEach(function () {
+            middleware = rewire('../../../as-middleware');
+        });
+
+        function makeWebRequest(expressInstance, done) {
+            expressInstance(
+                {path: '/', url: '/', params: {}, route: {}},
+                {
+                    locals: {}, render: done, redirect: done,
+                    setHeader: function () {}
+                },
+                done
+            );
+        }
+
+        it('handles web requests after startup (simple test)', function (done) {
+            var expressInstance = middleware(defaultConfig),
+                ghostInitializationPromise = expressInstance.ghostPromise;
+
+            makeWebRequest(expressInstance, function () {
+                ghostInitializationPromise.isResolved().should.be.true;
+                done();
+            });
+        });
+
+        describe('performs initialization and request handling', function () {
+            var sandbox;
+
+            beforeEach(function () {
+                sandbox = sinon.sandbox.create();
+            });
+
+            afterEach(function () {
+                sandbox.restore();
+            });
+
+            it('in exactly the right order', function (done) {
+                var ghostInstance,
+                    ghostInitializationPromise,
+                    serverConfigPromise,
+                    serverConfigResolver,
+                    mockServer,
+
+                    expectedMountpath = '/a/mount/path',
+                    expectedExpressParent = function () {},
+
+                // build a log of the order in which events actually occurred
+                    sequenceOfOperations = [];
+
+                // set stubs and spies to log events occurring within Ghost
+                //   (ones that go into Ghost's dependencies)
+                mockServer = function (req, res, next) {
+                    mockServer.mountpath.should.equal(expectedMountpath);
+                    mockServer.parent.should.equal(expectedExpressParent);
+
+                    sequenceOfOperations.push('handled request');
+                    next();
+                } ;
+                serverConfigPromise = new Promise(function (fn) {
+                    serverConfigResolver = fn;
+                });
+                middleware.__set__('logStartMessages', function () {
+                    sequenceOfOperations.push('logged start message');
+                });
+                sandbox.stub(
+                    middleware.__get__('config'),
+                    'init',
+                    function () { return serverConfigPromise; }
+                );
+                sandbox.stub(
+                    middleware.__get__('ghost'),
+                    'setupMiddleware',
+                    function (configInfoPromise) {
+                        var allDonePromise = configInfoPromise.then(function () { });
+                        return [allDonePromise, mockServer];
+                    }
+                );
+
+                // generate 'from outside of Ghost' activity in order for situation under test
+                //   -- first, start Ghost initializing
+                sequenceOfOperations.push('started initialization');
+                ghostInstance = middleware(defaultConfig);
+                ghostInstance.mountpath = expectedMountpath;
+                ghostInstance.parent = expectedExpressParent;
+                ghostInitializationPromise = ghostInstance.ghostPromise;
+
+                // set stubs and spies to log events occurring within Ghost
+                //   (ones attached the middleware instance itself)
+                ghostInitializationPromise.then(function () {
+                    sequenceOfOperations.push('finished initialization');
+                });
+                function assertionsAtEnd() {
+                    // verify that Ghost did its bits at the right points in the sequence
+                    sequenceOfOperations.should.eql([
+                        'started initialization',
+                        'made request',
+                        'finished long-running initialization step',
+                        'logged start message',
+                        'finished initialization',
+                        'handled request'
+                    ]);
+                    done();
+                }
+
+                //   -- next, simulate a request coming to us through the parent Express app
+                sequenceOfOperations.push('made request');
+                makeWebRequest(ghostInstance, assertionsAtEnd);
+
+                //   -- then, allow Ghost's initialization process to complete
+                sequenceOfOperations.push('finished long-running initialization step');
+                serverConfigResolver();
+            });
+        });
+    });
+});

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -379,55 +379,13 @@ describe('Config', function () {
             // trick bootstrap into thinking that the config file doesn't exist yet
             var existsStub = sandbox.stub(fs, 'stat', function (file, cb) { return cb(true); }),
                 // ensure that the file creation is a stub, the tests shouldn't really create a file
-                writeFileStub = sandbox.stub(config, 'writeFile').returns(Promise.resolve()),
-                validateStub = sandbox.stub(config, 'validate').returns(Promise.resolve());
+                writeFileStub = sandbox.stub(config, 'writeFile').returns(Promise.resolve());
+            readFileStub.returns(defaultConfig);
 
             config.load().then(function () {
                 existsStub.calledOnce.should.be.true;
                 writeFileStub.calledOnce.should.be.true;
-                validateStub.calledOnce.should.be.true;
-                done();
-            }).catch(done);
-        });
-
-        it('accepts urls with a valid scheme', function (done) {
-            // replace the config file with invalid data
-            overrideConfig({url: 'http://testurl.com'});
-
-            config.load().then(function (localConfig) {
-                localConfig.url.should.equal('http://testurl.com');
-
-                // Next test
-                overrideConfig({url: 'https://testurl.com'});
-                return config.load();
-            }).then(function (localConfig) {
-                localConfig.url.should.equal('https://testurl.com');
-
-                // Next test
-                overrideConfig({url: 'http://testurl.com/blog/'});
-                return config.load();
-            }).then(function (localConfig) {
-                localConfig.url.should.equal('http://testurl.com/blog/');
-
-                // Next test
-                overrideConfig({url: 'http://testurl.com/ghostly/'});
-                return config.load();
-            }).then(function (localConfig) {
-                localConfig.url.should.equal('http://testurl.com/ghostly/');
-
-                done();
-            }).catch(done);
-        });
-
-        it('rejects a fqdn without a scheme', function (done) {
-            overrideConfig({url: 'example.com'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
+                readFileStub.calledOnce.should.be.true;
                 done();
             }).catch(done);
         });
@@ -445,210 +403,175 @@ describe('Config', function () {
             }).catch(done);
         });
 
-        it('rejects a hostname with a scheme', function (done) {
-            overrideConfig({url: 'https://example'});
+        describe('accepts a socket in server configuration', function () {
+            it('default permissions if not user-defined', function (done) {
+                overrideConfig({server: {socket: 'test'}});
 
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
+                config.load().then(function () {
+                    var socketConfig = config.getSocket();
 
-                done();
-            }).catch(done);
-        });
+                    socketConfig.should.be.an.Object;
+                    socketConfig.path.should.equal('test');
+                    socketConfig.permissions.should.equal('660');
 
-        it('rejects a url with an unsupported scheme', function (done) {
-            overrideConfig({url: 'ftp://example.com'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('rejects a url with a protocol relative scheme', function (done) {
-            overrideConfig({url: '//example.com'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('does not permit the word ghost as a url path', function (done) {
-            overrideConfig({url: 'http://example.com/ghost/'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('does not permit the word ghost to be a component in a url path', function (done) {
-            overrideConfig({url: 'http://example.com/blog/ghost/'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('does not permit the word ghost to be a component in a url path', function (done) {
-            overrideConfig({url: 'http://example.com/ghost/blog/'});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('does not permit database config to be falsy', function (done) {
-            // replace the config file with invalid data
-            overrideConfig({database: false});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('does not permit database config to be empty', function (done) {
-            // replace the config file with invalid data
-            overrideConfig({database: {}});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('requires server to be present', function (done) {
-            overrideConfig({server: false});
-
-            config.load().then(function (localConfig) {
-                /*jshint unused:false*/
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('allows server to use a socket', function (done) {
-            overrideConfig({server: {socket: 'test'}});
-
-            config.load().then(function () {
-                var socketConfig = config.getSocket();
-
-                socketConfig.should.be.an.Object;
-                socketConfig.path.should.equal('test');
-                socketConfig.permissions.should.equal('660');
-
-                done();
-            }).catch(done);
-        });
-
-        it('allows server to use a socket and user-defined permissions', function (done) {
-            overrideConfig({
-                server: {
-                    socket: {
-                        path: 'test',
-                        permissions: '666'
-                    }
-                }
+                    done();
+                }).catch(done);
             });
 
-            config.load().then(function () {
-                var socketConfig = config.getSocket();
+            it('supports user-defined permissions', function (done) {
+                overrideConfig({
+                    server: {
+                        socket: {
+                            path: 'test',
+                            permissions: '666'
+                        }
+                    }
+                });
 
-                socketConfig.should.be.an.Object;
-                socketConfig.path.should.equal('test');
-                socketConfig.permissions.should.equal('666');
+                config.load().then(function () {
+                    var socketConfig = config.getSocket();
 
-                done();
-            }).catch(done);
+                    socketConfig.should.be.an.Object;
+                    socketConfig.path.should.equal('test');
+                    socketConfig.permissions.should.equal('666');
+
+                    done();
+                }).catch(done);
+            });
+        });
+    });
+
+    describe('configuration validation', function () {
+        var testConfig, serverSetup;
+
+        describe('for all server setups', function () {
+            beforeEach(function () { serverSetup = 'standalone'; });  // any valid setup value OK
+
+            describe('rejects', function () {
+                afterEach(function () {
+                    config.findErrors(testConfig, serverSetup).should.be.ok;
+                });
+
+                it('if the database config is falsy', function () {
+                    testConfig = _.extend({}, defaultConfig, {database: false});
+                });
+
+                it('if the database config is empty', function () {
+                    testConfig = _.extend({}, defaultConfig, {database: {}});
+                });
+            });
         });
 
-        it('allows server to have a host and a port', function (done) {
-            overrideConfig({server: {host: '127.0.0.1', port: '2368'}});
+        describe('for stand-alone servers', function () {
+            beforeEach(function () { serverSetup = 'standalone'; });
 
-            config.load().then(function (localConfig) {
-                should.exist(localConfig);
-                localConfig.server.host.should.equal('127.0.0.1');
-                localConfig.server.port.should.equal('2368');
+            it('accepts urls with a valid scheme', function () {
+                var validUrls = [
+                    'http://testurl.com',
+                    'https://testurl.com',
+                    'http://testurl.com/blog/',
+                    'http://testurl.com/ghostly/'
+                ];
 
-                done();
-            }).catch(done);
+                _.forEach(validUrls, function (url) {
+                    testConfig = _.extend({}, defaultConfig, {url: url});
+                    should(!!config.findErrors(testConfig, serverSetup)).equal(false, 'Shouldn\'t be any errors in the URL ' + url);
+                });
+            });
+
+            describe('rejects', function () {
+                afterEach(function () {
+                    config.findErrors(testConfig, serverSetup).should.be.ok;
+                });
+
+                it('a fqdn without a scheme', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'example.com'});
+                });
+
+                it('a hostname without a scheme', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'example'});
+                    config.findErrors(testConfig, serverSetup).should.be.ok;
+                });
+
+                it('a hostname with a scheme', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'https://example'});
+                });
+
+                it('a url with an unsupported scheme', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'ftp://example.com'});
+                });
+
+                it('a url with a protocol relative scheme', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: '//example.com'});
+                });
+
+                it('the word ghost as a url path', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'http://example.com/ghost/'});
+                });
+
+                it('the word ghost as a component in a url path', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'http://example.com/blog/ghost/'});
+                });
+
+                it('the word ghost as a component in a url path', function () {
+                    testConfig = _.extend({}, defaultConfig, {url: 'http://example.com/ghost/blog/'});
+                });
+
+                it('unless server is present', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: false});
+                });
+
+                it('server if there is a host but no port', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: {host: '127.0.0.1'}});
+                });
+
+                it('server if there is a port but no host', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: {port: '2368'}});
+                });
+
+                it('server if configuration is empty', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: {}});
+                });
+            });
+
+            describe('allows server to ', function () {
+                afterEach(function () {
+                    should(!!config.findErrors(testConfig, serverSetup)).not.be.ok;
+                });
+
+                it('use a socket', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: {socket: 'test'}});
+                });
+
+                it('have a host and a port', function () {
+                    testConfig = _.extend({}, defaultConfig, {server: {host: '127.0.0.1', port: '2368'}});
+                });
+            });
         });
 
-        it('rejects server if there is a host but no port', function (done) {
-            overrideConfig({server: {host: '127.0.0.1'}});
+        describe('for middleware servers', function () {
+            var defaultMiddlewareConfig;
 
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
+            beforeEach(function () {
+                serverSetup = 'middleware';
+                defaultMiddlewareConfig = {
+                    database: defaultConfig.database
+                };
+            });
 
-                done();
-            }).catch(done);
-        });
+            describe('rejects', function () {
+                afterEach(function () {
+                    config.findErrors(testConfig, serverSetup).should.be.ok;
+                });
 
-        it('rejects server if there is a port but no host', function (done) {
-            overrideConfig({server: {port: '2368'}});
+                it('configurations that contain a "server" key', function () {
+                    testConfig = _.extend({}, defaultMiddlewareConfig, {server: {}});
+                });
 
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
-        });
-
-        it('rejects server if configuration is empty', function (done) {
-            overrideConfig({server: {}});
-
-            config.load().then(function () {
-                done(expectedError);
-            }).catch(function (err) {
-                should.exist(err);
-                err.should.be.an.Error;
-
-                done();
-            }).catch(done);
+                it('configurations that contain a "url" key', function () {
+                    testConfig = _.extend({}, defaultMiddlewareConfig, {url: 'scheme:host/path'});
+                });
+            });
         });
     });
 

--- a/core/test/unit/ghost_server_spec.js
+++ b/core/test/unit/ghost_server_spec.js
@@ -1,0 +1,36 @@
+/*globals describe, it*/
+var should          = require('should'),
+    express         = require('express'),
+    _               = require('lodash'),
+    rewire          = require('rewire'),
+
+    // Stuff we are testing
+    GhostServer     = rewire('../../server/ghost-server');
+
+describe('GhostServer', function () {
+    describe('instantiating', function () {
+        describe('configured as a stand-alone app', function () {
+            it('schedules a warning message to appear if the server doesn\'t start', function () {
+                var ghost,
+                    config = GhostServer.__get__('config');
+                _.merge(config, config._config);
+
+                ghost = new GhostServer(express());
+                should(ghost.upgradeWarning).not.equal(undefined);
+            });
+        });
+
+        describe('configured to run as Express middleware', function () {
+            it('doesn\'t schedule a warning message', function () {
+                var ghost,
+                    config = GhostServer.__get__('config');
+                config.asMiddleware = true;
+                delete config.server;
+                delete config.url;
+
+                ghost = new GhostServer(express());
+                should(ghost.upgradeWarning).equal(undefined);
+            });
+        });
+    });
+});

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -3,11 +3,14 @@
 var should          = require('should'),
     _               = require('lodash'),
     crypto          = require('crypto'),
+    rewire          = require('rewire'),
 
     // Stuff we are testing
     defaultSettings = require('../../server/data/default-settings'),
     schema          = require('../../server/data/schema'),
-    permissions     = require('../../server/data/fixtures/permissions/permissions');
+    // Use 'rewire' to force a clean load.  Otherwise execution of addAllPermissions by other tests can cause
+    //    'object_type' keys to be in the hash when we check it, which the expected md5 values don't include.
+    permissions     = rewire('../../server/data/fixtures/permissions/permissions');
 
 // To stop jshint complaining
 should.equal(true, true);

--- a/core/test/unit/xmlrpc_spec.js
+++ b/core/test/unit/xmlrpc_spec.js
@@ -1,44 +1,74 @@
 /*globals describe, beforeEach, afterEach, it*/
 /*jshint expr:true*/
 var nock            = require('nock'),
-    should          = require('should'),
-    sinon           = require('sinon'),
+    should          = require('should'),                           // jshint ignore:line
     testUtils       = require('../utils'),
-    xmlrpc          = require('../../server/data/xml/xmlrpc'),
     events          = require('../../server/events'),
+    rewire          = require('rewire'),
+
+    // code under test
+    xmlrpc          = rewire('../../server/data/xml/xmlrpc'),
+
     // storing current environment
     currentEnv      = process.env.NODE_ENV;
 
-// To stop jshint complaining
-should.equal(true, true);
-
 describe('XMLRPC', function () {
-    var sandbox;
-
+    var ping1, ping2, testPost;
     beforeEach(function () {
-        sandbox = sinon.sandbox.create();
-        // give environment a value that will ping
-        process.env.NODE_ENV = 'production';
+        ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200);
+        ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200);
+        testPost = {
+            toJSON: function () {
+                return testUtils.DataGenerator.Content.posts[2];
+            }
+        };
     });
 
-    afterEach(function () {
-        sandbox.restore();
-        // reset the environment
-        process.env.NODE_ENV = currentEnv;
+    describe('in the production environment', function () {
+        beforeEach(function () {
+            // give environment a value that will ping
+            process.env.NODE_ENV = 'production';
+        });
+
+        afterEach(function () {
+            // reset the environment
+            process.env.NODE_ENV = currentEnv;
+        });
+
+        it('should execute two pings', function () {
+            xmlrpc.init();
+            events.emit('post.published', testPost);
+            ping1.isDone().should.be.true;
+            ping2.isDone().should.be.true;
+        });
+
+        describe('before the blog path is available', function () {
+            var config, defaultTestingUrl;
+            beforeEach(function () {
+                config = xmlrpc.__get__('config')._config;
+                defaultTestingUrl = config.url;
+                delete config.url;
+            });
+            afterEach(function () {
+                // restore because tests don't reload config between each
+                config.url = defaultTestingUrl;
+            });
+
+            it('should not ping', function () {
+                xmlrpc.init();
+                events.emit('post.published', testPost);
+                ping1.isDone().should.be.false;
+                ping2.isDone().should.be.false;
+            });
+        });
     });
 
-    it('should execute two pings', function () {
-        var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
-            ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
-            testPost = {
-                toJSON: function () {
-                    return testUtils.DataGenerator.Content.posts[2];
-                }
-            };
-
-        xmlrpc.init();
-        events.emit('post.published', testPost);
-        ping1.isDone().should.be.true;
-        ping2.isDone().should.be.true;
+    describe('in non-production environments', function () {
+        it('should not ping', function () {
+            xmlrpc.init();
+            events.emit('post.published', testPost);
+            ping1.isDone().should.be.false;
+            ping2.isDone().should.be.false;
+        });
     });
 });


### PR DESCRIPTION
Allow Ghost to be used as middleware within another Express app.

closes #827 #3849
- Ghost can now be mounted as middleware in another Express app by
  `app.use('/blog', require('ghost/as-middleware')(ghostConfigHash));`
- Update messaging to account for server versus middleware.
- Allow access to Ghost's initialization-complete promise through the
  `.ghostPromise` property added to the middleware instance returned.
  (Neither the framing app used for functional tests nor an example
  Express app showing Ghost used as middleware needs this, but examples
  of its use can be found in `test/unit/as_middleware_spec.js`.)
- When used as middleware, `ghostConfigHash` should not contain `url` or
  a `server` block.
- Base URL and path for Ghost determined dynamically from the .mountpath
  and request information provided by Express.
- Ghost configuration can contain `generate404s` and `generate500s`
  keys.  When their values are `false`, Ghost will no longer serve the
  associated pages.
- Created new grunt task `test-middleware-functional` that runs the
  `test-functional` tests against a test server including Ghost as
  middleware (plus a number of other tasks/assets needed to support).
  Did _not_ add this to the set of tasks run by `grunt validate` for
  fear of impact on build times.

Design issues:
- I'm not necessarily happy with making Ghost's initialization promise
  available as a property of the Express middleware instance we return,
  but it seemed like the least of evils, and I'm not aware of any other
  Express component that has this need reference for guidance.  Any
  alternative suggestion would be welcome.

Refactors:
- Validation of the content of Ghost's configuration was moved out of
  the file-loading method and is now invoked by `config.init` so that
  checks apply to both files and passed-in configuration hashes.
- The entry `asMiddleware:true` is automatically added to the config
  when Ghost is initialized through the middleware entry point, so that
  internal code that only operates in this case can test for an explicit
  configuration.
- `checkNodeVersion()` was moved out of `ghost-server.js` and into
  `utils/startup-check.js` so that it could be shared between server and
  middleware configurations of Ghost.

References:
- The individual commits squashed into this PR are available on the branch
  git://github.com/gleneivey/Ghost.git#separate_middleware_entry_point
- A trivial example Express application that incorporates Ghost as a
  middleware component is in
  https://github.com/gleneivey/example-express-with-ghost-middleware
- A wiki page that may be copied into the main Ghost wiki, describing
  how to configure/use Ghost as middleware is available at
  https://github.com/gleneivey/Ghost/wiki/Using-Ghost-as-Express-Middleware
