### PR TITLE
Do not include url and author_id in post payload.

### DIFF
--- a/core/client/serializers/post.js
+++ b/core/client/serializers/post.js
@@ -52,10 +52,14 @@ var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         var root = Ember.String.pluralize(type.typeKey),
             data = this.serialize(record, options);
 
-        // Don't ever pass uuid's
+        // Properties that exist on the model but we don't want sent in the payload
+
         delete data.uuid;
-        // Don't send HTML
         delete data.html;
+        // Inserted locally as a convenience.
+        delete data.author_id;
+        // Read-only virtual property.
+        delete data.url;
 
         hash[root] = [data];
     }


### PR DESCRIPTION
No Issue.
- Neither of these properties should be included in the
  payload sent from the client to the API.  URL is a
  read-only virtual property, and author_id is inserted
  locally as a convenience.
