### PR TITLE
Do not use static and {{bind-attr}} for the same attribute.

### DIFF
--- a/core/client/templates/editor-save-button.hbs
+++ b/core/client/templates/editor-save-button.hbs
@@ -5,10 +5,10 @@
 {{/gh-dropdown-button}}
 {{#gh-dropdown name="post-save-menu" closeOnClick="true" tagName="div" classNames="dropdown editor-options"}}
     <ul class="dropdown-menu dropdown-triangle-bottom-right">
-        <li class="post-save-publish" {{bind-attr class="willPublish:active"}}>
+        <li {{bind-attr class=":post-save-publish willPublish:active"}}>
             <a {{action "setSaveType" "publish"}} href="#">{{view.publishText}}</a>
         </li>
-        <li class="post-save-draft" {{bind-attr class="willPublish::active"}}>
+        <li {{bind-attr class=":post-save-draft willPublish::active"}}>
             <a {{action "setSaveType" "draft"}} href="#">{{view.draftText}}</a>
         </li>
         <li class="divider delete"></li>


### PR DESCRIPTION
No issue.

This would work in pre-HTMLBars land for the initial render (but any rerenders would lose the static attribute name). Added https://github.com/emberjs/ember.js/pull/10096 to throw an assertion when this occurs.
