### PR TITLE
it translation fix

### DIFF
--- a/it/installation/deploy.md
+++ b/it/installation/deploy.md
@@ -16,24 +16,24 @@ next_section: upgrading
 
 Dunque sei pronto a scaricare Ghost? Eccellente!
 
-La prima decisione da prendere è se vuoi installare Ghost manualmente o se preferisci usare un'installer.
+La prima decisione da prendere è se vuoi installare Ghost manualmente o se preferisci usare un installer.
 
 ### Installers
 
-Al momento le alternative con installers semplici da usare sono principalmente:
+Al momento le alternative con installer semplici da usare sono principalmente:
 
 *   Rilasciare sul cloud di [Bitnami](http://wiki.bitnami.com/Applications/BitNami_Ghost).
 *   Avviare Ghost tramite [Rackspace deployments](http://developer.rackspace.com/blog/launch-ghost-with-rackspace-deployments.html).
-*   Configurare [DigitalOcean Droplet](https://www.digitalocean.com/community/articles/how-to-use-the-digitalocean-ghost-application).
+*   Configurare un [droplet su DigitalOcean](https://www.digitalocean.com/community/articles/how-to-use-the-digitalocean-ghost-application).
 
 ### Installazione Manuale
 
 Hai bisogno di un servizio di hosting che abbia o ti permetta di installare [Node.js](http://nodejs.org).
-    Ciò significa qualcosa come un cloud ([Amazon EC2](http://aws.amazon.com/ec2/), [DigitalOcean](http://www.digitalocean.com), [Rackspace Cloud](http://www.rackspace.com/cloud/)), VPS ([Webfaction](https://www.webfaction.com/), [Dreamhost](http://www.dreamhost.com/servers/vps/)) o altri pacchetti con accesso SSH (terminale) e che ti permettano di installare Node.js. Ne esistono molti, alcuni molto economici.
+    Ciò significa qualcosa come un cloud ([Amazon EC2](http://aws.amazon.com/ec2/), [DigitalOcean](http://www.digitalocean.com), [Rackspace Cloud](http://www.rackspace.com/cloud/)), VPS ([Webfaction](https://www.webfaction.com/), [Dreamhost](http://www.dreamhost.com/servers/vps/)) o altri pacchetti con accesso SSH (terminale) e che ti permettano di installare Node.js. Ne esistono diversi, alcuni molto economici.
 
-Attualmente non sono utilizzabili hosting condivisi stile cPanel in quanto solitamente concepiti per hosting PHP. Sebbene alcuni offrano Ruby, dunque in futuro potrebbero offrire Node.js essendo simili.
+Attualmente non sono utilizzabili hosting condivisi stile cPanel, in quanto solitamente concepiti per hosting PHP. Alcuni di essi offrono Ruby, dunque in futuro potrebbero darti la possibilità di usare anche Node.js, essendo simili.
 
-<p>Sfortunatamente molte delle soluzioni di cloud non designate specificatamente per Node, come **Nodejitsu** o **Heroku**, **NON** sono compatibili con Ghost. Funzionano inizialmente, ma cancellano i tuoi files, dunque tutte le immagini caricate e il database scompaiono. Heroku supporta MySQL quindi potresti adoperarlo, ma perderesti ugualmente le immagini caricate.
+<p>Sfortunatamente molte delle soluzioni di cloud non concepite specificatamente per Node.js, come **Nodejitsu** o **Heroku**, **NON** sono compatibili con Ghost. Funzionano inizialmente, ma cancellano i tuoi file, dunque tutte le immagini caricate e il database scompaiono. Heroku supporta MySQL quindi potresti adoperarlo, ma perderesti ugualmente le immagini caricate.
 
 I seguenti links contengono istruzioni su come configurare:
 
@@ -46,7 +46,7 @@ I seguenti links contengono istruzioni su come configurare:
 
 ## Rendere Ghost permanente
 
-Il metodo precedentemente descritto per avviare Ghost è `npm start`. É valido  per sviluppare localmente e per testare, tuttavia avviare Ghost da riga di comando implica interromperne l'erogazione una volta chiuso il terminale o la sessione SSH. Per evitare che Ghost si interrompa occorre eseguirlo come servizio. Ci sono due modi per arrivare a questo risultato.
+Il metodo precedentemente descritto per avviare Ghost è `npm start`. È valido per sviluppare localmente e per testare, tuttavia avviare Ghost da riga di comando implica interromperne l'erogazione una volta chiuso il terminale o la sessione SSH. Per evitare che Ghost si interrompa occorre eseguirlo come servizio. Ci sono due modi per ottenere questo risultato.
 
 ### Forever ([https://npmjs.org/package/forever](https://npmjs.org/package/forever))
 
@@ -87,7 +87,7 @@ Puoi consultare la [documentazione di Supervisor](http://supervisord.org) per ul
 
 ### Init Script
 
-I sistemi Linux usano scripts di init per avviare al boot del sistema. Questi scripts sono presenti in /etc/init.d. Per rendere Ghost permanente anche in caso di riavvio puoi utilizzare uno script di init. L'esempio seguente funziona con Ubuntu ed è stato testato con **Ubuntu 12.04**.
+I sistemi Linux usano script di init per avviare al boot del sistema. Questi scripts sono presenti in /etc/init.d. Per rendere Ghost permanente anche in caso di riavvio puoi utilizzare uno script di init. L'esempio seguente funziona con Ubuntu ed è stato testato con **Ubuntu 12.04**.
 
 
 *   Crea il file /etc/init.d/ghost:
@@ -134,7 +134,7 @@ I sistemi Linux usano scripts di init per avviare al boot del sistema. Questi sc
     $ sudo update-rc.d ghost enable
     ```
 
-*   Assicuriamoci che il tuo utente possa modificare i file, ad esempio config.js (nella cartella di installazione di Ghost), aggiungendoti al gruppo utenti di ghost:
+*   Assicurati che il tuo utente possa modificare i file, ad esempio config.js (nella cartella di installazione di Ghost), aggiungendoti al gruppo utenti di ghost:
     ```
     $ sudo adduser USERNAME ghost
     ```
@@ -190,20 +190,20 @@ Diamo per scontato che Ghost sia già in esecuzione come servizio in background 
 
 ## Configurare Ghost con SSL <a id="ssl"></a>
 
-Dopo di configurare il tuo dominio, è buona idea assicurare l’interfaccia di amministrazione o forse pure tutto il resto del tuo blog utilizzando HTTPS. Si consiglia la protezione dell’interfaccia di amministrazione con HTTPS perchè il username e password sono tramessi in testo normale se non si attiva la crittografia.
+Dopo aver configurato il tuo dominio, è buona idea assicurare l’interfaccia di amministrazione o anche il resto del tuo blog utilizzando HTTPS. Si consiglia la protezione dell’interfaccia di amministrazione con HTTPS perchè username e password sono tramessi in testo normale se non si attiva la crittografia.
 
-L'esempio seguente mostra come configurare SSL. Partiamo dal presupposto che segui questa guida dall'inizio e quindi stai utilizzando nginx come server proxy. Configurazione con un altro server proxy sarebbe molto simile.
+L'esempio seguente mostra come configurare SSL. Partiamo dal presupposto che segui questa guida dall'inizio e quindi stai utilizzando nginx come server proxy. La configurazione con un altro server proxy sarebbe molto simile.
 
-Prima bisogna ottenere un certificato SSL da un fornitore di certificati affidabile. Il tuo fornitore vi darà istruzioni per generare la tua chiave privata e CRS (certificate signing request). Dopo di avere ricevuto il certificato, copia il file CRT dal tuo fornitore di certificato e il KEY file generato durante la trasmissione del CSR al server.
+Prima bisogna ottenere un certificato SSL da un fornitore di certificati affidabile. Il tuo fornitore ti darà istruzioni per generare la tua chiave privata e CRS (certificate signing request). Dopo aver ricevuto il certificato, copia il file CRT dal tuo fornitore di certificato e il KEY file generato durante la trasmissione del CSR al server.
 
 - `mkdir /etc/nginx/ssl`
 - `cp server.crt /etc/nginx/ssl/server.crt`
 - `cp server.key /etc/nginx/ssl/server.key`
 
-Dopo queste due file sono a posto, è necessario aggiornare la configurazione di nginx.
+Dopo che questi due file sono a posto, è necessario aggiornare la configurazione di nginx.
 
 *   Apri il file di configurazione di nginx con un editor di testo (per esempio `sudo nano /etc/nginx/sites-available/ghost.conf`)
-*   Aggiungi le impostazioni indicate con qui giù con `+` al tuo file di configurazioneÑ
+*   Aggiungi le impostazioni indicate qui sotto con `+` al tuo file di configurazione
 
     ```
      server {
@@ -229,8 +229,8 @@ Dopo queste due file sono a posto, è necessario aggiornare la configurazione di
     $ sudo service nginx restart
     ```
 
-Dopo questi passi, dovrebbe essere possibile aprire la pagina di amministrazione del tuo blog attraverso un collegamento sicuro con HTTPS. Se vuoi che tutto il tuo traffico utilizzi SSL, è possibile modificare il protocollo di impostazioni url nel file config.js a https (per esempio, 'url' https://my-ghost-blog.com '`). Questo forzerà l'uso di SSL per frontend e admin. Qualsiasi richiesta tramite HTTP verrà reindirizzata a HTTPS. Se includi l'immagini nel tuo post che vengono da un dominio HTTP farà apparire un avvertimento 'insecure content'. Script e font da domini HTTP non funzioneranno.
+Dopo questi passi, dovrebbe essere possibile aprire la pagina di amministrazione del tuo blog attraverso un collegamento sicuro con HTTPS. Se vuoi che tutto il tuo traffico utilizzi SSL, è possibile modificare il protocollo di impostazioni url nel file config.js a https (per esempio, 'url' https://my-ghost-blog.com '`). Questo forzerà l'uso di SSL per frontend e admin. Qualsiasi richiesta tramite HTTP verrà reindirizzata a HTTPS. Includere delle immagini nei tuoi post che provengono da un dominio HTTP farà apparire l'avvertimento 'insecure content'. Script e font da domini HTTP non funzioneranno.
 
-Nella maggior parte dei casi vorrete forzare SSL per l'interfaccia di amministrazione e frontend per servire via HTTP e HTTPS. L'opzione `forceAdminSSL: true` è stata introdotta per forzare SSL nella pagina di amministrazione.
+Nella maggior parte dei casi vorrai forzare SSL per l'interfaccia di amministrazione e frontend per servire via HTTP e HTTPS. L'opzione `forceAdminSSL: true` è stata introdotta per forzare SSL nella pagina di amministrazione.
 
-Se avete bisogno di ulteriori informazione sulla configurazione di SSL per il tuo server proxy, la documentazione ufficiale [nginx](http://nginx.org/en/docs/http/configuring_https_servers.html) e [apache](http://httpd.apache.org/docs/current/ssl/ssl_howto.html) sono un posto perfetto per iniziare.
+Se hai bisogno di ulteriori informazioni sulla configurazione di SSL per il tuo server proxy, la documentazione ufficiale [nginx](http://nginx.org/en/docs/http/configuring_https_servers.html) e [apache](http://httpd.apache.org/docs/current/ssl/ssl_howto.html) sono il posto perfetto per iniziare.

--- a/it/installation/index.md
+++ b/it/installation/index.md
@@ -11,13 +11,13 @@ next_section: mac
 
 ## Panoramica <a id="overview"></a>
 
-<p class="note"><strong>Note</strong> Ghost requires Node.js <strong>0.10.x</strong> (latest stable). We recommend Node.js <strong>0.10.30</strong> & npm <strong>1.4.21</strong>.</p>
+<p class="note"><strong>Nota</strong> Ghost richiede Node.js <strong>0.10.x</strong> (l'ultima versione stabile). Ti raccomandiamo Node.js <strong>0.10.30</strong> e npm <strong>1.4.21</strong>.</p>
 
 La documentazione di Ghost è ancora "Work in Progress", viene aggiornata e migliorata regolarmente. Se hai problemi o hai suggerimenti su come migliorare, faccelo sapere.
 
 Ghost è sviluppato in [Node.js](http://nodejs.org), e richiede la versione `0.10.*` (l'ultima versione stabile).
 
-Far funzionare Ghost in locale sul tuo computer è abbastanza semplice, ma prima è necessario che tu installi Node.js.
+Far funzionare Ghost in locale sul tuo computer è abbastanza semplice, ma prima è necessario installare Node.js.
 
 ### Cos'è Node.js?
 

--- a/it/installation/linux.md
+++ b/it/installation/linux.md
@@ -15,18 +15,18 @@ next_section: deploy
 
 # Installazione su Linux <a id="install-linux"></a>
 
-<p class="note"><strong>Note</strong> Ghost requires Node.js <strong>0.10.x</strong> (latest stable). We recommend Node.js <strong>0.10.30</strong> & npm <strong>1.4.21</strong>.</p>
+<p class="note"><strong>Nota</strong> Ghost richiede Node.js <strong>0.10.x</strong> (l'ultima versione stabile). Ti raccomandiamo Node.js <strong>0.10.30</strong> e npm <strong>1.4.21</strong>.</p>
 
 ### Installare Node
 
-*   Si può procedere in due modi: scaricare l'archivio `.tar.gz` da [http://nodejs.org](http://nodejs.org), oppure puoi seguire le istruzioni per [installare dal package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
-*   Controlla di avere Node e npm installati, digitando nel terminale, prima `node -v`, per controllare di avere Node.js installato, e `npm -v` per verificare di aver installato npm.
+*   Puoi procedere in due modi: scaricando l'archivio `.tar.gz` da [http://nodejs.org](http://nodejs.org), oppure seguendo le istruzioni per [installare dal package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager).
+*   Controlla di avere Node.js e npm installati, digitando nel terminale, prima `node -v`, per controllare di avere Node.js installato, e `npm -v` per verificare di aver installato npm.
 
 ### Installare ed eseguire Ghost
 
 **Se stai usando Linux sul tuo desktop, segui le seguenti istruzioni:**
 
-*  Nella [pagina dei download](https://ghost.org/download/), premi il pulsante per scaricare l'ultimo file zip ed estrailo nella cartella da cui vuoi eseguire Ghost.
+*  Nella [pagina dei download](https://ghost.org/download/), premi sul pulsante per scaricare il file zip più recente ed estrailo nella cartella da cui vuoi eseguire Ghost.
 
 
 **Se hai accesso a Linux soltanto come ospite o tramite ssh, e quindi hai a disposizione soltanto il terminale, allora segui queste istruzioni:**
@@ -68,5 +68,5 @@ next_section: deploy
 *   Ghost sarà in esecuzione all'indirizzo **127.0.0.1:2368**<br />
     <span class="note">Puoi cambiare l'indirizzo IP e la porta nel file **config.js**</span>
 
-*   In un browser, visita [http://127.0.0.1:2368](http://127.0.0.1:2368) per vedere il tuo blog Ghost appena installato
-*   Visita [http://127.0.0.1:2368/ghost](http://127.0.0.1:2368/ghost) e crea un utente admin per poter entrare nel pannello di amministrazione.
+*   Nel browser, visita [http://127.0.0.1:2368](http://127.0.0.1:2368) per vedere il tuo blog Ghost appena installato.
+*   Visita [http://127.0.0.1:2368/ghost](http://127.0.0.1:2368/ghost) e crea un utente amministratore per poter entrare nel pannello di amministrazione.

--- a/it/installation/mac.md
+++ b/it/installation/mac.md
@@ -15,31 +15,31 @@ next_section: windows
 
 # Installazione su Mac <a id="install-mac"></a>
 
-<p class="note"><strong>Note</strong> Ghost requires Node.js <strong>0.10.x</strong> (latest stable). We recommend Node.js <strong>0.10.30</strong> & npm <strong>1.4.21</strong>.</p>
+<p class="note"><strong>Nota</strong> Ghost richiede Node.js <strong>0.10.x</strong> (l'ultima versione stabile). Ti raccomandiamo Node.js <strong>0.10.30</strong> e npm <strong>1.4.21</strong>.</p>
 
-Per installare Node.js e Ghost sul tuo mac avrai bisogno di un terminale. Puoi aprirne uno con spotlight scrivendo "Terminal".
+Per installare Node.js e Ghost sul tuo Mac avrai bisogno di una finestra aperta del Terminale. Puoi aprirne una con Spotlight scrivendo "Terminale".
 
-### Installazione di Node
+### Installazione di Node.js
 
-*   Sul sito [http://nodejs.org](http://nodejs.org) premi install e verrà scaricato un file '.pkg'.
-*   Clicca su download per aprire l'installer, che installerà sia node che npm (il gestore di pacchetti di node).
+*   Sul sito [http://nodejs.org](http://nodejs.org) premi install per scaricare un file '.pkg'.
+*   Clicca su download per aprire l'installer, che installerà sia Node.js che npm (il gestore di pacchetti di Node.js).
 *   Avanza nelle fasi di installazione ed alla fine inserisci la tua password e clicca 'install software'.
 *   Una volta che l'installazione è completata, torna nel terminale e scrivi `echo $PATH`. Assicurati che '/usr/local/bin/' sia nel tuo path.
 
 <p class="note"><strong>Nota:</strong> Se '/usr/local/bin' non è presente nel tuo $PATH, dai un'occhiata alla <a href="{% if page.lang %}/{{ page.lang }}{% endif %}/installation/troubleshooting#export-path">risoluzione dei problemi</a> per capire come aggiungerlo.</p>
 
-Se hai problemi e non sai come andare avanti puoi guardare [l'intero processo in azione qui](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-node-mac.gif "Installa Node sul Mac").
+Se hai problemi e non sai come andare avanti puoi guardare [l'intero processo in azione qui](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-node-mac.gif "Installa Node.js sul Mac").
 
 ### Installa e Lancia Ghost
 
 *   Nella [pagina download](https://ghost.org/download/), premi il pulsante per scaricare il file zip più recente.
-*   Clicca sulla freccia a fianco del file appena scaricato, e seleziona 'mostra nel finder'.
-*   Nel finder, fai doppio-click sullo zip scaricato per estrarlo.
-*   Dopodich&egrave;, prendi la cartella 'ghost-#.#.#' appena estratta e trascinala nella barra delle tab del terminale, in modo che venga aperta una nuova tab del terminale nella posizione corretta.
-*   Nella nuova tab scrivi `npm install --production` <span class="note">fai attenzione ai due trattini</span>.
-*   Quando npm ha terminato l'installazione, scrivi `npm start` per lanciare Ghost in modalità sviluppo.
-*   Apri il tuo browser preferito, vai alla pagina <code class="path">127.0.0.1:2368</code> per vedere il tuo nuovo Blog Ghost.
-*   Visita la pagina <code class="path">127.0.0.1:2368/ghost</code> per creare un utente admin e loggarti all'interno di Ghost.
+*   Clicca sulla freccia a fianco del file appena scaricato, e seleziona 'Mostra nel Finder'.
+*   Nel Finder, fai doppio-click sullo zip scaricato per estrarlo.
+*   Dopodich&egrave;, prendi la cartella 'ghost-#.#.#' appena estratta e trascinala nella barra delle tab del terminale, in modo che venga aperta un nuovo pannello del terminale nella posizione corretta.
+*   Nel nuovo pannello scrivi `npm install --production` <span class="note">fai attenzione ai due trattini</span>.
+*   Quando npm ha terminato l'installazione, scrivi `npm start` per lanciare Ghost in modalità sviluppo (development mode).
+*   Apri il tuo browser preferito e vai alla pagina <code class="path">127.0.0.1:2368</code> per vedere il tuo nuovo Blog Ghost.
+*   Visita la pagina <code class="path">127.0.0.1:2368/ghost</code> per creare un utente amministratore e loggarti all'interno di Ghost.
 *   Guarda la [documentazione sull'utilizzo](/usage) per i prossimi passi.
 
 ![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-mac.gif)

--- a/it/installation/troubleshooting.md
+++ b/it/installation/troubleshooting.md
@@ -18,7 +18,7 @@ prev_section: upgrading
     <dt id="export-path">'/usr/local/bin' non appare in $PATH</dt>
     <dd>Puoi aggiungerlo come segue:
         <ul>
-            <li>Da terminale digita <code>cd ~</code>, ti porterà alla tua cartella home (per digitare il carattere ~ con la tastiera italiana, premi ALT + 126)</li>
+            <li>Da terminale digita <code>cd ~</code>, ti porterà alla tua cartella home (per digitare il carattere ~ con la tastiera italiana, premi ALT + 126 o ALT + 5 su Mac~)</li>
             <li>Ora digita <code>ls -al</code> per mostrare tutti i files e le sottocartelle in questa cartella, inclusi quelli nascosti</li>
             <li>Dovresti vedere un file <code class="path">.profile</code> o <code class="path">.bash_profile</code>, in caso contrario digita <code>touch .bash_profile</code> per crearlo</li>
             <li>Successivamente digita <code>open -a Textedit .bash_profile</code> per aprire il file con Textedit.</li>
@@ -28,11 +28,11 @@ prev_section: upgrading
     </dd>
     <dt id="sqlite3-errors">SQLite3 non si installa</dt>
     <dd>
-        <p>Il pacchetto SQLite3 comprende binari precompilati per le più comuni architetture. Se stai usando una distro linux meno popolare o altri sistemi unix-like, potresti ottenere da SQLite3 un errore 404 in quanto non è in grado di trovare i binari per la tua piattaforma.</p>
-        <p>La soluzione è forzare la ricompilazione di SQLite3. Ti occorreranno Python & gcc. Prova ad eseguire <code>npm install sqlite3 --build-from-source</code></p>
-        <p>In caso di errore probabilmente ti mancano dipendenze di Python o di gcc, su Linux prova ad eseguire <code>sudo npm install -g node-gyp</code>, <code>sudo apt-get install build-essential</code> e <code>sudo apt-get install python-software-properties python g++ make</code> prima di riprovare a compilare il sorgente.</p>
+        <p>Il pacchetto SQLite3 comprende binari precompilati per le più comuni architetture. Se stai usando una distro Linux meno popolare o altri sistemi Unix-like, potresti ottenere da SQLite3 un errore 404 in quanto non è in grado di trovare i binari per la tua piattaforma.</p>
+        <p>La soluzione è forzare la ricompilazione di SQLite3. Ti occorreranno Python e gcc. Prova ad eseguire <code>npm install sqlite3 --build-from-source</code></p>
+        <p>In caso di errore probabilmente ti mancano dipendenze di Python o di gcc: su Linux prova ad eseguire <code>sudo npm install -g node-gyp</code>, <code>sudo apt-get install build-essential</code> e <code>sudo apt-get install python-software-properties python g++ make</code> prima di riprovare a compilare il sorgente.</p>
         <p>Per ulteriori informazioni sulla compilazione consulta: <a href="https://github.com/developmentseed/node-sqlite3/wiki/Binaries">https://github.com/developmentseed/node-sqlite3/wiki/Binaries</a></p>
-        <p>Una volta compilati i binari per la tua piattaforma, segui le <a href="https://github.com/developmentseed/node-sqlite3/wiki/Binaries#creating-new-binaries">instruzioni qui</a> per inoltrare i binari al progetto node-sqlite, affinché i futuri utenti non incorreranno nello stesso problema.</p>
+        <p>Una volta compilati i binari per la tua piattaforma, segui le <a href="https://github.com/developmentseed/node-sqlite3/wiki/Binaries#creating-new-binaries">istruzioni qui</a> per inoltrare i binari al progetto node-sqlite, affinché i futuri utenti non incorrano nello stesso problema.</p>
     </dd>
     <dt id="image-uploads">Non riesco a fare l'upload delle immagini</dt>
     <dd>
@@ -42,7 +42,7 @@ prev_section: upgrading
         <ul>
             <li>Accedi al tuo server e digita <code>sudo nano /etc/nginx/conf.d/default.conf</code> per aprire il file di configurazione.</li>
             <li>Dopo la riga con <code>server_name</code> aggiungi: <code>client_max_body_size 10M;</code></li>
-            <li>Infine premi <kbd>ctrl</kbd> + <kbd>x</kbd> per uscire. Nano ti chiederà se vuoi salvare, quindi digita <kbd>y</kbd> per acconsentire e premi <kbd>enter</kbd> per salvare il file.</li>
+            <li>Infine premi <kbd>ctrl</kbd> + <kbd>x</kbd> per uscire; nano ti chiederà se vuoi salvare, quindi digita <kbd>y</kbd> per acconsentire e premi <kbd>Invio</kbd> per salvare il file.</li>
         </ul>
     </dd>
 </dl>

--- a/it/installation/upgrading.md
+++ b/it/installation/upgrading.md
@@ -18,7 +18,7 @@ Aggiornare Ghost è una vera passeggiata.
 
 Ci sono un paio di modi. Verranno prima descritti i passi generici da seguire, e poi nel dettaglio come procedere in maniera [punta e clicca](#how-to) e [linea di comando](#cli), in modo che tu possa scegliere il metodo con il quale ti trovi meglio.
 
-<p class="note"><strong>Fai un Backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
+<p class="note"><strong>Fai un backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
 
 ## Panoramica
 
@@ -28,7 +28,7 @@ Ghost, una volta installato, ha una struttura simile a quella mostrata sulla sin
 
 Aggiornare Ghost significa semplicemente sostituire i file vecchi con quelli nuovi, ri-eseguire `npm install` per aggiornare le dipendenze nella cartella <code class="path">node_modules</code> e poi far ripartire Ghost in modo che le modifiche abbiano effetto.
 
-Ricorda, Ghost di default salva tutti i tuoi dati (temi, immagini, etc) nella cartella <code class="path">content</code>, quindi fai attenzione a non toccarla! Sostituisci solo i file nella cartella <code class="path">core</code> e nella root, e tutto andrà bene.
+Ricorda, Ghost di default salva tutti i tuoi dati (temi, immagini, etc) nella cartella <code class="path">content</code>, quindi fai attenzione a non toccarla! Sostituisci solo i file nella cartella <code class="path">core</code> e nella root e tutto andrà bene.
 
 ## Come eseguire un backup <a id="backing-up"></a>
 
@@ -37,14 +37,14 @@ Ricorda, Ghost di default salva tutti i tuoi dati (temi, immagini, etc) nella ca
 *   Per fare il backup di tutti i tuoi dati nel database, fai il login in Ghost e vai alla pagina <code class="path">/ghost/debug/</code>. Premi il pulsante "Export" per scaricare un file JSON contenente tutti i tuoi dati. Fatto.
 *   Per fare il backup dei tuoi temi e le immagini che hai caricato, devi fare una copia di tutti i file che trovi nelle cartelle <code class="path">content/themes</code> e <code class="path">content/images</code>.
 
-<p class="note"><strong>Nota:</strong> Se vuoi, puoi fare una copia del database direttamente dalla cartella <code class="path">content/data</code> ma Ghost <strong>non deve</strong> essere in esecuzione. Per favore, prima termina il processo.</p>
+<p class="note"><strong>Nota:</strong> Se vuoi, puoi fare una copia del database direttamente dalla cartella <code class="path">content/data</code> ma Ghost <strong>non deve</strong> essere in esecuzione. Per favore, prima ferma il processo.</p>
 
 
 ## Come effettuare l'aggiornamento <a id="how-to"></a>
 
 Come fare l'aggiornamento sulla tua macchina locale.
 
-<p class="warn"><strong>ATTENZIONE:</strong> <strong>NON</strong> copiare e incollare tutta la cartella Ghost in un'installazione esistente su mac. <strong>NON</strong> scegliere <kbd>SOSTITUISCI</kbd> se stai facendo l'upload con transmit o altri software FTP, scegli <strong>UNISCI</strong>.</p>
+<p class="warn"><strong>ATTENZIONE:</strong> <strong>NON</strong> copiare e incollare tutta la cartella Ghost in un'installazione esistente su Mac. <strong>NON</strong> scegliere <kbd>SOSTITUISCI</kbd> se stai facendo l'upload con transmit o altri software FTP, scegli <strong>UNISCI</strong>.</p>
 
 *   Scarica l'ultima versione di Ghost da [Ghost.org](http://ghost.org/download/)
 *   Estrai lo zip in una posizione temporanea
@@ -56,11 +56,11 @@ Come fare l'aggiornamento sulla tua macchina locale.
 
 ## Linea di comando <a id="cli"></a>
 
-<p class="note"><strong>Fai un Backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
+<p class="note"><strong>Fai un backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
 
 ### Linea di comando su mac <a id="cli-mac"></a>
 
-Lo screencast qua sotto mostra come aggiornare Ghost ponendo che il file zip sia stato scaricato nella cartella <code class="path">~/Downloads</code> e che Ghost sia installato in <code class="path">~/ghost</code>. <span class="note">**Nota:** `~` indica la cartella home su mac e linux</span>
+Lo screencast qua sotto mostra come aggiornare Ghost ponendo che il file zip sia stato scaricato nella cartella <code class="path">~/Downloads</code> e che Ghost sia installato in <code class="path">~/ghost</code>. <span class="note">**Nota:** `~` indica la cartella home su Mac e Linux</span>
 
 ![Upgrading Ghost](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/mac-update.gif)
 
@@ -91,7 +91,7 @@ I passi nello screencast sono:
 
 ### Come aggiornare una Droplet su DigitalOcean <a id="digitalocean"></a>
 
-<p class="note"><strong>Fai un Backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
+<p class="note"><strong>Fai un backup!</strong> Prima di aggiornare è sempre bene effettuare un backup. Prima leggi <a href="#backing-up">come eseguire un backup</a>!</p>
 
 *   Prima di tutto devi trovare l'URL dalla quale scaricare l'ultima release di Ghost. Dovrebbe essere simile a `http://ghost.org/zip/ghost-latest.zip`
 *   Una volta che hai l'URL per la versione più recente, nella console della tua Droplet esegui `cd /var/www/` per spostarti dove c'è la tua codebase di Ghost

--- a/it/installation/windows.md
+++ b/it/installation/windows.md
@@ -14,20 +14,20 @@ next_section: linux
 
 # Installazione su Windows <a id="install-windows"></a>
 
-<p class="note"><strong>Note</strong> Ghost requires Node.js <strong>0.10.x</strong> (latest stable). We recommend Node.js <strong>0.10.30</strong> & npm <strong>1.4.21</strong>.</p>
+<p class="note"><strong>Nota</strong> Ghost richiede Node.js <strong>0.10.x</strong> (l'ultima versione stabile). Ti raccomandiamo Node.js <strong>0.10.30</strong> e npm <strong>1.4.21</strong>.</p>
 
 ### Installare Node.js
 
 *   Su [http://nodejs.org](http://nodejs.org) clicca installa, per scaricare il file '.msi'.
-*   Clicca sul file scaricato per aprire il programma di installazione; in questo modo installi sia Node.js che npm.
-*   Prosegui con le istruzioni mostrate dal programma di installazione, fino a quando sullo schermo non comparirà un messaggio che conferma l'installazione per Node.js.
+*   Clicca sul file scaricato per aprire il programma di installazione; in questo modo installi sia Node che npm.
+*   Prosegui con le istruzioni mostrate dal programma di installazione, fino a quando sullo schermo non comparirà un messaggio che conferma l'installazione per Node.
 
 Se hai problemi in questa fase, guarda tutto [questo video](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-node-win.gif "Installa node su Windows"), ti può aiutare.
 
 ### Scarica ed estrai Ghost
 
-*   Nella [pagina dei download](https://ghost.org/download/), premi sul pulsante per scaricare l'ultimo file zip.
-*   Clicca sulla freccia 'next' (avanti) per scaricare il file più recente, e scegli 'mostra nella cartella'.
+*   Nella [pagina dei download](https://ghost.org/download/), premi sul pulsante per scaricare il file zip più recente.
+*   Clicca sulla freccia 'Next' (avanti) per scaricare il file più recente, e scegli 'Mostra nella cartella'.
 *   Quando si apre la cartella, clicca con il pulsante destro del mouse sul file zip scaricato e scegli 'Estrai tutto'.
 
 Se hai problemi, guarda il video per l'intero [processo passo dopo passo](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-win.gif "Installare Ghost su Windows - Parte 1").
@@ -35,11 +35,11 @@ Se hai problemi, guarda il video per l'intero [processo passo dopo passo](https:
 ### Installa ed Esegui Ghost
 
 *   Nel tuo menu Start, cerca 'Node.js' e scegli la voce 'Node.js Command Prompt' (Prompt dei comandi Node.js).
-*   Nel prompt dei comandi di Node, devi posizionarti all'interno della cartella dove hai estratto Ghost. Digita: `cd Downloads/ghost-#.#.#` (sostituisci gli hash con la versione di Ghost che hai scaricato).
+*   Nel prompt dei comandi di Node.js, devi posizionarti all'interno della cartella dove hai estratto Ghost. Digita: `cd Downloads/ghost-#.#.#` (sostituisci gli hash con la versione di Ghost che hai scaricato).
 *   Ora, nel prompt dei comandi, digita `npm install --production` <span class="note">fai atttenzione ai due trattini</span>.
 *   Quando npm ha terminato di installare, digita `npm start` per avviare Ghost in modalità sviluppo (development mode).
-*   Nel browser, digita nella barra dell'url <code class="path">127.0.0.1:2368</code> per vedere il tuo blog Ghost funzionante
+*   Nel browser, digita nella barra dell'url <code class="path">127.0.0.1:2368</code> per vedere il tuo blog Ghost funzionante.
 *   Nella barra dell'url, digita <code class="path">127.0.0.1:2368/ghost</code> e crea il tuo utente amministratore per loggarti e gestire la tua installazione di Ghost, in modalità sviluppo.
-*   Vedi la [documentazione di riferimento](/usage) per altre istruzioni successive
+*   Guarda la [documentazione sull'utilizzo](/usage) per i prossimi passi.
 
 ![](https://s3-eu-west-1.amazonaws.com/ghost-website-cdn/install-ghost-win-2.gif "Installare Ghost su Windows - Parte 2")

--- a/it/mail/index.md
+++ b/it/mail/index.md
@@ -10,7 +10,7 @@ chapter: mail
 
 ## Configurazione Email <a id="email-config"></a>
 
-La documentazione seguente, spiega come configurare le email in Ghost. Ghost utilizza [Nodemailer](https://github.com/andris9/Nodemailer), la loro documentazione contiene diversi altri esempi di configurazione. 
+La documentazione seguente spiega come configurare le email in Ghost. Ghost utilizza [Nodemailer](https://github.com/andris9/Nodemailer), la loro documentazione contiene diversi altri esempi di configurazione. 
 
 ### Cosa aspetti?
 
@@ -18,7 +18,7 @@ Se hai familiarità con PHP, allora sarai abituato ad avere le email magicamente
 
 Ma non aver paura, configurare le email è una cosa che va fatta una sola volta e questa guida ti darà una mano.
 
-### Ma perchè?
+### Ma perché?
 
 Al momento, l'unico utilizzo delle email da parte di Ghost è durante l'invio di una nuova password nel caso dimenticassi la tua. Non è molto, ma non sottovalutare l'utilità di questa funzione nel caso ne dovessi mai aver bisogno.
 

--- a/it/quickstart/quickstart.md
+++ b/it/quickstart/quickstart.md
@@ -10,19 +10,19 @@ section: quickstart
 
 # Panoramica <a id="overview"></a>
 
-La Guida ai Primi passi con Ghost è indicata a coloro che hanno già familiarità con [Node](http://nodejs.org), o tecnologie simili come ruby on rails. Se sei nuovo da queste parti, è consigliabile cominciare dalla [Guida all'installazione](/installation.html).
+La Guida ai Primi passi con Ghost è indicata a coloro che hanno già familiarità con [Node](http://nodejs.org), o tecnologie simili come Ruby on Rails. Se sei nuovo da queste parti, è consigliabile cominciare dalla [Guida all'installazione](/installation.html).
 
 ## Metti Ghost in funzione locale <a id="ghost-local"></a>
 
 Ghost richiede Node versione `0.10.*` (l'ultima versione stabile).
 
-Se ancora non l'avete, vai a <http://nodejs.org> e scarica l'ultima versione di Node.js. L'installer configurerá Node e npm, l'eccellente gestore di pacchetti di Node.
+Se ancora non ce l'hai, vai su <http://nodejs.org> e scarica l'ultima versione di Node.js. L'installer configurerà Node e npm, l'eccellente gestore di pacchetti di Node.
 
-Per gli utenti di Linux, piuttosto di installare dall'archivio `.tar.gz`, si consiglia [installare dal package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
+Per gli utenti di Linux, piuttosto che installare dall'archivio `.tar.gz`, si consiglia di [installare dal package manager](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager)
 
 Scarica l'ultima versione di Ghost da [Ghost.org/download/](https://ghost.org/download/). Estrai l'archivio nella cartella in cui vuoi eseguire Ghost - ovunque sia!
 
-Apri un terminale (mac/linux) o prompt dei comandi (windows) e raggiungi la cartella root del tuo achivio estratto di Ghost (dove si trova .json).
+Apri un terminale (Mac/Linux) o prompt dei comandi (Windows) e raggiungi la cartella dove hai estratto l'archivio di Ghost (dove si trova .json).
 
 Per installare Ghost, lancia `npm install --production`
 

--- a/zh_TW/installation/mac.md
+++ b/zh_TW/installation/mac.md
@@ -4,7 +4,7 @@ layout: installation
 meta_title: 如何在主機上安裝 Ghost - Ghost 繁體中文文件
 meta_description: 這裡詳細敘述如何在本地或遠端環境中安裝 Ghost 部落格平台。
 heading: 安裝 Ghost &amp; 開始嘗試
-subheading:開始創建新部落格的第一步
+subheading: 開始創建新部落格的第一步
 permalink: /zh_TW/installation/mac/
 chapter: installation
 section: mac


### PR DESCRIPTION
I'm reviewing the italian translation of the docs, here are some fixes
- Added translation for Node.js installation note
- Fixed some major translation error and weird expressions
- Fixed inconsistencies of Node.js name (sometimes called node, Node, node.js)
- Removed plurals of english terms (as explained [here](http://www.treccani.it/magazine/lingua_italiana/domande_e_risposte/grammatica/grammatica_391.html))
- Rephrased some sentences that were too literal in favor of a more clear translation
- Fixed some unnecessary person change in verbs
- Fixed some typos
