### PR TITLE
Fix time-zone related test failures.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -770,6 +770,9 @@ var _              = require('lodash'),
             function () {
                 process.env.NODE_ENV = process.env.TRAVIS ? process.env.NODE_ENV : 'testing';
                 cfg.express.test.options.node_env = process.env.NODE_ENV;
+
+                // Always run tests in the UTC time zone for consistent results
+                process.env.TZ = 'UTC';
             });
 
         // #### Ensure Config *(Utility Task)*


### PR DESCRIPTION
Before this patch, I was getting a test failure like this:

```
AssertionError: expected 1419008400000 to equal 1418990400000
```

The two numbers above represent timestamps in the epoch format that are exactly
5 hours apart from each other-- the difference from laptop's native time zone
compared to UTC.

After explicitly setting the time zone to UTC, the tests pass as expected.

This issue may not manifest itself on Travis, or Vagrant Linux VMs on Mac,
which may already be natively running in UTC.

The patch only affects the tests running and doesn't affect the time zone
setting for the running application.
