### PR TITLE
Add `error` class styles for inputs

### DIFF
--- a/core/client/assets/sass/components/uploader.scss
+++ b/core/client/assets/sass/components/uploader.scss
@@ -106,16 +106,12 @@
 
         &.url {
             font: -webkit-small-control;
-            width: 100%;
             vertical-align: middle;
             padding: 9px 7px;
             margin: 10px 0;
             outline: 0;
             font-size: 1.1em;
             background: #fff;
-            border: #e3e1d5 1px solid;
-            border-radius: 4px;
-            transition: all 0.15s ease-in-out;
 
             + .btn.btn-blue {
                 color: #fff;

--- a/core/client/assets/sass/patterns/forms.scss
+++ b/core/client/assets/sass/patterns/forms.scss
@@ -195,6 +195,10 @@ select {
 
     transition: border-color 0.15s linear;
 
+    &.error {
+        border-color: $red;
+    }
+
     &:focus {
         border-color: $brown;
         outline: 0;


### PR DESCRIPTION
No issue

Adds a red border to inputs when a `error` class is applied

Also DRY's up the URL input a tad.
