### PR TITLE
Reverting mysql to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "xml": "0.0.12"
     },
     "optionalDependencies": {
-        "mysql": "2.5.2",
+        "mysql": "2.1.1",
         "pg.js": "3.6.2"
     },
     "devDependencies": {


### PR DESCRIPTION
I am currently doing some testing on this but I believe it is fine with knex 0.7.3
- Unfortunately mysql has changed the way it handles the charset setting such that
  it now causes encoding issues on many setups where 'utf8' is apparently not the
  correct setting.
- We need to revert this upgrade until the issue is fixed or we have a way to handle
  it nicely for our users.
