### PR TITLE
Updated meta helpers to use tag meta data if present

### DIFF
--- a/core/server/helpers/meta_description.js
+++ b/core/server/helpers/meta_description.js
@@ -21,8 +21,12 @@ meta_description = function () {
             description = blog.description;
         } else if (this.author) {
             description = /\/page\//.test(this.relativeUrl) ? '' : this.author.bio;
-        } else if (this.tag || /\/page\//.test(this.relativeUrl)) {
-            description = '';
+        } else if (this.tag) {
+            if (/\/page\//.test(this.relativeUrl)) {
+                description = '';
+            } else {
+                description = _.isEmpty(this.tag.meta_description) ? '' : this.tag.meta_description;
+            }
         } else if (this.post) {
             description = _.isEmpty(this.post.meta_description) ? '' : this.post.meta_description;
         }

--- a/core/server/helpers/meta_title.js
+++ b/core/server/helpers/meta_title.js
@@ -32,7 +32,7 @@ meta_title = function (options) {
         } else if (this.author) {
             title = this.author.name + pageString + ' - ' + blog.title;
         } else if (this.tag) {
-            title = this.tag.name + pageString + ' - ' + blog.title;
+            title = _.isEmpty(this.tag.meta_title) ? this.tag.name + pageString + ' - ' + blog.title : this.tag.meta_title;
         } else if (this.post) {
             title = _.isEmpty(this.post.meta_title) ? this.post.title : this.post.meta_title;
         } else {

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -64,6 +64,26 @@ describe('{{meta_description}} helper', function () {
         }).catch(done);
     });
 
+    it('returns tag meta_description if present for a tag page', function (done) {
+        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}};
+        helpers.meta_description.call(tag).then(function (rendered) {
+            should.exist(rendered);
+            String(rendered).should.equal('Rasper is the Cool Red Casper');
+
+            done();
+        }).catch(done);
+    });
+
+    it('returns empty description on paginated tag page that has meta data', function (done) {
+        var tag = {relativeUrl: '/tag/rasper-red/page/2/', tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}};
+        helpers.meta_description.call(tag).then(function (rendered) {
+            should.exist(rendered);
+            String(rendered).should.equal('');
+
+            done();
+        }).catch(done);
+    });
+
     it('returns correct description for an author page', function (done) {
         var author = {relativeUrl: '/author/donald', author: {bio: 'I am a Duck.'}};
         helpers.meta_description.call(author).then(function (rendered) {

--- a/core/test/unit/server_helpers/meta_title_spec.js
+++ b/core/test/unit/server_helpers/meta_title_spec.js
@@ -84,6 +84,26 @@ describe('{{meta_title}} helper', function () {
         }).catch(done);
     });
 
+    it('uses tag meta_title to override default response on tag page', function (done) {
+        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}};
+        helpers.meta_title.call(tag).then(function (rendered) {
+            should.exist(rendered);
+            String(rendered).should.equal('Sasper Red');
+
+            done();
+        }).catch(done);
+    });
+
+    it('uses tag meta_title to override default response on paginated tag page', function (done) {
+        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}};
+        helpers.meta_title.call(tag).then(function (rendered) {
+            should.exist(rendered);
+            String(rendered).should.equal('Sasper Red');
+
+            done();
+        }).catch(done);
+    });
+
     it('returns correct title for an author page', function (done) {
         var author = {relativeUrl: '/author/donald', author: {name: 'Donald Duck'}};
         helpers.meta_title.call(author).then(function (rendered) {


### PR DESCRIPTION
No issue
- Tag Meta title and description override default response
- Tag Meta title present on all pages
- Tag Meta description available only on first page
  - Updates tests
