### PR TITLE
Update PSM Date and Time to be Selectable Instead of Text

### DIFF
--- a/core/client/assets/sass/patterns/forms.scss
+++ b/core/client/assets/sass/patterns/forms.scss
@@ -49,7 +49,8 @@ form {
     input[type="tel"],
     input[type="text"],
     input[type="url"],
-    input[type="date"] {
+    input[type="date"],
+    input[type="datetime-local"] {
         padding-left: 3.2rem;
     }
     .gh-select {
@@ -144,6 +145,7 @@ input[type="tel"],
 input[type="text"],
 input[type="url"],
 input[type="date"],
+input[type="datetime-local"],
 textarea,
 .gh-select,
 select {
@@ -164,6 +166,11 @@ select {
         outline: 0;
     }
 
+}
+
+// Fix for iOS where this element _looks_ like a <select> element
+input[type="datetime-local"] {
+    -webkit-appearance: none;
 }
 
 textarea {

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -19,7 +19,7 @@
             <div class="form-group">
                 <label for="post-setting-date">Publish Date</label>
                 <span class="input-icon icon-calendar">
-                    {{gh-input class="post-setting-date" id="post-setting-date" value=publishedAtValue name="post-setting-date" focus-out="setPublishedAt" stopEnterKeyDownPropagation="true"}}
+                    {{gh-input type="datetime-local" class="post-setting-date" id="post-setting-date" value=publishedAtValue name="post-setting-date" focus-out="setPublishedAt" stopEnterKeyDownPropagation="true"}}
                 </span>
             </div>
 

--- a/core/client/utils/date-formatting.js
+++ b/core/client/utils/date-formatting.js
@@ -14,9 +14,10 @@ parseDateFormats = ['DD MMM YY @ HH:mm', 'DD MMM YY HH:mm',
                         'DD-MM-YY @ HH:mm', 'DD-MM-YY HH:mm',
                         'DD-MM-YYYY @ HH:mm', 'DD-MM-YYYY HH:mm',
                         'YYYY-MM-DD @ HH:mm', 'YYYY-MM-DD HH:mm',
-                        'DD MMM @ HH:mm', 'DD MMM HH:mm'];
+                        'DD MMM @ HH:mm', 'DD MMM HH:mm',
+                        'YYYY-MM-DDTHH:mm'];
 
-displayDateFormat = 'DD MMM YY @ HH:mm';
+displayDateFormat = 'YYYY-MM-DDTHH:mm';
 
 // Add missing timestamps
 verifyTimeStamp = function (dateString) {


### PR DESCRIPTION
No Issue (Yet)

I updated the date and time inside the post settings menu so that it can be selected via calendar or using up and down arrows, etc. Thought it might be easier than having to type in the date with the @ time etc.

![screen shot 2014-11-13 at 1 31 17 pm](https://cloud.githubusercontent.com/assets/4715098/5037046/6a295c26-6b39-11e4-8012-9d0062ecd304.png)
![screen shot 2014-11-13 at 1 31 23 pm](https://cloud.githubusercontent.com/assets/4715098/5037045/6a2708c2-6b39-11e4-9d95-14302eb28160.png)

I have tested it a little bit and believe it is working and haven't had any problems with saving or new posts.

I can create an issue and update the PR if this is something that you want merged. If not, just go ahead and close.
