### PR TITLE
Add Post Image to RSS Feed

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -510,6 +510,11 @@ frontendControllers = {
                             },
                             htmlContent = cheerio.load(post.html, {decodeEntities: false});
 
+                        if (post.image) {
+                            htmlContent('p').first().before('<img src="' + post.image + '" />');
+                            htmlContent('img').attr('alt', post.title);
+                        }
+
                         // convert relative resource urls to absolute
                         ['href', 'src'].forEach(function (attributeName) {
                             htmlContent('[' + attributeName + ']').each(function (ix, el) {


### PR DESCRIPTION
Closes #4888
- If a post cover image exists, it is added to the `description` tag (at the very front). This allows RSS readers to pic up the picture.

(You guys might not want this, in which case you can just throw it away. I like the idea of a post cover image and it's a super small fix, which is why I made it :smiley:)
