### PR TITLE
Fix some validation bugs

### DIFF
--- a/core/client/app/mixins/validation-engine.js
+++ b/core/client/app/mixins/validation-engine.js
@@ -125,17 +125,15 @@ export default Ember.Mixin.create({
                 return reject(['The validator specified, "' + type + '", did not exist!']);
             }
 
+            if (opts.property) {
+                model.get('errors').remove(opts.property);
+            } else {
+                model.get('errors').clear();
+            }
+
             passed = validator.check(model, opts.property);
 
-            if (passed) {
-                if (opts.property) {
-                    model.get('errors').remove(opts.property);
-                } else {
-                    model.get('errors').clear();
-                }
-                return resolve();
-            }
-            return reject();
+            return (passed) ? resolve() : reject();
         });
     },
 

--- a/core/client/app/validators/reset.js
+++ b/core/client/app/validators/reset.js
@@ -5,13 +5,11 @@ var ResetValidator = BaseValidator.create({
         var p1 = model.get('newPassword'),
             p2 = model.get('ne2Password');
 
-        if (!validator.equals(p1, p2)) {
-            model.get('errors').add('ne2Password', 'The two new passwords don\'t match.');
-            this.invalidate();
-        }
-
         if (!validator.isLength(p1, 8)) {
             model.get('errors').add('newPassword', 'The password is not long enough.');
+            this.invalidate();
+        } else if (!validator.equals(p1, p2)) {
+            model.get('errors').add('ne2Password', 'The two new passwords don\'t match.');
             this.invalidate();
         }
     }

--- a/core/client/app/validators/setting.js
+++ b/core/client/app/validators/setting.js
@@ -30,18 +30,14 @@ var SettingValidator = BaseValidator.create({
     postsPerPage: function (model) {
         var postsPerPage = model.get('postsPerPage');
 
-        if (postsPerPage > 1000) {
-            model.get('errors').add('postsPerPage', 'The maximum number of posts per page is 1000');
-            this.invalidate();
-        }
-
-        if (postsPerPage < 1) {
-            model.get('errors').add('postsPerPage', 'The minimum number of posts per page is 1');
-            this.invalidate();
-        }
-
         if (!validator.isInt(postsPerPage)) {
             model.get('errors').add('postsPerPage', 'Posts per page must be a number');
+            this.invalidate();
+        } else if (postsPerPage > 1000) {
+            model.get('errors').add('postsPerPage', 'The maximum number of posts per page is 1000');
+            this.invalidate();
+        } else if (postsPerPage < 1) {
+            model.get('errors').add('postsPerPage', 'The minimum number of posts per page is 1');
             this.invalidate();
         }
     }


### PR DESCRIPTION
refs #5520
- all errors (or just one if property is specified) are cleared before running the checks to make sure that old errors get cleared
- fixed up validators to be slightly more sane as mutually exclusive tests aren't all being checked if one fails
