### PR TITLE
Loads correct screen after author refreshes page in editor

### DIFF
--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -18,10 +18,6 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
 
         post = this.store.getById('post', postId);
 
-        if (post) {
-            return post;
-        }
-
         paginationSettings = {
             id: postId,
             status: 'all',
@@ -36,7 +32,7 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
             return self.store.find('post', paginationSettings).then(function (records) {
                 var post = records.get('firstObject');
 
-                if (user.get('isAuthor') && post.isAuthoredByUser(user)) {
+                if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
                     // do not show the post if they are an author but not this posts author
                     post = null;
                 }


### PR DESCRIPTION
closes #4415
- corrected logic around author check
- fixes a bug where it was possible to see editor for other author posts
