### PR TITLE
Fix watch task paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,10 +67,8 @@ var _              = require('lodash'),
                     files: [
                         'content/themes/casper/assets/css/*.css',
                         'content/themes/casper/assets/js/*.js',
-                        'core/client/dist/*.js',
-                        'core/client/dist/*.css',
-                        'core/built/scripts/*.js',
-                        'core/client/app/html/*.html'
+                        'core/built/assets/*.js',
+                        'core/client/dist/index.html'
                     ],
                     options: {
                         livereload: true


### PR DESCRIPTION
Closes #5322

Pretty boring, but this basically all comes down to the grunt watch task not watching the correct paths.  At some point the longstanding `core/built/scripts/` was changed to `core/built/assets/` and the grunt task wasn't updated to match.  The path to the `index.html` that serves up the client needed to be adjusted also.
