### PR TITLE
Enable .fade-out animations in Safari

### DIFF
--- a/core/client/assets/sass/components/navigation.scss
+++ b/core/client/assets/sass/components/navigation.scss
@@ -177,7 +177,7 @@
         }
 
         &.fade-out {
-            animation-duration: 0;
+            animation-duration: 0.01s;
         }
 
         .dropdown-menu {

--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -573,7 +573,7 @@ body.zen {
         }
 
         &.fade-out {
-            animation-duration: 0;
+            animation-duration: 0.01s;
         }
 
         .dropdown-menu {


### PR DESCRIPTION
Closes #4432
- Random sidenote: Safari is a whiny non-animating wuss and figuring this out took way longer than one would think.
