### PR TITLE
Fix up title/slug handling on posts.

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -196,12 +196,11 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
 
     titleObserver: function () {
         var debounceId,
-            title = this.get('title'),
-            slug = this.get('slug');
+            title = this.get('title');
 
         // generate a slug if a post is new and doesn't have a title yet or
         // if the title is still '(Untitled)' and the slug is unaltered.
-        if ((this.get('isNew') && !title) || title === '(Untitled)' && /^untitled(-\d+){0,1}$/.test(slug)) {
+        if ((this.get('isNew') && !title) || title === '(Untitled)') {
             debounceId = Ember.run.debounce(this, 'generateAndSetSlug', ['slug'], 700);
         }
 

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -14,6 +14,13 @@ var EditorNewRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, base
 
     setupController: function (controller, model) {
         this._super(controller, model);
+
+        var psm = this.controllerFor('post-settings-menu');
+
+        // make sure there are no titleObserver functions hanging around
+        // from previous posts
+        psm.removeObserver('titleScratch', psm, 'titleObserver');
+
         controller.set('scratch', '');
         controller.set('titleScratch', '');
 


### PR DESCRIPTION
Refs #4323
- Remove any titleScratch observers that may be hanging
  around on the post-settings-menu controller from previous posts.
- Change logic around when to regenerate slugs on posts that are
  "(Untitled)" so that slug generation continues after slug no
  longer resembles "untitled."
