### PR TITLE
PSM: Reset 'Published Date'

### DIFF
--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -74,8 +74,15 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             .create(deferred);
     }),
 
-    publishedAtValue: Ember.computed('published_at', function () {
+    /*jshint unused:false */
+    publishedAtValue: Ember.computed('published_at', function (key, value) {
         var pubDate = this.get('published_at');
+
+        // We're using a fake setter to reset
+        // the cache for this property
+        if (arguments.length > 1) {
+            return formatDate(moment());
+        }
 
         if (pubDate) {
             return formatDate(pubDate);
@@ -83,6 +90,7 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
 
         return formatDate(moment());
     }),
+    /*jshint unused:true */
 
     slugValue: boundOneWay('slug'),
 
@@ -463,6 +471,10 @@ var PostSettingsMenuController = Ember.ObjectController.extend({
             if (uploader && uploader[0]) {
                 uploader[0].uploaderUi.reset();
             }
+        },
+
+        resetPubDate: function () {
+            this.set('publishedAtValue', '');
         }
     }
 });

--- a/core/client/routes/editor/new.js
+++ b/core/client/routes/editor/new.js
@@ -20,8 +20,9 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
         // from previous posts
         psm.removeObserver('titleScratch', psm, 'titleObserver');
 
-        // Ensure that the PSM Image Uploader resets
+        // Ensure that the PSM Image Uploader and Publish Date selector resets
         psm.send('resetUploader');
+        psm.send('resetPubDate');
 
         this._super(controller, model);
     }


### PR DESCRIPTION
Closes #4557
- The underlying issue is that the PSM is already loaded when Ember
  routes from an existing post to a new post. Instead of resetting the
  ‘Published Date’ value manually (with jQuery), I’m using Ember’s
  computed property setter to ‘refresh’ the cache for that property. I
  believe that this Ember solution is better than manually going in and
  resetting it with jQuery.
