### PR TITLE
Minor shortcut amends

### DIFF
--- a/core/client/components/gh-codemirror.js
+++ b/core/client/components/gh-codemirror.js
@@ -64,7 +64,15 @@ var Codemirror = Ember.TextArea.extend(MarkerManager, {
             dragDrop:       false,
             extraKeys: {
                 Home:   'goLineLeft',
-                End:    'goLineRight'
+                End:    'goLineRight',
+                'Ctrl-U': false,
+                'Cmd-U': false,
+                'Shift-Ctrl-U': false,
+                'Shift-Cmd-U': false,
+                'Ctrl-S': false,
+                'Cmd-S': false,
+                'Ctrl-D': false,
+                'Cmd-D': false
             }
         });
 

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -17,9 +17,9 @@ shortcuts['ctrl+alt+u'] = {action: 'codeMirrorShortcut', options: {type: 'strike
 shortcuts[ctrlOrCmd + '+b'] = {action: 'codeMirrorShortcut', options: {type: 'bold'}};
 shortcuts[ctrlOrCmd + '+i'] = {action: 'codeMirrorShortcut', options: {type: 'italic'}};
 
-shortcuts['ctrl+U'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
-shortcuts['ctrl+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
-shortcuts['ctrl+alt+shift+U'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
+shortcuts['ctrl+u'] = {action: 'codeMirrorShortcut', options: {type: 'uppercase'}};
+shortcuts['ctrl+shift+u'] = {action: 'codeMirrorShortcut', options: {type: 'lowercase'}};
+shortcuts['ctrl+alt+shift+u'] = {action: 'codeMirrorShortcut', options: {type: 'titlecase'}};
 shortcuts[ctrlOrCmd + '+shift+c'] = {action: 'codeMirrorShortcut', options: {type: 'copyHTML'}};
 
 //Headings


### PR DESCRIPTION
issue #1463
- disables some of codemirrors default shortcuts to prevent them clashing
- minor cleanup of shortcut listing

There's probably a lot more improvements I could make here, but this is a start.
