### PR TITLE
Abstract the allowed file types out of API

### DIFF
--- a/core/server/api/upload.js
+++ b/core/server/api/upload.js
@@ -1,4 +1,6 @@
-var Promise = require('bluebird'),
+var _       = require('lodash'),
+    config  = require('../config'),
+    Promise = require('bluebird'),
     path    = require('path'),
     fs      = require('fs-extra'),
     storage = require('../storage'),
@@ -7,8 +9,7 @@ var Promise = require('bluebird'),
     upload;
 
 function isImage(type, ext) {
-    if ((type === 'image/jpeg' || type === 'image/png' || type === 'image/gif' || type === 'image/svg+xml')
-            && (ext === '.jpg' || ext === '.jpeg' || ext === '.png' || ext === '.gif' || ext === '.svg' || ext === '.svgz')) {
+    if (_.contains(config.uploads.contentTypes, type) && _.contains(config.uploads.extensions, ext)) {
         return true;
     }
     return false;

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -139,6 +139,11 @@ ConfigManager.prototype.set = function (config) {
             // protected slugs cannot be changed or removed
             reserved: ['admin', 'app', 'apps', 'archive', 'archives', 'categories', 'category', 'dashboard', 'feed', 'ghost-admin', 'login', 'logout', 'page', 'pages', 'post', 'posts', 'public', 'register', 'setup', 'signin', 'signout', 'signup', 'tag', 'tags', 'user', 'users', 'wp-admin', 'wp-login'],
             protected: ['ghost', 'rss']
+        },
+        uploads: {
+            // Used by the upload API to limit uploads to images
+            extensions: ['.jpg', '.jpeg', '.gif', '.png', '.svg', '.svgz'],
+            contentTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
         }
     });
 


### PR DESCRIPTION
closes #1891
- Moves contentType and extension check to config
