### PR TITLE
Make preview URLs include trailing slash when slug is given

### DIFF
--- a/core/client/components/gh-url-preview.js
+++ b/core/client/components/gh-url-preview.js
@@ -18,7 +18,7 @@ var urlPreview = Ember.Component.extend({
             slug = this.get('slug') ? this.get('slug') : '',
 
             // Join parts of the URL together with slashes
-            theUrl = noSchemeBlogUrl + '/' + prefix + slug;
+            theUrl = noSchemeBlogUrl + '/' + prefix + (slug ? slug + '/' : '');
 
         this.set('the-url', theUrl);
     }.on('didInsertElement').observes('slug')


### PR DESCRIPTION
- the trailing slash isn't shown usually
- slash added when a slug is given to be more correct
