### PR TITLE
Abstracting away the deprecatedItems

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -144,7 +144,8 @@ ConfigManager.prototype.set = function (config) {
             // Used by the upload API to limit uploads to images
             extensions: ['.jpg', '.jpeg', '.gif', '.png', '.svg', '.svgz'],
             contentTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
-        }
+        },
+        deprecatedItems: ['updateCheck', 'mail.fromaddress']
     });
 
     // Also pass config object to
@@ -324,10 +325,8 @@ ConfigManager.prototype.isPrivacyDisabled = function (privacyFlag) {
  * Check if any of the currently set config items are deprecated, and issues a warning.
  */
 ConfigManager.prototype.checkDeprecated = function () {
-    var deprecatedItems = ['updateCheck', 'mail.fromaddress'],
-        self = this;
-
-    _.each(deprecatedItems, function (property) {
+    var self = this;
+    _.each(this.deprecatedItems, function (property) {
         self.displayDeprecated(self, property.split('.'), []);
     });
 };

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -795,5 +795,14 @@ describe('Config', function () {
             // Future tests: This is important here!
             resetEnvironment();
         });
+
+        it('can not modify the deprecatedItems on the config object', function () {
+            config.set({
+                deprecatedItems: ['foo']
+            });
+
+            config.deprecatedItems.should.not.equal(['foo']);
+            resetEnvironment();
+        });
     });
 });


### PR DESCRIPTION
Closes #4189
- moved `deprecatedItems` from within the function to the default config object
- added tests (config object can not be unset / reset)
