### PR TITLE
Display correct minimum character count in setup's password field

### DIFF
--- a/core/client/app/templates/setup/two.hbs
+++ b/core/client/app/templates/setup/two.hbs
@@ -33,7 +33,7 @@
         <div class="form-group">
             <label for="password">Password</label>
             <span class="input-icon icon-lock">
-                {{input type="password" name="password" placeholder="At least 7 characters" class="gh-input" autofocus="autofocus" autocorrect="off" value=password }}
+                {{input type="password" name="password" placeholder="At least 8 characters" class="gh-input" autofocus="autofocus" autocorrect="off" value=password }}
                 <div class="pw-strength">
                     <div class="pw-strength-dot"></div>
                     <div class="pw-strength-dot"></div>


### PR DESCRIPTION
issue #5314
- replace 7 (incorrect) with 8 (correct) in setup's password field placeholder text
