### PR TITLE
Editor Save Button/Notifcations: Post vs Page

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -50,6 +50,10 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         return this.get('model.tags').mapBy('name');
     }),
 
+    postOrPage: Ember.computed('model.page', function () {
+        return this.get('model.page') ? 'Page' : 'Post';
+    }),
+
     // compares previousTagNames to tagNames
     tagNamesEqual: function () {
         var tagNames = this.get('tagNames'),
@@ -191,7 +195,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
             path = this.get('ghostPaths.url').join(this.get('config.blogUrl'), this.get('model.url'));
 
         if (status === 'published') {
-            message += '&nbsp;<a href="' + path + '">View Post</a>';
+            message += '&nbsp;<a href="' + path + '">View ' + this.get('postOrPage') + '</a>';
         }
         this.notifications.showSuccess(message, {delayed: delay});
     },

--- a/core/client/templates/editor-save-button.hbs
+++ b/core/client/templates/editor-save-button.hbs
@@ -13,7 +13,7 @@
         </li>
         <li class="divider delete"></li>
         <li class="delete">
-            <a {{action "openModal" "delete-post" this}} href="#">Delete Post</a>
+            <a {{action "openModal" "delete-post" this}} href="#">{{view.deleteText}}</a>
         </li>
     </ul>
 {{/gh-dropdown}}

--- a/core/client/views/editor-save-button.js
+++ b/core/client/views/editor-save-button.js
@@ -8,12 +8,16 @@ var EditorSaveButtonView = Ember.View.extend({
         return this.get('controller.model.isPublished') !== this.get('controller.willPublish');
     }),
 
-    publishText: Ember.computed('controller.model.isPublished', function () {
-        return this.get('controller.model.isPublished') ? 'Update Post' : 'Publish Now';
+    publishText: Ember.computed('controller.model.isPublished', 'controller.pageOrPost', function () {
+        return this.get('controller.model.isPublished') ? 'Update ' + this.get('controller.postOrPage') : 'Publish Now';
     }),
 
     draftText: Ember.computed('controller.model.isPublished', function () {
         return this.get('controller.model.isPublished') ? 'Unpublish' : 'Save Draft';
+    }),
+
+    deleteText: Ember.computed('controller.postOrPage', function () {
+        return 'Delete ' + this.get('controller.postOrPage');
     }),
 
     saveText: Ember.computed('controller.willPublish', function () {


### PR DESCRIPTION
Closes #4768
- Notifications that used to read ‘View Post’ now read ‘View Page’ if
  the post is actually a page
- The Editor Save Button now also makes a distinction between posts and
  pages
