### PR TITLE
Fix post tags input.

### DIFF
--- a/core/client/views/post-tags-input.js
+++ b/core/client/views/post-tags-input.js
@@ -50,10 +50,6 @@ var PostTagsInputView = Ember.View.extend({
 
         focusOut: function () {
             this.get('parentView').set('hasFocus', false);
-
-            // if (!Ember.isEmpty(this.get('value'))) {
-            //     this.get('parentView.controller').send('addNewTag');
-            // }
         },
 
         keyDown: function (event) {


### PR DESCRIPTION
Closes #4378. Closes #4455.
- Trim whitespace from tag names on entry.
- Prevent duplicate tags in suggestion list.
- Fix unhandled exception that happens when backspace is pressed in
  an empty tags input box.
