### PR TITLE
Add `order` property when parsing Navigation JSON

### DIFF
--- a/core/client/assets/sass/layouts/settings.scss
+++ b/core/client/assets/sass/layouts/settings.scss
@@ -403,7 +403,11 @@
 
     // &.last-navigation-item {
     &:last-child {
-        padding-left: 27px; // .navigation-item-drag-handle width + horizontal padding
+        padding-left: 27px; // simulate .navigation-item-drag-handle width + horizontal padding
+
+        .navigation-item-drag-handle {
+            display: none;
+        }
     }
 }
 

--- a/core/client/controllers/settings/navigation.js
+++ b/core/client/controllers/settings/navigation.js
@@ -20,7 +20,8 @@ NavigationController = Ember.Controller.extend({
 
     navigationItems: Ember.computed('model.navigation', function () {
         var navItems,
-            lastItem;
+            lastItem,
+            order = 0;
 
         try {
             navItems = JSON.parse(this.get('model.navigation') || [{}]);
@@ -29,6 +30,8 @@ NavigationController = Ember.Controller.extend({
         }
 
         navItems = navItems.map(function (item) {
+            item.order = order;
+            order = order + 1;
             return NavItem.create(item);
         });
 
@@ -86,8 +89,10 @@ NavigationController = Ember.Controller.extend({
                 order = 0;
 
             navItems.forEach(function (item) {
-                item.set('order', order);
-                order = order + 1; // Increment order order by one
+                if (!item.last) { // Make sure we never apply an `order` attr to the last item
+                    item.set('order', order);
+                    order = order + 1; // Increment order order by one
+                }
             });
         },
 


### PR DESCRIPTION
Closes #4927
- Add `order` property when parsing Navigation JSON
- Fixes CSS issue where the placeholder nav item drag handle was still visible
