### PR TITLE
Replace fs.exists (deprecated) with fs.stat

### DIFF
--- a/core/server/apps/dependencies.js
+++ b/core/server/apps/dependencies.js
@@ -15,9 +15,9 @@ AppDependencies.prototype.install = function installAppDependencies() {
         self = this;
 
     return new Promise(function (resolve, reject) {
-        fs.exists(path.join(self.appPath, 'package.json'), function (exists) {
-            if (!exists) {
-                // Nothing to do, resolve right away?
+        fs.stat(path.join(self.appPath, 'package.json'), function (err) {
+            if (err) {
+                // File doesn't exist - nothing to do, resolve right away?
                 resolve();
             } else {
                 // Run npm install in the app directory

--- a/core/server/apps/permissions.js
+++ b/core/server/apps/permissions.js
@@ -37,7 +37,8 @@ AppPermissions.prototype.checkPackageContentsExists = function () {
 
     // Mostly just broken out for stubbing in unit tests
     return new Promise(function (resolve) {
-        fs.exists(self.packagePath, function (exists) {
+        fs.stat(self.packagePath, function (err) {
+            var exists = !err;
             resolve(exists);
         });
     });

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -227,8 +227,9 @@ ConfigManager.prototype.load = function (configFilePath) {
     /* Check for config file and copy from config.example.js
         if one doesn't exist. After that, start the server. */
     return new Promise(function (resolve, reject) {
-        fs.exists(self._config.paths.config, function (exists) {
-            var pendingConfig;
+        fs.stat(self._config.paths.config, function (err) {
+            var exists = (err) ? false : true,
+                pendingConfig;
 
             if (!exists) {
                 pendingConfig = self.writeFile();
@@ -250,8 +251,9 @@ ConfigManager.prototype.writeFile = function () {
         configExamplePath = this._config.paths.configExample;
 
     return new Promise(function (resolve, reject) {
-        fs.exists(configExamplePath, function checkTemplate(templateExists) {
-            var read,
+        fs.stat(configExamplePath, function checkTemplate(err) {
+            var templateExists = (err) ? false : true,
+                read,
                 write,
                 error;
 

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -77,11 +77,14 @@ function builtFilesExist() {
                         '\nhttps://github.com/TryGhost/Ghost#getting-started';
 
         return new Promise(function (resolve, reject) {
-            fs.exists(fileName, function (exists) {
+            fs.stat(fileName, function (statErr) {
+                var exists = (statErr) ? false : true,
+                    err;
+
                 if (exists) {
                     resolve(true);
                 } else {
-                    var err = new Error(errorMessage);
+                    err = new Error(errorMessage);
 
                     err.help = errorHelp;
                     reject(err);

--- a/core/server/storage/local-file-store.js
+++ b/core/server/storage/local-file-store.js
@@ -42,7 +42,8 @@ LocalFileStore.prototype.save = function (image, targetDir) {
 
 LocalFileStore.prototype.exists = function (filename) {
     return new Promise(function (resolve) {
-        fs.exists(filename, function (exists) {
+        fs.stat(filename, function (err) {
+            var exists = !err;
             resolve(exists);
         });
     });

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -328,7 +328,7 @@ describe('Config', function () {
 
         it('creates the config file if one does not exist', function (done) {
                 // trick bootstrap into thinking that the config file doesn't exist yet
-            var existsStub = sandbox.stub(fs, 'exists', function (file, cb) { return cb(false); }),
+            var existsStub = sandbox.stub(fs, 'stat', function (file, cb) { return cb(true); }),
                 // ensure that the file creation is a stub, the tests shouldn't really create a file
                 writeFileStub = sandbox.stub(config, 'writeFile').returns(Promise.resolve()),
                 validateStub = sandbox.stub(config, 'validate').returns(Promise.resolve());

--- a/core/test/unit/storage_local-file-store_spec.js
+++ b/core/test/unit/storage_local-file-store_spec.js
@@ -27,7 +27,7 @@ describe('Local File System Storage', function () {
 
         sinon.stub(fs, 'mkdirs').yields();
         sinon.stub(fs, 'copy').yields();
-        sinon.stub(fs, 'exists').yields(false);
+        sinon.stub(fs, 'stat').yields(true);
         sinon.stub(fs, 'unlink').yields();
 
         image = {
@@ -45,7 +45,7 @@ describe('Local File System Storage', function () {
     afterEach(function () {
         fs.mkdirs.restore();
         fs.copy.restore();
-        fs.exists.restore();
+        fs.stat.restore();
         fs.unlink.restore();
         this.clock.restore();
     });
@@ -96,13 +96,13 @@ describe('Local File System Storage', function () {
     it('can upload two different images with the same name without overwriting the first', function (done) {
         // Sun Sep 08 2013 10:57
         this.clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).yields(true);
 
         // if on windows need to setup with back slashes
         // doesn't hurt for the test to cope with both
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(true);
 
         localFileStore.save(image).then(function (url) {
             url.should.equal('/content/images/2013/09/IMAGE-1.jpg');
@@ -113,18 +113,18 @@ describe('Local File System Storage', function () {
     it('can upload five different images with the same name without overwriting the first', function (done) {
         // Sun Sep 08 2013 10:57
         this.clock = sinon.useFakeTimers(new Date(2013, 8, 8, 10, 57).getTime());
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE-2.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE-3.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('./content/images/2013/09/IMAGE-4.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-2.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-3.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-4.jpg')).yields(true);
 
         // windows setup
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-2.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-3.jpg')).yields(true);
-        fs.exists.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-4.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-2.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-3.jpg')).yields(false);
+        fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-4.jpg')).yields(true);
 
         localFileStore.save(image).then(function (url) {
             url.should.equal('/content/images/2013/09/IMAGE-4.jpg');


### PR DESCRIPTION
Closes #4847
- Replaces the deprecated fs.exists() with fs.stat().
