### PR TITLE
Bumped up node-sqlite3 version number to fix broken build on non x86 …

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rss": "1.1.1",
     "semver": "4.3.3",
     "showdown-ghost": "0.3.6",
-    "sqlite3": "3.0.6",
+    "sqlite3": "3.0.8",
     "unidecode": "0.1.3",
     "validator": "3.39.0",
     "xml": "1.0.0"


### PR DESCRIPTION
…devices such as the RPi

This was discussed and resolved over at the node-sqlite3 [issues page.](https://github.com/mapbox/node-sqlite3/issues/445)
