### PR TITLE
Adding comprehensive subdirectory route tests

### DIFF
--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -688,6 +688,154 @@ describe('Frontend Routing', function () {
         });
     });
 
+    describe('Subdirectory (no slash)', function () {
+        var forkedGhost, request;
+        before(function (done) {
+            var configTest = testUtils.fork.config();
+            configTest.url = 'http://localhost/blog';
+
+            testUtils.fork.ghost(configTest, 'testsubdir')
+                .then(function (child) {
+                    forkedGhost = child;
+                    request = require('supertest');
+                    request = request('http://localhost:' + child.port);
+                }).then(done).catch(done);
+        });
+
+        after(function (done) {
+            if (forkedGhost) {
+                forkedGhost.kill(done);
+            } else {
+                done(new Error('No forked ghost process exists, test setup must have failed.'));
+            }
+        });
+
+        it('http://localhost should 404', function (done) {
+            request.get('/')
+                .expect(404)
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/ should 404', function (done) {
+            request.get('/')
+                .expect(404)
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/blog should 303 to  http://localhost/blog/', function (done) {
+            request.get('/blog')
+                .expect(303)
+                .expect('Location', '/blog/')
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/blog/ should 200', function (done) {
+            request.get('/blog/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/blog/welcome-to-ghost should 301 to http://localhost/blog/welcome-to-ghost/', function (done) {
+            request.get('/blog/welcome-to-ghost')
+                .expect(301)
+                .expect('Location', '/blog/welcome-to-ghost/')
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/blog/welcome-to-ghost/ should 200', function (done) {
+            request.get('/blog/welcome-to-ghost/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
+            request.get('/blog/tag/getting-started')
+                .expect(301)
+                .expect('Location', '/blog/tag/getting-started/')
+                .end(doEnd(done));
+        });
+
+        it('/blog/tag/getting-started/ should 200', function (done) {
+            request.get('/blog/tag/getting-started/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+    });
+
+    describe('Subdirectory (with slash)', function () {
+        var forkedGhost, request;
+        before(function (done) {
+            var configTest = testUtils.fork.config();
+            configTest.url = 'http://localhost/blog/';
+
+            testUtils.fork.ghost(configTest, 'testsubdir')
+                .then(function (child) {
+                    forkedGhost = child;
+                    request = require('supertest');
+                    request = request('http://localhost:' + child.port);
+                }).then(done).catch(done);
+        });
+
+        after(function (done) {
+            if (forkedGhost) {
+                forkedGhost.kill(done);
+            } else {
+                done(new Error('No forked ghost process exists, test setup must have failed.'));
+            }
+        });
+
+        it('http://localhost should 404', function (done) {
+            request.get('/')
+                .expect(404)
+                .end(doEnd(done));
+        });
+
+        it('http://localhost/ should 404', function (done) {
+            request.get('/')
+                .expect(404)
+                .end(doEnd(done));
+        });
+
+        it('/blog should 303 to /blog/', function (done) {
+            request.get('/blog')
+                .expect(303)
+                .expect('Location', '/blog/')
+                .end(doEnd(done));
+        });
+
+        it('/blog/ should 200', function (done) {
+            request.get('/blog/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('/blog/welcome-to-ghost should 301 to /blog/welcome-to-ghost/', function (done) {
+            request.get('/blog/welcome-to-ghost')
+                .expect(301)
+                .expect('Location', '/blog/welcome-to-ghost/')
+                .end(doEnd(done));
+        });
+
+        it('/blog/welcome-to-ghost/ should 200', function (done) {
+            request.get('/blog/welcome-to-ghost/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
+            request.get('/blog/tag/getting-started')
+                .expect(301)
+                .expect('Location', '/blog/tag/getting-started/')
+                .end(doEnd(done));
+        });
+
+        it('/blog/tag/getting-started/ should 200', function (done) {
+            request.get('/blog/tag/getting-started/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+    });
+
     // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
     describe('HTTPS', function () {
         var forkedGhost, request;

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -83,6 +83,8 @@ function forkGhost(newConfig, envName) {
                     env.GHOST_CONFIG = newConfigFile;
                     env.NODE_ENV = envName;
                     child = cp.fork(path.join(config.paths.appRoot, 'index.js'), {env: env});
+                    // return the port to make it easier to do requests
+                    child.port = port;
                     // periodic check until forked Ghost is running and is listening on the port
                     pingCheck = setInterval(function () {
                         var socket = net.connect(port);


### PR DESCRIPTION
This PR adds new tests which cover the subdirectory behaviour. It verifies that the behaviour reported in #4476 is not reproducible in the default case, and that PR #4477 breaks the standard redirection behaviour.

closes #2230, refs #4477, #4476
- Test that subdirectories route correctly no matter how they're specified
