### PR TITLE
Return computed url with post object

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -82,10 +82,8 @@ cacheInvalidationHeader = function (req, result) {
             // Don't set x-cache-invalidate header for drafts
             if (hasStatusChanged || wasDeleted || wasPublishedUpdated) {
                 cacheInvalidate = '/, /page/*, /rss/, /rss/*, /tag/*, /author/*, /sitemap-*.xml';
-                if (id && post.slug) {
-                    return config.urlForPost(settings, post).then(function (postUrl) {
-                        return cacheInvalidate + ', ' + postUrl;
-                    });
+                if (id && post.slug && post.url) {
+                    cacheInvalidate +=  ', ' + post.url;
                 }
             }
         }

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -31,7 +31,7 @@ function ConfigManager(config) {
 
     // Allow other modules to be externally accessible.
     this.urlFor = configUrl.urlFor;
-    this.urlForPost = configUrl.urlForPost;
+    this.urlPathForPost = configUrl.urlPathForPost;
 
     // If we're given an initial config object then we can set it.
     if (config && _.isObject(config)) {

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -53,7 +53,7 @@ function createUrl(urlPath, absolute, secure) {
 // Creates the url path for a post, given a post and a permalink
 // Parameters:
 // - post - a json object representing a post
-// - permalinks - a json object containing the permalinks setting
+// - permalinks - a string containing the permalinks setting
 function urlPathForPost(post, permalinks) {
     var output = '',
         tags = {
@@ -68,7 +68,7 @@ function urlPathForPost(post, permalinks) {
     if (post.page) {
         output += '/:slug/';
     } else {
-        output += permalinks.value;
+        output += permalinks;
     }
 
     // replace tags like :slug or :year with actual values
@@ -124,9 +124,9 @@ function urlFor(context, data, absolute) {
         urlPath = context.relativeUrl;
     } else if (_.isString(context) && _.indexOf(knownObjects, context) !== -1) {
         // trying to create a url for an object
-        if (context === 'post' && data.post && data.permalinks) {
-            urlPath = urlPathForPost(data.post, data.permalinks);
-            secure = data.post.secure;
+        if (context === 'post' && data.post) {
+            urlPath = data.post.url;
+            secure = data.secure;
         } else if (context === 'tag' && data.tag) {
             urlPath = '/tag/' + data.tag.slug + '/';
             secure = data.tag.secure;
@@ -161,21 +161,6 @@ function urlFor(context, data, absolute) {
     return createUrl(urlPath, absolute, secure);
 }
 
-// ## urlForPost
-// This method is async as we have to fetch the permalinks
-// Get the permalink setting and then get a URL for the given post
-// Parameters
-// - settings - passed reference to api.settings
-// - post - a json object representing a post
-// - absolute (optional, default:false) - boolean whether or not the url should be absolute
-function urlForPost(settings, post, absolute) {
-    return settings.read('permalinks').then(function (response) {
-        var permalinks = response.settings[0];
-
-        return urlFor('post', {post: post, permalinks: permalinks}, absolute);
-    });
-}
-
 module.exports.setConfig = setConfig;
 module.exports.urlFor = urlFor;
-module.exports.urlForPost = urlForPost;
+module.exports.urlPathForPost = urlPathForPost;

--- a/core/server/helpers/url.js
+++ b/core/server/helpers/url.js
@@ -6,7 +6,6 @@
 
 var Promise         = require('bluebird'),
     config          = require('../config'),
-    api             = require('../api'),
     schema          = require('../data/schema').checks,
     url;
 
@@ -14,7 +13,7 @@ url = function (options) {
     var absolute = options && options.hash.absolute;
 
     if (schema.isPost(this)) {
-        return config.urlForPost(api.settings, this, absolute);
+        return Promise.resolve(config.urlFor('post', {post: this}, absolute));
     }
 
     if (schema.isTag(this)) {

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -1,20 +1,20 @@
 /*globals describe, before, beforeEach, afterEach, it */
 /*jshint expr:true*/
-var testUtils   = require('../../utils'),
-    should      = require('should'),
-    sinon       = require('sinon'),
-    Promise     = require('bluebird'),
-    _           = require('lodash'),
+var testUtils       = require('../../utils'),
+    should          = require('should'),
+    sinon           = require('sinon'),
+    Promise         = require('bluebird'),
+    _               = require('lodash'),
 
 // Stuff we are testing
-    ModelUser   = require('../../../server/models'),
-    UserAPI     = require('../../../server/api/users'),
-    mail        = require('../../../server/api/mail'),
+    ModelUser       = require('../../../server/models'),
+    UserAPI         = require('../../../server/api/users'),
+    mail            = require('../../../server/api/mail'),
 
-    context     = testUtils.context,
-    userIdFor   = testUtils.users.ids,
-    roleIdFor   = testUtils.roles.ids,
-    sandbox     = sinon.sandbox.create();
+    context         = testUtils.context,
+    userIdFor       = testUtils.users.ids,
+    roleIdFor       = testUtils.roles.ids,
+    sandbox         = sinon.sandbox.create();
 
 describe('Users API', function () {
     // Keep the DB clean

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -44,7 +44,8 @@ describe('{{url}} helper', function () {
             markdown: 'ff',
             title: 'title',
             slug: 'slug',
-            created_at: new Date(0)
+            created_at: new Date(0),
+            url: '/slug/'
         }).then(function (rendered) {
             should.exist(rendered);
             rendered.should.equal('/slug/');
@@ -54,7 +55,7 @@ describe('{{url}} helper', function () {
 
     it('should output an absolute URL if the option is present', function (done) {
         helpers.url.call(
-            {html: 'content', markdown: 'ff', title: 'title', slug: 'slug', created_at: new Date(0)},
+            {html: 'content', markdown: 'ff', title: 'title', slug: 'slug', url: '/slug/', created_at: new Date(0)},
             {hash: {absolute: 'true'}}
         ).then(function (rendered) {
             should.exist(rendered);

--- a/core/test/unit/xmlrpc_spec.js
+++ b/core/test/unit/xmlrpc_spec.js
@@ -1,11 +1,9 @@
 /*globals describe, beforeEach, afterEach, it*/
 /*jshint expr:true*/
 var nock            = require('nock'),
-    settings        = require('../../server/api').settings,
     should          = require('should'),
     sinon           = require('sinon'),
     testUtils       = require('../utils'),
-    Promise         = require('bluebird'),
     xmlrpc          = require('../../server/xmlrpc'),
     // storing current environment
     currentEnv      = process.env.NODE_ENV;
@@ -28,20 +26,15 @@ describe('XMLRPC', function () {
         process.env.NODE_ENV = currentEnv;
     });
 
-    it('should execute two pings', function (done) {
+    it('should execute two pings', function () {
         var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
             ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
-            testPost = testUtils.DataGenerator.Content.posts[2],
-            settingsStub = sandbox.stub(settings, 'read', function () {
-                return Promise.resolve({settings: [{value: '/:slug/'}]});
-            });
+            testPost = testUtils.DataGenerator.Content.posts[2];
+
         /*jshint unused:false */
 
-        xmlrpc.ping(testPost).then(function () {
-            ping1.isDone().should.be.true;
-            ping2.isDone().should.be.true;
-
-            done();
-        }).catch(done);
+        xmlrpc.ping(testPost);
+        ping1.isDone().should.be.true;
+        ping2.isDone().should.be.true;
     });
 });

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -13,7 +13,7 @@ var url             = require('url'),
         pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
         post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
             'featured', 'image', 'status', 'language', 'created_at', 'created_by', 'updated_at',
-            'updated_by', 'published_at', 'published_by', 'page', 'author'
+            'updated_by', 'published_at', 'published_by', 'page', 'author', 'url'
         ],
         settings: ['settings', 'meta'],
         setting: ['id', 'uuid', 'key', 'value', 'type', 'created_at', 'created_by', 'updated_at', 'updated_by'],


### PR DESCRIPTION
closes #4445
- post model gets permalink format
- post model queries urlPathForPost to return computed url with post
- url helper modified to use post.url
- urlForPost method abolished and replaced where necessary
- updated tests.
