### PR TITLE
Correct reset passsword screen markup and styles

### DIFF
--- a/core/client/app/templates/reset.hbs
+++ b/core/client/app/templates/reset.hbs
@@ -1,11 +1,15 @@
-<section class="reset-box js-reset-box fade-in">
-    <form id="reset" class="reset-form" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
-        <div class="password-wrap">
-            {{input value=newPassword class="gh-input password" type="password" placeholder="Password" name="newpassword" autofocus="autofocus" }}
-        </div>
-        <div class="password-wrap">
-            {{input value=ne2Password class="gh-input password" type="password" placeholder="Confirm Password" name="ne2password" }}
-        </div>
-        <button class="btn btn-blue" type="submit" disabled={{submitting}}>Reset Password</button>
-    </form>
-</section>
+<div class="gh-flow">
+    <div class="gh-flow-content-wrap">
+        <section class="gh-flow-content fade-in">
+            <form id="reset" class="gh-signin" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
+                <div class="form-group">
+                    {{input value=newPassword class="gh-input password" type="password" placeholder="Password" name="newpassword" autofocus="autofocus" }}
+                </div>
+                <div class="form-group">
+                    {{input value=ne2Password class="gh-input password" type="password" placeholder="Confirm Password" name="ne2password" }}
+                </div>
+                <button class="btn btn-blue btn-block" type="submit" disabled={{submitting}}>Reset Password</button>
+            </form>
+        </section>
+    </div>
+</div>


### PR DESCRIPTION
closes #5524
- added styles for reset page, similar to sign in but seperated for easy change further down the line.
- changed markup to reflect added css changes.
- remove html classes that are redundant.
