### PR TITLE
Finish tag post count UI.  Misc tag related fixes

### DIFF
--- a/core/client/controllers/modals/delete-tag.js
+++ b/core/client/controllers/modals/delete-tag.js
@@ -1,7 +1,7 @@
-var DeleteTagController = Ember.Controller.extend({
-    inflection: function () {
-        return this.get('model').get('post_count') > 1 ? 'posts' : 'post';
-    }.property('model'),
+var DeleteTagController = Ember.ObjectController.extend({
+    postInflection: Ember.computed('post_count', function () {
+        return this.get('post_count') > 1 ? 'posts' : 'post';
+    }),
 
     actions: {
         confirmAccept: function () {

--- a/core/client/controllers/post-tags-input.js
+++ b/core/client/controllers/post-tags-input.js
@@ -33,7 +33,7 @@ var PostTagsInputController = Ember.Controller.extend({
         // queries hit a full store cache and we don't see empty or out-of-date
         // suggestion lists
         loadAllTags: function () {
-            this.store.find('tag');
+            this.store.find('tag', {limit: 'all'});
         },
 
         addNewTag: function () {
@@ -52,8 +52,13 @@ var PostTagsInputController = Ember.Controller.extend({
 
             // add existing tag if we have a match
             existingTags = this.store.all('tag').filter(function (tag) {
+                if (tag.get('isNew')) {
+                    return false;
+                }
+
                 return tag.get('name').toLowerCase() === searchTerm;
             });
+
             if (existingTags.get('length')) {
                 this.send('addTag', existingTags.get('firstObject'));
             } else {
@@ -185,7 +190,7 @@ var PostTagsInputController = Ember.Controller.extend({
     findMatchingTags: function (searchTerm) {
         var matchingTags,
             self = this,
-            allTags = this.store.all('tag'),
+            allTags = this.store.all('tag').filterBy('isNew', false),
             deDupe = {};
 
         if (allTags.get('length') === 0) {

--- a/core/client/controllers/settings/tags.js
+++ b/core/client/controllers/settings/tags.js
@@ -92,7 +92,7 @@ var TagsController = Ember.ArrayController.extend(PaginationMixin, SettingsMenuM
 
     actions: {
         newTag: function () {
-            this.set('activeTag', this.store.createRecord('tag'));
+            this.set('activeTag', this.store.createRecord('tag', {post_count: 0}));
             this.send('openSettingsMenu');
         },
 

--- a/core/client/mixins/pagination-controller.js
+++ b/core/client/mixins/pagination-controller.js
@@ -4,25 +4,8 @@ var PaginationControllerMixin = Ember.Mixin.create({
     // set from PaginationRouteMixin
     paginationSettings: null,
 
-    // holds the next page to load during infinite scroll
-    nextPage: null,
-
     // indicates whether we're currently loading the next page
     isLoading: null,
-
-    /**
-     *
-     * @param {object} options: {
-     *                      modelType: <String> name of the model that will be paginated
-     *                  }
-     */
-    init: function (options) {
-        this._super(options);
-
-        var metadata = this.store.metadataFor(options.modelType);
-
-        this.set('nextPage', metadata.pagination.next);
-    },
 
     /**
      * Takes an ajax response, concatenates any error messages, then generates an error notification.
@@ -51,7 +34,8 @@ var PaginationControllerMixin = Ember.Mixin.create({
             var self = this,
                 store = this.get('store'),
                 recordType = this.get('model').get('type'),
-                nextPage = this.get('nextPage'),
+                metadata = this.store.metadataFor(recordType),
+                nextPage = metadata.pagination && metadata.pagination.next,
                 paginationSettings = this.get('paginationSettings');
 
             if (nextPage) {
@@ -59,14 +43,16 @@ var PaginationControllerMixin = Ember.Mixin.create({
                 this.set('paginationSettings.page', nextPage);
 
                 store.find(recordType, paginationSettings).then(function () {
-                    var metadata = store.metadataFor(recordType);
-
-                    self.set('nextPage', metadata.pagination.next);
                     self.set('isLoading', false);
                 }, function (response) {
                     self.reportLoadError(response);
                 });
             }
+        },
+
+        resetPagination: function () {
+            this.set('paginationSettings.page', 1);
+            this.store.metaForType('tag', {pagination: undefined});
         }
     }
 });

--- a/core/client/routes/settings/tags.js
+++ b/core/client/routes/settings/tags.js
@@ -2,7 +2,16 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import PaginationRouteMixin from 'ghost/mixins/pagination-route';
 
-var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
+var TagsRoute,
+    paginationSettings;
+
+paginationSettings = {
+    page: 1,
+    include: 'post_count',
+    limit: 15
+};
+
+TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
 
     actions: {
         willTransition: function () {
@@ -22,12 +31,16 @@ var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMi
     },
 
     model: function () {
-        return this.store.find('tag', {include: 'post_count'});
+        this.store.unloadAll('tag');
+
+        return this.store.filter('tag', paginationSettings, function (tag) {
+            return !tag.get('isNew');
+        });
     },
 
     setupController: function (controller, model) {
         this._super(controller, model);
-        this.setupPagination();
+        this.setupPagination(paginationSettings);
     },
 
     renderTemplate: function (controller, model) {
@@ -37,6 +50,10 @@ var TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMi
             outlet: 'settings-menu',
             view: 'settings/tags/settings-menu'
         });
+    },
+
+    deactivate: function () {
+        this.controller.send('resetPagination');
     }
 });
 

--- a/core/client/serializers/post.js
+++ b/core/client/serializers/post.js
@@ -47,6 +47,7 @@ var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
 
     serializeIntoHash: function (hash, type, record, options) {
         options = options || {};
+        options.includeId = true;
 
         // We have a plural root in the API
         var root = Ember.String.pluralize(type.typeKey),

--- a/core/client/serializers/tag.js
+++ b/core/client/serializers/tag.js
@@ -1,18 +1,17 @@
 import ApplicationSerializer from 'ghost/serializers/application';
 
-var TagSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
-
+var TagSerializer = ApplicationSerializer.extend({
     serializeIntoHash: function (hash, type, record, options) {
         options = options || {};
+        options.includeId = true;
 
-        // We have a plural root in the API
         var root = Ember.String.pluralize(type.typeKey),
             data = this.serialize(record, options);
 
         // Properties that exist on the model but we don't want sent in the payload
 
-        delete data.post_count;
         delete data.uuid;
+        delete data.post_count;
 
         hash[root] = [data];
     }

--- a/core/client/templates/modals/delete-tag.hbs
+++ b/core/client/templates/modals/delete-tag.hbs
@@ -1,10 +1,9 @@
-{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide,centered" animation="fade"
+{{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide"
     title="Are you sure you want to delete this tag?" confirm=confirm}}
 
-    <p>You're about to delete "<strong>{{model.name}}</strong>".<br /> 
-    {{#if model.post_count}}
-    <span class="red">This tag will be removed from {{model.post_count}} {{inflection}}.</span>
+    {{#if post_count}}
+        <strong>WARNING:</strong> <span class="red">This tag is attached to {{post_count}} {{postInflection}}.</span> You're about to delete "<strong>{{name}}</strong>". This is permanent! No backups, no restores, no magic undo button. We warned you, ok?
+    {{else}}
+        <strong>WARNING:</strong> You're about to delete "<strong>{{name}}</strong>". This is permanent! No backups, no restores, no magic undo button. We warned you, ok?</p>
     {{/if}}
-    This is permanent! No backups, no restores, no magic undo button. <br /> We warned you, ok?</p>
-
 {{/gh-modal-dialog}}


### PR DESCRIPTION
Issue #4683
- Finish setting up pagination in tag management page.
- Add post count warning to delete tag modal.  Fix styling.
- Make sure tag input menu is loading all tags.
- Only include saved tags in tag input suggestion list.
- Unload tag records from store when entering tag route so that
  we get accurate post count.
- Add a resetPagination action to pagination-controller-mixin for
  cases where we want to start fresh.
- Include tag.id when sending tag payload to API.
