### PR TITLE
Fix high latency autosave bug in editor.new

### DIFF
--- a/core/client/templates/editor/edit.hbs
+++ b/core/client/templates/editor/edit.hbs
@@ -19,7 +19,7 @@
         <section id="entry-markdown-content" class="entry-markdown-content">
             {{gh-codemirror value=scratch scrollInfo=view.markdownScrollInfo
             setCodeMirror="setCodeMirror" openModal="openModal" typingPause="autoSave"
-            focus=shouldFocusEditor onFocusIn="autoSaveNew"}}
+            focus=shouldFocusEditor focusCursorAtEnd=model.isDirty onFocusIn="autoSaveNew"}}
         </section>
     </section>
 


### PR DESCRIPTION
Closes #4400 
- Clean up willtransition logic in editor-base-route

Known bug: If you have typed into the body before the transition, after the transition completes your cursor is reset to the start of the line.
I've tried fixing this by having codemirror intelligently `goToDocEnd` after being initialized, but it instead places it halfway. I'm still working on a fix for that. I'm not sure what's the greater evil; 4400 or the one-time cursor jump.

The problem comes from the fact that the entire template is torn down and rebuilt, even though nothing actually changes. I think that the ultimate solution for this may be to remove the `editor.new` and `editor.edit` routes in favor of just having an `editor` route. new/edit already share almost all of their code, and I feel like the separation between the two has caused a lot of issues as we try to refactor autosave ( #4321's attempted fixes, for example )
