### PR TITLE
Removes whitespace issue that was preventing grunt init from working

### DIFF
--- a/core/client/app/templates/setup/three.hbs
+++ b/core/client/app/templates/setup/three.hbs
@@ -8,8 +8,7 @@
 
     <form class="gh-flow-invite">
         <label>Enter one email address per line, we’ll handle the rest! <i class="icon-mail"></i></label>
-        {{textarea class="gh-input" name="users" placeholder="john@example.com
-sally.sanders@example.com" value=users}}
+        {{textarea class="gh-input" name="users" placeholder="john@example.com" value=users}}
     </form>
 
     <button {{action 'invite'}} class="btn btn-default btn-lg btn-block {{buttonClass}}">


### PR DESCRIPTION
closes #5454
- removed newline and put the offending string on one line within the file
