### PR TITLE
Autosave by observing model.scratch in editor

### DIFF
--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -40,37 +40,11 @@ Editor = Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
     },
 
     /**
-     * Use keypress events to trigger autosave
-     */
-    changeHandler: function () {
-        // onChange is sent to trigger autosave
-        this.sendAction('onChange');
-    },
-
-    /**
-     * Bind to the keypress event once the element is in the DOM
-     * Use keypress because it's the most reliable cross browser
-     */
-    attachChangeHandler: function () {
-        this.$().on('keypress', Ember.run.bind(this, this.changeHandler));
-    }.on('didInsertElement'),
-
-    /**
-     * Unbind from the keypress event when the element is no longer in the DOM
-     */
-    detachChangeHandler: function () {
-        this.$().off('keypress');
-        Ember.run.cancel(this.get('fixHeightThrottle'));
-    }.on('willDestroyElement'),
-
-    /**
      * Disable editing in the textarea (used while an upload is in progress)
      */
     disable: function () {
         var textarea = this.get('element');
         textarea.setAttribute('readonly', 'readonly');
-
-        this.detachChangeHandler();
     },
 
     /**
@@ -79,11 +53,6 @@ Editor = Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
     enable: function () {
         var textarea = this.get('element');
         textarea.removeAttribute('readonly');
-
-        // clicking the trash button on an image dropzone causes this function to fire.
-        // this line is a hack to prevent multiple event handlers from being attached.
-        this.detachChangeHandler();
-        this.attachChangeHandler();
     }
 });
 

--- a/core/client/app/mixins/editor-base-route.js
+++ b/core/client/app/mixins/editor-base-route.js
@@ -110,12 +110,11 @@ var EditorBaseRoute = Ember.Mixin.create(styleBody, ShortcutsRoute, loadingIndic
     },
 
     setupController: function (controller, model) {
+        model.set('scratch', model.get('markdown'));
+        model.set('titleScratch', model.get('title'));
+
         this._super(controller, model);
         var tags = model.get('tags');
-
-        controller.set('model.scratch', model.get('markdown'));
-
-        controller.set('model.titleScratch', model.get('title'));
 
         if (tags) {
             // used to check if anything has changed in the editor

--- a/core/client/app/templates/editor/edit.hbs
+++ b/core/client/app/templates/editor/edit.hbs
@@ -18,9 +18,8 @@
         </header>
         <section id="entry-markdown-content" class="entry-markdown-content">
             {{gh-ed-editor classNames="markdown-editor js-markdown-editor" tabindex="1" spellcheck="true" value=model.scratch
-            scrollInfo=view.editorScrollInfo
-            setEditor="setEditor" openModal="openModal" onChange="autoSave"
-            focus=shouldFocusEditor focusCursorAtEnd=model.isDirty onFocusIn="autoSaveNew"}}
+            scrollInfo=view.editorScrollInfo focus=shouldFocusEditor focusCursorAtEnd=model.isDirty
+            setEditor="setEditor" openModal="openModal" onFocusIn="autoSaveNew"}}
         </section>
     </section>
 


### PR DESCRIPTION
No issue
- removes keypress handling in the editor component
- automated value changes via shortcuts still autosave
