### PR TITLE
ES6 module version of ic-ajax instead of global

### DIFF
--- a/core/client/.jshintrc
+++ b/core/client/.jshintrc
@@ -6,7 +6,6 @@
     "-Notification",
     "$",
     "validator",
-    "ic",
     "moment"
   ],
   "browser": true,

--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -36,7 +36,6 @@ app = new EmberApp({
 // 'dem Scripts
 app.import('bower_components/loader.js/loader.js');
 app.import('bower_components/jquery/dist/jquery.js');
-app.import('bower_components/ic-ajax/dist/globals/main.js');
 app.import('bower_components/ember-load-initializers/ember-load-initializers.js');
 app.import('bower_components/validator-js/validator.js');
 app.import('bower_components/rangyinputs/rangyinputs-jquery-src.js');

--- a/core/client/app/controllers/modals/delete-all.js
+++ b/core/client/app/controllers/modals/delete-all.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
-var DeleteAllController = Ember.Controller.extend({
+import {request as ajax} from 'ic-ajax';
+
+export default Ember.Controller.extend({
     actions: {
         confirmAccept: function () {
             var self = this;
 
-            ic.ajax.request(this.get('ghostPaths.url').api('db'), {
+            ajax(this.get('ghostPaths.url').api('db'), {
                 type: 'DELETE'
             }).then(function () {
                 self.notifications.showSuccess('All content deleted from database.');
@@ -31,5 +33,3 @@ var DeleteAllController = Ember.Controller.extend({
         }
     }
 });
-
-export default DeleteAllController;

--- a/core/client/app/controllers/modals/transfer-owner.js
+++ b/core/client/app/controllers/modals/transfer-owner.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
-var TransferOwnerController = Ember.Controller.extend({
+import {request as ajax} from 'ic-ajax';
+
+export default Ember.Controller.extend({
     actions: {
         confirmAccept: function () {
             var user = this.get('model'),
@@ -8,7 +10,7 @@ var TransferOwnerController = Ember.Controller.extend({
 
             self.get('dropdown').closeDropdowns();
 
-            ic.ajax.request(url, {
+            ajax(url, {
                 type: 'PUT',
                 data: {
                     owner: [{
@@ -49,5 +51,3 @@ var TransferOwnerController = Ember.Controller.extend({
         }
     }
 });
-
-export default TransferOwnerController;

--- a/core/client/app/controllers/reset.js
+++ b/core/client/app/controllers/reset.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import ajax from 'ghost/utils/ajax';
+import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var ResetController = Ember.Controller.extend(ValidationEngine, {
+export default Ember.Controller.extend(ValidationEngine, {
     newPassword: '',
     ne2Password: '',
     token: '',
@@ -56,5 +56,3 @@ var ResetController = Ember.Controller.extend(ValidationEngine, {
         }
     }
 });
-
-export default ResetController;

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
-var LabsController = Ember.Controller.extend(Ember.Evented, {
+import {request as ajax} from 'ic-ajax';
+
+export default Ember.Controller.extend(Ember.Evented, {
     needs: ['feature'],
 
     uploadButtonText: 'Import',
@@ -34,7 +36,7 @@ var LabsController = Ember.Controller.extend(Ember.Evented, {
 
             formData.append('importfile', file);
 
-            ic.ajax.request(this.get('ghostPaths.url').api('db'), {
+            ajax(this.get('ghostPaths.url').api('db'), {
                 type: 'POST',
                 data: formData,
                 dataType: 'json',
@@ -77,7 +79,7 @@ var LabsController = Ember.Controller.extend(Ember.Evented, {
         sendTestEmail: function () {
             var self = this;
 
-            ic.ajax.request(this.get('ghostPaths.url').api('mail', 'test'), {
+            ajax(this.get('ghostPaths.url').api('mail', 'test'), {
                 type: 'POST'
             }).then(function () {
                 self.notifications.showSuccess('Check your email for the test message.');
@@ -91,5 +93,3 @@ var LabsController = Ember.Controller.extend(Ember.Evented, {
         }
     }
 });
-
-export default LabsController;

--- a/core/client/app/controllers/setup.js
+++ b/core/client/app/controllers/setup.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import ajax from 'ghost/utils/ajax';
+import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var SetupController = Ember.Controller.extend(ValidationEngine, {
+export default Ember.Controller.extend(ValidationEngine, {
     blogTitle: null,
     name: null,
     email: null,
@@ -48,5 +48,3 @@ var SetupController = Ember.Controller.extend(ValidationEngine, {
         }
     }
 });
-
-export default SetupController;

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
-import ajax from 'ghost/utils/ajax';
+import {request as ajax} from 'ic-ajax';
 
-var SigninController = Ember.Controller.extend(ValidationEngine, {
+export default Ember.Controller.extend(ValidationEngine, {
     validationType: 'signin',
 
     submitting: false,
@@ -63,5 +63,3 @@ var SigninController = Ember.Controller.extend(ValidationEngine, {
         }
     }
 });
-
-export default SigninController;

--- a/core/client/app/controllers/signup.js
+++ b/core/client/app/controllers/signup.js
@@ -1,8 +1,8 @@
 import Ember from 'ember';
-import ajax from 'ghost/utils/ajax';
+import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var SignupController = Ember.Controller.extend(ValidationEngine, {
+export default Ember.Controller.extend(ValidationEngine, {
     submitting: false,
 
     // ValidationEngine settings
@@ -46,5 +46,3 @@ var SignupController = Ember.Controller.extend(ValidationEngine, {
         }
     }
 });
-
-export default SignupController;

--- a/core/client/app/mixins/pagination-controller.js
+++ b/core/client/app/mixins/pagination-controller.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import { getRequestErrorMessage } from 'ghost/utils/ajax';
+import getRequestErrorMessage from 'ghost/utils/ajax';
 
-var PaginationControllerMixin = Ember.Mixin.create({
+export default Ember.Mixin.create({
     // set from PaginationRouteMixin
     paginationSettings: null,
 
@@ -57,5 +57,3 @@ var PaginationControllerMixin = Ember.Mixin.create({
         }
     }
 });
-
-export default PaginationControllerMixin;

--- a/core/client/app/mixins/validation-engine.js
+++ b/core/client/app/mixins/validation-engine.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-import {getRequestErrorMessage} from 'ghost/utils/ajax';
+import getRequestErrorMessage from 'ghost/utils/ajax';
 
 import ValidatorExtensions from 'ghost/utils/validator-extensions';
 import PostValidator from 'ghost/validators/post';
@@ -61,7 +61,7 @@ function formatErrors(errors, opts) {
 * It will be able to validate any properties on itself (or the model it passes to validate())
 * with the use of a declared validator.
 */
-var ValidationEngine = Ember.Mixin.create({
+export default Ember.Mixin.create({
     // these validators can be passed a model to validate when the class that
     // mixes in the ValidationEngine declares a validationType equal to a key on this object.
     // the model is either passed in via `this.validate({ model: object })`
@@ -174,5 +174,3 @@ var ValidationEngine = Ember.Mixin.create({
         });
     }
 });
-
-export default ValidationEngine;

--- a/core/client/app/models/slug-generator.js
+++ b/core/client/app/models/slug-generator.js
@@ -1,11 +1,15 @@
 import Ember from 'ember';
-var SlugGenerator = Ember.Object.extend({
+import {request as ajax} from 'ic-ajax';
+
+export default Ember.Object.extend({
     ghostPaths: null,
     slugType: null,
     value: null,
+
     toString: function () {
         return this.get('value');
     },
+
     generateSlug: function (textToSlugify) {
         var self = this,
             url;
@@ -16,14 +20,14 @@ var SlugGenerator = Ember.Object.extend({
 
         url = this.get('ghostPaths.url').api('slugs', this.get('slugType'), encodeURIComponent(textToSlugify));
 
-        return ic.ajax.request(url, {
+        return ajax(url, {
             type: 'GET'
         }).then(function (response) {
             var slug = response.slugs[0].slug;
+
             self.set('value', slug);
+
             return slug;
         });
     }
 });
-
-export default SlugGenerator;

--- a/core/client/app/models/user.js
+++ b/core/client/app/models/user.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 import DS from 'ember-data';
+import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 import SelectiveSaveMixin from 'ghost/mixins/selective-save';
 
-var User = DS.Model.extend(SelectiveSaveMixin, ValidationEngine, {
+export default DS.Model.extend(SelectiveSaveMixin, ValidationEngine, {
     validationType: 'user',
 
     uuid: DS.attr('string'),
@@ -49,7 +50,7 @@ var User = DS.Model.extend(SelectiveSaveMixin, ValidationEngine, {
     saveNewPassword: function () {
         var url = this.get('ghostPaths.url').api('users', 'password');
 
-        return ic.ajax.request(url, {
+        return ajax(url, {
             type: 'PUT',
             data: {
                 password: [{
@@ -69,7 +70,7 @@ var User = DS.Model.extend(SelectiveSaveMixin, ValidationEngine, {
                 roles: fullUserData.roles
             };
 
-        return ic.ajax.request(this.get('ghostPaths.url').api('users'), {
+        return ajax(this.get('ghostPaths.url').api('users'), {
             type: 'POST',
             data: JSON.stringify({users: [userData]}),
             contentType: 'application/json'
@@ -102,5 +103,3 @@ var User = DS.Model.extend(SelectiveSaveMixin, ValidationEngine, {
 
     pending: Ember.computed.equal('status', 'invited-pending').property('status')
 });
-
-export default User;

--- a/core/client/app/routes/about.js
+++ b/core/client/app/routes/about.js
@@ -1,27 +1,32 @@
+import {request as ajax} from 'ic-ajax';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import styleBody from 'ghost/mixins/style-body';
 
-var AboutRoute = AuthenticatedRoute.extend(styleBody, {
+export default AuthenticatedRoute.extend(styleBody, {
     titleToken: 'About',
 
     classNames: ['view-about'],
 
     cachedConfig: false,
+
     model: function () {
         var cachedConfig = this.get('cachedConfig'),
             self = this;
+
         if (cachedConfig) {
             return cachedConfig;
         }
 
-        return ic.ajax.request(this.get('ghostPaths.url').api('configuration'))
+        return ajax(this.get('ghostPaths.url').api('configuration'))
             .then(function (configurationResponse) {
                 var configKeyValues = configurationResponse.configuration;
+
                 cachedConfig = {};
                 configKeyValues.forEach(function (configKeyValue) {
                     cachedConfig[configKeyValue.key] = configKeyValue.value;
                 });
                 self.set('cachedConfig', cachedConfig);
+
                 return cachedConfig;
             });
     },
@@ -30,5 +35,3 @@ var AboutRoute = AuthenticatedRoute.extend(styleBody, {
         this.render('about', {into: 'application'});
     }
 });
-
-export default AboutRoute;

--- a/core/client/app/routes/setup.js
+++ b/core/client/app/routes/setup.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import {request as ajax} from 'ic-ajax';
 import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 
-var SetupRoute = Ember.Route.extend(styleBody, {
+export default Ember.Route.extend(styleBody, {
     titleToken: 'Setup',
 
     classNames: ['ghost-setup'],
@@ -20,7 +21,7 @@ var SetupRoute = Ember.Route.extend(styleBody, {
         }
 
         // If user is not logged in, check the state of the setup process via the API
-        return ic.ajax.request(this.get('ghostPaths.url').api('authentication/setup'), {
+        return ajax(this.get('ghostPaths.url').api('authentication/setup'), {
             type: 'GET'
         }).then(function (result) {
             var setup = result.setup[0].status;
@@ -31,5 +32,3 @@ var SetupRoute = Ember.Route.extend(styleBody, {
         });
     }
 });
-
-export default SetupRoute;

--- a/core/client/app/routes/signup.js
+++ b/core/client/app/routes/signup.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
+import {request as ajax} from 'ic-ajax';
 import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 
-var SignupRoute = Ember.Route.extend(styleBody, {
+export default Ember.Route.extend(styleBody, {
     classNames: ['ghost-signup'],
 
     beforeModel: function () {
@@ -32,7 +33,7 @@ var SignupRoute = Ember.Route.extend(styleBody, {
             model.set('email', email);
             model.set('token', params.token);
 
-            return ic.ajax.request({
+            return ajax({
                 url: self.get('ghostPaths.url').api('authentication', 'invitation'),
                 type: 'GET',
                 dataType: 'json',
@@ -60,5 +61,3 @@ var SignupRoute = Ember.Route.extend(styleBody, {
         this.controllerFor('signup').setProperties({email: '', password: '', token: ''});
     }
 });
-
-export default SignupRoute;

--- a/core/client/app/utils/ajax.js
+++ b/core/client/app/utils/ajax.js
@@ -1,13 +1,8 @@
 import Ember from 'ember';
-/* global ic */
-
-var ajax = function () {
-    return ic.ajax.request.apply(null, arguments);
-};
 
 // Used in API request fail handlers to parse a standard api error
 // response json for the message to display
-function getRequestErrorMessage(request, performConcat) {
+export default function getRequestErrorMessage(request, performConcat) {
     var message,
         msgDetail;
 
@@ -47,6 +42,3 @@ function getRequestErrorMessage(request, performConcat) {
 
     return message;
 }
-
-export {getRequestErrorMessage, ajax};
-export default ajax;

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -10,7 +10,6 @@
     "ember-simple-auth": "0.8.0-beta.2",
     "fastclick": "1.0.6",
     "google-caja": "5669.0.0",
-    "ic-ajax": "2.0.2",
     "jquery": "1.11.2",
     "jquery-file-upload": "9.5.6",
     "jquery-hammerjs": "1.0.1",


### PR DESCRIPTION
Instead of including both the ES6 module version of ic-ajax that ships with ember-cli and the legacy global version, remove the global version and switch project to use ES6 import style.
