### PR TITLE
Update bluebird promise library

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     },
     "dependencies": {
         "bcryptjs": "2.1.0",
-        "bluebird": "2.4.2",
+        "bluebird": "2.9.25",
         "body-parser": "1.10.0",
         "bookshelf": "0.7.9",
         "busboy": "0.2.9",


### PR DESCRIPTION
Going to isolate this one since it's a big jump from 2.4.2 to 2.9.25.  Link to change log: https://github.com/petkaantonov/bluebird/blob/master/changelog.md#242-2014-12-21

No Issue
- bluebird@2.9.25
