### PR TITLE
Removes deprecated body classes

### DIFF
--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -32,20 +32,14 @@ body_class = function () {
 
     if (_.isString(this.relativeUrl) && this.relativeUrl.match(/\/(page\/\d)/)) {
         classes.push('paged');
-        // To be removed from pages by #2597 when we're ready to deprecate this
-        classes.push('archive-template');
     } else if (!this.relativeUrl || this.relativeUrl === '/' || this.relativeUrl === '') {
         classes.push('home-template');
-    } else if (post) {
-        // To be removed from pages by #2597 when we're ready to deprecate this
-        // i.e. this should be if (post && !page) { ... }
+    } else if (post && !page) {
         classes.push('post-template');
     }
 
     if (page) {
         classes.push('page-template');
-        // To be removed by #2597 when we're ready to deprecate this
-        classes.push('page');
     }
 
     if (tags) {
@@ -61,9 +55,6 @@ body_class = function () {
             view = template.getThemeViewForPost(paths, post).split('-');
 
             if (view[0] === 'page' && view.length > 1) {
-                classes.push(view.join('-'));
-                // To be removed by #2597 when we're ready to deprecate this
-                view.splice(1, 0, 'template');
                 classes.push(view.join('-'));
             }
         }

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -77,11 +77,11 @@ describe('{{body_class}} helper', function () {
 
             rendered[0].string.should.equal('home-template');
             rendered[1].string.should.equal('post-template');
-            rendered[2].string.should.equal('paged archive-template');
+            rendered[2].string.should.equal('paged');
             rendered[3].string.should.equal('tag-template tag-foo');
-            rendered[4].string.should.equal('tag-template tag-foo paged archive-template');
+            rendered[4].string.should.equal('tag-template tag-foo paged');
             rendered[5].string.should.equal('author-template author-bar');
-            rendered[6].string.should.equal('author-template author-bar paged archive-template');
+            rendered[6].string.should.equal('author-template author-bar paged');
 
             done();
         }).catch(done);
@@ -111,7 +111,7 @@ describe('{{body_class}} helper', function () {
             }
         }).then(function (rendered) {
             should.exist(rendered);
-            rendered.string.should.equal('post-template page-template page page-about page-template-about');
+            rendered.string.should.equal('post-template page-template page page-about');
 
             done();
         }).catch(done);


### PR DESCRIPTION
closes #2597
- removed archive-template from body_class.js
- removed archive-template spec from body_class_spec.js
- removed page-template-about spec from body_class_spec.js

Remove missed spec for archive-template

Remove missed spec for archive-template
