### PR TITLE
Do not eagerly fetch relations in when finding all posts

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -248,7 +248,9 @@ Post = ghostBookshelf.Model.extend({
      */
     findAll:  function (options) {
         options = options || {};
-        options.withRelated = _.union(['tags', 'fields'], options.include);
+
+        // fetch relations passed to options.include
+        options.withRelated = options.include;
         return ghostBookshelf.Model.findAll.call(this, options);
     },
 


### PR DESCRIPTION
fixes #4232
- do not fetch tags and fields in post.findAll()
