### PR TITLE
Adds 'save' shortcut to settings screens

### DIFF
--- a/core/client/routes/settings/general.js
+++ b/core/client/routes/settings/general.js
@@ -2,8 +2,15 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
+import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
+import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, {
+var shortcuts = {},
+    SettingsGeneralRoute;
+
+shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
+
+SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, ShortcutsRoute, {
     classNames: ['settings-view-general'],
 
     beforeModel: function () {
@@ -16,6 +23,14 @@ var SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator
         return this.store.find('setting', {type: 'blog,theme'}).then(function (records) {
             return records.get('firstObject');
         });
+    },
+
+    shortcuts: shortcuts,
+
+    actions: {
+        save: function () {
+            this.get('controller').send('save');
+        }
     }
 });
 

--- a/core/client/routes/settings/users/user.js
+++ b/core/client/routes/settings/users/user.js
@@ -1,7 +1,14 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import styleBody from 'ghost/mixins/style-body';
+import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
+import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, {
+var shortcuts = {},
+    SettingsUserRoute;
+
+shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
+
+SettingsUserRoute = AuthenticatedRoute.extend(styleBody, ShortcutsRoute, {
     classNames: ['settings-view-user'],
 
     model: function (params) {
@@ -44,6 +51,14 @@ var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, {
         }
 
         this._super();
+    },
+
+    shortcuts: shortcuts,
+
+    actions: {
+        save: function () {
+            this.get('controller').send('save');
+        }
     }
 });
 

--- a/core/client/utils/ctrl-or-cmd.js
+++ b/core/client/utils/ctrl-or-cmd.js
@@ -1,0 +1,3 @@
+var ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
+
+export default ctrlOrCmd;

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -1,5 +1,6 @@
-var shortcuts = {},
-    ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
+import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
+
+var shortcuts = {};
 
 // General editor shortcuts
 shortcuts[ctrlOrCmd + '+s'] = 'save';


### PR DESCRIPTION
closes #4414
- adds `ctrl/cmd+s` shortcuts to `settings/general` screen
- adds `ctrl/cmd+s` shortcuts to `settings/user/xx` screen
- extracts `ctrlOrCmd` variable to separate module for reuse
