### PR TITLE
Add public API endpoint permission handling

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -39,20 +39,6 @@ posts = {
             tasks;
 
         /**
-         * ### Handle Permissions
-         * We need to either be an authorised user, or only return published posts.
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            if (!(options.context && options.context.user)) {
-                options.status = 'published';
-            }
-
-            return options;
-        }
-
-        /**
          * ### Model Query
          *  Make the call to the Model layer
          * @param {Object} options
@@ -65,7 +51,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {opts: permittedOptions}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'browse'),
             utils.convertOptions(allowedIncludes),
             modelQuery
         ];
@@ -87,19 +73,6 @@ posts = {
             tasks;
 
         /**
-         * ### Handle Permissions
-         * We need to either be an authorised user, or only return published posts.
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            if (!options.data.uuid && !(options.context && options.context.user)) {
-                options.data.status = 'published';
-            }
-            return options;
-        }
-
-        /**
          * ### Model Query
          * Make the call to the Model layer
          * @param {Object} options
@@ -112,7 +85,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {attrs: attrs}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'read'),
             utils.convertOptions(allowedIncludes),
             modelQuery
         ];

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -27,20 +27,6 @@ tags = {
         var tasks;
 
         /**
-         * ### Handle Permissions
-         * We need to be an authorised user to perform this action
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            return canThis(options.context).browse.tag().then(function permissionGranted() {
-                return options;
-            }).catch(function handleError(error) {
-                return errors.handleAPIError(error, 'You do not have permission to browse tags.');
-            });
-        }
-
-        /**
          * ### Model Query
          * Make the call to the Model layer
          * @param {Object} options
@@ -53,7 +39,7 @@ tags = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {opts: utils.browseDefaultOptions}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'browse'),
             utils.convertOptions(allowedIncludes),
             doQuery
         ];
@@ -72,20 +58,6 @@ tags = {
             tasks;
 
         /**
-         * ### Handle Permissions
-         * We need to be an authorised user to perform this action
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            return canThis(options.context).read.tag().then(function permissionGranted() {
-                return options;
-            }).catch(function handleError(error) {
-                return errors.handleAPIError(error, 'You do not have permission to read tags.');
-            });
-        }
-
-        /**
          * ### Model Query
          * Make the call to the Model layer
          * @param {Object} options
@@ -98,7 +70,7 @@ tags = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {attrs: attrs}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'read'),
             utils.convertOptions(allowedIncludes),
             doQuery
         ];

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -78,20 +78,6 @@ users = {
             tasks;
 
         /**
-         * ### Handle Permissions
-         * We need to either be an authorised user, or only return published posts.
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            return canThis(options.context).browse.user().then(function permissionGranted() {
-                return options;
-            }).catch(function handleError(error) {
-                return errors.handleAPIError(error, 'You do not have permission to browse users.');
-            });
-        }
-
-        /**
          * ### Model Query
          * Make the call to the Model layer
          * @param {Object} options
@@ -104,7 +90,7 @@ users = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {opts: permittedOptions}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'browse'),
             utils.convertOptions(allowedIncludes),
             doQuery
         ];
@@ -122,18 +108,9 @@ users = {
         var attrs = ['id', 'slug', 'status', 'email', 'role'],
             tasks;
 
-        /**
-         * ### Handle Permissions
-         * Convert 'me' safely
-         * @param {Object} options
-         * @returns {Object} options
-         */
-        function handlePermissions(options) {
-            if (options.data.id === 'me' && options.context && options.context.user) {
-                options.data.id = options.context.user;
-            }
-
-            return options;
+        // Special handling for id = 'me'
+        if (options.id === 'me' && options.context && options.context.user) {
+            options.id = options.context.user;
         }
 
         /**
@@ -149,7 +126,7 @@ users = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             utils.validate(docName, {attrs: attrs}),
-            handlePermissions,
+            utils.handlePublicPermissions(docName, 'read'),
             utils.convertOptions(allowedIncludes),
             doQuery
         ];

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -1,10 +1,12 @@
 // # API Utils
 // Shared helpers for working with the API
-var Promise    = require('bluebird'),
-    _          = require('lodash'),
-    path       = require('path'),
-    errors     = require('../errors'),
-    validation = require('../data/validation'),
+var Promise = require('bluebird'),
+    _       = require('lodash'),
+    path    = require('path'),
+    errors  = require('../errors'),
+    permissions = require('../permissions'),
+    validation  = require('../data/validation'),
+
     utils;
 
 utils = {
@@ -131,13 +133,67 @@ utils = {
         return errors;
     },
 
+    /**
+     * ## Is Public Context?
+     * If this is a public context, return true
+     * @param {Object} options
+     * @returns {Boolean}
+     */
+    isPublicContext: function isPublicContext(options) {
+        return permissions.parseContext(options.context).public;
+    },
+    /**
+     * ## Apply Public Permissions
+     * Update the options object so that the rules reflect what is permitted to be retrieved from a public request
+     * @param {String} docName
+     * @param {String} method (read || browse)
+     * @param {Object} options
+     * @returns {Object} options
+     */
+    applyPublicPermissions: function applyPublicPermissions(docName, method, options) {
+        return permissions.applyPublicRules(docName, method, options);
+    },
+
+    /**
+     * ## Handle Public Permissions
+     * @param {String} docName
+     * @param {String} method (read || browse)
+     * @returns {Function}
+     */
+    handlePublicPermissions: function handlePublicPermissions(docName, method) {
+        var singular = docName.replace(/s$/, '');
+
+        /**
+         * Check if this is a public request, if so use the public permissions, otherwise use standard canThis
+         * @param {Object} options
+         * @returns {Object} options
+         */
+        return function doHandlePublicPermissions(options) {
+            var permsPromise;
+
+            if (utils.isPublicContext(options)) {
+                permsPromise = utils.applyPublicPermissions(docName, method, options);
+            } else {
+                permsPromise = permissions.canThis(options.context)[method][singular](options.data);
+            }
+
+            return permsPromise.then(function permissionGranted() {
+                return options;
+            }).catch(function handleError(error) {
+                return errors.handleAPIError(error);
+            });
+        };
+    },
+
     prepareInclude: function prepareInclude(include, allowedIncludes) {
         include = include || '';
         include = _.intersection(include.split(','), allowedIncludes);
 
         return include;
     },
+
     /**
+     * ## Convert Options
      * @param {Array} allowedIncludes
      * @returns {Function} doConversion
      */

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -20,28 +20,88 @@ function hasActionsMap() {
     });
 }
 
-// TODO: Move this to its own file so others can use it?
 function parseContext(context) {
     // Parse what's passed to canThis.beginCheck for standard user and app scopes
     var parsed = {
             internal: false,
             user: null,
-            app: null
+            app: null,
+            public: true
         };
 
     if (context && (context === 'internal' || context.internal)) {
         parsed.internal = true;
+        parsed.public = false;
     }
 
     if (context && context.user) {
         parsed.user = context.user;
+        parsed.public = false;
     }
 
     if (context && context.app) {
         parsed.app = context.app;
+        parsed.public = false;
     }
 
     return parsed;
+}
+
+function applyStatusRules(docName, method, opts) {
+    var errorMsg = 'You do not have permission to retrieve ' + docName + ' with that status';
+
+    // Enforce status 'active' for users
+    if (docName === 'users') {
+        if (!opts.status) {
+            return 'active';
+        } else if (opts.status !== 'active') {
+            throw errorMsg;
+        }
+    }
+
+    // Enforce status 'published' for posts
+    if (docName === 'posts') {
+        if (!opts.status) {
+            return 'published';
+        } else if (
+            method === 'read'
+            && (opts.status === 'draft' || opts.status === 'all')
+            && _.isString(opts.uuid) && _.isUndefined(opts.id) && _.isUndefined(opts.slug)
+        ) {
+            // public read requests can retrieve a draft, but only by UUID
+            return opts.status;
+        } else if (opts.status !== 'published') {
+            // any other parameter would make this a permissions error
+            throw errorMsg;
+        }
+    }
+
+    return opts.status;
+}
+
+/**
+ * API Public Permission Rules
+ * This method enforces the rules for public requests
+ * @param {String} docName
+ * @param {String} method (read || browse)
+ * @param {Object} options
+ * @returns {Object} options
+ */
+function applyPublicRules(docName, method, options) {
+    try {
+        // If this is a public context
+        if (parseContext(options.context).public === true) {
+            if (method === 'browse') {
+                options.status = applyStatusRules(docName, method, options);
+            } else if (method === 'read') {
+                options.data.status = applyStatusRules(docName, method, options.data);
+            }
+        }
+
+        return Promise.resolve(options);
+    } catch (err) {
+        return Promise.reject(err);
+    }
 }
 
 // Base class for canThis call results
@@ -244,5 +304,7 @@ module.exports = exported = {
     init: init,
     refresh: refresh,
     canThis: canThis,
+    parseContext: parseContext,
+    applyPublicRules: applyPublicRules,
     actionsMap: {}
 };

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -126,15 +126,35 @@ describe('Post API', function () {
 
         it('without context.user cannot fetch all posts', function (done) {
             PostAPI.browse({status: 'all'}).then(function (results) {
-                should.exist(results);
-                testUtils.API.checkResponse(results, 'posts');
-                should.exist(results.posts);
-                results.posts.length.should.eql(4);
-                results.posts[0].status.should.eql('published');
-                testUtils.API.checkResponse(results.posts[0], 'post');
+                should.not.exist(results);
 
+                done(new Error('should not provide results if invalid status provided'));
+            }).catch(function (err) {
+                err.errorType.should.eql('NoPermissionError');
                 done();
-            }).catch(done);
+            });
+        });
+
+        it('without context.user cannot fetch draft posts', function (done) {
+            PostAPI.browse({status: 'draft'}).then(function (results) {
+                should.not.exist(results);
+
+                done(new Error('should not provide results if invalid status provided'));
+            }).catch(function (err) {
+                err.errorType.should.eql('NoPermissionError');
+                done();
+            });
+        });
+
+        it('without context.user cannot use uuid to fetch draft posts in browse', function (done) {
+            PostAPI.browse({status: 'draft', uuid: 'imastring'}).then(function (results) {
+                should.not.exist(results);
+
+                done(new Error('should not provide results if invalid status provided'));
+            }).catch(function (err) {
+                err.errorType.should.eql('NoPermissionError');
+                done();
+            });
         });
 
         it('with context.user can fetch drafts', function (done) {
@@ -230,15 +250,13 @@ describe('Post API', function () {
         });
 
         it('without context.user cannot fetch draft', function (done) {
-            PostAPI.read({slug: 'unfinished', status: 'draft'}).then(function (results) {
-                should.not.exist(results.posts);
-                done();
+            PostAPI.read({slug: 'unfinished', status: 'draft'}).then(function () {
+                done(new Error('Should not return a result with no permission'));
             }).catch(function (err) {
                 should.exist(err);
-                err.message.should.eql('Post not found.');
-
+                err.errorType.should.eql('NoPermissionError');
                 done();
-            });
+            }).catch(done);
         });
 
         it('with context.user can fetch a draft', function (done) {
@@ -260,13 +278,13 @@ describe('Post API', function () {
 
         it('cannot fetch post with unknown id', function (done) {
             PostAPI.read({context: {user: 1}, slug: 'not-a-post'}).then(function () {
-                done();
+                done(new Error('Should not return a result with unknown id'));
             }).catch(function (err) {
                 should.exist(err);
                 err.message.should.eql('Post not found.');
 
                 done();
-            });
+            }).catch(done);
         });
 
         it('can fetch post with by id', function (done) {

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -49,15 +49,15 @@ describe('Users API', function () {
     });
 
     describe('Browse', function () {
-        function checkBrowseResponse(response, count) {
+        function checkBrowseResponse(response, count, additional, missing) {
             should.exist(response);
             testUtils.API.checkResponse(response, 'users');
             should.exist(response.users);
             response.users.should.have.length(count);
-            testUtils.API.checkResponse(response.users[0], 'user');
-            testUtils.API.checkResponse(response.users[1], 'user');
-            testUtils.API.checkResponse(response.users[2], 'user');
-            testUtils.API.checkResponse(response.users[3], 'user');
+            testUtils.API.checkResponse(response.users[0], 'user', additional, missing);
+            testUtils.API.checkResponse(response.users[1], 'user', additional, missing);
+            testUtils.API.checkResponse(response.users[2], 'user', additional, missing);
+            testUtils.API.checkResponse(response.users[3], 'user', additional, missing);
         }
 
         it('Owner can browse', function (done) {
@@ -88,9 +88,16 @@ describe('Users API', function () {
             }).catch(done);
         });
 
-        it('No-auth CANNOT browse', function (done) {
-            UserAPI.browse().then(function () {
-                done(new Error('Browse users is not denied without authentication.'));
+        it('No-auth CAN browse, but only gets filtered active users', function (done) {
+            UserAPI.browse().then(function (response) {
+                checkBrowseResponse(response, 7, null, ['email']);
+                done();
+            }).catch(done);
+        });
+
+        it('No-auth CANNOT browse non-active users', function (done) {
+            UserAPI.browse({status: 'invited'}).then(function () {
+                done(new Error('Browse non-active users is not denied without authentication.'));
             }, function () {
                 done();
             }).catch(done);
@@ -109,21 +116,6 @@ describe('Users API', function () {
                     done();
                 }).catch(done);
             });
-        });
-
-        it('Author can browse', function (done) {
-            UserAPI.browse(context.author).then(function (response) {
-                checkBrowseResponse(response, 7);
-                done();
-            }).catch(done);
-        });
-
-        it('No-auth CANNOT browse', function (done) {
-            UserAPI.browse().then(function () {
-                done(new Error('Browse users is not denied without authentication.'));
-            }, function () {
-                done();
-            }).catch(done);
         });
 
         it('Can browse all', function (done) {


### PR DESCRIPTION
This PR moves the rule handling for what data public access can retrieve into a singlular place (inside of the permissions system), and ensure that anyone attempting to get access to data they shouldn't gets a permissions error (rather than having their query modified).

With this PR, the get helper would be able to make GET requests to the Post, User & Tag endpoints only. Once we have the client auth in place, we'll be able to use this to provide read only access to the API over HTTP, and to explicitly hard-code in a client ID for the frontend controller & GET helper if we want (useful for logging where requests come from?).

It probably needs a bit more work to refactor out the `handlePermissions` functions into a util so the code isn't duplicated 6 times, but it's nearly there :)

refs #4004, #5614
- added new public permission handling functions to permissions
- updated posts, tags and users endpoints to handle public permissions or normal permissions
- added test coverage for the new code
