### PR TITLE
Re-add Node-Sass Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
         "grunt-update-submodules": "~0.4.1",
         "matchdep": "~0.3.0",
         "nock": "0.47.0",
+        "node-sass": "~1.1.4",
         "require-dir": "~0.1.0",
         "rewire": "~2.1.0",
         "should": "~4.0.4",


### PR DESCRIPTION
References #4355 and #4372

There was an issue where Libsass/node-sass would strip media queries (https://github.com/sass/libsass/issues/566 & https://github.com/sass/node-sass/issues/487). It is fixed now, but the dependencies in grunt-sass have not yet been updated.

This PR requires a never version of node-sass which fixes the issue.
