### PR TITLE
Allow admin app to run when active theme missing

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -94,7 +94,10 @@ function configHbsForContext(req, res, next) {
     }
 
     hbs.updateTemplateOptions({data: {blog: themeData}});
-    blogApp.set('views', path.join(config.paths.themePath, blogApp.get('activeTheme')));
+
+    if (config.paths.themePath && blogApp.get('activeTheme')) {
+        blogApp.set('views', path.join(config.paths.themePath, blogApp.get('activeTheme')));
+    }
 
     // Pass 'secure' flag to the view engine
     // so that templates can choose 'url' vs 'urlSSL'
@@ -110,6 +113,7 @@ function configHbsForContext(req, res, next) {
 function updateActiveTheme(req, res, next) {
     api.settings.read({context: {internal: true}, key: 'activeTheme'}).then(function (response) {
         var activeTheme = response.settings[0];
+
         // Check if the theme changed
         if (activeTheme.value !== blogApp.get('activeTheme')) {
             // Change theme
@@ -117,6 +121,15 @@ function updateActiveTheme(req, res, next) {
                 if (!res.isAdmin) {
                     // Throw an error if the theme is not available, but not on the admin UI
                     return errors.throwError('The currently active theme ' + activeTheme.value + ' is missing.');
+                } else {
+                    // At this point the activated theme is not present and the current
+                    // request is for the admin client.  In order to allow the user access
+                    // to the admin client we set an hbs instance on the app so that middleware
+                    // processing can continue.
+                    blogApp.engine('hbs', hbs.express3());
+                    errors.logWarn('The currently active theme "' + activeTheme.value + '" is missing.');
+
+                    return next();
                 }
             } else {
                 activateTheme(activeTheme.value);


### PR DESCRIPTION
Closes #5155
- If the theme that has been set to active is missing, set
  a default express-hbs instance on the express app and allow
  middleware processing to continue so that the admin client can
  be accessed.
- Log a warning when this happens.
- Fix issue where frontend error page was not being rendered
  correctly.
