### PR TITLE
Allow re-authentication in editor after 401 response

### DIFF
--- a/core/client/assets/sass/components/modals.scss
+++ b/core/client/assets/sass/components/modals.scss
@@ -166,3 +166,38 @@
 .modal-style-centered {
     text-align: center;
 }
+
+// Modal login styles
+.modal-body .login-form {
+    display: block; // Override inherited `display: table-cell;`
+
+    .password-wrap {
+        input {
+            width: 100%;
+        }
+    }
+
+    @media (max-width: 900px) {
+        margin: 0 auto;
+        max-width: 264px;
+
+        .password-wrap {
+            width: 100%;
+            margin: 0 auto 1em;
+        }
+
+        .btn {
+            margin: 0;
+            width: 100%;
+            margin-bottom: 1em;
+        }
+    }
+
+    @media (min-width: 901px) {
+        display: flex;
+
+        .password-wrap {
+            flex: 1;
+        }
+    }
+}

--- a/core/client/controllers/modals/signin.js
+++ b/core/client/controllers/modals/signin.js
@@ -1,12 +1,30 @@
-import SigninController from '../signin';
+import SigninController from 'ghost/controllers/signin';
 
 export default SigninController.extend({
+    needs: 'application',
+
+    identification: Ember.computed('session.user.email', function () {
+        return this.get('session.user.email');
+    }),
+
     actions: {
-        authenticate: function (data) {
-            var self = this;
-            this._super(data).then(function () {
+        authenticate: function () {
+            var appController = this.get('controllers.application'),
+                self = this;
+
+            appController.set('skipAuthSuccessHandler', true);
+
+            this._super().then(function () {
                 self.send('closeModal');
+                self.notifications.showSuccess('Login successful.');
+                self.set('password', '');
+            }).finally(function () {
+                appController.set('skipAuthSuccessHandler', undefined);
             });
+        },
+
+        confirmAccept: function () {
+            this.send('validateAndAuthenticate');
         }
     }
 });

--- a/core/client/controllers/modals/signin.js
+++ b/core/client/controllers/modals/signin.js
@@ -1,0 +1,12 @@
+import SigninController from '../signin';
+
+export default SigninController.extend({
+    actions: {
+        authenticate: function (data) {
+            var self = this;
+            this._super(data).then(function () {
+                self.send('closeModal');
+            });
+        }
+    }
+});

--- a/core/client/initializers/authentication.js
+++ b/core/client/initializers/authentication.js
@@ -27,9 +27,9 @@ AuthenticationInitializer = {
         };
 
         SimpleAuth.Session.reopen({
-            user: Ember.computed(function () {
+            user: function () {
                 return container.lookup('store:main').find('user', 'me');
-            })
+            }).property()
         });
 
         SimpleAuth.Authenticators.OAuth2.reopen({

--- a/core/client/initializers/authentication.js
+++ b/core/client/initializers/authentication.js
@@ -15,7 +15,7 @@ AuthenticationInitializer = {
 
         window.ENV['simple-auth'] = {
             authenticationRoute: 'signin',
-            routeAfterAuthentication: 'content',
+            routeAfterAuthentication: 'posts',
             authorizer: 'simple-auth-authorizer:oauth2-bearer',
             localStorageKey: 'ghost' + (Ghost.subdir.indexOf('/') === 0 ? '-' + Ghost.subdir.substr(1) : '') + ':session'
         };
@@ -27,9 +27,9 @@ AuthenticationInitializer = {
         };
 
         SimpleAuth.Session.reopen({
-            user: function () {
+            user: Ember.computed(function () {
                 return container.lookup('store:main').find('user', 'me');
-            }).property()
+            })
         });
 
         SimpleAuth.Authenticators.OAuth2.reopen({

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -23,22 +23,6 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
     },
 
     actions: {
-        authorizationFailed: function () {
-            var currentRoute = this.get('controller').get('currentRouteName'),
-                editorController;
-
-            if (currentRoute.split('.')[0] === 'editor') {
-                editorController = this.controllerFor(currentRoute);
-
-                if (editorController.get('isDirty')) {
-                    this.send('openModal', 'auth-failed-unsaved', editorController);
-                    return;
-                }
-            }
-
-            this._super();
-        },
-
         toggleGlobalMobileNav: function () {
             this.toggleProperty('controller.showGlobalMobileNav');
         },
@@ -46,9 +30,11 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
         openSettingsMenu: function () {
             this.set('controller.showSettingsMenu', true);
         },
+
         closeSettingsMenu: function () {
             this.set('controller.showSettingsMenu', false);
         },
+
         toggleSettingsMenu: function () {
             this.toggleProperty('controller.showSettingsMenu');
         },

--- a/core/client/routes/application.js
+++ b/core/client/routes/application.js
@@ -63,7 +63,13 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
         },
 
         sessionAuthenticationSucceeded: function () {
-            var self = this;
+            var appController = this.controllerFor('application'),
+                self = this;
+
+            if (appController && appController.get('skipAuthSuccessHandler')) {
+                return;
+            }
+
             this.store.find('user', 'me').then(function (user) {
                 self.send('signedIn', user);
                 var attemptedTransition = self.get('session').get('attemptedTransition');

--- a/core/client/routes/editor/edit.js
+++ b/core/client/routes/editor/edit.js
@@ -48,6 +48,12 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
                 return self.replaceWith('posts.index');
             }
         });
+    },
+
+    actions: {
+         authorizationFailed: function () {
+            this.send('openModal', 'signin');
+        }
     }
 });
 

--- a/core/client/templates/modals/signin.hbs
+++ b/core/client/templates/modals/signin.hbs
@@ -1,0 +1,14 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+    title="Please login again" confirm=confirm}}
+
+        <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
+            <div class="email-wrap">
+                {{input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" autocapitalize="off" autocorrect="off" value=identification}}
+            </div>
+            <div class="password-wrap">
+                {{input class="password" type="password" placeholder="Password" name="password" value=password}}
+            </div>
+            <button class="button-save" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
+       </form>
+
+{{/gh-modal-dialog}}

--- a/core/client/templates/modals/signin.hbs
+++ b/core/client/templates/modals/signin.hbs
@@ -1,14 +1,11 @@
-{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
-    title="Please login again" confirm=confirm}}
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide" animation="fade"
+    title="Please re-authenticate" confirm=confirm}}
 
-        <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
-            <div class="email-wrap">
-                {{input class="email" type="email" placeholder="Email Address" name="identification" autofocus="autofocus" autocapitalize="off" autocorrect="off" value=identification}}
-            </div>
+        <form id="login" class="login-form" method="post" novalidate="novalidate" {{action "validateAndAuthenticate" on="submit"}}>
             <div class="password-wrap">
                 {{input class="password" type="password" placeholder="Password" name="password" value=password}}
             </div>
-            <button class="button-save" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
+            <button class="btn btn-blue" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>
        </form>
 
 {{/gh-modal-dialog}}

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -2,8 +2,7 @@
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
             <span class="input-icon icon-mail">
-                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" 
-                autocapitalize="off" autocorrect="off" value=identification}}
+                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" value=identification}}
             </span>
         </div>
         <div class="password-wrap">


### PR DESCRIPTION
This PR supersedes #3492.  The commit from #3492 has been rebased and is now working.  There are some UX and other minor details that need to be sorted out:

A couple things I noticed right away (there are likely others as well):
- There's currently no feedback after the re-authentication succeeds or fails.
- Credentials need to be cleared from the controller after the re-auth attempt.
- The modal needs to be styled.
