### PR TITLE
Hide Nav Settings based on permissions

### DIFF
--- a/core/client/app/helpers/gh-user-can.js
+++ b/core/client/app/helpers/gh-user-can.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+// Handlebars Helper {{gh-user-can}}
+// Usage: call helper as with first parameter of session.user and second parameter the minimum role
+// e.g - {{#if (gh-user-can session.user 'admin')}} 'block content' {{/if}}
+// @param1 session.user
+// @param2 'admin' or 'editor'
+
+export function ghUserCan(params) {
+    if (params[1] === 'admin') {
+        return !!(params[0].get('isOwner') || params[0].get('isAdmin'));
+    } else if (params[1] === 'editor') {
+        return !!(params[0].get('isOwner') || params[0].get('isAdmin') || params[0].get('isEditor'));
+    }
+    return false;
+}
+
+export default Ember.HTMLBars.makeBoundHelper(ghUserCan);

--- a/core/client/app/templates/components/gh-nav-menu.hbs
+++ b/core/client/app/templates/components/gh-nav-menu.hbs
@@ -27,15 +27,17 @@
         <li>{{#link-to "settings.users" classNames="gh-nav-main-users"}}<i class="icon-team"></i>Team{{/link-to}}</li>
         {{!<li><a href="#"><i class="icon-idea"></i>Ideas</a></li>}}
     </ul>
-    <ul class="gh-nav-list gh-nav-settings">
-        <li class="gh-nav-list-h">Settings</li>
-        <li>{{#link-to "settings.general" classNames="gh-nav-settings-general"}}<i class="icon-settings"></i>General{{/link-to}}</li>
-        {{!<li><i class="icon-design"></i>Themes</li>}}
-        <li>{{#link-to "settings.navigation" classNames="gh-nav-settings-navigation"}}<i class="icon-compass"></i>Navigation{{/link-to}}</li>
-        <li>{{#link-to "settings.tags" classNames="gh-nav-settings-tags"}}<i class="icon-tag"></i>Tags{{/link-to}}</li>
-        <li>{{#link-to "settings.code-injection" classNames="gh-nav-settings-code-injection"}}<i class="icon-code"></i>Code Injection{{/link-to}}</li>
-        <li>{{#link-to "settings.labs" classNames="gh-nav-settings-labs"}}<i class="icon-apps"></i>Labs{{/link-to}}</li>
-    </ul>
+    {{#if (gh-user-can session.user 'admin')}}
+        <ul class="gh-nav-list gh-nav-settings">
+            <li class="gh-nav-list-h">Settings</li>
+            <li>{{#link-to "settings.general" classNames="gh-nav-settings-general"}}<i class="icon-settings"></i>General{{/link-to}}</li>
+            {{!<li><i class="icon-design"></i>Themes</li>}}
+            <li>{{#link-to "settings.navigation" classNames="gh-nav-settings-navigation"}}<i class="icon-compass"></i>Navigation{{/link-to}}</li>
+            <li>{{#link-to "settings.tags" classNames="gh-nav-settings-tags"}}<i class="icon-tag"></i>Tags{{/link-to}}</li>
+            <li>{{#link-to "settings.code-injection" classNames="gh-nav-settings-code-injection"}}<i class="icon-code"></i>Code Injection{{/link-to}}</li>
+            <li>{{#link-to "settings.labs" classNames="gh-nav-settings-labs"}}<i class="icon-apps"></i>Labs{{/link-to}}</li>
+        </ul>
+    {{/if}}
 </section>
 <footer class="gh-nav-footer">
     {{gh-menu-toggle desktopAction="toggleAutoNav" mobileAction="closeMobileMenu"}}

--- a/core/client/tests/unit/helpers/gh-user-can-test.js
+++ b/core/client/tests/unit/helpers/gh-user-can-test.js
@@ -1,0 +1,97 @@
+import {
+    describeModule,
+    it
+} from 'ember-mocha';
+import {
+    ghUserCan
+} from 'ghost/helpers/gh-user-can';
+
+describe ('GhUserCanHelper', function () {
+    // Mock up roles and test for truthy
+    describe ('Owner role', function () {
+        var user = {get: function (role) {
+                if (role === 'isOwner') {
+                    return true;
+                } else if (role === 'isAdmin') {
+                    return false;
+                } else if (role === 'isEditor') {
+                    return false;
+                }
+            }
+        };
+        it(' - can be Admin', function () {
+            var result = ghUserCan([user, 'admin']);
+            expect(result).to.equal(true);
+        });
+        it(' - can be Editor', function () {
+            var result = ghUserCan([user, 'editor']);
+            expect(result).to.equal(true);
+        });
+    });
+
+    describe ('Administrator role', function () {
+        var user = {
+            get: function (role) {
+                if (role === 'isOwner') {
+                    return false;
+                } else if (role === 'isAdmin') {
+                    return true;
+                } else if (role === 'isEditor') {
+                    return false;
+                }
+            }
+        };
+        it(' - can be Admin', function () {
+            var result = ghUserCan([user, 'admin']);
+            expect(result).to.equal(true);
+        });
+        it(' - can be Editor', function () {
+            var result = ghUserCan([user, 'editor']);
+            expect(result).to.equal(true);
+        });
+    });
+
+    describe ('Editor role', function () {
+        var user = {
+            get: function (role) {
+                if (role === 'isOwner') {
+                    return false;
+                } else if (role === 'isAdmin') {
+                    return false;
+                } else if (role === 'isEditor') {
+                    return true;
+                }
+            }
+        };
+        it(' - cannot be Admin', function () {
+            var result = ghUserCan([user, 'admin']);
+            expect(result).to.equal(false);
+        });
+        it(' - can be Editor', function () {
+            var result = ghUserCan([user, 'editor']);
+            expect(result).to.equal(true);
+        });
+    });
+
+    describe ('Author role', function () {
+        var user = {
+            get: function (role) {
+                if (role === 'isOwner') {
+                    return false;
+                } else if (role === 'isAdmin') {
+                    return false;
+                } else if (role === 'isEditor') {
+                    return false;
+                }
+            }
+        };
+        it(' - cannot be Admin', function () {
+            var result = ghUserCan([user, 'admin']);
+            expect(result).to.equal(false);
+        });
+        it(' - cannot be Editor', function () {
+            var result = ghUserCan([user, 'editor']);
+            expect(result).to.equal(false);
+        });
+    });
+});


### PR DESCRIPTION
closes #5403
- adds gh-user-can helper to group user by minimum permissions
- hide Nav settings menu for users below admin level
