### PR TITLE
Check error object before dereference

### DIFF
--- a/core/server/mail.js
+++ b/core/server/mail.js
@@ -92,7 +92,8 @@ GhostMailer.prototype.send = function (message) {
 
             response.statusHandler.once('failed', function (data) {
                 var reason = 'Email Error: Failed sending email';
-                if (data.error.errno === 'ENOTFOUND') {
+
+                if (data.error && data.error.errno === 'ENOTFOUND') {
                     reason += ': there is no mail server at this address: ' + data.domain;
                 }
                 reason += '.';
@@ -100,7 +101,13 @@ GhostMailer.prototype.send = function (message) {
             });
 
             response.statusHandler.once('requeue', function (data) {
-                return reject(new Error('Email Error: message was not sent, requeued. Probably will not be sent. :( \nMore info: ' + data.error.message));
+                var errorMessage = 'Email Error: message was not sent, requeued. Probably will not be sent. :(';
+
+                if (data.error && data.error.message) {
+                    errorMessage += '\nMore info: ' + data.error.message;
+                }
+
+                return reject(new Error(errorMessage));
             });
 
             response.statusHandler.once('sent', function () {


### PR DESCRIPTION
Refs #5095 

Prevent the mail error handler from blowing up if `data.errors` is not present.
