### PR TITLE
Use previousAttributes when model is destroyed 

### DIFF
--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -136,6 +136,10 @@ _.extend(BaseSiteMapGenerator.prototype, {
 
     removeUrl: function (model) {
         var datum = model.toJSON();
+        // When the model is destroyed we need to fetch previousAttributes
+        if (!datum.id) {
+            datum = model.previousAttributes();
+        }
         this.removeFromLookups(datum);
 
         this.lastModified = Date.now();

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -107,7 +107,6 @@ Post = ghostBookshelf.Model.extend({
             if (model.previous('status') === 'published') {
                 model.emitChange('unpublished');
             }
-
             model.emitChange('deleted');
         });
     },


### PR DESCRIPTION
fixes #5589 

---

The destroyed event gets the model after all attributes have been cleared. Only way to access the id (for removing it from the sitemap) is via previousAttributes.
