### PR TITLE
Remove jshint rules that are no longer supported

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
       "node": true,
       "browser": false,
-      "nomen": false,
       "strict": false,
       "sub": true,
       "eqeqeq": true,
@@ -19,9 +18,6 @@
       "regexp": true,
       "undef": true,
       "unused": true,
-      "trailing": true,
       "indent": 4,
-      "onevar": true,
-      "white": true,
       "predef": [ "-Promise" ]
 }

--- a/core/client/.jshintrc
+++ b/core/client/.jshintrc
@@ -1,7 +1,6 @@
 {
     "node": false,
     "browser": true,
-    "nomen": false,
     "bitwise": true,
     "curly": true,
     "eqeqeq": true,
@@ -16,11 +15,8 @@
     "regexp": true,
     "undef": true,
     "unused": true,
-    "trailing": true,
     "indent": 4,
     "esnext": true,
-    "onevar": true,
-    "white": true,
     "quotmark": "single",
     "globals": {
         "Ember": true,
@@ -32,5 +28,6 @@
         "ic": true,
         "NProgress": true,
         "moment": true
-    }
+    },
+    "predef": ["-Notification"]
 }

--- a/core/test/.jshintrc
+++ b/core/test/.jshintrc
@@ -1,7 +1,6 @@
 {
       "node": true,
       "browser": true,
-      "nomen": false,
       "strict": false,
       "sub": true,
       "eqeqeq": true,
@@ -19,10 +18,7 @@
       "regexp": true,
       "undef": true,
       "unused": true,
-      "trailing": true,
       "indent": 4,
-      "onevar": true,
-      "white": true,
       "quotmark": "single",
       "predef": [ "-Promise" ]
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "grunt-contrib-compress": "~0.11.0",
         "grunt-contrib-concat": "~0.5.0",
         "grunt-contrib-copy": "~0.5.0",
-        "grunt-contrib-jshint": "~0.10.0",
+        "grunt-contrib-jshint": "~0.11.0",
         "grunt-contrib-uglify": "~0.6.0",
         "grunt-contrib-watch": "~0.6.1",
         "grunt-docker": "~0.0.8",


### PR DESCRIPTION
No Issue
- grunt-contrib-jshint@0.11.0.
- remove error about browser global Notification being redefined.
