### PR TITLE
Improve RSS feed

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -15,6 +15,7 @@ var moment      = require('moment'),
     template    = require('../helpers/template'),
     errors      = require('../errors'),
     cheerio     = require('cheerio'),
+    downsize    = require('downsize'),
     routeMatch  = require('path-match')(),
 
     frontendControllers,
@@ -500,7 +501,10 @@ frontendControllers = {
                     generator: 'Ghost ' + trimmedVersion,
                     feed_url: feedUrl,
                     site_url: siteUrl,
-                    ttl: '60'
+                    ttl: '60',
+                    custom_namespaces: {
+                        content: 'http://purl.org/rss/1.0/modules/content/'
+                    }
                 });
 
                 // If page is greater than number of pages we have, redirect to last page
@@ -566,11 +570,18 @@ frontendControllers = {
                             });
                         });
 
-                        item.description = htmlContent.html();
+                        item.custom_elements = [{
+                            'content:encoded': {
+                                _cdata: htmlContent.html()
+                            }
+                        }];
+
+                        item.description = post.meta_description || downsize(htmlContent.html(), {words: 50});
+
                         feed.item(item);
                     });
                 }).then(function () {
-                    res.set('Content-Type', 'application/rss+xml; charset=UTF-8');
+                    res.set('Content-Type', 'text/xml; charset=UTF-8');
                     res.send(feed.xml());
                 });
             });

--- a/core/test/functional/routes/frontend_test.js
+++ b/core/test/functional/routes/frontend_test.js
@@ -376,7 +376,7 @@ describe('Frontend Routing', function () {
 
         it('should respond with xml', function (done) {
             request.get('/rss/')
-                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
+                .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(function (err, res) {
@@ -394,8 +394,9 @@ describe('Frontend Routing', function () {
                         siteDescription = '<description><![CDATA[Just a blogging platform.]]></description>',
                         siteUrl = '<link>http://127.0.0.1:2369/</link>',
                         postTitle = '<![CDATA[Welcome to Ghost]]>',
-                        postStart = '<description><![CDATA[<p>You\'re live!',
-                        postEnd = 'you think :)</p>]]></description>',
+                        descStart = '<description><![CDATA[<p>You\'re live!',
+                        postStart = '<content:encoded><![CDATA[<p>You\'re live!',
+                        postEnd = 'you think :)</p>]]></content:encoded>',
                         postLink = '<link>http://127.0.0.1:2369/welcome-to-ghost/</link>',
                         postCreator = '<dc:creator><![CDATA[Joe Bloggs]]>',
                         author = '<author>';
@@ -405,6 +406,7 @@ describe('Frontend Routing', function () {
                     content.indexOf(siteDescription).should.be.above(0);
                     content.indexOf(siteUrl).should.be.above(0);
                     content.indexOf(postTitle).should.be.above(0);
+                    content.indexOf(descStart).should.be.above(0);
                     content.indexOf(postStart).should.be.above(0);
                     content.indexOf(postEnd).should.be.above(0);
                     content.indexOf(postLink).should.be.above(0);
@@ -434,11 +436,45 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
-        describe('RSS pages', function () {
+        describe('More RSS', function () {
             before(function (done) {
                 testUtils.fixtures.insertPosts().then(function () {
-                    return testUtils.fixtures.insertMorePosts(11);
-                }).then(function () {
+                    done();
+                }).catch(done);
+            });
+
+            it('should use meta_description where available', function (done) {
+                request.get('/rss/')
+                    .expect('Content-Type', 'text/xml; charset=utf-8')
+                    .expect('Cache-Control', testUtils.cacheRules['public'])
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        var content = res.text,
+                            post1End = 'you think :)</p>]]></content:encoded>',
+                            post3Title = '<title><![CDATA[Short and Sweet\]\]>',
+                            post3DescStart = '<description><![CDATA[test stuff',
+                            post3ContentStart = '<content:encoded><![CDATA[<h2 id=\"testing\">testing</h2>',
+                            endIndex = content.indexOf(post1End);
+
+                        content.indexOf('<rss').should.be.above(0);
+                        content.indexOf(post1End).should.be.above(0);
+                        content.indexOf(post3Title).should.be.above(endIndex);
+                        content.indexOf(post3DescStart).should.be.above(endIndex);
+                        content.indexOf(post3ContentStart).should.be.above(endIndex);
+                        content.indexOf('</rss>').should.be.above(0);
+
+                        done();
+                    });
+            });
+        });
+
+        describe('RSS pages', function () {
+            before(function (done) {
+                testUtils.fixtures.insertMorePosts(11).then(function () {
                     done();
                 }).catch(done);
             });
@@ -899,7 +935,7 @@ describe('Frontend Routing', function () {
 
         it('should serve RSS with date permalink', function (done) {
             request.get('/rss/')
-                .expect('Content-Type', 'application/rss+xml; charset=utf-8')
+                .expect('Content-Type', 'text/xml; charset=utf-8')
                 .expect('Cache-Control', testUtils.cacheRules['public'])
                 .expect(200)
                 .end(function (err, res) {

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -23,6 +23,7 @@ DataGenerator.Content = {
             slug: "short-and-sweet",
             markdown: "## testing\n\nmctesters\n\n- test\n- line\n- items",
             html: "<h2 id=\"testing\">testing</h2>\n\n<p>mctesters</p>\n\n<ul>\n<li>test</li>\n<li>line</li>\n<li>items</li>\n</ul>",
+            meta_description: "test stuff",
             published_at: new Date("2015-01-03")
         },
         {

--- a/package.json
+++ b/package.json
@@ -60,13 +60,13 @@
         "passport-oauth2-client-password": "0.1.2",
         "path-match": "1.2.2",
         "request": "2.51.0",
-        "rss": "1.0.0",
+        "rss": "1.1.1",
         "semver": "4.1.0",
         "showdown-ghost": "0.3.6",
         "sqlite3": "3.0.5",
         "unidecode": "0.1.3",
         "validator": "3.28.0",
-        "xml": "0.0.12"
+        "xml": "1.0.0"
     },
     "optionalDependencies": {
         "mysql": "2.1.1",


### PR DESCRIPTION
This is still a WIP because there needs to be a fallback for description. I was intending to make this meta_description, or if that is empty, use the first 50 words of the content (until #5060 is done, when we can use the first paragraph).

This issue addresses the first two items of this comment: https://github.com/TryGhost/Ghost/issues/2263#issuecomment-84939861

refs #2263
- Switch content type back to text/xml
- Use content:encode for full content
