### PR TITLE
Update express-hbs & registerAsyncHelper function

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -47,10 +47,15 @@ coreHelpers.helperMissing = function (arg) {
 
 // Register an async handlebars helper for a given handlebars instance
 function registerAsyncHelper(hbs, name, fn) {
-    hbs.registerAsyncHelper(name, function (options, cb) {
-        // Wrap the function passed in with a when.resolve so it can
-        // return either a promise or a value
-        Promise.resolve(fn.call(this, options)).then(function (result) {
+    hbs.registerAsyncHelper(name, function (context, options, cb) {
+        // Handle the case where we only get context and cb
+        if (!cb) {
+            cb = options;
+            options = undefined;
+        }
+
+        // Wrap the function passed in with a when.resolve so it can return either a promise or a value
+        Promise.resolve(fn.call(this, context, options)).then(function (result) {
             cb(result);
         }).catch(function (err) {
             errors.logAndThrowError(err, 'registerAsyncThemeHelper: ' + name);

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -52,7 +52,12 @@ function activateTheme(activeTheme) {
     blogApp.cache = {};
 
     // set view engine
-    hbsOptions = {partialsDir: [config.paths.helperTemplates]};
+    hbsOptions = {
+        partialsDir: [config.paths.helperTemplates],
+        onCompile: function (exhbs, source) {
+            return exhbs.handlebars.compile(source, {preventIndent: true});
+        }
+    };
 
     fs.stat(themePartials, function (err, stats) {
         // Check that the theme has a partials directory before trying to use it

--- a/core/test/unit/server_helpers/navigation_spec.js
+++ b/core/test/unit/server_helpers/navigation_spec.js
@@ -18,7 +18,10 @@ describe('{{navigation}} helper', function () {
 
     before(function (done) {
         utils.loadHelpers();
-        hbs.express3({partialsDir: [utils.config.paths.helperTemplates]});
+        hbs.express3({
+            partialsDir: [utils.config.paths.helperTemplates]
+        });
+
         hbs.cachePartials(function () {
             done();
         });

--- a/core/test/unit/server_helpers/pagination_spec.js
+++ b/core/test/unit/server_helpers/pagination_spec.js
@@ -12,6 +12,7 @@ describe('{{pagination}} helper', function () {
     before(function (done) {
         utils.loadHelpers();
         hbs.express3({partialsDir: [utils.config.paths.helperTemplates]});
+
         hbs.cachePartials(function () {
             done();
         });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "connect-slashes": "1.3.0",
         "downsize": "0.0.8",
         "express": "4.12.0",
-        "express-hbs": "0.7.11",
+        "express-hbs": "0.8.4",
         "extract-zip": "1.0.3",
         "fs-extra": "0.13.0",
         "glob": "4.3.2",


### PR DESCRIPTION
This is needed for both the get helper and the prev/next helpers.

Note there is a currently not-working similar update here: #5053 - this update works though :)

refs #4439, refs #4799 
- Update express-hbs to 0.8.3
- Update registerAsyncHelper to support passing through options when needed
- Will be used by the get and prev/next helpers
