### PR TITLE
Increase font-weight of admin nav items

### DIFF
--- a/core/client/app/styles/components/navigation.scss
+++ b/core/client/app/styles/components/navigation.scss
@@ -54,7 +54,7 @@
     padding-right: 10px;
     font-size: 1.1rem;
     letter-spacing: 1px;
-    font-weight: 200;
+    font-weight: 700;
     line-height: 1.1em;
 }
 


### PR DESCRIPTION
The current navigation item style is not readable on some screens because it is too thin. It is also quite unusual to make navigation items thinner instead of bold. This patch sets the `font-weight` from 200 to 700. The requested front style is already loaded by the application and therefore no new resources are required (we use `<link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />`, which btw does not load the current font weight of 200).

Before:
![screenshot from 2015-04-04 23 55 12](https://cloud.githubusercontent.com/assets/1529400/6994793/1ba844b0-db26-11e4-8a62-3173a40765e4.png)

After:
![screenshot from 2015-04-04 23 54 48](https://cloud.githubusercontent.com/assets/1529400/6994795/23702bae-db26-11e4-9d01-8821b90b915a.png)
