### PR TITLE
Save meta title and meta desc on post save

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -66,7 +66,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         return hashCurrent === hashPrevious;
     },
 
-    // a hook created in editor-route-base's setupController
+    // a hook created in editor-base-route's setupController
     modelSaved: function () {
         var model = this.get('model');
 
@@ -231,6 +231,8 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             }
 
             this.set('title', this.get('titleScratch'));
+            this.set('meta_title', psmController.get('metaTitleScratch'));
+            this.set('meta_description', psmController.get('metaDescriptionScratch'));
 
             if (!this.get('slug')) {
                 // Cancel any pending slug generation that may still be queued in the

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -1,11 +1,9 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
-import base from 'ghost/mixins/editor-route-base';
+import base from 'ghost/mixins/editor-base-route';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
 var EditorEditRoute = AuthenticatedRoute.extend(base, {
-    classNames: ['editor'],
-
     model: function (params) {
         var self = this,
             post,
@@ -50,57 +48,6 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
                 return self.transitionTo('posts.index');
             });
         });
-    },
-
-    serialize: function (model) {
-        return {post_id: model.get('id')};
-    },
-
-    setupController: function (controller, model) {
-        this._super(controller, model);
-
-        controller.set('scratch', model.get('markdown'));
-
-        controller.set('titleScratch', model.get('title'));
-
-        // used to check if anything has changed in the editor
-        controller.set('previousTagNames', model.get('tags').mapBy('name'));
-
-        // attach model-related listeners created in editor-route-base
-        this.attachModelHooks(controller, model);
-    },
-
-    actions: {
-        willTransition: function (transition) {
-            var controller = this.get('controller'),
-                isDirty = controller.get('isDirty'),
-
-                model = controller.get('model'),
-                isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted'),
-                modelIsDirty = model.get('isDirty');
-
-            this.send('closeSettingsMenu');
-
-            // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
-            // the record has already been deleted and the deletion persisted.
-            //
-            // in either case  we can probably just transition now.
-            // in the former case the server will return the record, thereby updating it.
-            // @TODO: this will break if the model fails server-side validation.
-            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
-                transition.abort();
-                this.send('openModal', 'leave-editor', [controller, transition]);
-                return;
-            }
-
-            // since the transition is now certain to complete..
-            window.onbeforeunload = null;
-
-            // remove model-related listeners created in editor-route-base
-            this.detachModelHooks(controller, model);
-        }
     }
 });
 

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -1,9 +1,7 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
-import base from 'ghost/mixins/editor-route-base';
+import base from 'ghost/mixins/editor-base-route';
 
 var EditorNewRoute = AuthenticatedRoute.extend(base, {
-    classNames: ['editor'],
-
     model: function () {
         var self = this;
         return this.get('session.user').then(function (user) {
@@ -14,60 +12,13 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
     },
 
     setupController: function (controller, model) {
-        this._super(controller, model);
-
         var psm = this.controllerFor('post-settings-menu');
 
         // make sure there are no titleObserver functions hanging around
         // from previous posts
         psm.removeObserver('titleScratch', psm, 'titleObserver');
 
-        controller.set('scratch', '');
-        controller.set('titleScratch', '');
-
-        // used to check if anything has changed in the editor
-        controller.set('previousTagNames', Ember.A());
-
-        // attach model-related listeners created in editor-route-base
-        this.attachModelHooks(controller, model);
-    },
-
-    actions: {
-        willTransition: function (transition) {
-            var controller = this.get('controller'),
-                isDirty = controller.get('isDirty'),
-
-                model = controller.get('model'),
-                isNew = model.get('isNew'),
-                isSaving = model.get('isSaving'),
-                isDeleted = model.get('isDeleted'),
-                modelIsDirty = model.get('isDirty');
-
-            this.send('closeSettingsMenu');
-
-            // when `isDeleted && isSaving`, model is in-flight, being saved
-            // to the server. when `isDeleted && !isSaving && !modelIsDirty`,
-            // the record has already been deleted and the deletion persisted.
-            //
-            // in either case  we can probably just transition now.
-            // in the former case the server will return the record, thereby updating it.
-            // @TODO: this will break if the model fails server-side validation.
-            if (!(isDeleted && isSaving) && !(isDeleted && !isSaving && !modelIsDirty) && isDirty) {
-                transition.abort();
-                this.send('openModal', 'leave-editor', [controller, transition]);
-                return;
-            }
-
-            if (isNew) {
-                model.deleteRecord();
-            }
-
-            // since the transition is now certain to complete..
-            window.onbeforeunload = null;
-
-            // remove model-related listeners created in editor-route-base
-            this.detachModelHooks(controller, model);
-        }
+        this._super(controller, model);
     }
 });
 

--- a/core/client/utils/codemirror-shortcuts.js
+++ b/core/client/utils/codemirror-shortcuts.js
@@ -2,7 +2,7 @@
 // jscs:disable disallowSpacesInsideParentheses
 
 /** Set up a shortcut function to be called via router actions.
- *  See editor-route-base
+ *  See editor-base-route
  */
 
 import titleize from 'ghost/utils/titleize';


### PR DESCRIPTION
Closes #4369
I may also have gotten carried away refactoring the editor-base-route mixin.
- Renamed `editor-route-base` -> `editor-base-route` to bring it in alignment with the view and controller mixins
- Consolidated editor route code into editor-base-route
- Removed `serialize` from EditorEditRoute, as it reimplemented the ember default

![save meta](https://cloud.githubusercontent.com/assets/1207005/4894781/f360bd5c-63d9-11e4-9f5b-9085fdeb51f4.gif)
