### PR TITLE
No more source maps in grunt prod

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -655,7 +655,7 @@ var _              = require('lodash'),
             uglify: {
                 prod: {
                     options: {
-                        sourceMap: true
+                        sourceMap: false
                     },
                     files: {
                         'core/built/public/jquery.min.js': 'core/built/public/jquery.js',


### PR DESCRIPTION
refs #4955
- needed to build on ubuntu 14.14 with node 12 (DO image)
- barely used anyway, as release task has it disabled
