### PR TITLE
Don't escape path for ember

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -315,7 +315,7 @@ var _              = require('lodash'),
                     },
                     options: {
                         execOptions: {
-                            cwd: path.resolve(cwd + '/core/client/'),
+                            cwd: path.resolve(process.cwd() + '/core/client/'),
                             stdout: false
                         }
                     }


### PR DESCRIPTION
This has been tested on mac & windows.

closes #5495
- we have to escape paths for bower, but ember already does this
