### PR TITLE
Re-add X icon

### DIFF
--- a/core/client/app/styles/modules/icons.scss
+++ b/core/client/app/styles/modules/icons.scss
@@ -399,7 +399,9 @@ $i-x:                   \f634;
 .icon-weather-sun:before {
     content: '#{$i-weather-sun}';
 }
-x
+.icon-x:before {
+    content: '#{$i-x}';
+}
 
 // Specific icon size adjustments
 .icon-list:before {


### PR DESCRIPTION
No issue

The `icon-x` class got messed up when I attempted to dry up our icon code in both https://github.com/TryGhost/Ghost/pull/4948 and https://github.com/PaulAdamDavis/Ghost/commit/69fb78150d097d4abb8bfa6d017d674a157a3d0e. All that was left was an `x` in the file.

This adds that class back, so the `icon-x` icon works again.
