### PR TITLE
Autosave for whitespace-only titles

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -233,7 +233,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             this.set('status', status);
 
             // Set a default title
-            if (!this.get('titleScratch')) {
+            if (!this.get('titleScratch').trim()) {
                 this.set('titleScratch', '(Untitled)');
             }
 


### PR DESCRIPTION
closes #4625
- trim white space form `titleScratch` to enable autosave for
  whitespace-only titles
