### PR TITLE
Workaround for outlook, who doesn't like quoted-printable encoding

### DIFF
--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -76,7 +76,8 @@ GhostMailer.prototype.send = function (message) {
     message = _.extend(message, {
         from: self.from(),
         to: to,
-        generateTextFromHTML: true
+        generateTextFromHTML: true,
+	encoding: 'base64' // Outlook doesn't like default 'quoted-printable' encoding inside links when the url is splited with '='
     });
 
     return new Promise(function (resolve, reject) {


### PR DESCRIPTION
For example, outlook 2013 plus would not interpert the following html
(encoded via quoted-printable encoding):

```
<a href=3D=22http://engineering=
.como.com/ghost/signup/MTQxNTcwNzM5MTYwN3x5dXJ5QG5peC5jby5pbHx3NVBmUUN4RGZr=
cGhKc3FPOElybXNZNWtzR0FMTU9tRFI5UlNyRWQ4SGJZPQ=3D=3D/=22 style=3D=22color: =
#5ba4e5;=22>Click here to activate your account</a>
```

The workournd forces node-mailer to use base64, which outlook understands
well.
