### PR TITLE
Updates middleware to allow for public facing REST endpoints

### DIFF
--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -3,6 +3,7 @@
 // middleware_spec.js
 
 var _           = require('lodash'),
+    parse       = require('url').parse,
     express     = require('express'),
     busboy      = require('./ghost-busboy'),
     config      = require('../config'),
@@ -11,6 +12,11 @@ var _           = require('lodash'),
     passport    = require('passport'),
     errors      = require('../errors'),
     utils       = require('../utils'),
+    pathMatch   = require('path-match')({
+        sensitive: false,
+        strict: false,
+        end: true,
+    }),
 
     middleware,
     blogApp,
@@ -32,6 +38,40 @@ function cacheOauthServer(server) {
     oauthServer = server;
 }
 
+function inPublicPaths(req){
+    var path,
+        subPath,
+        ApiRouteBase = '/ghost/api/v0.1/';
+    ApiRouteBase = ApiRouteBase.substring(0, ApiRouteBase.length - 1);
+
+    var defaultPublicApi = {
+        '*': [
+            '/authentication/'
+        ],
+        'GET': [
+            '/posts/',
+            '/posts/:id',
+            '/posts/slug/:slugId',
+            '/users/:id',
+            '/users/slug/:slug',
+        ],
+    }
+    var publicPaths = _.extend({}, defaultPublicApi, config._config.publicApi);
+
+    // SubPath is the url path starting after any default subdirectories
+    // it is stripped of anything after the two levels `/ghost/.*?/` as the reset link has an argument
+    path = req.path;
+    /*jslint regexp:true, unparam:true*/
+    subPath = path.replace(/^(\/.*?\/.*?\/)(.*)?/, function (match, a) {
+        return a;
+    });
+
+    function passes(allowedPath){
+        return pathMatch(ApiRouteBase + allowedPath)(parse(req.url).pathname) !== false;
+    }
+    return _.any(publicPaths[req.method], passes) || _.any(publicPaths['*'], passes);
+}
+
 middleware = {
 
     // ### Authenticate Middleware
@@ -51,7 +91,7 @@ middleware = {
         });
 
         if (subPath.indexOf('/ghost/api/') === 0
-            && path.indexOf('/ghost/api/v0.1/authentication/') !== 0) {
+            && !inPublicPaths(req)) {
             return passport.authenticate('bearer', {session: false, failWithError: true},
                 function (err, user, info) {
                     if (err) {

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -45,14 +45,10 @@ function inPublicPaths(req){
     ApiRouteBase = ApiRouteBase.substring(0, ApiRouteBase.length - 1);
 
     var defaultPublicApi = {
-        '*': [
-            '/authentication/'
-        ],
         'GET': [
             '/posts/',
             '/posts/:id',
             '/posts/slug/:slugId',
-            '/users/:id',
             '/users/slug/:slug',
         ],
     };
@@ -90,8 +86,8 @@ middleware = {
             return a;
         });
 
-        if (subPath.indexOf('/ghost/api/') === 0
-            && !inPublicPaths(req)) {
+        if(subPath.indexOf('/ghost/api/') === 0
+            && path.indexOf('/ghost/api/v0.1/authentication/') !== 0 && !inPublicPaths(req)) {
             return passport.authenticate('bearer', {session: false, failWithError: true},
                 function (err, user, info) {
                     if (err) {

--- a/core/server/middleware/middleware.js
+++ b/core/server/middleware/middleware.js
@@ -55,7 +55,7 @@ function inPublicPaths(req){
             '/users/:id',
             '/users/slug/:slug',
         ],
-    }
+    };
     var publicPaths = _.extend({}, defaultPublicApi, config._config.publicApi);
 
     // SubPath is the url path starting after any default subdirectories

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -111,7 +111,7 @@ CanThisResult.prototype.buildObjectTypeHandlers = function (objTypes, actType, c
                     };
                 // Check user permissions for matching action, object and id.
 
-                if (_.any(loadedPermissions.user.roles, {name: 'Owner'})) {
+                if (userPermissions && _.any(loadedPermissions.user.roles, {name: 'Owner'})) {
                     hasUserPermission = true;
                 } else if (!_.isEmpty(userPermissions)) {
                     hasUserPermission = _.any(userPermissions, checkPermission);


### PR DESCRIPTION
Updates middleware to allow for public facing endpoints.
By default, the every ghost REST API endpoint was locked behind authentication. This update allows individual endpoints to be accessible to the public without any user being signed in. Each individual endpoint will still control its own permissions. 

By default, this includes:
- /ghost/api/v0.1/posts, 
- /ghost/api/v0.1/posts/:id, 
- /ghost/api/v0.1/posts/slug/:id, 
- /ghost/api/v0.1/users/slug/:id, 
