### PR TITLE
Allow theme to override favicon and sitemap

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -262,10 +262,6 @@ setupMiddleware = function (blogAppInstance, adminApp) {
         }
     }
 
-    // Favicon
-    blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
-    blogApp.use(serveSharedFile('sitemap.xsl', 'text/xsl', utils.ONE_DAY_S));
-
     // Static assets
     blogApp.use('/shared', express['static'](path.join(corePath, '/shared'), {maxAge: utils.ONE_HOUR_MS}));
     blogApp.use('/content/images', storage.getStorage().serve());
@@ -290,8 +286,10 @@ setupMiddleware = function (blogAppInstance, adminApp) {
     // Theme only config
     blogApp.use(middleware.staticTheme());
 
-    // Serve robots.txt if not found in theme
+    // Serve robots.txt, favicon.ico, and sitemap.xsl if not found in theme
     blogApp.use(serveSharedFile('robots.txt', 'text/plain', utils.ONE_HOUR_S));
+    blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
+    blogApp.use(serveSharedFile('sitemap.xsl', 'text/xsl', utils.ONE_DAY_S));
 
     // site map
     sitemapHandler(blogApp);


### PR DESCRIPTION
This is my suggested fix for #4597.  See that issue for details.

Rearrange the route setup order so that the theme-specified overrides
for favicon.ico and sitemap.xsl take priority over the defaults.

Theme overrides must be placed in the top level directory of that theme,
eg. 'content/themes/casper/favicon.ico'
