### PR TITLE
Remove dependency on globally-installed grunt-cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,8 @@ Please do **NOT** use the master branch of Ghost in production. If you are using
 
 #### Quickstart:
 
-1. `npm install -g grunt-cli`
 1. `npm install`
-1. `grunt init` (and `grunt prod` if you want to run Ghost in production mode)
+1. `npm run grunt-init` (and `npm run grunt-prod` if you want to run Ghost in production mode)
 1. `npm start`
 
 Full instructions & troubleshooting tips can be found in the [Contributing Guide](https://github.com/TryGhost/Ghost/blob/master/CONTRIBUTING.md) under the heading "[Working on Ghost Core](https://github.com/TryGhost/Ghost/blob/master/CONTRIBUTING.md#working-on-ghost-core)".

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "main": "./core/index",
     "scripts": {
         "start": "node index",
+        "grunt-init": "grunt init",
+        "grunt-prod": "grunt prod",
         "test": "./node_modules/.bin/grunt validate --verbose"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "start": "node index",
         "grunt-init": "grunt init",
         "grunt-prod": "grunt prod",
-        "test": "./node_modules/.bin/grunt validate --verbose"
+        "test": "grunt validate --verbose"
     },
     "engines": {
         "node": "~0.10.0"


### PR DESCRIPTION
Grunt-cli is already being installed as a devDependency, allowing it to be used through the package.json `scripts` section. This way the maintainers can always keep grunt-cli's version up-to-date, and remove one step from the setup process, as well as no longer needing to install grunt-cli twice.
