### PR TITLE
Change sitemap root location

### DIFF
--- a/core/server/data/sitemap/handler.js
+++ b/core/server/data/sitemap/handler.js
@@ -16,13 +16,7 @@ module.exports = function (blogApp) {
             return sitemap.getSiteMapXml(type, page);
         };
 
-    // Redirect normal sitemap.xml requests to sitemap-index.xml
     blogApp.get('/sitemap.xml', function (req, res) {
-        res.set({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S});
-        res.redirect(301, req.baseUrl + '/sitemap-index.xml');
-    });
-
-    blogApp.get('/sitemap-index.xml', function (req, res) {
         res.set({
             'Cache-Control': 'public, max-age=' + utils.ONE_HOUR_S,
             'Content-Type': 'text/xml'

--- a/core/shared/robots.txt
+++ b/core/shared/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Sitemap: /sitemap-index.xml
+Sitemap: /sitemap.xml
 Disallow: /ghost/

--- a/core/shared/sitemap.xsl
+++ b/core/shared/sitemap.xsl
@@ -95,7 +95,7 @@
                         </table>
                     </xsl:if>
                     <xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &lt; 1">
-                        <p class="desc"><a href="/sitemap-index.xml" class="back-link">&#8592; Back to index</a></p>
+                        <p class="desc"><a href="/sitemap.xml" class="back-link">&#8592; Back to index</a></p>
                         <table id="sitemap" cellpadding="3">
                             <thead>
                                 <tr>
@@ -135,13 +135,13 @@
                                 </xsl:for-each>
                             </tbody>
                         </table>
-                        <p class="desc"><a href="/sitemap-index.xml" class="back-link">&#8592; Back to index</a></p>
+                        <p class="desc"><a href="/sitemap.xml" class="back-link">&#8592; Back to index</a></p>
                     </xsl:if>
                 </div>
                 <script type="text/javascript">
                     <![CDATA[
                     window.onload = function() {
-                        var sitemapIndex = window.location.href.replace(/sitemap-.*\.xml$/, 'sitemap-index.xml'),
+                        var sitemapIndex = window.location.href.replace(/sitemap-.*\.xml$/, 'sitemap.xml'),
                             links = document.querySelectorAll('.back-link'),
                             i;
                         if (links.length > 0) {

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -935,15 +935,8 @@ describe('Frontend Routing', function () {
             }).catch(done);
         });
 
-        it('should redirect for /sitemap.xml', function (done) {
+        it('should serve sitemap.xml', function (done) {
             request.get('/sitemap.xml')
-                .expect(301)
-                .expect('location', /sitemap-index.xml/)
-                .end(doEnd(done));
-        });
-
-        it('should serve sitemap-index.xml', function (done) {
-            request.get('/sitemap-index.xml')
                 .expect(200)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .end(doEnd(done));


### PR DESCRIPTION
Closes #4590
- Removes `-index` from the root sitemap
- Removes redirects (which send sitemap.xml to sitemap-index.xml)
- Adjust tests
