### PR TITLE
Improve Ghost startup checks and errors

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -340,14 +340,6 @@ ConfigManager.prototype.validate = function () {
         return Promise.reject(e);
     }
 
-    // Check if we don't even have a config
-    if (!config) {
-        errors.logError(new Error('Cannot find the configuration for the current NODE_ENV'), 'NODE_ENV=' + envVal,
-            'Ensure your config.js has a section for the current NODE_ENV value and is formatted properly.');
-
-        return Promise.reject(new Error('Unable to load config for NODE_ENV=' + envVal));
-    }
-
     // Check that our url is valid
     if (!validator.isURL(config.url, {protocols: ['http', 'https'], require_protocol: true})) {
         errors.logError(new Error('Your site url in config.js is invalid.'), config.url, 'Please make sure this is a valid url before restarting');

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -3,8 +3,6 @@
 var Promise = require('bluebird'),
     chalk = require('chalk'),
     fs = require('fs'),
-    semver = require('semver'),
-    packageInfo = require('../../package.json'),
     errors = require('./errors'),
     config = require('./config');
 
@@ -18,7 +16,6 @@ function GhostServer(rootApp) {
     this.httpServer = null;
     this.connections = {};
     this.connectionId = 0;
-    this.upgradeWarning = setTimeout(this.logUpgradeWarning.bind(this), 5000);
 
     // Expose config module for use externally.
     this.config = config;
@@ -78,7 +75,6 @@ GhostServer.prototype.start = function (externalApp) {
         self.httpServer.on('connection', self.connection.bind(self));
         self.httpServer.on('listening', function () {
             self.logStartMessages();
-            clearTimeout(self.upgradeWarning);
             resolve(self);
         });
     });
@@ -167,21 +163,6 @@ GhostServer.prototype.closeConnections = function () {
  * ### Log Start Messages
  */
 GhostServer.prototype.logStartMessages = function () {
-    // Tell users if their node version is not supported, and exit
-    if (!semver.satisfies(process.versions.node, packageInfo.engines.node) &&
-        !semver.satisfies(process.versions.node, packageInfo.engines.iojs)) {
-        console.log(
-            chalk.red('\nERROR: Unsupported version of Node'),
-            chalk.red('\nGhost needs Node version'),
-            chalk.yellow(packageInfo.engines.node),
-            chalk.red('you are using version'),
-            chalk.yellow(process.versions.node),
-            chalk.green('\nPlease go to http://nodejs.org to get a supported version')
-        );
-
-        process.exit(0);
-    }
-
     // Startup & Shutdown messages
     if (process.env.NODE_ENV === 'production') {
         console.log(
@@ -227,20 +208,6 @@ GhostServer.prototype.logStartMessages = function () {
  */
 GhostServer.prototype.logShutdownMessages = function () {
     console.log(chalk.red('Ghost is closing connections'));
-};
-
-/**
- * ### Log Upgrade Warning
- * Warning that the API for the node module version of Ghost changed in 0.5.2
- *
- * *This should be removed soon*
- */
-GhostServer.prototype.logUpgradeWarning = function () {
-    errors.logWarn(
-        'Ghost no longer starts automatically when using it as an npm module.',
-        'If you\'re seeing this message, you may need to update your custom code.',
-        'Please see the docs at http://tinyurl.com/npm-upgrade for more information.'
-    );
 };
 
 module.exports = GhostServer;

--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -9,9 +9,56 @@ var packages = require('../../../package.json'),
 
 checks = {
     check: function check() {
+        this.nodeVersion();
+        this.nodeEnv();
         this.packages();
         this.contentPath();
         this.sqlite();
+    },
+
+    // Make sure the node version is supported
+    nodeVersion: function checkNodeVersion() {
+        // Tell users if their node version is not supported, and exit
+        try {
+            var semver = require('semver');
+            if (!semver.satisfies(process.versions.node, packages.engines.node) &&
+                !semver.satisfies(process.versions.node, packages.engines.iojs)) {
+                console.error('\x1B[31mERROR: Unsupported version of Node');
+                console.error('\x1B[31mGhost needs Node version ' + packages.engines.node +
+                              ' you are using version ' + process.versions.node + '\033[0m\n');
+                console.error('\x1B[32mPlease go to http://nodejs.org to get a supported version\033[0m');
+
+                process.exit(0);
+            }
+        } catch (e) {
+            return;
+        }
+    },
+
+    nodeEnv: function checkNodeEnvState() {
+        // Check if config path resolves, if not check for NODE_ENV in config.example.js prior to copy
+        var fd,
+            configFile,
+            config;
+
+        try {
+            fd = fs.openSync(configFilePath, 'r');
+            fs.closeSync(fd);
+        } catch (e) {
+            configFilePath = path.join(appRoot, 'config.example.js');
+        }
+
+        configFile = require(configFilePath);
+        config = configFile[mode];
+
+        if (!config) {
+            console.error('\x1B[31mERROR: Cannot find the configuration for the current NODE_ENV: ' +
+                            process.env.NODE_ENV + '\033[0m\n');
+            console.error('\x1B[32mEnsure your config.js has a section for the current NODE_ENV value' +
+                            ' and is formatted properly.\033[0m');
+
+            process.exit(0);
+        }
     },
 
     // Make sure package.json dependencies have been installed.


### PR DESCRIPTION
closes #5358
- Moved node version check and exits if not supported
- Removed upgrade warning from `ghost-server.js`
- Perform a check for NODE_ENV, uses `config.example.js` if none apparent
- Removed NODE_ENV check from `core/server/config/index.js` as with new check, this code would never be used
