### PR TITLE
Add Connection UI

### DIFF
--- a/core/client/app/controllers/feature.js
+++ b/core/client/app/controllers/feature.js
@@ -24,6 +24,10 @@ var FeatureController = Ember.Controller.extend(Ember.PromiseProxyMixin, {
         }
 
         return value;
+    }),
+
+    connectionsUI: Ember.computed('config.connectionsUI', 'labs.connectionsUI', function () {
+        return this.get('config.connectionsUI') || this.get('labs.connectionsUI');
     })
 });
 

--- a/core/client/app/controllers/settings.js
+++ b/core/client/app/controllers/settings.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 var SettingsController = Ember.Controller.extend({
+    needs: ['feature'],
 
     showGeneral: Ember.computed('session.user.name', function () {
         return this.get('session.user.isAuthor') || this.get('session.user.isEditor') ? false : true;
@@ -21,6 +22,9 @@ var SettingsController = Ember.Controller.extend({
     }),
     showAbout: Ember.computed('session.user.name', function () {
         return this.get('session.user.isAuthor') ? false : true;
+    }),
+    showConnections: Ember.computed('controllers.feature.connectionsUI', function () {
+        return !this.get('controllers.feature.connectionsUI') ? false : true;
     })
 });
 

--- a/core/client/app/controllers/settings/connections.js
+++ b/core/client/app/controllers/settings/connections.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+var SettingsConnectionsController = Ember.Controller.extend({
+
+    // Just an example image to show off the template correctly
+    connectionImage: Ember.computed(function () {
+        return this.get('ghostPaths.url').asset('/shared/img/user-image.png');
+    })
+});
+
+export default SettingsConnectionsController;

--- a/core/client/app/router.js
+++ b/core/client/app/router.js
@@ -43,6 +43,7 @@ Router.map(function () {
         this.route('labs');
         this.route('code-injection');
         this.route('navigation');
+        this.route('connections');
     });
 
     // Redirect debug to settings labs

--- a/core/client/app/routes/settings/connections.js
+++ b/core/client/app/routes/settings/connections.js
@@ -1,0 +1,9 @@
+import AuthenticatedRoute from 'ghost/routes/authenticated';
+import styleBody from 'ghost/mixins/style-body';
+
+var SettingsConnectionsRoute = AuthenticatedRoute.extend(styleBody, {
+    titleToken: 'Connections',
+    classNames: ['settings-view-connections']
+});
+
+export default SettingsConnectionsRoute;

--- a/core/client/app/styles/layouts/settings.scss
+++ b/core/client/app/styles/layouts/settings.scss
@@ -11,6 +11,7 @@
 // * Custom Permalinks
 // * Navigation
 // * Code Injection
+// * Connections
 // ------------------------------------------------------------
 
 
@@ -543,5 +544,137 @@
         border-color: $brown;
         outline: 0;
     }
+}
 
+
+//
+// Connections
+// --------------------------------------------------
+
+@media (min-width: 900px) {
+    .settings-view-connections .settings-view-header {
+        display: none;
+    }
+}
+
+.connections-group + .connections-group {
+    margin-top: 62px;
+}
+
+.connections-group-title {
+    font-size: 2.6rem;
+    line-height: 1.3;
+    font-weight: normal;
+    color: $darkgrey;
+    margin-bottom: 0.5em;
+}
+
+.connections-group-description {
+    font-size: 1.8rem;
+    line-height: 1.5;
+    color: $midgrey;
+    max-width: 695px;
+}
+
+.connection-item {
+    border-top: 1px solid $lightgrey;
+    padding-top: 11px;
+    padding-bottom: 11px;
+    position: relative;
+    padding-left: 62px; // 46px image + 16px right margin
+}
+
+
+.connection-image {
+    width: 46px;
+    height: 46px;
+    border-radius: 3px;
+    overflow: hidden;
+    position: absolute;
+    top: 11px;
+    left: 0;
+
+    img {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 100%;
+        transform: translate(-50%, -50%);
+    }
+}
+
+.connection-text {
+    @media (min-width: 500px) {
+        float: left;
+        width: calc(100% - 160px);
+    }
+}
+
+.connection-title {
+    font-size: 1.8rem;
+    font-weight: bold;
+    color: $grey;
+    display: inline-block;
+    margin-right: 3px;
+}
+
+.connection-last-used {
+    font-size: 1.3rem;
+    color: $brown;
+
+    @media (max-width: 499px) {
+        display: block;
+        margin-top: -5px;
+    }
+}
+
+.connection-username {
+    font-size: 1.4rem;
+    color: $blue;
+
+    @media (max-width: 499px) {
+        display: block;
+        margin-top: -5px;
+    }
+
+    @media (min-width: 500px) {
+        &:before {
+            content: '/';
+            color: $brown;
+            display: inline-block;
+            margin-left: -3px;
+            margin-right: 4px;
+        }
+    }
+}
+
+.connection-description {
+    font-size: 1.6rem;
+    line-height: 1.4;
+    color: $midgrey;
+
+    @media (max-width: 499px) {
+        margin: -2px 0 0 0;
+    }
+
+    @media (min-width: 500px) {
+        margin: -5px 0 0 0;
+    }
+}
+
+.connection-revoke {
+    margin-top: 7px;
+
+    &:before {
+        position: relative;
+        top: 2px;
+        display: inline-block;
+        margin-right: 7px;
+        font-size: 14px;
+        transform: rotate(45deg);
+    }
+
+    @media (min-width: 500px) {
+        float: right;
+    }
 }

--- a/core/client/app/templates/settings.hbs
+++ b/core/client/app/templates/settings.hbs
@@ -34,6 +34,10 @@
             {{#if showAbout}}
                 {{gh-activating-list-item route="settings.about" title="About" classNames="settings-nav-about icon-pacman"}}
             {{/if}}
+
+            {{#if showConnections}}
+                {{gh-activating-list-item route="settings.connections" title="Connections" classNames="settings-nav-connections icon-services"}}
+            {{/if}}
         </ul>
     </nav>
 

--- a/core/client/app/templates/settings/connections.hbs
+++ b/core/client/app/templates/settings/connections.hbs
@@ -1,0 +1,56 @@
+<header class="settings-view-header">
+    {{#link-to "settings" class="btn btn-default btn-back"}}Back{{/link-to}}
+    <h2 class="page-title">Connections</h2>
+</header>
+
+<section class="content settings-connections">
+
+    <div class="connections-group">
+        <h2 class="connections-group-title">Clients</h2>
+        <p class="connections-group-description">These are services which connect to Ghost - for example a desktop editor which allows you to send content into your Ghost account.</p>
+
+        <div class="connection-item clearfix">
+            <span class="connection-image"><img src="{{connectionImage}}" alt="Blogo icon"></span>
+            <div class="connection-text">
+                <span class="connection-title">Blogo</span>
+                <span class="connection-last-used">Last used on Mar 12, 2015</span>
+                <p class="connection-description">A simple, fast desktop publishing app for OSX</p>
+            </div>
+            <button class="connection-revoke btn btn-red icon-add">Revoke Access</button>
+        </div>
+    </div>
+
+    <div class="connections-group">
+        <h2 class="connections-group-title">Accounts</h2>
+        <p class="connections-group-description">These are services which Ghost connects to - for example sending a post from your Ghost account to one of your social networks for distribution.</p>
+
+        <div class="connection-item clearfix">
+            <span class="connection-image"><img src="{{connectionImage}}" alt="GitHub icon"></span>
+            <div class="connection-text">
+                <span class="connection-title">GitHub</span>
+                <a href="#" class="connection-username">tryghost</a>
+                <p class="connection-description">Source control and code management.</p>
+            </div>
+            <button class="connection-revoke btn btn-red icon-add">Remove</button>
+        </div>
+        <div class="connection-item clearfix">
+            <span class="connection-image"><img src="{{connectionImage}}" alt="Twitter icon"></span>
+            <div class="connection-text">
+                <span class="connection-title">Twitter</span>
+                <a href="#" class="connection-username">tryghost</a>
+                <p class="connection-description">Social networking and microblogging service.</p>
+            </div>
+            <button class="connection-revoke btn btn-red icon-add">Remove</button>
+        </div>
+        <div class="connection-item clearfix">
+            <span class="connection-image"><img src="{{connectionImage}}" alt="Google icon"></span>
+            <div class="connection-text">
+                <span class="connection-title">Google</span>
+                <a href="#" class="connection-username">john@ghost.org</a>
+                <p class="connection-description">Authentication for Google services.</p>
+            </div>
+            <button class="connection-revoke btn btn-red icon-add">Remove</button>
+        </div>
+    </div>
+
+</section>

--- a/core/client/app/views/settings/connections.js
+++ b/core/client/app/views/settings/connections.js
@@ -1,0 +1,5 @@
+import BaseView from 'ghost/views/settings/content-base';
+
+var SettingsConnectionsView = BaseView.extend();
+
+export default SettingsConnectionsView;

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -11,6 +11,7 @@ function getValidKeys() {
     var validKeys = {
             fileStorage: config.fileStorage === false ? false : true,
             apps: config.apps === true ? true : false,
+            connectionsUI: config.connectionsUI === true ? true : false,
             version: config.ghostVersion,
             environment: process.env.NODE_ENV,
             database: config.database.client,


### PR DESCRIPTION
References #4177
- Adds the Connections UI behind a config flag

This has no concept of user permissions – it is enabled for everyone if the config flag is set.

The original Sketch file has very slightly different colours than what\s used here. I have used the closest matching existing colour variable for consistency.

Preview Screenshots
- [Desktop](https://cloud.githubusercontent.com/assets/390392/7034988/7188dbb2-dd7c-11e4-93fa-824e2d3b9794.png)
- [Tablet](https://cloud.githubusercontent.com/assets/390392/7034990/7549cab8-dd7c-11e4-8a8c-b94ef84edce7.png)
- [Mobile](https://cloud.githubusercontent.com/assets/390392/7034994/790db772-dd7c-11e4-8514-9dbfcb1132bb.png)
