### PR TITLE
Do not add autofocus attribute unless set to focus

### DIFF
--- a/core/client/components/gh-trim-focus-input.js
+++ b/core/client/components/gh-trim-focus-input.js
@@ -5,16 +5,20 @@ var TrimFocusInput = Ember.TextField.extend({
     attributeBindings: ['autofocus'],
 
     autofocus: Ember.computed(function () {
-        return (device.ios()) ? false : 'autofocus';
+        if (this.get('focus')) {
+            return (device.ios()) ? false : 'autofocus';
+        }
+
+        return false;
     }),
 
-    setFocus: function () {
+    didInsertElement: function () {
         // This fix is required until Mobile Safari has reliable
         // autofocus, select() or focus() support
-        if (this.focus && !device.ios()) {
+        if (this.get('focus') && !device.ios()) {
             this.$().val(this.$().val()).focus();
         }
-    }.on('didInsertElement'),
+    },
 
     focusOut: function () {
         var text = this.$().val();

--- a/core/test/client/unit/components/gh-trim-focus-input_test.js
+++ b/core/test/client/unit/components/gh-trim-focus-input_test.js
@@ -15,4 +15,26 @@ describeComponent('gh-trim-focus-input', function () {
         component.$().focusout();
         expect(component.$().val()).to.equal('some random stuff');
     });
+
+    it('does not have the autofocus attribute if not set to focus', function () {
+        var component = this.subject({
+            value: 'some text',
+            focus: false
+        });
+
+        this.render();
+
+        expect(component.$().attr('autofocus')).to.not.be.ok;
+    });
+
+    it('has the autofocus attribute if set to focus', function () {
+        var component = this.subject({
+            value: 'some text',
+            focus: true
+        });
+
+        this.render();
+
+        expect(component.$().attr('autofocus')).to.be.ok;
+    });
 });


### PR DESCRIPTION
No Issue
- Don't add the "autofocus" attribute to the input element unless the "focus" property is set to true.

You can see the autofocus attribute causing trouble by reloading the app and opening the editor (or reloading on the editor screen).  The autofocus attribute causes the title input to be focused when the template is first rendered.
