### PR TITLE
Rework gh-activating-list-item for new link-to

### DIFF
--- a/core/client/app/components/gh-activating-list-item.js
+++ b/core/client/app/components/gh-activating-list-item.js
@@ -8,5 +8,13 @@ export default Ember.Component.extend({
 
     unfocusLink: function () {
         this.$('a').blur();
-    }.on('click')
+    }.on('click'),
+
+    actions: {
+        setActive: function (value) {
+            Ember.run.schedule('afterRender', this, function () {
+                this.set('active', value);
+            });
+        }
+    }
 });

--- a/core/client/app/templates/components/gh-activating-list-item.hbs
+++ b/core/client/app/templates/components/gh-activating-list-item.hbs
@@ -1,1 +1,1 @@
-{{#link-to route alternateActive=active classNameBindings="linkClasses"}}{{title}}{{yield}}{{/link-to}}
+{{#link-to route alternateActive=(action "setActive") classNameBindings="linkClasses"}}{{title}}{{yield}}{{/link-to}}

--- a/core/client/app/utils/link-component.js
+++ b/core/client/app/utils/link-component.js
@@ -4,7 +4,9 @@ Ember.LinkComponent.reopen({
     active: Ember.computed('attrs.params', '_routing.currentState', function () {
         var isActive = this._super();
 
-        Ember.set(this, 'alternateActive', isActive);
+        if (typeof this.attrs.alternateActive === 'function') {
+            this.attrs.alternateActive(isActive);
+        }
 
         return isActive;
     }),


### PR DESCRIPTION
Handle `alternateActive` via a closure action because it's no longer getting two-way bound.
