### PR TITLE
Added req.locals to the prePostRender filter params

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -145,7 +145,7 @@ frontendControllers = {
             setReqCtx(req, page.posts);
 
             // Render the page of posts
-            filters.doFilter('prePostsRender', page.posts).then(function (posts) {
+            filters.doFilter('prePostsRender', page.posts, res.locals).then(function (posts) {
                 getActiveThemePaths().then(function (paths) {
                     var view = paths.hasOwnProperty('home.hbs') ? 'home' : 'index';
 
@@ -197,7 +197,7 @@ frontendControllers = {
             }
 
             // Render the page of posts
-            filters.doFilter('prePostsRender', page.posts).then(function (posts) {
+            filters.doFilter('prePostsRender', page.posts, res.locals).then(function (posts) {
                 getActiveThemePaths().then(function (paths) {
                     var view = template.getThemeViewForTag(paths, options.tag),
                     // Format data for template
@@ -251,7 +251,7 @@ frontendControllers = {
             }
 
             // Render the page of posts
-            filters.doFilter('prePostsRender', page.posts).then(function (posts) {
+            filters.doFilter('prePostsRender', page.posts, res.locals).then(function (posts) {
                 getActiveThemePaths().then(function (paths) {
                     var view = paths.hasOwnProperty('author.hbs') ? 'author' : 'index',
                         // Format data for template
@@ -336,7 +336,7 @@ frontendControllers = {
 
                 setReqCtx(req, post);
 
-                filters.doFilter('prePostsRender', post).then(function (post) {
+                filters.doFilter('prePostsRender', post, res.locals).then(function (post) {
                     getActiveThemePaths().then(function (paths) {
                         var view = template.getThemeViewForPost(paths, post),
                             response = formatResponse(post);


### PR DESCRIPTION
Gives access to the current relative url in the prePostsRender filter

closes #2559
- Added res.locals as a second parameter to the prePostsRender filter call.
