### PR TITLE
[WIP] Use partialIndent hbs option to prevent indent issues

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -52,7 +52,18 @@ function activateTheme(activeTheme) {
     blogApp.cache = {};
 
     // set view engine
-    hbsOptions = {partialsDir: [config.paths.helperTemplates]};
+    hbsOptions = {
+        partialsDir: [config.paths.helperTemplates],
+        // override the default compile
+        onCompile: function(exhbs, source, filename) {
+            var options;
+            if (filename && filename.indexOf('partials') !== -1) {
+                options = {preventIndent: true};
+            }
+
+            return exhbs.handlebars.compile(source, options);
+        }
+    };
 
     fs.stat(themePartials, function (err, stats) {
         // Check that the theme has a partials directory before trying to use it

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "connect-slashes": "1.3.0",
         "downsize": "0.0.8",
         "express": "4.12.0",
-        "express-hbs": "0.7.11",
+        "express-hbs": "0.8.2",
         "extract-zip": "1.0.3",
         "fs-extra": "0.13.0",
         "glob": "4.3.2",


### PR DESCRIPTION
Raising this here just as a place for discussion - I did attempt to update express-hbs to 0.8.2 so that we could use the `preventIndent` compiler flag, which should fix #4364 

However for some reason it's not working. 

I have tried tracing it through, the problem doesn't seem to be with express-hbs as in handlebars' compiler.js, the option is present in `compileInput` but not in `PartialStatement`. I don't know the code well enough yet but if anyone fancies taking a look it would be appreciated
