### PR TITLE
Use an explicit action name in action helper

### DIFF
--- a/core/client/components/gh-modal-dialog.js
+++ b/core/client/components/gh-modal-dialog.js
@@ -29,7 +29,8 @@ var ModalDialog = Ember.Component.extend({
         confirm: function (type) {
             this.sendAction('confirm' + type);
             this.close();
-        }
+        },
+        noBubble: Ember.K
     },
 
     klass: Ember.computed('type', 'style', function () {

--- a/core/client/templates/components/gh-modal-dialog.hbs
+++ b/core/client/templates/components/gh-modal-dialog.hbs
@@ -1,6 +1,6 @@
 <div class="modal-container js-modal-container" {{action "closeModal"}}>
     <article {{bind-attr class="klass :js-modal"}}>
-        <section class="modal-content" {{action bubbles=false preventDefault=false}}>
+        <section class="modal-content" {{action "noBubble" bubbles=false preventDefault=false}}>
             {{#if title}}<header class="modal-header"><h1>{{title}}</h1></header>{{/if}}
             {{#if showClose}}<a class="close" href="" title="Close" {{action "closeModal"}}><span class="hidden">Close</span></a>{{/if}}
             <section class="modal-body">


### PR DESCRIPTION
No Issue
- Clicking on the body of a modal dialog causes an
  unhandled exception in the console.  Add an explicit
  action name to the helper.
