### PR TITLE
Fix leave modal when leaving new post

### DIFF
--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -15,6 +15,7 @@ var EditorNewRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, base
     setupController: function (controller, model) {
         this._super(controller, model);
         controller.set('scratch', '');
+        controller.set('titleScratch', '');
 
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', Ember.A());


### PR DESCRIPTION
no ref
- set titleScratch to empty string if unset

---
1. Click "New Post"
2. Click "Back"
3. Post leave modal appears.
