### PR TITLE
Avoid infinite transition loop

### DIFF
--- a/core/client/app/mixins/current-user-settings.js
+++ b/core/client/app/mixins/current-user-settings.js
@@ -1,9 +1,5 @@
 import Ember from 'ember';
 var CurrentUserSettings = Ember.Mixin.create({
-    currentUser: function () {
-        return this.store.find('user', 'me');
-    },
-
     transitionAuthor: function () {
         var self = this;
 

--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -76,7 +76,7 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
                 return;
             }
 
-            this.store.find('user', 'me').then(function (user) {
+            this.get('session.user').then(function (user) {
                 self.send('signedIn', user);
                 var attemptedTransition = self.get('session').get('attemptedTransition');
                 if (attemptedTransition) {
@@ -138,10 +138,14 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
             var self = this;
 
             if (this.session.isAuthenticated) {
-                this.store.findAll('notification').then(function (serverNotifications) {
-                    serverNotifications.forEach(function (notification) {
-                        self.notifications.handleNotification(notification, isDelayed);
-                    });
+                this.get('session.user').then(function (user) {
+                    if (!user.get('isAuthor') && !user.get('isEditor')) {
+                        self.store.findAll('notification').then(function (serverNotifications) {
+                            serverNotifications.forEach(function (notification) {
+                                self.notifications.handleNotification(notification, isDelayed);
+                            });
+                        });
+                    }
                 });
             }
         },

--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -43,7 +43,7 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
     afterModel: function (post) {
         var self = this;
 
-        return self.store.find('user', 'me').then(function (user) {
+        return self.get('session.user').then(function (user) {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
                 return self.replaceWith('posts.index');
             }

--- a/core/client/app/routes/posts.js
+++ b/core/client/app/routes/posts.js
@@ -22,7 +22,7 @@ PostsRoute = AuthenticatedRoute.extend(ShortcutsRoute, styleBody, loadingIndicat
     model: function () {
         var self = this;
 
-        return this.store.find('user', 'me').then(function (user) {
+        return this.get('session.user').then(function (user) {
             if (user.get('isAuthor')) {
                 paginationSettings.author = user.get('slug');
             }

--- a/core/client/app/routes/posts/index.js
+++ b/core/client/app/routes/posts/index.js
@@ -23,7 +23,7 @@ var PostsIndexRoute = MobileIndexRoute.extend(SimpleAuth.AuthenticatedRouteMixin
             posts = this.store.all('post'),
             post;
 
-        return this.store.find('user', 'me').then(function (user) {
+        return this.get('session.user').then(function (user) {
             post = posts.find(function (post) {
                 // Authors can only see posts they've written
                 if (user.get('isAuthor')) {

--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -42,7 +42,7 @@ var PostsPostRoute = AuthenticatedRoute.extend(loadingIndicator, ShortcutsRoute,
     afterModel: function (post) {
         var self = this;
 
-        return self.store.find('user', 'me').then(function (user) {
+        return self.get('session.user').then(function (user) {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
                 return self.replaceWith('posts.index');
             }

--- a/core/client/app/routes/settings/apps.js
+++ b/core/client/app/routes/settings/apps.js
@@ -12,7 +12,7 @@ var AppsRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
             return this.transitionTo('settings.general');
         }
 
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },

--- a/core/client/app/routes/settings/code-injection.js
+++ b/core/client/app/routes/settings/code-injection.js
@@ -7,7 +7,7 @@ var SettingsCodeInjectionRoute = AuthenticatedRoute.extend(styleBody, loadingInd
     classNames: ['settings-view-code'],
 
     beforeModel: function () {
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },

--- a/core/client/app/routes/settings/general.js
+++ b/core/client/app/routes/settings/general.js
@@ -9,7 +9,7 @@ var SettingsGeneralRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator
     classNames: ['settings-view-general'],
 
     beforeModel: function () {
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },

--- a/core/client/app/routes/settings/index.js
+++ b/core/client/app/routes/settings/index.js
@@ -10,7 +10,7 @@ var SettingsIndexRoute = MobileIndexRoute.extend(SimpleAuth.AuthenticatedRouteMi
     // is mobile
     beforeModel: function () {
         var self = this;
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor())
             .then(function () {

--- a/core/client/app/routes/settings/labs.js
+++ b/core/client/app/routes/settings/labs.js
@@ -8,7 +8,7 @@ var LabsRoute = AuthenticatedRoute.extend(styleBody, loadingIndicator, CurrentUs
 
     classNames: ['settings'],
     beforeModel: function () {
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -9,7 +9,8 @@ var NavigationRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, 
     classNames: ['settings-view-navigation'],
 
     beforeModel: function () {
-        return this.currentUser().then(this.transitionAuthor());
+        return this.get('session.user')
+            .then(this.transitionAuthor());
     },
 
     model: function () {

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -21,7 +21,7 @@ TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin,
     titleToken: 'Tags',
 
     beforeModel: function () {
-        return this.currentUser()
+        return this.get('session.user')
             .then(this.transitionAuthor());
     },
 

--- a/core/client/app/routes/settings/users.js
+++ b/core/client/app/routes/settings/users.js
@@ -1,11 +1,5 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
-import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 
-var UsersRoute = AuthenticatedRoute.extend(CurrentUserSettings, {
-    beforeModel: function () {
-        return this.currentUser()
-            .then(this.transitionAuthor());
-    }
-});
+var UsersRoute = AuthenticatedRoute.extend();
 
 export default UsersRoute;

--- a/core/client/app/routes/settings/users/index.js
+++ b/core/client/app/routes/settings/users/index.js
@@ -1,4 +1,5 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
+import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import PaginationRouteMixin from 'ghost/mixins/pagination-route';
 import styleBody from 'ghost/mixins/style-body';
 
@@ -11,7 +12,7 @@ paginationSettings = {
     status: 'active'
 };
 
-UsersIndexRoute = AuthenticatedRoute.extend(styleBody, PaginationRouteMixin, {
+UsersIndexRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, PaginationRouteMixin, {
     titleToken: 'Users',
 
     classNames: ['settings-view-users'],
@@ -21,11 +22,16 @@ UsersIndexRoute = AuthenticatedRoute.extend(styleBody, PaginationRouteMixin, {
         this.setupPagination(paginationSettings);
     },
 
+    beforeModel: function () {
+        return this.get('session.user')
+            .then(this.transitionAuthor());
+    },
+
     model: function () {
         var self = this;
 
         return self.store.find('user', {limit: 'all', status: 'invited'}).then(function () {
-            return self.store.find('user', 'me').then(function (currentUser) {
+            return self.get('session.user').then(function (currentUser) {
                 if (currentUser.get('isEditor')) {
                     // Editors only see authors in the list
                     paginationSettings.role = 'Author';

--- a/core/client/app/routes/settings/users/user.js
+++ b/core/client/app/routes/settings/users/user.js
@@ -1,7 +1,8 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
+import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
 
-var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, {
+var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'User',
 
     classNames: ['settings-view-user'],
@@ -25,7 +26,7 @@ var SettingsUserRoute = AuthenticatedRoute.extend(styleBody, {
 
     afterModel: function (user) {
         var self = this;
-        this.store.find('user', 'me').then(function (currentUser) {
+        return this.get('session.user').then(function (currentUser) {
             var isOwnProfile = user.get('id') === currentUser.get('id'),
                 isAuthor = currentUser.get('isAuthor'),
                 isEditor = currentUser.get('isEditor');


### PR DESCRIPTION
This is a first pass at trying to fix the bug with authors not being able to access their profiles. 

It seems the users route suddenly caused an infinite transition loop. The code is unchanged, so must be due to a change in Ember? Moving the transition down to users/index.js resolves the issue.

Whilst I was there I also got rid of the console error (which was unrelated) by wrapping the fetch for notifications in a user role check - this is probably hiding an underlying issue which likely does need resolving, but I've no idea why that's suddenly triggering an error (ember bug?)

Also, I changed all of the calls to `this.store.find('user', 'me')` to use `this.get('session.user')`. It seems like the right thing to do, but I'm not 100% sure whether this will pick up changes to the user - I kind of assume that because it's ember, it will, but I need to test.

fixes #5136
- wrap notification fetch with a user role check to remove console error
- move author transition down to local route for users/user so that there's no infinite loop
- replace all store calls to fetch the current user with the session user instead
