### PR TITLE
Update Ember-Data.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Countable": "2.0.2",
     "device": "git://github.com/matthewhudson/device.js#5347a275b66020a0d4dfe9aad81a488f8cce448d",
     "ember": "1.9.0",
-    "ember-data": "1.0.0-beta.11",
+    "ember-data": "1.0.0-beta.12",
     "ember-load-initializers": "git://github.com/stefanpenner/ember-load-initializers.git#0.0.1",
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",
     "ember-simple-auth": "0.7.2",

--- a/core/client/models/post.js
+++ b/core/client/models/post.js
@@ -19,8 +19,11 @@ var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     author: DS.belongsTo('user',  {async: true}),
     author_id: DS.attr('number'),
     updated_at: DS.attr('moment-date'),
+    updated_by: DS.attr(),
     published_at: DS.attr('moment-date'),
     published_by: DS.belongsTo('user', {async: true}),
+    created_at: DS.attr('moment-date'),
+    created_by: DS.attr(),
     tags: DS.hasMany('tag', {embedded: 'always'}),
     url: DS.attr('string'),
 

--- a/core/client/models/role.js
+++ b/core/client/models/role.js
@@ -4,6 +4,8 @@ var Role = DS.Model.extend({
     description: DS.attr('string'),
     created_at: DS.attr('moment-date'),
     updated_at: DS.attr('moment-date'),
+    created_by: DS.attr(),
+    updated_by: DS.attr(),
 
     lowerCaseName: Ember.computed('name', function () {
         return this.get('name').toLocaleLowerCase();

--- a/core/client/models/tag.js
+++ b/core/client/models/tag.js
@@ -8,10 +8,15 @@ var Tag = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     name: DS.attr('string'),
     slug: DS.attr('string'),
     description: DS.attr('string'),
-    parent_id: DS.attr('number'),
+    parent: DS.attr(),
     meta_title: DS.attr('string'),
     meta_description: DS.attr('string'),
-    image: DS.attr('string')
+    image: DS.attr('string'),
+    hidden: DS.attr('boolean'),
+    created_at: DS.attr('moment-date'),
+    updated_at: DS.attr('moment-date'),
+    created_by: DS.attr(),
+    updated_by: DS.attr()
 });
 
 export default Tag;


### PR DESCRIPTION
No Issue
- ember-data@beta.12
- ember-data now warns if a payload contains properties that do
  not exist in the model.  Because of this all missing model
  attributes have been added (without their relationship defined)
  because they're currently unused and we don't need to generate
  additional API requests to resolve the async relationships.
