### PR TITLE
fix bug in which `logError` could not resolve an err without `message`

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -107,7 +107,13 @@ errors = {
 
         stack = err ? err.stack : null;
 
-        err = _.isString(err) ? err : (_.isObject(err) ? err.message : 'An unknown error occurred.');
+        if (!_.isString(err)) {
+            if (_.isObject(err) && _.isString(err.message)) {
+                err = err.message;
+            } else {
+                err = 'An unknown error occurred.';
+            }
+        }
 
         // Overwrite error to provide information that this is probably a permission problem
         // TODO: https://github.com/TryGhost/Ghost/issues/3687


### PR DESCRIPTION
fixed #4381
- if an error object has no property `message`, an new error could been produced
