### PR TITLE
Fixed issue with word count for non ASCII letters. 

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -59,5 +59,6 @@ app.import('bower_components/codemirror/mode/htmlmixed/htmlmixed.js');
 app.import('bower_components/codemirror/mode/xml/xml.js');
 app.import('bower_components/codemirror/mode/css/css.js');
 app.import('bower_components/codemirror/mode/javascript/javascript.js');
+app.import('bower_components/xregexp/xregexp-all.js');
 
 module.exports = app.toTree();

--- a/core/client/app/utils/word-count.js
+++ b/core/client/app/utils/word-count.js
@@ -1,7 +1,12 @@
 // jscs: disable
+/* global XRegExp */
+
 function wordCount(s) {
+
+    var nonANumLetters = new XRegExp("[^\\s\\d\\p{L}]", "g"); // all non-alphanumeric letters regexp
+
     s = s.replace(/<(.|\n)*?>/g, ' '); // strip tags
-    s = s.replace(/[^\w\s]/g, ''); // ignore non-alphanumeric letters
+    s = s.replace(nonANumLetters, ''); // ignore non-alphanumeric letters
     s = s.replace(/(^\s*)|(\s*$)/gi, ''); // exclude starting and ending white-space
     s = s.replace(/\n /gi, ' '); // convert newlines to spaces
     s = s.replace(/\n+/gi, ' ');

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -25,7 +25,8 @@
     "nprogress": "0.1.6",
     "rangyinputs": "1.2.0",
     "showdown-ghost": "0.3.6",
-    "validator-js": "3.39.0"
+    "validator-js": "3.39.0",
+    "xregexp": "2.0.0"
 
   },
   "devDependencies": {


### PR DESCRIPTION
There is a problem with a word count for non ascii letters (words). 

![ghost word count in editor is not working](https://cloud.githubusercontent.com/assets/2828920/7440788/651bdc1c-f0d2-11e4-831a-d7d9ebe96c77.png)

Solution: 

1) Added XRegExp library for easier expression building. 
2) Changed non-alphanumeric regex to one that was generated by XRegExp library.  
