### PR TITLE
Do not display "auth failed" modal on clean posts.

### DIFF
--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -20,12 +20,16 @@ var ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shor
 
     actions: {
         authorizationFailed: function () {
-            var currentRoute = this.get('controller').get('currentRouteName');
+            var currentRoute = this.get('controller').get('currentRouteName'),
+                editorController;
 
             if (currentRoute.split('.')[0] === 'editor') {
-                this.send('openModal', 'auth-failed-unsaved', this.controllerFor(currentRoute));
+                editorController = this.controllerFor(currentRoute);
 
-                return;
+                if (editorController.get('isDirty')) {
+                    this.send('openModal', 'auth-failed-unsaved', editorController);
+                    return;
+                }
             }
 
             this._super();


### PR DESCRIPTION
Refs #4543
- Check EditorController.isDirty before displaying the
  authorization failed modal dialog.  This prevents the modal
  appearing immediately upon entering the editor in cases where
  auth has failed prior to opening the editor.
