### PR TITLE
Ensure importer tests don't clash

### DIFF
--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -671,8 +671,6 @@ describe('Import', function () {
 describe('Import (new test structure)', function () {
     before(testUtils.teardown);
 
-    after(testUtils.teardown);
-
     describe('imports multi user data onto blank ghost install', function () {
         var exportData;
 


### PR DESCRIPTION
no issue
- I've noticed the importer tests going wrong on SQLite a couple of times recently.
- I think it's because the teardowns were clashing, hopefully this will help

Should fix this:

![](http://puu.sh/iaIua.png)
