### PR TITLE
Fix {{meta_description}} within {{#foreach posts}}

### DIFF
--- a/core/server/helpers/meta_description.js
+++ b/core/server/helpers/meta_description.js
@@ -15,7 +15,9 @@ meta_description = function () {
     var description,
         blog;
 
-    if (_.isString(this.relativeUrl)) {
+    if (_.isUndefined(this.relativeUrl)) {
+        description = this.meta_description;
+    } else if (_.isString(this.relativeUrl)) {
         blog = config.theme;
         if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
             description = blog.description;

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -123,4 +123,14 @@ describe('{{meta_description}} helper', function () {
             done();
         }).catch(done);
     });
+
+    it('returns meta_description when used within {{#foreach posts}}', function (done) {
+        var post = {meta_description: 'Nice post with nice content.'};
+        helpers.meta_description.call(post).then(function (rendered) {
+            should.exist(rendered);
+            String(rendered).should.equal('Nice post with nice content.');
+
+            done();
+        }).catch(done);
+    });
 });


### PR DESCRIPTION
closes #4850
- use `this.meta_descrption` if possible. This is the case when being used within `{{#foreach posts}}` where `this` already refers to the current post
