### PR TITLE
Invite link url broken on a submodule

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -26,7 +26,6 @@ function prepareInclude(include) {
 
 sendInviteEmail = function sendInviteEmail(user) {
     var emailData;
-
     return Promise.join(
         users.read({id: user.created_by}),
         settings.read({key: 'title'}),
@@ -46,8 +45,8 @@ sendInviteEmail = function sendInviteEmail(user) {
         return dataProvider.User.generateResetToken(user.email, expires, dbHash);
     }).then(function (resetToken) {
         var baseUrl = config.forceAdminSSL ? (config.urlSSL || config.url) : config.url;
-
-        emailData.resetLink = baseUrl.replace(/\/$/, '') + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
+        console.log('¡¡¡' + config.paths.subdir);
+        emailData.resetLink = baseUrl.replace(/\/$/, '') + config.paths.subdir + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
 
         return mail.generateContent({data: emailData, template: 'invite-user'});
     }).then(function (emailContent) {

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -26,7 +26,7 @@ function prepareInclude(include) {
 
 sendInviteEmail = function sendInviteEmail(user) {
     var emailData;
-    
+
     return Promise.join(
         users.read({id: user.created_by}),
         settings.read({key: 'title'}),
@@ -46,7 +46,6 @@ sendInviteEmail = function sendInviteEmail(user) {
         return dataProvider.User.generateResetToken(user.email, expires, dbHash);
     }).then(function (resetToken) {
         var baseUrl = config.forceAdminSSL ? (config.urlSSL || config.url) : config.url;
-        console.log('¡¡¡' + config.paths.subdir);
         emailData.resetLink = baseUrl.replace(/\/$/, '') + config.paths.subdir + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
 
         return mail.generateContent({data: emailData, template: 'invite-user'});

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -46,6 +46,7 @@ sendInviteEmail = function sendInviteEmail(user) {
         return dataProvider.User.generateResetToken(user.email, expires, dbHash);
     }).then(function (resetToken) {
         var baseUrl = config.forceAdminSSL ? (config.urlSSL || config.url) : config.url;
+
         emailData.resetLink = baseUrl.replace(/\/$/, '') + config.paths.subdir + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
 
         return mail.generateContent({data: emailData, template: 'invite-user'});

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -47,7 +47,7 @@ sendInviteEmail = function sendInviteEmail(user) {
     }).then(function (resetToken) {
         var baseUrl = config.forceAdminSSL ? (config.urlSSL || config.url) : config.url;
 
-        emailData.resetLink = baseUrl.replace(/\/$/, '') + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
+        emailData.resetLink = baseUrl.replace(/\/$/, '') + config.paths.subdir + '/ghost/signup/' + globalUtils.encodeBase64URLsafe(resetToken) + '/';
 
         return mail.generateContent({data: emailData, template: 'invite-user'});
     }).then(function (emailContent) {

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -26,6 +26,7 @@ function prepareInclude(include) {
 
 sendInviteEmail = function sendInviteEmail(user) {
     var emailData;
+    
     return Promise.join(
         users.read({id: user.created_by}),
         settings.read({key: 'title'}),


### PR DESCRIPTION
Fixes #5212.
### Issue Summary

When Ghost is being used on a sub-folder, the invitation link sent to a new user is pointing to the base url of the website ignoring the subfolder.
### Steps to Reproduce
1. Configure ghost on a sub-folder (see issue description).
2. Send an invitation to a new user.

**User clicks on the link:**
**Expected result:**  User gets the registration page.
**Actual result:** User gets a non-existing URL because the link is not having the subfolder ('''config.paths.subdir''') part.
### Technical Details

Affects every version on every system on every database.
