### PR TITLE
Tag Management: Delete Flow

### DIFF
--- a/core/client/assets/sass/components/settings-menu.scss
+++ b/core/client/assets/sass/components/settings-menu.scss
@@ -143,6 +143,23 @@
         height: 108px;
     }
 
+    .tag-delete-button {
+        padding: 0;
+        color: $red;
+
+        &:before {
+            margin-right: 4px;
+            top: -1px;
+            position: relative;
+        }
+
+        &:hover {
+            &, &:before {
+                color: darken($red, 10%);
+            }
+        }
+    }
+
     .nav-list {
         margin-top: 3rem;
     }

--- a/core/client/controllers/modals/delete-tag.js
+++ b/core/client/controllers/modals/delete-tag.js
@@ -1,0 +1,34 @@
+var DeleteTagController = Ember.Controller.extend({
+    actions: {
+        confirmAccept: function () {
+            var tag = this.get('model'),
+                name = tag.get('name'),
+                self = this;
+
+            this.send('closeSettingsMenu');
+
+            tag.destroyRecord().then(function () {
+                self.notifications.showSuccess('Deleted ' + name);
+            }).catch(function (error) {
+                self.notifications.showAPIError(error);
+            });
+        },
+
+        confirmReject: function () {
+            return false;
+        }
+    },
+
+    confirm: {
+        accept: {
+            text: 'Delete',
+            buttonClass: 'btn btn-red'
+        },
+        reject: {
+            text: 'Cancel',
+            buttonClass: 'btn btn-default btn-minor'
+        }
+    }
+});
+
+export default DeleteTagController;

--- a/core/client/controllers/settings/tags.js
+++ b/core/client/controllers/settings/tags.js
@@ -114,19 +114,6 @@ var TagsController = Ember.ArrayController.extend(PaginationMixin, {
             this.send('openSettingsMenu');
         },
 
-        deleteTag: function (tag) {
-            var name = tag.get('name'),
-                self = this;
-
-            this.send('closeSettingsMenu');
-
-            tag.destroyRecord().then(function () {
-                self.notifications.showSuccess('Deleted ' + name);
-            }).catch(function (error) {
-                self.notifications.showAPIError(error);
-            });
-        },
-
         saveActiveTagName: function (name) {
             this.saveActiveTagProperty('name', name);
         },

--- a/core/client/templates/modals/delete-tag.hbs
+++ b/core/client/templates/modals/delete-tag.hbs
@@ -1,0 +1,6 @@
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+    title="Are you sure you want to delete this tag?" confirm=confirm}}
+
+    <p>You're about to delete "<strong>{{model.name}}</strong>".<br />This is permanent! No backups, no restores, no magic undo button. <br /> We warned you, ok?</p>
+
+{{/gh-modal-dialog}}

--- a/core/client/templates/settings/tags/settings-menu.hbs
+++ b/core/client/templates/settings/tags/settings-menu.hbs
@@ -35,7 +35,7 @@
                 </ul>
 
                 {{#unless activeTag.isNew}}
-                    <button type="button" class="btn btn-red icon-trash" {{action "deleteTag" activeTag}}>Delete Tag</button>
+                    <button type="button" class="btn btn-link btn-sm tag-delete-button icon-trash" {{action "openModal" "delete-tag" activeTag}}>Delete Tag</button>
                 {{/unless}}
             </form>
         </div>


### PR DESCRIPTION
Closes #4633
- The ‘delete’ button is now a smaller plain text link, opening a
  confirmation modal analog to the delete user/post flow
- Adding a post count is dependent on #4654, but the modal is already a
  neat step up from the immediate, warning-less deletion.

![screen shot 2014-12-15 at 9 07 08 am](https://cloud.githubusercontent.com/assets/1426799/5440036/dd65c6de-8439-11e4-83cc-80e87130cdc4.png)
![screen shot 2014-12-15 at 9 07 15 am](https://cloud.githubusercontent.com/assets/1426799/5440037/ddde4334-8439-11e4-94f1-3abc3ac74dd0.png)
