### PR TITLE
Key Navigation: Shortcuts, Ensure Tab+Enter Navigation

### DIFF
--- a/core/client/initializers/link-to.js
+++ b/core/client/initializers/link-to.js
@@ -1,0 +1,25 @@
+var enhanceLinkTo = {
+    name: 'modify-linkto',
+
+    initialize: function () {
+        Ember.LinkView.reopen({
+            attributeBindings: ['accesskey'],
+
+            // Ensure that [Enter] is handled by a link-to
+            // element *if* the current keyboard focus is
+            // on that element
+            keyDown: function (e) {
+                if (e && e.keyCode && e.keyCode === 13) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    e.currentTarget.click();
+                    return false;
+                }
+
+                return true;
+            }
+        });
+    }
+};
+
+export default enhanceLinkTo;

--- a/core/client/templates/-navbar.hbs
+++ b/core/client/templates/-navbar.hbs
@@ -1,19 +1,19 @@
 <nav class="global-nav" role="navigation">
 
-    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="Visit blog">
+    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="Visit blog" accesskey="b">
         <div class="nav-label"><i class="icon-ghost"></i> <span>Visit blog</span> </div>
     </a>
 
-    {{#link-to "posts" classNames="nav-item nav-content js-nav-item"}}
+    {{#link-to "posts" classNames="nav-item nav-content js-nav-item" accesskey="c"}}
         <div class="nav-label"><i class="icon-content"></i> Content</div>
     {{/link-to}}
 
-    {{#link-to "editor.new" classNames="nav-item nav-new js-nav-item"}}
+    {{#link-to "editor.new" classNames="nav-item nav-new js-nav-item" accesskey="n"}}
         <div class="nav-label"><i class="icon-add"></i> New Post</div>
     {{/link-to}}
 
     {{#unless session.user.isAuthor}}
-    {{#link-to "settings" classNames="nav-item nav-settings js-nav-item"}}
+    {{#link-to "settings" classNames="nav-item nav-settings js-nav-item" accesskey="s"}}
         <div class="nav-label"><i class="icon-settings2"></i> Settings</div>
     {{/link-to}}
     {{/unless}}


### PR DESCRIPTION
Closes #4996
- Ensures that keyboard navigation with `tab` and `enter` works on \ghost - not just for the big navigation items, but also on the post list.
- Bonus global keyboard shortcuts! HTML allows for the `accesskey` attribute, which gives us the following:

| Route | Blog (Frontpage) | Content | New Post | Settings |
| --- | --- | --- | --- | --- |
| Accesskey | `B` | `C` | `N` | S |

For reference, here are the shortcuts that each browser exposes using `accesskey`:

<table class="reference notranslate" id="table2">
<tbody><tr>
<th style="width:19%">Browser</th>
<th style="width:27%">Windows</th>
<th style="width:27%">Linux</th>
<th style="width:27%">Mac</th>
</tr>
<tr>
<td>Internet Explorer</td>
<td>[Alt] + <em>accesskey</em></td>
<td>N/A</td>
<td></td>
</tr>
<tr>
<td>Chrome</td>
<td>[Alt] + <em>accesskey</em></td>
<td>[Alt] + <em>accesskey</em></td>
<td>[Control] [Alt] + <em>accesskey</em></td>
</tr>
<tr>
<td>Firefox</td>
<td>[Alt] [Shift] + <em>accesskey</em></td>
<td>[Alt] [Shift] + <em>accesskey</em></td>
<td>[Control] [Alt] + <em>accesskey</em></td>
</tr>
<tr>
<td>Safari</td>
<td>[Alt] + <em>accesskey</em></td>
<td>N/A</td>
<td>[Control] [Alt] + <em>accesskey</em></td>
</tr>
<tr>
<td>Opera</td>
<td colspan="3">Opera 15 or newer: [Alt] + <em>accesskey<br></em>Opera 12.1 or older: [Shift] [Esc] + <em>accesskey</em></td>
</tr>
</tbody></table>
