### PR TITLE
Fix cache-control header for API routes

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -311,6 +311,7 @@ setupMiddleware = function (blogAppInstance, adminApp) {
     // ### Caching
     blogApp.use(middleware.cacheControl('public'));
     adminApp.use(middleware.cacheControl('private'));
+    blogApp.use(routes.apiBaseUri, middleware.cacheControl('private'));
 
     // enable authentication
     blogApp.use(middleware.authenticate);

--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -9,14 +9,7 @@ var request    = require('supertest'),
     should     = require('should'),
 
     testUtils  = require('../../utils'),
-    ghost      = require('../../../../core'),
-
-    cacheRules = {
-        public: 'public, max-age=0',
-        hour:  'public, max-age=' + testUtils.ONE_HOUR_S,
-        year:  'public, max-age=' + testUtils.ONE_YEAR_S,
-        private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-    };
+    ghost      = require('../../../../core');
 
 describe('Admin Routing', function () {
     function doEnd(done) {
@@ -67,7 +60,7 @@ describe('Admin Routing', function () {
         it('should redirect /logout/ to /ghost/signout/', function (done) {
             request.get('/logout/')
                 .expect('Location', '/ghost/signout/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEndNoAuth(done));
         });
@@ -75,7 +68,7 @@ describe('Admin Routing', function () {
         it('should redirect /signout/ to /ghost/signout/', function (done) {
             request.get('/signout/')
                 .expect('Location', '/ghost/signout/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEndNoAuth(done));
         });
@@ -83,7 +76,7 @@ describe('Admin Routing', function () {
         it('should redirect /signup/ to /ghost/signup/', function (done) {
             request.get('/signup/')
                 .expect('Location', '/ghost/signup/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEndNoAuth(done));
         });
@@ -92,7 +85,7 @@ describe('Admin Routing', function () {
         it('should redirect /signin/ to /ghost/', function (done) {
             request.get('/signin/')
                 .expect('Location', '/ghost/')
-                .expect('Cache-Control', cacheRules.public)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(302)
                 .end(doEndNoAuth(done));
         });
@@ -100,7 +93,7 @@ describe('Admin Routing', function () {
         it('should redirect /admin/ to /ghost/', function (done) {
             request.get('/admin/')
                 .expect('Location', '/ghost/')
-                .expect('Cache-Control', cacheRules.public)
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .expect(302)
                 .end(doEndNoAuth(done));
         });
@@ -191,7 +184,7 @@ describe('Admin Routing', function () {
         it('should redirect from /ghost/ to /ghost/setup/ when no user/not installed yet', function (done) {
             request.get('/ghost/')
                 .expect('Location', /ghost\/setup/)
-                .expect('Cache-Control', cacheRules['private'])
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -199,7 +192,7 @@ describe('Admin Routing', function () {
         it('should redirect from /ghost/signin/ to /ghost/setup/ when no user', function (done) {
             request.get('/ghost/signin/')
                 .expect('Location', /ghost\/setup/)
-                .expect('Cache-Control', cacheRules['private'])
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -207,7 +200,7 @@ describe('Admin Routing', function () {
         it('should respond with html for /ghost/setup/', function (done) {
             request.get('/ghost/setup/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['private'])
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -251,14 +244,14 @@ describe('Admin Routing', function () {
 //        it('should respond with html for /ghost/forgotten/', function (done) {
 //            request.get('/ghost/forgotten/')
 //                .expect('Content-Type', /html/)
-//                .expect('Cache-Control', cacheRules['private'])
+//                .expect('Cache-Control', testUtils.cacheRules['private'])
 //                .expect(200)
 //                .end(doEnd(done));
 //        });
 //
 //        it('should respond 404 for /ghost/reset/', function (done) {
 //            request.get('/ghost/reset/')
-//                .expect('Cache-Control', cacheRules['private'])
+//                .expect('Cache-Control', testUtils.cacheRules['private'])
 //                .expect(404)
 //                .expect(/Page Not Found/)
 //                .end(doEnd(done));
@@ -267,7 +260,7 @@ describe('Admin Routing', function () {
 //        it('should redirect /ghost/reset/*/', function (done) {
 //            request.get('/ghost/reset/athing/')
 //                .expect('Location', /ghost\/forgotten/)
-//                .expect('Cache-Control', cacheRules['private'])
+//                .expect('Cache-Control', testUtils.cacheRules['private'])
 //                .expect(302)
 //                .end(doEnd(done));
 //        });

--- a/core/test/functional/routes/api/authentication_test.js
+++ b/core/test/functional/routes/api/authentication_test.js
@@ -36,6 +36,8 @@ describe('Authentication API', function () {
         request.post(testUtils.API.getApiQuery('authentication/token'))
             .send({grant_type: 'password', username: user.email, password: user.password, client_id: 'ghost-admin'})
             .expect('Content-Type', /json/)
+            // TODO: make it possible to override oauth2orize's header so that this is consistent
+            .expect('Cache-Control', 'no-store')
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -55,6 +57,7 @@ describe('Authentication API', function () {
         request.post(testUtils.API.getApiQuery('authentication/token'))
             .send({grant_type: 'password', username: 'invalid@email.com', password: user.password, client_id: 'ghost-admin'})
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(404)
             .end(function (err, res) {
                 if (err) {
@@ -71,6 +74,7 @@ describe('Authentication API', function () {
         request.post(testUtils.API.getApiQuery('authentication/token'))
             .send({grant_type: 'password', username: user.email, password: 'invalid', client_id: 'ghost-admin'})
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(401)
             .end(function (err, res) {
                 if (err) {
@@ -87,6 +91,8 @@ describe('Authentication API', function () {
         request.post(testUtils.API.getApiQuery('authentication/token'))
             .send({grant_type: 'password', username: user.email, password: user.password, client_id: 'ghost-admin'})
             .expect('Content-Type', /json/)
+            // TODO: make it possible to override oauth2orize's header so that this is consistent
+            .expect('Cache-Control', 'no-store')
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -96,6 +102,8 @@ describe('Authentication API', function () {
                 request.post(testUtils.API.getApiQuery('authentication/token'))
                     .send({grant_type: 'refresh_token', refresh_token: refreshToken, client_id: 'ghost-admin'})
                     .expect('Content-Type', /json/)
+                    // TODO: make it possible to override oauth2orize's header so that this is consistent
+                   .expect('Cache-Control', 'no-store')
                     .expect(200)
                     .end(function (err, res) {
                         if (err) {
@@ -113,6 +121,7 @@ describe('Authentication API', function () {
         request.post(testUtils.API.getApiQuery('authentication/token'))
             .send({grant_type: 'refresh_token', refresh_token: 'invalid', client_id: 'ghost-admin'})
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(403)
             .end(function (err, res) {
                 if (err) {

--- a/core/test/functional/routes/api/db_test.js
+++ b/core/test/functional/routes/api/db_test.js
@@ -35,6 +35,7 @@ describe('DB API', function () {
         request.get(testUtils.API.getApiQuery('db/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .expect('Content-Disposition', /Attachment; filename="[A-Za-z0-9._-]+\.json"/)
             .end(function (err, res) {

--- a/core/test/functional/routes/api/error_test.js
+++ b/core/test/functional/routes/api/error_test.js
@@ -30,6 +30,7 @@ describe('Unauthorized', function () {
     describe('Unauthorized API', function () {
         it('can\'t retrieve posts', function (done) {
             request.get(testUtils.API.getApiQuery('posts/'))
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(401)
                 .end(function firstRequest(err, res) {
                     if (err) {

--- a/core/test/functional/routes/api/notifications_test.js
+++ b/core/test/functional/routes/api/notifications_test.js
@@ -43,6 +43,7 @@ describe('Notifications API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send({notifications: [newNotification]})
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {
@@ -77,6 +78,7 @@ describe('Notifications API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send({notifications: [newNotification]})
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -39,6 +39,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -62,6 +63,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/?staticPages=all'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -85,6 +87,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/?staticPages=all&status=all'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -106,6 +109,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/?staticPages=true'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -127,6 +131,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/?status=draft'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -151,6 +156,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -178,6 +184,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/slug/welcome-to-ghost/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -204,6 +211,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/?include=author,tags,created_by'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -229,6 +237,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/7/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -250,6 +259,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/99/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -269,6 +279,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/5/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -288,6 +299,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/8/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -317,6 +329,7 @@ describe('Post API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send(newPost)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {
@@ -340,6 +353,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(draftPost)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -368,6 +382,7 @@ describe('Post API', function () {
                                 .set('Authorization', 'Bearer ' + accesstoken)
                                 .send(publishedPost)
                                 .expect('Content-Type', /json/)
+                                .expect('Cache-Control', testUtils.cacheRules['private'])
                                 .expect(200)
                                 .end(function (err, res) {
                                     if (err) {
@@ -404,6 +419,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/?include=tags'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -420,6 +436,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -448,6 +465,7 @@ describe('Post API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send(newPost)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {
@@ -467,6 +485,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(draftPost)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -491,6 +510,7 @@ describe('Post API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send(newPost)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {
@@ -511,6 +531,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(draftPost)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -528,6 +549,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/?include=tags'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -543,6 +565,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -564,6 +587,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/7/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -579,6 +603,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -600,6 +625,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/7/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -615,6 +641,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(422)
                         .end(function (err, res) {
                             if (err) {
@@ -634,6 +661,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     /*jshint unused:false*/
                     if (err) {
@@ -645,6 +673,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + 'invalidtoken')
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(401)
                         .end(function (err, res) {
                             /*jshint unused:false*/
@@ -661,6 +690,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/?include=tags'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -676,6 +706,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -701,6 +732,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/1/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -715,6 +747,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(404)
                         .end(function (err, res) {
                             if (err) {
@@ -738,6 +771,7 @@ describe('Post API', function () {
             request.del(testUtils.API.getApiQuery('posts/' + deletePostId + '/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -760,6 +794,7 @@ describe('Post API', function () {
             request.del(testUtils.API.getApiQuery('posts/99/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -784,6 +819,7 @@ describe('Post API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .send(newPost)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(201)
                 .end(function (err, res) {
                     if (err) {
@@ -800,6 +836,7 @@ describe('Post API', function () {
                     request.del(testUtils.API.getApiQuery('posts/' + draftPost.posts[0].id + '/'))
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -821,6 +858,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('settings/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -833,6 +871,7 @@ describe('Post API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(jsonResponse)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .end(function (err, res) {
                             /*jshint unused:false*/
                             if (err) {
@@ -847,6 +886,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('settings/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -858,6 +898,7 @@ describe('Post API', function () {
                     request.put(testUtils.API.getApiQuery('settings/'))
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .send(jsonResponse)
                         .end(function (err, res) {
                             /*jshint unused:false*/
@@ -875,6 +916,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/2/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -897,6 +939,7 @@ describe('Post API', function () {
             request.get(testUtils.API.getApiQuery('posts/2/?include=tags'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -911,6 +954,7 @@ describe('Post API', function () {
                     request.put(testUtils.API.getApiQuery('posts/2/'))
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .send(jsonResponse)
                         .expect(200)
                         .end(function (err, res) {

--- a/core/test/functional/routes/api/settings_test.js
+++ b/core/test/functional/routes/api/settings_test.js
@@ -38,6 +38,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -57,6 +58,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/title/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -80,6 +82,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/testsetting/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(404)
             .end(function (err, res) {
                 if (err) {
@@ -99,6 +102,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .end(function (err, res) {
                 if (err) {
                     return done(err);
@@ -119,6 +123,7 @@ describe('Settings API', function () {
                     .set('Authorization', 'Bearer ' + accesstoken)
                     .send(settingToChange)
                     .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
                     .expect(200)
                     .end(function (err, res) {
                         if (err) {
@@ -139,6 +144,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .end(function (err, res) {
                 if (err) {
                     return done(err);
@@ -168,6 +174,7 @@ describe('Settings API', function () {
         request.get(testUtils.API.getApiQuery('settings/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .end(function (err, res) {
                 if (err) {
                     return done(err);
@@ -183,6 +190,7 @@ describe('Settings API', function () {
                     .set('Authorization', 'Bearer ' + accesstoken)
                     .send(jsonResponse)
                     .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
                     .expect(404)
                     .end(function (err, res) {
                         if (err) {

--- a/core/test/functional/routes/api/slugs_test.js
+++ b/core/test/functional/routes/api/slugs_test.js
@@ -37,6 +37,7 @@ describe('Slug API', function () {
         request.get(testUtils.API.getApiQuery('slugs/post/a post title/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -59,6 +60,7 @@ describe('Slug API', function () {
         request.get(testUtils.API.getApiQuery('slugs/post/atag/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -81,6 +83,7 @@ describe('Slug API', function () {
         request.get(testUtils.API.getApiQuery('slugs/user/user name/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -103,6 +106,7 @@ describe('Slug API', function () {
         request.get(testUtils.API.getApiQuery('slugs/app/cool app/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {
@@ -125,6 +129,7 @@ describe('Slug API', function () {
         request.get(testUtils.API.getApiQuery('slugs/unknown/who knows/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(400)
             .end(function (err, res) {
                 if (err) {

--- a/core/test/functional/routes/api/tags_test.js
+++ b/core/test/functional/routes/api/tags_test.js
@@ -37,6 +37,7 @@ describe('Tag API', function () {
         request.get(testUtils.API.getApiQuery('tags/'))
             .set('Authorization', 'Bearer ' + accesstoken)
             .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules['private'])
             .expect(200)
             .end(function (err, res) {
                 if (err) {

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -38,6 +38,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -63,6 +64,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -86,6 +88,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/me/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -107,6 +110,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/1/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -128,6 +132,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -149,6 +154,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/email/jbloggs%40example.com/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -170,6 +176,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/me/?include=roles'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -192,6 +199,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/me/?include=roles,roles.permissions'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -216,6 +224,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/?include=roles,roles.permissions'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(200)
                 .end(function (err, res) {
                     if (err) {
@@ -240,6 +249,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/99/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -259,6 +269,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/slug/blargh/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .end(function (err, res) {
                     if (err) {
@@ -279,6 +290,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/me/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -298,6 +310,7 @@ describe('User API', function () {
                         .set('Authorization', 'Bearer ' + accesstoken)
                         .send(dataToSend)
                         .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
                         .expect(200)
                         .end(function (err, res) {
                             if (err) {
@@ -319,6 +332,7 @@ describe('User API', function () {
             request.get(testUtils.API.getApiQuery('users/me/'))
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .end(function (err, res) {
                     if (err) {
                         return done(err);

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -10,15 +10,7 @@ var request    = require('supertest'),
     moment     = require('moment'),
 
     testUtils  = require('../../utils'),
-    ghost      = require('../../../../core'),
-
-    cacheRules = {
-        public: 'public, max-age=0',
-        day: 'public, max-age=' + testUtils.ONE_DAY_S,
-        hour:  'public, max-age=' + testUtils.ONE_HOUR_S,
-        year:  'public, max-age=' + testUtils.ONE_YEAR_S,
-        private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-    };
+    ghost      = require('../../../../core');
 
 describe('Frontend Routing', function () {
     function doEnd(done) {
@@ -58,7 +50,7 @@ describe('Frontend Routing', function () {
         it('should respond with html', function (done) {
             request.get('/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -66,7 +58,7 @@ describe('Frontend Routing', function () {
         it('should not have as second page', function (done) {
             request.get('/page/2/')
                 .expect('Location', '/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -76,7 +68,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/welcome-to-ghost')
                 .expect('Location', '/welcome-to-ghost/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -91,7 +83,7 @@ describe('Frontend Routing', function () {
         it('should respond with html for valid url', function (done) {
             request.get('/welcome-to-ghost/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -101,7 +93,7 @@ describe('Frontend Routing', function () {
             var date  = moment().format('YYYY/MM/DD');
 
             request.get('/' + date + '/welcome-to-ghost/')
-                // .expect('Cache-Control', cacheRules['private'])
+                // .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));
@@ -109,7 +101,7 @@ describe('Frontend Routing', function () {
 
         it('should 404 for unknown post', function (done) {
             request.get('/spectacular/')
-                .expect('Cache-Control', cacheRules['private'])
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));
@@ -120,7 +112,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/welcome-to-ghost/edit')
                 .expect('Location', '/welcome-to-ghost/edit/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -128,14 +120,14 @@ describe('Frontend Routing', function () {
         it('should redirect to editor', function (done) {
             request.get('/welcome-to-ghost/edit/')
                 .expect('Location', '/ghost/editor/1/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
 
         it('should 404 for non-edit parameter', function (done) {
             request.get('/welcome-to-ghost/notedit/')
-                .expect('Cache-Control', cacheRules['private'])
+                .expect('Cache-Control', testUtils.cacheRules['private'])
                 .expect(404)
                 .expect(/Page Not Found/)
                 .end(doEnd(done));
@@ -186,7 +178,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/rss')
                 .expect('Location', '/rss/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -194,7 +186,7 @@ describe('Frontend Routing', function () {
         it('should respond with xml', function (done) {
             request.get('/rss/')
                 .expect('Content-Type', /xml/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -203,7 +195,7 @@ describe('Frontend Routing', function () {
             request.get('/rss/2/')
                 // TODO this should probably redirect straight to /rss/ with 301?
                 .expect('Location', '/rss/1/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -211,7 +203,7 @@ describe('Frontend Routing', function () {
         it('should get redirected to /rss/ from /feed/', function (done) {
             request.get('/feed/')
                 .expect('Location', '/rss/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -234,7 +226,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/page/2')
                 .expect('Location', '/page/2/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -242,7 +234,7 @@ describe('Frontend Routing', function () {
         it('should respond with html', function (done) {
             request.get('/page/2/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -250,7 +242,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/page/1/')
                 .expect('Location', '/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -259,7 +251,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/page/4/')
                 .expect('Location', '/page/3/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -267,7 +259,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/page/0/')
                 .expect('Location', '/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -282,7 +274,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/rss/2')
                 .expect('Location', '/rss/2/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -290,7 +282,7 @@ describe('Frontend Routing', function () {
         it('should respond with xml', function (done) {
             request.get('/rss/2/')
                 .expect('Content-Type', /xml/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -298,7 +290,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/rss/1/')
                 .expect('Location', '/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -307,7 +299,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/rss/3/')
                 .expect('Location', '/rss/2/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -315,7 +307,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/rss/0/')
                 .expect('Location', '/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -325,7 +317,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/tag/getting-started/rss')
                 .expect('Location', '/tag/getting-started/rss/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -333,7 +325,7 @@ describe('Frontend Routing', function () {
         it('should respond with xml', function (done) {
             request.get('/tag/getting-started/rss/')
                 .expect('Content-Type', /xml/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -341,7 +333,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/tag/getting-started/rss/1/')
                 .expect('Location', '/tag/getting-started/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -350,7 +342,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/tag/getting-started/rss/2/')
                 .expect('Location', '/tag/getting-started/rss/1/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -358,7 +350,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/tag/getting-started/rss/0/')
                 .expect('Location', '/tag/getting-started/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -368,7 +360,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/author/ghost-owner/rss')
                 .expect('Location', '/author/ghost-owner/rss/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -376,7 +368,7 @@ describe('Frontend Routing', function () {
         it('should respond with xml', function (done) {
             request.get('/author/ghost-owner/rss/')
                 .expect('Content-Type', /xml/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -384,7 +376,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/author/ghost-owner/rss/1/')
                 .expect('Location', '/author/ghost-owner/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -393,7 +385,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/author/ghost-owner/rss/3/')
                 .expect('Location', '/author/ghost-owner/rss/2/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -401,7 +393,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/author/ghost-owner/rss/0/')
                 .expect('Location', '/author/ghost-owner/rss/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -411,7 +403,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/static-page-test')
                 .expect('Location', '/static-page-test/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -419,7 +411,7 @@ describe('Frontend Routing', function () {
         it('should respond with xml', function (done) {
             request.get('/static-page-test/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -430,7 +422,7 @@ describe('Frontend Routing', function () {
         // Badly formed regexs can cause breakage if a post slug starts with the 5 letters ghost
         it('should retrieve a blog post with ghost at the start of the url', function (done) {
             request.get('/ghostly-kitchen-sink/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -439,28 +431,28 @@ describe('Frontend Routing', function () {
     describe('Static assets', function () {
         it('should retrieve shared assets', function (done) {
             request.get('/shared/img/user-image.png')
-                .expect('Cache-Control', cacheRules.hour)
+                .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect(200)
                 .end(doEnd(done));
         });
 
         it('should retrieve theme assets', function (done) {
             request.get('/assets/css/screen.css')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(200)
                 .end(doEnd(done));
         });
 
         it('should retrieve built assets', function (done) {
             request.get('/ghost/scripts/vendor-dev.js')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(200)
                 .end(doEnd(done));
         });
 
         it('should retrieve default robots.txt', function (done) {
             request.get('/robots.txt')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect('ETag', /[0-9a-f]{32}/i)
                 .expect(200)
                 .end(doEnd(done));
@@ -468,7 +460,7 @@ describe('Frontend Routing', function () {
 
         it('should retrieve default favicon.ico', function (done) {
             request.get('/favicon.ico')
-                .expect('Cache-Control', cacheRules.day)
+                .expect('Cache-Control', testUtils.cacheRules.day)
                 .expect('ETag', /[0-9a-f]{32}/i)
                 .expect(200)
                 .end(doEnd(done));
@@ -477,7 +469,7 @@ describe('Frontend Routing', function () {
         // at the moment there is no image fixture to test
         // it('should retrieve image assets', function (done) {
         // request.get('/content/images/some.jpg')
-        //    .expect('Cache-Control', cacheRules.year)
+        //    .expect('Cache-Control', testUtils.cacheRules.year)
         //    .end(doEnd(done));
         // });
     });
@@ -502,7 +494,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/tag/injection/page/2')
                 .expect('Location', '/tag/injection/page/2/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -510,7 +502,7 @@ describe('Frontend Routing', function () {
         it('should respond with html', function (done) {
             request.get('/tag/injection/page/2/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -518,7 +510,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/tag/injection/page/1/')
                 .expect('Location', '/tag/injection/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -527,7 +519,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/tag/injection/page/4/')
                 .expect('Location', '/tag/injection/page/3/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -535,7 +527,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/tag/injection/page/0/')
                 .expect('Location', '/tag/injection/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -559,7 +551,7 @@ describe('Frontend Routing', function () {
         it('should redirect without slash', function (done) {
             request.get('/author/ghost-owner/page/2')
                 .expect('Location', '/author/ghost-owner/page/2/')
-                .expect('Cache-Control', cacheRules.year)
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .expect(301)
                 .end(doEnd(done));
         });
@@ -567,7 +559,7 @@ describe('Frontend Routing', function () {
         it('should respond with html', function (done) {
             request.get('/author/ghost-owner/page/2/')
                 .expect('Content-Type', /html/)
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(doEnd(done));
         });
@@ -575,7 +567,7 @@ describe('Frontend Routing', function () {
         it('should redirect page 1', function (done) {
             request.get('/author/ghost-owner/page/1/')
                 .expect('Location', '/author/ghost-owner/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 // TODO: This should probably be a 301?
                 .expect(302)
                 .end(doEnd(done));
@@ -584,7 +576,7 @@ describe('Frontend Routing', function () {
         it('should redirect to last page if page too high', function (done) {
             request.get('/author/ghost-owner/page/4/')
                 .expect('Location', '/author/ghost-owner/page/3/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });
@@ -592,7 +584,7 @@ describe('Frontend Routing', function () {
         it('should redirect to first page if page too low', function (done) {
             request.get('/author/ghost-owner/page/0/')
                 .expect('Location', '/author/ghost-owner/')
-                .expect('Cache-Control', cacheRules['public'])
+                .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(302)
                 .end(doEnd(done));
         });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -538,7 +538,12 @@ module.exports = {
             author: 3
         }
     },
-    ONE_HOUR_S: 3600,
-    ONE_DAY_S: 86400,
-    ONE_YEAR_S: 31536000
+
+    cacheRules: {
+        public: 'public, max-age=0',
+        hour:  'public, max-age=' + 3600,
+        day: 'public, max-age=' + 86400,
+        year:  'public, max-age=' + 31536000,
+        private: 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+    }
 };


### PR DESCRIPTION
closes #4157
- adds cache-control header back to api routes
- moves cache rules object into testUtils
- adds cache-control header test to every existing API test
