### PR TITLE
Dynamic Titles in Ghost Admin

### DIFF
--- a/core/client/initializers/ghost-config.js
+++ b/core/client/initializers/ghost-config.js
@@ -5,10 +5,11 @@ var ConfigInitializer = {
         var apps = $('body').data('apps'),
             tagsUI = $('body').data('tagsui'),
             fileStorage = $('body').data('filestorage'),
-            blogUrl = $('body').data('blogurl');
+            blogUrl = $('body').data('blogurl'),
+            blogTitle = $('body').data('blogtitle');
 
         application.register(
-            'ghost:config', {apps: apps, fileStorage: fileStorage, blogUrl: blogUrl, tagsUI: tagsUI}, {instantiate: false}
+            'ghost:config', {apps: apps, fileStorage: fileStorage, blogUrl: blogUrl, tagsUI: tagsUI, blogTitle: blogTitle}, {instantiate: false}
         );
 
         application.inject('route', 'config', 'ghost:config');

--- a/core/client/router.js
+++ b/core/client/router.js
@@ -1,8 +1,12 @@
 /*global Ember */
+/* jshint unused: false */
 import ghostPaths from 'ghost/utils/ghost-paths';
+import documentTitle from 'ghost/utils/document-title';
 
 // ensure we don't share routes between all Router instances
 var Router = Ember.Router.extend();
+
+documentTitle();
 
 Router.reopen({
     location: 'trailing-history', // use HTML5 History API instead of hash-tag based URLs

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -14,6 +14,10 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
         enter: {action: 'confirmModal', scope: 'modal'}
     },
 
+    title: function (tokens) {
+        return tokens.join(' - ') + ' - ' + this.get('config.blogTitle');
+    },
+
     actions: {
         authorizationFailed: function () {
             var currentRoute = this.get('controller').get('currentRouteName');

--- a/core/client/routes/debug.js
+++ b/core/client/routes/debug.js
@@ -3,6 +3,8 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var DebugRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, {
+    titleToken: 'Debug',
+
     classNames: ['settings'],
 
     beforeModel: function (transition) {

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -4,6 +4,8 @@ import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
 var EditorEditRoute = AuthenticatedRoute.extend(base, {
+    titleToken: 'Editor',
+
     model: function (params) {
         var self = this,
             post,

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -2,6 +2,8 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import base from 'ghost/mixins/editor-base-route';
 
 var EditorNewRoute = AuthenticatedRoute.extend(base, {
+    titleToken: 'Editor',
+
     model: function () {
         var self = this;
         return this.get('session.user').then(function (user) {

--- a/core/client/routes/error404.js
+++ b/core/client/routes/error404.js
@@ -1,6 +1,7 @@
 var Error404Route = Ember.Route.extend({
     controllerName: 'error',
     templateName: 'error',
+    titleToken: 'Error',
 
     model: function () {
         return {

--- a/core/client/routes/forgotten.js
+++ b/core/client/routes/forgotten.js
@@ -2,6 +2,8 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var ForgottenRoute = Ember.Route.extend(styleBody, loadingIndicator, {
+    titleToken: 'Forgotten Password',
+
     classNames: ['ghost-forgotten']
 });
 

--- a/core/client/routes/posts.js
+++ b/core/client/routes/posts.js
@@ -14,6 +14,8 @@ paginationSettings = {
 };
 
 PostsRoute = AuthenticatedRoute.extend(ShortcutsRoute, styleBody, loadingIndicator, PaginationRouteMixin, {
+    titleToken: 'Content',
+
     classNames: ['manage'],
 
     model: function () {

--- a/core/client/routes/settings.js
+++ b/core/client/routes/settings.js
@@ -3,6 +3,8 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SettingsRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, {
+    titleToken: 'Settings',
+
     classNames: ['settings']
 });
 

--- a/core/client/routes/settings/about.js
+++ b/core/client/routes/settings/about.js
@@ -3,6 +3,8 @@ import loadingIndicator from 'ghost/mixins/loading-indicator';
 import styleBody from 'ghost/mixins/style-body';
 
 var SettingsAboutRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, {
+    titleToken: 'About',
+
     classNames: ['settings-view-about'],
 
     cachedConfig: false,

--- a/core/client/routes/settings/apps.js
+++ b/core/client/routes/settings/apps.js
@@ -3,6 +3,8 @@ import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
 
 var AppsRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
+    titleToken: 'Apps',
+
     classNames: ['settings-view-apps'],
 
     beforeModel: function () {

--- a/core/client/routes/settings/general.js
+++ b/core/client/routes/settings/general.js
@@ -11,6 +11,8 @@ var shortcuts = {},
 shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
 
 SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, ShortcutsRoute, {
+    titleToken: 'General',
+
     classNames: ['settings-view-general'],
 
     beforeModel: function () {

--- a/core/client/routes/settings/index.js
+++ b/core/client/routes/settings/index.js
@@ -3,6 +3,8 @@ import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import mobileQuery from 'ghost/utils/mobile';
 
 var SettingsIndexRoute = MobileIndexRoute.extend(SimpleAuth.AuthenticatedRouteMixin, CurrentUserSettings, {
+    titleToken: 'Settings',
+
     // Redirect users without permission to view settings,
     // and show the settings.general route unless the user
     // is mobile

--- a/core/client/routes/settings/tags.js
+++ b/core/client/routes/settings/tags.js
@@ -3,6 +3,8 @@ import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 
 var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, {
 
+    titleToken: 'Tags',
+
     beforeModel: function () {
         if (!this.get('config.tagsUI')) {
             return this.transitionTo('settings.general');

--- a/core/client/routes/settings/users/index.js
+++ b/core/client/routes/settings/users/index.js
@@ -12,6 +12,8 @@ paginationSettings = {
 };
 
 UsersIndexRoute = AuthenticatedRoute.extend(styleBody, PaginationRouteMixin, {
+    titleToken: 'Users',
+
     classNames: ['settings-view-users'],
 
     setupController: function (controller, model) {

--- a/core/client/routes/settings/users/user.js
+++ b/core/client/routes/settings/users/user.js
@@ -9,6 +9,8 @@ var shortcuts = {},
 shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
 
 SettingsUserRoute = AuthenticatedRoute.extend(styleBody, ShortcutsRoute, {
+    titleToken: 'User',
+
     classNames: ['settings-view-user'],
 
     model: function (params) {

--- a/core/client/routes/setup.js
+++ b/core/client/routes/setup.js
@@ -2,6 +2,8 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SetupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
+    titleToken: 'Setup',
+
     classNames: ['ghost-setup'],
 
     // use the beforeModel hook to check to see whether or not setup has been

--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -2,7 +2,10 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
+    titleToken: 'Sign In',
+
     classNames: ['ghost-login'],
+
     beforeModel: function () {
         if (this.get('session').isAuthenticated) {
             this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);

--- a/core/client/routes/signout.js
+++ b/core/client/routes/signout.js
@@ -3,6 +3,8 @@ import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SignoutRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, {
+    titleToken: 'Sign Out',
+
     classNames: ['ghost-signout'],
 
     afterModel: function (model, transition) {

--- a/core/client/utils/document-title.js
+++ b/core/client/utils/document-title.js
@@ -1,0 +1,60 @@
+var documentTitle = function () {
+    Ember.Route.reopen({
+        // `titleToken` can either be a static string or a function
+        // that accepts a model object and returns a string (or array
+        // of strings if there are multiple tokens).
+        titleToken: null,
+
+        // `title` can either be a static string or a function
+        // that accepts an array of tokens and returns a string
+        // that will be the document title. The `collectTitleTokens` action
+        // stops bubbling once a route is encountered that has a `title`
+        // defined.
+        title: null,
+
+        _actions: {
+            collectTitleTokens: function (tokens) {
+                var titleToken = this.titleToken,
+                    finalTitle;
+
+                if (typeof this.titleToken === 'function') {
+                    titleToken = this.titleToken(this.currentModel);
+                }
+
+                if (Ember.isArray(titleToken)) {
+                    tokens.unshift.apply(this, titleToken);
+                } else if (titleToken) {
+                    tokens.unshift(titleToken);
+                }
+
+                if (this.title) {
+                    if (typeof this.title === 'function') {
+                        finalTitle = this.title(tokens);
+                    } else {
+                        finalTitle = this.title;
+                    }
+
+                    this.router.setTitle(finalTitle);
+                } else {
+                    return true;
+                }
+            }
+        }
+    });
+
+    Ember.Router.reopen({
+        updateTitle: function () {
+            this.send('collectTitleTokens', []);
+        }.on('didTransition'),
+
+        setTitle: function (title) {
+            if (Ember.testing) {
+                this._title = title;
+            } else {
+                window.document.title = title;
+            }
+        }
+    });
+};
+
+export default documentTitle;

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -97,6 +97,17 @@ coreHelpers.blog_url = function (context, options) {
     return config.theme.url.toString();
 };
 
+// ### Blog Title helper
+//
+// *Usage example:*
+// `{{blog_title}}`
+//
+// Returns the config value for url.
+coreHelpers.blog_title = function (context, options) {
+    /*jshint unused:false*/
+    return config.theme.title.toString();
+};
+
 coreHelpers.helperMissing = function (arg) {
     if (arguments.length === 2) {
         return undefined;
@@ -170,6 +181,7 @@ registerHelpers = function (adminHbs) {
     registerAdminHelper('file_storage', coreHelpers.file_storage);
     registerAdminHelper('tags_ui', coreHelpers.tags_ui);
 
+    registerAdminHelper('blog_title', coreHelpers.blog_title);
     registerAdminHelper('blog_url', coreHelpers.blog_url);
 };
 

--- a/core/server/views/default.hbs
+++ b/core/server/views/default.hbs
@@ -34,7 +34,7 @@
     {{/unless}}
     <link rel="stylesheet" href="{{asset "css/ghost.min.css" ghost="true"}}" />
 </head>
-<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-tagsui="{{tags_ui}}" data-blogurl="{{blog_url}}">
+<body class="{{bodyClass}}" data-apps="{{apps}}" data-filestorage="{{file_storage}}" data-tagsui="{{tags_ui}}" data-blogurl="{{blog_url}}" data-blogtitle="{{blog_title}}">
 
     {{{ghost_script_tags}}}
 

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -5,7 +5,7 @@
 
 CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('root', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Content - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -68,7 +68,7 @@ CasperTest.begin('Admin navigation bar is correct', 28, function suite(test) {
 
 CasperTest.begin('Can transition to the editor and back', 6, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('root', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Content - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 

--- a/core/test/functional/client/content_test.js
+++ b/core/test/functional/client/content_test.js
@@ -9,7 +9,7 @@ CasperTest.begin('Content screen is correct', 17, function suite(test) {
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -57,7 +57,7 @@ CasperTest.begin('Content list shows correct post status', 5, function testStati
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -104,7 +104,7 @@ CasperTest.begin('Content list shows correct post status', 5, function testStati
 //    // Placeholder for infinite scrolling/pagination tests (will need to setup 16+ posts).
 //
 //    casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-//        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+//        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
 //        test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
 //    });
 // });
@@ -115,7 +115,7 @@ CasperTest.begin('Posts can be marked as featured', 6, function suite(test) {
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 

--- a/core/test/functional/client/editor_test.js
+++ b/core/test/functional/client/editor_test.js
@@ -11,7 +11,7 @@ CasperTest.begin('Ghost editor functions correctly', 20, function suite(test) {
     };
 
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
         test.assertExists('.entry-markdown', 'Ghost editor is present');
         test.assertExists('.entry-preview', 'Ghost preview is present');
@@ -148,7 +148,7 @@ CasperTest.begin('Image Uploads', 24, function suite(test) {
     };
 
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -198,7 +198,7 @@ CasperTest.begin('Image Uploads', 24, function suite(test) {
 
     // Test image source location
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -222,7 +222,7 @@ CasperTest.begin('Image Uploads', 24, function suite(test) {
 
     // Test image url source location
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -274,7 +274,7 @@ CasperTest.begin('Image Uploads', 24, function suite(test) {
 
 CasperTest.begin('Tag editor', 7, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -302,7 +302,7 @@ CasperTest.begin('Tag editor', 7, function suite(test) {
 
 CasperTest.begin('Publish menu - new post', 10, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -353,7 +353,7 @@ CasperTest.begin('Publish menu - new post', 10, function suite(test) {
 CasperTest.begin('Publish menu - existing post', 23, function suite(test) {
     // Create a post, save it and test refreshed editor
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -473,7 +473,7 @@ CasperTest.begin('Publish menu - delete post', 7, function testDeleteModal(test)
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -521,7 +521,7 @@ CasperTest.begin('Publish menu - delete post', 7, function testDeleteModal(test)
 
 CasperTest.begin('Publish menu - new post status is correct after failed save', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -566,7 +566,7 @@ CasperTest.begin('Publish menu - new post status is correct after failed save', 
 
 CasperTest.begin('Publish menu - existing post status is correct after failed save', 6, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -620,7 +620,7 @@ CasperTest.begin('Publish menu - existing post status is correct after failed sa
 // test the markdown help modal
 CasperTest.begin('Markdown help modal', 5, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -646,7 +646,7 @@ CasperTest.begin('Markdown help modal', 5, function suite(test) {
 // test editor title input is correct after changing a post attribute in the post-settings-menu
 CasperTest.begin('Title input is set correctly after using the Post-Settings-Menu', function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -693,7 +693,7 @@ CasperTest.begin('Title input is set correctly after using the Post-Settings-Men
 // test editor content input is correct after changing a post attribute in the post-settings-menu
 CasperTest.begin('Editor content is set correctly after using the Post-Settings-Menu', function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 

--- a/core/test/functional/client/psm_test.js
+++ b/core/test/functional/client/psm_test.js
@@ -5,7 +5,7 @@
 
 CasperTest.begin('Post settings menu', 10, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('editor', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Editor - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/editor\/$/, 'Landed on the correct URL');
     });
 
@@ -47,7 +47,7 @@ CasperTest.begin('Post url can be changed', 4, function suite(test) {
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -85,7 +85,7 @@ CasperTest.begin('Post published date can be changed', 4, function suite(test) {
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -123,7 +123,7 @@ CasperTest.begin('Post can be changed to static page', 2, function suite(test) {
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 
@@ -154,7 +154,7 @@ CasperTest.begin('Post url input is reset from all whitespace back to original v
 
     // Begin test
     casper.thenOpenAndWaitForPageLoad('content', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Title is "Ghost Admin"');
+        test.assertTitle('Content - Test Blog', 'Title is "Content - Test Blog"');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL');
     });
 

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -10,7 +10,7 @@ var generalTabDetector = '.settings-content form#settings-general',
 
 CasperTest.begin('Settings screen is correct', 15, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - General - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/general\/$/, 'Landed on the correct URL');
     });
 
@@ -46,7 +46,7 @@ CasperTest.begin('Settings screen is correct', 15, function suite(test) {
 // ## General settings tests
 CasperTest.begin('General settings pane is correct', 8, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.general', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - General - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/general\/$/, 'Landed on the correct URL');
     });
 
@@ -110,7 +110,7 @@ CasperTest.begin('General settings pane is correct', 8, function suite(test) {
 // ## General settings validations tests
 CasperTest.begin('General settings validation is correct', 6, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.general', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - General - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/general\/$/, 'Landed on the correct URL');
     });
 
@@ -198,7 +198,7 @@ CasperTest.begin('Users screen is correct', 9, function suite(test) {
 // ### User settings tests
 CasperTest.begin('Can save settings', 7, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost Admin title is GhostAdmin');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost Admin title is correct');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'settings.users.user has correct URL');
     });
 
@@ -273,7 +273,7 @@ CasperTest.begin('User settings screen resets all whitespace slug to original va
     var slug;
 
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -301,7 +301,7 @@ CasperTest.begin('User settings screen change slug handles duplicate slug', 4, f
     var slug;
 
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -332,7 +332,7 @@ CasperTest.begin('User settings screen validates email', 6, function suite(test)
     var email;
 
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -378,7 +378,7 @@ CasperTest.begin('User settings screen validates email', 6, function suite(test)
 // TODO: user needs to be loaded whenever it is edited (multi user)
 CasperTest.begin('User settings screen shows remaining characters for Bio properly', 4, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -403,7 +403,7 @@ CasperTest.begin('User settings screen shows remaining characters for Bio proper
 
 CasperTest.begin('Ensure user bio field length validation', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -422,7 +422,7 @@ CasperTest.begin('Ensure user bio field length validation', 3, function suite(te
 
 CasperTest.begin('Ensure user url field validation', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 
@@ -441,7 +441,7 @@ CasperTest.begin('Ensure user url field validation', 3, function suite(test) {
 
 CasperTest.begin('Ensure user location field length validation', 3, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.users.user', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Settings - User - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/settings\/users\/test\/$/, 'Ghost doesn\'t require login this time');
     });
 

--- a/core/test/functional/client/signin_test.js
+++ b/core/test/functional/client/signin_test.js
@@ -6,7 +6,7 @@
 CasperTest.begin('Ghost admin will load login page', 3, function suite(test) {
     CasperTest.Routines.signout.run(test);
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'We should be presented with the signin page.');
 
         casper.then(function testLink() {
@@ -34,7 +34,7 @@ CasperTest.begin('Login limit is in place', 4, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 
@@ -62,7 +62,7 @@ CasperTest.begin('Can login to Ghost', 5, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 
@@ -85,7 +85,7 @@ CasperTest.begin('Authenticated user is redirected', 8, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 
@@ -116,7 +116,7 @@ CasperTest.begin('Ensure email field form validation', 3, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 

--- a/core/test/functional/client/signout_test.js
+++ b/core/test/functional/client/signout_test.js
@@ -7,7 +7,7 @@ CasperTest.begin('Ghost signout works correctly', 3, function suite(test) {
     CasperTest.Routines.signin.run(test);
 
     casper.thenOpenAndWaitForPageLoad('root', function then() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Content - Test Blog', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/\d+\/$/, 'Landed on the correct URL without signing in');
     });
 

--- a/core/test/functional/setup/setup_test.js
+++ b/core/test/functional/setup/setup_test.js
@@ -38,7 +38,7 @@ CasperTest.begin('Ghost setup fails properly', 6, function suite(test) {
 
 CasperTest.begin('Authenticated user is redirected', 8, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
-        test.assertTitle('Ghost Admin', 'Ghost admin has no title');
+        test.assertTitle('Sign In - ghost', 'Ghost admin has incorrect title');
         test.assertUrlMatch(/ghost\/signin\/$/, 'Landed on the correct URL');
     });
 


### PR DESCRIPTION
Closes #4487 
- Every route can set a title token that is combined with the blog’s
  title, resulting in titles like ‘Content - Test Blog’.
- Subroutes are supported (‘Settings - General - Test Blog’)
- The blog’s name is applied to and taken from the `config` object to
  spare Ember a REST call via `store.find(‘settings’)`.
- Tests have been changed to test for the new titles.
- The initially proposed solution
  (https://github.com/paddle8/ember-document-title) doesn’t play nice
  with EAK, which is why I went with this solution
  (https://gist.github.com/machty/8413411) by Ember.JS core dev @Machty.
