### PR TITLE
Add revoke method back into authentication api

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -287,6 +287,25 @@ authentication = {
         }).then(function (result) {
             return Promise.resolve({users: [result]});
         });
+    },
+
+    revoke: function (object) {
+        var token;
+
+        if (object.token_type_hint && object.token_type_hint === 'access_token') {
+            token = dataProvider.Accesstoken;
+        } else if (object.token_type_hint && object.token_type_hint === 'refresh_token') {
+            token = dataProvider.Refreshtoken;
+        } else {
+            return errors.BadRequestError('Invalid token_type_hint given.');
+        }
+
+        return token.destroyByToken({token: object.token}).then(function () {
+            return Promise.resolve({token: object.token});
+        }, function () {
+            // On error we still want a 200. See https://tools.ietf.org/html/rfc7009#page-5
+            return Promise.resolve({token: object.token, error: 'Invalid token provided'});
+        });
     }
 };
 


### PR DESCRIPTION
(gives sheepish grin)
As it turns out, I accidentally deleted the authentication/revoke api method when I added the authentication PUT route. This adds the revoke method back in.

closes #5530
- adds revoke api method back into code base
