### PR TITLE
Update pg package and convert data to correct type

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     },
     "optionalDependencies": {
         "mysql": "2.1.1",
-        "pg.js": "3.6.2"
+        "pg": "4.1.1"
     },
     "devDependencies": {
         "blanket": "~1.1.6",


### PR DESCRIPTION
No Issue
- Switch 'pg.js' package for 'pg' as the native bindings are
  now an optional add-on to pg and pg.js has been deprecated.
- pg@4.1.1
- Set the driver's parser to automatically convert integer data
  returned from postgres into a javascript integer.
