### PR TITLE
Removes hash after the url when clicking Meta Data

### DIFF
--- a/core/client/assets/sass/patterns/navlist.scss
+++ b/core/client/assets/sass/patterns/navlist.scss
@@ -43,6 +43,10 @@
         border-bottom: 1px solid #E0DFD7;
     }
 
+    button {
+        text-align: left;
+    }
+
     a {
         color: $darkgrey;
     }

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -29,7 +29,7 @@
 
     }}
 
-    <div class="nav-item user-menu" data-href="#">
+    <div class="nav-item user-menu">
         {{#gh-dropdown-button dropdownName="user-menu" tagName="div" classNames="nav-label clearfix"}}
             {{#if session.user.image}}
             <div class="image"><img {{bind-attr src=session.user.image alt=userImageAlt}} /></div>

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -42,10 +42,10 @@
 
             <ul class="nav-list nav-list-block">
                 {{#gh-tab tagName="li" classNames="nav-list-item"}}
-                    <a href="#">
+                    <button type="button">
                         <b>Meta Data</b>
                         <span>Extra content for SEO and social media.</span>
-                    </a>
+                    </button>
                 {{/gh-tab}}
             </ul>
 


### PR DESCRIPTION
Removes that hash appended to the URL when clicking Meta Data in post settings.

Closes #4386

When clicking 'Meta Data' the click event appends a # to the URL. I replaced the a with a button element so that won't happen anymore. The button has a type attribute because it will try and submit the form without it. Added text-align: left to the navlist button because the button centers it's content by default.
