### PR TITLE
Reimplement fastclick library

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -49,7 +49,6 @@ app.import('bower_components/keymaster/keymaster.js');
 app.import('bower_components/devicejs/lib/device.js');
 app.import('bower_components/jquery-ui/ui/jquery-ui.js');
 app.import('bower_components/jquery-file-upload/js/jquery.fileupload.js');
-app.import('bower_components/fastclick/lib/fastclick.js');
 app.import('bower_components/google-caja/html-css-sanitizer-bundle.js');
 app.import('bower_components/jqueryui-touch-punch/jquery.ui.touch-punch.js');
 app.import('bower_components/codemirror/lib/codemirror.js');

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -25,6 +25,7 @@
     "ember-cli-babel": "^4.1.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.0.8",
+    "ember-cli-fastclick": "1.0.3",
     "ember-cli-htmlbars": "^0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",


### PR DESCRIPTION
closes #5375
- adds an addon for fast click to the npm dependencies of the ember-cli application
