### PR TITLE
Prevent publish-bar from floating up on mobile

### DIFF
--- a/core/client/assets/sass/layouts/editor.scss
+++ b/core/client/assets/sass/layouts/editor.scss
@@ -96,7 +96,6 @@
             width: 100%;
             border: none;
             z-index: 100;
-            min-height: 380px;
 
             .markdown,
             .entry-preview-content {


### PR DESCRIPTION
This solves the issue where if the height of your screen is below a certain amount the publish bar scrolls up due to the editor input being too big.
### To reproduce
1. Open the editor in chrome
2. Hit the emulation button
3. Select a small device, like the iphone 4
4. Scroll up and down on the page (not the header)

![ghost-publish-bar](https://cloud.githubusercontent.com/assets/34726/5217784/1afdf01e-7613-11e4-867a-9b31b417425e.gif)
