### PR TITLE
Reset slugValue when the user changes

### DIFF
--- a/core/client/controllers/settings/users/user.js
+++ b/core/client/controllers/settings/users/user.js
@@ -1,5 +1,6 @@
 import SlugGenerator from 'ghost/models/slug-generator';
 import isNumber from 'ghost/utils/isNumber';
+import boundOneWay from 'ghost/utils/bound-one-way';
 
 var SettingsUserController = Ember.ObjectController.extend({
 
@@ -7,7 +8,7 @@ var SettingsUserController = Ember.ObjectController.extend({
 
     email: Ember.computed.readOnly('user.email'),
 
-    slugValue: Ember.computed.oneWay('user.slug'),
+    slugValue: boundOneWay('user.slug'),
 
     lastPromise: null,
 


### PR DESCRIPTION
Closes #4411
- Previously, saving the user’s slug would lead to the slug value being
  ‘stuck’ on that saved value, even if one navigated to a different
  user’s profile settings.
