### PR TITLE
Clean up and update ember dependencies

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -34,9 +34,6 @@ app = new EmberApp({
 });
 
 // 'dem Scripts
-app.import('bower_components/loader.js/loader.js');
-app.import('bower_components/jquery/dist/jquery.js');
-app.import('bower_components/ember-load-initializers/ember-load-initializers.js');
 app.import('bower_components/validator-js/validator.js');
 app.import('bower_components/rangyinputs/rangyinputs-jquery-src.js');
 app.import('bower_components/showdown-ghost/src/showdown.js');

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -5,8 +5,11 @@
     "codemirror": "5.2.0",
     "devicejs": "0.2.7",
     "ember": "1.12.1",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
+    "ember-cli-test-loader": "0.1.3",
     "ember-data": "1.0.0-beta.18",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
+    "ember-mocha": "0.7.0",
     "ember-resolver": "0.1.15",
     "ember-simple-auth": "0.8.0-beta.2",
     "fastclick": "1.0.6",
@@ -18,18 +21,12 @@
     "jqueryui-touch-punch": "furf/jquery-ui-touch-punch",
     "keymaster": "1.6.3",
     "loader.js": "3.2.1",
-    "moment": "2.10.2",
+    "moment": "2.10.3",
     "normalize.css": "3.0.3",
     "password-generator": "git://github.com/bermi/password-generator#49accd7",
     "rangyinputs": "1.2.0",
     "showdown-ghost": "0.3.6",
     "validator-js": "3.39.0",
     "xregexp": "2.0.0"
-
-  },
-  "devDependencies": {
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "0.1.3",
-    "ember-mocha": "0.6.0"
   }
 }

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -29,7 +29,7 @@
     "ember-cli-htmlbars": "^0.7.4",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-mocha": "^0.5.0",
+    "ember-cli-mocha": "^0.7.0",
     "ember-cli-simple-auth": "0.8.0-beta.2",
     "ember-cli-simple-auth-oauth2": "0.8.0-beta.2",
     "ember-cli-uglify": "1.0.1",


### PR DESCRIPTION
No Issue
- Remove unneeded imports from Brocfile.js.
- Move devDependencies up to dependencies.
- Update ember-mocha dependencies.
- moment@2.10.3 to match version used on backend.
