### PR TITLE
Improve handling of forked processes in tests.

### DIFF
--- a/core/test/functional/routes/admin_test.js
+++ b/core/test/functional/routes/admin_test.js
@@ -126,6 +126,8 @@ describe('Admin Routing', function () {
         after(function (done) {
             if (forkedGhost) {
                 forkedGhost.kill(done);
+            } else {
+                done(new Error('No forked ghost process exists, test setup must have failed.'));
             }
         });
 
@@ -162,6 +164,8 @@ describe('Admin Routing', function () {
         after(function (done) {
             if (forkedGhost) {
                 forkedGhost.kill(done);
+            } else {
+                done(new Error('No forked ghost process exists, test setup must have failed.'));
             }
         });
 

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -707,6 +707,8 @@ describe('Frontend Routing', function () {
         after(function (done) {
             if (forkedGhost) {
                 forkedGhost.kill(done);
+            } else {
+                done(new Error('No forked ghost process exists, test setup must have failed.'));
             }
         });
 

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -96,7 +96,8 @@ function forkGhost(newConfig, envName) {
                             /*jshint unused:false*/
                             pingTries = pingTries + 1;
                             // continue checking
-                            if (pingTries >= 20 && pingStop()) {
+                            if (pingTries >= 50 && pingStop()) {
+                                child.kill();
                                 reject(new Error('Timed out waiting for child process'));
                             }
                         });
@@ -105,11 +106,14 @@ function forkGhost(newConfig, envName) {
                     child.on('exit', function (code, signal) {
                         /*jshint unused:false*/
                         child.exited = true;
+
+                        fs.unlink(newConfigFile, function () {
+                            // swallow any errors -- file may not exist if fork() failed
+                        });
+
                         if (pingStop()) {
                             reject(new Error('Child process exit code: ' + code));
                         }
-                        // cleanup the temporary config file
-                        fs.unlink(newConfigFile);
                     });
 
                     // override kill() to have an async callback


### PR DESCRIPTION
Closes #4277
- Increase the wait time for forked processes to spin up.
- If we give up on waiting for a forked process, send it a kill signal so if it comes alive later it doesn't sit in the
  background forever.
- Fail fast if test setup fails instead of waiting for the timeout.
