### PR TITLE
[WIP] New Image Uploader Component

### DIFF
--- a/core/client/app/components/gh-upload-modal.js
+++ b/core/client/app/components/gh-upload-modal.js
@@ -1,15 +1,10 @@
 import Ember from 'ember';
 import ModalDialog from 'ghost/components/gh-modal-dialog';
-import upload from 'ghost/assets/lib/uploader';
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
 var UploadModal = ModalDialog.extend({
     layoutName: 'components/gh-modal-dialog',
 
-    didInsertElement: function () {
-        this._super();
-        upload.call(this.$('.js-drop-zone'), {fileStorage: this.get('config.fileStorage')});
-    },
     keyDown: function () {
         this.setErrorState(false);
     },

--- a/core/client/app/components/gh-uploader.js
+++ b/core/client/app/components/gh-uploader.js
@@ -1,21 +1,142 @@
 import Ember from 'ember';
-import uploader from 'ghost/assets/lib/uploader';
+import ghostPaths from 'ghost/utils/ghost-paths';
 
-var PostImageUploader = Ember.Component.extend({
-    classNames: ['image-uploader', 'js-post-image-upload'],
+var ImageUploader = Ember.Component.extend({
 
-    imageSource: Ember.computed('image', function () {
-        return this.get('image') || '';
+    cancelMode: false,
+    cancelUrl: Ember.computed('cancelMode', function () {
+        return (this.get('cancelMode') === 'url' && this.get('fileStorage'));
     }),
+    editor: true,
+    enableExtras: true,
+    fileStorage: Ember.computed(function () {
+        return this.get('config.fileStorage');
+    }),
+    loading: false,
+    loadingCat: Ember.computed(function () {
+        return ghostPaths().subdir + '/ghost/img/loadingcat.gif';
+    }),
+    rightClass: false,
+    saveButtonDisabled: false,
+    showImage: true,
+    uploaderClass: 'image-uploader',
+    urlUi: false,
+    imageUploadButton: false,
+
+    $dropzone: null,
+
+    // Image
+    imgWidth: 'auto',
+    imgHeight: 'auto',
+    imgStyle: Ember.computed('imgWidth', 'imgHeight', function () {
+        return 'width: ' + this.get('imgWidth') + '; height: ' + this.get('imgHeight') + '; display: block;';
+    }),
+
+    // Progressbar
+    progressbar: false,
+    progress: 0,
+    progressBarStyle: Ember.computed('progress', function () {
+        return 'width: ' + this.get('progress') + '%';
+    }),
+
+    uploadFolder: Ember.computed(function () {
+        return ghostPaths().apiRoot + '/uploads/';
+    }),
+
+    // Fail Messages
+    errorMaxSize: 'The image you uploaded was larger than the maximum file size your server allows.',
+    errorFileType: 'The image type you uploaded is not supported. Please use .PNG, .JPG, .GIF, .SVG.',
+    errorGeneric: 'Something went wrong :(',
+    errorText: '',
+    error: Ember.computed('errorText', function () {
+        return (this.get('errorText') && this.get('errorText') !== '');
+    }),
+
+    // Reset Observer
+    imageChanged: Ember.observer('image', function () {
+        Ember.run.once(this, 'reset');
+    }),
+
+    reset: function () {
+        var image = this.get('image');
+
+        if (!image || image === '') {
+            this.send('initWithDropzone');
+        } else if (!this.get('progressbar') && image) {
+            this.send('initWithImage');
+        }
+    },
+
+    // This binds a jQuery Fileupload to the component. It is called during component setup.
+    _bindFileUpload: function () {
+        var self = this,
+            $dropzone = this.$();
+
+        this.set('$dropzone', $dropzone);
+
+        this.$().fileupload().fileupload('option', {
+            url: this.get('uploadFolder'),
+            dropZone: this.get('fileStorage') ? $dropzone : null,
+
+            add: function (event, data) {
+                self.set('saveButtonDisabled', true);
+                self.set('rightClass', false);
+                self.set('urlUi', false);
+
+                $dropzone.trigger('uploadstart', [$dropzone.attr('id')]);
+                $dropzone.find('span.media, div.description, a.image-url, a.image-webcam')
+                    .animate({opacity: 0}, 250, function () {
+                        self.set('progressbar', true);
+                        $dropzone.find('div.description').hide().css({opacity: 100});
+                        $('div.js-upload-progress').animate({opacity: 100}, 250);
+
+                        data.submit();
+                    });
+
+                self.sendAction('uploadstarted', event, data);
+            },
+
+            progressall: function (event, data) {
+                var progress = parseInt(data.loaded / data.total * 100, 10);
+                self.set('progress', progress);
+
+                if (self._actions && self._actions.uploadprogress) {
+                    self.sendAction('uploadprogress', event, [progress, data]);
+                }
+            },
+
+            fail: function (event, data) {
+                self.set('saveButtonDisabled', false);
+                self.sendAction('uploadfailure', event, data.result);
+
+                if (data.jqXHR.status === 413) {
+                    self.set('errorText', self.get('errorMaxSize'));
+                } else if (data.jqXHR.status === 415) {
+                    self.set('errorText', self.get('errorFileType'));
+                } else {
+                    self.set('errorText', self.get('errorGeneric'));
+                }
+
+                $dropzone.find('div.js-fail, button.js-fail').fadeIn(1500);
+                $dropzone.find('button.js-fail').on('click', function () {
+                    $dropzone.css({minHeight: 0});
+                    $dropzone.find('div.description').show();
+                    self.set('enableExtras', false);
+                    self.init();
+                });
+            },
+
+            done: function (event, data) {
+                self.send('complete', event, data.result);
+            }
+        });
+
+        this.send('init');
+    },
 
     setup: function () {
         var $this = this.$(),
             self = this;
-
-        this.set('uploaderReference', uploader.call($this, {
-            editor: true,
-            fileStorage: this.get('config.fileStorage')
-        }));
 
         $this.on('uploadsuccess', function (event, result) {
             if (result && result !== '' && result !== 'http://') {
@@ -26,14 +147,147 @@ var PostImageUploader = Ember.Component.extend({
         $this.on('imagecleared', function () {
             self.sendAction('canceled');
         });
+
+        this._bindFileUpload();
     }.on('didInsertElement'),
 
     removeListeners: function () {
-        var $this = this.$();
+        this.get('$dropzone').off();
+    }.on('willDestroyElement'),
 
-        $this.off();
-        $this.find('.js-cancel').off();
-    }.on('willDestroyElement')
+    actions: {
+        init: function () {
+            this.set('saveButtonDisabled', false);
+
+            if (!this.get('image') || this.get('image') === '') {
+                this.send('initWithDropzone');
+            } else {
+                this.send('initWithImage');
+            }
+        },
+
+        initWithDropzone: function () {
+            var $dropzone = this.get('$dropzone');
+
+            this.set('showImage', false);
+            this.set('cancelMode', false);
+            this.set('enableExtras', true);
+            this.set('rightClass', false);
+            this.set('urlUi', false);
+            this.set('progressbar', false);
+            this.set('uploaderClass', 'image-uploader');
+
+            $dropzone.find('div.description').show();
+
+            if (!this.get('fileStorage')) {
+                this.send('initUrl');
+            }
+        },
+
+        initUrl: function () {
+            this.set('enableExtras', false);
+            this.set('uploaderClass', 'image-uploader image-uploader-url');
+            this.set('rightClass', true);
+            this.set('cancelMode', 'url');
+            this.set('urlUi', true);
+            this.set('cancelMode', 'url');
+        },
+
+        initWithImage: function () {
+            var $dropzone = this.get('$dropzone');
+
+            this.set('uploaderClass', 'pre-image-uploader');
+            this.set('cancelMode', 'image');
+            this.set('showImage', true);
+            $dropzone.css({height: 'auto'});
+            $dropzone.find('div.description').hide();
+            $dropzone.find('img.js-upload-target').show();
+        },
+
+        cancel: function () {
+            var $dropzone = this.get('$dropzone');
+
+            this.set('uploaderClass', 'image-uploader');
+
+            switch (this.get('cancelMode')) {
+                case 'url':
+                    $dropzone.find('div.description').show();
+                    break;
+                case 'image':
+                    this.set('progressbar', false);
+                    this.set('rightClass', true);
+                    this.set('enableExtras', false);
+                    break;
+                default:
+                    break;
+            }
+
+            $dropzone.trigger('imagecleared');
+            this.set('image', '');
+        },
+
+        confirmUrl: function () {
+            var $dropzone = this.get('$dropzone'),
+                imageUrl = this.get('imageUrl');
+
+            if (imageUrl === '') {
+                $dropzone.trigger('uploadsuccess', 'http://');
+                this.send('initWithDropzone');
+            } else {
+                this.send('complete', null, imageUrl);
+            }
+        },
+
+        complete: function (event, result) {
+            var self = this,
+                $dropzone = this.get('$dropzone'),
+                $progress = this.$('.progress'),
+                showImage, animateDropzone, preLoadImage;
+
+            showImage = function () {
+                self.set('loading', false);
+                self.set('showImage', true);
+
+                $dropzone.find('div.description').hide();
+                $dropzone.css({height: 'auto'});
+                $dropzone.delay(250).animate({opacity: 100}, 1000, function () {
+                    self.set('saveButtonDisabled', false);
+                    self.send('init');
+                });
+            };
+
+            animateDropzone = function ($img) {
+                $dropzone.animate({opacity: 0}, 250, function () {
+                    self.set('uploaderClass', 'pre-image-uploader');
+                    self.set('enableExtras', false);
+                    self.set('urlUi', false);
+
+                    $dropzone.css({minHeight: 0});
+                    $dropzone.animate({height: $img.height()}, 250, function () {
+                        showImage();
+                    });
+                });
+            };
+
+            preLoadImage = function () {
+                var $img = $dropzone.find('img.js-upload-target');
+
+                self.set('showImage', false);
+
+                $img.one('load', function () {
+                    animateDropzone($img);
+                });
+                $progress.animate({opacity: 0}, 250, function () {
+                    self.set('loading', true);
+                    self.set('image', result);
+                });
+                $dropzone.trigger('uploadsuccess', [result]);
+            };
+
+            preLoadImage();
+        }
+    }
+
 });
 
-export default PostImageUploader;
+export default ImageUploader;

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -10,7 +10,6 @@ var PostSettingsMenuController = Ember.Controller.extend(SettingsMenuMixin, {
     debounceId: null,
     lastPromise: null,
     selectedAuthor: null,
-    uploaderReference: null,
 
     initializeSelectedAuthor: function () {
         var self = this;
@@ -444,14 +443,6 @@ var PostSettingsMenuController = Ember.Controller.extend(SettingsMenuMixin, {
                 self.showErrors(errors);
                 self.get('model').rollback();
             });
-        },
-
-        resetUploader: function () {
-            var uploader = this.get('uploaderReference');
-
-            if (uploader && uploader[0]) {
-                uploader[0].uploaderUi.reset();
-            }
         },
 
         resetPubDate: function () {

--- a/core/client/app/routes/editor/new.js
+++ b/core/client/app/routes/editor/new.js
@@ -16,12 +16,13 @@ var EditorNewRoute = AuthenticatedRoute.extend(base, {
     setupController: function (controller, model) {
         var psm = this.controllerFor('post-settings-menu');
 
+        this._super(controller, model);
+
         // make sure there are no titleObserver functions hanging around
         // from previous posts
         psm.removeObserver('titleScratch', psm, 'titleObserver');
 
-        // Ensure that the PSM Image Uploader and Publish Date selector resets
-        psm.send('resetUploader');
+        // Ensure that the Publish Date selector resets
         psm.send('resetPubDate');
 
         this._super(controller, model);

--- a/core/client/app/styles/components/uploader.scss
+++ b/core/client/app/styles/components/uploader.scss
@@ -138,6 +138,10 @@
         background-size: contain;
     }
 
+    .fileupload-loading-standalone {
+        top: '56px';
+    }
+
     .failed {
         position: relative;
         top: -40px;

--- a/core/client/app/templates/components/gh-uploader.hbs
+++ b/core/client/app/templates/components/gh-uploader.hbs
@@ -1,6 +1,54 @@
-<span class="media">
-    <span class="hidden">Image Upload</span>
-</span>
-<img class="js-upload-target" {{bind-attr src=imageSource}} />
-<div class="description">{{description}}<strong></strong></div>
-<input data-url="upload" class="js-fileupload main fileupload" type="file" name="uploadimage">
+<div {{bind-attr class="uploaderClass :js-post-image-upload"}} >
+    {{#if enableExtras}}
+    <span class="media">
+        <span class="hidden">Image Upload</span>
+    </span>
+    {{/if}}
+
+    {{#if loading}}
+        <img {{bind-attr class=":fileupload-loading editor::fileupload-loading-standalone" src=loadingCat}} />
+    {{/if}}
+
+    <img {{bind-attr class=":js-upload-target showImage::hidden" src=image style=imgStyle }} />
+
+    {{#if urlUi}}
+        <div class="js-url">
+            {{input value=imageUrl class="url js-upload-url" type="url" placeholder="http://"}}
+            {{#if editor}}
+                <button {{action "confirmUrl"}} class="btn btn-blue js-button-accept" {{bind-attr disabled=saveButtonDisabled}}>Save</button>
+            {{/if}}
+        </div>
+    {{/if}}
+
+    <div class="description">
+        {{#if description}}
+            {{description}}
+        {{else}}
+            <span>Add image</span>
+        {{/if}}
+    </div>
+
+    <input data-url="upload" {{bind-attr class=":js-fileupload :main :fileupload rightClass:right"}} type="file" name="uploadimage">
+    {{#if enableExtras}}
+        {{#if error}}
+            <div class="js-fail failed">{{errorText}}</div>
+        {{/if}}
+
+        {{#if progressbar}}
+            <div class="js-upload-progress progress progress-success active" role="progressbar" aria-valuemin="0" aria-valuemax="100">
+                <div {{bind-attr style=progressBarStyle class=":js-upload-progress-bar :bar error:fail"}}></div>
+            </div>
+        {{/if}}
+
+        <button class="js-fail btn btn-green" style="display: none">Try Again</button>
+        <a {{action "initUrl"}}class="image-url" title="Add image from URL">
+            <span class="hidden">URL</span>
+        </a>
+    {{/if}}
+    {{#if cancelMode}}
+        {{#if cancelUrl}}
+            <a {{action "initWithDropzone"}} class="image-upload" title="Add image"><span class="hidden">Upload</span></a>
+        {{/if}}
+        <a {{action "cancel"}} class="image-cancel js-cancel" title="Delete"><span class="hidden">Delete</span></a>
+    {{/if}}
+</div>

--- a/core/client/app/templates/modals/upload.hbs
+++ b/core/client/app/templates/modals/upload.hbs
@@ -1,7 +1,3 @@
 {{#gh-upload-modal action="closeModal" close=true type="action" style="wide" model=model imageType=imageType}}
-  <section class="js-drop-zone">
-      <img class="js-upload-target" {{bind-attr src=src}} alt="logo">
-      <input data-url="upload" class="js-fileupload main" type="file" name="uploadimage" {{bind-attr accept=acceptEncoding}} >
-  </section>
-
+    {{gh-uploader image=src description=description}}
 {{/gh-upload-modal}}

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -7,7 +7,7 @@
             <button class="close icon-x settings-menu-header-action" {{action "closeSettingsMenu"}}><span class="hidden">Close</span></button>
         </div>
         <div class="settings-menu-content">
-            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" description="Add post image" image=model.image uploaderReference=uploaderReference tagName="section"}}
+            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" description="Add post image" image=model.image}}
             <form>
             <div class="form-group">
                 <label for="url">Post URL</label>

--- a/core/client/app/templates/settings/tags/settings-menu.hbs
+++ b/core/client/app/templates/settings/tags/settings-menu.hbs
@@ -8,7 +8,7 @@
             </button>
         </div>
         <div class="settings-menu-content">
-            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" description="Add tag image" image=activeTag.image uploaderReference=uploaderReference tagName="section"}}
+            {{gh-uploader uploaded="setCoverImage" canceled="clearCoverImage" description="Add tag image" image=activeTag.image tagName="section"}}
             <form>
                 <div class="form-group">
                     <label>Name</label>

--- a/core/client/app/views/settings/tags/settings-menu.js
+++ b/core/client/app/views/settings/tags/settings-menu.js
@@ -4,21 +4,6 @@ var TagsSettingsMenuView = Ember.View.extend({
         return this.get('controller.model.isNew') ?
             'Add Tag' :
             'Save Tag';
-    }),
-
-    // This observer loads and resets the uploader whenever the active tag changes,
-    // ensuring that we can reuse the whole settings menu.
-    updateUploader: Ember.observer('controller.activeTag.image', 'controller.uploaderReference', function () {
-        var uploader = this.get('controller.uploaderReference'),
-            image = this.get('controller.activeTag.image');
-
-        if (uploader && uploader[0]) {
-            if (image) {
-                uploader[0].uploaderUi.initWithImage();
-            } else {
-                uploader[0].uploaderUi.reset();
-            }
-        }
     })
 });
 

--- a/core/test/functional/client/settings_test.js
+++ b/core/test/functional/client/settings_test.js
@@ -51,7 +51,7 @@ CasperTest.begin('General settings pane is correct', 8, function suite(test) {
     });
 
     function assertImageUploaderModalThenClose() {
-        test.assertSelectorHasText('.description', 'Add image');
+        test.assertSelectorHasText('.description span', 'Add image');
         casper.click('.modal-container .js-button-accept');
         casper.waitForSelector('.notification-success', function onSuccess() {
             test.assert(true, 'Got success notification');
@@ -65,7 +65,7 @@ CasperTest.begin('General settings pane is correct', 8, function suite(test) {
         casper.click('.js-modal-logo');
     });
 
-    casper.waitForSelector('.modal-container .modal-content .js-drop-zone .description',
+    casper.waitForSelector('.modal-container .modal-content .image-uploader .description',
         assertImageUploaderModalThenClose, casper.failOnTimeout(test, 'No upload logo modal container appeared'));
 
     // Test Blog Cover Upload Button
@@ -73,7 +73,7 @@ CasperTest.begin('General settings pane is correct', 8, function suite(test) {
         casper.click('.js-modal-cover');
     });
 
-    casper.waitForSelector('.modal-container .modal-content .js-drop-zone .description',
+    casper.waitForSelector('.modal-container .modal-content .image-uploader .description',
         assertImageUploaderModalThenClose, casper.failOnTimeout(test, 'No upload cover modal container appeared'));
 
     function handleSettingsRequest(requestData) {


### PR DESCRIPTION
Now on top of Ember Cli! This is a first milestone on our way to removing the old image
uploader. In this approach, the image upload works exactly like the old
one, but is an Ember component merely using jQuery for it's fileupload
features - but using Ember for properties and most DOM manipulations.
- Aware of context change (no reset call from parent controllers :tada:)
- Integrated in PSM, Tag Settings, Setting Modals
