### PR TITLE
Added Highlight to Markdown Help

### DIFF
--- a/core/client/templates/modals/markdown.hbs
+++ b/core/client/templates/modals/markdown.hbs
@@ -51,6 +51,11 @@
                 <td>Ctrl + Q</td>
             </tr>
             <tr>
+                <td><mark>Highlight</mark></td>
+                <td>==Highlight==</td>
+                <td></td>
+            </tr>
+            <tr>
                 <td>H1</td>
                 <td># Heading</td>
                 <td></td>


### PR DESCRIPTION
No Issue
- Added highlight syntax to the 'Markdown Help' modal window

I could not find evidence of a shortcut, but let me know if there is one and I can add it in.
