### PR TITLE
Fix argument handling in gh-path helper.

### DIFF
--- a/core/client/helpers/ghost-paths.js
+++ b/core/client/helpers/ghost-paths.js
@@ -7,24 +7,43 @@
 import ghostPaths from 'ghost/utils/ghost-paths';
 
 function ghostPathsHelper(path, url) {
-    var base;
+    var base,
+        argsLength = arguments.length,
+        paths = ghostPaths();
+
+    // function is always invoked with at least one parameter, so if
+    // arguments.length is 1 there were 0 arguments passed in explicitly
+    if (argsLength === 1) {
+        path = 'blog';
+    } else if (argsLength === 2 && !/^(blog|admin|api)$/.test(path)) {
+        url = path;
+        path = 'blog';
+    }
 
     switch (path.toString()) {
         case 'blog':
-            base = ghostPaths().blogRoot;
+            base = paths.blogRoot;
             break;
         case 'admin':
-            base = ghostPaths().adminRoot;
+            base = paths.adminRoot;
             break;
         case 'api':
-            base = ghostPaths().apiRoot;
+            base = paths.apiRoot;
             break;
         default:
-            base = ghostPaths().blogRoot;
+            base = paths.blogRoot;
             break;
     }
 
+    // handle leading and trailing slashes
+
+    base = base[base.length - 1] !== '/' ? base + '/' : base;
+
     if (url && url.length > 0) {
+        if (url[0] === '/') {
+            url = url.substr(1);
+        }
+
         base = base + url;
     }
 


### PR DESCRIPTION
No Issue
- Make helper behave as stated in description when variable
  number of arguments are passed in.
- Handle leading and trailing slashes when creating output
  url partial.
