### PR TITLE
[WIP] Fix minor styling bugs

### DIFF
--- a/core/client/assets/sass/layouts/auth.scss
+++ b/core/client/assets/sass/layouts/auth.scss
@@ -18,7 +18,7 @@
     }
 
     main {
-        top: 15px;
+        padding-top: 15px;
     }
 
     input {

--- a/core/client/assets/sass/layouts/default.scss
+++ b/core/client/assets/sass/layouts/default.scss
@@ -62,9 +62,7 @@
     top: 0;
     right: 0;
     bottom: 0;
-    overflow: auto;
-    overflow-x: hidden;
-    -webkit-overflow-scrolling: touch;
+    overflow: hidden;
     transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
     transform: translate3d(60px, 0px, 0px);
     body.right-outlet-expanded & {
@@ -78,6 +76,9 @@
         left: 0;
         transform: translate3d(0, 0px, 0px);
         opacity: 1;
+
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
 
         transition: transform $side-outlet-transition-duration cubic-bezier(0.1, 0.7, 0.1, 1);
 

--- a/core/client/assets/sass/layouts/setup.scss
+++ b/core/client/assets/sass/layouts/setup.scss
@@ -14,7 +14,7 @@
     }
 
     main {
-        top: 15px;
+        padding-top: 15px;
         overflow: auto;
         -webkit-overflow-scrolling: touch;
         @media (max-width: 550px) {

--- a/core/client/assets/sass/layouts/setup.scss
+++ b/core/client/assets/sass/layouts/setup.scss
@@ -15,6 +15,8 @@
 
     main {
         top: 15px;
+        overflow: auto;
+        -webkit-overflow-scrolling: touch;
         @media (max-width: 550px) {
             top: 0;
         }


### PR DESCRIPTION
No issue

This is a result of an internal conversation about some bugs in 0.5.2 where some issues were discovered which require really small fixes. These fixes include:
- On Android, the PSM could be horizontally scrolled.
- Notifications on the setup and authentication screens where cut off at the top - [Screenshot](https://cloud.githubusercontent.com/assets/390392/4430393/ddb0e2f4-462c-11e4-9ba2-4a1742393232.png)
- The setup screen wasn't scrollable

Will rebase and rename before removing the [WIP] badge.
