### PR TITLE
Add grunt testem alias + some DRY in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -810,7 +810,7 @@ var _              = require('lodash'),
                 grunt.log.write('no test provided');
             }
 
-            grunt.task.run('setTestEnv', 'shell:test:' + test);
+            grunt.task.run('test-setup', 'shell:test:' + test);
         });
 
         // ### Validate
@@ -825,21 +825,30 @@ var _              = require('lodash'),
         grunt.registerTask('validate', 'Run tests and lint code',
             ['init', 'test-all']);
 
-        // ### Test
+        // ### Test-All
         // **Main testing task**
         //
-        // `grunt test` will lint and test your pre-built local Ghost codebase.
+        // `grunt test-all` will lint and test your pre-built local Ghost codebase.
         //
-        // `grunt test` runs jshint and jscs as well as the 4 test suites. See the individual sub tasks below for
+        // `grunt test-all` runs jshint and jscs as well as all 6 test suites. See the individual sub tasks below for
         // details of each of the test suites.
         //
         grunt.registerTask('test-all', 'Run tests and lint code',
-            ['jshint', 'jscs', 'test-routes', 'test-module', 'test-unit', 'test-integration', 'test-functional', 'shell:testem']);
+            ['lint', 'test-routes', 'test-module', 'test-unit', 'test-integration', 'test-functional', 'shell:testem']
+        );
 
         // ### Lint
         //
         // `grunt lint` will run the linter and the code style checker so you can make sure your code is pretty
-        grunt.registerTask('lint', 'Run the code style checks and linter', ['jshint', 'jscs']);
+        grunt.registerTask('lint', 'Run the code style checks and linter',
+            ['jshint', 'jscs']
+        );
+
+        // ### test-setup *(utility)(
+        // `grunt test-setup` will run all the setup tasks required for running tests
+        grunt.registerTask('test-setup', 'Setup ready to run tests',
+            ['clean:test', 'setTestEnv', 'ensureConfig']
+        );
 
         // ### Unit Tests *(sub task)*
         // `grunt test-unit` will run just the unit tests
@@ -859,7 +868,8 @@ var _              = require('lodash'),
         // Unit tests do **not** touch the database.
         // A coverage report can be generated for these tests using the `grunt test-coverage` task.
         grunt.registerTask('test-unit', 'Run unit tests (mocha)',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:unit']);
+            ['test-setup', 'mochacli:unit']
+        );
 
         // ### Integration tests *(sub task)*
         // `grunt test-integration` will run just the integration tests
@@ -888,7 +898,8 @@ var _              = require('lodash'),
         //
         // A coverage report can be generated for these tests using the `grunt test-coverage` task.
         grunt.registerTask('test-integration', 'Run integration tests (mocha + db access)',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:integration']);
+            ['test-setup', 'mochacli:integration']
+        );
 
         // ### Route tests *(sub task)*
         // `grunt test-routes` will run just the route tests
@@ -909,7 +920,8 @@ var _              = require('lodash'),
         // are working as expected, including checking the headers and status codes received. It is very easy and
         // quick to test many permutations of routes / urls in the system.
         grunt.registerTask('test-routes', 'Run functional route tests (mocha)',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:routes']);
+            ['test-setup', 'mochacli:routes']
+        );
 
         // ### Module tests *(sub task)*
         // `grunt test-module` will run just the module tests
@@ -917,16 +929,13 @@ var _              = require('lodash'),
         // The purpose of the module tests is to ensure that Ghost can be used as an npm module and exposes all
         // required methods to interact with it.
         grunt.registerTask('test-module', 'Run functional module tests (mocha)',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'mochacli:module']);
+            ['test-setup', 'mochacli:module']
+        );
 
-        // ### Functional tests for the setup process
-        // `grunt test-functional-setup will run just the functional tests for the setup page.
-        //
-        // Setup only works with a brand new database, so it needs to run isolated from the rest of
-        // the functional tests.
-        grunt.registerTask('test-functional-setup', 'Run functional tests for setup',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'cleanDatabase', 'express:test',
-            'spawnCasperJS:setup', 'express:test:stop']
+        // ### Ember unit tests *(sub task)*
+        // `grunt testem` will run just the ember unit tests
+        grunt.registerTask('testem', 'Run the ember unit tests',
+            ['test-setup', 'shell:testem']
         );
 
         // ### Functional tests *(sub task)*
@@ -948,8 +957,16 @@ var _              = require('lodash'),
         // The purpose of the functional tests is to ensure that Ghost is working as is expected from a user perspective
         // including buttons and other important interactions in the admin UI.
         grunt.registerTask('test-functional', 'Run functional interface tests (CasperJS)',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'cleanDatabase', 'express:test', 'spawnCasperJS', 'express:test:stop',
-            'test-functional-setup']
+            ['test-setup', 'cleanDatabase', 'express:test', 'spawnCasperJS', 'express:test:stop', 'test-functional-setup']
+        );
+
+        // ### Functional tests for the setup process
+        // `grunt test-functional-setup will run just the functional tests for the setup page.
+        //
+        // Setup only works with a brand new database, so it needs to run isolated from the rest of
+        // the functional tests.
+        grunt.registerTask('test-functional-setup', 'Run functional tests for setup',
+            ['test-setup', 'cleanDatabase', 'express:test', 'spawnCasperJS:setup', 'express:test:stop']
         );
 
         // ### Coverage
@@ -962,7 +979,8 @@ var _              = require('lodash'),
         //
         // Key areas for coverage are: helpers and theme elements, apps / GDK, the api and model layers.
         grunt.registerTask('test-coverage', 'Generate unit and integration (mocha) tests coverage report',
-            ['clean:test', 'setTestEnv', 'ensureConfig', 'shell:coverage']);
+            ['test-setup', 'shell:coverage']
+        );
 
         // ## Building assets
         //


### PR DESCRIPTION
refs #2990
- add an alias for grunt testem
- add test-setup task to dry up some tasks
