### PR TITLE
Removing incorrect 405 handling

### DIFF
--- a/core/server/middleware/api-error-handlers.js
+++ b/core/server/middleware/api-error-handlers.js
@@ -1,9 +1,5 @@
 var errors = require('../errors');
 
-module.exports.methodNotAllowed = function methodNotAllowed(req, res, next) {
-    next(new errors.MethodNotAllowedError('Unknown method: ' + req.path));
-};
-
 module.exports.errorHandler = function errorHandler(err, req, res, next) {
     /*jshint unused:false */
     var httpErrors = errors.formatHttpErrors(err);

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -91,8 +91,6 @@ apiRoutes = function apiRoutes(middleware) {
     router.post('/uploads', middleware.busboy, api.http(api.uploads.add));
 
     // API Router middleware
-    router.use(middleware.api.methodNotAllowed);
-
     router.use(middleware.api.errorHandler);
 
     return router;

--- a/core/test/unit/middleware/api-error-handlers_spec.js
+++ b/core/test/unit/middleware/api-error-handlers_spec.js
@@ -25,19 +25,6 @@ describe('Middleware: API Error Handlers', function () {
         sandbox.restore();
     });
 
-    describe('methodNotAllowed', function () {
-        it('calls next with an error', function () {
-            req.path = 'test';
-
-            middleware.api.methodNotAllowed(req, res, next);
-
-            next.calledOnce.should.be.true;
-            next.firstCall.args[0].code.should.equal(405);
-            next.firstCall.args[0].errorType.should.equal('MethodNotAllowedError');
-            next.firstCall.args[0].message.should.match(/test$/);
-        });
-    });
-
     describe('errorHandler', function () {
         it('sends a JSON error response', function () {
             errors.logError = sandbox.spy(errors, 'logError');


### PR DESCRIPTION
refs #2757
- As per this convo: https://ghost.slack.com/archives/ghost/p1436895553007431 the 405 handling in Ghost is acting
  as a catch all, rather than only returning when the wrong HTTP method is used for a valid resource.
- Implementing proper 405 with express is a challenge, and therefore we defer doing this work until it is needed
