### PR TITLE
splitting client authentication-related middleware in to its own file

### DIFF
--- a/core/server/middleware/client-auth.js
+++ b/core/server/middleware/client-auth.js
@@ -1,0 +1,35 @@
+var passport    = require('passport'),
+    _           = require('lodash'),
+    oauthServer,
+
+    clientAuth;
+
+function cacheOauthServer(server) {
+    oauthServer = server;
+}
+
+clientAuth = {
+    // work around to handle missing client_secret
+    // oauth2orize needs it, but untrusted clients don't have it
+    addClientSecret: function addClientSecret(req, res, next) {
+        if (_.isEmpty(req.body.client_secret)) {
+            req.body.client_secret = 'not_available';
+        }
+        next();
+    },
+
+    // ### Authenticate Client Middleware
+    // authenticate client that is asking for an access token
+    authenticateClient: function authenticateClient(req, res, next) {
+        return passport.authenticate(['oauth2-client-password'], {session: false})(req, res, next);
+    },
+
+    // ### Generate access token Middleware
+    // register the oauth2orize middleware for password and refresh token grants
+    generateAccessToken: function generateAccessToken(req, res, next) {
+        return oauthServer.token()(req, res, next);
+    }
+};
+
+module.exports = clientAuth;
+module.exports.cacheOauthServer = cacheOauthServer;

--- a/core/test/unit/middleware/clientAuth_spec.js
+++ b/core/test/unit/middleware/clientAuth_spec.js
@@ -1,0 +1,44 @@
+/*globals describe, beforeEach, it*/
+/*jshint expr:true*/
+var should          = require('should'),
+    sinon           = require('sinon'),
+
+    middleware      = require('../../../server/middleware').middleware;
+
+describe('Middleware: Client Auth', function () {
+    var req, res, next;
+
+    beforeEach(function () {
+        req = {};
+        res = {};
+        next = sinon.spy();
+    });
+
+    describe('addClientSecret', function () {
+        it('sets a `client_secret` if not part of body', function () {
+            var requestBody = {};
+
+            req.body = requestBody;
+
+            middleware.addClientSecret(req, res, next);
+
+            next.called.should.be.true;
+            should(req.body).have.property('client_secret');
+            req.body.client_secret.should.not.be.empty;
+        });
+
+        it('does not tamper with `client_secret` if already present', function () {
+            var requestBody = {
+                client_secret: 'keep-it-safe-keep-it-secret'
+            };
+
+            req.body = requestBody;
+
+            middleware.addClientSecret(req, res, next);
+
+            next.called.should.be.true;
+            should(req.body).have.property('client_secret');
+            req.body.client_secret.should.equal('keep-it-safe-keep-it-secret');
+        });
+    });
+});


### PR DESCRIPTION
- refs #5286
- splitting client authentication-related middleware in to its own file
- created test cases for `addClientSecret`
- not sure `generateAccessToken` and `authenticateClient` are worth testing since there isn't any custom logic
