### PR TITLE
Only import can override published_by

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -132,8 +132,9 @@ Post = ghostBookshelf.Model.extend({
             if (!this.get('published_at')) {
                 this.set('published_at', new Date());
             }
-            // This will need to go elsewhere in the API layer.
-            if (!this.get('published_by')) {
+
+            // unless published_by is set and we're importing, set published_by to contextUser
+            if (!(this.get('published_by') && options.importing)) {
                 this.set('published_by', this.contextUser(options));
             }
         }


### PR DESCRIPTION
no issue
- published_by should be set to the current user, unless we are in import mode

Credits: Matteo Beccaro
