### PR TITLE
Allow config object to be passed in ghost init

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -138,15 +138,17 @@ function init(options) {
     // It returns a promise that is resolved when the application
     // has finished starting up.
 
-    // Load our config.js file from the local file system and merge with default config.
-    return config.load(options.config).then(function () {
-        // If no config filepath was provided as an option. Assume options is a config object.
-        if (typeof options.config !== 'undefined') {
-            return this;
+    function configPromise() {
+        if (options.config || process.env.GHOST_CONFIG) {
+            // Load the config file
+            return config.load(options.config);
         }
 
-        return config.set(options);
-    }).then(function () {
+        // Assume options is a config object
+        return config.init(options);
+    }
+
+    return configPromise().then(function () {
         return config.checkDeprecated();
     }).then(function () {
         // Make sure javascript files have been built via grunt concat

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -138,8 +138,15 @@ function init(options) {
     // It returns a promise that is resolved when the application
     // has finished starting up.
 
-    // Load our config.js file from the local file system.
+    // Load our config.js file from the local file system and merge with default config.
     return config.load(options.config).then(function () {
+        // If no config filepath was provided as an option. Assume options is a config object.
+        if (typeof options.config !== 'undefined') {
+            return this;
+        }
+
+        return config.set(options);
+    }).then(function () {
         return config.checkDeprecated();
     }).then(function () {
         // Make sure javascript files have been built via grunt concat

--- a/core/test/functional/module/module_test.js
+++ b/core/test/functional/module/module_test.js
@@ -56,5 +56,20 @@ describe('Module', function () {
                 done(e);
             });
         });
+
+        it('should accept config object in init', function (done) {
+            var config = {
+                server: {
+                    port: 9000
+                }
+            };
+
+            ghost(config).then(function (ghostServer) {
+                should.equal(ghostServer.config.server.port, 9000);
+                done();
+            }).catch(function (e) {
+                done(e);
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR allows a config object to be passed into Ghost's init function. If no options.config property is passed in, the options object is assumed to be a config object.
