### PR TITLE
Fixed issue where Gravatars with rating higher than G would cause a 404 ...

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -876,20 +876,21 @@ User = ghostBookshelf.Model.extend({
     gravatarLookup: function (userData) {
         var gravatarUrl = '//www.gravatar.com/avatar/' +
                 crypto.createHash('md5').update(userData.email.toLowerCase().trim()).digest('hex') +
-                '?d=404&s=250';
+                '?s=250';
 
         return new Promise(function (resolve) {
             if (config.isPrivacyDisabled('useGravatar')) {
                 return resolve(userData);
             }
 
-            request({url: 'http:' + gravatarUrl, timeout: 2000}, function (err, response) {
+            request({url: 'http:' + gravatarUrl + '&d=404&r=x', timeout: 2000}, function (err, response) {
                 if (err) {
                     // just resolve with no image url
                     return resolve(userData);
                 }
 
                 if (response.statusCode !== 404) {
+                    gravatarUrl += '&d=mm&r=x';
                     userData.image = gravatarUrl;
                 }
 


### PR DESCRIPTION
...error.

closes #4770
- Check for Gravatar now allows the highest rating for images
- Defaults to silhouette in the event a user deletes their Gravatar
- Allows highest rating for Gravatars (x), since Ghost should have no opinion on image ratings.
