### PR TITLE
Added ability to use <!--more--> tag

### DIFF
--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -20,6 +20,9 @@ content = function (options) {
     });
 
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
+        if (_.contains(this.html, '<!--more-->')) {
+            return new hbs.handlebars.SafeString(this.html.split('<!--more-->', 2)[0]);
+        }
         // Legacy function: {{content words="0"}} should return leading tags.
         if (truncateOptions.hasOwnProperty('words') && truncateOptions.words === 0) {
             return new hbs.handlebars.SafeString(


### PR DESCRIPTION
closes #4933
- allows truncating your blog entries with `<!--more-->` tag so that only the first part of certain posts are displayed on the homepage.
- follows same structure as wordpress [more tag](https://en.support.wordpress.com/splitting-content/more-tag/) to keep the learning curve low for transitioning from WP to Ghost
- theme's don't need to change anything for this to take effect, checks if post `_.contains` a `<!--more-->` tag
- if a `<!--more-->` tag exists, it supersedes a `{{content words="20"}}` or `{{content characters="256"}}` tag
- if a `<!--more-->` tag does not exist, it falls back to what the theme has set.
