### PR TITLE
Use absolute frontend URL in admin

### DIFF
--- a/core/client/app/templates/-navbar.hbs
+++ b/core/client/app/templates/-navbar.hbs
@@ -1,6 +1,6 @@
 <nav class="global-nav" role="navigation">
 
-    <a class="nav-item ghost-logo" href="{{gh-path 'blog'}}" title="Visit blog">
+    <a class="nav-item ghost-logo" href="{{config.blogUrl}}/" title="Visit blog">
         <div class="nav-label"><i class="icon-ghost"></i> <span>Visit blog</span> </div>
     </a>
 

--- a/core/test/functional/client/app_test.js
+++ b/core/test/functional/client/app_test.js
@@ -17,7 +17,7 @@ CasperTest.begin('Admin navigation bar is correct', 45, function suite(test) {
 
         // Logo
         test.assertExists('.ghost-logo', 'Ghost logo home page link exists');
-        test.assertEquals(logoHref, '/', 'Ghost logo link href is correct');
+        test.assertEquals(logoHref, 'http://127.0.0.1:2369/', 'Ghost logo link href is correct');
 
         // Content
         test.assertExists('.nav-content', 'Content nav item exists');


### PR DESCRIPTION
closes #5288
- use the config.blogURL as the frontend URL from the admin
- we know this is given to us without a trailing slash, so it's 100% safe to hard code this
- TODO: make all of the url generation a lot nicer i.e. #1833
