### PR TITLE
Swap button order on deleter-user modal

### DIFF
--- a/core/client/templates/components/gh-modal-dialog.hbs
+++ b/core/client/templates/components/gh-modal-dialog.hbs
@@ -8,11 +8,11 @@
             </section>
             {{#if confirm}}
             <footer class="modal-footer">
-                <button type="button" {{bind-attr class="acceptButtonClass :js-button-accept"}} {{action "confirm" "accept"}}>
-                    {{confirm.accept.text}}
-                </button>
                 <button type="button" {{bind-attr class="rejectButtonClass :js-button-reject"}} {{action "confirm" "reject"}}>
                     {{confirm.reject.text}}
+                </button>
+                <button type="button" {{bind-attr class="acceptButtonClass :js-button-accept"}} {{action "confirm" "accept"}}>
+                    {{confirm.accept.text}}
                 </button>
             </footer>
             {{/if}}


### PR DESCRIPTION
Issue #4583
- In the delete-user modal, the delete button should be on the right, cancel on the left.
- Approach recommended by @jaswilli in #4583 because it changes just this modal rather than all of them.
