### PR TITLE
Mark html notifications as html-safe, else escape

### DIFF
--- a/core/client/mixins/editor-base-controller.js
+++ b/core/client/mixins/editor-base-controller.js
@@ -197,7 +197,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
         if (status === 'published') {
             message += '&nbsp;<a href="' + path + '">View ' + this.get('postOrPage') + '</a>';
         }
-        this.notifications.showSuccess(message, {delayed: delay});
+        this.notifications.showSuccess(message.htmlSafe(), {delayed: delay});
     },
 
     showErrorNotification: function (prevStatus, status, errors, delay) {
@@ -206,7 +206,7 @@ EditorControllerMixin = Ember.Mixin.create(MarkerManager, {
 
         message += '<br />' + error;
 
-        this.notifications.showError(message, {delayed: delay});
+        this.notifications.showError(message.htmlSafe(), {delayed: delay});
     },
 
     shouldFocusTitle: Ember.computed.alias('model.isNew'),

--- a/core/client/mixins/validation-engine.js
+++ b/core/client/mixins/validation-engine.js
@@ -29,12 +29,15 @@ function formatErrors(errors, opts) {
         // get the validator's error messages from the array.
         // normalize array members to map to strings.
         message = errors.map(function (error) {
+            var errorMessage;
             if (typeof error === 'string') {
-                return error;
+                errorMessage = error;
+            } else {
+                errorMessage = error.message;
             }
 
-            return error.message;
-        }).join('<br />');
+            return Ember.Handlebars.Utils.escapeExpression(errorMessage);
+        }).join('<br />').htmlSafe();
     } else if (errors instanceof Error) {
         message += errors.message || '.';
     } else if (typeof errors === 'object') {

--- a/core/client/templates/components/gh-notification.hbs
+++ b/core/client/templates/components/gh-notification.hbs
@@ -1,6 +1,6 @@
 <section {{bind-attr class=":js-notification typeClass"}}>
     <span class="notification-message">
-        {{{message.message}}}
+        {{message.message}}
     </span>
     <button class="close" {{action "closeNotification"}}><span class="hidden">Close</span></button>
 </section>


### PR DESCRIPTION
no issue
- Use the double-tash escaping output for notification messages
- Mark known and trusted html notifications as html-safe

Credits: Abdel Adim Oisif
