### PR TITLE
API - no more m-2-m relation ids by default

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -15,6 +15,7 @@ var Promise         = require('bluebird'),
 function prepareInclude(include) {
     var index;
 
+    include = include || '';
     include = _.intersection(include.split(','), allowedIncludes);
     index = include.indexOf('author');
 

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -19,6 +19,7 @@ var Promise         = require('bluebird'),
 
 // ## Helpers
 function prepareInclude(include) {
+    include = include || '';
     include = _.intersection(include.split(','), allowedIncludes);
     return include;
 }
@@ -154,7 +155,7 @@ users = {
                         roleId = parseInt(role.id || role, 10);
 
                     return dataProvider.User.findOne(
-                        {id: options.context.user, status: 'all'}, {include: 'roles'}
+                        {id: options.context.user, status: 'all'}, {include: ['roles']}
                     ).then(function (contextUser) {
                         var contextRoleId = contextUser.related('roles').toJSON()[0].id;
 

--- a/core/server/data/import/000.js
+++ b/core/server/data/import/000.js
@@ -36,7 +36,7 @@ Importer000.prototype.canImport = function (data) {
 Importer000.prototype.loadUsers = function () {
     var users = {all: {}};
 
-    return models.User.findAll({include: 'roles'}).then(function (_users) {
+    return models.User.findAll({include: ['roles']}).then(function (_users) {
         _users.forEach(function (user) {
             users.all[user.get('email')] = {realId: user.get('id')};
             if (user.related('roles').toJSON()[0] && user.related('roles').toJSON()[0].name === 'Owner') {

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -143,10 +143,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             return attrs;
         }
 
-        if (options && options.idOnly) {
-            return attrs.id;
-        }
-
         if (options && options.include) {
             this.include = _.union(this.include, options.include);
         }
@@ -154,12 +150,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         _.each(this.relations, function (relation, key) {
             if (key.substring(0, 7) !== '_pivot_') {
                 // if include is set, expand to full object
-                // 'toMany' relationships are included with ids if not expanded
                 var fullKey = _.isEmpty(options.name) ? key : options.name + '.' + key;
                 if (_.contains(self.include, fullKey)) {
                     attrs[key] = relation.toJSON({name: fullKey, include: self.include});
-                } else if (relation.hasOwnProperty('length')) {
-                    attrs[key] = relation.toJSON({idOnly: true});
                 }
             }
         });

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -250,7 +250,7 @@ Post = ghostBookshelf.Model.extend({
         options = options || {};
 
         // fetch relations passed to options.include
-        options.withRelated = options.include;
+        options.withRelated = _.union(options.withRelated, options.include);
         return ghostBookshelf.Model.findAll.call(this, options);
     },
 
@@ -323,7 +323,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         // Add related objects
-        options.withRelated = _.union(['tags', 'fields'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         // If a query param for a tag is attached
         // we need to fetch the tag model to find its id
@@ -468,7 +468,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         // Add related objects
-        options.withRelated = _.union(['tags', 'fields'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         return ghostBookshelf.Model.findOne.call(this, data, options);
     },

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -158,7 +158,7 @@ User = ghostBookshelf.Model.extend({
      */
     findAll:  function (options) {
         options = options || {};
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
         return ghostBookshelf.Model.findAll.call(this, options);
     },
 
@@ -237,7 +237,7 @@ User = ghostBookshelf.Model.extend({
         }
 
         // Add related objects
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         // only include a limit-query if a numeric limit is provided
         if (_.isNumber(options.limit)) {
@@ -356,7 +356,7 @@ User = ghostBookshelf.Model.extend({
         delete data.status;
 
         options = options || {};
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         // Support finding by role
         if (data.role) {
@@ -397,7 +397,7 @@ User = ghostBookshelf.Model.extend({
             roleId;
 
         options = options || {};
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         return ghostBookshelf.Model.edit.call(this, data, options).then(function (user) {
             if (data.roles) {
@@ -449,7 +449,7 @@ User = ghostBookshelf.Model.extend({
             roles;
 
         options = this.filterOptions(options, 'add');
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
 
         return ghostBookshelf.model('Role').findOne({name: 'Author'}, _.pick(options, 'transacting')).then(function (authorRole) {
             // Get the role we're going to assign to this user, or the author role if there isn't one
@@ -502,7 +502,7 @@ User = ghostBookshelf.Model.extend({
             userData = this.filterData(data);
 
         options = this.filterOptions(options, 'setup');
-        options.withRelated = _.union(['roles'], options.include);
+        options.withRelated = _.union(options.withRelated, options.include);
         options.shortSlug = true;
 
         return validatePasswordLength(userData.password).then(function () {
@@ -529,12 +529,16 @@ User = ghostBookshelf.Model.extend({
             userModel = userModelOrId,
             origArgs;
 
-        // If we passed in an id instead of a model, get the model then check the permissions
+        // If we passed in a model without its related roles, we need to fetch it again
+        if (_.isObject(userModelOrId) && !_.isObject(userModelOrId.related('roles'))) {
+            userModelOrId = userModelOrId.id;
+        }
+        // If we passed in an id instead of a model get the model first
         if (_.isNumber(userModelOrId) || _.isString(userModelOrId)) {
             // Grab the original args without the first one
             origArgs = _.toArray(arguments).slice(1);
             // Get the actual post model
-            return this.findOne({id: userModelOrId, status: 'all'}).then(function (foundUserModel) {
+            return this.findOne({id: userModelOrId, status: 'all'}, {include: ['roles']}).then(function (foundUserModel) {
                 // Build up the original args but substitute with actual model
                 var newArgs = [foundUserModel].concat(origArgs);
 
@@ -825,18 +829,18 @@ User = ghostBookshelf.Model.extend({
             return ghostBookshelf.model('Role').findOne({name: 'Owner'});
         }).then(function (result) {
             ownerRole = result;
-            return User.findOne({id: options.context.user});
+            return User.findOne({id: options.context.user}, {include: ['roles']});
         }).then(function (ctxUser) {
             // check if user has the owner role
             var currentRoles = ctxUser.toJSON().roles;
-            if (!_.contains(currentRoles, ownerRole.id)) {
+            if (!_.any(currentRoles, {id: ownerRole.id})) {
                 return Promise.reject(new errors.NoPermissionError('Only owners are able to transfer the owner role.'));
             }
             contextUser = ctxUser;
-            return User.findOne({id: object.id});
+            return User.findOne({id: object.id}, {include: ['roles']});
         }).then(function (user) {
             var currentRoles = user.toJSON().roles;
-            if (!_.contains(currentRoles, adminRole.id)) {
+            if (!_.any(currentRoles, {id: adminRole.id})) {
                 return Promise.reject(new errors.ValidationError('Only administrators can be assigned the owner role.'));
             }
 

--- a/core/test/functional/routes/api/posts_test.js
+++ b/core/test/functional/routes/api/posts_test.js
@@ -175,7 +175,8 @@ describe('Post API', function () {
                     jsonResponse.posts[0].author.should.be.a.Number;
                     testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true;
                     jsonResponse.posts[0].created_by.should.be.a.Number;
-                    jsonResponse.posts[0].tags[0].should.be.a.Number;
+                    // Tags aren't included by default
+                    should.not.exist(jsonResponse.posts[0].tags);
                     done();
                 });
         });
@@ -202,7 +203,8 @@ describe('Post API', function () {
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
                     jsonResponse.posts[0].author.should.be.a.Number;
                     jsonResponse.posts[0].created_by.should.be.a.Number;
-                    jsonResponse.posts[0].tags[0].should.be.a.Number;
+                    // Tags aren't included by default
+                    should.not.exist(jsonResponse.posts[0].tags);
                     done();
                 });
         });
@@ -222,7 +224,7 @@ describe('Post API', function () {
                     var jsonResponse = res.body;
                     jsonResponse.should.exist;
                     jsonResponse.posts.should.exist;
-                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post', 'tags');
                     jsonResponse.posts[0].page.should.eql(0);
 
                     jsonResponse.posts[0].author.should.be.an.Object;
@@ -342,7 +344,7 @@ describe('Post API', function () {
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
                     draftPost.posts[0].status = publishedState;
-                    testUtils.API.checkResponse(draftPost.posts[0], 'post');
+                    testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
 
                     draftPost.posts[0].tags.should.exist;
                     draftPost.posts[0].tags.length.should.be.above(0);
@@ -371,7 +373,7 @@ describe('Post API', function () {
                             publishedPost.posts.length.should.be.above(0);
                             publishedPost.posts[0].title.should.eql(newTitle);
                             publishedPost.posts[0].status.should.eql(publishedState);
-                            testUtils.API.checkResponse(publishedPost.posts[0], 'post');
+                            testUtils.API.checkResponse(publishedPost.posts[0], 'post', 'tags');
 
                             publishedPost.posts[0].tags.should.exist;
                             publishedPost.posts[0].tags.length.should.be.above(0);
@@ -399,7 +401,7 @@ describe('Post API', function () {
                                     updatedPost.posts[0].title.should.eql(newTitle);
                                     testUtils.API.isISO8601(updatedPost.posts[0].created_at).should.be.true;
                                     testUtils.API.isISO8601(updatedPost.posts[0].updated_at).should.be.true;
-                                    testUtils.API.checkResponse(updatedPost.posts[0], 'post');
+                                    testUtils.API.checkResponse(updatedPost.posts[0], 'post', 'tags');
 
                                     updatedPost.posts[0].tags.should.exist;
                                     updatedPost.posts[0].tags.length.should.be.above(0);
@@ -477,7 +479,7 @@ describe('Post API', function () {
                     draftPost.posts.should.exist;
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
-                    testUtils.API.checkResponse(draftPost.posts[0], 'post');
+                    testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
 
                     draftPost.posts[0].title = 'Vote for Casper in red';
 
@@ -522,7 +524,7 @@ describe('Post API', function () {
                     draftPost.posts.should.exist;
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
-                    testUtils.API.checkResponse(draftPost.posts[0], 'post');
+                    testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
 
                     draftPost.posts[0].title = 'Vote for Casper in red';
                     draftPost.posts[0].status = draftState;

--- a/core/test/functional/routes/api/users_test.js
+++ b/core/test/functional/routes/api/users_test.js
@@ -50,7 +50,7 @@ describe('User API', function () {
                     testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
                     testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true;
                     testUtils.API.isISO8601(jsonResponse.users[0].created_at).should.be.true;
@@ -77,7 +77,29 @@ describe('User API', function () {
                     testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                    done();
+                });
+        });
+
+        it('can retrieve all users with roles', function (done) {
+            request.get(testUtils.API.getApiQuery('users/?include=roles'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules['private'])
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    jsonResponse.users.should.exist;
+                    testUtils.API.checkResponse(jsonResponse, 'users');
+
+                    jsonResponse.users.should.have.length(1);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', 'roles');
                     done();
                 });
         });
@@ -101,7 +123,7 @@ describe('User API', function () {
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                     done();
                 });
         });
@@ -123,7 +145,7 @@ describe('User API', function () {
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                     done();
                 });
         });
@@ -145,7 +167,7 @@ describe('User API', function () {
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                     done();
                 });
         });
@@ -167,7 +189,7 @@ describe('User API', function () {
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                     done();
                 });
         });
@@ -300,7 +322,7 @@ describe('User API', function () {
                         changedValue = 'http://joe-bloggs.ghost.org',
                         dataToSend;
                     jsonResponse.users[0].should.exist;
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
                     dataToSend = {users: [
                         {website: changedValue}
@@ -322,7 +344,7 @@ describe('User API', function () {
                             putBody.users[0].should.exist;
                             putBody.users[0].website.should.eql(changedValue);
                             putBody.users[0].email.should.eql(jsonResponse.users[0].email);
-                            testUtils.API.checkResponse(putBody.users[0], 'user', ['roles']);
+                            testUtils.API.checkResponse(putBody.users[0], 'user');
                             done();
                         });
                 });

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -49,7 +49,7 @@ describe('Authentication API', function () {
                     should.exist(result.users);
                     should.not.exist(result.meta);
                     result.users.should.have.length(1);
-                    testUtils.API.checkResponse(result.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(result.users[0], 'user');
 
                     var newUser = result.users[0];
 

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -53,7 +53,7 @@ describe('Configuration API', function () {
         config.set(updatedConfig);
         ConfigurationAPI.__set__('config', updatedConfig);
 
-        ConfigurationAPI.read(_.extend(testUtils.context.owner, {key: 'database'})).then(function (response) {
+        ConfigurationAPI.read(_.extend({}, testUtils.context.owner, {key: 'database'})).then(function (response) {
             should.exist(response);
             should.exist(response.configuration);
             testUtils.API.checkResponse(response.configuration[0], 'configuration');

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -43,7 +43,7 @@ describe('Post API', function () {
             var post;
 
             should.exist(found);
-            testUtils.API.checkResponse(found.posts[0], 'post');
+            testUtils.API.checkResponse(found.posts[0], 'post', 'tags');
 
             post = found.posts[0];
 

--- a/core/test/integration/api/api_roles_spec.js
+++ b/core/test/integration/api/api_roles_spec.js
@@ -78,21 +78,21 @@ describe('Roles API', function () {
         }
 
         it('Owner can assign all', function (done) {
-            RoleAPI.browse(_.extend(context.owner, {permissions: 'assign'})).then(function (response) {
+            RoleAPI.browse(_.extend({}, context.owner, {permissions: 'assign'})).then(function (response) {
                 checkBrowseResponse(response);
                 done();
             }).catch(done);
         });
 
         it('Admin can assign all', function (done) {
-            RoleAPI.browse(_.extend(context.admin, {permissions: 'assign'})).then(function (response) {
+            RoleAPI.browse(_.extend({}, context.admin, {permissions: 'assign'})).then(function (response) {
                 checkBrowseResponse(response);
                 done();
             }).catch(done);
         });
 
         it('Editor can assign Author', function (done) {
-            RoleAPI.browse(_.extend(context.editor, {permissions: 'assign'})).then(function (response) {
+            RoleAPI.browse(_.extend({}, context.editor, {permissions: 'assign'})).then(function (response) {
                 should.exist(response);
                 should.exist(response.roles);
                 testUtils.API.checkResponse(response, 'roles');
@@ -104,7 +104,7 @@ describe('Roles API', function () {
         });
 
         it('Author CANNOT assign any', function (done) {
-            RoleAPI.browse(_.extend(context.author, {permissions: 'assign'})).then(function (response) {
+            RoleAPI.browse(_.extend({}, context.author, {permissions: 'assign'})).then(function (response) {
                 should.exist(response);
                 should.exist(response.roles);
                 testUtils.API.checkResponse(response, 'roles');

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -43,10 +43,10 @@ describe('Users API', function () {
             testUtils.API.checkResponse(response, 'users');
             should.exist(response.users);
             response.users.should.have.length(count);
-            testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
-            testUtils.API.checkResponse(response.users[1], 'user', ['roles']);
-            testUtils.API.checkResponse(response.users[2], 'user', ['roles']);
-            testUtils.API.checkResponse(response.users[3], 'user', ['roles']);
+            testUtils.API.checkResponse(response.users[0], 'user');
+            testUtils.API.checkResponse(response.users[1], 'user');
+            testUtils.API.checkResponse(response.users[2], 'user');
+            testUtils.API.checkResponse(response.users[3], 'user');
         }
 
         it('Owner can browse', function (done) {
@@ -87,12 +87,12 @@ describe('Users API', function () {
 
         it('Can browse invited/invited-pending (admin)', function (done) {
             testUtils.fixtures.createInvitedUsers().then(function () {
-                UserAPI.browse(_.extend(testUtils.context.admin, {status: 'invited'})).then(function (response) {
+                UserAPI.browse(_.extend({}, testUtils.context.admin, {status: 'invited'})).then(function (response) {
                     should.exist(response);
                     testUtils.API.checkResponse(response, 'users');
                     should.exist(response.users);
                     response.users.should.have.length(3);
-                    testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
+                    testUtils.API.checkResponse(response.users[0], 'user');
                     response.users[0].status.should.equal('invited-pending');
 
                     done();
@@ -116,8 +116,23 @@ describe('Users API', function () {
         });
 
         it('Can browse all', function (done) {
-            UserAPI.browse(_.extend(testUtils.context.admin, {status: 'all'})).then(function (response) {
+            UserAPI.browse(_.extend({}, testUtils.context.admin, {status: 'all'})).then(function (response) {
                 checkBrowseResponse(response, 7);
+                done();
+            }).catch(done);
+        });
+
+        it('Can browse with roles', function (done) {
+            UserAPI.browse(_.extend({}, testUtils.context.admin, {status: 'all', include: 'roles'})).then(function (response) {
+                should.exist(response);
+                testUtils.API.checkResponse(response, 'users');
+                should.exist(response.users);
+                response.users.should.have.length(7);
+                response.users.should.have.length(7);
+                testUtils.API.checkResponse(response.users[0], 'user', 'roles');
+                testUtils.API.checkResponse(response.users[1], 'user', 'roles');
+                testUtils.API.checkResponse(response.users[2], 'user', 'roles');
+                testUtils.API.checkResponse(response.users[3], 'user', 'roles');
                 done();
             }).catch(done);
         });
@@ -129,7 +144,7 @@ describe('Users API', function () {
             should.not.exist(response.meta);
             should.exist(response.users);
             response.users[0].id.should.eql(1);
-            testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
+            testUtils.API.checkResponse(response.users[0], 'user');
             response.users[0].created_at.should.be.a.Date;
         }
 
@@ -141,7 +156,8 @@ describe('Users API', function () {
         });
 
         it('Admin can read', function (done) {
-            UserAPI.read(_.extend({}, context.admin, {id: userIdFor.owner})).then(function (response) {
+            var stuff = _.extend({}, context.admin, {id: userIdFor.owner});
+            UserAPI.read(stuff).then(function (response) {
                 checkReadResponse(response);
 
                 done();
@@ -178,7 +194,7 @@ describe('Users API', function () {
             should.not.exist(response.meta);
             should.exist(response.users);
             response.users.should.have.length(1);
-            testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
+            testUtils.API.checkResponse(response.users[0], 'user');
             response.users[0].name.should.equal(newName);
             response.users[0].updated_at.should.be.a.Date;
         }
@@ -535,7 +551,7 @@ describe('Users API', function () {
             should.exist(response.users);
             should.not.exist(response.meta);
             response.users.should.have.length(1);
-            testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
+            testUtils.API.checkResponse(response.users[0], 'user');
             response.users[0].created_at.should.be.a.Date;
         }
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -6,6 +6,7 @@ var testUtils       = require('../../utils'),
     _               = require('lodash'),
 
     // Stuff we are testing
+    ghostBookshelf  = require('../../../server/models/base'),
     PostModel       = require('../../../server/models/post').Post,
     DataGenerator   = testUtils.DataGenerator,
     context         = testUtils.context.owner;
@@ -144,7 +145,7 @@ describe('Post Model', function () {
                 post.id.should.equal(firstPost);
                 post.title.should.not.equal('new title');
 
-                return PostModel.edit({title: 'new title'}, _.extend(context, {id: firstPost}));
+                return PostModel.edit({title: 'new title'}, _.extend({}, context, {id: firstPost}));
             }).then(function (edited) {
                 should.exist(edited);
                 edited.attributes.title.should.equal('new title');
@@ -359,26 +360,30 @@ describe('Post Model', function () {
             var firstItemData = {id: 1};
 
             // Test that we have the post we expect, with exactly one tag
-            PostModel.findOne(firstItemData).then(function (results) {
+            PostModel.findOne(firstItemData, {include: ['tags']}).then(function (results) {
                 var post;
                 should.exist(results);
                 post = results.toJSON();
                 post.id.should.equal(firstItemData.id);
                 post.tags.should.have.length(2);
-                post.tags[0].should.equal(firstItemData.id);
+                post.tags[0].id.should.equal(firstItemData.id);
 
                 // Destroy the post
                 return PostModel.destroy(firstItemData);
             }).then(function (response) {
                 var deleted = response.toJSON();
 
-                deleted.tags.should.be.empty;
                 should.equal(deleted.author, undefined);
 
                 // Double check we can't find the post again
                 return PostModel.findOne(firstItemData);
             }).then(function (newResults) {
                 should.equal(newResults, null);
+
+                // Double check we can't find any related tags
+                return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
+            }).then(function (postsTags) {
+                postsTags.should.be.empty;
 
                 done();
             }).catch(done);

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -134,7 +134,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = existingTagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function (postModel) {
                     var tagNames = postModel.related('tags').models.map(function (t) { return t.attributes.name; });
                     tagNames.sort().should.eql(seededTagNames);
@@ -160,7 +160,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function (postModel) {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -187,7 +187,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function () {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -216,7 +216,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function (postModel) {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -241,7 +241,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function (postModel) {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -272,7 +272,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function () {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -311,7 +311,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function () {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -346,7 +346,7 @@ describe('Tag Model', function () {
                     postModel = postModel.toJSON();
                     postModel.tags = tagData;
 
-                    return PostModel.edit(postModel, _.extend(context, {id: postModel.id, withRelated: ['tags']}));
+                    return PostModel.edit(postModel, _.extend({}, context, {id: postModel.id, withRelated: ['tags']}));
                 }).then(function () {
                     return PostModel.findOne({id: postModel.id, status: 'all'}, {withRelated: ['tags']});
                 }).then(function (reloadedPost) {
@@ -365,7 +365,7 @@ describe('Tag Model', function () {
             });
 
             it('can add a tag to a post on creation', function (done) {
-                var newPost = _.extend(testUtils.DataGenerator.forModel.posts[0], {tags: [{name: 'test_tag_1'}]});
+                var newPost = _.extend({}, testUtils.DataGenerator.forModel.posts[0], {tags: [{name: 'test_tag_1'}]});
 
                 PostModel.add(newPost, context).then(function (createdPost) {
                     return PostModel.findOne({id: createdPost.id, status: 'all'}, {withRelated: ['tags']});

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -316,7 +316,7 @@ describe('User Model', function run() {
             RoleModel.findOne().then(function (role) {
                 userData.roles = [role.toJSON()];
 
-                return UserModel.add(userData, _.extend({}, context));
+                return UserModel.add(userData, _.extend({}, context, {include: ['roles']}));
             }).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -13,7 +13,7 @@ var url             = require('url'),
         pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
         post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
             'featured', 'image', 'status', 'language', 'created_at', 'created_by', 'updated_at',
-            'updated_by', 'published_at', 'published_by', 'page', 'author', 'tags', 'fields'
+            'updated_by', 'published_at', 'published_by', 'page', 'author'
         ],
         settings: ['settings', 'meta'],
         setting: ['id', 'uuid', 'key', 'value', 'type', 'created_at', 'created_by', 'updated_at', 'updated_by'],


### PR DESCRIPTION
closes #4498
- remove toJSON code which returns only IDs from objects
- don't auto-include tags & fields in post responses
- don't auto-include roles in user responses
- fix #allthethings that made assumptions about the auto-includes, or otherwise were only working because of the auto-include
