### PR TITLE
Use 'author' for relation instead of 'author_id'

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -13,15 +13,8 @@ var Promise         = require('bluebird'),
 
 // ## Helpers
 function prepareInclude(include) {
-    var index;
-
     include = include || '';
     include = _.intersection(include.split(','), allowedIncludes);
-    index = include.indexOf('author');
-
-    if (index !== -1) {
-        include[index] = 'author_id';
-    }
 
     return include;
 }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -239,7 +239,7 @@ Post = ghostBookshelf.Model.extend({
     },
 
     // Relations
-    author_id: function authorId() {
+    author: function author() {
         return this.belongsTo('User', 'author_id');
     },
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -66,7 +66,7 @@ describe('Post Model', function () {
             });
 
             it('can findAll, returning all related data', function (done) {
-                PostModel.findAll({include: ['author_id', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
+                PostModel.findAll({include: ['author', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
                     .then(function (results) {
                         should.exist(results);
                         results.length.should.be.above(0);
@@ -99,7 +99,7 @@ describe('Post Model', function () {
             });
 
             it('can findPage, returning all related data', function (done) {
-                PostModel.findPage({include: ['author_id', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
+                PostModel.findPage({include: ['author', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
                     .then(function (results) {
                         should.exist(results);
 
@@ -268,7 +268,7 @@ describe('Post Model', function () {
             it('can findOne, returning all related data', function (done) {
                 var firstPost;
                 // TODO: should take author :-/
-                PostModel.findOne({}, {include: ['author_id', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
+                PostModel.findOne({}, {include: ['author', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
                     .then(function (result) {
                         should.exist(result);
                         firstPost = result.toJSON();


### PR DESCRIPTION
This simplifies the relation / includes logic. No reason why this wasn't done before as far as I'm aware - just a missed simplification.
- this clears a todo in the codebase & gets rid of a few lines of unnecessary code
