### PR TITLE
Follow symlinks when resolving theme paths.

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -98,16 +98,18 @@ validateSettings = function (defaultSettings, model) {
     return Promise.resolve();
 };
 
-// A Promise that will resolve to an object with a property for each installed theme.
-// This is necessary because certain configuration data is only available while Ghost
-// is running and at times the validations are used when it's not (e.g. tests)
-availableThemes = requireTree(config.paths.themePath);
-
 validateActiveTheme = function (themeName) {
     // If Ghost is running and its availableThemes collection exists
     // give it priority.
     if (config.paths.availableThemes && Object.keys(config.paths.availableThemes).length > 0) {
         availableThemes = Promise.resolve(config.paths.availableThemes);
+    }
+
+    if (!availableThemes) {
+        // A Promise that will resolve to an object with a property for each installed theme.
+        // This is necessary because certain configuration data is only available while Ghost
+        // is running and at times the validations are used when it's not (e.g. tests)
+        availableThemes = requireTree(config.paths.themePath);
     }
 
     return availableThemes.then(function (themes) {

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -19,7 +19,7 @@ models = {
         self.Base = require('./base');
 
         // Require all files in this directory
-        return requireTree.readAll(__dirname).then(function (modelFiles) {
+        return requireTree.readAll(__dirname, {followSymlinks: false}).then(function (modelFiles) {
             // For each found file, excluding those we don't want,
             // we will require it and cache it here.
             _.each(modelFiles, function (path, fileName) {


### PR DESCRIPTION
Closes #4225
- If a theme is symlinked in the themes directory, follow
  the symlink so that the theme object is populated correctly.
- Only do the fallback loading of theme data in the validations
  module if it doesn't exist in config.
