### PR TITLE
Fixes Wide Admin Nav Bar in Firefox

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -32,6 +32,7 @@
     flex: 0 0 235px;
     display: flex;
     flex-direction: column;
+    min-width: 0;
     border-right: #e1e1e1 1px solid;
     background: #f6f6f6;
     transform: translateX(0);
@@ -69,6 +70,7 @@
 .gh-nav-menu-details {
     flex-grow: 1;
     padding-right: 10px;
+    min-width: 0;
 }
 
 .gh-nav-menu-details-blog {


### PR DESCRIPTION
closes #5402
- Added `min-width: 0` to both `.gh-nav-menu-details` and `.gh-nav`
- Looks like Firefox doesn’t handle flex white-space as gracefully as others right now

Before:
![screen shot 2015-06-15 at 8 54 33 pm](https://cloud.githubusercontent.com/assets/4715098/8175544/c9a8e652-13a0-11e5-9b20-a81a527b6e5f.png)

After:
![screen shot 2015-06-15 at 8 50 29 pm](https://cloud.githubusercontent.com/assets/4715098/8175547/cf6ea982-13a0-11e5-8b43-a02cbe59da75.png)
