### PR TITLE
Update Image URL Input Styles

### DIFF
--- a/core/client/assets/sass/components/settings-menu.scss
+++ b/core/client/assets/sass/components/settings-menu.scss
@@ -134,8 +134,8 @@
         padding-bottom: 35px;
         margin: 0 0 1.6rem 0;
 
-        input {
-            width: auto;
+        &.image-uploader-url {
+            padding: 35px 45px;
         }
     }
 

--- a/core/client/assets/sass/components/uploader.scss
+++ b/core/client/assets/sass/components/uploader.scss
@@ -106,7 +106,7 @@
 
         &.url {
             font: -webkit-small-control;
-            width: 276px;
+            width: 100%;
             vertical-align: middle;
             padding: 9px 7px;
             margin: 10px 0;
@@ -116,6 +116,10 @@
             border: #e3e1d5 1px solid;
             border-radius: 4px;
             transition: all 0.15s ease-in-out;
+
+            + .btn.btn-blue {
+                color: #fff;
+            }
         }
     }
 


### PR DESCRIPTION
No issue

The style for the URL input when uploading images are a bit broken.
This PR reduces the horizontal spacing in the settings menu uploader (to widen the input), corrects the button with black text in the editor uploader and makes sure all image upload inputs fill the container.

**Before**

![editor-pre](https://cloud.githubusercontent.com/assets/390392/5719298/1e259960-9b0f-11e4-9a04-8141bf54e3b4.png)

![settings-menu-pre](https://cloud.githubusercontent.com/assets/390392/5719299/20bac83a-9b0f-11e4-92f1-0bbd5de1ef63.png)

![modal-pre](https://cloud.githubusercontent.com/assets/390392/5719300/22f294ca-9b0f-11e4-8ebe-ad225a36af35.png)

**After**

![editor-post](https://cloud.githubusercontent.com/assets/390392/5719302/26fdfbb8-9b0f-11e4-915d-0146457f0ee7.png)

![settings-menu-post](https://cloud.githubusercontent.com/assets/390392/5719304/292ba4b2-9b0f-11e4-82b9-8f7982c618ae.png)

![modal-post](https://cloud.githubusercontent.com/assets/390392/5719305/2b4e4de4-9b0f-11e4-93b4-a5b33396d74e.png)
