### PR TITLE
Fixed Bug Showing Full HTML Inside Code Block

### DIFF
--- a/core/shared/lib/showdown/extensions/ghostfootnotes.js
+++ b/core/shared/lib/showdown/extensions/ghostfootnotes.js
@@ -79,7 +79,20 @@ function replaceEndFootnotes(text, converter) {
                     }
 
                     // Extract pre blocks
+                    text = text.replace(/<(pre|code)>[\s\S]*?<\/(\1)>/gim, function (x) {
+                        var hash = hashId();
+                        preExtractions[hash] = x;
+                        return '{gfm-js-extract-pre-' + hash + '}';
+                    }, 'm');
+
                     text = text.replace(/```[\s\S]*?\n```/gim, function (x) {
+                        var hash = hashId();
+                        preExtractions[hash] = x;
+                        return '{gfm-js-extract-pre-' + hash + '}';
+                    }, 'm');
+
+                    // Extract code blocks
+                    text = text.replace(/`[\s\S]*?`/gim, function (x) {
                         var hash = hashId();
                         preExtractions[hash] = x;
                         return '{gfm-js-extract-pre-' + hash + '}';

--- a/core/test/unit/showdown_footnotes_spec.js
+++ b/core/test/unit/showdown_footnotes_spec.js
@@ -103,4 +103,40 @@ describe('Ghost footnotes showdown extension', function () {
 
         processedMarkup.should.match(testPhrase.output);
     });
+
+    it('should show markdown inside code block', function () {
+        var testPhrase = {
+            input: '<code>[^n]<\/code>',
+            output: '<code>[^n]<\/code>'
+        }, processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        processedMarkup.should.match(testPhrase.output);
+    });
+
+    it('should show markdown inside pre block', function () {
+        var testPhrase = {
+            input: '<pre>[^n]<\/pre>',
+            output: '<pre>[^n]<\/pre>'
+        }, processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        processedMarkup.should.match(testPhrase.output);
+    });
+
+    it('should show markdown inside single tick', function () {
+        var testPhrase = {
+            input: '`[^n]`',
+            output: '`[^n]`'
+        }, processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        processedMarkup.should.match(testPhrase.output);
+    });
+
+    it('should show markdown inside triple tick', function () {
+        var testPhrase = {
+            input: '```[^n]```',
+            output: '```[^n]```'
+        }, processedMarkup = _ConvertPhrase(testPhrase.input);
+
+        processedMarkup.should.match(testPhrase.output);
+    });
 });


### PR DESCRIPTION
Closes #4700 
- Added text.replace for `<pre>`, `<code>`, and single tick (`) which were missing
- Added tests for `<pre>, <code>, single tick, triple tick`
