### PR TITLE
@media queries abstraction

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "nprogress": "0.1.2",
     "showdown": "git://github.com/ErisDS/showdown.git#v0.3.2-ghost",
     "validator-js": "3.4.0",
-    "google-caja": "5669.0.0"
+    "google-caja": "5669.0.0",
+    "sass-mq": "~1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,6 @@
     "showdown": "git://github.com/ErisDS/showdown.git#v0.3.2-ghost",
     "validator-js": "3.4.0",
     "google-caja": "5669.0.0",
-    "sass-mq": "~1"
+    "sass-mq": "git://github.com/kaelig/sass-mq.git#682753925e952f8c5ec364bdbfd6cddc4f1ded70"
   }
 }

--- a/core/client/assets/sass/components/notifications.scss
+++ b/core/client/assets/sass/components/notifications.scss
@@ -5,7 +5,7 @@
 // Wrapper
 .notifications {
 
-    @media (min-width: 401px) {
+    @include mq(phablet) {
         position: absolute;
         bottom: 0;
         left: 0;
@@ -17,7 +17,7 @@
         }
     }
 
-    @media (max-width: 400px) {
+    @include mq($to: phablet) {
         position: fixed;
         top: 0;
         left: 0;
@@ -61,7 +61,7 @@
     box-shadow: $shadow;
     transform: translateZ(0);
 
-    @media (max-width: 400px) {
+    @include mq($to: phablet) {
         margin-bottom: 1px;
     }
 

--- a/core/client/assets/sass/helpers/variables.scss
+++ b/core/client/assets/sass/helpers/variables.scss
@@ -30,6 +30,30 @@ $list-colours:
 
 
 //
+// Breakpoints
+// --------------------------------------------------
+// Breakpoints referenced in current project state:
+//
+//  <= & > 350px
+//  <= & > 400px
+//  <= & > 500px
+//  <=     550px
+//  <= & > 600px
+//  <= & > 630px
+//  <= & > 650px
+//  >=     768px
+//  <= & > 900px
+//  <= & > 1000px
+
+// Potential candidates for breakpoint naming conventions:
+$mq-breakpoints: (
+    (phablet 401px)
+    (tablet  601px)
+    (desktop 901px)
+    (wide    1001px)
+);
+
+//
 // Styles
 // --------------------------------------------------
 

--- a/core/client/assets/sass/screen.scss
+++ b/core/client/assets/sass/screen.scss
@@ -6,6 +6,7 @@
 @import "helpers/mixins";
 @import "helpers/icons";
 @import "helpers/animations";
+@import "../../../../bower_components/sass-mq/_mq"; // via Bower
 
 
 //


### PR DESCRIPTION
**n.b.: This PR is a work in progress** destined to start the discussion around @media queries abstraction.

@PaulAdamDavis and I were just chatting about media queries tonight and I kinda was joking about opening a PR to spark up the conversation in a more formal way. But I got home, installed the project locally (surprisingly easily!), and started coding.

The benefit of abstracting media queries is that by having a centralised, single source of truth where all major breakpoints are defined, you can iterate on the product with more confidence and velocity.

sass-mq (http://git.io/sass-mq) can help with that ([in version 1.4.0](https://github.com/guardian/sass-mq/tree/v1.4.0), to be compatible with Libsass). Feel free to browse the README of sass-mq if you want to know the specifics.

I found a number of different breakpoints/tweakpoints. Is there a reason why there are so many? See this list:

```
<= & > 350px
<= & > 400px
<= & > 500px
<=     550px
<= & > 600px
<= & > 630px
<= & > 650px
>=     768px
<= & > 900px
<= & > 1000px
```

Sometimes having a @media query abstraction prevents proliferation and helps keeping the codebase maintainable. Maybe it would help reducing the number of breakpoints?

Let me know your thoughts and if I can help further. Ideally you could take that branch as is and just iterate on it if you like the principles behind sass-mq.
