### PR TITLE
Always get latest post from API when editing

### DIFF
--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -8,7 +8,6 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
 
     model: function (params) {
         var self = this,
-            post,
             postId,
             query;
 
@@ -16,11 +15,6 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
 
         if (!isNumber(postId) || !isFinite(postId) || postId % 1 !== 0 || postId <= 0) {
             return this.transitionTo('error404', 'editor/' + params.post_id);
-        }
-
-        post = this.store.getById('post', postId);
-        if (post) {
-            return post;
         }
 
         query = {

--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -61,7 +61,7 @@ var PostsPostRoute = AuthenticatedRoute.extend(ShortcutsRoute, {
 
     actions: {
         openEditor: function () {
-            this.transitionTo('editor.edit', this.get('controller.model'));
+            this.transitionTo('editor.edit', this.get('controller.model.id'));
         },
 
         deletePost: function () {

--- a/core/client/app/templates/posts.hbs
+++ b/core/client/app/templates/posts.hbs
@@ -11,7 +11,7 @@
         {{#view "paginated-scroll-box" tagName="section" classNames="content-list-content js-content-scrollbox"}}
         <ol class="posts-list">
             {{#each controller itemController="posts/post" itemView="post-item-view" itemTagName="li" as |post|}}
-                {{#link-to "posts.post" post.model class="permalink" alternateActive=view.active title="Edit this post"}}
+                {{#link-to "posts.post" post.model.id class="permalink" alternateActive=view.active title="Edit this post"}}
                     <h3 class="entry-title">{{post.model.title}}</h3>
                     <section class="entry-meta">
                         <span class="avatar" style={{post.authorAvatarBackground}}>

--- a/core/client/app/templates/posts/post.hbs
+++ b/core/client/app/templates/posts/post.hbs
@@ -1,10 +1,10 @@
 <section class="post-controls">
-    {{#link-to "editor.edit" model class="btn btn-minor post-edit"}}<i class="icon-edit"></i>{{/link-to}}
+    {{#link-to "editor.edit" model.id class="btn btn-minor post-edit"}}<i class="icon-edit"></i>{{/link-to}}
 </section>
 
 {{#view "content-preview-content-view" tagName="section"}}
     <div class="wrapper">
-        <h1 class="content-preview-title">{{#link-to "editor.edit" model}}{{model.title}}{{/link-to}}</h1>
+        <h1 class="content-preview-title">{{#link-to "editor.edit" model.id}}{{model.title}}{{/link-to}}</h1>
         {{gh-format-html model.html}}
     </div>
 {{/view}}


### PR DESCRIPTION
Closes #5450
- No longer provide the edit route a model when transitioning from the
  posts list/content screen and no longer check to see if a copy of the
  post already exists in the store from the model hook.
