### PR TITLE
Custom showdown extensions should be linted

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,8 +44,7 @@ var _              = require('lodash'),
                     'core/*.js',
                     'core/server/**/*.js',
                     'core/shared/**/*.js',
-                    '!core/shared/vendor/**/*.js',
-                    '!core/shared/lib/**/*.js'
+                    '!core/shared/vendor/**/*.js'
                 ]
             }
         },

--- a/core/shared/lib/showdown/extensions/ghostgfm.js
+++ b/core/shared/lib/showdown/extensions/ghostgfm.js
@@ -15,30 +15,31 @@
             {
                 // strike-through
                 // NOTE: showdown already replaced "~" with "~T", so we need to adjust accordingly.
-                type    : 'lang',
-                regex   : '(~T){2}([^~]+)(~T){2}',
-                replace : function (match, prefix, content, suffix) {
+                type: 'lang',
+                regex: '(~T){2}([^~]+)(~T){2}',
+                replace: function (match, prefix, content) {
                     return '<del>' + content + '</del>';
                 }
             },
             {
                 // Escaped tildes
                 // NOTE: showdown already replaced "~" with "~T", and this char doesn't get escaped properly.
-                type    : 'lang',
-                regex   : '\\\\(~T)',
-                replace : function (match,  content) {
+                type: 'lang',
+                regex: '\\\\(~T)',
+                replace: function (match,  content) {
                     return content;
                 }
             },
             {
                 // GFM newline and underscore modifications, happen BEFORE showdown
-                type    : 'lang',
-                filter  : function (text) {
+                type: 'lang',
+                filter: function (text) {
                     var extractions = {},
                         imageMarkdownRegex = /^(?:\{(.*?)\})?!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?$/gim,
                         hashID = 0;
 
                     function hashId() {
+                        /*jshint plusplus:false*/
                         return hashID++;
                     }
 
@@ -46,18 +47,17 @@
                     text = text.replace(/<pre>[\s\S]*?<\/pre>/gim, function (x) {
                         var hash = hashId();
                         extractions[hash] = x;
-                        return "{gfm-js-extract-pre-" + hash + "}";
+                        return '{gfm-js-extract-pre-' + hash + '}';
                     }, 'm');
 
                     // Extract code blocks
                     text = text.replace(/```[\s\S]*```/gim, function (x) {
                         var hash = hashId();
                         extractions[hash] = x;
-                        return "{gfm-js-extract-code-" + hash + "}";
+                        return '{gfm-js-extract-code-' + hash + '}';
                     }, 'm');
 
-
-                    //prevent foo_bar and foo_bar_baz from ending up with an italic word in the middle
+                    // prevent foo_bar and foo_bar_baz from ending up with an italic word in the middle
                     text = text.replace(/(^(?! {4}|\t)(?!__)\w+_\w+_\w[\w_]*)/gm, function (x) {
                         return x.replace(/_/gm, '\\_');
                     });
@@ -67,9 +67,11 @@
                     });
 
                     // in very clear cases, let newlines become <br /> tags
-                    text = text.replace(/^[\w\<\"\'][^\n]*\n+/gm, function (x) {
-                        return x.match(/\n{2}/) ? x : x.trim() + "  \n";
+                     /*jshint -W049 */
+                    text = text.replace(/^[\w\<\'\'][^\n]*\n+/gm, function (x) {
+                        return x.match(/\n{2}/) ? x : x.trim() + '  \n';
                     });
+                     /*jshint +W049 */
 
                     // better URL support, but no title support
                     text = text.replace(imageMarkdownRegex, function (match, key, alt, src) {
@@ -81,9 +83,8 @@
                     });
 
                     text = text.replace(/\{gfm-js-extract-pre-([0-9]+)\}/gm, function (x, y) {
-                        return "\n\n" + extractions[y];
+                        return '\n\n' + extractions[y];
                     });
-
 
                     return text;
                 }
@@ -101,13 +102,14 @@
 
             {
                 // GFM autolinking & custom image handling, happens AFTER showdown
-                type    : 'html',
-                filter  : function (text) {
+                type: 'html',
+                filter: function (text) {
                     var refExtractions = {},
                         preExtractions = {},
                         hashID = 0;
 
                     function hashId() {
+                        /*jshint plusplus:false*/
                         return hashID++;
                     }
 
@@ -115,7 +117,7 @@
                     text = text.replace(/<(pre|code)>[\s\S]*?<\/(\1)>/gim, function (x) {
                         var hash = hashId();
                         preExtractions[hash] = x;
-                        return "{gfm-js-extract-pre-" + hash + "}";
+                        return '{gfm-js-extract-pre-' + hash + '}';
                     }, 'm');
 
                     // filter out def urls
@@ -124,12 +126,13 @@
                         function (x) {
                             var hash = hashId();
                             refExtractions[hash] = x;
-                            return "{gfm-js-extract-ref-url-" + hash + "}";
+                            return '{gfm-js-extract-ref-url-' + hash + '}';
                         });
 
                     // match a URL
                     // adapted from https://gist.github.com/jorilallo/1283095#L158
                     // and http://blog.stevenlevithan.com/archives/mimic-lookbehind-javascript
+                    /*jshint -W049 */
                     text = text.replace(/(\]\(|\]|\[|<a[^\>]*?\>)?https?\:\/\/[^"\s\<\>]*[^.,;'">\:\s\<\>\)\]\!]/gmi,
                         function (wholeMatch, lookBehind, matchIndex) {
                             // Check we are not inside an HTML tag
@@ -138,8 +141,9 @@
                                 return wholeMatch;
                             }
                             // If we have a matching lookBehind, this is a failure, else wrap the match in <a> tag
-                            return lookBehind ? wholeMatch : "<a href='" + wholeMatch + "'>" + wholeMatch + "</a>";
+                            return lookBehind ? wholeMatch : '<a href=\'' + wholeMatch + '\'>' + wholeMatch + '</a>';
                         });
+                    /*jshint +W049 */
 
                     // replace extractions
                     text = text.replace(/\{gfm-js-extract-pre-([0-9]+)\}/gm, function (x, y) {
@@ -147,7 +151,7 @@
                     });
 
                     text = text.replace(/\{gfm-js-extract-ref-url-([0-9]+)\}/gi, function (x, y) {
-                        return "\n\n" + refExtractions[y];
+                        return '\n\n' + refExtractions[y];
                     });
 
                     return text;

--- a/core/shared/lib/showdown/extensions/ghostimagepreview.js
+++ b/core/shared/lib/showdown/extensions/ghostimagepreview.js
@@ -1,11 +1,11 @@
 /* jshint node:true, browser:true */
+/* global Ember */
 
 // Ghost Image Preview
 //
 // Manages the conversion of image markdown `![]()` from markdown into the HTML image preview
 // This provides a dropzone and other interface elements for adding images
 // Is only used in the admin client.
-
 
 var Ghost = Ghost || {};
 (function () {


### PR DESCRIPTION
ref #4243
- Removing /lib/ from the list of things which aren't linted, as this is
  all custom code
- Fixing up the two files to pass linting, erring on the side of caution
  with disabling regexp rules vs fixing regexes!
