### PR TITLE
Clean up hardcoded ghost paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -975,7 +975,7 @@ var _              = require('lodash'),
                 count: 20
             }).then(function makeContributorTemplate(contributors) {
                 var contributorTemplate = '<li>\n\t<a href="<%githubUrl%>" title="<%name%>">\n' +
-                    '\t\t<img src="{{unbound ghostPaths.contributorsDir}}/<%name%>" alt="<%name%>">\n' +
+                    '\t\t<img src="{{gh-path "admin" "/img/contributors"}}/<%name%>" alt="<%name%>">\n' +
                     '\t</a>\n</li>';
 
                 grunt.verbose.writeln('Creating contributors template.');

--- a/core/client/templates/error.hbs
+++ b/core/client/templates/error.hbs
@@ -1,7 +1,7 @@
 <section class="error-content error-404 js-error-container">
     <section class="error-details">
          <figure class="error-image">
-             <img class="error-ghost" {{bind-attr src=ghostPaths.errorImageSrc srcset=ghostPaths.errorImageSrcSet}} />
+             <img class="error-ghost" src="{{gh-path 'admin' '/img/404-ghost@2x.png'}}" srcset="{{gh-path 'admin' '/img/404-ghost.png'}} 1x, {{gh-path 'admin' '/img/404-ghost@2x.png'}} 2x" />
          </figure>
          <section class="error-message">
              <h1 class="error-code">{{code}}</h1>

--- a/core/client/utils/ghost-paths.js
+++ b/core/client/utils/ghost-paths.js
@@ -25,10 +25,6 @@ function ghostPaths() {
         blogRoot: subdir + '/',
         adminRoot: adminRoot,
         apiRoot: apiRoot,
-        contributorsDir: assetUrl('/ghost/img/contributors'),
-        errorImageSrc: assetUrl('/ghost/img/404-ghost@2x.png'),
-        errorImageSrcSet: assetUrl('/ghost/img/404-ghost.png') + ' 1x, ' +
-            assetUrl('/ghost/img/404-ghost@2x.png') + ' 2x',
 
         url: {
             admin: function () {

--- a/core/client/views/application.js
+++ b/core/client/views/application.js
@@ -3,8 +3,6 @@ import mobileQuery from 'ghost/utils/mobile';
 var ApplicationView = Ember.View.extend({
     elementId: 'container',
 
-    blogRoot: Ember.computed.alias('controller.ghostPaths.blogRoot'),
-
     setupGlobalMobileNav: function () {
         // #### Navigating within the sidebar closes it.
         var self = this;


### PR DESCRIPTION
Clean up hardcoded ghost paths

closes #4144
- made contributors template use the `gh-path` helper
- Removing blogRoot from application.js
- made error image use the `gh-path` helper
