### PR TITLE
Switch to using grunt raw on travis 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "main": "./core/index",
     "scripts": {
         "start": "node index",
-        "test": "./node_modules/.bin/grunt validate --verbose"
+        "test": "grunt validate --verbose"
     },
     "engines": {
         "node": "~0.10.0 || ~0.12.0",


### PR DESCRIPTION
Our travis tests are currently failing regularly and randomly with the error:

`sh: 1: grunt: not found`. 

I'm testing out a fix to see if it works although there's no guarantee because it seems to work for some builds and not others regardless of whether you restart or clear the cache.
