### PR TITLE
Use absolute url for post preview link

### DIFF
--- a/core/client/app/initializers/ghost-config.js
+++ b/core/client/app/initializers/ghost-config.js
@@ -8,6 +8,7 @@ var ConfigInitializer = {
         application.register('ghost:config', config, {instantiate: false});
 
         application.inject('route', 'config', 'ghost:config');
+        application.inject('model:post', 'config', 'ghost:config');
         application.inject('controller', 'config', 'ghost:config');
         application.inject('component', 'config', 'ghost:config');
     }

--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -222,10 +222,11 @@ EditorControllerMixin = Ember.Mixin.create({
 
     showSaveNotification: function (prevStatus, status, delay) {
         var message = this.messageMap.success.post[prevStatus][status],
-            path = this.get('ghostPaths.url').join(this.get('config.blogUrl'), this.get('model.url'));
+            path = this.get('model.absoluteUrl'),
+            type = this.get('postOrPage');
 
         if (status === 'published') {
-            message += '&nbsp;<a href="' + path + '">View ' + this.get('postOrPage') + '</a>';
+            message += `&nbsp;<a href="${path}">View ${type}</a>`;
         }
         this.notifications.showSuccess(message.htmlSafe(), {delayed: delay});
     },

--- a/core/client/app/models/post.js
+++ b/core/client/app/models/post.js
@@ -29,6 +29,12 @@ var Post = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
     tags: DS.hasMany('tag', {embedded: 'always'}),
     url: DS.attr('string'),
 
+    absoluteUrl: Ember.computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
+        var blogUrl = this.get('config.blogUrl'),
+            postUrl = this.get('url');
+        return this.get('ghostPaths.url').join(blogUrl, postUrl);
+    }),
+
     scratch: null,
     titleScratch: null,
 

--- a/core/client/app/templates/posts/post.hbs
+++ b/core/client/app/templates/posts/post.hbs
@@ -7,7 +7,7 @@
     <small class="post-published-by">
         <span class="status">
             {{#if isPublished}}
-                <a title="{{model.title}}" href="{{model.url}}">Published</a>
+                <a title="{{model.title}}" href="{{model.absoluteUrl}}">Published</a>
             {{else}}
                 Written
             {{/if}}


### PR DESCRIPTION
Closes #5116
- adds new CP `absoluteUrl` to PostModel
- use `absoluteUrl` in the two places we link previews
- swap out some code for es6 loveliness
