### PR TITLE
Ignore non-words in word counter

### DIFF
--- a/core/client/utils/word-count.js
+++ b/core/client/utils/word-count.js
@@ -1,11 +1,13 @@
 // jscs: disable
 function wordCount(s) {
-    s = s.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
-    s = s.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
-    s = s.replace(/\n /gi, '\n'); // exclude newline with a start spacing
-    s = s.replace(/\n+/gi, '\n');
+    s = s.replace(/<(.|\n)*?>/g, ' '); // strip tags
+    s = s.replace(/[^\w\s]/g, ''); // ignore non-alphanumeric letters
+    s = s.replace(/(^\s*)|(\s*$)/gi, ''); // exclude starting and ending white-space
+    s = s.replace(/\n /gi, ' '); // convert newlines to spaces
+    s = s.replace(/\n+/gi, ' ');
+    s = s.replace(/[ ]{2,}/gi, ' '); // convert 2 or more spaces to 1
 
-    return s.split(/ |\n/).length;
+    return s.split(' ').length;
 }
 
 export default wordCount;


### PR DESCRIPTION
Refer to #4714

This makes three changes to the word counter:
1) Anything inside brackets (like html tags) don't contribute to the word count.
2) Words without alphanumeric characters in them don't count (This means markdown syntax should effectively be ignored)
3) I noticed an issue where if you typed a word, hit the spacebar once, hit enter once, and then typed another word, it would count an extra word since the string is split on both spaces and newlines. This is fixed now.
