### PR TITLE
Removing test assets from release zip

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@ node_modules/**
 *.iml
 config.js
 core/built/**/*.map
+core/built/**/test-*
 core/client/**
 core/test/**
 CONTRIBUTING.md


### PR DESCRIPTION
no issue
- no need for test assets in the release zip, this reduces the size of the final zip
