### PR TITLE
Fix invalid image helper URLs when using a subdir.

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -139,6 +139,9 @@ function urlFor(context, data, absolute) {
             imagePathRe = new RegExp('^' + ghostConfig.paths.subdir + '/' + ghostConfig.paths.imagesRelPath);
             absolute = imagePathRe.test(data.image) ? absolute : false;
             secure = data.image.secure;
+
+            // Remove the sub-directory from the URL because createUrl() will add it back.
+            urlPath = urlPath.replace(new RegExp('^' + ghostConfig.paths.subdir), '');
         }
         // other objects are recognised but not yet supported
     } else if (_.isString(context) && _.indexOf(_.keys(knownPaths), context) !== -1) {

--- a/core/test/unit/server_helpers/image_spec.js
+++ b/core/test/unit/server_helpers/image_spec.js
@@ -67,3 +67,44 @@ describe('{{image}} helper', function () {
         }).catch(done);
     });
 });
+
+describe('{{image}} helper when Ghost is running on a sub-directory', function () {
+    var sandbox;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+        utils.overrideConfig({url: 'http://testurl.com/blog'});
+        utils.loadHelpers();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    after(function () {
+        utils.restoreConfig();
+    });
+
+    it('should output relative url of image', function (done) {
+        helpers.image.call({
+            image: '/blog/content/images/image-relative-url.png',
+            author: {
+                image: '/blog/content/images/author-image-relatve-url.png'
+            }
+        }).then(function (rendered) {
+            should.exist(rendered);
+            rendered.should.equal('/blog/content/images/image-relative-url.png');
+            done();
+        }).catch(done);
+    });
+
+    it('should output absolute url of image if the option is present ', function (done) {
+        helpers.image.call({image: '/blog/content/images/image-relative-url.png',
+        author: {image: '/blog/content/images/author-image-relatve-url.png'}},
+        {hash: {absolute: 'true'}}).then(function (rendered) {
+            should.exist(rendered);
+            rendered.should.equal('http://testurl.com/blog/content/images/image-relative-url.png');
+            done();
+        }).catch(done);
+    });
+});


### PR DESCRIPTION
If Ghost is running under a sub-directory, image URLs that are saved include the sub-directory.  The problem is that `config.createUrl()` adds the sub-directory when building URLs, so any time a URL is generated the output will contain the sub-directory twice, e.g. `http://my-ghost-blog.com/subdir/subdir/content/image.png`.

This affects metadata tags that include image URLs and post cover images.
