### PR TITLE
Ensure Post Image Uploader Reset

### DIFF
--- a/core/client/assets/lib/uploader.js
+++ b/core/client/assets/lib/uploader.js
@@ -237,6 +237,13 @@ UploadUi = function ($dropzone, settings) {
             } else {
                 this.initWithImage();
             }
+        },
+
+        reset: function () {
+            $dropzone.find('.js-url').remove();
+            $dropzone.find('.js-fileupload').removeClass('right');
+            this.removeExtras();
+            this.initWithDropzone();
         }
     });
 };
@@ -253,6 +260,7 @@ upload = function (options) {
             ui;
 
         ui = new UploadUi($dropzone, settings);
+        this.uploaderUi = ui;
         ui.init();
     });
 };

--- a/core/client/components/gh-uploader.js
+++ b/core/client/components/gh-uploader.js
@@ -7,10 +7,10 @@ var PostImageUploader = Ember.Component.extend({
         var $this = this.$(),
             self = this;
 
-        uploader.call($this, {
+        this.set('uploaderReference', uploader.call($this, {
             editor: true,
             fileStorage: this.get('config.fileStorage')
-        });
+        }));
 
         $this.on('uploadsuccess', function (event, result) {
             if (result && result !== '' && result !== 'http://') {

--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -451,6 +451,14 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
 
         closeSubview: function () {
             this.set('isViewingSubview', false);
+        },
+
+        resetUploader: function () {
+            var uploader = this.get('uploaderReference');
+
+            if (uploader && uploader[0]) {
+                uploader[0].uploaderUi.reset();
+            }
         }
     }
 });

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -18,6 +18,9 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
         // from previous posts
         psm.removeObserver('titleScratch', psm, 'titleObserver');
 
+        // Ensure that the PSM Image Uploader resets
+        psm.send('resetUploader');
+
         this._super(controller, model);
     }
 });

--- a/core/client/templates/post-settings-menu.hbs
+++ b/core/client/templates/post-settings-menu.hbs
@@ -7,7 +7,7 @@
             <button class="close icon-x settings-menu-header-action" {{action "closeSettingsMenu"}}><span class="hidden">Close</span></button>
         </div>
         <div class="settings-menu-content">
-            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" image=image tagName="section"}}
+            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" image=image uploaderReference=uploaderReference tagName="section"}}
             <form>
             <div class="form-group">
                 <label for="url">Post URL</label>


### PR DESCRIPTION
Closes #4431
- The PSM does not reset on a transition from editor (existing post) to
  editor (new post). If the existing post had a cover image, the image
  uploader would not be reset during the transition and appear slightly
  broken in the editor for the new post.
- In this PR: A reference to the uploader is saved, allowing the route
  for editor/new to instruct the PSM controller to have the uploader
  reset.
