### PR TITLE
Create Tags Management Stubs for Ember

### DIFF
--- a/core/client/controllers/settings.js
+++ b/core/client/controllers/settings.js
@@ -1,5 +1,6 @@
 var SettingsController = Ember.Controller.extend({
-    showApps: Ember.computed.bool('config.apps')
+    showApps: Ember.computed.bool('config.apps'),
+    showTags: Ember.computed.bool('config.tagsUI')
 });
 
 export default SettingsController;

--- a/core/client/initializers/ghost-config.js
+++ b/core/client/initializers/ghost-config.js
@@ -3,11 +3,12 @@ var ConfigInitializer = {
 
     initialize: function (container, application) {
         var apps = $('body').data('apps'),
+            tagsUI = $('body').data('tagsui'),
             fileStorage = $('body').data('filestorage'),
             blogUrl = $('body').data('blogurl');
 
         application.register(
-            'ghost:config', {apps: apps, fileStorage: fileStorage, blogUrl: blogUrl}, {instantiate: false}
+            'ghost:config', {apps: apps, fileStorage: fileStorage, blogUrl: blogUrl, tagsUI: tagsUI}, {instantiate: false}
         );
 
         application.inject('route', 'config', 'ghost:config');

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -39,6 +39,7 @@ Router.map(function () {
         });
 
         this.route('about');
+        this.route('tags');
     });
 
     this.route('debug');

--- a/core/client/routes/settings/tags.js
+++ b/core/client/routes/settings/tags.js
@@ -1,0 +1,20 @@
+import AuthenticatedRoute from 'ghost/routes/authenticated';
+import CurrentUserSettings from 'ghost/mixins/current-user-settings';
+
+var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, {
+
+    beforeModel: function () {
+        if (!this.get('config.tagsUI')) {
+            return this.transitionTo('settings.general');
+        }
+
+        return this.currentUser()
+            .then(this.transitionAuthor());
+    },
+
+    model: function () {
+        return this.store.find('tag');
+    }
+});
+
+export default TagsRoute;

--- a/core/client/templates/settings.hbs
+++ b/core/client/templates/settings.hbs
@@ -11,6 +11,11 @@
                     {{gh-activating-list-item route="settings.general" title="General" classNames="settings-nav-general icon-settings"}}
                 {{/unless}}
 
+                {{! Whilst tag management is still in development only show tags button if there if tagsUI is true in config.js --}}
+                {{#if showTags}}
+                    {{gh-activating-list-item route="settings.tags" title="Tags" classNames="settings-nav-tags icon-tag"}}
+                {{/if}}
+
                 {{gh-activating-list-item route="settings.users" title="Users" classNames="settings-nav-users icon-users"}}
 
             {{/unless}}

--- a/core/client/templates/settings/tags.hbs
+++ b/core/client/templates/settings/tags.hbs
@@ -1,0 +1,85 @@
+<header class="settings-view-header">
+    <a class="btn btn-default btn-back active" href="/ghost/settings/">Back</a>
+    <h2 class="page-title">Tags</h2>
+    <section class="page-actions">
+        <button type="button" class="btn btn-green">New Tag</button>
+        <span class="tags-search">
+            <button href="#" class="btn btn-default">
+                <i class="icon-search"></i>
+                <span class="hidden">Search Tags</span>
+            </button>
+            <input type="text" class="tags-search-input">
+        </span>
+    </section>
+</header>
+
+<section class="content settings-tags">
+ {{#each}}
+     <div class="settings-tag">
+         <a href="#" class="tag-title">{{name}}</a>
+         <span class="label label-default">/{{slug}}</span>
+         <p class="tag-description">{{description}}</p>
+         <span class="tags-count">N/A</span>
+     </div>
+ {{/each}}
+</section>
+{{!--  This is the example markup
+<section class="content settings-tags">
+
+    <div class="settings-tag">
+        <a href="#" class="tag-title">News</a>
+        <span class="label label-default">/news</span>
+        <p class="tag-description">The latest news, reviews and information from around the world</p>
+        <span class="tags-count">20</span>
+
+        <div class="settings-tag">
+            <a href="#" class="tag-title">General</a>
+            <span class="label label-default">/news/general</span>
+            <p class="tag-description">My go-to category when I’m not really sure what else to file news</p>
+            <span class="tags-count">7</span>
+        </div>
+    </div>
+
+    <div class="settings-tag">
+        <a href="#" class="tag-title">Image</a>
+        <span class="label label-alt">Private</span>
+        <p class="tag-description">All posts with the “image” post format</p>
+        <span class="tags-count">12</span>
+    </div>
+
+    <div class="settings-tag">
+        <a href="#" class="tag-title">Kittens</a>
+        <span class="label label-default">/kittens</span>
+        <p class="tag-description">My sordid past and wrongdoings</p>
+        <span class="tags-count">9</span>
+
+        <div class="settings-tag">
+            <a href="#" class="tag-title">A Short History of Nearly Everything</a>
+            <span class="label label-default">/kittens/a-short-history</span>
+            <span class="tags-count">4</span>
+
+            <div class="settings-tag">
+                <a href="#" class="tag-title">In Parts</a>
+                <span class="label label-default">/kittens/a-short-history/in-parts</span>
+                <p class="tag-description">Lorem ipsum kittens innit</p>
+                <span class="tags-count">2</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="settings-tag">
+        <a href="#" class="tag-title">Video</a>
+        <span class="label label-default">Private</span>
+        <p class="tag-description">All posts containing a YouTube video link</p>
+        <span class="tags-count">6</span>
+    </div>
+
+    <div class="settings-tag">
+        <a href="#" class="tag-title">The End</a>
+        <span class="label label-default">/the-end</span>
+        <p class="tag-description">The final frontier</p>
+        <span class="tags-count">1</span>
+    </div>
+
+</section>
+--}}

--- a/core/client/views/settings/tags.js
+++ b/core/client/views/settings/tags.js
@@ -1,0 +1,5 @@
+import BaseView from 'ghost/views/settings/content-base';
+
+var SettingsTagsView = BaseView.extend();
+
+export default SettingsTagsView;

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -12,6 +12,7 @@ function getValidKeys() {
     var validKeys = {
             fileStorage: config.fileStorage === false ? false : true,
             apps: config.apps === true ? true : false,
+            tagsUI: config.tagsUI === true ? true : false,
             version: false,
             environment: process.env.NODE_ENV,
             database: config.database.client,

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -72,6 +72,20 @@ coreHelpers.apps = function (context, options) {
     return 'false';
 };
 
+// ### TagsUI helper
+//
+// *Usage example:*
+// `{{tags_ui}}`
+//
+// Returns the config value for tagsUI or false if no value present
+coreHelpers.tags_ui = function (context, options) {
+    /*jshint unused:false*/
+    if (config.hasOwnProperty('tagsUI')) {
+        return config.tagsUI.toString();
+    }
+    return 'false';
+};
+
 // ### Blog Url helper
 //
 // *Usage example:*
@@ -154,6 +168,8 @@ registerHelpers = function (adminHbs) {
     registerAdminHelper('asset', coreHelpers.asset);
     registerAdminHelper('apps', coreHelpers.apps);
     registerAdminHelper('file_storage', coreHelpers.file_storage);
+    registerAdminHelper('tags_ui', coreHelpers.tags_ui);
+
     registerAdminHelper('blog_url', coreHelpers.blog_url);
 };
 

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -34,7 +34,7 @@
     {{/unless}}
     <link rel="stylesheet" href="{{asset "css/ghost.min.css" ghost="true"}}" />
 </head>
-<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-blogurl="{{blog_url}}">
+<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-tagsui="{{tags_ui}}" data-blogurl="{{blog_url}}">
 
     {{{ghost_script_tags}}}
 


### PR DESCRIPTION
closes #4260
- Adds "tags" route inside of the settings routes.
- Adds this route to router.js
- Links the route from the settings.hbs template
- Adds demo tags html in tag.hbs template
- Adds flag for tagsUI
