### PR TITLE
[WIP] Delete empty posts when leaving editor route

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -66,7 +66,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         return hashCurrent === hashPrevious;
     },
 
-    // a hook created in editor-route-base's setupController
+    // a hook created in editor-base-route's setupController
     modelSaved: function () {
         var model = this.get('model');
 

--- a/core/client/mixins/editor-base-route.js
+++ b/core/client/mixins/editor-base-route.js
@@ -23,6 +23,53 @@ var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
         // The actual functionality is implemented in utils/codemirror-shortcuts
         codeMirrorShortcut: function (options) {
             this.get('controller.codemirror').shortcut(options.type);
+        },
+
+        willTransition: function (transition) {
+            var controller = this.get('controller'),
+                isDirty = controller.get('isDirty'),
+
+                model = controller.get('model'),
+                isSaving = model.get('isSaving'),
+                isDeleted = model.get('isDeleted'),
+                modelIsDirty = model.get('isDirty');
+
+            this.send('closeSettingsMenu');
+
+            // when `isDeleted && isSaving`, model is in-flight, being saved
+            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
+            // the record has already been deleted and the deletion persisted.
+            //
+            // in either case  we can probably just transition now.
+            // in the former case the server will return the record, thereby updating it.
+            // @TODO: this will break if the model fails server-side validation.
+            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
+                transition.abort();
+                this.send('openModal', 'leave-editor', [controller, transition]);
+                return;
+            }
+            // since the transition is now certain to complete..
+            window.onbeforeunload = null;
+
+            // remove model-related listeners created in editor-base-route
+            this.detachModelHooks(controller, model);
+            // Bubble the action for the EditorRoute to catch
+            return true;
+        },
+
+        // Delete empty posts locally, or autosaved posts on the server
+        // when leaving the editor route.
+        deleteEmptyPosts: function () {
+            var model = this.controller.get('model');
+            // Delete unsaved, empty records from the store
+            if (model.get('isNew')) {
+                model.deleteRecord();
+                return;
+            }
+            // A blank, autosaved post - kill it serverside as well.
+            if (model.get('title') === '(Untitled)' && !model.get('markdown')) {
+                return model.destroyRecord();
+            }
         }
     },
 

--- a/core/client/routes/editor.js
+++ b/core/client/routes/editor.js
@@ -1,0 +1,13 @@
+var EditorRoute = Ember.Route.extend({
+    actions: {
+        willTransition: function (transition) {
+            // If leaving the editor routes,
+            // delete empty post model.
+            if (!/^editor/.test(transition.targetName)) {
+                this.send('deleteEmptyPosts');
+            }
+        }
+    }
+});
+
+export default EditorRoute;

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -1,4 +1,4 @@
-import base from 'ghost/mixins/editor-route-base';
+import base from 'ghost/mixins/editor-base-route';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
@@ -65,41 +65,8 @@ var EditorEditRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, bas
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', model.get('tags').mapBy('name'));
 
-        // attach model-related listeners created in editor-route-base
+        // attach model-related listeners created in editor-base-route
         this.attachModelHooks(controller, model);
-    },
-
-    actions: {
-        willTransition: function (transition) {
-            var controller = this.get('controller'),
-                isDirty = controller.get('isDirty'),
-
-                model = controller.get('model'),
-                isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted'),
-                modelIsDirty = model.get('isDirty');
-
-            this.send('closeSettingsMenu');
-
-            // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
-            // the record has already been deleted and the deletion persisted.
-            //
-            // in either case  we can probably just transition now.
-            // in the former case the server will return the record, thereby updating it.
-            // @TODO: this will break if the model fails server-side validation.
-            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
-                transition.abort();
-                this.send('openModal', 'leave-editor', [controller, transition]);
-                return;
-            }
-
-            // since the transition is now certain to complete..
-            window.onbeforeunload = null;
-
-            // remove model-related listeners created in editor-route-base
-            this.detachModelHooks(controller, model);
-        }
     }
 });
 

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -1,4 +1,4 @@
-import base from 'ghost/mixins/editor-route-base';
+import base from 'ghost/mixins/editor-base-route';
 
 var EditorNewRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, base, {
     classNames: ['editor'],
@@ -27,46 +27,8 @@ var EditorNewRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin, base
         // used to check if anything has changed in the editor
         controller.set('previousTagNames', Ember.A());
 
-        // attach model-related listeners created in editor-route-base
+        // attach model-related listeners created in editor-base-route
         this.attachModelHooks(controller, model);
-    },
-
-    actions: {
-        willTransition: function (transition) {
-            var controller = this.get('controller'),
-                isDirty = controller.get('isDirty'),
-
-                model = controller.get('model'),
-                isNew = model.get('isNew'),
-                isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted'),
-                modelIsDirty = model.get('isDirty');
-
-            this.send('closeSettingsMenu');
-
-            // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
-            // the record has already been deleted and the deletion persisted.
-            //
-            // in either case  we can probably just transition now.
-            // in the former case the server will return the record, thereby updating it.
-            // @TODO: this will break if the model fails server-side validation.
-            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
-                transition.abort();
-                this.send('openModal', 'leave-editor', [controller, transition]);
-                return;
-            }
-
-            if (isNew) {
-                model.deleteRecord();
-            }
-
-            // since the transition is now certain to complete..
-            window.onbeforeunload = null;
-
-            // remove model-related listeners created in editor-route-base
-            this.detachModelHooks(controller, model);
-        }
     }
 });
 

--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -2,7 +2,7 @@
 // jscs:disable disallowSpacesInsideParentheses
 
 /** Set up a shortcut function to be called via router actions.
- *  See editor-route-base
+ *  See editor-base-route
  */
 
 import titleize from 'ghost/utils/titleize';


### PR DESCRIPTION
Closes #4321
- Renamed editor-route-base to editor-base-route to fit the naming scheme of editor-base-view and editor-base-controller
- Moved duplicate willTransition functionality from editor/edit and editor/new to editor-base-route
- editor-base-route passes willTransition actions up the route chain
- EditorRoute deletes a post with no bodyScratch and a title of `(Untitled)` on willTransition
