### PR TITLE
Add 'id' to post sort fields. So there is no longer equally sorted posts.

### DIFF
--- a/core/client/controllers/posts.js
+++ b/core/client/controllers/posts.js
@@ -36,9 +36,11 @@ var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
     //     status: ASC
     //     published_at: DESC
     //     updated_at: DESC
+    //     id: DESC
     orderBy: function (item1, item2) {
         var updated1 = item1.get('updated_at'),
             updated2 = item2.get('updated_at'),
+            idResult,
             statusResult,
             updatedAtResult,
             publishedAtResult;
@@ -53,12 +55,17 @@ var PostsController = Ember.ArrayController.extend(PaginationControllerMixin, {
             return 1;
         }
 
+        idResult = Ember.compare(parseInt(item1.get('id')), parseInt(item2.get('id')));
         statusResult = Ember.compare(item1.get('status'), item2.get('status'));
         updatedAtResult = Ember.compare(updated1.valueOf(), updated2.valueOf());
         publishedAtResult = publishedAtCompare(item1, item2);
 
         if (statusResult === 0) {
             if (publishedAtResult === 0) {
+                if (updatedAtResult === 0) {
+                    // This should be DESC
+                    return idResult * -1;
+                }
                 // This should be DESC
                 return updatedAtResult * -1;
             }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -435,6 +435,7 @@ Post = ghostBookshelf.Model.extend({
                     .query('orderBy', 'status', 'ASC')
                     .query('orderBy', 'published_at', 'DESC')
                     .query('orderBy', 'updated_at', 'DESC')
+                    .query('orderBy', 'id', 'DESC')
                     .fetch(_.omit(options, 'page', 'limit'));
             })
 


### PR DESCRIPTION
closes #4648
- Add id to order by fields on posts API
- Order by id on posts controller
