### PR TITLE
Added static front page support

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -167,8 +167,8 @@ frontendControllers = {
                 page: pageParam
             };
 
-        // No negative pages, or page 1
-        if (isNaN(pageParam) || pageParam < 1 || (pageParam === 1 && req.route.path === '/page/:page/')) {
+        // No negative pages
+        if (isNaN(pageParam) || pageParam < 1) {
             return res.redirect(config.paths.subdir + '/');
         }
 
@@ -183,12 +183,12 @@ frontendControllers = {
             // Render the page of posts
             filters.doFilter('prePostsRender', page.posts).then(function (posts) {
                 getActiveThemePaths().then(function (paths) {
-                    var view = paths.hasOwnProperty('home.hbs') ? 'home' : 'index';
+                    var view = 'index';
 
-                    // If we're on a page then we always render the index
-                    // template.
-                    if (pageParam > 1) {
-                        view = 'index';
+                    // Render home template if no page number is defined
+                    // and the home.hbs file is found
+                    if (req.params.page === undefined && paths.hasOwnProperty('home.hbs')) {
+                        view = 'home';
                     }
 
                     setResponseContext(req, res);


### PR DESCRIPTION
Very simple 2 line change to the frontend router. This checks if a `home.hbs` file is present, and if so, will use that as the static front page. The `index.hbs` file continues to function as a normal blog page.

The `/page/1` redirect to `/` has been removed. When using a static front page, the path `/page/1` is used to access the blog.
