### PR TITLE
Check all users when generating slug

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -61,7 +61,7 @@ User = ghostBookshelf.Model.extend({
         if (this.hasChanged('slug') || !this.get('slug')) {
             // Generating a slug requires a db call to look for conflicting slugs
             return ghostBookshelf.Model.generateSlug(User, this.get('slug') || this.get('name'),
-                {transacting: options.transacting, shortSlug: !this.get('slug')})
+                {status: 'all', transacting: options.transacting, shortSlug: !this.get('slug')})
                 .then(function (slug) {
                     self.set({slug: slug});
                 });

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -492,6 +492,27 @@ describe('Users API', function () {
                         done();
                     }).catch(done);
             });
+
+            it('Can add two users with the same local-part in their email addresses', function (done) {
+                newUser.roles = [roleIdFor.author];
+
+                UserAPI.add({users: [newUser]}, _.extend({}, context.owner, {include: 'roles'}))
+                    .then(function (response) {
+                        checkAddResponse(response);
+                        response.users[0].id.should.eql(8);
+                        response.users[0].roles[0].name.should.equal('Author');
+                    }).then(function () {
+                        newUser.email = newUser.email.split('@')[0] + '@someotherdomain.com';
+                        return UserAPI.add({users: [newUser]}, _.extend({}, context.owner, {include: 'roles'}))
+                            .then(function (response) {
+                                checkAddResponse(response);
+                                response.users[0].id.should.eql(9);
+                                response.users[0].roles[0].name.should.equal('Author');
+
+                                done();
+                            });
+                    }).catch(done);
+            });
         });
 
         describe('Editor', function () {


### PR DESCRIPTION
No Issue
- Set 'status: all` when calling generateSlug from the user model
  so that all user slugs are checked for duplicates instead of
  only active users.

Error can be reproduced by inviting a user (`user@example.com`) and then inviting another user that shares the same local-part with the first user's email address (e.g., `user@example.net`).  Currently only "active" user slugs are checked for duplicates, so both users will end up with the same slug and the second invitation will cause an error.
