### PR TITLE
Set 'value' property before a dependent CP is used

### DIFF
--- a/core/client/components/gh-navitem-url-input.js
+++ b/core/client/components/gh-navitem-url-input.js
@@ -27,13 +27,13 @@ var NavItemUrlInputComponent = Ember.TextField.extend({
         var url = this.get('url'),
             baseUrl = this.get('baseUrl');
 
+        this.set('value', url);
+
         // if we have a relative url, create the absolute url to be displayed in the input
         if (this.get('isRelative')) {
             url = joinUrlParts(baseUrl, url);
+            this.set('value', url);
         }
-
-        this.set('value', url);
-        this.sendAction('change', this.get('value'));
     },
 
     focusIn: function (event) {


### PR DESCRIPTION
No issue.
- Make sure value property has been set before computed
  property isRelative is referenced.
