### PR TITLE
Fixup finding user by role name

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -357,7 +357,10 @@ User = ghostBookshelf.Model.extend({
      */
     findOne: function (data, options) {
         var query,
-            status;
+            status,
+            lookupRole = data.role;
+
+        delete data.role;
 
         data = _.extend({
             status: 'active'
@@ -370,17 +373,19 @@ User = ghostBookshelf.Model.extend({
         options.withRelated = _.union(options.withRelated, options.include);
 
         // Support finding by role
-        if (data.role) {
-            options.withRelated = [{
-                roles: function (qb) {
-                    qb.where('name', data.role);
-                }
-            }];
-            delete data.role;
-        }
+        if (lookupRole) {
+            options.withRelated = _.union(options.withRelated, ['roles']);
+            options.include = _.union(options.include, ['roles']);
 
-        // We pass include to forge so that toJSON has access
-        query = this.forge(data, {include: options.include});
+            query = this.forge(data, {include: options.include});
+
+            query.query('join', 'roles_users', 'users.id', '=', 'roles_users.id');
+            query.query('join', 'roles', 'roles_users.role_id', '=', 'roles.id');
+            query.query('where', 'roles.name', '=', lookupRole);
+        } else {
+            // We pass include to forge so that toJSON has access
+            query = this.forge(data, {include: options.include});
+        }
 
         data = this.filterData(data);
 

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -301,6 +301,29 @@ describe('User Model', function run() {
             }).catch(done);
         });
 
+        it('can findOne by role name', function (done) {
+            return testUtils.fixtures.createExtraUsers().then(function () {
+                return Promise.join(UserModel.findOne({role: 'Owner'}), UserModel.findOne({role: 'Editor'}));
+            }).then(function (results) {
+                var owner = results[0],
+                    editor = results[1];
+
+                should.exist(owner);
+                should.exist(editor);
+
+                owner = owner.toJSON();
+                editor = editor.toJSON();
+
+                should.exist(owner.roles);
+                should.exist(editor.roles);
+
+                owner.roles[0].name.should.equal('Owner');
+                editor.roles[0].name.should.equal('Editor');
+
+                done();
+            }).catch(done);
+        });
+
         it('can edit', function (done) {
             var firstUser = 1;
 


### PR DESCRIPTION
No Issue.
- Build up query object to lookup a user by the name of a role.  Return user with "roles" objects included.
- Add test for findOne by role.
