### PR TITLE
Move bottom notifications outlet outside of <main>

### DIFF
--- a/core/client/assets/sass/components/notifications.scss
+++ b/core/client/assets/sass/components/notifications.scss
@@ -20,26 +20,14 @@
         left: 0;
         right: 0;
         z-index: 9999;
-        transition: transform $settings-menu-transition cubic-bezier($settings-menu-bezier);
-
-        // This selector ends up being `body.settings-menu-expanded .notifications`
-        body.settings-menu-expanded & {
-            transform: translate3d(100%, 0px, 0px);
-        }
     }
 
     @media (min-width: 401px) {
         position: absolute;
         bottom: 0;
         left: 0;
-        z-index: 980;
+        z-index: 800;
         width: 300px;
-        transition: transform $settings-menu-transition cubic-bezier($settings-menu-bezier);
-
-        // This selector ends up being `body.settings-menu-expanded .notifications`
-        body.settings-menu-expanded & {
-            transform: translate3d(350px, 0px, 0px);
-        }
     }
 }//.notifications
 

--- a/core/client/templates/application.hbs
+++ b/core/client/templates/application.hbs
@@ -6,9 +6,10 @@
 
 <main id="gh-main" class="viewport" role="main" {{bind-attr data-notification-count=topNotificationCount}}>
     {{gh-notifications location="top" notify="topNotificationChange"}}
-    {{gh-notifications location="bottom"}}
     {{outlet}}
 </main>
+
+{{gh-notifications location="bottom"}}
 
 {{outlet "modal"}}
 


### PR DESCRIPTION
Closes #4379
- Moves the bottom notification outlet _outside_ the `<main>` element which allows notifications to show above the nav bar
- Removes (the now unnecessary) code which counter-positioned the bottom notifications when a Settings Menu was opened.

The way these notifications look or are positioned at various viewport sizes **has not changed**.
