### PR TITLE
[WIP] Correct the Reset Passsword screen markup and styles

### DIFF
--- a/core/client/app/styles/app.css
+++ b/core/client/app/styles/app.css
@@ -33,6 +33,7 @@
 @import "layouts/main.css";
 @import "layouts/flow.css";
 @import "layouts/auth.css";
+@import "layouts/reset.css";
 @import "layouts/content.css";
 @import "layouts/editor.css";
 @import "layouts/settings.css";

--- a/core/client/app/styles/layouts/reset.css
+++ b/core/client/app/styles/layouts/reset.css
@@ -1,0 +1,23 @@
+/* Reset
+/* ---------------------------------------------------------- */
+
+.gh-reset {
+	position: relative;
+	margin: 30px auto;
+	padding: 40px;
+	max-width: 400px;
+	width: 100%;
+	border: #dae1e3 1px solid;
+	background: #f8fbfd;
+	border-radius: 5px;
+	text-align: left;
+}
+
+.gh-reset .form-group {
+	margin-bottom: 1.5rem;
+}
+
+.gh-reset .btn {
+	margin: 0;
+	padding: 12px;
+}

--- a/core/client/app/templates/reset.hbs
+++ b/core/client/app/templates/reset.hbs
@@ -1,11 +1,15 @@
-<section class="reset-box js-reset-box fade-in">
-    <form id="reset" class="reset-form" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
-        <div class="password-wrap">
-            {{input value=newPassword class="gh-input password" type="password" placeholder="Password" name="newpassword" autofocus="autofocus" }}
-        </div>
-        <div class="password-wrap">
-            {{input value=ne2Password class="gh-input password" type="password" placeholder="Confirm Password" name="ne2password" }}
-        </div>
-        <button class="btn btn-blue" type="submit" disabled={{submitting}}>Reset Password</button>
-    </form>
-</section>
+<div class="gh-flow">
+    <div class="gh-flow-content-wrap">
+        <section class="gh-flow-content fade-in">
+            <form id="reset" class="gh-reset" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
+                <div class="form-group">
+                    {{input value=newPassword class="gh-input password" type="password" placeholder="Password" name="newpassword" autofocus="autofocus" }}
+                </div>
+                <div class="form-group">
+                    {{input value=ne2Password class="gh-input password" type="password" placeholder="Confirm Password" name="ne2password" }}
+                </div>
+                <button class="btn btn-blue btn-block" type="submit" disabled={{submitting}}>Reset Password</button>
+            </form>
+        </section>
+    </div>
+</div>


### PR DESCRIPTION
closes #5524
- added styles for reset page, similar to sign in but seperated for easy change further down the line.
- changed markup to reflect added css changes.
- remove html classes that are redundant.
