### PR TITLE
Retry API request when buildAboutPage gets 202

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1043,7 +1043,8 @@ var _              = require('lodash'),
                     repo: 'ghost',
                     oauthKey: oauthKey,
                     releaseDate: ninetyDaysAgo,
-                    count: 20
+                    count: 20,
+                    retry: true
                 })
             ).then(function (results) {
                 var contributors = results[1],

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
         "sinon": "~1.12.2",
         "supertest": "~0.15.0",
         "testem": "^0.6.23",
-        "top-gh-contribs": "0.0.6"
+        "top-gh-contribs": "^1.0.0"
     }
 }


### PR DESCRIPTION
No Issue.
- top-gh-contribs@1.0.0.
- Enable 'retry' option which will retry the GitHub API request
  in the event it receives a status of 202 (retry momentarily).
