### PR TITLE
Frontend Controller Refactor

### DIFF
--- a/core/server/helpers/template.js
+++ b/core/server/helpers/template.js
@@ -44,21 +44,21 @@ templates.getThemeViewForPost = function (themePaths, post) {
     return view;
 };
 
-// Given a theme object and a tag slug this will return
+// Given a theme object and a slug this will return
 // which theme template page should be used.
 // If no default or custom tag template exists then 'index'
 // will be returned
-// If no custom tag template exists but a default does then
-// 'tag' will be returned
-// If given a tag slug and a custom tag template
+// If no custom template exists but a default does then
+// the default will be returned
+// If given a slug and a custom template
 // exits it will return that view.
-templates.getThemeViewForTag = function (themePaths, tag) {
-    var customTagView = 'tag-' + tag,
-        view = 'tag';
+templates.getThemeViewForChannel = function (themePaths, channelName, slug) {
+    var customChannelView = channelName + '-' + slug,
+        view = channelName;
 
-    if (themePaths.hasOwnProperty(customTagView + '.hbs')) {
-        view = customTagView;
-    } else if (!themePaths.hasOwnProperty('tag.hbs')) {
+    if (themePaths.hasOwnProperty(customChannelView + '.hbs')) {
+        view = customChannelView;
+    } else if (!themePaths.hasOwnProperty(channelName + '.hbs')) {
         view = 'index';
     }
 

--- a/core/test/unit/server_helpers_template_spec.js
+++ b/core/test/unit/server_helpers_template_spec.js
@@ -51,7 +51,7 @@ describe('Helpers Template', function () {
         });
     });
 
-    describe('getThemeViewForTag', function () {
+    describe('getThemeViewForChannel', function () {
         var themePathsWithTagViews = {
                 assets: null,
                 'default.hbs': '/content/themes/casper/default.hbs',
@@ -64,19 +64,20 @@ describe('Helpers Template', function () {
                 'default.hbs': '/content/themes/casper/default.hbs',
                 'index.hbs': '/content/themes/casper/index.hbs'
             },
-            TAG_CUSTOM_EXISTS = 'design',
-            TAG_DEFAULT = 'development';
+            CHANNEL = 'tag',
+            CUSTOM_EXISTS = 'design',
+            DEFAULT = 'development';
 
         it('will return correct view for a tag', function () {
-            var view = template.getThemeViewForTag(themePathsWithTagViews, TAG_CUSTOM_EXISTS);
+            var view = template.getThemeViewForChannel(themePathsWithTagViews, CHANNEL, CUSTOM_EXISTS);
             view.should.exist;
             view.should.eql('tag-design');
 
-            view = template.getThemeViewForTag(themePathsWithTagViews, TAG_DEFAULT);
+            view = template.getThemeViewForChannel(themePathsWithTagViews, CHANNEL, DEFAULT);
             view.should.exist;
             view.should.eql('tag');
 
-            view = template.getThemeViewForTag(themePaths, TAG_DEFAULT);
+            view = template.getThemeViewForChannel(themePaths, CHANNEL, DEFAULT);
             view.should.exist;
             view.should.eql('index');
         });


### PR DESCRIPTION
closes #5192, refs #5091 

This PR refactors the frontend controller, combining the functions for the homepage, tag, and author routes into one function, with the intent of using it for channels in the future.
