### PR TITLE
Summary downsize update

### DIFF
--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -1,5 +1,5 @@
 // # Content Helper
-// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}}`
+// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}}`, `{{content characters="256" round="true"}}`
 //
 // Turns content html into a safestring so that the user doesn't have to
 // escape it or tell handlebars to leave it alone with a triple-brace.
@@ -13,22 +13,30 @@ var hbs             = require('express-hbs'),
     content;
 
 content = function (options) {
-    var truncateOptions = (options || {}).hash || {};
-    truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
-    _.keys(truncateOptions).map(function (key) {
-        truncateOptions[key] = parseInt(truncateOptions[key], 10);
+    var inputOptions = (options || {}).hash || {},
+        intOptions,
+        boolOptions;
+
+    intOptions = _.pick(inputOptions, ['words', 'characters']);
+    _.keys(intOptions).map(function (key) {
+        intOptions[key] = parseInt(intOptions[key], 10);
     });
 
-    if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
+    boolOptions = _.pick(inputOptions, ['round']);
+    _.keys(boolOptions).map(function (key) {
+        boolOptions[key] = _.isString(boolOptions[key]) && boolOptions[key].toLowerCase() === 'true' ? true : false;
+    });
+
+    if (intOptions.hasOwnProperty('words') || intOptions.hasOwnProperty('characters')) {
         // Legacy function: {{content words="0"}} should return leading tags.
-        if (truncateOptions.hasOwnProperty('words') && truncateOptions.words === 0) {
+        if (intOptions.hasOwnProperty('words') && intOptions.words === 0) {
             return new hbs.handlebars.SafeString(
                 downzero(this.html)
             );
         }
 
         return new hbs.handlebars.SafeString(
-            downsize(this.html, truncateOptions)
+            downsize(this.html, _.extend(intOptions, boolOptions))
         );
     }
 

--- a/core/test/unit/server_helpers/content_spec.js
+++ b/core/test/unit/server_helpers/content_spec.js
@@ -36,7 +36,7 @@ describe('{{content}} helper', function () {
                 );
 
         should.exist(rendered);
-        rendered.string.should.equal('<p>Hello <strong>World</strong></p>');
+        rendered.string.should.equal('<p>Hello <strong>World!</strong></p>');
     });
 
     it('can truncate html to 0 words', function () {
@@ -178,5 +178,75 @@ describe('{{content}} helper', function () {
 
         should.exist(rendered);
         rendered.string.should.equal('<p>Hello <strong>Wo</strong></p>');
+    });
+
+    it('can defer truncating html until the end of a matching <p> tag when round=\"true\" is specified.', function () {
+        var html = '<p>I am a first paragraph. I am longer than 2 words.</p><p>I am a second paragraph.</p>',
+            rendered = (
+                helpers.content
+                    .call(
+                        {html: html},
+                        {hash: {words: 2, round: 'true'}}
+                    )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal('<p>I am a first paragraph. I am longer than 2 words.</p>');
+    });
+
+    it('can defer truncating html until the end of a matching <pre> tag when round=\"true\" is specified.', function () {
+        var html = '<pre>I am a first pre. I am longer than 2 words.</pre><p>I am a second contextful element.</p>',
+            rendered = (
+                helpers.content
+                    .call(
+                        {html: html},
+                        {hash: {words: 2, round: 'true'}}
+                    )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal('<pre>I am a first pre. I am longer than 2 words.</pre>');
+    });
+
+    it('can defer truncating html until the end of a matching <blockquote> tag when round=\"true\" is specified.', function () {
+        var html = '<blockquote>I am a first blockquote. I am longer than 2 words.</blockquote><p>I am a second contextful element.</p>',
+            rendered = (
+                helpers.content
+                    .call(
+                        {html: html},
+                        {hash: {characters: 2, round: 'true'}}
+                    )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal('<blockquote>I am a first blockquote. I am longer than 2 words.</blockquote>');
+    });
+
+    it('can defer truncating html until the end of a matching <ul> tag when round=\"true\" is specified.', function () {
+        var html = '<ul><li>I am a first ul.</li><li>I am longer than 2 words.</li></ul><p>I am a second contextful element.</p>',
+            rendered = (
+                helpers.content
+                    .call(
+                        {html: html},
+                        {hash: {words: 2, round: 'true'}}
+                    )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal('<ul><li>I am a first ul.</li><li>I am longer than 2 words.</li></ul>');
+    });
+
+    it('can defer truncating html until the end of a matching <ol> tag when round=\"true\" is specified.', function () {
+        var html = '<ol><li>I am a first ol.</li><li>I am longer than 2 words.</li></ol><p>I am a second contextful element.</p>',
+            rendered = (
+                helpers.content
+                    .call(
+                        {html: html},
+                        {hash: {characters: 2, round: 'true'}}
+                    )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal('<ol><li>I am a first ol.</li><li>I am longer than 2 words.</li></ol>');
     });
 });

--- a/core/test/unit/server_helpers/excerpt_spec.js
+++ b/core/test/unit/server_helpers/excerpt_spec.js
@@ -40,7 +40,7 @@ describe('{{excerpt}} Helper', function () {
 
     it('can truncate html by word', function () {
         var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
-            expected = 'Hello World',
+            expected = 'Hello World!',
             rendered = (
                 helpers.excerpt.call(
                     {html: html},

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "colors": "0.6.2",
         "compression": "1.2.0",
         "connect-slashes": "1.2.0",
-        "downsize": "0.0.5",
+        "downsize": "0.0.8",
         "express": "4.9.2",
         "express-hbs": "0.7.11",
         "fs-extra": "0.12.0",


### PR DESCRIPTION
Introduces downsize v 0.0.8 and uses its contextual tags api to provide a round="true" (up)rounding feature to the content helper.

I've elected to implement this for the {{content}} helper first; the {{excerpt}} helper currently strips html before passing it to downsize. I want to think a bit about how smart we can be with that interaction, and I'd love to land this first.
### ce3e7b2
- downsize 0.0.5 -> 0.0.8
- downsize is now better at punctuation, update {{content}} and {{excerpt}} tests appropriately.
  ###16c38bf
- Passthrough to Downsize 'contextual tags' functionality.
- Allows for awaiting a markdown segment level closing tag before truncating content.
- Includes tests.

relates to https://github.com/TryGhost/Ghost/issues/4017

@ErisDS 
