### PR TITLE
Handle null/undefined value in test assertion.

### DIFF
--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -43,7 +43,7 @@ describe('Settings Model', function () {
             }).then(function (found) {
                 should.exist(found);
 
-                found.get('value').should.equal(firstSetting.attributes.value);
+                should(found.get('value')).equal(firstSetting.attributes.value);
                 found.get('created_at').should.be.an.instanceof(Date);
 
                 done();


### PR DESCRIPTION
No Issue.
- Test is not guaranteed to get a setting that has a "value"
  so we need to handle the case where it's null or undefined.

This fixes a test failure that's been popping up now and then on the postgres build.
