### PR TITLE
[WIP] `{{#get}}` helper + filter parameter

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -23,7 +23,7 @@ utils = {
     // ### Manual Default Options
     // These must be provided by the endpoint
     // browseDefaultOptions - valid for all browse api endpoints
-    browseDefaultOptions: ['page', 'limit', 'fields'],
+    browseDefaultOptions: ['page', 'limit', 'fields', 'filter'],
     // idDefaultOptions - valid whenever an id is valid
     idDefaultOptions: ['id'],
 
@@ -116,7 +116,7 @@ utils = {
                 name: {}
             },
             // these values are sanitised/validated separately
-            noValidation = ['data', 'context', 'include'],
+            noValidation = ['data', 'context', 'include', 'filter'],
             errors = [];
 
         _.each(options, function (value, key) {

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -1,0 +1,106 @@
+// # Get Helper
+// Usage: `{{#get "posts" limit="5"}}`, `{{#get "tags" limit="all"}}`
+// Fetches data from the API
+
+var _               = require('lodash'),
+    hbs             = require('express-hbs'),
+    errors          = require('../errors'),
+    api             = require('../api'),
+    jsonpath        = require('jsonpath'),
+
+    resources       = ['posts', 'tags', 'users'],
+    pathAliases     = {
+        'post.tags': 'post.tags[*].slug',
+        'post.author':  'post.author.slug'
+    },
+    get;
+
+function doBrowse(context, options) {
+    var browse = true;
+    if (options.limit && options.limit === 1) {
+        browse = false;
+    }
+
+    if (options.id || options.slug) {
+        browse = false;
+    }
+
+    return browse;
+}
+
+function resolvePaths(data, value) {
+    var regex = /\{\{(.*?)\}\}/g;
+
+    value = value.replace(regex, function (match, path) {
+        var result;
+
+        // Handle tag, author and role aliases
+        path = pathAliases[path] ? pathAliases[path] : path;
+
+        result = jsonpath.query(data, path);
+
+        if (_.isArray(result)) {
+            result = result.join(',');
+        }
+
+        return result;
+    });
+
+    return value;
+}
+
+function parseOptions(data, options) {
+    options = _.omit(options.hash, 'context');
+    if (_.isArray(options.tag)) {
+        options.tag = _.pluck(options.tag, 'slug').join(',');
+    }
+
+    if (_.isString(options.filter)) {
+        options.filter = resolvePaths(data, options.filter);
+    }
+
+    return options;
+}
+
+get = function get(context, options) {
+    options = options || {};
+    options.hash = options.hash || {};
+
+    var self = this,
+        data,
+        apiOptions,
+        apiMethod;
+
+    if (!_.contains(resources, context)) {
+        errors.logWarn('Invalid resource given to get helper');
+        return;
+    }
+
+    if (options.data) {
+        data = hbs.handlebars.createFrame(options.data);
+    }
+
+    // Determine if this is a read or browse
+    apiMethod = doBrowse(context, options) ? api[context].browse : api[context].read;
+    // Parse the options we're going to pass to the API
+    apiOptions = parseOptions(this, options);
+
+    return apiMethod(apiOptions).then(function success(result) {
+        var data = _.merge(self, result);
+        if (_.isEmpty(result[context])) {
+            return options.inverse(self);
+        }
+
+        return options.fn(data, {
+            data: data,
+            blockParams: [result[context]]
+        });
+    }).catch(function error(err) {
+        if (data) {
+            data.error = err.message;
+        }
+        return options.inverse(self, {data: data});
+    });
+};
+
+module.exports = get;

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -21,6 +21,7 @@ coreHelpers.date  = require('./date');
 coreHelpers.encode  = require('./encode');
 coreHelpers.excerpt  = require('./excerpt');
 coreHelpers.foreach = require('./foreach');
+coreHelpers.get = require('./get');
 coreHelpers.ghost_foot = require('./ghost_foot');
 coreHelpers.ghost_head = require('./ghost_head');
 coreHelpers.image = require('./image');
@@ -117,6 +118,7 @@ registerHelpers = function (adminHbs) {
     registerAsyncThemeHelper('post_class', coreHelpers.post_class);
     registerAsyncThemeHelper('next_post', coreHelpers.next_post);
     registerAsyncThemeHelper('prev_post', coreHelpers.prev_post);
+    registerAsyncThemeHelper('get', coreHelpers.get);
 
     // Register admin helpers
     registerAdminHelper('asset', coreHelpers.asset);

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -19,6 +19,7 @@ var _          = require('lodash'),
     validation = require('../../data/validation'),
     baseUtils  = require('./utils'),
     pagination = require('./pagination'),
+    gql        = require('ghost-gql'),
 
     ghostBookshelf;
 
@@ -281,6 +282,16 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             // If there are `where` conditionals specified, add those to the query.
             if (options.where) {
                 itemCollection.query('where', options.where);
+            }
+
+            // Apply FILTER
+            if (options.filter) {
+                options.filter = gql.parse(options.filter);
+                itemCollection.query(function (qb) {
+                    gql.knexify(qb, options.filter);
+                });
+
+                baseUtils.filtering.joins(options.filter.joins, itemCollection);
             }
 
             // Setup filter joins / queries

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -52,6 +52,20 @@ filtering = {
                 .query('where', 'roles_users.role_id', '=', filterObjects.roles.id);
         }
     },
+    joins: function joins(joinTables, itemCollection) {
+        if (joinTables && joinTables.indexOf('tags') > -1) {
+            itemCollection
+                .query('join', 'posts_tags', 'posts_tags.post_id', '=', 'posts.id')
+                .query('join', 'tags', 'posts_tags.tag_id', '=', 'tags.id')
+                .query('groupBy', 'posts.id')
+                .query('orderByRaw', 'count(tags.id) DESC');
+        }
+
+        if (joinTables && joinTables.indexOf('author') > -1) {
+            itemCollection
+                .query('join', 'users as author', 'author.id', '=', 'posts.author_id');
+        }
+    },
     formatResponse: function formatResponse(filterObjects, options, data) {
         if (!_.isEmpty(filterObjects)) {
             data.meta.filters = {};

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -358,7 +358,7 @@ Post = ghostBookshelf.Model.extend({
             if (!_.isBoolean(options.staticPages)) {
                 options.staticPages = _.contains(['true', '1'], options.staticPages);
             }
-            options.where.page = options.staticPages;
+            options.where['posts.page'] = options.staticPages;
         }
 
         if (_.has(options, 'featured')) {
@@ -366,7 +366,7 @@ Post = ghostBookshelf.Model.extend({
             if (!_.isBoolean(options.featured)) {
                 options.featured = _.contains(['true', '1'], options.featured);
             }
-            options.where.featured = options.featured;
+            options.where['posts.featured'] = options.featured;
         }
 
         // Unless `all` is passed as an option, filter on
@@ -374,7 +374,7 @@ Post = ghostBookshelf.Model.extend({
         if (options.status !== 'all') {
             // make sure that status is valid
             options.status = _.contains(['published', 'draft'], options.status) ? options.status : 'published';
-            options.where.status = options.status;
+            options.where['posts.status'] = options.status;
         }
 
         return options;
@@ -393,7 +393,7 @@ Post = ghostBookshelf.Model.extend({
             validOptions = {
                 findAll: ['withRelated'],
                 findOne: ['importing', 'withRelated'],
-                findPage: ['page', 'limit', 'columns', 'status', 'staticPages', 'featured'],
+                findPage: ['page', 'limit', 'columns', 'filter', 'status', 'staticPages', 'featured'],
                 add: ['importing']
             };
 

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -18,7 +18,7 @@ describe('API Utils', function () {
     describe('Default Options', function () {
         it('should provide a set of default options', function () {
             apiUtils.globalDefaultOptions.should.eql(['context', 'include']);
-            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields']);
+            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields', 'filter']);
             apiUtils.dataDefaultOptions.should.eql(['data']);
             apiUtils.idDefaultOptions.should.eql(['id']);
         });

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -1,0 +1,63 @@
+/*globals describe, before, beforeEach, afterEach, it*/
+/*jshint expr:true*/
+var should         = require('should'),
+    sinon          = require('sinon'),
+    hbs            = require('express-hbs'),
+    Promise        = require('bluebird'),
+    utils          = require('./utils'),
+
+// Stuff we are testing
+    handlebars     = hbs.handlebars,
+    helpers        = require('../../../server/helpers'),
+    api            = require('../../../server/api');
+
+describe('{{#get}} helper', function () {
+    var sandbox;
+
+    before(function () {
+        utils.loadHelpers();
+    });
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('has loaded get block helper', function () {
+        should.exist(handlebars.helpers.get);
+    });
+
+    describe('posts', function () {
+        var testPostsObj = {
+            posts: [
+                {id: 1}
+            ]
+        };
+        beforeEach(function () {
+            sandbox.stub(api.posts, 'browse', function () {
+                return Promise.resolve(testPostsObj);
+            });
+        });
+
+        it('should handle default posts call', function (done) {
+            var fn = sinon.spy(),
+                inverse = sinon.spy();
+
+            helpers.get.call(
+                {},
+                'posts',
+                {hash: {}, fn: fn, inverse: inverse}
+            ).then(function () {
+                fn.called.should.be.true;
+                fn.firstCall.args[0].should.be.an.Object;
+                fn.firstCall.args[0].should.eql(testPostsObj);
+                inverse.called.should.be.false;
+
+                done();
+            }).catch(done);
+        });
+    });
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "html-to-text": "1.3.0",
     "intl": "1.0.0",
     "intl-messageformat": "1.1.0",
+    "jsonpath": "0.1.8",
     "knex": "0.7.3",
     "lodash": "3.10.0",
     "moment": "2.10.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "express-hbs": "0.8.4",
     "extract-zip": "1.0.3",
     "fs-extra": "0.18.4",
+    "ghost-gql": "ErisDS/GQL.git#initial",
     "glob": "4.3.2",
     "html-to-text": "1.3.0",
     "intl": "1.0.0",


### PR DESCRIPTION
This PR is a very rough WIP, featuring 2 individual pieces of work:
- an initial implementation of the `{{#get}}` helper, refs #4439
- adding the `filter` parameter to the API, refs #5604 - main body of the work is in https://github.com/TryGhost/GQL/pull/2

Each piece will eventually be split into 3 complete PRs with full tests. This PR is here so that people can start to see and play with the functionality being added.

If you pull down this PR (**tip:** this blog post explains how http://dev.ghost.org/easy-git-pr-test/)

You'll be able to start playing with the get helper in your themes. 

Evolving documentation exists on the get helper issue: #4439 but the basics are as follows:
- `{{#get}}{{/get}}` is a block helper, so it has opening and closing tags and supports else.
- the first thing you pass to it should be the type of resource you want to get: posts, tags or users and they need to be enclosed in double quotes
- you can then pass options such as `include`, `limit` or `filter` to modify the query
- filter is described in depth in #5604 
- once you've done your `get` you can loop over the resources you've fetched using foreach

Here's an example:

```
{{#get "posts" limit="5" filter="featured:true"}}
    <ol>
        {{#foreach posts}}
            <li><a href="{{url}}"><span class="number" aria-hidden="true">{{@number}}</span>{{title}}</a></li>
        {{/foreach}}
    </ol>
{{/get}}
```

The main things which are not working yet (off the top of my head) are advanced joins from users and tags, filtering based on dates, pages behaviour needs to be fixed by #5151 and please also note that there is no `order` parameter yet #5602.

Have fun and leave lots of feedback please!
