### PR TITLE
New Content Helper - Post cut (preview)

### DIFF
--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -1,10 +1,11 @@
 // # Content Helper
-// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}}`
+// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}},  `{{content preview="true"}}``
 //
 // Turns content html into a safestring so that the user doesn't have to
 // escape it or tell handlebars to leave it alone with a triple-brace.
 //
 // Enables tag-safe truncation of content by characters or words.
+// 
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
@@ -14,7 +15,7 @@ var hbs             = require('express-hbs'),
 
 content = function (options) {
     var truncateOptions = (options || {}).hash || {};
-    truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
+    truncateOptions = _.pick(truncateOptions, ['words', 'characters', 'preview']);
     _.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
@@ -30,6 +31,13 @@ content = function (options) {
         return new hbs.handlebars.SafeString(
             downsize(this.html, truncateOptions)
         );
+    } else if (truncateOptions.hasOwnProperty('preview')) {
+        var split = this.html.split('<!--preview-->', 2)
+        var output = split[0]
+        if (split[1]) {
+            output += '<div class="continue"></div>'
+        }
+        return new hbs.handlebars.SafeString(output)
     }
 
     return new hbs.handlebars.SafeString(this.html);


### PR DESCRIPTION
Yet another way to cut content. This way is used on most popular russain IT collective blog Habrahabr.ru. It's very handy if you need to cut conent and don't use post preview image feature in Ghost 0.5+. So, now you can save any image in posts list and use unique image in header on post page (like at the Medium).

Example http://ipestov.com (Ghost version 4.2). 

Author of this idea - http://spiralcodestudio.com/manual-post-cut-for-ghost/
