### PR TITLE
Fix layout error when there's no user name

### DIFF
--- a/core/client/templates/settings/users/user.hbs
+++ b/core/client/templates/settings/users/user.hbs
@@ -1,4 +1,4 @@
-<header class="settings-subview-header">
+<header class="settings-subview-header clearfix">
     {{#unless session.user.isAuthor}}
         {{#link-to "settings.users" class="btn btn-default btn-back" tagName="button"}}<i class="icon-chevron-left"></i>Users{{/link-to}}
     {{/unless}}


### PR DESCRIPTION
No issue
- Adds a clearfix to the user settings header to prevent a broken layout when there's no name.

![oops](https://cloud.githubusercontent.com/assets/390392/5942048/f01307a6-a70c-11e4-9f55-1ceba71184e3.gif)
