### PR TITLE
[WIP] Regenerate slug when the post is a draft and never been published

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -159,6 +159,14 @@ Post = ghostBookshelf.Model.extend({
                     self.set({slug: slug});
                 });
         }
+
+        // The post hasn't been published but the title has changed. slug needs to be regenerated:
+        if(this.get('status') == 'draft' && this.get('published_at') == null) {
+            return ghostBookshelf.Model.generateSlug(Post, this.get('title'), {status: 'all', transacting: options.transacting})
+                .then(function (slug) {
+                    self.set({slug: slug});
+                });
+        }
     },
 
     creating: function (model, attr, options) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -161,7 +161,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         // The post hasn't been published but the title has changed. slug needs to be regenerated:
-        if(this.get('status') == 'draft' && this.get('published_at') == null) {
+        if (this.get('status') === 'draft' && this.get('published_at') === null) {
             return ghostBookshelf.Model.generateSlug(Post, this.get('title'), {status: 'all', transacting: options.transacting})
                 .then(function (slug) {
                     self.set({slug: slug});


### PR DESCRIPTION
Fixes #5062.
### Issue Summary

The slug is not being updated when the user is editing a post without publishing it. It should be updated till the post is published and then, if the post is updated (title) keep the same slug unless the user updates it manually.
### Steps to Reproduce
1. Create a post and save it as a Draft.
2. Update the post title.

**Open the database and find the slug for the updated post**
**Expected result:** The slug has been updated.
**Actual result:** The slug hasn't been updated.
### Technical Details

Every version on every platform on every DB affected.
