### PR TITLE
Refactor Importer

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -1,56 +1,18 @@
 // # DB API
 // API for DB operations
-var dataExport       = require('../data/export'),
-    dataImport       = require('../data/import'),
-    dataProvider     = require('../models'),
-    fs               = require('fs-extra'),
+var _                = require('lodash'),
     Promise          = require('bluebird'),
-    _                = require('lodash'),
-    path             = require('path'),
-    os               = require('os'),
-    glob             = require('glob'),
-    uuid             = require('node-uuid'),
-    extract          = require('extract-zip'),
-    errors           = require('../../server/errors'),
+    dataExport       = require('../data/export'),
+    importer         = require('../data/importer'),
+    models           = require('../models'),
+    errors           = require('../errors'),
     canThis          = require('../permissions').canThis,
     utils            = require('./utils'),
+
     api              = {},
-    db,
-    types = ['application/octet-stream', 'application/json', 'application/zip', 'application/x-zip-compressed'],
-    extensions = ['.json', '.zip'];
+    db;
 
 api.settings         = require('./settings');
-
-// TODO refactor this out of here
-function isJSON(ext) {
-    return ext === '.json';
-}
-
-function isZip(ext) {
-    return ext === '.zip';
-}
-
-function getJSONFileContents(filepath, ext) {
-    if (isJSON(ext)) {
-    // if it's just a JSON file, read it
-        return Promise.promisify(fs.readFile)(filepath);
-    } else if (isZip(ext)) {
-        var tmpdir = path.join(os.tmpdir(), uuid.v4());
-
-        return Promise.promisify(extract)(filepath, {dir: tmpdir}).then(function () {
-            return Promise.promisify(glob)('**/*.json', {cwd: tmpdir}).then(function (files) {
-                if (files[0]) {
-                    // @TODO: handle multiple JSON files
-                    return Promise.promisify(fs.readFile)(path.join(tmpdir, files[0]));
-                } else {
-                    return Promise.reject(new errors.UnsupportedMediaTypeError(
-                        'Zip did not include any content to import.'
-                    ));
-                }
-            });
-        });
-    }
-}
 
 /**
  * ## DB API Methods
@@ -90,9 +52,6 @@ db = {
      */
     importContent: function (options) {
         options = options || {};
-        var databaseVersion,
-            ext,
-            filepath;
 
         // Check if a file was provided
         if (!utils.checkFileExists(options, 'importfile')) {
@@ -100,58 +59,20 @@ db = {
         }
 
         // Check if the file is valid
-        if (!utils.checkFileIsValid(options.importfile, types, extensions)) {
+        if (!utils.checkFileIsValid(options.importfile, importer.getTypes(), importer.getExtensions())) {
             return Promise.reject(new errors.UnsupportedMediaTypeError(
-                'Please select either a .json or .zip file to import.'
+                'Unsupported file. Please try any of the following formats: ' +
+                    _.reduce(importer.getExtensions(), function (memo, ext) {
+                        return memo ? memo + ', ' + ext : ext;
+                    })
             ));
         }
 
-        // TODO refactor this out of here
-        filepath = options.importfile.path;
-        ext = path.extname(options.importfile.name).toLowerCase();
-
         // Permissions check
         return canThis(options.context).importContent.db().then(function () {
-            return api.settings.read(
-                {key: 'databaseVersion', context: {internal: true}}
-            ).then(function (response) {
-                var setting = response.settings[0];
-
-                return setting.value;
-            }).then(function (version) {
-                databaseVersion = version;
-                // Read the file contents
-                return getJSONFileContents(filepath, ext);
-            }).then(function (fileContents) {
-                var importData;
-
-                // Parse the json data
-                try {
-                    importData = JSON.parse(fileContents);
-
-                    // if importData follows JSON-API format `{ db: [exportedData] }`
-                    if (_.keys(importData).length === 1 && Array.isArray(importData.db)) {
-                        importData = importData.db[0];
-                    }
-                } catch (e) {
-                    errors.logError(e, 'API DB import content', 'check that the import file is valid JSON.');
-                    return Promise.reject(new errors.BadRequestError('Failed to parse the import JSON file.'));
-                }
-
-                if (!importData.meta || !importData.meta.version) {
-                    return Promise.reject(
-                        new errors.ValidationError('Import data does not specify version', 'meta.version')
-                    );
-                }
-
-                // Import for the current version
-                return dataImport(databaseVersion, importData);
-            }).then(api.settings.updateSettingsCache)
-            .return({db: []})
-            .finally(function () {
-                // Unlink the file after import
-                return Promise.promisify(fs.unlink)(filepath);
-            });
+            return importer.importFromFile(options.importfile)
+                .then(api.settings.updateSettingsCache)
+                .return({db: []});
         }, function () {
             return Promise.reject(new errors.NoPermissionError('You do not have permission to import data (no rights).'));
         });
@@ -168,7 +89,7 @@ db = {
         options = options || {};
 
         return canThis(options.context).deleteAllContent.db().then(function () {
-            return Promise.resolve(dataProvider.deleteAllContent())
+            return Promise.resolve(models.deleteAllContent())
                 .return({db: []})
                 .catch(function (error) {
                     return Promise.reject(new errors.InternalServerError(error.message || error));

--- a/core/server/data/import/001.js
+++ b/core/server/data/import/001.js
@@ -1,8 +1,0 @@
-var Importer000 = require('./000');
-
-module.exports = {
-    Importer001: Importer000,
-    importData: function (data) {
-        return new Importer000.importData(data);
-    }
-};

--- a/core/server/data/import/002.js
+++ b/core/server/data/import/002.js
@@ -1,8 +1,0 @@
-var Importer000 = require('./000');
-
-module.exports = {
-    Importer002: Importer000,
-    importData: function (data) {
-        return new Importer000.importData(data);
-    }
-};

--- a/core/server/data/import/003.js
+++ b/core/server/data/import/003.js
@@ -1,8 +1,0 @@
-var Importer000 = require('./000');
-
-module.exports = {
-    Importer003: Importer000,
-    importData: function (data) {
-        return new Importer000.importData(data);
-    }
-};

--- a/core/server/data/import/data-importer.js
+++ b/core/server/data/import/data-importer.js
@@ -3,37 +3,15 @@ var Promise = require('bluebird'),
     models  = require('../../models'),
     utils   = require('./utils'),
 
-    Importer000;
+    DataImporter;
 
-Importer000 = function () {
-    _.bindAll(this, 'doImport');
+DataImporter = function () {};
 
-    this.version = '000';
-
-    this.importFrom = {
-        '000': this.doImport,
-        '001': this.doImport,
-        '002': this.doImport,
-        '003': this.doImport
-    };
+DataImporter.prototype.importData = function (data) {
+    return this.doImport(data);
 };
 
-Importer000.prototype.importData = function (data) {
-    return this.canImport(data)
-        .then(function (importerFunc) {
-            return importerFunc(data);
-        });
-};
-
-Importer000.prototype.canImport = function (data) {
-    if (data.meta && data.meta.version && this.importFrom[data.meta.version]) {
-        return Promise.resolve(this.importFrom[data.meta.version]);
-    }
-
-    return Promise.reject('Unsupported version of data: ' + data.meta.version);
-};
-
-Importer000.prototype.loadUsers = function () {
+DataImporter.prototype.loadUsers = function () {
     var users = {all: {}};
 
     return models.User.findAll({include: ['roles']}).then(function (_users) {
@@ -52,11 +30,7 @@ Importer000.prototype.loadUsers = function () {
     });
 };
 
-// Importer000.prototype.importerFunction = function (t) {
-//
-// };
-
-Importer000.prototype.doUserImport = function (t, tableData, users, errors) {
+DataImporter.prototype.doUserImport = function (t, tableData, users, errors) {
     var userOps = [],
         imported = [];
 
@@ -89,7 +63,7 @@ Importer000.prototype.doUserImport = function (t, tableData, users, errors) {
     return Promise.resolve({});
 };
 
-Importer000.prototype.doImport = function (data) {
+DataImporter.prototype.doImport = function (data) {
     var self = this,
         tableData = data.data,
         imported = {},
@@ -171,8 +145,8 @@ Importer000.prototype.doImport = function (data) {
 };
 
 module.exports = {
-    Importer000: Importer000,
+    DataImporter: DataImporter,
     importData: function (data) {
-        return new Importer000().importData(data);
+        return new DataImporter().importData(data);
     }
 };

--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -3,7 +3,6 @@ var Promise         = require('bluebird'),
     validation      = require('../validation'),
     errors          = require('../../errors'),
     uuid            = require('node-uuid'),
-    validator       = require('validator'),
     importer        = require('./data-importer'),
     tables          = require('../schema').tables,
     validate,
@@ -90,14 +89,14 @@ sanitize = function sanitize(data) {
         });
 
     _.each(tableNames, function (tableName) {
-        // Sanitize the table data for duplicates and valid uuid values
+        // Sanitize the table data for duplicates and valid uuid and created_at values
         var sanitizedTableData = _.transform(data.data[tableName], function (memo, importValues) {
             var uuidMissing = (!importValues.uuid && tables[tableName].uuid) ? true : false,
-                uuidMalformed = (importValues.uuid && !validator.isUUID(importValues.uuid)) ? true : false,
+                uuidMalformed = (importValues.uuid && !validation.validator.isUUID(importValues.uuid)) ? true : false,
                 isDuplicate,
                 problemTag;
 
-            // Check for correct UUID and fix if neccessary
+            // Check for correct UUID and fix if necessary
             if (uuidMissing || uuidMalformed) {
                 importValues.uuid = uuid.v4();
             }

--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -4,6 +4,7 @@ var Promise         = require('bluebird'),
     errors          = require('../../errors'),
     uuid            = require('node-uuid'),
     validator       = require('validator'),
+    importer        = require('./data-importer'),
     tables          = require('../schema').tables,
     validate,
     handleErrors,
@@ -184,25 +185,12 @@ validate = function validate(data) {
     });
 };
 
-module.exports = function (version, data) {
-    var importer,
-        sanitizeResults;
-
-    sanitizeResults = sanitize(data);
+module.exports = function (data) {
+    var sanitizeResults = sanitize(data);
 
     data = sanitizeResults.data;
 
     return validate(data).then(function () {
-        try {
-            importer = require('./' + version);
-        } catch (ignore) {
-            // Zero effs given
-        }
-
-        if (!importer) {
-            return Promise.reject('No importer found');
-        }
-
         return importer.importData(data);
     }).then(function () {
         return sanitizeResults;

--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -185,34 +185,25 @@ utils = {
         var ops = [];
 
         tableData = stripProperties(['id'], tableData);
-
         _.each(tableData, function (post) {
              // Validate minimum post fields
             if (areEmpty(post, 'title', 'slug', 'markdown')) {
                 return;
             }
 
-            ops.push(function () {
-                return models.Post.add(post, _.extend(internal, {transacting: transaction, importing: true}))
+             // The post importer has auto-timestamping disabled
+            if (!post.created_at) {
+                post.created_at = Date.now();
+            }
+
+            ops.push(models.Post.add(post, _.extend(internal, {transacting: transaction, importing: true}))
                     .catch(function (error) {
                         return Promise.reject({raw: error, model: 'post', data: post});
-                    });
-            });
+                    })
+            );
         });
 
-        return Promise.reduce(ops, function (results, op) {
-            return op().then(function (result) {
-                results.push(result);
-
-                return results;
-            }).catch(function (error) {
-                if (error) {
-                    results.push(error);
-                }
-
-                return results;
-            });
-        }, []).settle();
+        return Promise.settle(ops);
     },
 
     importUsers: function importUsers(tableData, existingUsers, transaction) {

--- a/core/server/data/importer/handlers/json.js
+++ b/core/server/data/importer/handlers/json.js
@@ -20,7 +20,11 @@ JSONHandler = {
                 importData = JSON.parse(fileData);
 
                 // if importData follows JSON-API format `{ db: [exportedData] }`
-                if (_.keys(importData).length === 1 && Array.isArray(importData.db)) {
+                if (_.keys(importData).length === 1) {
+                    if (!importData.db || !Array.isArray(importData.db)) {
+                        throw new Error('Invalid JSON format, expected `{ db: [exportedData] }`');
+                    }
+
                     importData = importData.db[0];
                 }
 

--- a/core/server/data/importer/handlers/json.js
+++ b/core/server/data/importer/handlers/json.js
@@ -1,0 +1,36 @@
+var _            = require('lodash'),
+    Promise      = require('bluebird'),
+    fs           = require('fs-extra'),
+    errors       = require('../../../errors'),
+    JSONHandler;
+
+JSONHandler = {
+    type: 'data',
+    extensions: ['.json'],
+    types: ['application/octet-stream', 'application/json'],
+
+    loadFile: function (files, startDir) {
+        /*jshint unused:false */
+        // @TODO: Handle multiple JSON files
+        var filePath = files[0].path;
+
+        return Promise.promisify(fs.readFile)(filePath).then(function (fileData) {
+            var importData;
+            try {
+                importData = JSON.parse(fileData);
+
+                // if importData follows JSON-API format `{ db: [exportedData] }`
+                if (_.keys(importData).length === 1 && Array.isArray(importData.db)) {
+                    importData = importData.db[0];
+                }
+
+                return importData;
+            } catch (e) {
+                errors.logError(e, 'API DB import content', 'check that the import file is valid JSON.');
+                return Promise.reject(new errors.BadRequestError('Failed to parse the import JSON file.'));
+            }
+        });
+    }
+};
+
+module.exports = JSONHandler;

--- a/core/server/data/importer/importers/data.js
+++ b/core/server/data/importer/importers/data.js
@@ -8,7 +8,7 @@ DataImporter = {
         return importData;
     },
     doImport: function (importData) {
-        return importer('003', importData);
+        return importer(importData);
     }
 };
 

--- a/core/server/data/importer/importers/data.js
+++ b/core/server/data/importer/importers/data.js
@@ -1,0 +1,15 @@
+var importer = require('../../import'),
+    DataImporter;
+
+DataImporter = {
+    type: 'data',
+    preProcess: function (importData) {
+        importData.preProcessedByData = true;
+        return importData;
+    },
+    doImport: function (importData) {
+        return importer('003', importData);
+    }
+};
+
+module.exports = DataImporter;

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -1,0 +1,163 @@
+var _            = require('lodash'),
+    Promise      = require('bluebird'),
+    sequence     = require('../../utils/sequence'),
+    pipeline     = require('../../utils/pipeline'),
+    fs           = require('fs-extra'),
+    path         = require('path'),
+    os           = require('os'),
+    glob         = require('glob'),
+    uuid         = require('node-uuid'),
+    extract      = require('extract-zip'),
+    errors       = require('../../errors'),
+    JSONHandler  = require('./handlers/json'),
+    DataImporter = require('./importers/data'),
+
+    defaults;
+
+defaults = {
+    extensions: ['.zip'],
+    types: ['application/zip', 'application/x-zip-compressed']
+};
+
+function ImportManager() {
+    this.importers = [DataImporter];
+    this.handlers = [JSONHandler];
+}
+
+_.extend(ImportManager.prototype, {
+    getExtensions: function () {
+        return _.flatten(_.union(_.pluck(this.handlers, 'extensions'), defaults.extensions));
+    },
+    getTypes: function () {
+        return _.flatten(_.union(_.pluck(this.handlers, 'types'), defaults.types));
+    },
+    getGlobPattern: function (handler) {
+        return '**/*+(' + _.reduce(handler.extensions, function (memo, ext) {
+            return memo !== '' ? memo + '|'  + ext : ext;
+        }, '') + ')';
+    },
+    isZip: function (ext) {
+        return _.contains(defaults.extensions, ext);
+    },
+    extractZip: function (filePath) {
+        var tmpDir = path.join(os.tmpdir(), uuid.v4());
+        return Promise.promisify(extract)(filePath, {dir: tmpDir}).then(function () {
+            return tmpDir;
+        });
+    },
+    processZip: function (file) {
+        var self = this;
+        return this.extractZip(file.path).then(function (directory) {
+            var ops = [],
+                importData = {},
+                startDir = glob.sync(file.name.replace('.zip', ''), {cwd: directory});
+
+            startDir = startDir[0] || false;
+
+            _.each(self.handlers, function (handler) {
+                if (importData.hasOwnProperty(handler.type)) {
+                    // This limitation is here to reduce the complexity of the importer for now
+                    return Promise.reject(new errors.UnsupportedMediaTypeError(
+                        'Zip file contains too many types of import data. Please split it up and import separately.'
+                    ));
+                }
+
+                var globPattern = self.getGlobPattern(handler),
+                    files = _.map(glob.sync(globPattern, {cwd: directory}), function (file) {
+                        return {name: file, path: path.join(directory, file)};
+                    });
+
+                if (files.length > 0) {
+                    ops.push(function () {
+                        return handler.loadFile(files, startDir).then(function (data) {
+                            importData[handler.type] = data;
+                        });
+                    });
+                }
+            });
+
+            if (ops.length === 0) {
+                return Promise.reject(new errors.UnsupportedMediaTypeError(
+                    'Zip did not include any content to import.'
+                ));
+            }
+
+            return sequence(ops).then(function () {
+                return importData;
+            });
+        });
+    },
+    processFile: function (file, ext) {
+        var fileHandler = _.find(this.handlers, function (handler) {
+            return _.contains(handler.extensions, ext);
+        });
+
+        return fileHandler.loadFile([_.pick(file, 'name', 'path')]).then(function (loadedData) {
+            // normalize the returned data
+            var importData = {};
+            importData[fileHandler.type] = loadedData;
+            return importData;
+        });
+    },
+    loadFile: function (file) {
+        var self = this,
+            ext = path.extname(file.name).toLowerCase();
+
+        return Promise.resolve(this.isZip(ext)).then(function (isZip) {
+            if (isZip) {
+                // If it's a zip, process the zip file
+                return self.processZip(file);
+            } else {
+                // Else process the file
+                return self.processFile(file, ext);
+            }
+        }).finally(function () {
+            return Promise.promisify(fs.unlink)(file.path);
+        });
+    },
+    preProcess: function (importData) {
+        var ops = [];
+        _.each(this.importers, function (importer) {
+            ops.push(function () {
+                return importer.preProcess(importData);
+            });
+        });
+
+        return pipeline(ops);
+    },
+    doImport: function (importData) {
+        var ops = [];
+        _.each(this.importers, function (importer) {
+            if (importData.hasOwnProperty(importer.type)) {
+                ops.push(function () {
+                    return importer.doImport(importData[importer.type]);
+                });
+            }
+        });
+
+        return sequence(ops).then(function (importResult) {
+            return importResult;
+        });
+    },
+    generateReport: function (importData) {
+        return importData;
+    },
+    importFromFile: function (file) {
+        var self = this;
+
+        // Step 1: Handle converting the file to usable data
+        return this.loadFile(file).then(function (importData) {
+            // Step 2: Let the importers pre-process the data
+            return self.preProcess(importData);
+        }).then(function (importData) {
+            // Step 3: Actually do the import
+            // @TODO: It would be cool to have some sort of dry run flag here
+            return self.doImport(importData);
+        }).then(function (importData) {
+            // Step 4: Finally, report on the import
+            return self.generateReport(importData);
+        });
+    }
+});
+
+module.exports = new ImportManager();

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -27,9 +27,8 @@ validator.extend('isEmptyOrURL', function (str) {
     return (_.isEmpty(str) || validator.isURL(str, {require_protocol: false}));
 });
 
-// Validation validation against schema attributes
-// values are checked against the validation objects
-// form schema.js
+// Validation against schema attributes
+// values are checked against the validation objects from schema.js
 validateSchema = function (tableName, model) {
     var columns = _.keys(schema[tableName]),
         validationErrors = [];
@@ -163,6 +162,7 @@ validate = function (value, key, validations) {
 };
 
 module.exports = {
+    validator: validator,
     validateSchema: validateSchema,
     validateSettings: validateSettings,
     validateActiveTheme: validateActiveTheme

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -13,13 +13,9 @@ var testUtils   = require('../utils/index'),
     config          = rewire('../../server/config'),
     defaultConfig   = rewire('../../../config.example')[process.env.NODE_ENV],
     migration       = rewire('../../server/data/migration'),
-    versioning      = require('../../server/data/versioning'),
     exporter        = require('../../server/data/export'),
     importer        = require('../../server/data/import'),
-    Importer000     = require('../../server/data/import/000'),
-    Importer001     = require('../../server/data/import/001'),
-    Importer002     = require('../../server/data/import/002'),
-    Importer003     = require('../../server/data/import/003'),
+    DataImporter    = require('../../server/data/import/data-importer'),
 
     knex,
     sandbox = sinon.sandbox.create();
@@ -45,58 +41,13 @@ describe('Import', function () {
             knex = config.database.knex;
         });
 
-        it('resolves 000', function (done) {
-            var importStub = sandbox.stub(Importer000, 'importData', function () {
+        it('resolves DataImporter', function (done) {
+            var importStub = sandbox.stub(DataImporter, 'importData', function () {
                     return Promise.resolve();
                 }),
                 fakeData = {test: true};
 
-            importer('000', fakeData).then(function () {
-                importStub.calledWith(fakeData).should.equal(true);
-
-                importStub.restore();
-
-                done();
-            }).catch(done);
-        });
-
-        it('resolves 001', function (done) {
-            var importStub = sandbox.stub(Importer001, 'importData', function () {
-                    return Promise.resolve();
-                }),
-                fakeData = {test: true};
-
-            importer('001', fakeData).then(function () {
-                importStub.calledWith(fakeData).should.equal(true);
-
-                importStub.restore();
-
-                done();
-            }).catch(done);
-        });
-
-        it('resolves 002', function (done) {
-            var importStub = sandbox.stub(Importer002, 'importData', function () {
-                    return Promise.resolve();
-                }),
-                fakeData = {test: true};
-
-            importer('002', fakeData).then(function () {
-                importStub.calledWith(fakeData).should.equal(true);
-
-                importStub.restore();
-
-                done();
-            }).catch(done);
-        });
-
-        it('resolves 003', function (done) {
-            var importStub = sandbox.stub(Importer003, 'importData', function () {
-                    return Promise.resolve();
-                }),
-                fakeData = {test: true};
-
-            importer('003', fakeData).then(function () {
+            importer(fakeData).then(function () {
                 importStub.calledWith(fakeData).should.equal(true);
 
                 importStub.restore();
@@ -117,7 +68,7 @@ describe('Import', function () {
 
             testUtils.fixtures.loadExportFixture('export-003').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function (importResult) {
                 should.exist(importResult);
                 should.exist(importResult.data);
@@ -132,7 +83,7 @@ describe('Import', function () {
 
             testUtils.fixtures.loadExportFixture('export-003-duplicate-posts').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function (importResult) {
                 should.exist(importResult.data.data.posts);
 
@@ -149,7 +100,7 @@ describe('Import', function () {
 
             testUtils.fixtures.loadExportFixture('export-003-duplicate-tags').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function (importResult) {
                 should.exist(importResult.data.data.tags);
                 should.exist(importResult.data.data.posts_tags);
@@ -170,24 +121,21 @@ describe('Import', function () {
         });
     });
 
-    describe('000', function () {
+    describe('DataImporter', function () {
         before(function ()  {
             knex = config.database.knex;
         });
         beforeEach(testUtils.setup('roles', 'owner', 'settings'));
 
-        should.exist(Importer000);
+        should.exist(DataImporter);
 
         it('imports data from 000', function (done) {
-            var exportData,
-                versioningStub = sandbox.stub(versioning, 'getDatabaseVersion', function () {
-                    return Promise.resolve('000');
-                });
+            var exportData;
 
             testUtils.fixtures.loadExportFixture('export-000').then(function (exported) {
                 exportData = exported;
 
-                return importer('000', exportData);
+                return importer(exportData);
             }).then(function () {
                 // Grab the data from tables
                 return Promise.all([
@@ -218,22 +166,11 @@ describe('Import', function () {
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
 
-                versioningStub.restore();
-
                 done();
             }).catch(done);
         });
-    });
 
-    describe('001', function () {
-        before(function ()  {
-            knex = config.database.knex;
-        });
-        beforeEach(testUtils.setup('roles', 'owner', 'settings'));
-
-        should.exist(Importer001);
-
-        it('safely imports data from 001', function (done) {
+        it('safely imports data, from 001', function (done) {
             var exportData,
                 timestamp = 1349928000000;
 
@@ -245,7 +182,7 @@ describe('Import', function () {
                 exportData.data.posts[0].updated_at = timestamp;
                 exportData.data.posts[0].published_at = timestamp;
 
-                return importer('001', exportData);
+                return importer(exportData);
             }).then(function () {
                 // Grab the data from tables
                 return Promise.all([
@@ -315,7 +252,7 @@ describe('Import', function () {
                 // change title to 151 characters
                 exportData.data.posts[0].title = new Array(152).join('a');
                 exportData.data.posts[0].tags = 'Tag';
-                return importer('001', exportData);
+                return importer(exportData);
             }).then(function () {
                 (1).should.eql(0, 'Data import should not resolve promise.');
             }, function (error) {
@@ -360,7 +297,7 @@ describe('Import', function () {
                 exportData = exported;
                 // change to blank settings key
                 exportData.data.settings[3].key = null;
-                return importer('001', exportData);
+                return importer(exportData);
             }).then(function () {
                 (1).should.eql(0, 'Data import should not resolve promise.');
             }, function (error) {
@@ -405,8 +342,6 @@ describe('Import', function () {
         });
         beforeEach(testUtils.setup('roles', 'owner', 'settings'));
 
-        should.exist(Importer002);
-
         it('safely imports data from 002', function (done) {
             var exportData,
                 timestamp = 1349928000000;
@@ -419,7 +354,7 @@ describe('Import', function () {
                 exportData.data.posts[0].updated_at = timestamp;
                 exportData.data.posts[0].published_at = timestamp;
 
-                return importer('002', exportData);
+                return importer(exportData);
             }).then(function () {
                 // Grab the data from tables
                 return Promise.all([
@@ -489,7 +424,7 @@ describe('Import', function () {
                 // change title to 151 characters
                 exportData.data.posts[0].title = new Array(152).join('a');
                 exportData.data.posts[0].tags = 'Tag';
-                return importer('002', exportData);
+                return importer(exportData);
             }).then(function () {
                 (1).should.eql(0, 'Data import should not resolve promise.');
             }, function (error) {
@@ -533,7 +468,7 @@ describe('Import', function () {
                 exportData = exported;
                 // change to blank settings key
                 exportData.data.settings[3].key = null;
-                return importer('002', exportData);
+                return importer(exportData);
             }).then(function () {
                 (1).should.eql(0, 'Data import should not resolve promise.');
             }, function (error) {
@@ -577,14 +512,12 @@ describe('Import', function () {
         });
         beforeEach(testUtils.setup('roles', 'owner', 'settings'));
 
-        should.exist(Importer003);
-
         it('safely imports data from 003 (single user)', function (done) {
             var exportData;
 
             testUtils.fixtures.loadExportFixture('export-003').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 // Grab the data from tables
                 return Promise.all([
@@ -629,7 +562,7 @@ describe('Import', function () {
 
             testUtils.fixtures.loadExportFixture('export-003-badValidation').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 done(new Error('Allowed import of duplicate data'));
             }).catch(function (response) {
@@ -652,7 +585,7 @@ describe('Import', function () {
             var exportData;
             testUtils.fixtures.loadExportFixture('export-003-dbErrors').then(function (exported) {
                 exportData = exported;
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 done(new Error('Allowed import of duplicate data'));
             }).catch(function (response) {
@@ -668,7 +601,7 @@ describe('Import', function () {
             testUtils.fixtures.loadExportFixture('export-003-mu-unknownAuthor').then(function (exported) {
                 exportData = exported;
 
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 done(new Error('Allowed import of unknown author'));
             }).catch(function (response) {
@@ -689,7 +622,7 @@ describe('Import', function () {
                 exportData.data.tags.length.should.be.above(1);
                 exportData.data.posts_tags.length.should.be.above(1);
 
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 done(new Error('Allowed import of invalid tags data'));
             }).catch(function (response) {
@@ -710,7 +643,7 @@ describe('Import', function () {
 
                 exportData.data.posts.length.should.be.above(1);
 
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 done(new Error('Allowed import of invalid tags data'));
             }).catch(function (response) {
@@ -727,7 +660,7 @@ describe('Import', function () {
 
                 exportData.data.posts.length.should.be.above(0);
 
-                return importer('003', exportData);
+                return importer(exportData);
             }).then(function () {
                 // Grab the data from tables
                 return knex('posts').select();
@@ -748,697 +681,693 @@ describe('Import', function () {
 describe('Import (new test structure)', function () {
     before(testUtils.teardown);
 
-    describe('003', function () {
+    after(testUtils.teardown);
+
+    describe('imports multi user data onto blank ghost install', function () {
+        var exportData;
+
+        before(function doImport(done) {
+            knex = config.database.knex;
+
+            testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
+                return testUtils.fixtures.loadExportFixture('export-003-mu');
+            }).then(function (exported) {
+                exportData = exported;
+                return importer(exportData);
+            }).then(function () {
+                done();
+            }).catch(done);
+        });
         after(testUtils.teardown);
 
-        should.exist(Importer003);
+        it('gets the right data', function (done) {
+            var fetchImported = Promise.join(
+                knex('posts').select(),
+                knex('settings').select(),
+                knex('tags').select()
+            );
 
-        describe('imports multi user data onto blank ghost install', function () {
-            var exportData;
+            fetchImported.then(function (importedData) {
+                var posts,
+                    settings,
+                    tags,
+                    post1,
+                    post2,
+                    post3;
 
-            before(function doImport(done) {
-                knex = config.database.knex;
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
 
-                testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
-                    return testUtils.fixtures.loadExportFixture('export-003-mu');
-                }).then(function (exported) {
-                    exportData = exported;
-                    return importer('003', exportData);
-                }).then(function () {
-                    done();
-                }).catch(done);
-            });
-            after(testUtils.teardown);
+                // Test posts, settings and tags
+                posts = importedData[0];
+                settings = importedData[1];
+                tags = importedData[2];
 
-            it('gets the right data', function (done) {
-                var fetchImported = Promise.join(
-                    knex('posts').select(),
-                    knex('settings').select(),
-                    knex('tags').select()
-                );
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
 
-                fetchImported.then(function (importedData) {
-                    var posts,
-                        settings,
-                        tags,
-                        post1,
-                        post2,
-                        post3;
+                // test posts
+                posts.length.should.equal(3, 'Wrong number of posts');
+                post1.title.should.equal(exportData.data.posts[0].title);
+                post2.title.should.equal(exportData.data.posts[1].title);
+                post3.title.should.equal(exportData.data.posts[2].title);
 
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
+                // test tags
+                tags.length.should.equal(3, 'should be 3 tags');
 
-                    // Test posts, settings and tags
-                    posts = importedData[0];
-                    settings = importedData[1];
-                    tags = importedData[2];
+                // test settings
+                settings.length.should.be.above(0, 'Wrong number of settings');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
 
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
-
-                    // test posts
-                    posts.length.should.equal(3, 'Wrong number of posts');
-                    post1.title.should.equal(exportData.data.posts[0].title);
-                    post2.title.should.equal(exportData.data.posts[1].title);
-                    post3.title.should.equal(exportData.data.posts[2].title);
-
-                    // test tags
-                    tags.length.should.equal(3, 'should be 3 tags');
-
-                    // test settings
-                    settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
-
-                    done();
-                }).catch(done);
-            });
-
-            it('imports users with correct roles and status', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('roles_users').select()
-                );
-
-                fetchImported.then(function (importedData) {
-                    var user1,
-                        user2,
-                        user3,
-                        users,
-                        rolesUsers;
-
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(2, 'Did not get data successfully');
-
-                    // Test the users and roles
-                    users = importedData[0];
-                    rolesUsers = importedData[1];
-
-                    // we imported 3 users
-                    // the original user should be untouched
-                    // the two news users should have been created
-                    users.length.should.equal(3, 'There should only be three users');
-
-                    // the owner user is first
-                    user1 = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    user2 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-                    user3 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[2].name;
-                    });
-
-                    user1.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
-                    user1.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
-                    user1.status.should.equal('active');
-                    user2.email.should.equal(exportData.data.users[1].email);
-                    user3.email.should.equal(exportData.data.users[2].email);
-
-                    // Newly created users should have a status of locked
-                    user2.status.should.equal('locked');
-                    user3.status.should.equal('locked');
-
-                    // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
-                    user2.created_by.should.equal(user1.id);
-                    user2.created_at.should.not.equal(exportData.data.users[1].created_at);
-                    user2.updated_by.should.equal(user1.id);
-                    user2.updated_at.should.not.equal(exportData.data.users[1].updated_at);
-                    user3.created_by.should.equal(user1.id);
-                    user3.created_at.should.not.equal(exportData.data.users[2].created_at);
-                    user3.updated_by.should.equal(user1.id);
-                    user3.updated_at.should.not.equal(exportData.data.users[2].updated_at);
-
-                    rolesUsers.length.should.equal(3, 'There should be 3 role relations');
-
-                    _.each(rolesUsers, function (roleUser) {
-                        if (roleUser.user_id === user1.id) {
-                            roleUser.role_id.should.equal(4, 'Original user should be an owner');
-                        }
-                        if (roleUser.user_id === user2.id) {
-                            roleUser.role_id.should.equal(1, 'Josephine should be an admin');
-                        }
-                        if (roleUser.user_id === user3.id) {
-                            roleUser.role_id.should.equal(3, 'Smith should be an author by default');
-                        }
-                    });
-
-                    done();
-                }).catch(done);
-            });
-
-            it('imports posts & tags with correct authors, owners etc', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('posts').select(),
-                    knex('tags').select()
-                );
-
-                fetchImported.then(function (importedData) {
-                    var users, user1, user2, user3,
-                        posts, post1, post2, post3,
-                        tags, tag1, tag2, tag3;
-
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
-
-                    // Test the users and roles
-                    users = importedData[0];
-                    posts = importedData[1];
-                    tags  = importedData[2];
-
-                    // Grab the users
-                    // the owner user is first
-                    user1 = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    user2 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-                    user3 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[2].name;
-                    });
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
-                    tag1 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[0].slug;
-                    });
-                    tag2 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[1].slug;
-                    });
-                    tag3 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[2].slug;
-                    });
-
-                    // Check the authors are correct
-                    post1.author_id.should.equal(user2.id);
-                    post2.author_id.should.equal(user3.id);
-                    post3.author_id.should.equal(user1.id);
-
-                    // Created by should be what was in the import file
-                    post1.created_by.should.equal(user1.id);
-                    post2.created_by.should.equal(user3.id);
-                    post3.created_by.should.equal(user1.id);
-
-                    // Updated by gets set to the current user
-                    post1.updated_by.should.equal(user1.id);
-                    post2.updated_by.should.equal(user1.id);
-                    post3.updated_by.should.equal(user1.id);
-
-                    // Published by should be what was in the import file
-                    post1.published_by.should.equal(user2.id);
-                    post2.published_by.should.equal(user3.id);
-                    post3.published_by.should.equal(user1.id);
-
-                    // Created by should be what was in the import file
-                    tag1.created_by.should.equal(user1.id);
-                    tag2.created_by.should.equal(user2.id);
-                    tag3.created_by.should.equal(user3.id);
-
-                    // Updated by gets set to the current user
-                    tag1.updated_by.should.equal(user1.id);
-                    tag2.updated_by.should.equal(user1.id);
-                    tag3.updated_by.should.equal(user1.id);
-
-                    done();
-                }).catch(done);
-            });
+                done();
+            }).catch(done);
         });
 
-        describe('imports multi user data with no owner onto blank ghost install', function () {
-            var exportData;
+        it('imports users with correct roles and status', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('roles_users').select()
+            );
 
-            before(function doImport(done) {
-                knex = config.database.knex;
+            fetchImported.then(function (importedData) {
+                var user1,
+                    user2,
+                    user3,
+                    users,
+                    rolesUsers;
 
-                testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
-                    return testUtils.fixtures.loadExportFixture('export-003-mu-noOwner');
-                }).then(function (exported) {
-                    exportData = exported;
-                    return importer('003', exportData);
-                }).then(function () {
-                    done();
-                }).catch(done);
-            });
-            after(testUtils.teardown);
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(2, 'Did not get data successfully');
 
-            it('gets the right data', function (done) {
-                var fetchImported = Promise.join(
-                    knex('posts').select(),
-                    knex('settings').select(),
-                    knex('tags').select()
-                );
+                // Test the users and roles
+                users = importedData[0];
+                rolesUsers = importedData[1];
 
-                fetchImported.then(function (importedData) {
-                    var posts,
-                        settings,
-                        tags,
-                        post1,
-                        post2,
-                        post3;
+                // we imported 3 users
+                // the original user should be untouched
+                // the two news users should have been created
+                users.length.should.equal(3, 'There should only be three users');
 
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
+                // the owner user is first
+                user1 = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                user2 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+                user3 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[2].name;
+                });
 
-                    // Test posts, settings and tags
-                    posts = importedData[0];
-                    settings = importedData[1];
-                    tags = importedData[2];
+                user1.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
+                user1.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
+                user1.status.should.equal('active');
+                user2.email.should.equal(exportData.data.users[1].email);
+                user3.email.should.equal(exportData.data.users[2].email);
 
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
+                // Newly created users should have a status of locked
+                user2.status.should.equal('locked');
+                user3.status.should.equal('locked');
 
-                    // test posts
-                    posts.length.should.equal(3, 'Wrong number of posts');
-                    post1.title.should.equal(exportData.data.posts[0].title);
-                    post2.title.should.equal(exportData.data.posts[1].title);
-                    post3.title.should.equal(exportData.data.posts[2].title);
+                // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
+                user2.created_by.should.equal(user1.id);
+                user2.created_at.should.not.equal(exportData.data.users[1].created_at);
+                user2.updated_by.should.equal(user1.id);
+                user2.updated_at.should.not.equal(exportData.data.users[1].updated_at);
+                user3.created_by.should.equal(user1.id);
+                user3.created_at.should.not.equal(exportData.data.users[2].created_at);
+                user3.updated_by.should.equal(user1.id);
+                user3.updated_at.should.not.equal(exportData.data.users[2].updated_at);
 
-                    // test tags
-                    tags.length.should.equal(3, 'should be 3 tags');
+                rolesUsers.length.should.equal(3, 'There should be 3 role relations');
 
-                    // test settings
-                    settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
+                _.each(rolesUsers, function (roleUser) {
+                    if (roleUser.user_id === user1.id) {
+                        roleUser.role_id.should.equal(4, 'Original user should be an owner');
+                    }
+                    if (roleUser.user_id === user2.id) {
+                        roleUser.role_id.should.equal(1, 'Josephine should be an admin');
+                    }
+                    if (roleUser.user_id === user3.id) {
+                        roleUser.role_id.should.equal(3, 'Smith should be an author by default');
+                    }
+                });
 
-                    done();
-                }).catch(done);
-            });
-
-            it('imports users with correct roles and status', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('roles_users').select()
-                );
-
-                fetchImported.then(function (importedData) {
-                    var user1,
-                        user2,
-                        user3,
-                        users,
-                        rolesUsers;
-
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(2, 'Did not get data successfully');
-
-                    // Test the users and roles
-                    users = importedData[0];
-                    rolesUsers = importedData[1];
-
-                    // we imported 3 users
-                    // the original user should be untouched
-                    // the two news users should have been created
-                    users.length.should.equal(3, 'There should only be three users');
-
-                    // the owner user is first
-                    user1 = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    user2 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[0].name;
-                    });
-                    user3 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-
-                    user1.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
-                    user1.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
-                    user1.status.should.equal('active');
-                    user2.email.should.equal(exportData.data.users[0].email);
-                    user3.email.should.equal(exportData.data.users[1].email);
-
-                    // Newly created users should have a status of locked
-                    user2.status.should.equal('locked');
-                    user3.status.should.equal('locked');
-
-                    // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
-                    user2.created_by.should.equal(user1.id);
-                    user2.created_at.should.not.equal(exportData.data.users[0].created_at);
-                    user2.updated_by.should.equal(user1.id);
-                    user2.updated_at.should.not.equal(exportData.data.users[0].updated_at);
-                    user3.created_by.should.equal(user1.id);
-                    user3.created_at.should.not.equal(exportData.data.users[1].created_at);
-                    user3.updated_by.should.equal(user1.id);
-                    user3.updated_at.should.not.equal(exportData.data.users[1].updated_at);
-
-                    rolesUsers.length.should.equal(3, 'There should be 3 role relations');
-
-                    _.each(rolesUsers, function (roleUser) {
-                        if (roleUser.user_id === user1.id) {
-                            roleUser.role_id.should.equal(4, 'Original user should be an owner');
-                        }
-                        if (roleUser.user_id === user2.id) {
-                            roleUser.role_id.should.equal(1, 'Josephine should be an admin');
-                        }
-                        if (roleUser.user_id === user3.id) {
-                            roleUser.role_id.should.equal(3, 'Smith should be an author by default');
-                        }
-                    });
-
-                    done();
-                }).catch(done);
-            });
-
-            it('imports posts & tags with correct authors, owners etc', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('posts').select(),
-                    knex('tags').select()
-                );
-
-                fetchImported.then(function (importedData) {
-                    var users, user1, user2, user3,
-                        posts, post1, post2, post3,
-                        tags, tag1, tag2, tag3;
-
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
-
-                    // Test the users and roles
-                    users = importedData[0];
-                    posts = importedData[1];
-                    tags  = importedData[2];
-
-                    // Grab the users
-                    // the owner user is first
-                    user1 = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    user2 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[0].name;
-                    });
-                    user3 = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
-                    tag1 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[0].slug;
-                    });
-                    tag2 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[1].slug;
-                    });
-                    tag3 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[2].slug;
-                    });
-
-                    // Check the authors are correct
-                    post1.author_id.should.equal(user2.id);
-                    post2.author_id.should.equal(user3.id);
-                    post3.author_id.should.equal(user1.id);
-
-                    // Created by should be what was in the import file
-                    post1.created_by.should.equal(user1.id);
-                    post2.created_by.should.equal(user3.id);
-                    post3.created_by.should.equal(user1.id);
-
-                    // Updated by gets set to the current user
-                    post1.updated_by.should.equal(user1.id);
-                    post2.updated_by.should.equal(user1.id);
-                    post3.updated_by.should.equal(user1.id);
-
-                    // Published by should be what was in the import file
-                    post1.published_by.should.equal(user2.id);
-                    post2.published_by.should.equal(user3.id);
-                    post3.published_by.should.equal(user1.id);
-
-                    // Created by should be what was in the import file
-                    tag1.created_by.should.equal(user1.id);
-                    tag2.created_by.should.equal(user2.id);
-                    tag3.created_by.should.equal(user3.id);
-
-                    // Updated by gets set to the current user
-                    tag1.updated_by.should.equal(user1.id);
-                    tag2.updated_by.should.equal(user1.id);
-                    tag3.updated_by.should.equal(user1.id);
-
-                    done();
-                }).catch(done);
-            });
+                done();
+            }).catch(done);
         });
 
-        describe('imports multi user data onto existing data', function () {
-            var exportData;
+        it('imports posts & tags with correct authors, owners etc', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('posts').select(),
+                knex('tags').select()
+            );
 
-            before(function doImport(done) {
-                knex = config.database.knex;
+            fetchImported.then(function (importedData) {
+                var users, user1, user2, user3,
+                    posts, post1, post2, post3,
+                    tags, tag1, tag2, tag3;
 
-                // initialise the blog with some data
-                testUtils.initFixtures('users:roles', 'posts', 'settings').then(function () {
-                    return testUtils.fixtures.loadExportFixture('export-003-mu');
-                }).then(function (exported) {
-                    exportData = exported;
-                    return importer('003', exportData);
-                }).then(function () {
-                    done();
-                }).catch(done);
-            });
-            after(testUtils.teardown);
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
 
-            it('gets the right data', function (done) {
-                var fetchImported = Promise.join(
-                    knex('posts').select(),
-                    knex('settings').select(),
-                    knex('tags').select()
+                // Test the users and roles
+                users = importedData[0];
+                posts = importedData[1];
+                tags  = importedData[2];
+
+                // Grab the users
+                // the owner user is first
+                user1 = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                user2 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+                user3 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[2].name;
+                });
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
+                tag1 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[0].slug;
+                });
+                tag2 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[1].slug;
+                });
+                tag3 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[2].slug;
+                });
+
+                // Check the authors are correct
+                post1.author_id.should.equal(user2.id);
+                post2.author_id.should.equal(user3.id);
+                post3.author_id.should.equal(user1.id);
+
+                // Created by should be what was in the import file
+                post1.created_by.should.equal(user1.id);
+                post2.created_by.should.equal(user3.id);
+                post3.created_by.should.equal(user1.id);
+
+                // Updated by gets set to the current user
+                post1.updated_by.should.equal(user1.id);
+                post2.updated_by.should.equal(user1.id);
+                post3.updated_by.should.equal(user1.id);
+
+                // Published by should be what was in the import file
+                post1.published_by.should.equal(user2.id);
+                post2.published_by.should.equal(user3.id);
+                post3.published_by.should.equal(user1.id);
+
+                // Created by should be what was in the import file
+                tag1.created_by.should.equal(user1.id);
+                tag2.created_by.should.equal(user2.id);
+                tag3.created_by.should.equal(user3.id);
+
+                // Updated by gets set to the current user
+                tag1.updated_by.should.equal(user1.id);
+                tag2.updated_by.should.equal(user1.id);
+                tag3.updated_by.should.equal(user1.id);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('imports multi user data with no owner onto blank ghost install', function () {
+        var exportData;
+
+        before(function doImport(done) {
+            knex = config.database.knex;
+
+            testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
+                return testUtils.fixtures.loadExportFixture('export-003-mu-noOwner');
+            }).then(function (exported) {
+                exportData = exported;
+                return importer(exportData);
+            }).then(function () {
+                done();
+            }).catch(done);
+        });
+        after(testUtils.teardown);
+
+        it('gets the right data', function (done) {
+            var fetchImported = Promise.join(
+                knex('posts').select(),
+                knex('settings').select(),
+                knex('tags').select()
+            );
+
+            fetchImported.then(function (importedData) {
+                var posts,
+                    settings,
+                    tags,
+                    post1,
+                    post2,
+                    post3;
+
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
+
+                // Test posts, settings and tags
+                posts = importedData[0];
+                settings = importedData[1];
+                tags = importedData[2];
+
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
+
+                // test posts
+                posts.length.should.equal(3, 'Wrong number of posts');
+                post1.title.should.equal(exportData.data.posts[0].title);
+                post2.title.should.equal(exportData.data.posts[1].title);
+                post3.title.should.equal(exportData.data.posts[2].title);
+
+                // test tags
+                tags.length.should.equal(3, 'should be 3 tags');
+
+                // test settings
+                settings.length.should.be.above(0, 'Wrong number of settings');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
+
+                done();
+            }).catch(done);
+        });
+
+        it('imports users with correct roles and status', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('roles_users').select()
+            );
+
+            fetchImported.then(function (importedData) {
+                var user1,
+                    user2,
+                    user3,
+                    users,
+                    rolesUsers;
+
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(2, 'Did not get data successfully');
+
+                // Test the users and roles
+                users = importedData[0];
+                rolesUsers = importedData[1];
+
+                // we imported 3 users
+                // the original user should be untouched
+                // the two news users should have been created
+                users.length.should.equal(3, 'There should only be three users');
+
+                // the owner user is first
+                user1 = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                user2 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[0].name;
+                });
+                user3 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+
+                user1.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
+                user1.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
+                user1.status.should.equal('active');
+                user2.email.should.equal(exportData.data.users[0].email);
+                user3.email.should.equal(exportData.data.users[1].email);
+
+                // Newly created users should have a status of locked
+                user2.status.should.equal('locked');
+                user3.status.should.equal('locked');
+
+                // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
+                user2.created_by.should.equal(user1.id);
+                user2.created_at.should.not.equal(exportData.data.users[0].created_at);
+                user2.updated_by.should.equal(user1.id);
+                user2.updated_at.should.not.equal(exportData.data.users[0].updated_at);
+                user3.created_by.should.equal(user1.id);
+                user3.created_at.should.not.equal(exportData.data.users[1].created_at);
+                user3.updated_by.should.equal(user1.id);
+                user3.updated_at.should.not.equal(exportData.data.users[1].updated_at);
+
+                rolesUsers.length.should.equal(3, 'There should be 3 role relations');
+
+                _.each(rolesUsers, function (roleUser) {
+                    if (roleUser.user_id === user1.id) {
+                        roleUser.role_id.should.equal(4, 'Original user should be an owner');
+                    }
+                    if (roleUser.user_id === user2.id) {
+                        roleUser.role_id.should.equal(1, 'Josephine should be an admin');
+                    }
+                    if (roleUser.user_id === user3.id) {
+                        roleUser.role_id.should.equal(3, 'Smith should be an author by default');
+                    }
+                });
+
+                done();
+            }).catch(done);
+        });
+
+        it('imports posts & tags with correct authors, owners etc', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('posts').select(),
+                knex('tags').select()
+            );
+
+            fetchImported.then(function (importedData) {
+                var users, user1, user2, user3,
+                    posts, post1, post2, post3,
+                    tags, tag1, tag2, tag3;
+
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
+
+                // Test the users and roles
+                users = importedData[0];
+                posts = importedData[1];
+                tags  = importedData[2];
+
+                // Grab the users
+                // the owner user is first
+                user1 = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                user2 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[0].name;
+                });
+                user3 = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
+                tag1 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[0].slug;
+                });
+                tag2 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[1].slug;
+                });
+                tag3 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[2].slug;
+                });
+
+                // Check the authors are correct
+                post1.author_id.should.equal(user2.id);
+                post2.author_id.should.equal(user3.id);
+                post3.author_id.should.equal(user1.id);
+
+                // Created by should be what was in the import file
+                post1.created_by.should.equal(user1.id);
+                post2.created_by.should.equal(user3.id);
+                post3.created_by.should.equal(user1.id);
+
+                // Updated by gets set to the current user
+                post1.updated_by.should.equal(user1.id);
+                post2.updated_by.should.equal(user1.id);
+                post3.updated_by.should.equal(user1.id);
+
+                // Published by should be what was in the import file
+                post1.published_by.should.equal(user2.id);
+                post2.published_by.should.equal(user3.id);
+                post3.published_by.should.equal(user1.id);
+
+                // Created by should be what was in the import file
+                tag1.created_by.should.equal(user1.id);
+                tag2.created_by.should.equal(user2.id);
+                tag3.created_by.should.equal(user3.id);
+
+                // Updated by gets set to the current user
+                tag1.updated_by.should.equal(user1.id);
+                tag2.updated_by.should.equal(user1.id);
+                tag3.updated_by.should.equal(user1.id);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('imports multi user data onto existing data', function () {
+        var exportData;
+
+        before(function doImport(done) {
+            knex = config.database.knex;
+
+            // initialise the blog with some data
+            testUtils.initFixtures('users:roles', 'posts', 'settings').then(function () {
+                return testUtils.fixtures.loadExportFixture('export-003-mu');
+            }).then(function (exported) {
+                exportData = exported;
+                return importer(exportData);
+            }).then(function () {
+                done();
+            }).catch(done);
+        });
+        after(testUtils.teardown);
+
+        it('gets the right data', function (done) {
+            var fetchImported = Promise.join(
+                knex('posts').select(),
+                knex('settings').select(),
+                knex('tags').select()
+            );
+
+            fetchImported.then(function (importedData) {
+                var posts,
+                    settings,
+                    tags,
+                    post1,
+                    post2,
+                    post3;
+
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
+
+                // Test posts, settings and tags
+                posts = importedData[0];
+                settings = importedData[1];
+                tags = importedData[2];
+
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
+
+                // test posts
+                posts.length.should.equal(
+                    (exportData.data.posts.length + testUtils.DataGenerator.Content.posts.length),
+                    'Wrong number of posts'
                 );
 
-                fetchImported.then(function (importedData) {
-                    var posts,
-                        settings,
-                        tags,
-                        post1,
-                        post2,
-                        post3;
+                posts[0].title.should.equal(testUtils.DataGenerator.Content.posts[0].title);
 
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
+                post1.title.should.equal(exportData.data.posts[0].title);
+                post2.title.should.equal(exportData.data.posts[1].title);
+                post3.title.should.equal(exportData.data.posts[2].title);
 
-                    // Test posts, settings and tags
-                    posts = importedData[0];
-                    settings = importedData[1];
-                    tags = importedData[2];
-
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
-
-                    // test posts
-                    posts.length.should.equal(
-                        (exportData.data.posts.length + testUtils.DataGenerator.Content.posts.length),
-                        'Wrong number of posts'
-                    );
-
-                    posts[0].title.should.equal(testUtils.DataGenerator.Content.posts[0].title);
-
-                    post1.title.should.equal(exportData.data.posts[0].title);
-                    post2.title.should.equal(exportData.data.posts[1].title);
-                    post3.title.should.equal(exportData.data.posts[2].title);
-
-                    // test tags
-                    tags.length.should.equal(
-                        (exportData.data.tags.length + testUtils.DataGenerator.Content.tags.length),
-                        'Wrong number of tags'
-                    );
-
-                    tags[0].name.should.equal(testUtils.DataGenerator.Content.tags[0].name);
-
-                    // test settings
-                    settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
-
-                    done();
-                }).catch(done);
-            });
-
-            it('imports users with correct roles and status', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('roles_users').select()
+                // test tags
+                tags.length.should.equal(
+                    (exportData.data.tags.length + testUtils.DataGenerator.Content.tags.length),
+                    'Wrong number of tags'
                 );
 
-                fetchImported.then(function (importedData) {
-                    var ownerUser,
-                        newUser,
-                        existingUser,
-                        users,
-                        rolesUsers;
+                tags[0].name.should.equal(testUtils.DataGenerator.Content.tags[0].name);
 
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(2, 'Did not get data successfully');
+                // test settings
+                settings.length.should.be.above(0, 'Wrong number of settings');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('003', 'Wrong database version');
 
-                    // Test the users and roles
-                    users = importedData[0];
-                    rolesUsers = importedData[1];
+                done();
+            }).catch(done);
+        });
 
-                    // we imported 3 users, there were already 4 users, only one of the imported users is new
-                    users.length.should.equal(5, 'There should only be three users');
+        it('imports users with correct roles and status', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('roles_users').select()
+            );
 
-                    // the owner user is first
-                    ownerUser = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    newUser = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-                    existingUser = _.find(users, function (user) {
-                        return user.name === exportData.data.users[2].name;
-                    });
+            fetchImported.then(function (importedData) {
+                var ownerUser,
+                    newUser,
+                    existingUser,
+                    users,
+                    rolesUsers;
 
-                    ownerUser.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
-                    ownerUser.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
-                    ownerUser.status.should.equal('active');
-                    newUser.email.should.equal(exportData.data.users[1].email);
-                    existingUser.email.should.equal(exportData.data.users[2].email);
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(2, 'Did not get data successfully');
 
-                    // Newly created users should have a status of locked
-                    newUser.status.should.equal('locked');
-                    // The already existing user should still have a status of active
-                    existingUser.status.should.equal('active');
+                // Test the users and roles
+                users = importedData[0];
+                rolesUsers = importedData[1];
 
-                    // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
-                    newUser.created_by.should.equal(ownerUser.id);
-                    newUser.created_at.should.not.equal(exportData.data.users[1].created_at);
-                    newUser.updated_by.should.equal(ownerUser.id);
-                    newUser.updated_at.should.not.equal(exportData.data.users[1].updated_at);
+                // we imported 3 users, there were already 4 users, only one of the imported users is new
+                users.length.should.equal(5, 'There should only be three users');
 
-                    rolesUsers.length.should.equal(5, 'There should be 5 role relations');
+                // the owner user is first
+                ownerUser = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                newUser = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+                existingUser = _.find(users, function (user) {
+                    return user.name === exportData.data.users[2].name;
+                });
 
-                    _.each(rolesUsers, function (roleUser) {
-                        if (roleUser.user_id === ownerUser.id) {
-                            roleUser.role_id.should.equal(4, 'Original user should be an owner');
-                        }
-                        if (roleUser.user_id === newUser.id) {
-                            roleUser.role_id.should.equal(1, 'New user should be an admin');
-                        }
-                        if (roleUser.user_id === existingUser.id) {
-                            roleUser.role_id.should.equal(1, 'Existing user was an admin');
-                        }
-                    });
+                ownerUser.email.should.equal(testUtils.DataGenerator.Content.users[0].email);
+                ownerUser.password.should.equal(testUtils.DataGenerator.Content.users[0].password);
+                ownerUser.status.should.equal('active');
+                newUser.email.should.equal(exportData.data.users[1].email);
+                existingUser.email.should.equal(exportData.data.users[2].email);
 
-                    done();
-                }).catch(done);
-            });
+                // Newly created users should have a status of locked
+                newUser.status.should.equal('locked');
+                // The already existing user should still have a status of active
+                existingUser.status.should.equal('active');
 
-            it('imports posts & tags with correct authors, owners etc', function (done) {
-                var fetchImported = Promise.join(
-                    knex('users').select(),
-                    knex('posts').select(),
-                    knex('tags').select()
-                );
+                // Newly created users should have created_at/_by and updated_at/_by set to when they were imported
+                newUser.created_by.should.equal(ownerUser.id);
+                newUser.created_at.should.not.equal(exportData.data.users[1].created_at);
+                newUser.updated_by.should.equal(ownerUser.id);
+                newUser.updated_at.should.not.equal(exportData.data.users[1].updated_at);
 
-                fetchImported.then(function (importedData) {
-                    var users, ownerUser, newUser, existingUser,
-                        posts, post1, post2, post3,
-                        tags, tag1, tag2, tag3;
+                rolesUsers.length.should.equal(5, 'There should be 5 role relations');
 
-                    // General data checks
-                    should.exist(importedData);
-                    importedData.length.should.equal(3, 'Did not get data successfully');
+                _.each(rolesUsers, function (roleUser) {
+                    if (roleUser.user_id === ownerUser.id) {
+                        roleUser.role_id.should.equal(4, 'Original user should be an owner');
+                    }
+                    if (roleUser.user_id === newUser.id) {
+                        roleUser.role_id.should.equal(1, 'New user should be an admin');
+                    }
+                    if (roleUser.user_id === existingUser.id) {
+                        roleUser.role_id.should.equal(1, 'Existing user was an admin');
+                    }
+                });
 
-                    // Test the users and roles
-                    users = importedData[0];
-                    posts = importedData[1];
-                    tags  = importedData[2];
+                done();
+            }).catch(done);
+        });
 
-                    // Grab the users
-                    // the owner user is first
-                    ownerUser = users[0];
-                    // the other two users should have the imported data, but they get inserted in different orders
-                    newUser = _.find(users, function (user) {
-                        return user.name === exportData.data.users[1].name;
-                    });
-                    existingUser = _.find(users, function (user) {
-                        return user.name === exportData.data.users[2].name;
-                    });
-                    post1 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[0].slug;
-                    });
-                    post2 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[1].slug;
-                    });
-                    post3 = _.find(posts, function (post) {
-                        return post.slug === exportData.data.posts[2].slug;
-                    });
-                    tag1 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[0].slug;
-                    });
-                    tag2 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[1].slug;
-                    });
-                    tag3 = _.find(tags, function (tag) {
-                        return tag.slug === exportData.data.tags[2].slug;
-                    });
+        it('imports posts & tags with correct authors, owners etc', function (done) {
+            var fetchImported = Promise.join(
+                knex('users').select(),
+                knex('posts').select(),
+                knex('tags').select()
+            );
 
-                    // Check the authors are correct
-                    post1.author_id.should.equal(newUser.id);
-                    post2.author_id.should.equal(existingUser.id);
-                    post3.author_id.should.equal(ownerUser.id);
+            fetchImported.then(function (importedData) {
+                var users, ownerUser, newUser, existingUser,
+                    posts, post1, post2, post3,
+                    tags, tag1, tag2, tag3;
 
-                    // Created by should be what was in the import file
-                    post1.created_by.should.equal(ownerUser.id);
-                    post2.created_by.should.equal(existingUser.id);
-                    post3.created_by.should.equal(ownerUser.id);
+                // General data checks
+                should.exist(importedData);
+                importedData.length.should.equal(3, 'Did not get data successfully');
 
-                    // Updated by gets set to the current user
-                    post1.updated_by.should.equal(ownerUser.id);
-                    post2.updated_by.should.equal(ownerUser.id);
-                    post3.updated_by.should.equal(ownerUser.id);
+                // Test the users and roles
+                users = importedData[0];
+                posts = importedData[1];
+                tags  = importedData[2];
 
-                    // Published by should be what was in the import file
-                    post1.published_by.should.equal(newUser.id);
-                    post2.published_by.should.equal(existingUser.id);
-                    post3.published_by.should.equal(ownerUser.id);
+                // Grab the users
+                // the owner user is first
+                ownerUser = users[0];
+                // the other two users should have the imported data, but they get inserted in different orders
+                newUser = _.find(users, function (user) {
+                    return user.name === exportData.data.users[1].name;
+                });
+                existingUser = _.find(users, function (user) {
+                    return user.name === exportData.data.users[2].name;
+                });
+                post1 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[0].slug;
+                });
+                post2 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[1].slug;
+                });
+                post3 = _.find(posts, function (post) {
+                    return post.slug === exportData.data.posts[2].slug;
+                });
+                tag1 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[0].slug;
+                });
+                tag2 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[1].slug;
+                });
+                tag3 = _.find(tags, function (tag) {
+                    return tag.slug === exportData.data.tags[2].slug;
+                });
 
-                    // Created by should be what was in the import file
-                    tag1.created_by.should.equal(ownerUser.id);
-                    tag2.created_by.should.equal(newUser.id);
-                    tag3.created_by.should.equal(existingUser.id);
+                // Check the authors are correct
+                post1.author_id.should.equal(newUser.id);
+                post2.author_id.should.equal(existingUser.id);
+                post3.author_id.should.equal(ownerUser.id);
 
-                    // Updated by gets set to the current user
-                    tag1.updated_by.should.equal(ownerUser.id);
-                    tag2.updated_by.should.equal(ownerUser.id);
-                    tag3.updated_by.should.equal(ownerUser.id);
+                // Created by should be what was in the import file
+                post1.created_by.should.equal(ownerUser.id);
+                post2.created_by.should.equal(existingUser.id);
+                post3.created_by.should.equal(ownerUser.id);
 
-                    done();
-                }).catch(done);
-            });
+                // Updated by gets set to the current user
+                post1.updated_by.should.equal(ownerUser.id);
+                post2.updated_by.should.equal(ownerUser.id);
+                post3.updated_by.should.equal(ownerUser.id);
+
+                // Published by should be what was in the import file
+                post1.published_by.should.equal(newUser.id);
+                post2.published_by.should.equal(existingUser.id);
+                post3.published_by.should.equal(ownerUser.id);
+
+                // Created by should be what was in the import file
+                tag1.created_by.should.equal(ownerUser.id);
+                tag2.created_by.should.equal(newUser.id);
+                tag3.created_by.should.equal(existingUser.id);
+
+                // Updated by gets set to the current user
+                tag1.updated_by.should.equal(ownerUser.id);
+                tag2.updated_by.should.equal(ownerUser.id);
+                tag3.updated_by.should.equal(ownerUser.id);
+
+                done();
+            }).catch(done);
         });
     });
 });


### PR DESCRIPTION
I've kept this as 3 commits for now, just so it's easier to see what changes I've made.

The first commit (88db807) is the main change, introducing a new `/data/importer/` folder which contains a `handlers` folder and an `importers` folder. The new `data/importer/data/` is just a hook into the old `/data/import/` code - I want to do more to move this around and separate it into two parts: data preprocessing and data storage, but it isn't necessary to get the rest of the import changes so I'm leaving this half-done for now.

This restructure allows for the creation of other handlers and importers which manage other file types. I've done a lot of this locally, so I'm reasonably confident this refactor is the right direction.

The second change here removes the concept of versioning from importing. We don't actually use it at present and it just makes migrations more complex (see #4479)

Finally, I made a couple of changes to the data importer itself as it wasn't working for me properly. I found that if created_at wasn't set on the post, then an SQLITE error was being thrown but not passed all the way through (reproduce with this: https://gist.github.com/ErisDS/5eff62547f66177f8057). The changes in the 3rd commit both fix the underlying problem with errors not being passed through and also adds an extra line to the post importer which sets created_at if it is not already set (if it's set, it should be honoured, if it's not set, it should be considered to be now.

If I could get a bit of a review of these changes, that'd be grand, then I'll squash:)
