### PR TITLE
Grunt task to look for vulnerabilities in dependencies added

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -678,7 +678,7 @@ var _              = require('lodash'),
             // ### grunt-retire
             // Grunt task to check for security fixes in dependencies
             retire : {
-                js      : ['index.js', 'Gruntfile.js', 'content/themes/**/.js', 'core/*.js', 'core/**/*.js'],
+                js      : ['index.js', 'Gruntfile.js', 'content/themes/**/*.js', 'core/*.js', 'core/**/*.js'],
                 node    : ['./'],
                 options : {
                     verbose        : true,
@@ -687,7 +687,7 @@ var _              = require('lodash'),
                     nodeRepository : 'https://raw.github.com/bekk/retire.js/master/repository/npmrepository.json'
                 }
             }
-            
+
         };
 
         // Load the configuration

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -673,7 +673,21 @@ var _              = require('lodash'),
                         params: '--init'
                     }
                 }
+            },
+
+            // ### grunt-retire
+            // Grunt task to check for security fixes in dependencies
+            retire : {
+                js      : ['index.js', 'Gruntfile.js', 'content/themes/**/.js', 'core/*.js', 'core/**/*.js'],
+                node    : ['./'],
+                options : {
+                    verbose        : true,
+                    packageOnly    : true,
+                    jsRepository   : 'https://raw.github.com/bekk/retire.js/master/repository/jsrepository.json',
+                    nodeRepository : 'https://raw.github.com/bekk/retire.js/master/repository/npmrepository.json'
+                }
             }
+            
         };
 
         // Load the configuration

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "grunt-express-server": "~0.4.19",
         "grunt-jscs": "~1.1.0",
         "grunt-mocha-cli": "~1.11.0",
+        "grunt-retire": "^0.3.7",
         "grunt-sass": "~0.16.1",
         "grunt-shell": "~1.1.1",
         "grunt-update-submodules": "~0.4.1",


### PR DESCRIPTION
To look for dependencies with known vulnerabilities. Now we still have one related with the project "htmlparser2", but the issue is still opened: fb55/htmlparser2#105

![retireghost](https://cloud.githubusercontent.com/assets/2753855/5693189/c385f458-9912-11e4-8c27-1826f4872ebe.png)
