### PR TITLE
Fix GhostTab and GhostTabPane array dependencies

### DIFF
--- a/core/client/components/gh-tab-pane.js
+++ b/core/client/components/gh-tab-pane.js
@@ -6,7 +6,8 @@ var TabPane = Ember.Component.extend({
         return this.nearestWithProperty('isTabsManager');
     }),
 
-    tab: Ember.computed('tabsManager.tabs.@each', function () {
+    tab: Ember.computed('tabsManager.tabs.[]', 'tabsManager.tabPanes.[]',
+    function () {
         var index = this.get('tabsManager.tabPanes').indexOf(this),
             tabs = this.get('tabsManager.tabs');
 


### PR DESCRIPTION
No issue
- TabPanes weren't finding their tab due to not listing all their dependencies in Ember.computed

I'm sorry :(
## Issue Summary

Tab panes aren't finding their tabs correctly! Without its tab, a tab pane can't know if it's active or not.
## Repro Steps
1. Go to the PSM
2. Click on the `Meta Data` tab to go to the metadata pane
3. Open the ember inspector, view all components, find the gh-tab-pane, look at its "tab" property. It is undefined

Why?
The tab-pane looks before its tab before either it or its tab have been registered with the manager. That's not a problem, so long as it looks again after the tab manager's tabs and tab-panes lists have been modified, but it's not doing that.
## Fix

First off, if you look at the code for a tab-pane to find its tab, you'll see it is doing a `Ember.get` on two different properties, but only depends on one of them. That's not good. Secondly, `@each` looks at the properties of objects in an array, rather than the length of the array itself, which is what `[]` is for.
