### PR TITLE
Update help link to point to slack

### DIFF
--- a/core/client/app/templates/settings/about.hbs
+++ b/core/client/app/templates/settings/about.hbs
@@ -31,7 +31,7 @@
             </div>
             <div class="about-help">
                 <a href="http://support.ghost.org" class="btn">User Documentation</a>
-                <a href="https://ghost.org/forum/" class="btn">Get Help With Ghost</a>
+                <a href="https://ghost.org/slack/" class="btn">Get Help With Ghost</a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
No Issue
- changes link from forum to slack on about page
