### PR TITLE
Fixed the invite user email to include the email address of the user …

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -28,7 +28,7 @@ sendInviteEmail = function sendInviteEmail(user) {
     var emailData;
 
     return Promise.join(
-        users.read({id: user.created_by}),
+        users.read({id: user.created_by, context: {internal: true}}),
         settings.read({key: 'title'}),
         settings.read({context: {internal: true}, key: 'dbHash'})
     ).then(function (values) {


### PR DESCRIPTION
Fixed the invite user email to include email address of the user who invited you

closes #5283
- due to the changes with the api call in pr #5159 the email address wasn't showing up
- modified the api call to fetch user data to pass the context object to the toJSON object
