### PR TITLE
[WIP] Remove authentication for public endpoints

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -4,25 +4,26 @@
 // Ghost's JSON API is integral to the workings of Ghost, regardless of whether you want to access data internally,
 // from a theme, an app, or from an external app, you'll use the Ghost JSON API to do so.
 
-var _              = require('lodash'),
-    Promise        = require('bluebird'),
-    config         = require('../config'),
+var _               = require('lodash'),
+    Promise         = require('bluebird'),
+    config          = require('../config'),
     // Include Endpoints
-    configuration  = require('./configuration'),
-    db             = require('./db'),
-    mail           = require('./mail'),
-    notifications  = require('./notifications'),
-    posts          = require('./posts'),
-    roles          = require('./roles'),
-    settings       = require('./settings'),
-    tags           = require('./tags'),
-    themes         = require('./themes'),
-    users          = require('./users'),
-    slugs          = require('./slugs'),
-    authentication = require('./authentication'),
-    uploads        = require('./upload'),
-    dataExport     = require('../data/export'),
-    errors         = require('../errors'),
+    configuration   = require('./configuration'),
+    db              = require('./db'),
+    mail            = require('./mail'),
+    notifications   = require('./notifications'),
+    posts           = require('./posts'),
+    roles           = require('./roles'),
+    settings        = require('./settings'),
+    tags            = require('./tags'),
+    themes          = require('./themes'),
+    users           = require('./users'),
+    slugs           = require('./slugs'),
+    authentication  = require('./authentication'),
+    uploads         = require('./upload'),
+    dataExport      = require('../data/export'),
+    publicEndpoints = require('./publicEndpoints'),
+    errors          = require('../errors'),
 
     http,
     formatHttpErrors,
@@ -289,7 +290,8 @@ module.exports = {
     users: users,
     slugs: slugs,
     authentication: authentication,
-    uploads: uploads
+    uploads: uploads,
+    publicEndpoints: publicEndpoints
 };
 
 /**

--- a/core/server/api/publicEndpoints.js
+++ b/core/server/api/publicEndpoints.js
@@ -4,39 +4,39 @@ var endpoints = [
         // /ghost/api/v0.1/posts/?status=published
         pathPattern: /^\/ghost\/api\/v0.1\/posts(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         // white listed allowed parameters
         opts: [
-            { status: 'published' }
+            {status: 'published'}
         ]
     },
     {
         // /ghost/api/v0.1/posts/:id
         pathPattern: /^\/ghost\/api\/v0.1\/posts\/[0-9](\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         // white listed allowed parameters
         opts: [
-            { status: 'published' }
+            {status: 'published'}
         ]
     },
     {
         // /ghost/api/v0.1/posts/slug/:slug
         pathPattern: /^\/ghost\/api\/v0.1\/posts\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         opts: [
-            { status: 'published' }
+            {status: 'published'}
         ]
     },
     {
         // /ghost/api/v0.1/users/:id/?status=active
         pathPattern: /^\/ghost\/api\/v0.1\/users\/[0-9](\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         // white listed allowed parameters
         opts: [
-            { status: 'active' }
+            {status: 'active'}
         ]
     },
     {
@@ -44,38 +44,38 @@ var endpoints = [
         // TODO: Use proper email regex here
         pathPattern:  /^\/ghost\/api\/v0.1\/users\/email\/.{1,}(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ]
+        verbs: ['GET']
     },
     {
         // /ghost/api/v0.1/users/slug/:slug
         pathPattern: /^\/ghost\/api\/v0.1\/users\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ]
+        verbs: ['GET']
     },
     {
         // /ghost/api/v0.1/tags/
         pathPattern: /^\/ghost\/api\/v0.1\/tags(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ]
+        verbs: ['GET']
     },
     {
         // /ghost/api/v0.1/settings/?type=blog
         pathPattern: /^\/ghost\/api\/v0.1\/settings(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         // white listed allowed parameters
         opts: [
-            { type: 'blog' }
+            {type: 'blog'}
         ]
     },
     {
         // /ghost/api/v0.1/settings/:key/?type=blog
         pathPattern: /^\/ghost\/api\/v0.1\/settings\/[0-9a-zA-Z]{1,}(\/)?$/,
         // white listed allowed verbs
-        verbs: [ 'GET' ],
+        verbs: ['GET'],
         // white listed allowed parameters
         opts: [
-            { type: 'blog' }
+            {type: 'blog'}
         ]
     }
 ];
@@ -87,7 +87,7 @@ function isUsingPublicParams(endpoint, req) {
 
     for (param in req.query) {
         if (req.query.hasOwnProperty(param)) {
-            for (i = 0; i < endpoint.opts.length; i++) {
+            for (i = 0; i < endpoint.opts.length; i += 1) {
                 allowedParam = endpoint.opts[ i ];
                 if (allowedParam[param] && req.query[param] === allowedParam[param]) {
                     return true;
@@ -99,14 +99,14 @@ function isUsingPublicParams(endpoint, req) {
 }
 
 function hasPublicVerb(endpoint, req) {
-  return (endpoint.verbs.indexOf(req.method) > -1);
+    return (endpoint.verbs.indexOf(req.method) > -1);
 }
 
 function isPathPublic(path) {
     var i,
         endpoint;
 
-    for (i = 0; i < endpoints.length; i++) {
+    for (i = 0; i < endpoints.length; i += 1) {
         endpoint = endpoints[i];
         if (endpoint.pathPattern.test(path)) {
             return endpoint;
@@ -114,14 +114,10 @@ function isPathPublic(path) {
     }
 }
 
-exports.isPublic = function(req, path) {
+exports.isPublic = function (req, path) {
     var endpoint = isPathPublic(path);
     if (endpoint && hasPublicVerb(endpoint, req) && isUsingPublicParams(endpoint, req)) {
         return true;
     }
     return false;
 };
-
-
-
-

--- a/core/server/api/publicEndpoints.js
+++ b/core/server/api/publicEndpoints.js
@@ -1,105 +1,99 @@
 
-var mailRegex = new RegExp('^\/ghost\/api\/v0.1\/users\/email\/(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))\/?$');
-
 var endpoints = [
     {
-      // /ghost/api/v0.1/posts/?status=published
-      pathPattern: /^\/ghost\/api\/v0.1\/posts(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      // white listed allowed parameters
-      opts: [
-          { status: 'published' }
-      ]
+        // /ghost/api/v0.1/posts/?status=published
+        pathPattern: /^\/ghost\/api\/v0.1\/posts(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        // white listed allowed parameters
+        opts: [
+            { status: 'published' }
+        ]
     },
     {
-      // /ghost/api/v0.1/posts/:id
-      pathPattern: /^\/ghost\/api\/v0.1\/posts\/[0-9](\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      // white listed allowed parameters
-      opts: [
-          { status: 'published' }
-      ]
+        // /ghost/api/v0.1/posts/:id
+        pathPattern: /^\/ghost\/api\/v0.1\/posts\/[0-9](\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        // white listed allowed parameters
+        opts: [
+            { status: 'published' }
+        ]
     },
     {
-      // /ghost/api/v0.1/posts/slug/:slug
-      pathPattern: /^\/ghost\/api\/v0.1\/posts\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      opts: [
-          { status: 'published' }
-      ]
+        // /ghost/api/v0.1/posts/slug/:slug
+        pathPattern: /^\/ghost\/api\/v0.1\/posts\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        opts: [
+            { status: 'published' }
+        ]
     },
     {
-      // /ghost/api/v0.1/users/:id/?status=active
-      pathPattern: /^\/ghost\/api\/v0.1\/users\/[0-9](\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      // white listed allowed parameters
-      opts: [
-          { status: 'active' }
-      ]
+        // /ghost/api/v0.1/users/:id/?status=active
+        pathPattern: /^\/ghost\/api\/v0.1\/users\/[0-9](\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        // white listed allowed parameters
+        opts: [
+            { status: 'active' }
+        ]
     },
     {
-      // /ghost/api/v0.1/users/email/:email/
-      // TODO: Use proper email regex here
-      pathPattern:  /^\/ghost\/api\/v0.1\/users\/email\/.{1,}(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ]
+        // /ghost/api/v0.1/users/email/:email/
+        // TODO: Use proper email regex here
+        pathPattern:  /^\/ghost\/api\/v0.1\/users\/email\/.{1,}(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ]
     },
     {
-      // /ghost/api/v0.1/users/slug/:slug
-      pathPattern: /^\/ghost\/api\/v0.1\/users\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ]
+        // /ghost/api/v0.1/users/slug/:slug
+        pathPattern: /^\/ghost\/api\/v0.1\/users\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ]
     },
     {
-      // /ghost/api/v0.1/tags/
-      pathPattern: /^\/ghost\/api\/v0.1\/tags(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ]
+        // /ghost/api/v0.1/tags/
+        pathPattern: /^\/ghost\/api\/v0.1\/tags(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ]
     },
     {
-      // /ghost/api/v0.1/settings/?type=blog
-      pathPattern: /^\/ghost\/api\/v0.1\/settings(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      // white listed allowed parameters
-      opts: [
-          { type: 'blog' }
-      ]
+        // /ghost/api/v0.1/settings/?type=blog
+        pathPattern: /^\/ghost\/api\/v0.1\/settings(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        // white listed allowed parameters
+        opts: [
+            { type: 'blog' }
+        ]
     },
     {
-      // /ghost/api/v0.1/settings/:key/?type=blog
-      pathPattern: /^\/ghost\/api\/v0.1\/settings\/[0-9a-zA-Z]{1,}(\/)?$/,
-      // white listed allowed verbs
-      verbs: [ 'GET' ],
-      // white listed allowed parameters
-      opts: [
-          { type: 'blog' }
-      ]
+        // /ghost/api/v0.1/settings/:key/?type=blog
+        pathPattern: /^\/ghost\/api\/v0.1\/settings\/[0-9a-zA-Z]{1,}(\/)?$/,
+        // white listed allowed verbs
+        verbs: [ 'GET' ],
+        // white listed allowed parameters
+        opts: [
+            { type: 'blog' }
+        ]
     }
-]
-
-exports.isPublic = function(req, path) {
-    var endpoint = isPathPublic(path);
-
-    if (endpoint && hasPublicVerb(endpoint, req) && isUsingPublicParams(endpoint, req)) {
-        return true;
-    }
-
-    return false;
-};
+];
 
 function isUsingPublicParams(endpoint, req) {
-    for (var param in req.query) {
-      for (var i = 0; i < endpoint.opts.length; i++) {
-        var allowedParam = endpoint.opts[ i ];
-        if (allowedParam[param] && req.query[param] === allowedParam[param]) {
-          return true;
+    var param,
+        i,
+        allowedParam;
+
+    for (param in req.query) {
+        if (req.query.hasOwnProperty(param)) {
+            for (i = 0; i < endpoint.opts.length; i++) {
+                allowedParam = endpoint.opts[ i ];
+                if (allowedParam[param] && req.query[param] === allowedParam[param]) {
+                    return true;
+                }
+            }
         }
-      }
     }
     return false;
 }
@@ -109,13 +103,24 @@ function hasPublicVerb(endpoint, req) {
 }
 
 function isPathPublic(path) {
-    for (var i = 0; i < endpoints.length; i++) {
-        var endpoint = endpoints[ i ];
+    var i,
+        endpoint;
+
+    for (i = 0; i < endpoints.length; i++) {
+        endpoint = endpoints[i];
         if (endpoint.pathPattern.test(path)) {
             return endpoint;
         }
     }
 }
+
+exports.isPublic = function(req, path) {
+    var endpoint = isPathPublic(path);
+    if (endpoint && hasPublicVerb(endpoint, req) && isUsingPublicParams(endpoint, req)) {
+        return true;
+    }
+    return false;
+};
 
 
 

--- a/core/server/api/publicEndpoints.js
+++ b/core/server/api/publicEndpoints.js
@@ -1,0 +1,122 @@
+
+var mailRegex = new RegExp('^\/ghost\/api\/v0.1\/users\/email\/(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))\/?$');
+
+var endpoints = [
+    {
+      // /ghost/api/v0.1/posts/?status=published
+      pathPattern: /^\/ghost\/api\/v0.1\/posts(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      // white listed allowed parameters
+      opts: [
+          { status: 'published' }
+      ]
+    },
+    {
+      // /ghost/api/v0.1/posts/:id
+      pathPattern: /^\/ghost\/api\/v0.1\/posts\/[0-9](\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      // white listed allowed parameters
+      opts: [
+          { status: 'published' }
+      ]
+    },
+    {
+      // /ghost/api/v0.1/posts/slug/:slug
+      pathPattern: /^\/ghost\/api\/v0.1\/posts\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      opts: [
+          { status: 'published' }
+      ]
+    },
+    {
+      // /ghost/api/v0.1/users/:id/?status=active
+      pathPattern: /^\/ghost\/api\/v0.1\/users\/[0-9](\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      // white listed allowed parameters
+      opts: [
+          { status: 'active' }
+      ]
+    },
+    {
+      // /ghost/api/v0.1/users/email/:email/
+      // TODO: Use proper email regex here
+      pathPattern:  /^\/ghost\/api\/v0.1\/users\/email\/.{1,}(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ]
+    },
+    {
+      // /ghost/api/v0.1/users/slug/:slug
+      pathPattern: /^\/ghost\/api\/v0.1\/users\/slug\/[a-zA-Z0-9\-]{1,}(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ]
+    },
+    {
+      // /ghost/api/v0.1/tags/
+      pathPattern: /^\/ghost\/api\/v0.1\/tags(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ]
+    },
+    {
+      // /ghost/api/v0.1/settings/?type=blog
+      pathPattern: /^\/ghost\/api\/v0.1\/settings(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      // white listed allowed parameters
+      opts: [
+          { type: 'blog' }
+      ]
+    },
+    {
+      // /ghost/api/v0.1/settings/:key/?type=blog
+      pathPattern: /^\/ghost\/api\/v0.1\/settings\/[0-9a-zA-Z]{1,}(\/)?$/,
+      // white listed allowed verbs
+      verbs: [ 'GET' ],
+      // white listed allowed parameters
+      opts: [
+          { type: 'blog' }
+      ]
+    }
+]
+
+exports.isPublic = function(req, path) {
+    var endpoint = isPathPublic(path);
+
+    if (endpoint && hasPublicVerb(endpoint, req) && isUsingPublicParams(endpoint, req)) {
+        return true;
+    }
+
+    return false;
+};
+
+function isUsingPublicParams(endpoint, req) {
+    for (var param in req.query) {
+      for (var i = 0; i < endpoint.opts.length; i++) {
+        var allowedParam = endpoint.opts[ i ];
+        if (allowedParam[param] && req.query[param] === allowedParam[param]) {
+          return true;
+        }
+      }
+    }
+    return false;
+}
+
+function hasPublicVerb(endpoint, req) {
+  return (endpoint.verbs.indexOf(req.method) > -1);
+}
+
+function isPathPublic(path) {
+    for (var i = 0; i < endpoints.length; i++) {
+        var endpoint = endpoints[ i ];
+        if (endpoint.pathPattern.test(path)) {
+            return endpoint;
+        }
+    }
+}
+
+
+
+

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -52,7 +52,6 @@ middleware = {
 
         if (subPath.indexOf('/ghost/api/') === 0
             && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
-
             if (api.publicEndpoints.isPublic(req, path)) {
                 return next(null, {}, {});
             } else {

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -53,8 +53,8 @@ middleware = {
         if (subPath.indexOf('/ghost/api/') === 0
             && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
 
-            if (api.publicEndpoints.isPublic(req, path)){
-              return next(null, {}, {});
+            if (api.publicEndpoints.isPublic(req, path)) {
+                return next(null, {}, {});
             } else {
                 return passport.authenticate('bearer', {session: false, failWithError: true},
                     function (err, user, info) {

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -52,27 +52,32 @@ middleware = {
 
         if (subPath.indexOf('/ghost/api/') === 0
             && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
-            return passport.authenticate('bearer', {session: false, failWithError: true},
-                function (err, user, info) {
-                    if (err) {
-                        return next(err); // will generate a 500 error
+
+            if (api.publicEndpoints.isPublic(req, path)){
+              return next(null, {}, {});
+            } else {
+                return passport.authenticate('bearer', {session: false, failWithError: true},
+                    function (err, user, info) {
+                        if (err) {
+                            return next(err); // will generate a 500 error
+                        }
+                        // Generate a JSON response reflecting authentication status
+                        if (!user) {
+                            var msg = {
+                                type: 'error',
+                                message: 'Please Sign In',
+                                status: 'passive'
+                            };
+                            res.status(401);
+                            return res.send(msg);
+                        }
+                        // TODO: figure out, why user & authInfo is lost
+                        req.authInfo = info;
+                        req.user = user;
+                        return next(null, user, info);
                     }
-                    // Generate a JSON response reflecting authentication status
-                    if (!user) {
-                        var msg = {
-                            type: 'error',
-                            message: 'Please Sign In',
-                            status: 'passive'
-                        };
-                        res.status(401);
-                        return res.send(msg);
-                    }
-                    // TODO: figure out, why user & authInfo is lost
-                    req.authInfo = info;
-                    req.user = user;
-                    return next(null, user, info);
-                }
-            )(req, res, next);
+                )(req, res, next);
+            }
         }
         next();
     },


### PR DESCRIPTION
WIP solution for https://github.com/TryGhost/Ghost/issues/4181

Feedback welcome!

Description:

There is a file core/server/api/publicEndpoints.js that defines all of the publicly available endpoints. These are represented as an array of objects. Each object contains a regex which matches the endpoint, an array allowable verbs (just GET for now - probably forever?), and optionally an array of objects which represent the allowable get queries.

In the middleware, before authentication occurs, the request path is passed along to the publicEndpoints module. The module tries to exist ASAP. If it doesn't match a public regex, false is immediately returned. Otherwise a check on the request method (GET) is performed, if it is anything other than the whitelisted verb, the test fails. Finally, get parameters are checked, if any extra or unexpected queries are sent along the entire test fails. If all the tests pass, then the module returns true and the middleware bypasses authentication sending an empty object instead of a user. This breaks a couple of the operations because a user model is expected. A potential solution is to have a built in Public API user which is used only for public facing API calls.

This seemed like a good approach as it makes it simple to add public calls (just add an object with the appropriate regex for the route, allowed verbs and allowed queries) and removing a public route just means removing the corresponding object.

Right now, the regexes are hard coded which isn't that big of a deal with the exception of the API version. This should be dynamically built based on a configuration so that when the API version updates, this code doesn't need to be changed.
