### PR TITLE
Fix up filtering implementation

### DIFF
--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -1,7 +1,6 @@
 // # Roles API
 // RESTful API for the Role resource
 var Promise         = require('bluebird'),
-    _               = require('lodash'),
     canThis         = require('../permissions').canThis,
     dataProvider    = require('../models'),
     errors          = require('../errors'),
@@ -28,37 +27,29 @@ roles = {
      * @returns {Promise(Roles)} Roles Collection
      */
     browse: function browse(options) {
-        var permissionMap = [];
         options = options || {};
 
         return canThis(options.context).browse.role().then(function () {
-            return dataProvider.Role.findAll(options).then(function (foundRoles) {
-                if (options.permissions === 'assign') {
-                    // Hacky implementation of filtering because when.filter is only available in when 3.4.0,
-                    // but that's buggy and kills other tests and introduces Heisenbugs. Until we turn everything
-                    // to Bluebird, this works. Sorry.
-                    // TODO: replace with better filter when bluebird lands
-                    _.each(foundRoles.toJSON(), function (role) {
-                        permissionMap.push(canThis(options.context).assign.role(role).then(function () {
-                            if (role.name === 'Owner') {
-                                return null;
-                            }
-                            return role;
-                        }).catch(function () {
-                            return null;
-                        }));
-                    });
+            return dataProvider.Role.findAll(options).then(function (results) {
+                var roles = results.map(function (r) {
+                    return r.toJSON();
+                });
 
-                    return Promise.all(permissionMap).then(function (resolved) {
-                        return {roles: _.filter(resolved, function (role) {
-                            return role !== null;
-                        })};
-                    }).catch(errors.logAndThrowError);
+                if (options.permissions !== 'assign') {
+                    return {roles: roles};
                 }
-                return {roles: foundRoles.toJSON()};
+
+                return Promise.filter(roles.map(function (role) {
+                    return canThis(options.context).assign.role(role)
+                    .return(role)
+                    .catch(function () {});
+                }), function (value) {
+                    return value && value.name !== 'Owner';
+                }).then(function (roles) {
+                    return {roles: roles};
+                });
             });
-        })
-        .catch(errors.logAndThrowError);
+        }).catch(errors.logAndThrowError);
     }
 };
 


### PR DESCRIPTION
Gets rid of a TODO.  Replaces a workaround filter implementation with one based on bluebird's `Promise.filter()`.
