### PR TITLE
Prevent notifications from overlapping menus

### DIFF
--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -8,9 +8,8 @@
 
 <main id="gh-main" class="viewport" role="main" data-notification-count={{topNotificationCount}}>
     {{outlet}}
+    {{gh-notifications location="bottom"}}
 </main>
-
-{{gh-notifications location="bottom"}}
 
 {{outlet "modal"}}
 


### PR DESCRIPTION
ref #5213

This fixes the issue above where notifications were overlapping pop up menus for tagging. My proposed solution is to move the notifications div into the `<main>` tag. 

Since notifications are now in the same context as the pop up menus, the higher z-index on the popup menus takes effect. I think this is the simplest way to solve the problem and will make future changes to any z-indexes more predictable.
