### PR TITLE
Check email duplicates, when edit user.

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -138,14 +138,22 @@ users = {
         return utils.checkObject(object, docName).then(function (data) {
             // Edit operation
             editOperation = function () {
-                return dataProvider.User.edit(data.users[0], options)
-                    .then(function (result) {
-                        if (result) {
-                            return {users: [result.toJSON()]};
-                        }
+                return dataProvider.User.getByEmail(
+                    data.users[0].email
+                ).then(function (foundUser) {
+                    if (foundUser && foundUser.id !== parseInt(data.users[0].id)) {
+                        return Promise.reject(new errors.BadRequestError('User with that email is already registered.'));
+                    }
 
-                        return Promise.reject(new errors.NotFoundError('User not found.'));
-                    });
+                    return dataProvider.User.edit(data.users[0], options)
+                        .then(function (result) {
+                            if (result) {
+                                return {users: [result.toJSON()]};
+                            }
+
+                            return Promise.reject(new errors.NotFoundError('User not found.'));
+                        });
+                });
             };
 
             // Check permissions

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -343,6 +343,18 @@ describe('Users API', function () {
                 done();
             }).catch(done);
         });
+
+        it('CANNOT set same email', function (done) {
+            var newEmail = testUtils.DataGenerator.forModel.users[3].email;
+            UserAPI.edit(
+                {users: [{email: newEmail}]}, _.extend({}, context.owner, {id: userIdFor.admin})
+            ).then(function () {
+                done(new Error('Email must be unique'));
+            }).catch(function (error) {
+                error.type.should.eql('BadRequestError');
+                done();
+            });
+        });
     });
 
     describe('Add', function () {


### PR DESCRIPTION
fixes #4735
- on user edit API, check whether email duplicated or not.
- added test.
