### PR TITLE
Fix publish bar tag scrolling div

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -641,6 +641,8 @@ body.zen {
     align-self: auto;
     margin-right: 10px;
     position: relative;
+    height: 40px;
+    overflow-y: hidden;
 
     .tags-wrapper {
         white-space: nowrap;
@@ -648,6 +650,7 @@ body.zen {
         -webkit-overflow-scrolling: touch;
         padding-top: 8px;
         padding-bottom: 9px;
+        height: 70px;
     }
 
     &:after {


### PR DESCRIPTION
Continues on from #4128
- Increases height of tags div and adds `overflow-y: hidden;` to its parent

In browsers with always-visible scrollbars, the tags were a bit screwed up. This fixes that.

![ss 2014-09-24 at 02 39 08](https://cloud.githubusercontent.com/assets/390392/4389499/aeeb4c72-43f5-11e4-992b-80a1405c0ee3.png)
