### PR TITLE
Removes "email" from settings

### DIFF
--- a/core/client/app/models/setting.js
+++ b/core/client/app/models/setting.js
@@ -7,7 +7,6 @@ var Setting = DS.Model.extend(NProgressSaveMixin, ValidationEngine, {
 
     title: DS.attr('string'),
     description: DS.attr('string'),
-    email: DS.attr('string'),
     logo: DS.attr('string'),
     cover: DS.attr('string'),
     defaultLang: DS.attr('string'),

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -47,11 +47,6 @@
         </div>
 
         <fieldset>
-            <div class="form-group">
-                <label for="email-address">Email Address</label>
-                {{input id="email-address" class="gh-input" name="general[email-address]" type="email" value=model.email autocapitalize="off" autocorrect="off"}}
-                <p>Address to use for admin notifications</p>
-            </div>
 
             <div class="form-group">
                 <label for="postsPerPage">Posts per page</label>

--- a/core/client/app/validators/setting.js
+++ b/core/client/app/validators/setting.js
@@ -4,7 +4,6 @@ var SettingValidator = Ember.Object.create({
         var validationErrors = [],
             title = model.get('title'),
             description = model.get('description'),
-            email = model.get('email'),
             postsPerPage = model.get('postsPerPage'),
             isPrivate    = model.get('isPrivate'),
             password     = model.get('password');
@@ -15,10 +14,6 @@ var SettingValidator = Ember.Object.create({
 
         if (!validator.isLength(description, 0, 200)) {
             validationErrors.push({message: 'Description is too long'});
-        }
-
-        if (!validator.isEmail(email) || !validator.isLength(email, 0, 254)) {
-            validationErrors.push({message: 'Supply a valid email address'});
         }
 
         if (isPrivate && password === '') {

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -221,8 +221,6 @@ authentication = {
         }).then(function (user) {
             var userSettings = [];
 
-            userSettings.push({key: 'email', value: setupUser.email});
-
             // Handles the additional values set by the setup screen.
             if (!_.isEmpty(setupUser.blogTitle)) {
                 userSettings.push({key: 'title', value: setupUser.blogTitle});

--- a/core/server/data/default-settings.json
+++ b/core/server/data/default-settings.json
@@ -20,13 +20,6 @@
         "description": {
             "defaultValue": "Just a blogging platform."
         },
-        "email": {
-            "defaultValue": "ghost@example.com",
-            "validations": {
-                "isNull": false,
-                "isEmail": true
-            }
-        },
         "logo": {
             "defaultValue": ""
         },

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -35,7 +35,7 @@ describe('Authentication API', function () {
                     name: 'test user',
                     email: 'test@example.com',
                     password: 'areallygoodpassword',
-                    title: 'a test blog'
+                    blogTitle: 'a test blog'
                 },
 
                 send = mail.__get__('mail.send');

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -199,8 +199,7 @@ describe('Import', function () {
                 var users = importedData[0],
                     posts = importedData[1],
                     settings = importedData[2],
-                    tags = importedData[3],
-                    exportEmail;
+                    tags = importedData[3];
 
                 // we always have 1 user, the default user we added
                 users.length.should.equal(1, 'There should only be one user');
@@ -222,10 +221,6 @@ describe('Import', function () {
 
                 // activeTheme should NOT have been overridden
                 _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
-
-                // email address should have been overridden
-                exportEmail = _.findWhere(exportData.data.settings, {key: 'email'}).value;
-                _.findWhere(settings, {key: 'email'}).value.should.equal(exportEmail, 'Wrong email in settings');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
@@ -371,8 +366,7 @@ describe('Import', function () {
                 var users = importedData[0],
                     posts = importedData[1],
                     settings = importedData[2],
-                    tags = importedData[3],
-                    exportEmail;
+                    tags = importedData[3];
 
                 // we always have 1 user, the owner user we added
                 users.length.should.equal(1, 'There should only be one user');
@@ -394,10 +388,6 @@ describe('Import', function () {
 
                 // activeTheme should NOT have been overridden
                 _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
-
-                // email address should have been overridden
-                exportEmail = _.findWhere(exportData.data.settings, {key: 'email'}).value;
-                _.findWhere(settings, {key: 'email'}).value.should.equal(exportEmail, 'Wrong email in settings');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');


### PR DESCRIPTION
closes #5299

Removes the settings email which is no longer used. Also fixes a couple of tests regarding this email in the importer, and a bug in the authentication spec test.
