### PR TITLE
Update readme with Slack support info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 - [Feature Requests](http://ideas.ghost.org/)
 - [Dev Blog](http://dev.ghost.org)
 
+**NOTE: If you’re stuck, can’t get something working or need some help, please head on over and join our [Slack community](https://ghost.org/slack/) rather than opening an issue.**
+
 
 # Quick Start Install
 
@@ -93,7 +95,7 @@ More general [install docs](http://support.ghost.org/installation/) here in case
 
 ![Ghost(Pro) + DigitalOcean](https://cloud.githubusercontent.com/assets/120485/8180331/d6674e32-1414-11e5-8ce4-2250e9994906.png)
 
-Save yourself time and headaches with our fully managed <strong><a href=“https://ghost.org/pricing/“>Ghost(Pro)</a></strong> service. Deploy a new instance of Ghost in a couple of clicks running on [DigitalOcean](https://digitalocean.com)’s rock solid infrastructure, with a worldwide CDN thrown in at no extra charge.
+Save yourself time and headaches with our fully managed **[Ghost(Pro)](https://ghost.org/pricing/)** service. Deploy a new instance of Ghost in a couple of clicks running on [DigitalOcean](https://digitalocean.com)’s rock solid infrastructure, with a worldwide CDN thrown in at no extra charge.
 
 All revenue from **Ghost(Pro**) goes to the Ghost Foundation, the non-profit org which funds the maintenance and further development of Ghost.
 


### PR DESCRIPTION
I'm not convinced this is going to work, but it's an attempt to get more people asking install questions in Slack rather than opening github issues. Also fix broken link to Ghost(Pro) further down, Github stripped the HTML so converted to Markdown.
