### PR TITLE
Trigger Change Event before Login

### DIFF
--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -15,6 +15,10 @@ var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControll
         validateAndAuthenticate: function () {
             var self = this;
 
+            // Manually trigger events for input fields, ensuring legacy compatibility with
+            // browsers and password managers that don't send proper events on autofill
+            $('#login').find('input').trigger('change');
+
             this.validate({format: false}).then(function () {
                 self.notifications.closePassive();
                 self.send('authenticate');


### PR DESCRIPTION
Ref #4651
- Manually triggering the change event ensures compatibility with
  legacy password managers and browsers not properly firing events on
  autofill (which leads to Ember not picking up the entered values).
- Confirmed to fix issues with Firefox <= v30 and Chrome < ~33 (I couldn't really figure out when Chrome started having autofill issues, but it does fix an error around 33, released in March this year).
