### PR TITLE
Redirect unauthorized users to signin from debug

### DIFF
--- a/core/client/routes/debug.js
+++ b/core/client/routes/debug.js
@@ -5,7 +5,9 @@ import loadingIndicator from 'ghost/mixins/loading-indicator';
 var DebugRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, {
     classNames: ['settings'],
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
+
         var self = this;
         this.store.find('user', 'me').then(function (user) {
             if (user.get('isAuthor') || user.get('isEditor')) {


### PR DESCRIPTION
Closes #4357
- Adds a call to `this._super()` in DebugRoute#beforeModel to hit the ember simpleauth mixin's beforemodel hook
