### PR TITLE
Close passive notifications on successful auto-save of meta-data

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -388,7 +388,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
+            this.get('model').save().then(function () {
+                self.notifications.closePassive();
+            }, function (errors) {
                 self.showErrors(errors);
             });
         },
@@ -410,7 +412,9 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
+            this.get('model').save().then(function () {
+                self.notifications.closePassive();
+            }, function (errors) {
                 self.showErrors(errors);
             });
         },


### PR DESCRIPTION
closes #4366
- Fire self.notifications.closePassive() on resolve for model.save()
