### PR TITLE
Enables SSL in the link tag for the prev and next page

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -525,12 +525,12 @@ coreHelpers.ghost_head = function (options) {
             if (self.pagination.prev) {
                 prev = (self.pagination.prev > 1 ? prev = '/page/' + self.pagination.prev + '/' : prev = '/');
                 prev = (trimmedUrl) ? '/' + trimmedUrl + prev : prev;
-                head.push('<link rel="prev" href="' + config.urlFor({relativeUrl: prev}, true) + '" />');
+                head.push('<link rel="prev" href="' + config.urlFor({relativeUrl: prev, secure: self.secure}, true) + '" />');
             }
             if (self.pagination.next) {
                 next = '/page/' + self.pagination.next + '/';
                 next = (trimmedUrl) ? '/' + trimmedUrl + next : next;
-                head.push('<link rel="next" href="' + config.urlFor({relativeUrl: next}, true) + '" />');
+                head.push('<link rel="next" href="' + config.urlFor({relativeUrl: next, secure: self.secure}, true) + '" />');
             }
         }
 


### PR DESCRIPTION
Fixes #4266

Enables SSL in the prev / next links in the head.

Tested on a vagrant machine:

![screen shot 2014-10-13 at 15 07 57](https://cloud.githubusercontent.com/assets/2955483/4614686/af1194b2-52e2-11e4-9b56-b53f89e3658a.png)
![screen shot 2014-10-13 at 15 07 21](https://cloud.githubusercontent.com/assets/2955483/4614687/af12940c-52e2-11e4-86d7-949784b61d57.png)
