### PR TITLE
Update grunt-sass to 0.17.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -347,7 +347,7 @@ var _              = require('lodash'),
             sass: {
                 compress: {
                     options: {
-                        outputStyle: 'nested', // TODO: Set back to 'compressed' working correctly with our dependencies
+                        outputStyle: 'compressed',
                         sourceMap: true
                     },
                     files: [

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "grunt-express-server": "~0.4.19",
         "grunt-jscs": "~1.2.0",
         "grunt-mocha-cli": "~1.11.0",
-        "grunt-sass": "~0.16.1",
+        "grunt-sass": "~0.17.0",
         "grunt-shell": "~1.1.1",
         "grunt-update-submodules": "~0.4.1",
         "matchdep": "~0.3.0",


### PR DESCRIPTION
No issue
- Allows us to use Sass Maps
- Fixes the 'compressed' output style, so we can have minified code again!

Side note: This takes our final CSS file from 160kb to 119kb :grinning: 
