### PR TITLE
Move upgrade notification to /settings/about/

### DIFF
--- a/core/client/app/controllers/settings/about.js
+++ b/core/client/app/controllers/settings/about.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+var SettingsAboutController = Ember.Controller.extend({
+    updateNotificationCount: 0,
+
+    actions: {
+       updateNotificationChange: function (count) {
+            this.set('updateNotificationCount', count);
+        }
+    }
+});
+
+export default SettingsAboutController;

--- a/core/client/app/styles/components/notifications.scss
+++ b/core/client/app/styles/components/notifications.scss
@@ -216,3 +216,12 @@
 .update-available main {
     bottom: 56px;
 }
+
+.notification-upgrade {
+    color: $red;
+
+    a {
+        color: $red;
+        text-decoration: underline;
+    }
+}

--- a/core/client/app/templates/settings/about.hbs
+++ b/core/client/app/templates/settings/about.hbs
@@ -11,7 +11,10 @@
             </span>
             <span class="version blue">v{{model.version}}</span>
         </h1>
-        <p>A free, open, simple publishing platform</p>
+        {{gh-notifications location="settings-about-upgrade" notify="updateNotificationChange"}}
+        {{#unless updateNotificationCount}}
+            <p>A free, open, simple publishing platform</p>
+        {{/unless}}
 
         <div class="about-environment-help clearfix">
             <div class="about-environment">

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -33,12 +33,11 @@ adminControllers = {
             }
 
             var notification = {
-                type: 'success',
-                location: 'top',
+                type: 'upgrade',
+                location: 'settings-about-upgrade',
                 dismissible: false,
                 status: 'persistent',
-                message: '<a href="https://ghost.org/download">Ghost ' + updateVersion +
-                '</a> is available! Hot Damn. Please <a href="http://support.ghost.org/how-to-upgrade/" target="_blank">upgrade</a> now'
+                message: 'Ghost ' + updateVersion + ' is available! Hot Damn. <a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a> to upgrade.'
             };
 
             return api.notifications.browse({context: {internal: true}}).then(function (results) {


### PR DESCRIPTION
Refs #5071
- Move the Upgrade notification from the top of the screen to the About page

Given that the 'custom messages' part of the issue is related but solves a different problem, It seemed best to tackle both parts of the issue as separate chunks of work, so I've not touched the custom messages part here.
