### PR TITLE
Set link [prev/next] tag to https if urlSSL is set.

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -64,12 +64,12 @@ ghost_head = function (options) {
             if (self.pagination.prev) {
                 prev = (self.pagination.prev > 1 ? prev = '/page/' + self.pagination.prev + '/' : prev = '/');
                 prev = (trimmedUrl) ? '/' + trimmedUrl + prev : prev;
-                head.push('<link rel="prev" href="' + config.urlFor({relativeUrl: prev}, true) + '" />');
+                head.push('<link rel="prev" href="' + config.urlFor({relativeUrl: prev, secure: self.secure}, true) + '" />');
             }
             if (self.pagination.next) {
                 next = '/page/' + self.pagination.next + '/';
                 next = (trimmedUrl) ? '/' + trimmedUrl + next : next;
-                head.push('<link rel="next" href="' + config.urlFor({relativeUrl: next}, true) + '" />');
+                head.push('<link rel="next" href="' + config.urlFor({relativeUrl: next, secure: self.secure}, true) + '" />');
             }
         }
 


### PR DESCRIPTION
The <link> tag for next/previous in the head doesn't update when the normal URL and the urlSSL change. This fixes that bug.

Fixes #4266
