### PR TITLE
Update top-gh-contribs to get contributors within last 90 days

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -945,7 +945,8 @@ var _              = require('lodash'),
         //     `grunt buildAboutPage --force`
         grunt.registerTask('buildAboutPage', 'Compile assets for the About Ghost page', function () {
             var done = this.async(),
-                templatePath = 'core/client/templates/-contributors.hbs';
+                templatePath = 'core/client/templates/-contributors.hbs',
+                ninetyDaysAgo = Date.now() - (1000 * 60 * 60 * 24 * 90);
 
             if (fs.existsSync(templatePath) && !grunt.option('force')) {
                 grunt.log.writeln('Contributors template already exists.');
@@ -957,7 +958,7 @@ var _              = require('lodash'),
             getTopContribs({
                 user: 'tryghost',
                 repo: 'ghost',
-                releaseTag: '0.4.2',
+                releaseDate: ninetyDaysAgo,
                 count: 20
             }).then(function makeContributorTemplate(contributors) {
                 var contributorTemplate = '<li>\n\t<a href="<%githubUrl%>" title="<%name%>">\n' +

--- a/package.json
+++ b/package.json
@@ -98,6 +98,6 @@
         "should": "~4.0.4",
         "sinon": "~1.10.3",
         "supertest": "~0.13.0",
-        "top-gh-contribs": "0.0.1"
+        "top-gh-contribs": "0.0.2"
     }
 }


### PR DESCRIPTION
Closes #4130
- Fixed up the dependency to take a date in MS and divide it by 1k, as GH's API doesn't do MS [ref](https://github.com/novaugust/top-gh-contribs/commit/034f5fd5a08de6f03e853e521f8d2574073ce438)
