### PR TITLE
Code injection syntax colour change

### DIFF
--- a/core/client/app/styles/layouts/settings.scss
+++ b/core/client/app/styles/layouts/settings.scss
@@ -544,4 +544,12 @@
         outline: 0;
     }
 
+    .CodeMirror {
+        border-radius: inherit; // Inherits from .settings-code-editor
+    }
+
+    // Overwrite bright yellow text
+    .cm-s-xq-light span.cm-meta {
+        color: #000;
+    }
 }


### PR DESCRIPTION
Closes #5179
- Overwrites the yellow code injection syntax highlighting (such as vendor prefixes in CSS) to be black, to match the rest of the property
- Adds rounded corners to the code injection CodeMorror wrapper to match its parents rounded corners (inherits the same value)
