### PR TITLE
Don't do autosave on new post

### DIFF
--- a/core/client/app/controllers/editor/new.js
+++ b/core/client/app/controllers/editor/new.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
 
 var EditorNewController = Ember.Controller.extend(EditorControllerMixin, {
+    // Overriding autoSave on the base controller, as the new controller shouldn't be autosaving
+    autoSave: Ember.K,
     actions: {
         /**
           * Redirect to editor after the first save

--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -31,26 +31,9 @@ EditorControllerMixin = Ember.Mixin.create({
             return self.get('isDirty') ? self.unloadDirtyMessage() : null;
         };
     },
-    lastModelId: null,
-    modelChanged: Ember.computed('model.id', function (key, value) {
-        var modelId = this.get('model.id');
-
-        if (arguments.length > 1) {
-            return value;
-        }
-
-        if (this.get('lastModelId') === modelId) {
-            return false;
-        }
-
-        this.set('lastModelId', modelId);
-        return true;
-    }),
     autoSave: function () {
         // Don't save just because we swapped out models
-        if (this.get('modelChanged')) {
-            this.set('modelChanged', false);
-        } else if (this.get('model.isDraft') && !this.get('model.isNew')) {
+        if (this.get('model.isDraft') && !this.get('model.isNew')) {
             var autoSaveId,
                 timedSaveId;
 


### PR DESCRIPTION
This fix works because we don't need to autosave whilst on the new controller. The autosave officially kicks in once you've entered a title and switched to the editor, at this point the editor transitions to a model with an ID and everything starts working. 

closes #5130
- rather than checking for a model change, noop autosave on new controller
