### PR TITLE
Ensure settings routes redirect to /signin when not authenticated

### DIFF
--- a/core/client/app/routes/settings/apps.js
+++ b/core/client/app/routes/settings/apps.js
@@ -10,7 +10,9 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     config: Ember.inject.service(),
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
+
         if (!this.get('config.apps')) {
             return this.transitionTo('settings.general');
         }

--- a/core/client/app/routes/settings/general.js
+++ b/core/client/app/routes/settings/general.js
@@ -7,7 +7,8 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['settings-view-general'],
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());

--- a/core/client/app/routes/settings/labs.js
+++ b/core/client/app/routes/settings/labs.js
@@ -7,7 +7,8 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['settings'],
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -7,7 +7,8 @@ var NavigationRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, 
 
     classNames: ['settings-view-navigation'],
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor());
     },

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -14,7 +14,8 @@ paginationSettings = {
 TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
     titleToken: 'Settings - Tags',
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor());
     },

--- a/core/client/app/routes/settings/users/index.js
+++ b/core/client/app/routes/settings/users/index.js
@@ -22,7 +22,8 @@ UsersIndexRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, Pagi
         this.setupPagination(paginationSettings);
     },
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor());
     },


### PR DESCRIPTION
closes #5412
- call this._super() in beforeModel hooks so that simple-auth can handle the transition before we hit any protected API endpoints
