### PR TITLE
Removed left overs from SASS to Myth conversion

### DIFF
--- a/core/client/app/styles/patterns/global.css
+++ b/core/client/app/styles/patterns/global.css
@@ -47,12 +47,12 @@ body {
     width: 100%;
     /* Prevent elastic scrolling on the whole page */
     height: 100%;
-    color: lighten(var(--darkgrey), 10%);
+    color: color(var(--darkgrey) lightness(+10%));
     font-size: 1.4rem;
 }
 
 ::selection {
-    background: lighten(var(--blue), 20%);
+    background: color(var(--blue) lightness(+20%));
 }
 
 
@@ -208,7 +208,7 @@ tt {
 code,
 tt {
     padding: 0.2em 0.4em;
-    background: lighten(#dfe1e3, 2%);
+    background: color(#dfe1e3 lightness(+2%));
     border-radius: 2px;
     vertical-align: top;
     white-space: pre-wrap;
@@ -220,7 +220,7 @@ pre {
     margin: 1.6em 0;
     padding: 10px;
     width: 100%;
-    background: lighten(#dfe1e3, 2%);
+    background: color(#dfe1e3 lightness(+2%));
     border-radius: 3px;
     white-space: pre;
     font-family: var(--font-family-mono);
@@ -370,7 +370,7 @@ img {
 
 @keyframes keyboard-focus-style-fade-out {
     from {
-        box-shadow: inset 0 0 30px 1px lighten(var(--midgrey), 20%);
+        box-shadow: inset 0 0 30px 1px color(var(--midgrey) lightness(+20%));
     }
     to {
         box-shadow: none;


### PR DESCRIPTION
As _fixer_ mentioned on Slack (also was mentioned in a [comment](https://github.com/TryGhost/Ghost/issues/5314#issuecomment-104943894)), for some reason Firefox didn't show styles for `::-moz-selection`. I've checked the code and it turned out that during SASS to Myth conversion (390c0179), `lighten` function from SASS has not been removed and browsers were ignoring property for which's value the function was used.

Current state of master:

![screenshot 2015-07-01 22 52 22](https://cloud.githubusercontent.com/assets/11782/8464794/4351a88a-2045-11e5-9c53-ba8f4dc2233c.png)
![screenshot 2015-07-01 22 52 26](https://cloud.githubusercontent.com/assets/11782/8464796/4635bca8-2045-11e5-81f0-240986ea5aaa.png)
![screenshot 2015-07-01 22 52 32](https://cloud.githubusercontent.com/assets/11782/8464799/489fee50-2045-11e5-945d-e489dedda619.png)

After applied changes:

![screenshot 2015-07-03 07 50 18](https://cloud.githubusercontent.com/assets/11782/8493277/3e974b7e-2158-11e5-9386-a7a39fd52825.png)
![screenshot 2015-07-03 07 49 46](https://cloud.githubusercontent.com/assets/11782/8493280/41f20ee4-2158-11e5-81a9-58b12282288d.png)
![screenshot 2015-07-03 07 50 02](https://cloud.githubusercontent.com/assets/11782/8493283/4481edbe-2158-11e5-9391-6f37f01a7a3c.png)
