### PR TITLE
Update to simple-auth 0.8

### DIFF
--- a/core/client/.jshintrc
+++ b/core/client/.jshintrc
@@ -7,7 +7,6 @@
     "$",
     "validator",
     "ic",
-    "SimpleAuth",
     "NProgress",
     "moment"
   ],

--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -52,8 +52,6 @@ app.import('bower_components/jquery-ui/ui/jquery-ui.js');
 app.import('bower_components/jquery-file-upload/js/jquery.fileupload.js');
 app.import('bower_components/fastclick/lib/fastclick.js');
 app.import('bower_components/nprogress/nprogress.js');
-app.import('bower_components/ember-simple-auth/simple-auth.js');
-app.import('bower_components/ember-simple-auth/simple-auth-oauth2.js');
 app.import('bower_components/google-caja/html-css-sanitizer-bundle.js');
 app.import('bower_components/jqueryui-touch-punch/jquery.ui.touch-punch.js');
 app.import('bower_components/codemirror/lib/codemirror.js');

--- a/core/client/app/controllers/modals/signin.js
+++ b/core/client/app/controllers/modals/signin.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default Ember.Controller.extend(SimpleAuth.AuthenticationControllerMixin, ValidationEngine, {
+export default Ember.Controller.extend(ValidationEngine, {
     needs: 'application',
-
-    authenticator: 'simple-auth-authenticator:oauth2-password-grant',
 
     validationType: 'signin',
 
@@ -15,11 +13,13 @@ export default Ember.Controller.extend(SimpleAuth.AuthenticationControllerMixin,
     actions: {
         authenticate: function () {
             var appController = this.get('controllers.application'),
+                authStrategy = 'simple-auth-authenticator:oauth2-password-grant',
+                data = this.getProperties('identification', 'password'),
                 self = this;
 
             appController.set('skipAuthSuccessHandler', true);
 
-            this._super(this.getProperties('identification', 'password')).then(function () {
+            this.get('session').authenticate(authStrategy, data).then(function () {
                 self.send('closeModal');
                 self.notifications.showSuccess('Login successful.');
                 self.set('password', '');

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -2,9 +2,7 @@ import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 import ajax from 'ghost/utils/ajax';
 
-var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControllerMixin, ValidationEngine, {
-    authenticator: 'simple-auth-authenticator:oauth2-password-grant',
-
+var SigninController = Ember.Controller.extend(ValidationEngine, {
     validationType: 'signin',
 
     submitting: false,
@@ -12,9 +10,10 @@ var SigninController = Ember.Controller.extend(SimpleAuth.AuthenticationControll
     actions: {
         authenticate: function () {
             var model = this.get('model'),
+                authStrategy = 'simple-auth-authenticator:oauth2-password-grant',
                 data = model.getProperties('identification', 'password');
 
-            this._super(data).catch(function () {
+            this.get('session').authenticate(authStrategy, data).catch(function () {
                 // if authentication fails a rejected promise will be returned.
                 // it needs to be caught so it doesn't generate an exception in the console,
                 // but it's actually "handled" by the sessionAuthenticationFailed action handler.

--- a/core/client/app/initializers/authentication.js
+++ b/core/client/app/initializers/authentication.js
@@ -1,39 +1,20 @@
 import Ember from 'ember';
-import ghostPaths from 'ghost/utils/ghost-paths';
+import Session from 'simple-auth/session';
+import OAuth2 from 'simple-auth-oauth2/authenticators/oauth2';
 
-var Ghost,
-    AuthenticationInitializer;
-
-Ghost = ghostPaths();
-
-AuthenticationInitializer = {
+var AuthenticationInitializer = {
     name: 'authentication',
     before: 'simple-auth',
     after: 'registerTrailingLocationHistory',
 
     initialize: function (container) {
-        window.ENV = window.ENV || {};
-
-        window.ENV['simple-auth'] = {
-            authenticationRoute: 'signin',
-            routeAfterAuthentication: 'posts',
-            authorizer: 'simple-auth-authorizer:oauth2-bearer',
-            localStorageKey: 'ghost' + (Ghost.subdir.indexOf('/') === 0 ? '-' + Ghost.subdir.substr(1) : '') + ':session'
-        };
-
-        window.ENV['simple-auth-oauth2'] = {
-            serverTokenEndpoint: Ghost.apiRoot + '/authentication/token',
-            serverTokenRevocationEndpoint: Ghost.apiRoot + '/authentication/revoke',
-            refreshAccessTokens: true
-        };
-
-        SimpleAuth.Session.reopen({
+        Session.reopen({
             user: Ember.computed(function () {
                 return container.lookup('store:main').find('user', 'me');
             })
         });
 
-        SimpleAuth.Authenticators.OAuth2.reopen({
+        OAuth2.reopen({
             makeRequest: function (url, data) {
                 data.client_id = 'ghost-admin';
                 return this._super(url, data);

--- a/core/client/app/initializers/simple-auth-env.js
+++ b/core/client/app/initializers/simple-auth-env.js
@@ -1,0 +1,16 @@
+import ENV from '../config/environment';
+import ghostPaths from 'ghost/utils/ghost-paths';
+
+var Ghost = ghostPaths();
+
+export default {
+    name: 'simple-auth-env',
+    before: 'simple-auth-oauth2',
+
+    initialize: function () {
+        ENV['simple-auth-oauth2'].serverTokenEndpoint = Ghost.apiRoot + '/authentication/token';
+        ENV['simple-auth-oauth2'].serverTokenRevocationEndpoint = Ghost.apiRoot + '/authentication/revoke';
+
+        ENV['simple-auth'].localStorageKey = 'ghost' + (Ghost.subdir.indexOf('/') === 0 ? '-' + Ghost.subdir.substr(1) : '') + ':session';
+    }
+};

--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -1,5 +1,8 @@
-import Ember from 'ember';
 /* global key */
+
+import Ember from 'ember';
+import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
+import Configuration from 'simple-auth/configuration';
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
@@ -10,7 +13,7 @@ shortcuts.esc = {action: 'closePopups', scope: 'all'};
 shortcuts.enter = {action: 'confirmModal', scope: 'modal'};
 shortcuts[ctrlOrCmd + '+s'] = {action: 'save', scope: 'all'};
 
-ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, ShortcutsRoute, {
+ApplicationRoute = Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     shortcuts: shortcuts,
 
     afterModel: function (model, transition) {
@@ -54,6 +57,10 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
             this.send('loadServerNotifications', true);
         },
 
+        invalidateSession: function () {
+            this.get('session').invalidate();
+        },
+
         sessionAuthenticationFailed: function (error) {
             if (error.errors) {
                 // These are server side errors, which can be marked as htmlSafe
@@ -83,7 +90,7 @@ ApplicationRoute = Ember.Route.extend(SimpleAuth.ApplicationRouteMixin, Shortcut
                     attemptedTransition.retry();
                     self.get('session').set('attemptedTransition', null);
                 } else {
-                    self.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+                    self.transitionTo(Configuration.routeAfterAuthentication);
                 }
             });
         },

--- a/core/client/app/routes/authenticated.js
+++ b/core/client/app/routes/authenticated.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
-var AuthenticatedRoute = Ember.Route.extend(SimpleAuth.AuthenticatedRouteMixin);
+import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
+
+var AuthenticatedRoute = Ember.Route.extend(AuthenticatedRouteMixin);
 
 export default AuthenticatedRoute;

--- a/core/client/app/routes/posts/index.js
+++ b/core/client/app/routes/posts/index.js
@@ -1,8 +1,9 @@
+import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 import MobileIndexRoute from 'ghost/routes/mobile-index-route';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 import mobileQuery from 'ghost/utils/mobile';
 
-var PostsIndexRoute = MobileIndexRoute.extend(SimpleAuth.AuthenticatedRouteMixin, loadingIndicator, {
+var PostsIndexRoute = MobileIndexRoute.extend(AuthenticatedRouteMixin, loadingIndicator, {
     noPosts: false,
 
     // Transition to a specific post if we're not on mobile

--- a/core/client/app/routes/reset.js
+++ b/core/client/app/routes/reset.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
@@ -8,7 +9,7 @@ var ResetRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     beforeModel: function () {
         if (this.get('session').isAuthenticated) {
             this.notifications.showWarn('You can\'t reset your password while you\'re signed in.', {delayed: true});
-            this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+            this.transitionTo(Configuration.routeAfterAuthentication);
         }
     },
 

--- a/core/client/app/routes/settings/index.js
+++ b/core/client/app/routes/settings/index.js
@@ -1,8 +1,9 @@
+import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 import MobileIndexRoute from 'ghost/routes/mobile-index-route';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import mobileQuery from 'ghost/utils/mobile';
 
-var SettingsIndexRoute = MobileIndexRoute.extend(SimpleAuth.AuthenticatedRouteMixin, CurrentUserSettings, {
+var SettingsIndexRoute = MobileIndexRoute.extend(AuthenticatedRouteMixin, CurrentUserSettings, {
     titleToken: 'Settings',
 
     // Redirect users without permission to view settings,

--- a/core/client/app/routes/setup.js
+++ b/core/client/app/routes/setup.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
@@ -15,7 +16,7 @@ var SetupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
 
         // If user is logged in, setup has already been completed.
         if (this.get('session').isAuthenticated) {
-            this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+            this.transitionTo(Configuration.routeAfterAuthentication);
             return;
         }
 

--- a/core/client/app/routes/signin.js
+++ b/core/client/app/routes/signin.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
@@ -9,7 +10,7 @@ var SigninRoute = Ember.Route.extend(styleBody, loadingIndicator, {
 
     beforeModel: function () {
         if (this.get('session').isAuthenticated) {
-            this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+            this.transitionTo(Configuration.routeAfterAuthentication);
         }
     },
 

--- a/core/client/app/routes/signup.js
+++ b/core/client/app/routes/signup.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
+import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 import loadingIndicator from 'ghost/mixins/loading-indicator';
 
 var SignupRoute = Ember.Route.extend(styleBody, loadingIndicator, {
     classNames: ['ghost-signup'],
+
     beforeModel: function () {
         if (this.get('session').isAuthenticated) {
             this.notifications.showWarn('You need to sign out to register as a new user.', {delayed: true});
-            this.transitionTo(SimpleAuth.Configuration.routeAfterAuthentication);
+            this.transitionTo(Configuration.routeAfterAuthentication);
         }
     },
 

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -7,7 +7,7 @@
     "ember-data": "1.0.0-beta.16.1",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
     "ember-resolver": "0.1.15",
-    "ember-simple-auth": "0.7.2",
+    "ember-simple-auth": "0.8.0-beta.2",
     "fastclick": "1.0.6",
     "google-caja": "5669.0.0",
     "ic-ajax": "2.0.2",

--- a/core/client/config/environment.js
+++ b/core/client/config/environment.js
@@ -17,6 +17,21 @@ module.exports = function (environment) {
         APP: {
               // Here you can pass flags/options to your application instance
               // when it is created
+        },
+
+        'simple-auth': {
+            authenticationRoute: 'signin',
+            routeAfterAuthentication: 'posts',
+            authorizer: 'simple-auth-authorizer:oauth2-bearer',
+
+            localStorageKey: '<overriden by initializers/simple-auth-env>'
+        },
+
+        'simple-auth-oauth2': {
+            refreshAccessTokens: true,
+
+            serverTokenEndpoint: '<overriden by initializers/simple-auth-env>',
+            serverTokenRevocationEndpoint: '<overriden by initializers/simple-auth-env>'
         }
     };
 

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -29,10 +29,12 @@
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-mocha": "^0.5.0",
-    "ember-myth": "0.0.2",
+    "ember-cli-simple-auth": "0.8.0-beta.2",
+    "ember-cli-simple-auth-oauth2": "0.8.0-beta.2",
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.16.1",
     "ember-export-application-global": "^1.0.2",
+    "ember-myth": "0.0.2",
     "fs-extra": "0.16.3",
     "glob": "^4.0.5"
   },


### PR DESCRIPTION
No issue
- ember-simple-auth@0.8.0-beta.2.
- Switch from SimpleAuth global to ember-cli-simple-auth and ES6 imports.
- Refactor controllers to handle changes in 0.8.
- Introduces a new initializer to override some configuration items that are set in environment.js but need
  to be set with information that's only (easily) available at runtime.
