### PR TITLE
Editor must be focused before allowing certain keyboard shortcuts.

### DIFF
--- a/core/client/mixins/editor-route-base.js
+++ b/core/client/mixins/editor-route-base.js
@@ -22,7 +22,10 @@ var EditorRouteBase = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
 
         // The actual functionality is implemented in utils/codemirror-shortcuts
         codeMirrorShortcut: function (options) {
-            this.get('controller.codemirror').shortcut(options.type);
+            // Only fire editor shortcuts when the editor has focus.
+            if (Ember.$('.CodeMirror.CodeMirror-focused').length > 0) {
+                this.get('controller.codemirror').shortcut(options.type);
+            }
         }
     },
 


### PR DESCRIPTION
closes #4253
- checked for the CodeMirror-focused class on the CodeMirror div
- used length to determine whether CodeMirror-focused has been added
- determines whether the editor has been focused on
