### PR TITLE
Fix signin form width bug

### DIFF
--- a/core/client/app/styles/layouts/auth.css
+++ b/core/client/app/styles/layouts/auth.css
@@ -6,6 +6,7 @@
     margin: 30px auto;
     padding: 40px;
     max-width: 400px;
+    width: 100%;
     border: #dae1e3 1px solid;
     background: #f8fbfd;
     border-radius: 5px;


### PR DESCRIPTION
No issue. Fixes bug where signin form was not expanding to its full width as a result of some earlier global changes. This sets an explicit fluid width with a max-width fallback so that it's always the correct size.
