### PR TITLE
New rss.item filter

### DIFF
--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -179,7 +179,9 @@ generateFeed = function generateFeed(data) {
             }
         });
 
-        feed.item(item);
+        filters.doFilter('rss.item', item, post).then(function then(item) {
+            feed.item(item);
+        });
     });
 
     return filters.doFilter('rss.feed', feed).then(function then(feed) {


### PR DESCRIPTION
Add rss.item filter
Add content/apps to the watch directory

---

Had a go at implementing a simple RSS / Podcasting feed app today. The code can be found at https://github.com/halfdan/Ghostcast. There are a few things missing to make it really usable:
- I had to hard code a few strings that would be better implemented as app settings (which aren't available yet)
- Had to restart express after each change (easy fix by changing the watch tasks - in this PR)
- I need access to each item and its post as the feed gets rendered (technically a flag on a post marking it as a "podcast episode" would help too) - I added a new `doFilter` for `rss.item`

I realize that the app project hasn't been kicked off again - thought I get this written down somewhere. 
