### PR TITLE
grunt test task - easily run single test files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -324,6 +324,13 @@ var _              = require('lodash'),
                     }
                 },
 
+                test: {
+                    command: function (test) {
+                        var mochaPath = path.resolve(cwd + '/node_modules/grunt-mocha-cli/node_modules/mocha/bin/mocha');
+                        return mochaPath  + ' --timeout=15000 --ui=bdd --reporter=spec core/test/' + test;
+                    }
+                },
+
                 // #### Generate coverage report
                 // See the `grunt test-coverage` task in the section on [Testing](#testing) for more information.
                 coverage: {
@@ -798,6 +805,14 @@ var _              = require('lodash'),
             });
         });
 
+        grunt.registerTask('test', function (test) {
+            if (!test) {
+                grunt.log.write('no test provided');
+            }
+
+            grunt.task.run('setTestEnv', 'shell:test:' + test);
+        });
+
         // ### Validate
         // **Main testing task**
         //
@@ -808,7 +823,7 @@ var _              = require('lodash'),
         //
         // `grunt validate` is called by `npm test` and is used by Travis.
         grunt.registerTask('validate', 'Run tests and lint code',
-            ['init', 'test']);
+            ['init', 'test-all']);
 
         // ### Test
         // **Main testing task**
@@ -818,7 +833,7 @@ var _              = require('lodash'),
         // `grunt test` runs jshint and jscs as well as the 4 test suites. See the individual sub tasks below for
         // details of each of the test suites.
         //
-        grunt.registerTask('test', 'Run tests and lint code',
+        grunt.registerTask('test-all', 'Run tests and lint code',
             ['jshint', 'jscs', 'test-routes', 'test-module', 'test-unit', 'test-integration', 'test-functional', 'shell:testem']);
 
         // ### Lint


### PR DESCRIPTION
no issue
- adds a new grunt test task, which takes a file option representing the path to the test file you want to run
  E.g. grunt test --file=unit/config_spec.js OR grunt test --file=integration/import_spec.js
- can run any unit, integration or route task
- can easily be expanded to handle running other tests in future
