### PR TITLE
Fix context setup (remove dep on req.route.path)

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -68,25 +68,27 @@ function setResponseContext(req, res, data) {
         pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
         tagPattern = new RegExp('^\\/' + config.routeKeywords.tag + '\\/'),
         authorPattern = new RegExp('^\\/' + config.routeKeywords.author + '\\/'),
-        privatePattern = new RegExp('^\\/' + config.routeKeywords.private + '\\/');
+        privatePattern = new RegExp('^\\/' + config.routeKeywords.private + '\\/'),
+        indexPattern = new RegExp('^\\/' + config.routeKeywords.page + '\\/'),
+        homePattern = new RegExp('^\\/$');
 
     // paged context
     if (!isNaN(pageParam) && pageParam > 1) {
         contexts.push('paged');
     }
 
-    if (req.route.path === '/' + config.routeKeywords.page + '/:page/') {
+    if (indexPattern.test(res.locals.relativeUrl)) {
         contexts.push('index');
-    } else if (req.route.path === '/') {
+    } else if (homePattern.test(res.locals.relativeUrl)) {
         contexts.push('home');
         contexts.push('index');
-    } else if (/\/rss\/(:page\/)?$/.test(req.route.path)) {
+    } else if (/^\/rss\//.test(res.locals.relativeUrl)) {
         contexts.push('rss');
-    } else if (privatePattern.test(req.route.path)) {
+    } else if (privatePattern.test(res.locals.relativeUrl)) {
         contexts.push('private');
-    } else if (tagPattern.test(req.route.path)) {
+    } else if (tagPattern.test(res.locals.relativeUrl)) {
         contexts.push('tag');
-    } else if (authorPattern.test(req.route.path)) {
+    } else if (authorPattern.test(res.locals.relativeUrl)) {
         contexts.push('author');
     } else if (data && data.post && data.post.page) {
         contexts.push('page');

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -14,10 +14,6 @@ var _        = require('lodash'),
     getFeedXml,
     feedCache = {};
 
-function isPaginated(req) {
-    return req.route.path.indexOf(':page') !== -1;
-}
-
 function isTag(req) {
     return req.originalUrl.indexOf('/' + config.routeKeywords.tag + '/') !== -1;
 }
@@ -209,7 +205,7 @@ generate = function (req, res, next) {
         options   = getOptions(req, pageParam, slugParam);
 
     // No negative pages, or page 1
-    if (isNaN(pageParam) || pageParam < 1 || (pageParam === 1 && isPaginated(req))) {
+    if (isNaN(pageParam) || pageParam < 1 || (req.params.page !== undefined && pageParam === 1)) {
         return res.redirect(baseUrl);
     }
 

--- a/core/test/unit/frontend_spec.js
+++ b/core/test/unit/frontend_spec.js
@@ -1467,7 +1467,7 @@ describe('Frontend Controller', function () {
 
         beforeEach(function () {
             res = {
-                locals: {version: ''},
+                locals: {version: '', relativeUrl: '/private/'},
                 render: sandbox.spy()
             },
             req = {


### PR DESCRIPTION
refs #5344 
- As a result of #5344, contexts are completely broken.
- This PR removes all dependence on req.route.path, and uses res.locals.relativeUrl
- res.locals.relativeUrl is used for many things and is dependable

I have a further PR coming which refactors where this context generation is done and will have unit tests  for that function. This PR fixes the immediate brokenness.
