### PR TITLE
Add reentrant conversion to Showdown footnotes.

### DIFF
--- a/core/shared/lib/showdown/extensions/ghostfootnotes.js
+++ b/core/shared/lib/showdown/extensions/ghostfootnotes.js
@@ -32,7 +32,7 @@ function replaceInlineFootnotes(text) {
     });
 }
 
-function replaceEndFootnotes(text) {
+function replaceEndFootnotes(text, converter) {
     // Expanded footnotes at the end e.g. "[^1]: cool stuff"
     var endRegex = /\[\^(\d|n)\]: ([\s\S]*?)$(?!    )/gim,
         m = text.match(endRegex),
@@ -45,12 +45,12 @@ function replaceEndFootnotes(text) {
         }
 
         content = content.replace(/\n    /g, '<br>');
-
+        content = converter.makeHtml(content);
+        content = content.replace(/<\/p>$/, '');
         var s = '<li class="footnote" id="fn:' + n + '">' +
-                  '<p>' + content + ' <a href="#fnref:' + n +
+                  content + ' <a href="#fnref:' + n +
                     '" title="return to article">↩</a>' +
-                  '</p>' +
-                '</li>';
+                '</p></li>';
 
         if (i === 0) {
             s = '<div class="footnotes"><ol>' + s;
@@ -66,7 +66,7 @@ function replaceEndFootnotes(text) {
 }
 
 (function () {
-    var footnotes = function () {
+    var footnotes = function (converter) {
         return [
             {
                 type: 'lang',
@@ -86,7 +86,7 @@ function replaceEndFootnotes(text) {
                     }, 'm');
 
                     text = replaceInlineFootnotes(text);
-                    text = replaceEndFootnotes(text);
+                    text = replaceEndFootnotes(text, converter);
 
                     // replace extractions
                     text = text.replace(/\{gfm-js-extract-pre-([0-9]+)\}/gm, function (x, y) {

--- a/core/test/unit/showdown_footnotes_spec.js
+++ b/core/test/unit/showdown_footnotes_spec.js
@@ -8,7 +8,9 @@
 var should      = require('should'),
 
     // Stuff we are testing
-    ghostfootnotes    = require('../../shared/lib/showdown/extensions/ghostfootnotes');
+    ghostfootnotes = require('../../shared/lib/showdown/extensions/ghostfootnotes'),
+    Showdown       = require('showdown-ghost'),
+    converter      = new Showdown.converter({extensions: []});
 
 // To stop jshint complaining
 should.equal(true, true);
@@ -23,7 +25,7 @@ function _ExecuteExtension(ext, text) {
 }
 
 function _ConvertPhrase(testPhrase) {
-    return ghostfootnotes().reduce(function (text, ext) {
+    return ghostfootnotes(converter).reduce(function (text, ext) {
         return _ExecuteExtension(ext, text);
     }, testPhrase);
 }
@@ -55,6 +57,15 @@ describe('Ghost footnotes showdown extension', function () {
         var testPhrase = {
             input: '[^1]: foo bar',
             output: /<div class="footnotes"><ol><li class="footnote" id="fn:1"><p>foo bar <a href="#fnref:1" title="return to article">↩<\/a><\/p><\/li><\/ol><\/div>/
+        }, processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        processedMarkup.should.match(testPhrase.output);
+    });
+
+    it('should expand Markdown inside footnotes', function () {
+        var testPhrase = {
+            input: '[^1]: *foo*',
+            output: /<em>foo<\/em>/
         }, processedMarkup = _ConvertPhrase(testPhrase.input);
 
         processedMarkup.should.match(testPhrase.output);


### PR DESCRIPTION
Fixes #4668.

However, note that multi-paragraph footnotes are still broken. I'm not sure how to fix this; there seems to be the intention that it should work, but I don't really understand the code, and for my purposes, just inline formatting is good enough for my footnotes.
