### PR TITLE
Add CORS headers to the RSS feed

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -546,6 +546,8 @@ frontendControllers = {
                     });
                 }).then(function () {
                     res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
+                    res.set('Access-Control-Allow-Origin', '*');
+                    res.set('Access-Control-Allow-Methods', 'GET');
                     res.send(feed.xml());
                 });
             });

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -417,6 +417,14 @@ describe('Frontend Routing', function () {
                 });
         });
 
+        it('should serve RSS with CORS headers', function (done) {
+            request.get('/rss/')
+                .expect('Access-Control-Allow-Origin', '*')
+                .expect('Access-Control-Allow-Methods', 'GET')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
         it('should not have as second page', function (done) {
             request.get('/rss/2/')
                 // TODO this should probably redirect straight to /rss/ with 301?


### PR DESCRIPTION
This PR adds cross origin headers to the RSS feed thus allowing it to be accessible by other webpages which wish to pull the feed using AJAX. This is useful if you want to include the latest X posts from your blog on an external site.

There are no particular security concerns to be worried about here as it only allows the `GET` method and nothing in the `rss` action changes any data.
