### PR TITLE
Tag Management: Working {{image}} helper

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -223,7 +223,8 @@ frontendControllers = {
 
                         // Format data for template
                         result = _.extend(formatPageResponse(posts, page), {
-                            tag: page.meta.filters.tags ? page.meta.filters.tags[0] : ''
+                            tag: page.meta.filters.tags ? page.meta.filters.tags[0] : '',
+                            image: page.meta.filters.tags && page.meta.filters.tags[0].image ? page.meta.filters.tags[0].image : ''
                         });
 
                     // If the resulting tag is '' then 404.


### PR DESCRIPTION
Ref #4605
- This small change sets the page’s `image` property for a tag page,
  therefore ensuring that `{{#if image}}` and `{{image}}`  can be used in
  themes just like it’s being used on post pages.
