### PR TITLE
Fixup validation engine to handle lack of proxying

### DIFF
--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -7,7 +7,8 @@ var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControll
 
     actions: {
         authenticate: function () {
-            var data = this.getProperties('identification', 'password');
+            var model = this.get('model'),
+                data = model.getProperties('identification', 'password');
 
             this._super(data).catch(function () {
                 // If simple-auth's authenticate rejects we need to catch it

--- a/core/client/controllers/signup.js
+++ b/core/client/controllers/signup.js
@@ -10,7 +10,8 @@ var SignupController = Ember.Controller.extend(ValidationEngine, {
     actions: {
         signup: function () {
             var self = this,
-                data = self.getProperties('model.name', 'model.email', 'model.password', 'model.token');
+                model = this.get('model'),
+                data = model.getProperties('name', 'email', 'password', 'token');
 
             self.notifications.closePassive();
 

--- a/core/client/mixins/validation-engine.js
+++ b/core/client/mixins/validation-engine.js
@@ -89,11 +89,24 @@ var ValidationEngine = Ember.Mixin.create({
     *                   the class that mixes in this mixin.
     */
     validate: function (opts) {
-        var model = opts.model || this,
-            type = this.get('validationType'),
-            validator = this.get('validators.' + type);
-
+        // jscs:disable safeContextKeyword
         opts = opts || {};
+
+        var model = this,
+            type,
+            validator;
+
+        if (opts.model) {
+            model = opts.model;
+        } else if (this instanceof DS.Model) {
+            model = this;
+        } else if (this.get('model')) {
+            model = this.get('model');
+        }
+
+        type = this.get('validationType') || model.get('validationType');
+        validator = this.get('validators.' + type) || model.get('validators.' + type);
+
         opts.validationType = type;
 
         return new Ember.RSVP.Promise(function (resolve, reject) {

--- a/core/client/routes/signin.js
+++ b/core/client/routes/signin.js
@@ -12,13 +12,22 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
         }
     },
 
+    model: function () {
+        return Ember.Object.create({
+            identification: '',
+            password: ''
+        });
+    },
+
     // the deactivate hook is called after a route has been exited.
     deactivate: function () {
         this._super();
 
-        // clear the properties that hold the credentials from the controller
-        // when we're no longer on the signin screen
-        this.controllerFor('signin').setProperties({identification: '', password: ''});
+        var controller = this.controllerFor('signin');
+
+        // clear the properties that hold the credentials when we're no longer on the signin screen
+        controller.set('model.identification', '');
+        controller.set('model.password', '');
     }
 });
 

--- a/core/client/routes/signup.js
+++ b/core/client/routes/signup.js
@@ -14,7 +14,7 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
         var self = this,
             tokenText,
             email,
-            model = {},
+            model = Ember.Object.create(),
             re = /^(?:[A-Za-z0-9_\-]{4})*(?:[A-Za-z0-9_\-]{2}|[A-Za-z0-9_\-]{3})?$/;
 
         return new Ember.RSVP.Promise(function (resolve) {
@@ -27,8 +27,8 @@ var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
             tokenText = atob(params.token);
             email = tokenText.split('|')[1];
 
-            model.email = email;
-            model.token = params.token;
+            model.set('email', email);
+            model.set('token', params.token);
 
             return ic.ajax.request({
                 url: self.get('ghostPaths.url').api('authentication', 'invitation'),

--- a/core/client/templates/signin.hbs
+++ b/core/client/templates/signin.hbs
@@ -2,12 +2,12 @@
     <form id="login" class="login-form" method="post" novalidate="novalidate" {{action 'validateAndAuthenticate' on='submit'}}>
         <div class="email-wrap">
             <span class="input-icon icon-mail">
-                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" value=identification}}
+                {{gh-trim-focus-input class="email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" value=model.identification}}
             </span>
         </div>
         <div class="password-wrap">
             <span class="input-icon icon-lock">
-                {{input class="password" type="password" placeholder="Password" name="password" value=password}}
+                {{input class="password" type="password" placeholder="Password" name="password" value=model.password}}
             </span>
         </div>
         <button class="btn btn-blue" type="submit" {{action "validateAndAuthenticate"}} {{bind-attr disabled=submitting}}>Log in</button>


### PR DESCRIPTION
Closes #4766
- Adjust ValidationEngine so it no longer assumes the properties
  it is validating are proxies via ObjectController.
- Fixup controllers, templates, and routes to use models where
  data needs to be validated.
