### PR TITLE
Fix gravatar request url.

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -849,7 +849,7 @@ User = ghostBookshelf.Model.extend({
                 resolve(userData);
             }
 
-            request({url: gravatarUrl, timeout: 2000}, function (err, response) {
+            request({url: 'http:' + gravatarUrl, timeout: 2000}, function (err, response) {
                 if (err) {
                     // just resolve with no image url
                     resolve(userData);


### PR DESCRIPTION
Refs #4367
- 'http:' was accidentally left out when passing the gravatar
  URL into request, and request requires the full scheme to be present.
