### PR TITLE
[WIP] Code Injection messaging improvements

### DIFF
--- a/core/client/templates/settings/code-injection.hbs
+++ b/core/client/templates/settings/code-injection.hbs
@@ -11,19 +11,19 @@
         <fieldset>
             <div class="form-group">
                 <p>
-                    Ghost allows you to inject code into the top and bottom of your template files without editing them. This allows for quick modifications to insert useful things like tracking codes and meta data.
+                    Ghost allows you to inject HTML code into the top and bottom of your template files without editing them. This allows for quick modifications to insert useful things like tracking codes and meta data. Visit the <a href="http://support.ghost.org/use-code-injection/">support article</a> for more info and troubleshooting tips.
                 </p>
             </div>
 
             <div class="form-group">
                 <label for="ghost-head">Blog Header</label>
-                <p>Code here will be injected to the \{{ghost_head}} helper at the top of your page</p>
+                <p>Code here will be injected to the \{{ghost_head}} helper at the top of your pages</p>
                 {{textarea id="ghost-head" name="codeInjection[ghost_head]" type="text" value=model.ghost_head}}
             </div>
 
             <div class="form-group">
                 <label for="ghost-foot">Blog Footer</label>
-                <p>Code here will be injected to the \{{ghost_foot}} helper at the bottom of your page</p>
+                <p>Code here will be injected to the \{{ghost_foot}} helper at the bottom of your pages</p>
                 {{textarea id="ghost-foot" name="codeInjection[ghost_foot]" type="text" value=model.ghost_foot}}
             </div>
         </fieldset>


### PR DESCRIPTION
refs #1993

This is a suggestion / talking point intended to determine what the requirements are for shipping Code Injection.

It's been blocked for a while, on a couple of details:
- [ ] the addition of theme checks to determine if `{{ghost_head}}` and `{{ghost_foot}}` are present in the theme
- [ ] line numbers / syntax highlighting see issue #4995
- [ ] messaging on the page

I'm leaning towards saying lets ship without the first 2, and this PR is meant to address the latter. The latter issue is purely to ensure that users understand they need to enter HTML, and what that might look like. Ordinarily I wouldn't recommend providing lots of verbiage on the page, but in this case the tool is sufficiently technical that I think the link to the support article might be warranted? It is purely a suggestion though, and definitely a departure from our approach elsewhere.
