### PR TITLE
Stick notifications to the top on short screens

### DIFF
--- a/core/client/assets/sass/components/notifications.scss
+++ b/core/client/assets/sass/components/notifications.scss
@@ -40,6 +40,10 @@
         body.settings-menu-expanded & {
             transform: translate3d(350px, 0px, 0px);
         }
+
+        @media (max-height: 300px) {
+            top: 75px;
+        }
     }
 }//.notifications
 


### PR DESCRIPTION
Closes #4379
- Ensure that notifications are at least 60px navbar + 15px margin from the top of the screen.
