### PR TITLE
Allow socket permissions to be set from config

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -41,11 +41,29 @@ function ConfigManager(config) {
 
 // Are we using sockets? Custom socket or the default?
 ConfigManager.prototype.getSocket = function () {
+    var socketConfig,
+        values = {
+            path: path.join(this._config.paths.contentPath, process.env.NODE_ENV + '.socket'),
+            permissions: '660'
+        };
+
     if (this._config.server.hasOwnProperty('socket')) {
-        return _.isString(this._config.server.socket) ?
-            this._config.server.socket :
-            path.join(this._config.paths.contentPath, process.env.NODE_ENV + '.socket');
+        socketConfig = this._config.server.socket;
+
+        if (_.isString(socketConfig)) {
+            values.path = socketConfig;
+
+            return values;
+        }
+
+        if (_.isObject(socketConfig)) {
+            values.path = socketConfig.path || values.path;
+            values.permissions = socketConfig.permissions || values.permissions;
+
+            return values;
+        }
     }
+
     return false;
 };
 

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -124,19 +124,19 @@ GhostServer.prototype.start = function (externalApp) {
 
     // ## Start Ghost App
     return new Promise(function (resolve) {
-        if (config.getSocket()) {
+        var socketConfig = config.getSocket();
+
+        if (socketConfig) {
             // Make sure the socket is gone before trying to create another
             try {
-                fs.unlinkSync(config.getSocket());
+                fs.unlinkSync(socketConfig.path);
             } catch (e) {
                 // We can ignore this.
             }
 
-            self.httpServer = rootApp.listen(
-                config.getSocket()
-            );
+            self.httpServer = rootApp.listen(socketConfig.path);
 
-            fs.chmod(config.getSocket(), '0660');
+            fs.chmod(socketConfig.path, socketConfig.permissions);
         } else {
             self.httpServer = rootApp.listen(
                 config.server.port,

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -519,9 +519,33 @@ describe('Config', function () {
         it('allows server to use a socket', function (done) {
             overrideConfig({server: {socket: 'test'}});
 
-            config.load().then(function (localConfig) {
-                should.exist(localConfig);
-                localConfig.server.socket.should.equal('test');
+            config.load().then(function () {
+                var socketConfig = config.getSocket();
+
+                socketConfig.should.be.an.Object;
+                socketConfig.path.should.equal('test');
+                socketConfig.permissions.should.equal('660');
+
+                done();
+            }).catch(done);
+        });
+
+        it('allows server to use a socket and user-defined permissions', function (done) {
+            overrideConfig({
+                server: {
+                    socket: {
+                        path: 'test',
+                        permissions: '666'
+                    }
+                }
+            });
+
+            config.load().then(function () {
+                var socketConfig = config.getSocket();
+
+                socketConfig.should.be.an.Object;
+                socketConfig.path.should.equal('test');
+                socketConfig.permissions.should.equal('666');
 
                 done();
             }).catch(done);


### PR DESCRIPTION
Closes #4478.
See also: #4347

Allows user-defined permissions to be set on a socket via `config.js`:

```
server: {
    socket: {
        path: '/tmp/ghost.sock',
        permissions: '666'
    }
}
```

The current method of defining only the socket filename is still supported (`socket: 'pathToSocket'`).
