### PR TITLE
Use gcc/g++ 4.8 for travis-ci builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ matrix:
   allow_failures:
     - env: DB=pg NODE_ENV=testing-pg
 before_install:
+  - add-apt-repository -y ppa:ubuntu-toolchain-r/test;
+  - apt-get update;
+  - apt-get install gcc-4.8 g++-4.8;
+  - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 20;
+  - update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 20;
+  - g++ --version;
   - git clone git://github.com/n1k0/casperjs.git ~/casperjs
   - cd ~/casperjs
   - git checkout tags/1.1-beta3


### PR DESCRIPTION
No Issue
- node-sass >=1.1.0 requires gcc/g++ 4.7 or higher.
