### PR TITLE
Change RSS content type & use absolute URL in meta

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -545,7 +545,7 @@ frontendControllers = {
                         feed.item(item);
                     });
                 }).then(function () {
-                    res.set('Content-Type', 'text/xml; charset=UTF-8');
+                    res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
                     res.send(feed.xml());
                 });
             });

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -156,7 +156,7 @@ ghost_head = function (options) {
 
         head.push('<meta name="generator" content="Ghost ' + trimmedVersion + '" />');
         head.push('<link rel="alternate" type="application/rss+xml" title="' +
-            title  + '" href="' + config.urlFor('rss') + '" />');
+            title  + '" href="' + config.urlFor('rss', null, true) + '" />');
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
         var headString = _.reduce(head, function (memo, item) { return memo + '\n    ' + item; }, '');

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -376,7 +376,7 @@ describe('Frontend Routing', function () {
 
         it('should respond with xml', function (done) {
             request.get('/rss/')
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(function (err, res) {
@@ -751,7 +751,7 @@ describe('Frontend Routing', function () {
 
         it('should serve RSS with date permalink', function (done) {
             request.get('/rss/')
-                .expect('Content-Type', 'text/xml; charset=utf-8')
+                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
                 .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(function (err, res) {

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -33,7 +33,7 @@ describe('{{ghost_head}} helper', function () {
             should.exist(rendered);
             rendered.string.should.equal('<link rel="canonical" href="http://testurl.com/" />\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -44,7 +44,7 @@ describe('{{ghost_head}} helper', function () {
             should.exist(rendered);
             rendered.string.should.equal('<link rel="canonical" href="http://testurl.com/" />\n' +
                 '    <meta name="generator" content="Ghost 0.9" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -96,7 +96,7 @@ describe('{{ghost_head}} helper', function () {
                 '    "image": "http://testurl.com/content/images/test-image.png",\n    "keywords": "tag1, tag2, tag3",\n' +
                 '    "description": "blog description..."\n}\n    </script>\n\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -149,7 +149,7 @@ describe('{{ghost_head}} helper', function () {
                 '    "image": "http://testurl.com/content/images/test-image.png",\n    "keywords": "tag1, tag2, tag3",\n' +
                 '    "description": "blog &quot;test&quot; description..."\n}\n    </script>\n\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -198,7 +198,7 @@ describe('{{ghost_head}} helper', function () {
                 '    "image": "http://testurl.com/content/images/test-image.png",\n' +
                 '    "description": "blog description..."\n}\n    </script>\n\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -246,7 +246,7 @@ describe('{{ghost_head}} helper', function () {
                 '    "datePublished": "' + post.published_at + '",\n    "dateModified": "' + post.updated_at + '",\n' +
                 '    "keywords": "tag1, tag2, tag3",\n    "description": "blog description..."\n}\n    </script>\n\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -279,7 +279,7 @@ describe('{{ghost_head}} helper', function () {
             should.exist(rendered);
             rendered.string.should.equal('<link rel="canonical" href="http://testurl.com/post/" />\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -290,7 +290,7 @@ describe('{{ghost_head}} helper', function () {
             should.exist(rendered);
             rendered.string.should.equal('<link rel="canonical" href="http://testurl.com/about/" />\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
 
             done();
         }).catch(done);
@@ -303,7 +303,7 @@ describe('{{ghost_head}} helper', function () {
                 '    <link rel="prev" href="http://testurl.com/page/2/" />\n' +
                 '    <link rel="next" href="http://testurl.com/page/4/" />\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
             done();
         }).catch(done);
     });
@@ -315,7 +315,7 @@ describe('{{ghost_head}} helper', function () {
                 '    <link rel="prev" href="http://testurl.com/" />\n' +
                 '    <link rel="next" href="http://testurl.com/page/3/" />\n' +
                 '    <meta name="generator" content="Ghost 0.3" />\n' +
-                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/rss/" />');
+                '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="http://testurl.com/rss/" />');
             done();
         }).catch(done);
     });
@@ -339,7 +339,8 @@ describe('{{ghost_head}} helper', function () {
                 should.exist(rendered);
                 rendered.string.should.equal('<link rel="canonical" href="http://testurl.com/blog/" />\n' +
                     '    <meta name="generator" content="Ghost 0.3" />\n' +
-                    '    <link rel="alternate" type="application/rss+xml" title="Ghost" href="/blog/rss/" />');
+                    '    <link rel="alternate" type="application/rss+xml" title="Ghost" ' +
+                    'href="http://testurl.com/blog/rss/" />');
 
                 done();
             }).catch(done);


### PR DESCRIPTION
This PR is the result of me trying to stop Google Chrome from displaying this message on our RSS feeds:

![](http://puu.sh/d4NUa.png)

The solution was to change the content type from `text/xml` to `application/rss+xml`. Now chrome displays a plain document. It would be nice to be able to provide some styling and have a pretty RSS feed in the future - that's a note for @halfdan and #3993.

Additionally, whilst looking around at examples of other people's RSS feeds trying to determine what caused Chrome to display the message, I noticed it was far more common to use an absolute URL for the `<link rel="alternate">` tag, so I've changed that too.

---

no issue
- changes the content type for the RSS feeds from text/xml to
  application/rss+xml
- changes the link rel=alternate tag to use an absolute URL for the feed
  in the blog meta data
