### PR TITLE
Prevent silent failures and recover after error.

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -109,6 +109,10 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
         promise = Ember.RSVP.resolve(afterSave).then(function () {
             return self.get('slugGenerator').generateSlug(title).then(function (slug) {
                 self.set(destination, slug);
+            }).catch(function () {
+                // Nothing to do (would be nice to log this somewhere though),
+                // but a rejected promise needs to be handled here so that a resolved
+                // promise is returned.
             });
         });
 

--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -116,6 +116,12 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             return true;
         }
 
+        // if the Adapter failed to save the model isError will be true
+        // and we should consider the model still dirty.
+        if (model.get('isError')) {
+            return true;
+        }
+
         // models created on the client always return `isDirty: true`,
         // so we need to see which properties have actually changed.
         if (model.get('isNew')) {
@@ -182,9 +188,10 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
     },
 
     showErrorNotification: function (prevStatus, status, errors, delay) {
-        var message = this.messageMap.errors.post[prevStatus][status];
+        var message = this.messageMap.errors.post[prevStatus][status],
+            error = (errors && errors[0] && errors[0].message) || 'Unknown Error';
 
-        message += '<br />' + errors[0].message;
+        message += '<br />' + error;
 
         this.notifications.showError(message, {delayed: delay});
     },
@@ -257,7 +264,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
                 self.set('status', prevStatus);
 
-                return Ember.RSVP.reject(errors);
+                return self.get('model');
             });
 
             psmController.set('lastPromise', promise);


### PR DESCRIPTION
Refs #4543
- Alway return model out of save handler so sub-classes which
  call this._super() on save have a model on success and failure.
- Always return resolved promise out of post slug generator.
- Test the errors object in the error notification helper to avoid
  throwing an unhandled exception and silently failing.
- Consider a post model "dirty" if it is in an error state.
