### PR TITLE
Disable image upload during setup for non persistent file storage

### DIFF
--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
     email: '',
     size: 90,
     hasUploadedImage: false,
+    fileStorage: true,
 
     ghostPaths: Ember.inject.service('ghost-paths'),
     hasEmail: Ember.computed.notEmpty('email'),

--- a/core/client/app/templates/components/gh-profile-image.hbs
+++ b/core/client/app/templates/components/gh-profile-image.hbs
@@ -1,12 +1,12 @@
 <figure class="account-image js-file-upload">
     {{#unless hasUploadedImage}}
-    <div class="placeholder-img" style={{defaultImage}}></div>
+        <div class="placeholder-img" style={{defaultImage}}></div>
 
-    {{#if hasEmail}}
-    <div id="account-image" class="gravatar-img" style={{imageBackground}}>
-        <span class="sr-only">User image</span>
-    </div>
-    {{/if}}
+        {{#if hasEmail}}
+            <div id="account-image" class="gravatar-img" style={{imageBackground}}>
+                <span class="sr-only">User image</span>
+            </div>
+        {{/if}}
     {{/unless}}
 
     <div class="js-img-preview"></div>
@@ -16,5 +16,5 @@
             <span class="sr-only">Upload an image</span>
         </i>
     </span>
-    <input type="file" class="file-uploader js-file-input" name="uploadimage">
+    {{#if fileStorage}}<input type="file" class="file-uploader js-file-input" name="uploadimage">{{/if}}
 </figure>

--- a/core/client/app/templates/setup.hbs
+++ b/core/client/app/templates/setup.hbs
@@ -1,5 +1,4 @@
 <div class="gh-flow">
-
     <header class="gh-flow-head">
         <nav class="gh-flow-nav">
             {{!-- TODO: this should only appear on screens 2 & 3 --}}
@@ -23,5 +22,4 @@
     <div class="gh-flow-content-wrap">
         {{outlet}}
     </div>
-
 </div>

--- a/core/client/app/templates/setup/two.hbs
+++ b/core/client/app/templates/setup/two.hbs
@@ -8,7 +8,7 @@
         <input style="display:none;" type="text" name="fakeusernameremembered"/>
         <input style="display:none;" type="password" name="fakepasswordremembered"/>
 
-        {{gh-profile-image email=email setImage="setImage"}}
+        {{gh-profile-image fileStorage=config.fileStorage email=email setImage="setImage"}}
         {{#gh-form-group errors=errors property="email"}}
             <label for="email-address">Email address</label>
             <span class="input-icon icon-mail">


### PR DESCRIPTION
closes #5550
- passes config.fileStorage into gh-profile-image component
- does not render input tag if fileStorage is set to false
