### PR TITLE
[Partial of #5483] Zelda Mobile Fixes

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -254,6 +254,9 @@
     .mobile-menu-expanded .gh-nav {
         transform: translate3d(0,0,0);
     }
+    .gh-nav-list {
+        font-size: 1.6rem;
+    }
 }
 
 
@@ -379,7 +382,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 0 20px;
-    height: 65px;
+    height: 50px;
     border-bottom: #dfe1e3 1px solid;
 }
 

--- a/core/client/app/templates/about.hbs
+++ b/core/client/app/templates/about.hbs
@@ -1,4 +1,8 @@
 <section class="gh-view js-settings-content">
+    <header class="view-header">
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}About Ghost{{/gh-view-title}} 
+    </header>
+
     <section class="view-content">
         <header class="gh-about-header">
             <img class="gh-logo" src="{{gh-path 'admin' '/img/ghost-logo.png'}}" alt="Ghost" />


### PR DESCRIPTION
Partial of #5483

Fixes the following in the list:
- no mobile menu on about page
  - Was missing the code entirely so added it to the `about.hbs`
- sidebar nav items too small on mobile
  - Changed font from 1.3em to 1.6em for < 500px
- main header too big
  - Changed from 65px to 50px

@JohnONolan: I expect you to want to make some changes, so just let me know if you want anything different or changed in some way.

Screenshots after my changes:
![img_0686](https://cloud.githubusercontent.com/assets/4715098/8345277/83d7165a-1aa1-11e5-91be-ddffceb25680.PNG)
![img_0687](https://cloud.githubusercontent.com/assets/4715098/8345281/89dc766c-1aa1-11e5-964c-5fde45f253bb.PNG)
