### PR TITLE
Add correct directories to travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ sudo: false
 cache:
   directories:
     - node_modules
-    - bower_components
+    - core/client/node_modules
+    - core/client/bower_components
 addons:
   postgresql: "9.3"
 env:


### PR DESCRIPTION
no ref

---

Adds bower_components and node_modules in `core/client` to travis cache to speed up build times.
