### PR TITLE
Fix config.example.js typo

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -30,7 +30,7 @@ config = {
     // ### Development **(default)**
     development: {
         // The url to use when providing links to the site, E.g. in RSS and email.
-        // Change this to your Ghost blogs published URL.
+        // Change this to your Ghost blog's published URL.
         url: 'http://localhost:2368',
 
         // Example mail config


### PR DESCRIPTION
Changed "blogs" to "blog's" on line 33
