### PR TITLE
Only attempt to `scrollTop` if element is available.

### DIFF
--- a/core/client/app/views/content-preview-content-view.js
+++ b/core/client/app/views/content-preview-content-view.js
@@ -13,7 +13,11 @@ var PostContentView = Ember.View.extend({
     },
 
     contentObserver: function () {
-        this.$().closest('.content-preview').scrollTop(0);
+        var el = this.$();
+
+        if (el) {
+            el.closest('.content-preview').scrollTop(0);
+        }
     }.observes('controller.content'),
 
     willDestroyElement: function () {


### PR DESCRIPTION
In later versions of Ember, the views and components can be stable
and are not guaranteed to be torn down before a new controller is
set on them.

In this case, the controller is initially set before the element has been
rendered to the DOM causing errors when invoking `closest` on undefined.
