### PR TITLE
Temporarily downgrade grunt-contrib-jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "grunt-contrib-compress": "~0.11.0",
         "grunt-contrib-concat": "~0.5.0",
         "grunt-contrib-copy": "~0.5.0",
-        "grunt-contrib-jshint": "~0.11.0",
+        "grunt-contrib-jshint": "~0.10.0",
         "grunt-contrib-uglify": "~0.6.0",
         "grunt-contrib-watch": "~0.6.1",
         "grunt-docker": "~0.0.8",


### PR DESCRIPTION
no issue
- grunt-contrib-jshint loosely depends on jshint ^2.6.0 and jshint seem to be having some backwards incompatibility issues with 2.6.1 etc.
- let's downgrade this temporarily (quick/safe option) until they sort their issues, then we can upgrade and make any required changes
