### PR TITLE
[WIP] Updates nodemailer to 1.3.2

### DIFF
--- a/core/test/integration/api/api_mail_spec.js
+++ b/core/test/integration/api/api_mail_spec.js
@@ -78,30 +78,30 @@ describe('Mail API', function () {
         });
 
         it('return correct failure message for domain doesn\'t exist', function (done) {
-            mailer.transport.transportType.should.eql('DIRECT');
+            mailer.transport.transporter.name.should.eql('SMTP (direct)');
             return MailAPI.send(mailDataNoDomain, testUtils.context.internal).then(function () {
                 done(new Error('Error message not shown.'));
             }, function (error) {
-                error.message.should.startWith('Email Error: Failed sending email');
+                error.message.should.startWith('Error: Sending failed');
                 error.type.should.eql('EmailError');
                 done();
             }).catch(done);
         });
 
         // This test doesn't work properly - it times out locally
-        it.skip('return correct failure message for no mail server at this address', function (done) {
-            mailer.transport.transportType.should.eql('DIRECT');
+        it('return correct failure message for no mail server at this address', function (done) {
+            mailer.transport.transporter.name.should.eql('SMTP (direct)');
             MailAPI.send(mailDataNoServer, testUtils.context.internal).then(function () {
                 done(new Error('Error message not shown.'));
             }, function (error) {
-                error.message.should.eql('Email Error: Failed sending email.');
+                error.message.should.eql('Error: Sending failed');
                 error.type.should.eql('EmailError');
                 done();
             }).catch(done);
         });
 
         it('return correct failure message for incomplete data', function (done) {
-            mailer.transport.transportType.should.eql('DIRECT');
+            mailer.transport.transporter.name.should.eql('SMTP (direct)');
 
             MailAPI.send(mailDataIncomplete, testUtils.context.internal).then(function () {
                 done(new Error('Error message not shown.'));
@@ -113,34 +113,29 @@ describe('Mail API', function () {
         });
     });
 
-    describe.skip('Stub', function () {
+    describe('Stub', function () {
         it('returns a success', function (done) {
-            config.set({mail: {transport: 'stub'}});
-
+            config.set({mail: {options: {service: 'stub'}}});
             mailer.init().then(function () {
-                mailer.transport.transportType.should.eql('STUB');
                 return MailAPI.send(mailDataNoServer, testUtils.context.internal);
             }).then(function (response) {
                 should.exist(response.mail);
                 should.exist(response.mail[0].message);
                 should.exist(response.mail[0].status);
-                response.mail[0].status.should.eql({message: 'Message Queued'});
                 response.mail[0].message.subject.should.eql('testemail');
                 done();
             }).catch(done);
         });
 
         it('returns a boo boo', function (done) {
-            config.set({mail: {transport: 'stub', error: 'Stub made a boo boo :('}});
-
+            config.set({mail: {options: {service: 'stub', error: 'Stub made a boo boo :('}}});
             mailer.init().then(function () {
-                mailer.transport.transportType.should.eql('STUB');
+                mailer.transport.transporter.name.should.eql('Stub');
                 return MailAPI.send(mailDataNoServer, testUtils.context.internal);
-            }).then(function (response) {
-                console.log('res', response.mail[0]);
+            }).then(function () {
                 done(new Error('Stub did not error'));
             }, function (error) {
-                error.message.should.startWith('Email Error: Failed sending email: there is no mail server at this address');
+                error.message.should.startWith('Error: Stub made a boo boo :(');
                 error.type.should.eql('EmailError');
                 done();
             }).catch(done);

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -11,7 +11,6 @@ var should          = require('should'),
 
 // Mock SMTP config
 SMTP = {
-    transport: 'SMTP',
     options: {
         service: 'Gmail',
         auth: {
@@ -37,7 +36,7 @@ describe('Mail', function () {
         config.set({mail: SMTP});
         mailer.init().then(function () {
             mailer.should.have.property('transport');
-            mailer.transport.transportType.should.eql('SMTP');
+            mailer.transport.transporter.name.should.eql('SMTP');
             mailer.transport.sendMail.should.be.a.function;
             done();
         }).catch(done);
@@ -47,7 +46,7 @@ describe('Mail', function () {
         config.set({mail: {}});
         mailer.init().then(function () {
             mailer.should.have.property('transport');
-            mailer.transport.transportType.should.eql('DIRECT');
+            mailer.transport.transporter.name.should.eql('SMTP (direct)');
             done();
         }).catch(done);
     });

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "moment": "2.8.3",
         "morgan": "1.5.0",
         "node-uuid": "1.4.2",
-        "nodemailer": "0.7.1",
+        "nodemailer": "1.3.2",
         "oauth2orize": "1.0.1",
         "passport": "0.2.1",
         "passport-http-bearer": "1.0.1",
@@ -98,6 +98,7 @@
         "sinon": "~1.12.2",
         "supertest": "~0.15.0",
         "testem": "^0.6.23",
-        "top-gh-contribs": "^1.0.0"
+        "top-gh-contribs": "^1.0.0",
+        "nodemailer-stub-transport": "1.0.0"
     }
 }


### PR DESCRIPTION
Fixes #5095
- Updates nodemailer from 0.7.x to 1.3.2
- Adds `nodemailer-wellknown` for common SMTP configs
- Adds `nodemailer-stub-transport` for development
- Adjusts tests so they work with changes in nodemailer
- (hopefully) fixes the timeouts
