### PR TITLE
Remove odd duplication from permissions.json

### DIFF
--- a/core/server/data/fixtures/permissions/permissions.json
+++ b/core/server/data/fixtures/permissions/permissions.json
@@ -160,7 +160,6 @@
             "slug": "all",
             "tag": "all",
             "user": "all",
-            "setting": ["browse", "read"],
             "role": "all"
         },
         "Author": {
@@ -169,7 +168,6 @@
             "slug": "all",
             "tag": ["browse", "read", "add"],
             "user": ["browse", "read"],
-            "setting": ["browse", "read"],
             "role": ["browse"]
         }
     }


### PR DESCRIPTION
no issue

Spotted weird duplication of the settings config in permissions.json & thought I'd clean it up
