### PR TITLE
RSS: Don't add trailing '/' to post image

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -561,20 +561,6 @@ frontendControllers = {
                                     attributeValue = attributeValue.substr(1);
                                 }
 
-                                // make sure URL has a trailing slash
-                                try {
-                                    parsed = url.parse(attributeValue);
-
-                                    if (parsed.pathname && parsed.pathname.slice(-1) !== '/') {
-                                        parsed.pathname += '/';
-
-                                        attributeValue = url.format(parsed);
-                                    }
-                                } catch (e) {
-                                    // if the URL we've built cannot be parsed, fall back to the unprocessed URL
-                                    return;
-                                }
-
                                 attributeValue = baseUrl + attributeValue;
                                 el.attr(attributeName, attributeValue);
                             });


### PR DESCRIPTION
Closes #4888

We automatically added a trailing slash to all non-absolute paths in
RSS, including post images. This fix ensures that trailing slashes
aren’t added to absolute paths including ‘content/images/‘.
