### PR TITLE
Fight fire with overflow.

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -32,6 +32,7 @@
     flex: 0 0 235px;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     border-right: #e1e1e1 1px solid;
     background: #f6f6f6;
     transform: translateX(0);
@@ -68,6 +69,7 @@
 
 .gh-nav-menu-details {
     flex-grow: 1;
+    overflow: hidden;
     padding-right: 10px;
 }
 


### PR DESCRIPTION
Prevents firefox from allowing blog title to overflow. This is an incredibly stupid fix for an incredibly stupid browser bug. Firefox is the worst modern browser in the world at basic layout rendering. Could someone let them know please? Closes #5430 as replacement.
