### PR TITLE
Remove duplicate subdirectory in RSS urls

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -562,6 +562,11 @@ frontendControllers = {
                                 // as the base URL, otherwise use the post's URL.
                                 baseUrl = attributeValue[0] === '/' ? siteUrl : item.url;
 
+                                // prevent double subdirectoreis
+                                if (attributeValue.indexOf(config.paths.subdir) === 0) {
+                                    attributeValue = attributeValue.replace(config.paths.subdir, '');
+                                }
+
                                 // prevent double slashes
                                 if (baseUrl.slice(-1) === '/' && attributeValue[0] === '/') {
                                     attributeValue = attributeValue.substr(1);


### PR DESCRIPTION
This is a quick and dirty fix for now, which is pretty bad because we keep having issues in this area. Ideally we need to be refactoring towards using smarter url functions centralised in `config/url.js` and properly tested.

However, I wanted to ensure that at least 'a' fix for this was included in the next release, plus I want to refactor the RSS feed to be event driven and that will mean moving all of this code, therefore it seems like a good idea to get all these changes in before I do that.

fixes #5064
