### PR TITLE
Change autolinked URLs to output nice quotes

### DIFF
--- a/core/shared/lib/showdown/extensions/ghostgfm.js
+++ b/core/shared/lib/showdown/extensions/ghostgfm.js
@@ -141,7 +141,7 @@
                                 return wholeMatch;
                             }
                             // If we have a matching lookBehind, this is a failure, else wrap the match in <a> tag
-                            return lookBehind ? wholeMatch : '<a href=\'' + wholeMatch + '\'>' + wholeMatch + '</a>';
+                            return lookBehind ? wholeMatch : '<a href="' + wholeMatch + '">' + wholeMatch + '</a>';
                         });
                     /*jshint +W049 */
 

--- a/core/test/unit/showdown_client_integrated_spec.js
+++ b/core/test/unit/showdown_client_integrated_spec.js
@@ -198,39 +198,39 @@ describe('Showdown client side converter', function () {
         var testPhrases = [
             {
                 input: 'http://google.co.uk',
-                output: /^<p><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>$/
+                output: /^<p><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>$/
             },
             {
                 input: 'https://atest.com/fizz/buzz?baz=fizzbuzz',
-                output: /^<p><a href=\'https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz\'>https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz<\/a><\/p>$/
+                output: /^<p><a href="https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz">https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz<\/a><\/p>$/
             },
             {
                 input: 'Some [ text (http://www.google.co.uk) some other text',
-                output: /^<p>Some \[ text \(<a href=\'http:\/\/www.google.co.uk\'>http:\/\/www.google.co.uk<\/a>\) some other text<\/p>$/
+                output: /^<p>Some \[ text \(<a href="http:\/\/www.google.co.uk">http:\/\/www.google.co.uk<\/a>\) some other text<\/p>$/
             },
             {
                 input: '>http://google.co.uk',
-                output: /^<blockquote>\n  <p><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>\n<\/blockquote>$/
+                output: /^<blockquote>\n  <p><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>\n<\/blockquote>$/
             },
             {
                 input: '> http://google.co.uk',
-                output: /^<blockquote>\n  <p><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>\n<\/blockquote>$/
+                output: /^<blockquote>\n  <p><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>\n<\/blockquote>$/
             },
             {
                 input: '<>>> http://google.co.uk',
-                output: /^<p>&lt;>>> <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>$/
+                output: /^<p>&lt;>>> <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>$/
             },
             {
                 input: '<strong>http://google.co.uk',
-                output: /^<p><strong><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>$/
+                output: /^<p><strong><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>$/
             },
             {
                 input: '# http://google.co.uk',
-                output: /^<h1 id="httpgooglecouk"><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/h1>$/
+                output: /^<h1 id="httpgooglecouk"><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/h1>$/
             },
             {
                 input: '* http://google.co.uk',
-                output: /^<ul>\n<li><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/li>\n<\/ul>$/
+                output: /^<ul>\n<li><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/li>\n<\/ul>$/
             }
         ],
         processedMarkup;
@@ -309,7 +309,7 @@ describe('Showdown client side converter', function () {
             },
             {
                 input: '<a href="http://facebook.com">test</a> http://google.co.uk',
-                output: /^<p><a href=\"http:\/\/facebook.com\">test<\/a> <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a><\/p>$/
+                output: /^<p><a href=\"http:\/\/facebook.com\">test<\/a> <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a><\/p>$/
             }
         ],
         processedMarkup;
@@ -475,11 +475,11 @@ describe('Showdown client side converter', function () {
             },
             {
                 input: '![http://google.co.uk/kitten.jpg](http://google.co.uk/kitten.jpg)',
-                output: /^<section.*?((?!<a href=\'http:\/\/google.co.uk\/kitten.jpg\').)*<\/section>$/
+                output: /^<section.*?((?!<a href="http:\/\/google.co.uk\/kitten.jpg").)*<\/section>$/
             },
             {
                 input: '![image stuff](http://dsurl.stuff/something)',
-                output: /^<section.*?((?!<a href=\'http:\/\/dsurl.stuff\/something\').)*<\/section>$/
+                output: /^<section.*?((?!<a href="http:\/\/dsurl.stuff\/something").)*<\/section>$/
             }
         ],
         processedMarkup;

--- a/core/test/unit/showdown_ghostGFM_spec.js
+++ b/core/test/unit/showdown_ghostGFM_spec.js
@@ -71,63 +71,63 @@ describe('Ghost GFM showdown extension', function () {
         var testPhrases = [
             {
                 input: 'http://google.co.uk',
-                output: /^<a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: 'https://atest.com/fizz/buzz?baz=fizzbuzz',
-                output: /^<a href=\'https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz\'>https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz<\/a>$/
+                output: /^<a href="https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz">https:\/\/atest.com\/fizz\/buzz\?baz=fizzbuzz<\/a>$/
             },
             {
                 input: 'Some text http://www.google.co.uk some other text',
-                output: /^Some text <a href=\'http:\/\/www.google.co.uk\'>http:\/\/www.google.co.uk<\/a> some other text$/
+                output: /^Some text <a href="http:\/\/www.google.co.uk">http:\/\/www.google.co.uk<\/a> some other text$/
             },
             {
                 input: 'Some [ text http://www.google.co.uk some other text',
-                output: /^Some \[ text <a href=\'http:\/\/www.google.co.uk\'>http:\/\/www.google.co.uk<\/a> some other text$/
+                output: /^Some \[ text <a href="http:\/\/www.google.co.uk">http:\/\/www.google.co.uk<\/a> some other text$/
             },
             {
                 input: 'Some [ text (http://www.google.co.uk) some other text',
-                output: /^Some \[ text \(<a href=\'http:\/\/www.google.co.uk\'>http:\/\/www.google.co.uk<\/a>\) some other text$/
+                output: /^Some \[ text \(<a href="http:\/\/www.google.co.uk">http:\/\/www.google.co.uk<\/a>\) some other text$/
             },
             {
                 input: '  http://google.co.uk  ',
-                output: /^  <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>  $/
+                output: /^  <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>  $/
             },
             {
                 input: '>http://google.co.uk',
-                output: /^><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '> http://google.co.uk',
-                output: /^> <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^> <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '<>>> http://google.co.uk',
-                output: /^<>>> <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<>>> <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '<>>>http://google.co.uk',
-                output: /^<>>><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<>>><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '<some text>>>http://google.co.uk',
-                output: /^<some text>>><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<some text>>><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '<strong>http://google.co.uk',
-                output: /^<strong><a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<strong><a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '# http://google.co.uk',
-                output: /^# <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^# <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '#http://google.co.uk',
-                output: /^#<a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^#<a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             },
             {
                 input: '* http://google.co.uk',
-                output: /^\* <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^\* <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             }
         ],
         processedMarkup;
@@ -158,7 +158,7 @@ describe('Ghost GFM showdown extension', function () {
             },
             {
                 input: '<a href="http://facebook.com">test</a> http://google.co.uk',
-                output: /^<a href="http:\/\/facebook.com">test<\/a> <a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>$/
+                output: /^<a href="http:\/\/facebook.com">test<\/a> <a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>$/
             }
         ],
         processedMarkup;
@@ -248,12 +248,12 @@ describe('Ghost GFM showdown extension', function () {
         var testPhrases = [
             {
                 input: '[1] (http://google.co.uk)',
-                output: /^\[1\] \(<a href=\'http:\/\/google.co.uk\'>http:\/\/google.co.uk<\/a>\)$/
+                output: /^\[1\] \(<a href="http:\/\/google.co.uk">http:\/\/google.co.uk<\/a>\)$/
             },
             {
                 input: '![1] (http://google.co.uk/kitten.jpg)',
                 output:
-                    /^!\[1\] \(<a href=\'http:\/\/google.co.uk\/kitten.jpg\'>http:\/\/google.co.uk\/kitten.jpg<\/a>\)$/
+                    /^!\[1\] \(<a href="http:\/\/google.co.uk\/kitten.jpg">http:\/\/google.co.uk\/kitten.jpg<\/a>\)$/
             }
         ],
         processedMarkup;


### PR DESCRIPTION
ref #4257
- This is a follow on from #4257 where I updated the codestyle.
- We were outputting escaped single quotes when double quotes would be much nicer.
- Changes the HTML output from our markdown conversion (non-breaking change)
- Updated tests to match the new output
