### PR TITLE
Format database-related error responses

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -193,6 +193,15 @@ errors = {
             return this.rejectError(error);
         }
 
+        // handle database errors
+        if (error.code && (error.errno || error.detail)) {
+            error.db_error_code = error.code;
+            error.type = 'DatabaseError';
+            error.code = 500;
+
+            return this.rejectError(error);
+        }
+
         return this.rejectError(new this.InternalServerError(error));
     },
 


### PR DESCRIPTION
Closes #4735
- Shows error message on client instead of "[object Object]".
- Server log shows error message instead of uknown error.
