### PR TITLE
Scroll post-item-view into view

### DIFF
--- a/core/client/templates/posts.hbs
+++ b/core/client/templates/posts.hbs
@@ -11,7 +11,7 @@
             </section>
             {{#link-to "editor.new" class="btn btn-green" title="New Post"}}<span class="hidden">New Post</span>{{/link-to}}
         </header>
-        {{#view "paginated-scroll-box" tagName="section" classNames="content-list-content"}}
+        {{#view "paginated-scroll-box" tagName="section" classNames="content-list-content js-content-scrollbox"}}
         <ol class="posts-list">
             {{#each itemController="posts/post" itemView="post-item-view" itemTagName="li"}}
             {{#link-to "posts.post" this class="permalink" title="Edit this post"}}

--- a/core/client/views/post-item-view.js
+++ b/core/client/views/post-item-view.js
@@ -13,8 +13,40 @@ var PostItemView = itemView.extend({
 
     click: function () {
         this.get('controller').send('showPostContent');
-    }
+    },
+    scrollIntoView: function () {
+        if (!this.get('active')) {
+            return;
+        }
+        var element = this.$(),
+            offset = element.offset().top,
+            elementHeight = element.height(),
+            container = Ember.$('.js-content-scrollbox'),
+            containerHeight = container.height(),
+            currentScroll = container.scrollTop(),
+            isBelowTop,
+            isAboveBottom,
+            isOnScreen;
 
+        isAboveBottom = offset < containerHeight;
+        isBelowTop = offset > elementHeight;
+
+        isOnScreen = isBelowTop && isAboveBottom;
+
+        if (!isOnScreen) {
+            // Scroll so that element is centered in container
+            // 40 is the amount of padding on the container
+            container.clearQueue().animate({
+                scrollTop: currentScroll + offset - 40 - containerHeight / 2
+            });
+        }
+    },
+    removeScrollBehaviour: function () {
+        this.removeObserver('active', this, this.scrollIntoView);
+    }.on('willDestroyElement'),
+    addScrollBehaviour: function () {
+        this.addObserver('active', this, this.scrollIntoView);
+    }.on('didInsertElement')
 });
 
 export default PostItemView;


### PR DESCRIPTION
Closes #3998
- If the active post changes and the newly active post is offscreen, scroll it into the middle of the screen

This means keyboards trigger infinite scrolling now!

![keyboard scrolling](https://cloud.githubusercontent.com/assets/1207005/5022999/41261acc-6aac-11e4-9bdd-f541ca8b79c9.gif)
