### PR TITLE
Replace gh-blog-url helper with a component.

### DIFF
--- a/core/client/app/components/gh-blog-url.js
+++ b/core/client/app/components/gh-blog-url.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+var blogUrl = Ember.Component.extend({
+    tagName: ''
+});
+
+export default blogUrl;

--- a/core/client/app/helpers/gh-blog-url.js
+++ b/core/client/app/helpers/gh-blog-url.js
@@ -1,6 +1,0 @@
-import Ember from 'ember';
-var blogUrl = Ember.HTMLBars.makeBoundHelper(function () {
-    return Ember.String.htmlSafe(this.get('config.blogUrl'));
-});
-
-export default blogUrl;

--- a/core/client/app/templates/components/gh-blog-url.hbs
+++ b/core/client/app/templates/components/gh-blog-url.hbs
@@ -1,0 +1,1 @@
+{{{config.blogUrl}}}


### PR DESCRIPTION
Accessing `this` inside an `Ember.HTMLBars.makeBoundHelper` will not
always return the containing `view` object.

Instead, use a component (which has a much more stable API in Glimmer-land).
