### PR TITLE
Use flexbox for post settings cog & publish button

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -452,8 +452,6 @@ body.zen {
     }
 
     .splitbtn {
-        margin-top: -2px;
-
         .btn {
             border-top: rgba(255,255,255,0.3) 1px solid;
         }
@@ -559,6 +557,10 @@ body.zen {
 }
 
 #entry-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-content: center;
+    align-items: center;
     margin-right: 6px;
     position: relative;
     .dropdown {
@@ -672,10 +674,9 @@ body.zen {
 }
 
 .publish-bar-actions {
-    flex: 0 1 auto;
+    display: flex;
+    flex: 1 0 auto;
     align-self: auto;
-    min-width: 174px;
-    max-width: 174px;
     text-align: right;
 }
 


### PR DESCRIPTION
Closes #4208
- Removes `min-width` & `max-width` from `.publish-bar-actions`
- Uses flexbox to correctly handle dynamic size (due to font size and text content of button)

**Min font size set at 6** (en-gb/en-us default)
![screen shot 2014-10-12 at 19 28 18](https://cloud.githubusercontent.com/assets/390392/4607049/1a7b459a-523e-11e4-9ccd-12e3490ef3f7.png)

**Min font size set at 12** (zh-cn default)
![screen shot 2014-10-12 at 19 28 29](https://cloud.githubusercontent.com/assets/390392/4607052/23ac65ae-523e-11e4-90e9-a77b415ca2a1.png)

This also correctly fixes the broken layout when zooming in and out.
