### PR TITLE
Prevent error when closing modal dialog

### DIFF
--- a/core/client/components/gh-modal-dialog.js
+++ b/core/client/components/gh-modal-dialog.js
@@ -13,9 +13,10 @@ var ModalDialog = Ember.Component.extend({
         this.$('.js-modal-background').on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', function (event) {
             if (event.originalEvent.animationName === 'fade-out') {
                 self.$('.js-modal, .js-modal-background').removeClass('open');
-                self.sendAction();
             }
         });
+
+        this.sendAction();
     },
 
     confirmaccept: 'confirmAccept',


### PR DESCRIPTION
No Issue
- Moved sendAction outside of the event handler as calling it
  from inside was generating an error in the console.

Error can be reproduced by causing a modal dialog to appear (delete post / delete tag) and then clicking "cancel."
