### PR TITLE
Improvements to the {{foreach}} helper

### DIFF
--- a/core/server/helpers/foreach.js
+++ b/core/server/helpers/foreach.js
@@ -2,71 +2,93 @@
 // Usage: `{{#foreach data}}{{/foreach}}`
 //
 // Block helper designed for looping through posts
-
 var hbs             = require('express-hbs'),
+    errors          = require('../errors'),
+
+    hbsUtils        = hbs.handlebars.Utils,
     foreach;
 
 foreach = function (context, options) {
+    if (!options) {
+        errors.logWarn('Need to pass an iterator to #foreach');
+    }
+
     var fn = options.fn,
         inverse = options.inverse,
         i = 0,
-        j = 0,
         columns = options.hash.columns,
-        key,
         ret = '',
-        data;
+        data,
+        contextPath;
+
+    if (options.data && options.ids) {
+        contextPath = hbsUtils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
+    }
+
+    if (hbsUtils.isFunction(context)) {
+        context = context.call(this);
+    }
 
     if (options.data) {
         data = hbs.handlebars.createFrame(options.data);
     }
 
-    function setKeys(_data, _i, _j, _columns) {
-        if (_i === 0) {
-            _data.first = true;
+    function execIteration(field, index, last) {
+        if (data) {
+            data.key = field;
+            data.index = index;
+            data.number = index + 1;
+            data.first = index === 0;
+            data.last = !!last;
+            data.even = index % 2 === 1;
+            data.odd = !data.even;
+            data.rowStart = index % columns === 0;
+            data.rowEnd = index % columns === (columns - 1);
+
+            if (contextPath) {
+                data.contextPath = contextPath + field;
+            }
         }
-        if (_i === _j - 1) {
-            _data.last = true;
-        }
-        // first post is index zero but still needs to be odd
-        if (_i % 2 === 1) {
-            _data.even = true;
-        } else {
-            _data.odd = true;
-        }
-        if (_i % _columns === 0) {
-            _data.rowStart = true;
-        } else if (_i % _columns === (_columns - 1)) {
-            _data.rowEnd = true;
-        }
-        return _data;
+
+        ret = ret + fn(context[field], {
+            data: data,
+            blockParams: hbsUtils.blockParams([context[field], field], [contextPath + field, null])
+        });
     }
+
+    function iterateArray(context) {
+        var j;
+        for (j = context.length; i < j; i += 1) {
+            execIteration(i, i, i === context.length - 1);
+        }
+    }
+
+    function iterateObject(context) {
+        var priorKey,
+            key;
+
+        for (key in context) {
+            if (context.hasOwnProperty(key)) {
+                // We're running the iterations one step out of sync so we can detect
+                // the last iteration without have to scan the object twice and create
+                // an itermediate keys array.
+                if (priorKey) {
+                    execIteration(priorKey, i - 1);
+                }
+                priorKey = key;
+                i += 1;
+            }
+        }
+        if (priorKey) {
+            execIteration(priorKey, i - 1, true);
+        }
+    }
+
     if (context && typeof context === 'object') {
-        if (context instanceof Array) {
-            for (j = context.length; i < j; i += 1) {
-                if (data) {
-                    data.index = i;
-                    data.first = data.rowEnd = data.rowStart = data.last = data.even = data.odd = false;
-                    data = setKeys(data, i, j, columns);
-                }
-                ret = ret + fn(context[i], {data: data});
-            }
+        if (hbsUtils.isArray(context)) {
+            iterateArray(context);
         } else {
-            for (key in context) {
-                if (context.hasOwnProperty(key)) {
-                    j += 1;
-                }
-            }
-            for (key in context) {
-                if (context.hasOwnProperty(key)) {
-                    if (data) {
-                        data.key = key;
-                        data.first = data.rowEnd = data.rowStart = data.last = data.even = data.odd = false;
-                        data = setKeys(data, i, j, columns);
-                    }
-                    ret = ret + fn(context[key], {data: data});
-                    i += 1;
-                }
-            }
+            iterateObject(context);
         }
     }
 


### PR DESCRIPTION
This PR does a couple of things:

Firstly, it brings our `{{#foreach}}` loop helper into line with Handlebars's built-in `{{#each}}`. Our version has more features, but the built-in one has gained new features since we implemented it, so I've added them back to ours. The main new thing here is block parameters, meaning you can do things like `{{#foreach posts as |post index|}}` if that takes your fancy.

The original reason I opened up the file, was to add a new `@number` data variable, which is nothing more complex than `@index + 1`. `@index` is nice, but when outputting numbers, it's more normal to start with 1, rather than 0. Handlebars doesn't give us a way to do the `+1` and although this is possible with HTML & CSS, it seems like a no-brainer to add it as it's so simple for us to support vs adding very complex list styles to a theme.

![](http://puu.sh/iH75M.png)

refs #4439
- Brings our custom foreach helper (which has extra features) back into line with Handlebar's own each helper
- Adds a new @number variable to foreach, so that building numbered lists is PEASY
- Improved the existing tests, and added a few more
