### PR TITLE
Update Ember to 1.10.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -380,6 +380,9 @@ var _              = require('lodash'),
             emberTemplates: {
                 dev: {
                     options: {
+                        templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
+                        handlebarsPath: 'bower_components/handlebars/handlebars.js',
+                        templateNamespace: 'HTMLBars',
                         templateBasePath: /core\/client\//,
                         templateFileExtensions: /\.hbs/,
                         templateRegistration: function (name, template) {
@@ -395,6 +398,9 @@ var _              = require('lodash'),
 
                 prod: {
                     options: {
+                        templateCompilerPath: 'bower_components/ember/ember-template-compiler.js',
+                        handlebarsPath: 'bower_components/handlebars/handlebars.js',
+                        templateNamespace: 'HTMLBars',
                         templateBasePath: /core\/client\//,
                         templateFileExtensions: /\.hbs/,
                         templateRegistration: function (name, template) {
@@ -571,8 +577,7 @@ var _              = require('lodash'),
                     src: [
                         'bower_components/loader.js/loader.js',
                         'bower_components/jquery/dist/jquery.js',
-                        'bower_components/handlebars/handlebars.js',
-                        'bower_components/ember/ember.js',
+                        'bower_components/ember/ember.debug.js',
                         'bower_components/ember-data/ember-data.js',
                         'bower_components/ember-resolver/dist/ember-resolver.js',
                         'bower_components/ic-ajax/dist/globals/main.js',
@@ -608,7 +613,6 @@ var _              = require('lodash'),
                     src: [
                         'bower_components/loader.js/loader.js',
                         'bower_components/jquery/dist/jquery.js',
-                        'bower_components/handlebars/handlebars.runtime.js',
                         'bower_components/ember/ember.prod.js',
                         'bower_components/ember-data/ember-data.prod.js',
                         'bower_components/ember-resolver/dist/ember-resolver.js',

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "codemirror": "4.0.1",
     "Countable": "2.0.2",
     "device": "git://github.com/matthewhudson/device.js#5347a275b66020a0d4dfe9aad81a488f8cce448d",
-    "ember": "1.9.0",
+    "ember": "1.10.0",
     "ember-data": "1.0.0-beta.14.1",
     "ember-load-initializers": "git://github.com/stefanpenner/ember-load-initializers.git#0.0.1",
     "ember-resolver": "git://github.com/stefanpenner/ember-jj-abrams-resolver.git#181251821cf513bb58d3e192faa13245a816f75e",

--- a/core/client/components/gh-uploader.js
+++ b/core/client/components/gh-uploader.js
@@ -3,6 +3,10 @@ import uploader from 'ghost/assets/lib/uploader';
 var PostImageUploader = Ember.Component.extend({
     classNames: ['image-uploader', 'js-post-image-upload'],
 
+    imageSource: Ember.computed('image', function () {
+        return this.get('image') || '';
+    }),
+
     setup: function () {
         var $this = this.$(),
             self = this;

--- a/core/client/controllers/post-settings-menu.js
+++ b/core/client/controllers/post-settings-menu.js
@@ -126,7 +126,7 @@ var PostSettingsMenuController = Ember.Controller.extend(SettingsMenuMixin, {
         if (metaTitle.length > 70) {
             metaTitle = metaTitle.substring(0, 70).trim();
             metaTitle = Ember.Handlebars.Utils.escapeExpression(metaTitle);
-            metaTitle = new Ember.Handlebars.SafeString(metaTitle + '&hellip;');
+            metaTitle = Ember.String.htmlSafe(metaTitle + '&hellip;');
         }
 
         return metaTitle;
@@ -162,7 +162,7 @@ var PostSettingsMenuController = Ember.Controller.extend(SettingsMenuMixin, {
             // Limit to 156 characters
             placeholder = placeholder.substring(0, 156).trim();
             placeholder = Ember.Handlebars.Utils.escapeExpression(placeholder);
-            placeholder = new Ember.Handlebars.SafeString(placeholder + '&hellip;');
+            placeholder = Ember.String.htmlSafe(placeholder + '&hellip;');
         }
 
         return placeholder;
@@ -180,7 +180,7 @@ var PostSettingsMenuController = Ember.Controller.extend(SettingsMenuMixin, {
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
-            seoURL = new Ember.Handlebars.SafeString(seoURL + '&hellip;');
+            seoURL = Ember.String.htmlSafe(seoURL + '&hellip;');
         }
 
         return seoURL;

--- a/core/client/controllers/post-tags-input.js
+++ b/core/client/controllers/post-tags-input.js
@@ -234,7 +234,7 @@ var PostTagsInputController = Ember.Controller.extend({
             suggestion = Ember.Object.create();
 
         highlightedName = tagName.replace(regex, '<mark>$1</mark>');
-        highlightedName = new Ember.Handlebars.SafeString(highlightedName);
+        highlightedName = Ember.String.htmlSafe(highlightedName);
 
         suggestion.set('tag', matchingTag);
         suggestion.set('highlightedName', highlightedName);

--- a/core/client/controllers/settings/general.js
+++ b/core/client/controllers/settings/general.js
@@ -1,6 +1,14 @@
 var SettingsGeneralController = Ember.Controller.extend({
     selectedTheme: null,
 
+    logoImageSource: Ember.computed('model.logo', function () {
+        return this.get('model.logo') || '';
+    }),
+
+    coverImageSource: Ember.computed('model.cover', function () {
+        return this.get('model.cover') || '';
+    }),
+
     isDatedPermalinks: Ember.computed('model.permalinks', function (key, value) {
         // setter
         if (arguments.length > 1) {

--- a/core/client/controllers/settings/tags.js
+++ b/core/client/controllers/settings/tags.js
@@ -52,7 +52,7 @@ var TagsController = Ember.ArrayController.extend(PaginationMixin, SettingsMenuM
         if (metaTitle && metaTitle.length > 70) {
             metaTitle = metaTitle.substring(0, 70).trim();
             metaTitle = Ember.Handlebars.Utils.escapeExpression(metaTitle);
-            metaTitle = new Ember.Handlebars.SafeString(metaTitle + '&hellip;');
+            metaTitle = Ember.String.htmlSafe(metaTitle + '&hellip;');
         }
 
         return metaTitle;
@@ -70,7 +70,7 @@ var TagsController = Ember.ArrayController.extend(PaginationMixin, SettingsMenuM
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
-            seoURL = new Ember.Handlebars.SafeString(seoURL + '&hellip;');
+            seoURL = Ember.String.htmlSafe(seoURL + '&hellip;');
         }
 
         return seoURL;
@@ -84,7 +84,7 @@ var TagsController = Ember.ArrayController.extend(PaginationMixin, SettingsMenuM
         if (metaDescription && metaDescription.length > 156) {
             metaDescription = metaDescription.substring(0, 156).trim();
             metaDescription = Ember.Handlebars.Utils.escapeExpression(metaDescription);
-            metaDescription = new Ember.Handlebars.SafeString(metaDescription + '&hellip;');
+            metaDescription = Ember.String.htmlSafe(metaDescription + '&hellip;');
         }
 
         return metaDescription;

--- a/core/client/helpers/gh-blog-url.js
+++ b/core/client/helpers/gh-blog-url.js
@@ -1,5 +1,5 @@
-var blogUrl = Ember.Handlebars.makeBoundHelper(function () {
-    return new Ember.Handlebars.SafeString(this.get('config.blogUrl'));
+var blogUrl = Ember.HTMLBars.makeBoundHelper(function () {
+    return Ember.String.htmlSafe(this.get('config.blogUrl'));
 });
 
 export default blogUrl;

--- a/core/client/helpers/gh-count-characters.js
+++ b/core/client/helpers/gh-count-characters.js
@@ -1,6 +1,14 @@
-var countCharacters = Ember.Handlebars.makeBoundHelper(function (content) {
+var countCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     var el = document.createElement('span'),
-        length = content ? content.length : 0;
+        length,
+        content;
+
+    if (!arr || !arr.length) {
+        return;
+    }
+
+    content = arr[0] || '';
+    length = content.length;
 
     el.className = 'word-count';
 
@@ -12,7 +20,7 @@ var countCharacters = Ember.Handlebars.makeBoundHelper(function (content) {
 
     el.innerHTML = 200 - length;
 
-    return new Ember.Handlebars.SafeString(el.outerHTML);
+    return Ember.String.htmlSafe(el.outerHTML);
 });
 
 export default countCharacters;

--- a/core/client/helpers/gh-count-down-characters.js
+++ b/core/client/helpers/gh-count-down-characters.js
@@ -1,6 +1,16 @@
-var countDownCharacters = Ember.Handlebars.makeBoundHelper(function (content, maxCharacters) {
+var countDownCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     var el = document.createElement('span'),
-        length = content ? content.length : 0;
+        content,
+        maxCharacters,
+        length;
+
+    if (!arr || arr.length < 2) {
+        return;
+    }
+
+    content = arr[0] || '';
+    maxCharacters = arr[1];
+    length = content.length;
 
     el.className = 'word-count';
 
@@ -12,7 +22,7 @@ var countDownCharacters = Ember.Handlebars.makeBoundHelper(function (content, ma
 
     el.innerHTML = length;
 
-    return new Ember.Handlebars.SafeString(el.outerHTML);
+    return Ember.String.htmlSafe(el.outerHTML);
 });
 
 export default countDownCharacters;

--- a/core/client/helpers/gh-count-words.js
+++ b/core/client/helpers/gh-count-words.js
@@ -1,11 +1,20 @@
 import counter from 'ghost/utils/word-count';
 
-var countWords = Ember.Handlebars.makeBoundHelper(function (markdown) {
+var countWords = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+    if (!arr || !arr.length) {
+        return;
+    }
+
+    var markdown,
+        count;
+
+    markdown = arr[0] || '';
+
     if (/^\s*$/.test(markdown)) {
         return '0 words';
     }
 
-    var count = counter(markdown || '');
+    count = counter(markdown);
 
     return count + (count === 1 ? ' word' : ' words');
 });

--- a/core/client/helpers/gh-format-html.js
+++ b/core/client/helpers/gh-format-html.js
@@ -1,8 +1,12 @@
-/* global Handlebars, html_sanitize*/
+/* global html_sanitize*/
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-var formatHTML = Ember.Handlebars.makeBoundHelper(function (html) {
-    var escapedhtml = html || '';
+var formatHTML = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+    if (!arr || !arr.length) {
+        return;
+    }
+
+    var escapedhtml = arr[0] || '';
 
     // replace script and iFrame
     escapedhtml = escapedhtml.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
@@ -15,7 +19,7 @@ var formatHTML = Ember.Handlebars.makeBoundHelper(function (html) {
     escapedhtml = html_sanitize(escapedhtml, cajaSanitizers.url, cajaSanitizers.id);
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
-    return new Handlebars.SafeString(escapedhtml);
+    return Ember.String.htmlSafe(escapedhtml);
 });
 
 export default formatHTML;

--- a/core/client/helpers/gh-format-markdown.js
+++ b/core/client/helpers/gh-format-markdown.js
@@ -1,4 +1,4 @@
-/* global Showdown, Handlebars, html_sanitize*/
+/* global Showdown, html_sanitize*/
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
 var showdown,
@@ -6,11 +6,16 @@ var showdown,
 
 showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
 
-formatMarkdown = Ember.Handlebars.makeBoundHelper(function (markdown) {
-    var escapedhtml = '';
+formatMarkdown = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+    if (!arr || !arr.length) {
+        return;
+    }
+
+    var escapedhtml = '',
+        markdown = arr[0] || '';
 
     // convert markdown to HTML
-    escapedhtml = showdown.makeHtml(markdown || '');
+    escapedhtml = showdown.makeHtml(markdown);
 
     // replace script and iFrame
     escapedhtml = escapedhtml.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
@@ -23,7 +28,7 @@ formatMarkdown = Ember.Handlebars.makeBoundHelper(function (markdown) {
     escapedhtml = html_sanitize(escapedhtml, cajaSanitizers.url, cajaSanitizers.id);
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
-    return new Handlebars.SafeString(escapedhtml);
+    return Ember.String.htmlSafe(escapedhtml);
 });
 
 export default formatMarkdown;

--- a/core/client/helpers/gh-format-timeago.js
+++ b/core/client/helpers/gh-format-timeago.js
@@ -1,5 +1,10 @@
-/* global moment */
-var formatTimeago = Ember.Handlebars.makeBoundHelper(function (timeago) {
+var formatTimeago = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+    if (!arr || !arr.length) {
+        return;
+    }
+
+    var timeago = arr[0];
+
     return moment(timeago).fromNow();
     // stefanpenner says cool for small number of timeagos.
     // For large numbers moment sucks => single Ember.Object based clock better

--- a/core/client/helpers/gh-path.js
+++ b/core/client/helpers/gh-path.js
@@ -47,7 +47,7 @@ function ghostPathsHelper(path, url) {
         base = base + url;
     }
 
-    return new Ember.Handlebars.SafeString(base);
+    return Ember.String.htmlSafe(base);
 }
 
 export default ghostPathsHelper;

--- a/core/client/templates/components/gh-uploader.hbs
+++ b/core/client/templates/components/gh-uploader.hbs
@@ -1,6 +1,6 @@
 <span class="media">
     <span class="hidden">Image Upload</span>
 </span>
-<img class="js-upload-target" {{bind-attr src=image}}>
+<img class="js-upload-target" {{bind-attr src=imageSource}} />
 <div class="description">{{description}}<strong></strong></div>
 <input data-url="upload" class="js-fileupload main fileupload" type="file" name="uploadimage">

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "grunt-contrib-uglify": "~0.6.0",
         "grunt-contrib-watch": "~0.6.1",
         "grunt-docker": "~0.0.8",
-        "grunt-ember-templates": "~0.5.0-alpha",
+        "grunt-ember-templates": "dgeb/grunt-ember-templates#88594c6",
         "grunt-es6-module-transpiler": "~0.6.0",
         "grunt-express-server": "~0.4.19",
         "grunt-jscs": "~1.2.0",


### PR DESCRIPTION
No issue.
- Ember@1.10.0
- Update grunt-ember-templates to version that supports HTMLBars.
- Update Gruntfile.js to compile templates with HTMLBars.
- Convert Handlebars code to its HTMLBars equivalent.
