### PR TITLE
Fix missing redirect on settings/code-injection when not authenticated

### DIFF
--- a/core/client/app/routes/settings/code-injection.js
+++ b/core/client/app/routes/settings/code-injection.js
@@ -6,7 +6,8 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Code Injection',
     classNames: ['settings-view-code'],
 
-    beforeModel: function () {
+    beforeModel: function (transition) {
+        this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());


### PR DESCRIPTION
related issue #5412
- code-injection route was overriding `beforeModel` without calling `super` which meant the redirect handling added in `AuthenticatedRoute` was being skipped
