### PR TITLE
Generate coverage and send it to Code Climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+# When changing node version also update it on line 35. 
 node_js:
   - "0.10"
   - "0.12"
@@ -28,3 +29,17 @@ before_install:
 before_script:
   - phantomjs --version
   - casperjs --version
+after_success:
+  - | 
+      if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+        if [[ "$DB" = "sqlite3" && "$TRAVIS_NODE_VERSION" = "0.10" ]]; then
+          echo "Generate coverage..."
+          grunt coverage
+          npm install -g codeclimate-test-reporter
+          codeclimate-test-reporter < core/test/coverage/lcov.info
+        else
+          echo "False DB and NODE_VERSION. No coverage generated."
+        fi
+      else
+        echo "This is a PR. No coverage generated."
+      fi


### PR DESCRIPTION
closes #2029
- when the build passed, on merge (no PR) and right DB and Node version (the first job), Travis generates the coverage report
- when finished, Travis sends the results to Code Climate

Travis will generate the code coverage only one time (at the first job) when
- it is a merge build and no PR
- the job passed
- it is the right DB and Node version (workaround for the first job)

and then send the data to Code Climate.
 When PR,  false job or job fails, no coverage data is generated.

You can see a working merge build [here](https://travis-ci.org/hoxoa/Ghost/builds/69023624) and a PR build [here](https://travis-ci.org/TryGhost/Ghost/builds/69023652).
