### PR TITLE
Fix meta description for static pages

### DIFF
--- a/core/server/helpers/meta_description.js
+++ b/core/server/helpers/meta_description.js
@@ -27,10 +27,8 @@ meta_description = function (options) {
         description = this.author.bio;
     } else if (_.contains(context, 'tag') && this.tag) {
         description = this.tag.meta_description;
-    } else if (_.contains(context, 'post') && this.post) {
+    } else if ((_.contains(context, 'post') || _.contains(context, 'page')) && this.post) {
         description = this.post.meta_description;
-    } else if (_.contains(context, 'page') && this.page) {
-        description = this.page.meta_description;
     }
 
     return filters.doFilter('meta_description', description).then(function (description) {


### PR DESCRIPTION
closes #5295
- modified meta_description helper to match meta_title helper for ‘page’ context
