### PR TITLE
Cache control for private blogs

### DIFF
--- a/core/server/middleware/cache-control.js
+++ b/core/server/middleware/cache-control.js
@@ -23,7 +23,11 @@ cacheControl = function (options) {
 
     return function cacheControlHeaders(req, res, next) {
         if (output) {
-            res.set({'Cache-Control': output});
+            if (res.isPrivateBlog) {
+                res.set({'Cache-Control': profiles['private']});
+            } else {
+                res.set({'Cache-Control': output});
+            }
         }
         next();
     };

--- a/core/test/unit/middleware/cache-control_spec.js
+++ b/core/test/unit/middleware/cache-control_spec.js
@@ -77,5 +77,18 @@ describe('Middleware: cacheControl', function () {
                 });
             });
         });
+
+        it('will override public with private for private blogs', function (done) {
+            res.isPrivateBlog = true;
+            middleware.cacheControl('public')(null, res, function (a) {
+                should.not.exist(a);
+                res.set.calledOnce.should.be.true;
+                res.set.calledWith({
+                    'Cache-Control':
+                        'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
+                });
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
no issue
- private blogs need to not be cached, so that the cookie is always checked
