### PR TITLE
Add link to published posts preview on content page

### DIFF
--- a/core/client/app/styles/layouts/content.scss
+++ b/core/client/app/styles/layouts/content.scss
@@ -258,6 +258,13 @@
         padding: 3px;
     }
 
+    .post-published-by .status a {
+        color: inherit;
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
     .normal {
         text-transform: none;
         margin: 0 3px;

--- a/core/client/app/templates/posts/post.hbs
+++ b/core/client/app/templates/posts/post.hbs
@@ -5,7 +5,13 @@
         <span class="sr-only">Star</span>
     </button>
     <small class="post-published-by">
-        <span class="status">{{#if isPublished}}Published{{else}}Written{{/if}}</span>
+        <span class="status">
+            {{#if isPublished}}
+                <a {{bind-attr title="model.title" href="model.url"}}>Published</a>
+            {{else}}
+                Written
+            {{/if}}
+        </span>
         <span class="normal">by</span>
         <span class="author">{{#if model.author.name}}{{model.author.name}}{{else}}{{model.author.email}}{{/if}}</span>
     </small>


### PR DESCRIPTION
Ref #1756
- the word "Published" in "Published by {{author}}" now links to the post on the front of the blog

This was just something I wanted while I was cruising through my backend today. cc @PaulAdamDavis on the styling, currently it's just this:

![screen shot 2015-04-02 at 17 41 29](https://cloud.githubusercontent.com/assets/1207005/6975887/89656ba4-d95f-11e4-9608-7f75f5be5ce2.png)
