### PR TITLE
Fix modal edge spacing

### DIFF
--- a/core/client/assets/sass/components/modals.scss
+++ b/core/client/assets/sass/components/modals.scss
@@ -21,9 +21,11 @@
     position: fixed;
     top: 0;
     bottom: 0;
-    left: 10px;
-    right: 10px;
+    left: 0;
+    right: 0;
     z-index: 1040;
+    padding-left: 10px;
+    padding-right: 10px;
     overflow-x: auto;
     overflow-y: scroll;
     transition: all 0.15s linear 0s;


### PR DESCRIPTION
No issue

The transparent border surrounding modals was being cut off.
This fix uses padding instead of adjusting the left & right valued to create space.

Before: 
![pasted_image_at_2014_12_23_13_49_360](https://cloud.githubusercontent.com/assets/390392/5537584/37f2fad2-8a9c-11e4-93d3-d3d857f4233d.png)

After:
![screen shot 2014-12-23 at 12 06 27](https://cloud.githubusercontent.com/assets/390392/5537587/3e151e4a-8a9c-11e4-8444-2d5cfe62e536.png)
