### PR TITLE
stop middleware converting favicon to string

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -215,7 +215,9 @@ function serveSharedFile(file, type, maxAge) {
                     if (err) {
                         return next(err);
                     }
-                    buf = buf.toString().replace('{{blog-url}}', config.url.replace(/\/$/, ''));
+                    if (type === 'text/xsl' || type === 'text/plain') {
+                        buf = buf.toString().replace('{{blog-url}}', config.url.replace(/\/$/, ''));
+                    }
                     content = {
                         headers: {
                             'Content-Type': type,


### PR DESCRIPTION
closes #4658
- adds conditional to prevent favicon being processed as a string
