### PR TITLE
Update Sass Grunt task output style

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -313,7 +313,7 @@ var _              = require('lodash'),
             sass: {
                 compress: {
                     options: {
-                        style: 'compressed',
+                        outputStyle: 'compressed',
                         sourceMap: true
                     },
                     files: [


### PR DESCRIPTION
No issue

A recent update to NodeSass changed the keyword for output style from `style` to `outputStyle`.
This updates that, thus making the minfied CSS, actually minfied.
