### PR TITLE
[WIP] Don't autosave on focus-in to editor

### DIFF
--- a/core/client/components/gh-post-title-input.js
+++ b/core/client/components/gh-post-title-input.js
@@ -1,0 +1,21 @@
+import FocusInput from 'ghost/components/gh-trim-focus-input';
+
+var PostTitleInput = FocusInput.extend({
+    click: function (event) {
+        this._super(event);
+        if (this.get('value') === '(Untitled)') {
+            this.$().select();
+        }
+    },
+    focusOut: function (event) {
+        this._super(event);
+        if (!this.get('value')) {
+            this.set('value', '(Untitled)');
+        }
+    },
+    selectOnInsert: function () {
+        this.$().select();
+    }.on('didInsertElement')
+});
+
+export default PostTitleInput;

--- a/core/client/components/gh-trim-focus-input.js
+++ b/core/client/components/gh-trim-focus-input.js
@@ -2,15 +2,14 @@ var TrimFocusInput = Ember.TextField.extend({
     focus: true,
 
     setFocus: function () {
-        if (this.focus) {
-            this.$().val(this.$().val()).focus();
+        if (this.get('focus')) {
+            this.$().focus();
         }
     }.on('didInsertElement'),
 
-    focusOut: function () {
-        var text = this.$().val();
-
-        this.$().val(text.trim());
+    focusOut: function (event) {
+        this._super(event);
+        this.set('value', this.get('value').trim());
     }
 });
 

--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -101,8 +101,8 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             afterSave = this.get('lastPromise'),
             promise;
 
-        // Only set an "untitled" slug once per post
-        if (title === '(Untitled)' && this.get('slug')) {
+        // Don't set a slug for an untitled post
+        if (title === '(Untitled)' || !title) {
             return;
         }
 

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -99,6 +99,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             markdown = this.get('markdown'),
             title = this.get('title'),
             titleScratch = this.get('titleScratch'),
+            isDefaultTitleState = (titleScratch === '(Untitled)' && !title),
             scratch = this.getMarkdown().withoutMarkers,
             changedAttributes;
 
@@ -106,7 +107,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             return true;
         }
 
-        if (titleScratch !== title) {
+        if (titleScratch !== title && !isDefaultTitleState) {
             return true;
         }
 
@@ -224,12 +225,6 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             // set markdown equal to what's in the editor, minus the image markers.
             this.set('markdown', this.getMarkdown().withoutMarkers);
             this.set('status', status);
-
-            // Set a default title
-            if (!this.get('titleScratch')) {
-                this.set('titleScratch', '(Untitled)');
-            }
-
             this.set('title', this.get('titleScratch'));
             this.set('meta_title', psmController.get('metaTitleScratch'));
             this.set('meta_description', psmController.get('metaDescriptionScratch'));
@@ -345,12 +340,6 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
                 autoSaveId = Ember.run.debounce(this, 'send', 'save', {silent: true, disableNProgress: true}, 3000);
                 this.set('autoSaveId', autoSaveId);
-            }
-        },
-
-        autoSaveNew: function () {
-            if (this.get('isNew')) {
-                this.send('save', {silent: true, disableNProgress: true});
             }
         }
     }

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -5,7 +5,7 @@ var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     validationType: 'post',
 
     uuid: DS.attr('string'),
-    title: DS.attr('string', {defaultValue: ''}),
+    title: DS.attr('string', {defaultValue: '(Untitled)'}),
     slug: DS.attr('string'),
     markdown: DS.attr('string', {defaultValue: ''}),
     html: DS.attr('string'),

--- a/core/client/templates/editor/edit.hbs
+++ b/core/client/templates/editor/edit.hbs
@@ -6,7 +6,7 @@
 <div class="page-content">
     <header>
         <section class="box entry-title">
-            {{gh-trim-focus-input type="text" id="entry-title" placeholder="Your Post Title" value=titleScratch
+            {{gh-post-title-input type="text" id="entry-title" placeholder="Your Post Title" value=titleScratch
             tabindex="1" focus=shouldFocusTitle}}
         </section>
     </header>
@@ -19,7 +19,7 @@
         <section id="entry-markdown-content" class="entry-markdown-content">
             {{gh-codemirror value=scratch scrollInfo=view.markdownScrollInfo
             setCodeMirror="setCodeMirror" openModal="openModal" typingPause="autoSave"
-            focus=shouldFocusEditor onFocusIn="autoSaveNew"}}
+            focus=shouldFocusEditor}}
         </section>
     </section>
 

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -126,22 +126,6 @@ screens = {
 casper.writeContentToCodeMirror = function (content) {
     var lines = content.split('\n');
 
-    // If we are on a new editor, the autosave is going to get triggered when we try to type, so we need to trigger
-    // that and wait for it to sort itself out
-    if (/ghost\/editor\/$/.test(casper.getCurrentUrl())) {
-        casper.waitForSelector('.CodeMirror-wrap textarea', function onSuccess() {
-            casper.click('.CodeMirror-wrap textarea');
-        }, function onTimeout() {
-            casper.test.fail('CodeMirror was not found on initial load.');
-        }, 2000);
-
-        casper.waitForUrl(/\/ghost\/editor\/\d+\/$/, function onSuccess() {
-            // do nothing
-        }, function onTimeout() {
-            casper.test.fail('The url didn\'t change: ' + casper.getCurrentUrl());
-        }, 2000);
-    }
-
     casper.waitForSelector('.CodeMirror-wrap textarea', function onSuccess() {
         casper.each(lines, function (self, line) {
             self.sendKeys('.CodeMirror-wrap textarea', line, {keepFocus: true});


### PR DESCRIPTION
Closes #4321
- Added a PostTitleInputComponent that sets its value to "(Untitled)" if it has no value on focusOut, and selects its text if its text is "(Untitled)" on a click.
- Removed autoSaveNew action firing onFocusIn of the markdown editor
- emberified the gh-trim-focus-input
- editor-base-controller is no longer responsible for setting a default title (horay!)
