### PR TITLE
Implements Ghost module tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -275,6 +275,13 @@ var _              = require('lodash'),
                     src: [
                         'core/test/functional/routes/**/*_test.js'
                     ]
+                },
+
+                // #### All Module tests
+                module: {
+                    src: [
+                        'core/test/functional/module/**/*_test.js'
+                    ]
                 }
             },
 
@@ -764,7 +771,7 @@ var _              = require('lodash'),
         // details of each of the test suites.
         //
         grunt.registerTask('test', 'Run tests and lint code',
-            ['jshint', 'jscs', 'test-routes', 'test-unit', 'test-integration', 'test-functional']);
+            ['jshint', 'jscs', 'test-routes', 'test-module', 'test-unit', 'test-integration', 'test-functional']);
 
         // ### Lint
         //
@@ -840,6 +847,14 @@ var _              = require('lodash'),
         // quick to test many permutations of routes / urls in the system.
         grunt.registerTask('test-routes', 'Run functional route tests (mocha)',
             ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:routes']);
+
+        // ### Module tests *(sub task)*
+        // `grunt test-module` will run just the module tests
+        //
+        // The purpose of the module tests is to ensure that Ghost can be used as an npm module and exposes all
+        // required methods to interact with it.
+        grunt.registerTask('test-module', 'Run functional module tests (mocha)',
+            ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:module']);
 
         // ### Functional tests for the setup process
         // `grunt test-functional-setup will run just the functional tests for the setup page.

--- a/core/test/functional/module/module_test.js
+++ b/core/test/functional/module/module_test.js
@@ -1,0 +1,60 @@
+/*global describe, it */
+/*jshint expr:true*/
+// # Module tests
+// This tests using Ghost as an npm module
+var should     = require('should'),
+
+    ghost      = require('../../../../core');
+
+describe('Module', function () {
+    describe('Setup', function () {
+        it('should resolve with a ghost-server instance', function (done) {
+            ghost().then(function (ghostServer) {
+                should.exist(ghostServer);
+
+                done();
+            }).catch(function (e) {
+                done(e);
+            });
+        });
+
+        it('should expose an express instance', function (done) {
+            ghost().then(function (ghostServer) {
+                should.exist(ghostServer);
+                should.exist(ghostServer.rootApp);
+
+                done();
+            }).catch(function (e) {
+                done(e);
+            });
+        });
+
+        it('should expose configuration values', function (done) {
+            ghost().then(function (ghostServer) {
+                should.exist(ghostServer);
+                should.exist(ghostServer.config);
+                should.exist(ghostServer.config.server);
+                should.exist(ghostServer.config.paths);
+                should.exist(ghostServer.config.paths.subdir);
+                should.equal(ghostServer.config.paths.subdir, '');
+
+                done();
+            }).catch(function (e) {
+                done(e);
+            });
+        });
+
+        it('should have start/stop/restart functions', function (done) {
+            ghost().then(function (ghostServer) {
+                should.exist(ghostServer);
+                ghostServer.start.should.be.a.Function;
+                ghostServer.restart.should.be.a.Function;
+                ghostServer.stop.should.be.a.Function;
+
+                done();
+            }).catch(function (e) {
+                done(e);
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes #2521
- Add new module tests
- Implements new `test-module` task to specifically run module tests
