### PR TITLE
Match labels with element ids.

### DIFF
--- a/core/client/templates/settings/code-injection.hbs
+++ b/core/client/templates/settings/code-injection.hbs
@@ -16,15 +16,15 @@
             </div>
 
             <div class="form-group">
-                <label for="blog-header">Blog Header</label>
+                <label for="ghost-head">Blog Header</label>
                 <p>Code here will be injected to the \{{ghost_head}} helper at the top of your page</p>
                 {{textarea id="ghost-head" name="codeInjection[ghost_head]" type="text" value=ghost_head}}
             </div>
 
             <div class="form-group">
-                <label for="blog-header">Blog Footer</label>
+                <label for="ghost-foot">Blog Footer</label>
                 <p>Code here will be injected to the \{{ghost_foot}} helper at the bottom of your page</p>
-                {{textarea id="blog-foot" name="codeInjection[ghost_foot]" type="text" value=ghost_foot}}
+                {{textarea id="ghost-foot" name="codeInjection[ghost_foot]" type="text" value=ghost_foot}}
             </div>
         </fieldset>
     </form>

--- a/core/server/helpers/ghost_foot.js
+++ b/core/server/helpers/ghost_foot.js
@@ -26,8 +26,6 @@ ghost_foot = function (options) {
 
     return api.settings.read({key: 'ghost_foot'}).then(function (response) {
         foot.push(response.settings[0].value);
-        return foot;
-    }).then(function (foot) {
         return filters.doFilter('ghost_foot', foot);
     }).then(function (foot) {
         var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -162,8 +162,6 @@ ghost_head = function (options) {
         return api.settings.read({key: 'ghost_head'});
     }).then(function (response) {
         head.push(response.settings[0].value);
-        return head;
-    }).then(function (head) {
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
         var headString = _.reduce(head, function (memo, item) { return memo + '\n    ' + item; }, '');


### PR DESCRIPTION
Refs #4578
- Match label "for" attributes with ids from the inputs they're
  labeling.
- Remove extra promise generation from ghost header and footer helpers.
