### PR TITLE
Fix up editor/preview scroll and post list loading

### DIFF
--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -28,6 +28,8 @@ Editor = Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
      * Sets up properties at render time
      */
     didInsertElement: function () {
+        this._super();
+
         this.setFocus();
 
         this.sendAction('setEditor', this);

--- a/core/client/app/mixins/ed-editor-scroll.js
+++ b/core/client/app/mixins/ed-editor-scroll.js
@@ -91,10 +91,14 @@ var EditorScroll = Ember.Mixin.create({
     },
 
     didInsertElement: function () {
+        this._super();
+
         this.attachScrollHandlers();
     },
 
     willDestroyElement: function () {
+        this._super();
+
         this.detachScrollHandlers();
     }
 });

--- a/core/client/app/mixins/pagination-view-infinite-scroll.js
+++ b/core/client/app/mixins/pagination-view-infinite-scroll.js
@@ -34,10 +34,14 @@ var PaginationViewInfiniteScrollMixin = Ember.Mixin.create({
     },
 
     didInsertElement: function () {
+        this._super();
+
         this.attachCheckScroll();
     },
 
     willDestroyElement: function () {
+        this._super();
+
         // unbind from the scroll event when the element is no longer in the DOM
         this.$().off('scroll');
     }

--- a/core/client/app/views/paginated-scroll-box.js
+++ b/core/client/app/views/paginated-scroll-box.js
@@ -15,10 +15,14 @@ var PaginatedScrollBox = Ember.View.extend(PaginationViewMixin, {
     },
 
     didInsertElement: function () {
+        this._super();
+
         this.attachScrollClassHandler();
     },
 
     willDestroyElement: function () {
+        this._super();
+
         // removes scroll class handler event
         this.$().off('scroll');
     }


### PR DESCRIPTION
Fixes broken posts list infinite scrolling and editor/preview synced scroll.

Refs #5381
- Invoke this._super() so mixed in lifecycle hooks run.
