### PR TITLE
Fix autofocus on post edit

### DIFF
--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -6,7 +6,7 @@ import EditorScroll from 'ghost/mixins/ed-editor-scroll';
 var Editor;
 
 Editor = Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
-    focus: true,
+    focus: false,
 
     /**
      * Tell the controller about focusIn events, will trigger an autosave on a new document

--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -236,7 +236,6 @@ export default Ember.Mixin.create({
     },
 
     shouldFocusTitle: Ember.computed.alias('model.isNew'),
-    shouldFocusEditor: Ember.computed.not('model.isNew'),
 
     actions: {
         save: function (options) {

--- a/core/client/app/templates/editor/edit.hbs
+++ b/core/client/app/templates/editor/edit.hbs
@@ -13,8 +13,7 @@
         </header>
         <section id="entry-markdown-content" class="entry-markdown-content">
             {{gh-ed-editor classNames="markdown-editor js-markdown-editor" tabindex="1" spellcheck="true" value=model.scratch
-            scrollInfo=view.editorScrollInfo focus=shouldFocusEditor focusCursorAtEnd=model.isDirty
-            setEditor="setEditor" openModal="openModal" onFocusIn="autoSaveNew"}}
+            scrollInfo=view.editorScrollInfo setEditor="setEditor" openModal="openModal" onFocusIn="autoSaveNew"}}
         </section>
     </section>
 


### PR DESCRIPTION
closes #5383
- sets the default focus of the editor component to false
- removes the check for model.isNew in editor controller
