### PR TITLE
Invited user can sign up successfully

### DIFF
--- a/core/client/app/controllers/signup.js
+++ b/core/client/app/controllers/signup.js
@@ -45,7 +45,9 @@ export default Ember.Controller.extend(ValidationEngine, {
                 });
             }).catch(function (errors) {
                 self.toggleProperty('submitting');
-                notifications.showErrors(errors);
+                if (errors) {
+                    notifications.showErrors(errors);
+                }
             });
         }
     }

--- a/core/client/app/routes/signup.js
+++ b/core/client/app/routes/signup.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import DS from 'ember-data';
 import {request as ajax} from 'ic-ajax';
 import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
@@ -35,6 +36,7 @@ export default Ember.Route.extend(styleBody, {
 
             model.set('email', email);
             model.set('token', params.token);
+            model.set('errors', DS.Errors.create());
 
             return ajax({
                 url: self.get('ghostPaths.url').api('authentication', 'invitation'),


### PR DESCRIPTION
issue #5525
- add `DS.Errors` to `signup` model
- add check for errors: run `showErrors` method only if errors are defined, like in `signin` controller

These changes fix issue when invited user is unable to sign up. But it still lacks displaying validation messages. 
