### PR TITLE
Update excerpt helper to properly filter HTML footnotes

### DIFF
--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -22,7 +22,7 @@ excerpt = function (options) {
     /*jslint regexp:true */
     excerpt = String(this.html);
     // Strip inline and bottom footnotes
-    excerpt = excerpt.replace(/<a.*?rel="footnote">.*?<\/a>/gi, '');
+    excerpt = excerpt.replace(/<a href="#fn.*?rel="footnote">.*?<\/a>/gi, '');
     excerpt = excerpt.replace(/<div class="footnotes"><ol>.*?<\/ol><\/div>/, '');
     // Strip other html
     excerpt = excerpt.replace(/<\/?[^>]+>/gi, '');


### PR DESCRIPTION
closes #4741
- updated regexp to properly filter out footnotes without removing too much text
- happened only when a link was used before a footnote
- old regexp was too 'greedy' and removed regular link together with the footnote
- new regexp uses a more specific <a> tag
