### PR TITLE
Updated admin navbar blog link title

### DIFF
--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -1,6 +1,6 @@
 <nav class="global-nav" role="navigation">
 
-    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="{{gh-path 'blog'}}">
+    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="Visit blog">
         <div class="nav-label"><i class="icon-ghost"></i> <span>Visit blog</span> </div>
     </a>
 


### PR DESCRIPTION
The admin navbar blog title used to just be `/`, or whatever the relative blog path was (hover over the ghost icon in the admin navbar). It now reads `Visit blog`, in accordance with the nav label. 
