### PR TITLE
Enable cycling header levels with ctrl+h.

### DIFF
--- a/core/client/templates/modals/markdown.hbs
+++ b/core/client/templates/modals/markdown.hbs
@@ -53,17 +53,17 @@
             <tr>
                 <td>H1</td>
                 <td># Heading</td>
-                <td>Ctrl + Alt + 1</td>
+                <td></td>
             </tr>
             <tr>
                 <td>H2</td>
                 <td>## Heading</td>
-                <td>Ctrl + Alt + 2</td>
+                <td>Ctrl/⌘ + H</td>
             </tr>
             <tr>
                 <td>H3</td>
                 <td>### Heading</td>
-                <td>Ctrl + Alt + 3</td>
+                <td>Ctrl/⌘ + H (x2)</td>
             </tr>
             </tbody>
         </table>

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -21,14 +21,7 @@ shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'
 shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
 shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
 shortcuts[ctrlOrCmd + '+shift+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
-
-//Headings
-shortcuts['ctrl+alt+1'] = {action: 'codeMirrorShortcut', options: {type: 'h1'}};
-shortcuts['ctrl+alt+2'] = {action: 'codeMirrorShortcut', options: {type: 'h2'}};
-shortcuts['ctrl+alt+3'] = {action: 'codeMirrorShortcut', options: {type: 'h3'}};
-shortcuts['ctrl+alt+4'] = {action: 'codeMirrorShortcut', options: {type: 'h4'}};
-shortcuts['ctrl+alt+5'] = {action: 'codeMirrorShortcut', options: {type: 'h5'}};
-shortcuts['ctrl+alt+6'] = {action: 'codeMirrorShortcut', options: {type: 'h6'}};
+shortcuts[ctrlOrCmd + '+h'] = {action: 'codeMirrorShortcut', options: {type: 'cycleHeaderLevel'}};
 
 //Formatting
 shortcuts['ctrl+q'] = {action: 'codeMirrorShortcut', options: {type: 'blockquote'}};


### PR DESCRIPTION
Note: This is a cleaned up version of #3484 - I've rebased it and modified the behaviour to cycle through h2 and h3, otherwise it's the same PR & it's @rwjblue's commit ;)
- Remove preexisting `ctrl+h` keymap.
- Add logic to cycle the header level.
  - Loops around after h3.
  - Sets cursor position to end of heading
  - Set initial level to h2.
- Remove `ctrl+alt+${NUM}` keymaps (as they do not work
  internationally).
