### PR TITLE
Cleanup posts template.

### DIFF
--- a/core/client/templates/posts.hbs
+++ b/core/client/templates/posts.hbs
@@ -14,24 +14,24 @@
         {{#view "paginated-scroll-box" tagName="section" classNames="content-list-content js-content-scrollbox"}}
         <ol class="posts-list">
             {{#each post in model itemController="posts/post" itemView="post-item-view" itemTagName="li"}}
-            {{#link-to "posts.post" post class="permalink" title="Edit this post"}}
-            <h3 class="entry-title">{{post.title}}</h3>
-            <section class="entry-meta">
-                <span class="status">
-                    {{#if post.isPublished}}
-                    {{#if post.page}}
-                    <span class="page">Page</span>
-                    {{else}}
-                    <time datetime="{{unbound post.published_at}}" class="date published">
-                        Published {{gh-format-timeago post.published_at}}
-                    </time>
-                    {{/if}}
-                    {{else}}
-                    <span class="draft">Draft</span>
-                    {{/if}}
-                </span>
-            </section>
-            {{/link-to}}
+                {{#link-to "posts.post" post class="permalink" alternateActive=view.active title="Edit this post"}}
+                    <h3 class="entry-title">{{post.title}}</h3>
+                    <section class="entry-meta">
+                        <span class="status">
+                            {{#if post.isPublished}}
+                                {{#if post.page}}
+                                    <span class="page">Page</span>
+                                {{else}}
+                                    <time datetime="{{unbound post.published_at}}" class="date published">
+                                        Published {{gh-format-timeago post.published_at}}
+                                    </time>
+                                {{/if}}
+                            {{else}}
+                                <span class="draft">Draft</span>
+                            {{/if}}
+                        </span>
+                    </section>
+                {{/link-to}}
             {{/each}}
         </ol>
         {{/view}}

--- a/core/client/views/item-view.js
+++ b/core/client/views/item-view.js
@@ -1,9 +1,0 @@
-var ItemView = Ember.View.extend({
-    classNameBindings: ['active'],
-
-    active: Ember.computed('childViews.firstObject.active', function () {
-        return this.get('childViews.firstObject.active');
-    })
-});
-
-export default ItemView;

--- a/core/client/views/post-item-view.js
+++ b/core/client/views/post-item-view.js
@@ -1,7 +1,7 @@
-import itemView from 'ghost/views/item-view';
+var PostItemView = Ember.View.extend({
+    classNameBindings: ['active', 'isFeatured:featured', 'isPage:page'],
 
-var PostItemView = itemView.extend({
-    classNameBindings: ['isFeatured:featured', 'isPage:page'],
+    active: null,
 
     isFeatured: Ember.computed.alias('controller.model.featured'),
 


### PR DESCRIPTION
No issue.
- Fix indentation (it was surprisingly hard for me to grok what was happening without indentation).
- Utilize `alternateActive` from `core/client/utils/link-view.js` to maintain the `active` state. Observing `childViews` is deprecated (and may not work properly in future versions of Ember).
- Remove now unused `item-view`.
