### PR TITLE
Revert "Allow notifications to sit over the nav bar"

### DIFF
--- a/core/client/assets/sass/layouts/default.scss
+++ b/core/client/assets/sass/layouts/default.scss
@@ -38,6 +38,7 @@
     bottom: 0;
     left: 0;
     overflow: hidden;
+    z-index: 500; // Above the .global-nav when collapsed
     transition: transform $settings-menu-transition cubic-bezier($settings-menu-bezier);
 
     @media (max-width: 900px) {
@@ -94,16 +95,6 @@
     @media (max-width: 900px) {
         top: 44px;
     }
-}
-
-// A <span> that wraps the main {{outlet}} which created a new z-index stack, separate to the nav
-.viewport-content {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 500; // Above the .global-nav when collapsed
 }
 
 

--- a/core/client/templates/application.hbs
+++ b/core/client/templates/application.hbs
@@ -7,9 +7,7 @@
 <main id="gh-main" class="viewport" role="main" {{bind-attr data-notification-count=topNotificationCount}}>
     {{gh-notifications location="top" notify="topNotificationChange"}}
     {{gh-notifications location="bottom"}}
-    <span class="viewport-content">
-        {{outlet}}
-    </span>
+    {{outlet}}
 </main>
 
 {{outlet modal}}


### PR DESCRIPTION
Reverts TryGhost/Ghost#4544

Something I sadly didn't see in testing #4544, was settings menus showed over the content, until the transition stopped. It's ugly and needs to go. Unfortunately, it's not a super quick fix and needs revisiting.

[Here's the issue](http://cl.ly/0e1I062p3A3w) < 500kb video
