### PR TITLE
Close tag settings menu on transition

### DIFF
--- a/core/client/routes/settings/tags.js
+++ b/core/client/routes/settings/tags.js
@@ -4,6 +4,12 @@ import PaginationRouteMixin from 'ghost/mixins/pagination-route';
 
 var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
 
+    actions: {
+        willTransition: function () {
+            this.send('closeSettingsMenu');
+        }
+    },
+
     beforeModel: function () {
         if (!this.get('config.tagsUI')) {
             return this.transitionTo('settings.general');


### PR DESCRIPTION
Closes #4504
- Adds a `willTransition` action that closes the tag settings menu when transitioning to another page
