### PR TITLE
Use nested output style for Sass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -313,7 +313,7 @@ var _              = require('lodash'),
             sass: {
                 compress: {
                     options: {
-                        outputStyle: 'compressed',
+                        outputStyle: 'nested', // TODO: Set back to 'compressed' working correctly with our dependencies
                         sourceMap: true
                     },
                     files: [


### PR DESCRIPTION
References #4389

As a result of https://github.com/TryGhost/Ghost/pull/4389#issuecomment-61637323 the best way to keep everything working nicely is to use the `nested` outputStyle for now.
