### PR TITLE
Add events to settings model

### DIFF
--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -59,12 +59,15 @@ Settings = ghostBookshelf.Model.extend({
 
         this.on('created', function (model) {
             model.emitChange('added');
+            model.emitChange(model.attributes.key + '.' + 'added');
         });
         this.on('updated', function (model) {
             model.emitChange('edited');
+            model.emitChange(model.attributes.key + '.' + 'edited');
         });
         this.on('destroyed', function (model) {
             model.emitChange('deleted');
+            model.emitChange(model.attributes.key + '.' + 'deleted');
         });
     },
 

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -80,8 +80,9 @@ describe('Settings Model', function () {
                 edited.attributes.key.should.equal('description');
                 edited.attributes.value.should.equal('new value');
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.calledWith('settings.edited').should.be.true;
+                eventSpy.calledTwice.should.be.true;
+                eventSpy.firstCall.calledWith('settings.edited').should.be.true;
+                eventSpy.secondCall.calledWith('settings.description.edited').should.be.true;
 
                 done();
             }).catch(done);
@@ -116,8 +117,11 @@ describe('Settings Model', function () {
                 editedModel.attributes.key.should.equal(model2.key);
                 editedModel.attributes.value.should.equal(model2.value);
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.calledWith('settings.edited').should.be.true;
+                eventSpy.callCount.should.equal(4);
+                eventSpy.getCall(0).calledWith('settings.edited').should.be.true;
+                eventSpy.getCall(1).calledWith('settings.description.edited').should.be.true;
+                eventSpy.getCall(2).calledWith('settings.edited').should.be.true;
+                eventSpy.getCall(3).calledWith('settings.title.edited').should.be.true;
 
                 done();
             }).catch(done);
@@ -136,8 +140,9 @@ describe('Settings Model', function () {
                 createdSetting.attributes.value.should.equal(newSetting.value, 'value is correct');
                 createdSetting.attributes.type.should.equal('core');
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.calledWith('settings.added').should.be.true;
+                eventSpy.calledTwice.should.be.true;
+                eventSpy.firstCall.calledWith('settings.added').should.be.true;
+                eventSpy.secondCall.calledWith('settings.TestSetting1.added').should.be.true;
 
                 done();
             }).catch(done);


### PR DESCRIPTION
closes #5370
- Add settings key in the event emission
- Update settings spec to test for events emitted with settings key
