### PR TITLE
Change avatars in user list back to cover

### DIFF
--- a/core/client/assets/sass/layouts/users.scss
+++ b/core/client/assets/sass/layouts/users.scss
@@ -76,7 +76,7 @@ a.object-list-item {
     display: block;
     border: 1px solid #979797;
     border-radius: 100%;
-    background-size: 105%;
+    background-size: cover;
     background-position: center center;
 }
 


### PR DESCRIPTION
Closes #4199

`background-size: 105%;` is a nono for square images. `background-size: cover;` is a better.
