### PR TITLE
Ensure templates are compiled with correct template compiler.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,6 +380,8 @@ var _              = require('lodash'),
             emberTemplates: {
                 dev: {
                     options: {
+                        templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
+                        handlebarsPath: 'bower_components/handlebars/handlebars.js',
                         templateBasePath: /core\/client\//,
                         templateFileExtensions: /\.hbs/,
                         templateRegistration: function (name, template) {


### PR DESCRIPTION
No issue.

Using the version of `ember-template-compiler.js` that ships with the
specific version of Ember that we are using will work in both 1.9
(Handlebars 2.0) AND 1.10 (HTMLBars). This prepares us for an easier
upgrade to 1.10 when it ships as stable.
