### PR TITLE
Fix previous and next helpers

### DIFF
--- a/core/server/helpers/prev_next.js
+++ b/core/server/helpers/prev_next.js
@@ -8,9 +8,10 @@ var api             = require('../api'),
     Promise         = require('bluebird'),
     fetch, prevNext;
 
-fetch = function (options) {
-    return api.posts.read(options).then(function (result) {
+fetch = function (apiOptions, options) {
+    return api.posts.read(apiOptions).then(function (result) {
         var related = result.posts[0];
+
         if (related.previous) {
             return options.fn(related.previous);
         } else if (related.next) {
@@ -26,10 +27,14 @@ fetch = function (options) {
 
 prevNext =  function (options) {
     options = options || {};
-    options.include = options.name === 'prev_post' ? 'previous' : 'next';
+
+    var apiOptions = {
+        include: options.name === 'prev_post' ? 'previous' : 'next'
+    };
+
     if (schema.isPost(this)) {
-        options.slug = this.slug;
-        return fetch(options);
+        apiOptions.slug = this.slug;
+        return fetch(apiOptions, options);
     } else {
         return Promise.resolve(options.inverse(this));
     }

--- a/core/server/models/base.js
+++ b/core/server/models/base.js
@@ -138,6 +138,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         var attrs = _.extend({}, this.attributes),
             self = this;
         options = options || {};
+        options = _.pick(options, ['shallow', 'baseKey', 'include', 'context']);
 
         if (options && options.shallow) {
             return attrs;
@@ -150,9 +151,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         _.each(this.relations, function (relation, key) {
             if (key.substring(0, 7) !== '_pivot_') {
                 // if include is set, expand to full object
-                var fullKey = _.isEmpty(options.name) ? key : options.name + '.' + key;
+                var fullKey = _.isEmpty(options.baseKey) ? key : options.baseKey + '.' + key;
                 if (_.contains(self.include, fullKey)) {
-                    attrs[key] = relation.toJSON(_.extend({}, options, {name: fullKey, include: self.include}));
+                    attrs[key] = relation.toJSON(_.extend({}, options, {baseKey: fullKey, include: self.include}));
                 }
             }
         });


### PR DESCRIPTION
fixes #5177 

This bug is caused by an interesting collection of oddnesses. All of the tests for the next/previous API calls and for the helper are passing, and that's not strictly incorrect. However the call the next/prev helper makes to the API includes all of the options from the helper, including one called `name`. 

In #5159, I changed the API/models to always pass options through to `toJSON`. However, those options are only filtered in the model layer, not the API layer, so in cases where the API calls `toJSON` (E.g. the `posts.read` call used in the next/prev helpers) the options passed in are unsanitized. This was a massive oversight on my part.

Deep inside of `toJSON`, there is some code to handle nested relations. This code makes use of a `name` option that gets passed recursively to `toJSON` in order to create nested keys.

As a result of the combination of these things: options from the helper getting passed through to the API, not being filtered, and then being used in toJSON the `name` property from the helper was incorrectly being used as the base for the key in `toJSON`, meaning that the next and previous posts were being casually thrown away before the API returned. Epic.

This PR contains two separate fixes for the two separate issues. The first one adds filtering to `toJSON` so that only allowed options are passed through. It also renames `name` to `baseKey` which is more specific and less likely to clash with other things. The second one changes the prev/next helper to not pass through the options from the helper to the API. 

Normally I'd do these as 2 separate PRs, but in the interest of expediency (_cough_ travis _cough_ I've combined them into one).
