### PR TITLE
Use gh-path for nav bar fallback avatar

### DIFF
--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -34,7 +34,7 @@
             {{#if session.user.image}}
             <div class="image"><img {{bind-attr src="session.user.image"}} alt="{{session.user.name}}'s profile picture" /></div>
             {{else}}
-            <div class="image"><img src="/shared/img/user-image.png" alt="Profile picture" /></div>
+            <div class="image"><img src="{{gh-path "blog" "shared/img/user-image.png"}}" alt="Profile picture" /></div>
             {{/if}}
             <div class="name">
                 {{session.user.name}} <i class="icon-chevron-down"></i>


### PR DESCRIPTION
Closes #4344
- Uses the `{{gh-path}}` helper to make the fallback avatar `src` work when Ghost is in a sub-directory
