### PR TITLE
Implements setting specific body classes

### DIFF
--- a/core/client/routes/settings/about.js
+++ b/core/client/routes/settings/about.js
@@ -1,6 +1,9 @@
 import loadingIndicator from 'ghost/mixins/loading-indicator';
+import styleBody from 'ghost/mixins/style-body';
 
-var SettingsAboutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, {
+var SettingsAboutRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, loadingIndicator, {
+    classNames: ['settings-view-about'],
+
     cachedConfig: false,
     model: function () {
         var cachedConfig = this.get('cachedConfig'),

--- a/core/client/routes/settings/apps.js
+++ b/core/client/routes/settings/apps.js
@@ -1,6 +1,9 @@
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
+import styleBody from 'ghost/mixins/style-body';
 
-var AppsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, CurrentUserSettings, {
+var AppsRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, CurrentUserSettings, {
+    classNames: ['settings-view-apps'],
+
     beforeModel: function () {
         if (!this.get('config.apps')) {
             return this.transitionTo('settings.general');

--- a/core/client/routes/settings/general.js
+++ b/core/client/routes/settings/general.js
@@ -1,7 +1,10 @@
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
+import styleBody from 'ghost/mixins/style-body';
 
-var SettingsGeneralRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, CurrentUserSettings, {
+var SettingsGeneralRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, loadingIndicator, CurrentUserSettings, {
+    classNames: ['settings-view-general'],
+
     beforeModel: function () {
         return this.currentUser()
             .then(this.transitionAuthor())

--- a/core/client/routes/settings/users/index.js
+++ b/core/client/routes/settings/users/index.js
@@ -1,4 +1,5 @@
 import PaginationRouteMixin from 'ghost/mixins/pagination-route';
+import styleBody from 'ghost/mixins/style-body';
 
 var paginationSettings = {
     page: 1,
@@ -6,7 +7,9 @@ var paginationSettings = {
     status: 'all'
 };
 
-var UsersIndexRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, PaginationRouteMixin, {
+var UsersIndexRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, styleBody, PaginationRouteMixin, {
+    classNames: ['settings-view-users'],
+
     setupController: function (controller, model) {
         this._super(controller, model);
         this.setupPagination(paginationSettings);

--- a/core/client/routes/settings/users/user.js
+++ b/core/client/routes/settings/users/user.js
@@ -1,4 +1,8 @@
-var SettingsUserRoute = Ember.Route.extend({
+import styleBody from 'ghost/mixins/style-body';
+
+var SettingsUserRoute = Ember.Route.extend(styleBody, {
+    classNames: ['settings-view-user'],
+
     model: function (params) {
         var self = this;
         // TODO: Make custom user adapter that uses /api/users/:slug endpoint


### PR DESCRIPTION
closes #4116
- Adds css classes to settings views

---

@JohnONolan 
1. All settings pages have the class `settings` - should that be kept?
2. Should there be a `settings-view-index` class on the settings.index route which is used on mobile to display only the menu?
