### PR TITLE
Add limit=all consistently to users, posts & tags

### DIFF
--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -23,12 +23,6 @@ tags = {
      */
     browse: function browse(options) {
         return canThis(options.context).browse.tag().then(function () {
-            if (options.limit && options.limit === 'all') {
-                return dataProvider.Tag.findAll(options).then(function (result) {
-                    return {tags: result.toJSON()};
-                });
-            }
-
             return dataProvider.Tag.findPage(options);
         }, function () {
             return Promise.reject(new errors.NoPermissionError('You do not have permission to browse tags.'));

--- a/core/server/data/sitemap/page-generator.js
+++ b/core/server/data/sitemap/page-generator.js
@@ -25,7 +25,8 @@ _.extend(PageMapGenerator.prototype, {
                 internal: true
             },
             status: 'published',
-            staticPages: true
+            staticPages: true,
+            limit: 'all'
         }).then(function (resp) {
             var homePage = {
                     id: 0,

--- a/core/server/data/sitemap/post-generator.js
+++ b/core/server/data/sitemap/post-generator.js
@@ -25,7 +25,8 @@ _.extend(PostMapGenerator.prototype, {
                 internal: true
             },
             status: 'published',
-            staticPages: false
+            staticPages: false,
+            limit: 'all'
         }).then(function (resp) {
             return resp.posts;
         });

--- a/core/server/data/sitemap/tag-generator.js
+++ b/core/server/data/sitemap/tag-generator.js
@@ -22,7 +22,8 @@ _.extend(TagsMapGenerator.prototype, {
         return api.tags.browse({
             context: {
                 internal: true
-            }
+            },
+            limit: 'all'
         }).then(function (resp) {
             return resp.tags;
         });

--- a/core/server/data/sitemap/user-generator.js
+++ b/core/server/data/sitemap/user-generator.js
@@ -23,7 +23,8 @@ _.extend(UserMapGenerator.prototype, {
         return api.users.browse({
             context: {
                 internal: true
-            }
+            },
+            limit: 'all'
         }).then(function (resp) {
             return resp.users;
         });

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -319,7 +319,7 @@ Post = ghostBookshelf.Model.extend({
             tagInstance = options.tag !== undefined ? ghostBookshelf.model('Tag').forge({slug: options.tag}) : false,
             authorInstance = options.author !== undefined ? ghostBookshelf.model('User').forge({slug: options.author}) : false;
 
-        if (options.limit) {
+        if (options.limit && options.limit !== 'all') {
             options.limit = parseInt(options.limit, 10) || 15;
         }
 
@@ -399,9 +399,14 @@ Post = ghostBookshelf.Model.extend({
                     postCollection
                         .query('where', 'author_id', '=', authorInstance.id);
                 }
+
+                if (_.isNumber(options.limit)) {
+                    postCollection
+                        .query('limit', options.limit)
+                        .query('offset', options.limit * (options.page - 1));
+                }
+
                 return postCollection
-                    .query('limit', options.limit)
-                    .query('offset', options.limit * (options.page - 1))
                     .query('orderBy', 'status', 'ASC')
                     .query('orderBy', 'published_at', 'DESC')
                     .query('orderBy', 'updated_at', 'DESC')
@@ -436,7 +441,7 @@ Post = ghostBookshelf.Model.extend({
             // Format response of data
             .then(function (resp) {
                 var totalPosts = parseInt(resp[0].aggregate, 10),
-                    calcPages = Math.ceil(totalPosts / options.limit),
+                    calcPages = Math.ceil(totalPosts / options.limit) || 0,
                     pagination = {},
                     meta = {},
                     data = {};

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -74,7 +74,7 @@ Tag = ghostBookshelf.Model.extend({
 
         var tagCollection = Tags.forge();
 
-        if (options.limit) {
+        if (options.limit && options.limit !== 'all') {
             options.limit = parseInt(options.limit, 10) || 15;
         }
 
@@ -90,9 +90,14 @@ Tag = ghostBookshelf.Model.extend({
             where: {}
         }, options);
 
+        // only include a limit-query if a numeric limit is provided
+        if (_.isNumber(options.limit)) {
+            tagCollection
+                .query('limit', options.limit)
+                .query('offset', options.limit * (options.page - 1));
+        }
+
         return tagCollection
-            .query('limit', options.limit)
-            .query('offset', options.limit * (options.page - 1))
             .fetch(_.omit(options, 'page', 'limit'))
         // Fetch pagination information
         .then(function () {
@@ -113,7 +118,7 @@ Tag = ghostBookshelf.Model.extend({
         // Format response of data
         .then(function (resp) {
             var totalTags = parseInt(resp[0].aggregate, 10),
-                calcPages = Math.ceil(totalTags / options.limit),
+                calcPages = Math.ceil(totalTags / options.limit) || 0,
                 pagination = {},
                 meta = {},
                 data = {};

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -309,7 +309,7 @@ User = ghostBookshelf.Model.extend({
             // Format response of data
             .then(function (resp) {
                 var totalUsers = parseInt(resp[0].aggregate, 10),
-                    calcPages = Math.ceil(totalUsers / options.limit),
+                    calcPages = Math.ceil(totalUsers / options.limit) || 0,
                     pagination = {},
                     meta = {},
                     data = {};

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -429,6 +429,13 @@ describe('Post Model', function () {
             }).then(function (paginationResult) {
                 paginationResult.meta.pagination.pages.should.equal(11);
 
+                return PostModel.findPage({limit: 'all', status: 'all'});
+            }).then(function (paginationResult) {
+                paginationResult.meta.pagination.page.should.equal(1);
+                paginationResult.meta.pagination.limit.should.equal('all');
+                paginationResult.meta.pagination.pages.should.equal(1);
+                paginationResult.posts.length.should.equal(107);
+
                 done();
             }).catch(done);
         });

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -37,6 +37,19 @@ describe('Tag Model', function () {
         }).catch(done);
     });
 
+    it('can findPage with limit all', function (done) {
+        testUtils.fixtures.insertPosts().then(function () {
+            return TagModel.findPage({limit: 'all'});
+        }).then(function (results) {
+            results.meta.pagination.page.should.equal(1);
+            results.meta.pagination.limit.should.equal('all');
+            results.meta.pagination.pages.should.equal(1);
+            results.tags.length.should.equal(5);
+
+            done();
+        }).catch(done);
+    });
+
     describe('a Post', function () {
         it('can add a tag', function (done) {
             var newPost = testUtils.DataGenerator.forModel.posts[0],

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -260,6 +260,19 @@ describe('User Model', function run() {
             }).catch(done);
         });
 
+        it('can findPage with limit all', function (done) {
+            return testUtils.fixtures.createExtraUsers().then(function () {
+                return UserModel.findPage({limit: 'all'});
+            }).then(function (results) {
+                results.meta.pagination.page.should.equal(1);
+                results.meta.pagination.limit.should.equal('all');
+                results.meta.pagination.pages.should.equal(1);
+                results.users.length.should.equal(7);
+
+                done();
+            }).catch(done);
+        });
+
         it('can NOT findPage for a page that overflows the datatype', function (done) {
             UserModel.findPage({page: 5700000000055345439587894375457849375284932759842375894372589243758947325894375894275894275894725897432859724309})
                 .then(function (paginationResult) {


### PR DESCRIPTION
refs #623, #4348
- this fixes sitemaps to list all posts, pages, tags and users
- makes the API behave consistently across all paginated resources
