### PR TITLE
Update syntax in ember templates.

### DIFF
--- a/core/client/templates/-import-errors.hbs
+++ b/core/client/templates/-import-errors.hbs
@@ -1,7 +1,7 @@
 {{#if importErrors}}
 <table class="table">
-{{#each importErrors}}
-    <tr><td>{{message}}</td></tr>
+{{#each error in importErrors}}
+    <tr><td>{{error.message}}</td></tr>
 {{/each}}
 </table>
 {{/if}}

--- a/core/client/templates/application.hbs
+++ b/core/client/templates/application.hbs
@@ -10,6 +10,6 @@
     {{outlet}}
 </main>
 
-{{outlet modal}}
+{{outlet "modal"}}
 
-{{outlet settings-menu}}
+{{outlet "settings-menu"}}

--- a/core/client/templates/components/gh-notifications.hbs
+++ b/core/client/templates/components/gh-notifications.hbs
@@ -1,3 +1,3 @@
-{{#each messages}}
-    {{gh-notification message=this}}
+{{#each message in messages}}
+    {{gh-notification message=message}}
 {{/each}}

--- a/core/client/templates/components/gh-role-selector.hbs
+++ b/core/client/templates/components/gh-role-selector.hbs
@@ -1,5 +1,5 @@
 <select {{bind-attr id=selectId name=selectName}}>
-{{#each roles}}
-<option {{bind-attr value=id}}>{{name}}</option>
+{{#each role in roles}}
+<option {{bind-attr value=role.id}}>{{role.name}}</option>
 {{/each}}
 </select>

--- a/core/client/templates/error.hbs
+++ b/core/client/templates/error.hbs
@@ -16,11 +16,11 @@
         <h3>Stack Trace</h3>
         <p><strong>{{message}}</strong></p>
         <ul class="error-stack-list">
-            {{#each stack}}
+            {{#each item in stack}}
                 <li>
                     at
-                    {{#if function}}<em class="error-stack-function">{{function}}</em>{{/if}}
-                    <span class="error-stack-file">({{at}})</span>
+                    {{#if item.function}}<em class="error-stack-function">{{item.function}}</em>{{/if}}
+                    <span class="error-stack-file">({{item.at}})</span>
                 </li>
             {{/each}}
         </ul>

--- a/core/client/templates/post-tags-input.hbs
+++ b/core/client/templates/post-tags-input.hbs
@@ -5,8 +5,8 @@
 </div>
 <div class="publish-bar-tags">
     <div class="tags-wrapper tags">
-        {{#each controller.tags}}
-           <span class="tag" {{action "deleteTag" this target=view}}>{{name}}</span>
+        {{#each tag in controller.tags}}
+           <span class="tag" {{action "deleteTag" tag target=view}}>{{tag.name}}</span>
         {{/each}}
     </div>
 </div>
@@ -14,8 +14,8 @@
     <input type="hidden" class="tags-holder" id="tags-holder">
     {{view view.tagInputView class="tag-input js-tag-input" id="tags" value=newTagText}}
     <ul class="suggestions dropdown-menu dropdown-triangle-bottom" {{bind-attr style=view.overlayStyles}}>
-        {{#each suggestions}}
-            {{#view view.suggestionView suggestion=this}}
+        {{#each suggestion in suggestions}}
+            {{#view view.suggestionView suggestion=suggestion}}
                 <a href="javascript:void(0);">{{view.suggestion.highlightedName}}</a>
             {{/view}}
         {{/each}}

--- a/core/client/templates/posts.hbs
+++ b/core/client/templates/posts.hbs
@@ -13,17 +13,17 @@
         </header>
         {{#view "paginated-scroll-box" tagName="section" classNames="content-list-content"}}
         <ol class="posts-list">
-            {{#each itemController="posts/post" itemView="post-item-view" itemTagName="li"}}
-            {{#link-to "posts.post" this class="permalink" title="Edit this post"}}
-            <h3 class="entry-title">{{title}}</h3>
+            {{#each post in model itemController="posts/post" itemView="post-item-view" itemTagName="li"}}
+            {{#link-to "posts.post" post class="permalink" title="Edit this post"}}
+            <h3 class="entry-title">{{post.title}}</h3>
             <section class="entry-meta">
                 <span class="status">
-                    {{#if isPublished}}
-                    {{#if page}}
+                    {{#if post.isPublished}}
+                    {{#if post.page}}
                     <span class="page">Page</span>
                     {{else}}
-                    <time datetime="{{unbound published_at}}" class="date published">
-                        Published {{gh-format-timeago published_at}}
+                    <time datetime="{{unbound post.published_at}}" class="date published">
+                        Published {{gh-format-timeago post.published_at}}
                     </time>
                     {{/if}}
                     {{else}}

--- a/core/client/templates/settings/apps.hbs
+++ b/core/client/templates/settings/apps.hbs
@@ -10,14 +10,14 @@
             <th>Status</th>
         </thead>
         <tbody>
-        {{#each itemController="settings/app"}}
+        {{#each app in model itemController="settings/app"}}
         <tr>
             <td>
-                {{#if package}}{{package.name}} - {{package.version}}{{else}}{{name}} - package.json missing :({{/if}}
+                {{#if app.package}}{{app.package.name}} - {{app.package.version}}{{else}}{{app.name}} - package.json missing :({{/if}}
             </td>
             <td>
-                <button type="button" {{action toggleApp this}} {{bind-attr class=":btn :js-button-active activeClass:btn-red inactiveClass:btn-green activeClass:js-button-deactivate"}}>
-                    {{buttonText}}
+                <button type="button" {{action toggleApp app}} {{bind-attr class=":btn :js-button-active activeClass:btn-red inactiveClass:btn-green activeClass:js-button-deactivate"}}>
+                    {{app.buttonText}}
                 </button>
             </td>
         </tr>

--- a/core/client/templates/settings/users/index.hbs
+++ b/core/client/templates/settings/users/index.hbs
@@ -15,16 +15,16 @@
 
             <h4 class="user-list-title">Invited users</h4>
 
-            {{#each invitedUsers itemController="settings/users/user"}}
+            {{#each user in invitedUsers itemController="settings/users/user"}}
                 <div class="user-list-item">
                     <span class="user-list-item-icon icon-mail">ic</span>
 
                     <div class="user-list-item-body">
-                        <span class="name">{{email}}</span><br>
-                            {{#if pending}}
+                        <span class="name">{{user.email}}</span><br>
+                            {{#if user.pending}}
                                 <span class="red">Invitation not sent - please try again</span>
                             {{else}}
-                                <span class="description">Invitation sent: {{created_at}}</span>
+                                <span class="description">Invitation sent: {{user.created_at}}</span>
                             {{/if}}
                     </div>
                     <aside class="user-list-item-aside">
@@ -42,23 +42,23 @@
 
         <h4 class="user-list-title">Active users</h4>
 
-        {{#each activeUsers itemController="settings/users/user"}}
-            {{#link-to 'settings.users.user' this class="user-list-item" }}
-                <span class="user-list-item-figure" {{bind-attr style=image}}>
-                    <span class="hidden">Photo of {{unbound name}}</span>
+        {{#each user in activeUsers itemController="settings/users/user"}}
+            {{#link-to 'settings.users.user' user class="user-list-item" }}
+                <span class="user-list-item-figure" {{bind-attr style=user.image}}>
+                    <span class="hidden">Photo of {{unbound user.name}}</span>
                 </span>
 
                 <div class="user-list-item-body">
                     <span class="name">
-                        {{name}}
+                        {{user.name}}
                     </span>
                     <br>
-                    <span class="description">Last seen: {{unbound last_login}}</span>
+                    <span class="description">Last seen: {{unbound user.last_login}}</span>
                 </div>
                 <aside class="user-list-item-aside">
-                    {{#unless isAuthor}}
-                        {{#each roles}}
-                            <span class="role-label {{unbound lowerCaseName}}">{{name}}</span>
+                    {{#unless user.isAuthor}}
+                        {{#each role in user.roles}}
+                            <span class="role-label {{unbound role.lowerCaseName}}">{{role.name}}</span>
                         {{/each}}
                     {{/unless}}
                 </aside>


### PR DESCRIPTION
No Issue.
- Outlet names must be quoted.
- {{#each}} helper will no longer implicitly switch context.
  Change usage to {{#each foo in bar}}.
