### PR TITLE
model.user.format() overide should call super to fix dateTime format

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -110,7 +110,7 @@ User = ghostBookshelf.Model.extend({
             protocols: ['http', 'https']})) {
             options.website = 'http://' + options.website;
         }
-        return options;
+        return ghostBookshelf.Model.prototype.format.call(this, options);
     },
 
     posts: function () {


### PR DESCRIPTION
Fix a problem that user model will fail to save if  mysql has option of STRICT_TRANS_TABLES 

closes #5066 
- add a parent call in user.format override function, which should fix dateTime format before user saved.
