### PR TITLE
set the viewport to a max height so that vertical scrolling doesnt break

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -13,6 +13,7 @@
 .gh-viewport {
     flex-grow: 1;
     display: flex;
+    max-height: 100%;
 }
 
 .gh-main {


### PR DESCRIPTION
closes #5401 

This seems deceptively simple. I'm not a flexbox pro, so someone who is might want to crazy check this.

For some reason, Firefox was not automatically vertically containing the `.gh-viewport` div inside of the parent `.gh-app`. `.gh-app` is set to 100vh height, so the whole screen, but `.gh-viewport` was stretching to contain the content.

This had two effects:
- content that was longer than the viewport was impossible to view, because `.gh-app` has `overflow: hidden`.
- The sidebar footer was hidden, because it would flex with the height of the content pane.

I simply put a `max-height: 100%` on `.gh-viewport`, so that it would match to `.gh-app`'s 100vh setting. This seems to work.
