### PR TITLE
Don't assume order of results in import test

### DIFF
--- a/core/test/unit/importer_spec.js
+++ b/core/test/unit/importer_spec.js
@@ -609,22 +609,26 @@ describe('Importer', function () {
                 // deleted-2014-12-19-test-1.md
                 // doesn't get imported ;)
 
+                // loadFile doesn't guarantee order of results
+                var one = result.data.posts[0].status === 'published' ? 0 : 1,
+                    two = one === 0 ? 1 : 0;
+
                 // published-2014-12-19-test-1.md
-                result.data.posts[0].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[0].status.should.eql('published');
-                result.data.posts[0].slug.should.eql('test-1');
-                result.data.posts[0].title.should.eql('Welcome to Ghost');
-                result.data.posts[0].published_at.should.eql(1418990400000);
-                moment(result.data.posts[0].published_at).format('DD MM YY HH:mm').should.eql('19 12 14 12:00');
-                result.data.posts[0].should.not.have.property('image');
+                result.data.posts[one].markdown.should.eql('You\'re live! Nice.');
+                result.data.posts[one].status.should.eql('published');
+                result.data.posts[one].slug.should.eql('test-1');
+                result.data.posts[one].title.should.eql('Welcome to Ghost');
+                result.data.posts[one].published_at.should.eql(1418990400000);
+                moment(result.data.posts[one].published_at).format('DD MM YY HH:mm').should.eql('19 12 14 12:00');
+                result.data.posts[one].should.not.have.property('image');
 
                 // draft-2014-12-19-test-3.md
-                result.data.posts[1].markdown.should.eql('You\'re live! Nice.');
-                result.data.posts[1].status.should.eql('draft');
-                result.data.posts[1].slug.should.eql('test-3');
-                result.data.posts[1].title.should.eql('Welcome to Ghost');
-                result.data.posts[1].created_at.should.eql(1418990400000);
-                result.data.posts[1].image.should.eql('/images/kitten.jpg');
+                result.data.posts[two].markdown.should.eql('You\'re live! Nice.');
+                result.data.posts[two].status.should.eql('draft');
+                result.data.posts[two].slug.should.eql('test-3');
+                result.data.posts[two].title.should.eql('Welcome to Ghost');
+                result.data.posts[two].created_at.should.eql(1418990400000);
+                result.data.posts[two].image.should.eql('/images/kitten.jpg');
 
                 done();
             }).catch(done);


### PR DESCRIPTION
No Issue
- Fixes intermittent test failure when order of results
  returned by loadFile() changes.

Example:

```
  1) Importer MarkdownHandler can import multiple files:

      AssertionError: expected 'draft' to equal 'published'
      + expected - actual

      +"published"
      -"draft"

      at Assertion.fail (/home/vagrant/src/ghost/node_modules/should/lib/assertion.js:186:17)
      at Assertion.prop.(anonymous function) [as eql] (/home/vagrant/src/ghost/node_modules/should/lib/assertion.js:61:14)
      at /home/vagrant/src/ghost/core/test/unit/importer_spec.js:614:52
      at tryCatch1 (/home/vagrant/src/ghost/node_modules/bluebird/js/main/util.js:21:21)
      at Promise._settlePromiseFromHandler (/home/vagrant/src/ghost/node_modules/bluebird/js/main/promise.js:591:13)
      at Promise._settlePromiseAt (/home/vagrant/src/ghost/node_modules/bluebird/js/main/promise.js:755:18)
      at Promise._settlePromises (/home/vagrant/src/ghost/node_modules/bluebird/js/main/promise.js:872:14)
      at Async._drainQueue (/home/vagrant/src/ghost/node_modules/bluebird/js/main/async.js:78:16)
      at Async._drainQueues (/home/vagrant/src/ghost/node_modules/bluebird/js/main/async.js:88:10)
      at Async.drainQueues (/home/vagrant/src/ghost/node_modules/bluebird/js/main/async.js:13:14)
      at process._tickDomainCallback (node.js:486:13)
```
