### PR TITLE
Modal spacing & warning colour

### DIFF
--- a/core/client/assets/sass/components/modals.scss
+++ b/core/client/assets/sass/components/modals.scss
@@ -124,6 +124,7 @@
 
 .modal-header {
     position: relative;
+    margin-bottom: 18px;
 
     h1 {
         display: inline-block;
@@ -136,6 +137,10 @@
 .modal-body {
     position: relative;
     overflow-y: auto;
+
+    .red {
+        color: $red;
+    }
 }
 
 .modal-footer {


### PR DESCRIPTION
Closes #4583
- Adds a `.red` class (used to make the post count red)
- Adds a little spacing under the modal header to things arent bunched up

![screen shot 2014-12-12 at 10 49 19](https://cloud.githubusercontent.com/assets/390392/5410469/c78bba0c-81ec-11e4-8cf6-2b9708d7ba26.png)
