### PR TITLE
Adjust reauth modal to handle removal of proxying

### DIFF
--- a/core/client/controllers/modals/signin.js
+++ b/core/client/controllers/modals/signin.js
@@ -1,7 +1,11 @@
-import SigninController from 'ghost/controllers/signin';
+import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default SigninController.extend({
+export default Ember.Controller.extend(SimpleAuth.AuthenticationControllerMixin, ValidationEngine, {
     needs: 'application',
+
+    authenticator: 'simple-auth-authenticator:oauth2-password-grant',
+
+    validationType: 'signin',
 
     identification: Ember.computed('session.user.email', function () {
         return this.get('session.user.email');
@@ -14,12 +18,31 @@ export default SigninController.extend({
 
             appController.set('skipAuthSuccessHandler', true);
 
-            this._super().then(function () {
+            this._super(this.getProperties('identification', 'password')).then(function () {
                 self.send('closeModal');
                 self.notifications.showSuccess('Login successful.');
                 self.set('password', '');
+            }).catch(function () {
+                // if authentication fails a rejected promise will be returned.
+                // it needs to be caught so it doesn't generate an exception in the console,
+                // but it's actually "handled" by the sessionAuthenticationFailed action handler.
             }).finally(function () {
                 appController.set('skipAuthSuccessHandler', undefined);
+            });
+        },
+
+        validateAndAuthenticate: function () {
+            var self = this;
+
+            // Manually trigger events for input fields, ensuring legacy compatibility with
+            // browsers and password managers that don't send proper events on autofill
+            $('#login').find('input').trigger('change');
+
+            this.validate({format: false}).then(function () {
+                self.notifications.closePassive();
+                self.send('authenticate');
+            }).catch(function (errors) {
+                self.notifications.showErrors(errors);
             });
         },
 

--- a/core/client/controllers/signin.js
+++ b/core/client/controllers/signin.js
@@ -11,8 +11,9 @@ var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControll
                 data = model.getProperties('identification', 'password');
 
             this._super(data).catch(function () {
-                // If simple-auth's authenticate rejects we need to catch it
-                // to avoid an unhandled rejection exception.
+                // if authentication fails a rejected promise will be returned.
+                // it needs to be caught so it doesn't generate an exception in the console,
+                // but it's actually "handled" by the sessionAuthenticationFailed action handler.
             });
         },
 


### PR DESCRIPTION
Closes #4907.
- The modal signin no longer inherits from the signin page
  controller to simplify the interaction with simple-auth.
