### PR TITLE
Fix floating header vertical shadows glitch

### DIFF
--- a/core/client/assets/sass/patterns/_shame.scss
+++ b/core/client/assets/sass/patterns/_shame.scss
@@ -100,30 +100,22 @@
 .scrolling {
 
     .floatingheader {
-        box-shadow:
-            rgba(0,0,0,0.03) 0 1px 3px,
-            rgba(255, 255, 255, 0.5) 0 -1px 0 inset;
+        box-shadow: rgba(0, 0, 0, 0.03) 0 1px 3px;
 
         &:before {
             content: "";
-            height: 40px;
+            position: absolute;
+            bottom: -5px;
+            left: 50%;
+            height: 5px;
             width: 80%;
-            position: absolute;
-            bottom: 0;
-            left: 50%;
             margin-left: -40%;
-            box-shadow: rgba(0,0,0,0.03) 0 2px 3px;
+            background-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.05) 0%,rgba(0, 0, 0, 0) 75%,rgba(0, 0, 0, 0) 100%);
+            background-position: 0px -5px;
+            background-size: 100% 200%;
+            z-index: -1;
         }
-        &:after {
-            content: "";
-            height: 40px;
-            width: 30%;
-            position: absolute;
-            bottom: 0;
-            left: 50%;
-            margin-left: -15%;
-            box-shadow: rgba(0,0,0,0.02) 0 3px 4px;
-        }
+
     } // .floatingheader
 
-} // .scrolling
+}//.scrolling


### PR DESCRIPTION
Closes #4340

Fixes a UI glitch where the vertical parts of a box shadow would show.
This fix changes those box shadows for 1 radial gradient, where only 5px of it is shown. No more vertical shadows.

Old:
![screen shot 2014-10-26 at 17 37 03](https://cloud.githubusercontent.com/assets/390392/4783808/b73a4ef0-5d36-11e4-8976-27953da5d787.png)

New: 
![screen shot 2014-10-26 at 17 33 42](https://cloud.githubusercontent.com/assets/390392/4783809/bd485cb0-5d36-11e4-9abd-7e7e83f12b04.png)
