### PR TITLE
Adds ctrl/cmd+s shortcut to whole application with a noop default

### DIFF
--- a/core/client/mixins/shortcuts-route.js
+++ b/core/client/mixins/shortcuts-route.js
@@ -74,11 +74,6 @@ var ShortcutsRoute = Ember.Mixin.create({
 
     activate: function () {
         this._super();
-
-        if (!this.shortcuts) {
-            return;
-        }
-
         this.registerShortcuts();
     },
 

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -1,17 +1,21 @@
 /* global key */
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
+import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, ShortcutsRoute, {
+var ApplicationRoute,
+    shortcuts = {};
+
+shortcuts.esc = {action: 'closePopups', scope: 'all'};
+shortcuts.enter = {action: 'confirmModal', scope: 'modal'};
+shortcuts[ctrlOrCmd + '+s'] = {action: 'save', scope: 'all'};
+
+ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, ShortcutsRoute, {
+    shortcuts: shortcuts,
 
     afterModel: function (model, transition) {
         if (this.get('session').isAuthenticated) {
             transition.send('loadServerNotifications');
         }
-    },
-
-    shortcuts: {
-        esc: {action: 'closePopups', scope: 'all'},
-        enter: {action: 'confirmModal', scope: 'modal'}
     },
 
     title: function (tokens) {
@@ -155,7 +159,10 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
                     errorObj.el.addClass('input-error');
                 }
             });
-        }
+        },
+
+        // noop default for unhandled save (used from shortcuts)
+        save: Ember.K
     }
 });
 

--- a/core/client/routes/settings/code-injection.js
+++ b/core/client/routes/settings/code-injection.js
@@ -2,15 +2,8 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var shortcuts = {},
-    SettingsCodeInjectionRoute;
-
-shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
-
-SettingsCodeInjectionRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, ShortcutsRoute, {
+var SettingsCodeInjectionRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, {
     classNames: ['settings-view-code'],
 
     beforeModel: function () {
@@ -24,8 +17,6 @@ SettingsCodeInjectionRoute = AuthenticatedRoute.extend(styleBody, loadingIndicat
             return records.get('firstObject');
         });
     },
-
-    shortcuts: shortcuts,
 
     actions: {
         save: function () {

--- a/core/client/routes/settings/general.js
+++ b/core/client/routes/settings/general.js
@@ -2,15 +2,8 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var shortcuts = {},
-    SettingsGeneralRoute;
-
-shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
-
-SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, ShortcutsRoute, {
+var SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUserSettings, {
     titleToken: 'General',
 
     classNames: ['settings-view-general'],
@@ -26,8 +19,6 @@ SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, Cu
             return records.get('firstObject');
         });
     },
-
-    shortcuts: shortcuts,
 
     actions: {
         save: function () {

--- a/core/client/routes/settings/users/user.js
+++ b/core/client/routes/settings/users/user.js
@@ -1,14 +1,7 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import styleBody from 'ghost/mixins/style-body';
-import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var shortcuts = {},
-    SettingsUserRoute;
-
-shortcuts[ctrlOrCmd + '+s'] = {action: 'save'};
-
-SettingsUserRoute = AuthenticatedRoute.extend(styleBody, ShortcutsRoute, {
+var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, {
     titleToken: 'User',
 
     classNames: ['settings-view-user'],
@@ -54,8 +47,6 @@ SettingsUserRoute = AuthenticatedRoute.extend(styleBody, ShortcutsRoute, {
 
         this._super();
     },
-
-    shortcuts: shortcuts,
 
     actions: {
         save: function () {

--- a/core/client/utils/editor-shortcuts.js
+++ b/core/client/utils/editor-shortcuts.js
@@ -3,7 +3,6 @@ import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 var shortcuts = {};
 
 // General editor shortcuts
-shortcuts[ctrlOrCmd + '+s'] = 'save';
 shortcuts[ctrlOrCmd + '+alt+p'] = 'publish';
 shortcuts['alt+shift+z'] = 'toggleZenMode';
 


### PR DESCRIPTION
closes #4516
- shortcut for ctrl/cmd+s on application level
- shortens a syntax for any route that is using 'save' method, shortcuts object doesn't have to be defined at all, only the save action.
