### PR TITLE
Double scrollbar fix

### DIFF
--- a/core/client/app/styles/layouts/default.scss
+++ b/core/client/app/styles/layouts/default.scss
@@ -89,10 +89,10 @@
     bottom: 0;
     left: 0;
     background: #fff;
-    overflow-y: auto;
-    overflow-x: hidden;
 
     @media (max-width: 900px) {
+        overflow-y: auto;
+        overflow-x: hidden;
         top: 44px;
     }
 }


### PR DESCRIPTION
![1805](https://cloud.githubusercontent.com/assets/5889006/7671157/71e79468-fcc1-11e4-9546-10b293fe648c.png)

When navigator window is too small, appears two Y scrollbars. (width > 900px;  height < 435px; )
I removed from .page-content the control of the overflow, and put it in @media (max-width: 900px).

As I see, it didn't break the mobile menu :)
