### PR TITLE
gh-trim-focus-input autofocus fix for iOS Safari

### DIFF
--- a/core/client/components/gh-trim-focus-input.js
+++ b/core/client/components/gh-trim-focus-input.js
@@ -1,8 +1,17 @@
+/*global device*/
 var TrimFocusInput = Ember.TextField.extend({
     focus: true,
 
+    attributeBindings: ['autofocus'],
+
+    autofocus: Ember.computed(function () {
+        return (device.ios()) ? false : 'autofocus';
+    }),
+
     setFocus: function () {
-        if (this.focus) {
+        // This fix is required until Mobile Safari has reliable
+        // autofocus, select() or focus() support
+        if (this.focus && !device.ios()) {
             this.$().val(this.$().val()).focus();
         }
     }.on('didInsertElement'),

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -2,7 +2,7 @@
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
             <span class="input-icon icon-mail">
-                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" 
+                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" 
                 autocapitalize="off" autocorrect="off" value=identification}}
             </span>
         </div>


### PR DESCRIPTION
Closes #4446
- Mobile Safari doesn’t support the HTML5 `autofocus` attribute, but
  also doesn’t play nice with jQuery’s `focus()` and `select()` methods.
- Mobile Safari wouldn’t automatically select the input field anyway,
  so this PR simply removes the “jumping input fields” error without
  changing any actual behaviour.
- Disallowing the programmatic selection of input fields (with select,
  focus or similar methods) is apparently considered a feature rather
  than a bug (ref http://bugs.jquery.com/ticket/12789)
