### PR TITLE
Node v0.12 & io.js support. [Rebased]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
+  - "iojs-v1.2.0"
 sudo: false
 cache:
   directories:

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -46,7 +46,8 @@ GhostServer.prototype.closeConnections = function () {
 
 GhostServer.prototype.logStartMessages = function () {
     // Tell users if their node version is not supported, and exit
-    if (!semver.satisfies(process.versions.node, packageInfo.engines.node)) {
+    if (!semver.satisfies(process.versions.node, packageInfo.engines.node) &&
+        !semver.satisfies(process.versions.node, packageInfo.engines.iojs)) {
         console.log(
             '\nERROR: Unsupported version of Node'.red,
             '\nGhost needs Node version'.red,

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -326,16 +326,17 @@ describe('Error handling', function () {
                 options.code.should.equal(404);
                 this.statusCode.should.equal(404);
 
-                // Test that the headers are correct
-                this._headers['cache-control'].should.equal(
-                    'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                );
-
                 done();
             });
 
             sandbox.stub(express.response, 'status', function (status) {
                 res.statusCode = status;
+                return res;
+            });
+
+            sandbox.stub(res, 'set', function (value) {
+                // Test that the headers are correct
+                value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
                 return res;
             });
 
@@ -356,16 +357,17 @@ describe('Error handling', function () {
                 options.code.should.equal(404);
                 this.statusCode.should.equal(404);
 
-                // Test that the headers are correct
-                this._headers['cache-control'].should.equal(
-                    'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                );
-
                 done();
             });
 
             sandbox.stub(express.response, 'status', function (status) {
                 res.statusCode = status;
+                return res;
+            });
+
+            sandbox.stub(res, 'set', function (value) {
+                // Test that the headers are correct
+                value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
                 return res;
             });
 
@@ -387,12 +389,13 @@ describe('Error handling', function () {
                 options.code.should.equal(500);
                 this.statusCode.should.equal(500);
 
-                // Test that the headers are correct
-                this._headers['cache-control'].should.equal(
-                    'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                );
-
                 done();
+            });
+
+            sandbox.stub(res, 'set', function (value) {
+                // Test that the headers are correct
+                value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
+                return res;
             });
 
             sandbox.stub(express.response, 'status', function (status) {
@@ -417,16 +420,17 @@ describe('Error handling', function () {
                 options.code.should.equal(500);
                 this.statusCode.should.equal(500);
 
-                // Test that the headers are correct
-                this._headers['cache-control'].should.equal(
-                    'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
-                );
-
                 done();
             });
 
             sandbox.stub(express.response, 'status', function (status) {
                 res.statusCode = status;
+                return res;
+            });
+
+            sandbox.stub(res, 'set', function (value) {
+                // Test that the headers are correct
+                value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
                 return res;
             });
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "test": "./node_modules/.bin/grunt validate --verbose"
     },
     "engines": {
-        "node": "~0.10.0"
+        "node": "~0.10.0 || ~0.12.0",
+        "iojs": "~1.2.0"
     },
     "engineStrict": true,
     "dependencies": {
@@ -46,7 +47,7 @@
         "extract-zip": "1.0.3",
         "fs-extra": "0.13.0",
         "glob": "4.3.2",
-        "html-to-text": "1.0.0",
+        "html-to-text": "1.2.0",
         "knex": "0.7.3",
         "lodash": "2.4.1",
         "moment": "2.8.3",
@@ -62,7 +63,7 @@
         "rss": "1.0.0",
         "semver": "4.1.0",
         "showdown-ghost": "0.3.4",
-        "sqlite3": "3.0.4",
+        "sqlite3": "3.0.5",
         "unidecode": "0.1.3",
         "validator": "3.28.0",
         "xml": "0.0.12"
@@ -91,7 +92,7 @@
         "grunt-express-server": "~0.4.19",
         "grunt-jscs": "~1.2.0",
         "grunt-mocha-cli": "~1.11.0",
-        "grunt-sass": "~0.17.0",
+        "grunt-sass": "~0.18.0",
         "grunt-shell": "~1.1.1",
         "grunt-update-submodules": "~0.4.1",
         "matchdep": "~0.3.0",


### PR DESCRIPTION
fixes #4811, refs #4240
- Add v0.12 to the build
- Fix express tests to work with iojs/0.12
- Add iojs-v1.2.0 to the build matrix
