### PR TITLE
Accept mailto: links

### DIFF
--- a/core/client/components/gh-navitem-url-input.js
+++ b/core/client/components/gh-navitem-url-input.js
@@ -20,7 +20,7 @@ var NavItemUrlInputComponent = Ember.TextField.extend({
     }),
 
     isRelative: Ember.computed('value', function () {
-        return !validator.isURL(this.get('value'));
+        return !validator.isURL(this.get('value')) && this.get('value').indexOf('mailto:') !== 0;
     }),
 
     didInsertElement: function () {
@@ -30,7 +30,7 @@ var NavItemUrlInputComponent = Ember.TextField.extend({
         this.set('value', url);
 
         // if we have a relative url, create the absolute url to be displayed in the input
-        if (this.get('isRelative')) {
+        if (this.get('isRelative') ) {
             url = joinUrlParts(baseUrl, url);
             this.set('value', url);
         }
@@ -80,6 +80,7 @@ var NavItemUrlInputComponent = Ember.TextField.extend({
         var url = this.get('value'),
             baseUrl = this.get('baseUrl');
 
+        // if we have a relative url, create the absolute url to be displayed in the input
         if (this.get('isRelative')) {
             this.set('value', joinUrlParts(baseUrl, url));
         }

--- a/core/client/controllers/settings/navigation.js
+++ b/core/client/controllers/settings/navigation.js
@@ -132,7 +132,7 @@ NavigationController = Ember.Controller.extend({
                     if (url[url.length - 1] !== '/') {
                         url += '/';
                     }
-                } else if (!validator.isURL(url) && url !== '' && url[0] !== '/') {
+                } else if (!validator.isURL(url) && url !== '' && url[0] !== '/' && url.indexOf('mailto:') !== 0) {
                     url = '/' + url;
                 }
 

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -170,7 +170,7 @@ function urlFor(context, data, absolute) {
     }
 
     // This url already has a protocol so is likely an external url to be returned
-    if (urlPath && urlPath.indexOf('://') !== -1) {
+    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.indexOf('mailto:') === 0)) {
         return urlPath;
     }
 


### PR DESCRIPTION
This is a short term fix, I think a bit of cleanup is needed to do this properly, but this makes the usecase possible for 0.5.10

refs #4989
- this allows users to enter mailto and output links via the navigation UI
- the navigation validation/cleanup needs a bit of a refactor to handle other kinds or URI, so leaving #4989 open for now
