### PR TITLE
This commit allows the excerpt helper to fully utilize all downsize options

### DIFF
--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -14,8 +14,7 @@ excerpt = function (options) {
     var truncateOptions = (options || {}).hash || {},
         excerpt;
 
-    truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
-    _.keys(truncateOptions).map(function (key) {
+    _.keys(_.pick(truncateOptions, ['words', 'characters'])).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 

--- a/core/test/unit/server_helpers/excerpt_spec.js
+++ b/core/test/unit/server_helpers/excerpt_spec.js
@@ -87,14 +87,13 @@ describe('{{excerpt}} Helper', function () {
 
     it('can truncate html by character', function () {
         var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
-            expected = 'Hello Wo',
+            expected = 'Hello Wo (contd)',
             rendered = (
                 helpers.excerpt.call(
                     {html: html},
-                    {hash: {characters: '8'}}
+                    {hash: {characters: '8', append: ' (contd)'}}
                 )
                 );
-
         should.exist(rendered);
         rendered.string.should.equal(expected);
     });


### PR DESCRIPTION
I rearranged the pick/map functions so that other options like "append" and "round" aren't filtered out of the truncateOptions object (the append option seems to be super useful!)
