### PR TITLE
Improve validation for user.website

### DIFF
--- a/core/client/validators/user.js
+++ b/core/client/validators/user.js
@@ -51,7 +51,7 @@ var UserValidator = Ember.Object.create({
             }
 
             if (!Ember.isEmpty(website) &&
-                (!validator.isURL(website, {protocols: ['http', 'https'], require_protocol: true}) ||
+                (!validator.isURL(website, {require_protocol: false}) ||
                 !validator.isLength(website, 0, 2000))) {
                 validationErrors.push({message: 'Website is not a valid url'});
             }

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -94,6 +94,16 @@ User = ghostBookshelf.Model.extend({
         return attrs;
     },
 
+    format: function (options) {
+        if (!_.isEmpty(options.website) &&
+            !validator.isURL(options.website, {
+            require_protocol: true,
+            protocols: ['http', 'https']})) {
+            options.website = 'http://' + options.website;
+        }
+        return options;
+    },
+
     posts: function () {
         return this.hasMany('Posts', 'created_by');
     },


### PR DESCRIPTION
closes #4444
- validate without protocol in server and client
- when saving the url, add `http://` if the url doesn't have a protocol
