### PR TITLE
Assign a higher priority to featured posts in the sitemap

### DIFF
--- a/core/server/data/sitemap/post-generator.js
+++ b/core/server/data/sitemap/post-generator.js
@@ -36,9 +36,9 @@ _.extend(PostMapGenerator.prototype, {
         return config.urlFor('post', {post: post, permalinks: permalinks}, true);
     },
 
-    getPriorityForDatum: function () {
-        // TODO: We could influence this with meta information
-        return 0.8;
+    getPriorityForDatum: function (post) {
+        // give a slightly higher priority to featured posts
+        return post.featured ? 0.9 : 0.8;
     },
 
     createUrlNodeFromDatum: function (datum) {

--- a/core/test/integration/sitemap_spec.js
+++ b/core/test/integration/sitemap_spec.js
@@ -415,10 +415,20 @@ describe('Sitemap', function () {
         });
 
         describe('PostGenerator', function () {
-            it('uses 0.8 priority for all posts', function () {
+            it('uses 0.9 priority for featured posts', function () {
                 var generator = new PostGenerator();
 
-                generator.getPriorityForDatum({}).should.equal(0.8);
+                generator.getPriorityForDatum({
+                    featured: true
+                }).should.equal(0.9);
+            });
+
+            it('uses 0.8 priority for all other (non-featured) posts', function () {
+                var generator = new PostGenerator();
+
+                generator.getPriorityForDatum({
+                    featured: false
+                }).should.equal(0.8);
             });
 
             it('adds an image:image element if post has a cover image', function () {


### PR DESCRIPTION
Closes #4792
- Made priority be 0.8 (as it currently is) for standard posts
- Made featured posts have a priority of 0.9
- Split the current test into two to check both above scenarios
