### PR TITLE
Add event handling to pagination plugin

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -61,6 +61,7 @@ Post = ghostBookshelf.Model.extend({
 
         // Ensures local copy of permalink setting is kept up to date
         this.on('fetching', getPermalinkSetting);
+        this.on('fetching:collection', getPermalinkSetting);
 
         this.on('created', function onCreated(model) {
             model.emitChange('added');

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -41,6 +41,7 @@ describe('Post Model', function () {
         function checkFirstPostData(firstPost) {
             should.not.exist(firstPost.author_id);
             firstPost.author.should.be.an.Object;
+            firstPost.url.should.equal('/html-ipsum/');
             firstPost.fields.should.be.an.Array;
             firstPost.tags.should.be.an.Array;
             firstPost.author.name.should.equal(DataGenerator.Content.users[0].name);
@@ -56,6 +57,14 @@ describe('Post Model', function () {
         }
 
         describe('findAll', function () {
+            beforeEach(function () {
+                sandbox.stub(SettingsModel, 'findOne', function () {
+                    return Promise.resolve({toJSON: function () {
+                        return {value: '/:slug/'};
+                    }});
+                });
+            });
+
             it('can findAll', function (done) {
                 PostModel.findAll().then(function (results) {
                     should.exist(results);
@@ -85,6 +94,14 @@ describe('Post Model', function () {
         });
 
         describe('findPage', function () {
+            beforeEach(function () {
+                sandbox.stub(SettingsModel, 'findOne', function () {
+                    return Promise.resolve({toJSON: function () {
+                        return {value: '/:slug/'};
+                    }});
+                });
+            });
+
             it('can findPage (default)', function (done) {
                 PostModel.findPage().then(function (results) {
                     should.exist(results);
@@ -267,7 +284,13 @@ describe('Post Model', function () {
 
             it('can findOne, returning all related data', function (done) {
                 var firstPost;
-                // TODO: should take author :-/
+
+                sandbox.stub(SettingsModel, 'findOne', function () {
+                    return Promise.resolve({toJSON: function () {
+                        return {value: '/:slug/'};
+                    }});
+                });
+
                 PostModel.findOne({}, {include: ['author', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
                     .then(function (result) {
                         should.exist(result);

--- a/core/test/unit/models_pagination_spec.js
+++ b/core/test/unit/models_pagination_spec.js
@@ -175,7 +175,7 @@ describe('pagination', function () {
     });
 
     describe('fetchPage', function () {
-        var model, bookshelf, mockQuery, fetch, colQuery;
+        var model, bookshelf, on, mockQuery, fetch, colQuery;
 
         before(function () {
             paginationUtils = pagination.__get__('paginationUtils');
@@ -197,15 +197,19 @@ describe('pagination', function () {
 
             fetch = sandbox.stub().returns(Promise.resolve({}));
             colQuery = sandbox.stub();
+            on = function () { return this; };
+            on = sandbox.spy(on);
 
             model = function () {};
             model.prototype.constructor = {
                 collection: sandbox.stub().returns({
+                    on: on,
                     fetch: fetch,
                     query: colQuery
                 })
             };
             model.prototype.query = sandbox.stub();
+            model.prototype.resetQuery = sandbox.stub();
             model.prototype.query.returns(mockQuery);
 
             bookshelf = {Model: model};
@@ -231,6 +235,8 @@ describe('pagination', function () {
                     model.prototype.query,
                     mockQuery.clone,
                     paginationUtils.query,
+                    on,
+                    on,
                     fetch,
                     paginationUtils.formatResponse
                 );
@@ -255,6 +261,10 @@ describe('pagination', function () {
                 mockQuery.count.calledOnce.should.be.true;
                 mockQuery.count.calledWith().should.be.true;
 
+                on.calledTwice.should.be.true;
+                on.firstCall.calledWith('fetching').should.be.true;
+                on.secondCall.calledWith('fetched').should.be.true;
+
                 fetch.calledOnce.should.be.true;
                 fetch.calledWith({}).should.be.true;
 
@@ -277,6 +287,8 @@ describe('pagination', function () {
                     mockQuery.clone,
                     paginationUtils.query,
                     colQuery,
+                    on,
+                    on,
                     fetch,
                     paginationUtils.formatResponse
                 );
@@ -303,6 +315,10 @@ describe('pagination', function () {
 
                 colQuery.calledOnce.should.be.true;
                 colQuery.calledWith('orderBy', 'undefined.id', 'DESC').should.be.true;
+
+                on.calledTwice.should.be.true;
+                on.firstCall.calledWith('fetching').should.be.true;
+                on.secondCall.calledWith('fetched').should.be.true;
 
                 fetch.calledOnce.should.be.true;
                 fetch.calledWith(orderOptions).should.be.true;


### PR DESCRIPTION
closes #5490
- use same event handling pattern as fetchAll
- add support for `fetching:collection` to post model
- add tests to check that url is fetched via findAll and findPage
