### PR TITLE
Clean up hidden accessibility text class

### DIFF
--- a/core/client/assets/sass/patterns/_shame.scss
+++ b/core/client/assets/sass/patterns/_shame.scss
@@ -4,40 +4,9 @@
 // A home for Styles that need to die in a fire, but are used
 // in lots of places.
 //
-// * Utilities
 // * Floating Header
 // * Scroll Shadows
 // ------------------------------------------------------------
-
-
-//
-// Utilities
-// --------------------------------------------------
-// We have more robust alternatives in global.scss
-// Are any of these actually even used anywhere?
-
-.hidden,
-.visuallyhidden,
-.screen-reader-text {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-}
-
-.visuallyhidden.focusable:active,
-.visuallyhidden.focusable:focus {
-    clip: auto;
-    height: auto;
-    margin: 0;
-    overflow: visible;
-    position: static;
-    width: auto;
-}
 
 
 //

--- a/core/client/templates/-publish-bar.hbs
+++ b/core/client/templates/-publish-bar.hbs
@@ -3,7 +3,9 @@
         {{render 'post-tags-input'}}
 
         <div class="publish-bar-actions">
-            <button type="button" class="post-settings" {{action "toggleSettingsMenu"}}></button>
+            <button type="button" class="post-settings" {{action "toggleSettingsMenu"}}>
+                <span class="sr-only">Post settings menu</span>
+            </button>
             {{view "editor-save-button" id="entry-actions" classNameBindings="model.isNew:unsaved"}}
         </div>
     </div>

--- a/core/client/templates/components/gh-navitem.hbs
+++ b/core/client/templates/components/gh-navitem.hbs
@@ -1,6 +1,6 @@
 {{#unless navItem.last}}
     <span class="navigation-item-drag-handle icon-grab">
-        <span class="hidden">Reorder</span>
+        <span class="sr-only">Reorder</span>
     </span>
 {{/unless}}
 <div class="navigation-inputs">
@@ -14,11 +14,11 @@
 <span class="navigation-item-action">
     {{#if navItem.last}}
         <button type="button" class="add-navigation-link icon-add" {{action "addItem"}}>
-            <span class="hidden">Add</span>
+            <span class="sr-only">Add</span>
         </button>
     {{else}}
         <button type="button" class="navigation-delete icon-trash" {{action "deleteItem" navItem}}>
-            <span class="hidden">Delete</span>
+            <span class="sr-only">Delete</span>
         </button>
     {{/if}}
 </span>

--- a/core/client/templates/post-tags-input.hbs
+++ b/core/client/templates/post-tags-input.hbs
@@ -1,6 +1,6 @@
 <div class="publish-bar-tags-icon">
     <label class="tag-label icon-tag" for="tags" title="Tags">
-        <span class="hidden">Tags</span>
+        <span class="sr-only">Tags</span>
     </label>
 </div>
 <div class="publish-bar-tags">

--- a/core/client/templates/posts/post.hbs
+++ b/core/client/templates/posts/post.hbs
@@ -2,7 +2,7 @@
     {{#link-to "posts" tagName="button" class="btn btn-default btn-back"}}Back{{/link-to}}
     <h2 class="page-title">Preview</h2>
     <button type="button" {{bind-attr class="model.featured:featured:unfeatured"}} title="Feature this post" {{action "toggleFeatured"}}>
-        <span class="hidden">Star</span>
+        <span class="sr-only">Star</span>
     </button>
     <small class="post-published-by">
         <span class="status">{{#if isPublished}}Published{{else}}Written{{/if}}</span>


### PR DESCRIPTION
Closes #4662
- Removed accessibility classes from `_shame.scss` in favour of those in `global.css`, which are from Bootstrap and better tested.
- Change many instances if `class="hidden"` to `class="sr-only"`, so text intended to help with accessibility is not hidden from screen readers, only visually hidden.
