### PR TITLE
Finish up post count support in tags API

### DIFF
--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -8,7 +8,16 @@ var Promise      = require('bluebird'),
     utils        = require('./utils'),
 
     docName      = 'tags',
+    allowedIncludes = ['post_count'],
     tags;
+
+// ## Helpers
+function prepareInclude(include) {
+    include = include || '';
+    include = _.intersection(include.split(','), allowedIncludes);
+
+    return include;
+}
 
 /**
  * ## Tags API Methods
@@ -22,7 +31,13 @@ tags = {
      * @returns {Promise(Tags)} Tags Collection
      */
     browse: function browse(options) {
+        options = options || {};
+
         return canThis(options.context).browse.tag().then(function () {
+            if (options.include) {
+                options.include = prepareInclude(options.include);
+            }
+
             return dataProvider.Tag.findPage(options);
         }, function () {
             return Promise.reject(new errors.NoPermissionError('You do not have permission to browse tags.'));
@@ -35,9 +50,16 @@ tags = {
      * @return {Promise(Tag)} Tag
      */
     read: function read(options) {
+        options = options || {};
+
         var attrs = ['id', 'slug'],
-        data = _.pick(options, attrs);
+            data = _.pick(options, attrs);
+
         return canThis(options.context).read.tag().then(function () {
+            if (options.include) {
+                options.include = prepareInclude(options.include);
+            }
+
             return dataProvider.Tag.findOne(data, options).then(function (result) {
                 if (result) {
                     return {tags: [result.toJSON()]};
@@ -59,6 +81,10 @@ tags = {
         options = options || {};
 
         return canThis(options.context).add.tag(object).then(function () {
+            if (options.include) {
+                options.include = prepareInclude(options.include);
+            }
+
             return utils.checkObject(object, docName).then(function (checkedTagData) {
                 return dataProvider.Tag.add(checkedTagData.tags[0], options);
             }).then(function (result) {
@@ -80,7 +106,13 @@ tags = {
      * @return {Promise(Tag)} Edited Tag
      */
     edit: function edit(object, options) {
+        options = options || {};
+
         return canThis(options.context).edit.tag(options.id).then(function () {
+            if (options.include) {
+                options.include = prepareInclude(options.include);
+            }
+
             return utils.checkObject(object, docName).then(function (checkedTagData) {
                 return dataProvider.Tag.edit(checkedTagData.tags[0], options);
             }).then(function (result) {
@@ -105,6 +137,8 @@ tags = {
      * @return {Promise(Tag)} Deleted Tag
      */
     destroy: function destroy(options) {
+        options = options || {};
+
         return canThis(options.context).destroy.tag(options.id).then(function () {
             return tags.read(options).then(function (result) {
                 return dataProvider.Tag.destroy(options).then(function () {

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -13,7 +13,7 @@ describe('Tags API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup('users:roles', 'tag', 'perms:tag', 'perms:init'));
+    beforeEach(testUtils.setup('users:roles', 'perms:tag', 'perms:init', 'posts'));
 
     should.exist(TagAPI);
 
@@ -157,6 +157,35 @@ describe('Tags API', function () {
                 results.tags.length.should.be.above(0);
                 testUtils.API.checkResponse(results.tags[0], 'tag');
                 results.tags[0].created_at.should.be.an.instanceof(Date);
+
+                done();
+            }).catch(done);
+        });
+
+        it('with include post_count', function (done) {
+            TagAPI.browse({context: {user: 1}, include: 'post_count'}).then(function (results) {
+                should.exist(results);
+                should.exist(results.tags);
+                results.tags.length.should.be.above(0);
+
+                testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
+                should.exist(results.tags[0].post_count);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('Read', function () {
+        it('returns post_count with include post_count', function (done) {
+            TagAPI.read({context: {user: 1}, include: 'post_count', slug: 'kitchen-sink'}).then(function (results) {
+                should.exist(results);
+                should.exist(results.tags);
+                results.tags.length.should.be.above(0);
+
+                testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
+                should.exist(results.tags[0].post_count);
+                results.tags[0].post_count.should.equal(2);
 
                 done();
             }).catch(done);

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -37,40 +37,46 @@ describe('Tag Model', function () {
         }).catch(done);
     });
 
-    it('can findPage with limit all', function (done) {
+    it('returns post_count if include post_count', function (done) {
         testUtils.fixtures.insertPosts().then(function () {
-            return TagModel.findPage({limit: 'all'});
-        }).then(function (results) {
-            results.meta.pagination.page.should.equal(1);
-            results.meta.pagination.limit.should.equal('all');
-            results.meta.pagination.pages.should.equal(1);
-            results.tags.length.should.equal(5);
+            TagModel.findOne({slug: 'kitchen-sink'}, {include: 'post_count'}).then(function (tag) {
+                should.exist(tag);
+                tag.get('post_count').should.equal(2);
 
-            done();
-        }).catch(done);
+                done();
+            }).catch(done);
+        });
     });
 
-    it('can findPage with post_count include', function (done) {
-        testUtils.fixtures.insertPosts().then(function () {
-            return TagModel.findPage({include: 'post_count'});
-        }).then(function (results) {
-            _.each(results.tags, function (tag) { tag.should.have.property('post_count'); });
-            _.findWhere(results.tags, {slug: 'kitchen-sink'}).post_count.should.equal(2);
-            _.findWhere(results.tags, {slug: 'pollo'}).post_count.should.equal(1);
-            _.findWhere(results.tags, {slug: 'injection'}).post_count.should.equal(0);
+    describe('findPage', function () {
+        beforeEach(function (done) {
+            testUtils.fixtures.insertPosts().then(function () {
+                done();
+            }).catch(done);
+        });
 
-            done();
-        }).catch(done);
-    });
+        it('with limit all', function (done) {
+            TagModel.findPage({limit: 'all'}).then(function (results) {
+                results.meta.pagination.page.should.equal(1);
+                results.meta.pagination.limit.should.equal('all');
+                results.meta.pagination.pages.should.equal(1);
+                results.tags.length.should.equal(5);
 
-    it('can findPage with post_count include and limit less then total_tags', function (done) {
-        testUtils.fixtures.insertPosts().then(function () {
-            return TagModel.findPage({include: 'post_count', limit: 2});
-        }).then(function (results) {
-            _.each(results.tags, function (tag) { tag.should.have.property('post_count'); });
+                done();
+            }).catch(done);
+        });
 
-            done();
-        }).catch(done);
+        it('with include post_count', function (done) {
+            TagModel.findPage({limit: 'all', include: 'post_count'}).then(function (results) {
+                results.meta.pagination.page.should.equal(1);
+                results.meta.pagination.limit.should.equal('all');
+                results.meta.pagination.pages.should.equal(1);
+                results.tags.length.should.equal(5);
+                should.exist(results.tags[0].post_count);
+
+                done();
+            }).catch(done);
+        });
     });
 
     describe('a Post', function () {


### PR DESCRIPTION
Refs #4521
- Handle 'include' query param in tags API.
- Add post_count support when fetching a tag with findOne.
- Remove post_count from options.include after processing.
- Extra database query no longer used to fetch post_count.
