### PR TITLE
Provide a more intuitive error message on sign-in for missing email

### DIFF
--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -4,7 +4,9 @@ var SigninValidator = Ember.Object.create({
         var data = model.getProperties('identification', 'password'),
             validationErrors = [];
 
-        if (!validator.isEmail(data.identification)) {
+        if (validator.empty(data.identification)) {
+            validationErrors.push('Please enter an email');
+        } else if (!validator.isEmail(data.identification)) {
             validationErrors.push('Invalid Email');
         }
 

--- a/core/test/functional/client/signin_test.js
+++ b/core/test/functional/client/signin_test.js
@@ -111,7 +111,7 @@ CasperTest.begin('Authenticated user is redirected', 6, function suite(test) {
     });
 }, true);
 
-CasperTest.begin('Ensure email field form validation', 3, function suite(test) {
+CasperTest.begin('Ensure email field form validation', 4, function suite(test) {
     CasperTest.Routines.signout.run(test);
 
     casper.thenOpenAndWaitForPageLoad('signin', function testTitleAndUrl() {
@@ -133,5 +133,17 @@ CasperTest.begin('Ensure email field form validation', 3, function suite(test) {
         test.assertSelectorHasText('.notification-error', 'Invalid Email', '.notification-error text is correct');
     }, function onTimeout() {
         test.fail('Email validation error did not appear');
+    }, 2000);
+
+    casper.then(function testMissingEmail() {
+        this.fillAndSave('form.gh-signin', {
+            identification: ''
+        });
+    });
+
+    casper.waitForSelectorTextChange('.notification-error', function onSuccess() {
+        test.assertSelectorHasText('.notification-error', 'Please enter an email', '.notification-error text is correct');
+    }, function onTimeout() {
+        test.fail('Missing Email validation error did not appear');
     }, 2000);
 }, true);


### PR DESCRIPTION
issue https://github.com/TryGhost/Ghost/issues/4651#issuecomment-112141801
- display "Please enter an email" validation message rather than "Invalid Email" when no email is entered
