### PR TITLE
Peg node-sass dependency to 1.0.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "morgan": "1.3.1",
         "node-uuid": "1.4.1",
         "nodemailer": "0.7.1",
+        "node-sass": "1.0.3",
         "oauth2orize": "1.0.1",
         "passport": "0.2.0",
         "passport-http-bearer": "1.0.1",


### PR DESCRIPTION
No Issue.
- grunt-sass has node-sass as a dependency (^1.0.0) but the build
  requirements of node-sass version 1.1.0 have changed and will
  fail without a newer version of the gnu compilers.
