### PR TITLE
Rename .object-list to .user-list

### DIFF
--- a/core/client/assets/sass/layouts/users.scss
+++ b/core/client/assets/sass/layouts/users.scss
@@ -3,21 +3,20 @@
 // --------------------------------------------------
 // Slug: /ghost/settings/users/
 // --------------------------------------------------
-// TODO: Rename everything. This is a layout, rather
-// than a re-usable component.
+
 
 .invited-users {
     margin-bottom: 34px;
 }
 
-.object-list-title {
+.user-list-title {
     font-size: 13px;
     font-weight: normal;
     color: $midbrown;
     margin-bottom: 14px;
 }
 
-.object-list-item {
+.user-list-item {
 
     @media (max-width: 500px) {
         display: block;
@@ -37,17 +36,21 @@
 
 }
 
-a.object-list-item {
+a.user-list-item {
     text-decoration: none;
 
     // Hover states only for large viewports
     @media (min-width: 601px) {
-        &:hover { background: lighten($lightbrown, 5%); }
-        &:last-of-type:hover { box-shadow: inset 0px -1px 0px $lightbrown; }
+        &:hover {
+            background: lighten($lightbrown, 5%);
+        }
+        &:last-of-type:hover {
+            box-shadow: inset 0px -1px 0px $lightbrown;
+        }
     }
 }
 
-.object-list-item-icon {
+.user-list-item-icon {
     width: 35px;
     height: 35px;
     display: block;
@@ -70,7 +73,7 @@ a.object-list-item {
     }
 }
 
-.object-list-item-figure {
+.user-list-item-figure {
     width: 35px;
     height: 35px;
     display: block;
@@ -80,15 +83,15 @@ a.object-list-item {
     background-position: center center;
 }
 
-.object-list-item-icon,
-.object-list-item-figure {
+.user-list-item-icon,
+.user-list-item-figure {
     @media (max-width: 500px) {
         float: left;
         margin-right: 15px;
     }
 }
 
-.object-list-item-body {
+.user-list-item-body {
     flex: 1 1 auto;
     align-items: stretch;
     padding-left: 15px;
@@ -112,16 +115,16 @@ a.object-list-item {
         margin-top: 3px;
     }
 
-} //.object-list-item-body
+}//.user-list-item-body
 
-.object-list-item-aside {
+.user-list-item-aside {
     @media (max-width: 500px) {
         float: left;
         width: 100%;
         margin: 12px 0 0 50px;
     }
 
-    .object-list-action:not(:first-of-type) {
+    .user-list-action:not(:first-of-type) {
         margin-left: 20px;
         @media (min-width: 501px) {
             margin-left: 50px;
@@ -136,9 +139,9 @@ a.object-list-item {
     .role-label + .role-label {
         margin-left: 5px;
     }
-} // .object-list-item-aside
+}//.user-list-item-aside
 
-.object-list-action {
+.user-list-action {
     font-size: 11px;
     text-transform: uppercase;
     text-decoration: underline;
@@ -178,7 +181,7 @@ a.object-list-item {
         background: $blue;
     }
 
-}
+}//.role-label
 
 //
 // User Actions
@@ -231,7 +234,7 @@ a.object-list-item {
             width: 100%;
         }
 
-    } //.form-group
+    }//.form-group
 
     .button-add {
         width: 100%;
@@ -240,4 +243,4 @@ a.object-list-item {
         line-height: 16px;
     }
 
-} //.invite-new-user
+}//.invite-new-user

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -1,9 +1,3 @@
-<script>
-$(document).ready(function() {
-    $('body').addClass('settings-view');
-});
-</script>
-
 <header class="settings-view-header">
     {{#link-to "settings" class="btn btn-default btn-back"}}Back{{/link-to}}
     <h2 class="page-title">Users</h2>
@@ -15,15 +9,15 @@ $(document).ready(function() {
 {{#view "settings/users/users-list-view" tagName="section" class="content settings-users" }}
     {{#if invitedUsers}}
 
-        <section class="object-list invited-users">
+        <section class="user-list invited-users">
 
-            <h4 class="object-list-title">Invited users</h4>
+            <h4 class="user-list-title">Invited users</h4>
 
             {{#each invitedUsers itemController="settings/users/user"}}
-                <div class="object-list-item">
-                    <span class="object-list-item-icon icon-mail">ic</span>
+                <div class="user-list-item">
+                    <span class="user-list-item-icon icon-mail">ic</span>
 
-                    <div class="object-list-item-body">
+                    <div class="user-list-item-body">
                         <span class="name">{{email}}</span><br>
                             {{#if pending}}
                                 <span class="red">Invitation not sent - please try again</span>
@@ -31,9 +25,9 @@ $(document).ready(function() {
                                 <span class="description">Invitation sent: {{created_at}}</span>
                             {{/if}}
                     </div>
-                    <aside class="object-list-item-aside">
-                        <a class="object-list-action" href="#" {{action "revoke"}}>Revoke</a>
-                        <a class="object-list-action" href="#" {{action "resend"}}>Resend</a>
+                    <aside class="user-list-item-aside">
+                        <a class="user-list-action" href="#" {{action "revoke"}}>Revoke</a>
+                        <a class="user-list-action" href="#" {{action "resend"}}>Resend</a>
                     </aside>
                 </div>
             {{/each}}
@@ -42,24 +36,24 @@ $(document).ready(function() {
 
     {{/if}}
 
-    <section class="object-list active-users">
+    <section class="user-list active-users">
 
-        <h4 class="object-list-title">Active users</h4>
+        <h4 class="user-list-title">Active users</h4>
 
         {{#each activeUsers itemController="settings/users/user"}}
-            {{#link-to 'settings.users.user' this class="object-list-item" }}
-                <span class="object-list-item-figure" {{bind-attr style=image}}>
+            {{#link-to 'settings.users.user' this class="user-list-item" }}
+                <span class="user-list-item-figure" {{bind-attr style=image}}>
                     <span class="hidden">Photo of {{unbound name}}</span>
                 </span>
 
-                <div class="object-list-item-body">
+                <div class="user-list-item-body">
                     <span class="name">
                         {{name}}
                     </span>
                     <br>
                     <span class="description">Last seen: {{unbound last_login}}</span>
                 </div>
-                <aside class="object-list-item-aside">
+                <aside class="user-list-item-aside">
                     {{#unless isAuthor}}
                         {{#each roles}}
                             <span class="role-label {{unbound lowerCaseName}}">{{name}}</span>

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -161,10 +161,10 @@ CasperTest.begin('Users screen is correct', 9, function suite(test) {
         test.assertUrlMatch(/ghost\/settings\/users\/$/, 'settings.users transitions to correct url');
     });
     casper.then(function usersScreenHasContent() {
-        test.assertSelectorHasText('.settings-users .object-list .object-list-title', 'Active users');
-        test.assertExists('.settings-users .object-list .object-list-item', 'Has an active user');
-        test.assertSelectorHasText('.settings-users .object-list-item .name', 'Test User');
-        test.assertExists('.settings-users .object-list-item .role-label.owner', 'First user has owner role displayed');
+        test.assertSelectorHasText('.settings-users .user-list .user-list-title', 'Active users');
+        test.assertExists('.settings-users .user-list .user-list-item', 'Has an active user');
+        test.assertSelectorHasText('.settings-users .user-list-item .name', 'Test User');
+        test.assertExists('.settings-users .user-list-item .role-label.owner', 'First user has owner role displayed');
 
         test.assertExists('.page-actions .btn-green', 'Add user button is on page.');
     });


### PR DESCRIPTION
No issue
References todo comment in [users.scss](https://github.com/TryGhost/Ghost/blob/91c07e37bf5f6467ff65181581e8c7621033ab31/core/client/assets/sass/layouts/users.scss#L6-L7)
- Renames anything starting with `.object-list` to `.user-list`
- Adjusts tests to match
- Removed unneeded jQuery block from `users/index.hbs`
