### PR TITLE
Refactor setup controller to only pass valid email into profile image component

### DIFF
--- a/core/client/app/controllers/setup/two.js
+++ b/core/client/app/controllers/setup/two.js
@@ -7,6 +7,7 @@ export default Ember.Controller.extend(ValidationEngine, {
     blogTitle: null,
     name: null,
     email: '',
+    validEmail: '',
     password: null,
     image: null,
     submitting: false,
@@ -102,6 +103,13 @@ export default Ember.Controller.extend(ValidationEngine, {
         },
         setImage: function (image) {
             this.set('image', image);
+        },
+        handleEmail: function () {
+            var self = this;
+
+            this.validate({property: 'email'}).then(function () {
+                self.set('validEmail', self.get('email'));
+            });
         }
     }
 });

--- a/core/client/app/templates/setup/two.hbs
+++ b/core/client/app/templates/setup/two.hbs
@@ -8,11 +8,11 @@
         <input style="display:none;" type="text" name="fakeusernameremembered"/>
         <input style="display:none;" type="password" name="fakepasswordremembered"/>
 
-        {{gh-profile-image fileStorage=config.fileStorage email=email setImage="setImage"}}
+        {{gh-profile-image fileStorage=config.fileStorage email=validEmail setImage="setImage"}}
         {{#gh-form-group errors=errors property="email"}}
             <label for="email-address">Email address</label>
             <span class="input-icon icon-mail">
-                {{gh-input type="email" name="email" placeholder="Eg. john@example.com" class="gh-input" autofocus="autofocus" autocorrect="off" value=email focusOut=(action "validate" "email")}}
+                {{gh-input type="email" name="email" placeholder="Eg. john@example.com" class="gh-input" autofocus="autofocus" autocorrect="off" value=email focusOut=(action "handleEmail")}}
             </span>
             {{gh-error-message errors=errors property="email"}}
         {{/gh-form-group}}


### PR DESCRIPTION
closes #5563

This fixes the problem by having a custom focusOut method for the email input in the setup/two controller. Instead of calling the validation check, it calls an action which calls the validation check, then if it passes sets a validEmail property, which is passed into the component.
