### PR TITLE
Fix active menu state on settings navigation

### DIFF
--- a/core/client/components/gh-activating-list-item.js
+++ b/core/client/components/gh-activating-list-item.js
@@ -1,7 +1,11 @@
 var ActivatingListItem = Ember.Component.extend({
     tagName: 'li',
     classNameBindings: ['active'],
-    active: false
+    active: false,
+
+    unfocusLink: function () {
+        this.$('a').blur();
+    }.on('click')
 });
 
 export default ActivatingListItem;


### PR DESCRIPTION
Fixes #4622

Unfocuses the {{link-to}} inside ActivatingListItem when it is clicked.
