### PR TITLE
Simplify navigation item reordering

### DIFF
--- a/core/client/views/settings/navigation.js
+++ b/core/client/views/settings/navigation.js
@@ -3,21 +3,25 @@ import BaseView from 'ghost/views/settings/content-base';
 var SettingsNavigationView = BaseView.extend({
 
     didInsertElement: function () {
-        var controller = this.get('controller'),
-            navContainer = Ember.$('.js-settings-navigation'),
-            navElements = '.navigation-item:not(.navigation-item:last-child)';
+        var navContainer = Ember.$('.js-settings-navigation'),
+            navElements = '.navigation-item:not(.navigation-item:last-child)',
+            self = this;
 
         navContainer.sortable({
             handle: '.navigation-item-drag-handle',
             items: navElements,
 
-            update: function () {
-                var indexes = [];
-                navContainer.find(navElements).each(function () {
-                    var order = Ember.$(this).data('order');
-                    indexes.push(order);
+            start: function (event, ui) {
+                Ember.run(function () {
+                    ui.item.data('start-index', ui.item.index());
                 });
-                controller.updateOrder(indexes);
+            },
+
+            update: function (event, ui) {
+                Ember.run(function () {
+                    self.get('controller').send('moveItem', ui.item.data('start-index'), ui.item.index());
+                    ui.item.remove();
+                });
             }
         });
     },

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -72,7 +72,7 @@
             "defaultValue": "{}"
         },
         "navigation": {
-            "defaultValue": "[{\"label\":\"Home\", \"url\":\"/\", \"order\":0}]"
+            "defaultValue": "[{\"label\":\"Home\", \"url\":\"/\"}]"
         }
     },
     "theme": {


### PR DESCRIPTION
Since we're storing navigation items in an ordered data structure, we can use the start index and new index from the Sortable plugin to do the reordering instead of indirectly from an "order" metadata property.
