### PR TITLE
Do not allow auto-save to publish a post

### DIFF
--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -35,12 +35,19 @@ EditorControllerMixin = Ember.Mixin.create({
         // Don't save just because we swapped out models
         if (this.get('model.isDraft') && !this.get('model.isNew')) {
             var autoSaveId,
-                timedSaveId;
+                timedSaveId,
+                saveOptions;
 
-            timedSaveId = Ember.run.throttle(this, 'send', 'save', {silent: true, disableNProgress: true}, 60000, false);
+            saveOptions = {
+                silent: true,
+                disableNProgress: true,
+                backgroundSave: true
+            };
+
+            timedSaveId = Ember.run.throttle(this, 'send', 'save', saveOptions, 60000, false);
             this.set('timedSaveId', timedSaveId);
 
-            autoSaveId = Ember.run.debounce(this, 'send', 'save', {silent: true, disableNProgress: true}, 3000);
+            autoSaveId = Ember.run.debounce(this, 'send', 'save', saveOptions, 3000);
             this.set('autoSaveId', autoSaveId);
         }
     }.observes('model.scratch'),
@@ -228,7 +235,7 @@ EditorControllerMixin = Ember.Mixin.create({
 
     actions: {
         save: function (options) {
-            var status = this.get('willPublish') ? 'published' : 'draft',
+            var status,
                 prevStatus = this.get('model.status'),
                 isNew = this.get('model.isNew'),
                 autoSaveId = this.get('autoSaveId'),
@@ -238,6 +245,13 @@ EditorControllerMixin = Ember.Mixin.create({
                 promise;
 
             options = options || {};
+
+            if (options.backgroundSave) {
+                // do not allow a post's status to be set to published by a background save
+                status = 'draft';
+            } else {
+                status = this.get('willPublish') ? 'published' : 'draft';
+            }
 
             if (autoSaveId) {
                 Ember.run.cancel(autoSaveId);
@@ -348,7 +362,7 @@ EditorControllerMixin = Ember.Mixin.create({
 
         autoSaveNew: function () {
             if (this.get('model.isNew')) {
-                this.send('save', {silent: true, disableNProgress: true});
+                this.send('save', {silent: true, disableNProgress: true, backgroundSave: true});
             }
         }
     }


### PR DESCRIPTION
This would change would prevent the auto-save from changing a post's status from draft -> published.  In general I think it makes sense for publishing a post to require the user to actually press "publish now," and I think #5235 has shown that having it triggered by a background save can be confusing.

Refs #5235
- Do not allow background saving (i.e. post auto-save) to affect the
  published status of a post.
