### PR TITLE
Improve config-parser JSON handling

### DIFF
--- a/core/client/app/utils/config-parser.js
+++ b/core/client/app/utils/config-parser.js
@@ -12,7 +12,12 @@ var isNumeric = function (num) {
         } else if (isNumeric(val)) {
             return +val;
         } else if (val.indexOf('{') === 0) {
-            return JSON.parse(val);
+            try {
+                return JSON.parse(val);
+            } catch (e) {
+                /*jshint unused:false */
+                return val;
+            }
         } else {
             return val;
         }


### PR DESCRIPTION
closes #5294

This improves a hack for parsing JSON to be more robust.
Now attempt to parse JSON, and if it's not possible it will fallback to treating the value is a string,
reverting the behaviour to what it would have been if we didn't have JSON parsing here.
