### PR TITLE
Broken link in contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Guidelines for bug reports:
    latest `master` or look for [closed issues in the current milestone](https://github.com/TryGhost/Ghost/issues?labels=&milestone=3&page=1&state=closed).
 
 3. **Isolate the problem** &mdash; ideally create a [reduced test
-   case](http://css-tricks.com/6263-reduced-test-cases/) and a live example.
+   case](https://css-tricks.com/reduced-test-cases/) and a live example.
 
 4. **Include a screencast if relevant** - Is your issue about a design or front end feature or bug? The most
 helpful thing in the world is if we can *see* what you're talking about.


### PR DESCRIPTION
fixes reduced test case link (it was an 404 link)
