### PR TITLE
Updating middleware authentication code to allow for public facing REST ...

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -293,7 +293,7 @@ settings = {
         var result = settingsResult(settingsCache, options.type);
 
         // If there is no context, return only blog settings
-        if (!options.context) {
+        if (!options.context || options.context.user === null) {
             return Promise.resolve(_.filter(result.settings, function (setting) { return setting.type === 'blog'; }));
         }
 

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -187,7 +187,13 @@ Tag = ghostBookshelf.Model.extend({
                 return tag.destroy(options);
             });
         });
-    }
+    },
+    permissible: function (modelId, actType/*, context, loadedPermissions, hasUserPermission, hasAppPermission*/) {
+        if(actType === "browse"){
+            return Promise.resolve();
+        }
+        return Promise.reject();
+    },
 });
 
 Tags = ghostBookshelf.Collection.extend({

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -55,7 +55,8 @@ CanThisResult.prototype.buildObjectTypeHandlers = function (objTypes, actType, c
         role:       Models.Role,
         user:       Models.User,
         permission: Models.Permission,
-        setting:    Models.Settings
+        setting:    Models.Settings,
+        tag:        Models.Tag
     };
 
     // Iterate through the object types, i.e. ['post', 'tag', 'user']
@@ -111,7 +112,7 @@ CanThisResult.prototype.buildObjectTypeHandlers = function (objTypes, actType, c
                     };
                 // Check user permissions for matching action, object and id.
 
-                if (_.any(loadedPermissions.user.roles, {name: 'Owner'})) {
+                if (userPermissions && _.any(loadedPermissions.user.roles, {name: 'Owner'})) {
                     hasUserPermission = true;
                 } else if (!_.isEmpty(userPermissions)) {
                     hasUserPermission = _.any(userPermissions, checkPermission);


### PR DESCRIPTION
Updating middleware authentication code to allow for public facing REST endpoints. 

Changes are made so that relevant information (posts, users, tags) can be accessible via public REST endpoints, without requiring a user to be logged in. Among other things, this allows the development of single page application for ghost. 

This was developed in parallel with [ghost-angular](https://github.com/patrickdbakke/ghost-angular), an adaptation of [casper](https://github.com/TryGhost/Casper) into a single-page-application theme. 
