### PR TITLE
Add Ghost version to config object.

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -112,6 +112,7 @@ ConfigManager.prototype.set = function (config) {
         database: {
             knex: knexInstance
         },
+        ghostVersion: packageInfo.version,
         paths: {
             appRoot:          appRoot,
             subdir:           subdir,

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -12,7 +12,6 @@ var api            = require('../api'),
     hbs            = require('express-hbs'),
     logger         = require('morgan'),
     middleware     = require('./middleware'),
-    packageInfo    = require('../../../package.json'),
     path           = require('path'),
     routes         = require('../routes'),
     slashes        = require('connect-slashes'),
@@ -36,7 +35,7 @@ var api            = require('../api'),
 function ghostLocals(req, res, next) {
     // Make sure we have a locals value.
     res.locals = res.locals || {};
-    res.locals.version = packageInfo.version;
+    res.locals.version = config.ghostVersion;
     // relative path from the URL
     res.locals.relativeUrl = req.path;
 

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -30,12 +30,11 @@ var crypto   = require('crypto'),
     api      = require('./api'),
     config   = require('./config'),
     errors   = require('./errors'),
-    packageInfo = require('../../package.json'),
 
     internal = {context: {internal: true}},
     allowedCheckEnvironments = ['development', 'production'],
     checkEndpoint = 'updates.ghost.org',
-    currentVersion = packageInfo.version;
+    currentVersion = config.ghostVersion;
 
 function updateCheckError(error) {
     api.settings.edit(


### PR DESCRIPTION
No Issue
- Use Ghost version value that is already loaded instead of
  reading package.json from the filesystem and parsing it on
  every call into the configuration API.
