### PR TITLE
Doesnt redirect with URL prefix

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -297,8 +297,7 @@ setupMiddleware = function (blogAppInstance, adminApp) {
     blogApp.use(slashes(true, {
         headers: {
             'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
-        },
-        base: config.paths.subdir
+        }
     }));
     blogApp.use(uncapitalise);
 


### PR DESCRIPTION
If you set the blog url to something like:
"https://blog.ghost.org/ghost"

Going to a valid URL without the slash is going to take you to bad places:
"https://blog.ghost.org/ghost" --> "https://blog.ghost.org/ghost/ghost/"

Fix: Assume the URL is valid, and don't slap on the prefix, since connect-slashes isn't responsible for this kind of validation.
