### PR TITLE
Issue #5371 added support for GET endpoint `/tags/slug/:slug`

### DIFF
--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -39,6 +39,7 @@ apiRoutes = function apiRoutes(middleware) {
     // ## Tags
     router.get('/tags', api.http(api.tags.browse));
     router.get('/tags/:id', api.http(api.tags.read));
+    router.get('/tags/slug/:slug', api.http(api.tags.read));
     router.post('/tags', api.http(api.tags.add));
     router.put('/tags/:id', api.http(api.tags.edit));
     router.del('/tags/:id', api.http(api.tags.destroy));

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -177,6 +177,10 @@ describe('Tags API', function () {
     });
 
     describe('Read', function () {
+        function extractFirstTag(tags) {
+            return _.filter(tags, {id: 1})[0];
+        }
+
         it('returns post_count with include post_count', function (done) {
             TagAPI.read({context: {user: 1}, include: 'post_count', slug: 'kitchen-sink'}).then(function (results) {
                 should.exist(results);
@@ -186,6 +190,23 @@ describe('Tags API', function () {
                 testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
                 should.exist(results.tags[0].post_count);
                 results.tags[0].post_count.should.equal(2);
+
+                done();
+            }).catch(done);
+        });
+
+        it('with slug', function (done) {
+            TagAPI.browse({context: {user: 1}}).then(function (results) {
+                should.exist(results);
+                should.exist(results.tags);
+                results.tags.length.should.be.above(0);
+
+                var firstTag = extractFirstTag(results.tags);
+
+                return TagAPI.read({context: {user: 1}, slug: firstTag.slug});
+            }).then(function (found) {
+                should.exist(found);
+                testUtils.API.checkResponse(found.tags[0], 'tag');
 
                 done();
             }).catch(done);

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -91,6 +91,31 @@ describe('Tag Model', function () {
         });
     });
 
+    describe('findOne', function () {
+        beforeEach(function (done) {
+            testUtils.fixtures.insertPosts().then(function () {
+                done();
+            }).catch(done);
+        });
+
+        it('with slug', function (done) {
+            var firstTag;
+
+            TagModel.findPage().then(function (results) {
+                should.exist(results);
+                should.exist(results.tags);
+                results.tags.length.should.be.above(0);
+                firstTag = results.tags[0];
+
+                return TagModel.findOne({slug: firstTag.slug});
+            }).then(function (found) {
+                should.exist(found);
+
+                done();
+            }).catch(done);
+        });
+    });
+
     describe('a Post', function () {
         it('can add a tag', function (done) {
             var newPost = testUtils.DataGenerator.forModel.posts[0],


### PR DESCRIPTION
I added supported for the new endpoint mentioned in issue #5371. I also added unit tests. I am not sure if I did the unit tests correctly and simply went off of the ones mentioned in the issue for the PostModel and PostAPI.

Let me know if I did it correctly please! From my understanding, the functionality already exists but the endpoint was simply missing.
