### PR TITLE
Fix contents of style and script tags being output in `{{excerpt}}` helper

### DIFF
--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -24,7 +24,9 @@ excerpt = function (options) {
     // Strip inline and bottom footnotes
     excerpt = excerpt.replace(/<a href="#fn.*?rel="footnote">.*?<\/a>/gi, '');
     excerpt = excerpt.replace(/<div class="footnotes"><ol>.*?<\/ol><\/div>/, '');
-    // Strip other html
+    // Strip other html (including contents of script and style tags)
+    excerpt = excerpt.replace(/<script([\S\s]*?)>([\S\s]*?)<\/script>/gi, '');
+    excerpt = excerpt.replace(/<style([\S\s]*?)>([\S\s]*?)<\/style>/ig, '');
     excerpt = excerpt.replace(/<\/?[^>]+>/gi, '');
     excerpt = excerpt.replace(/(\r\n|\n|\r)+/gm, ' ');
     /*jslint regexp:false */

--- a/core/test/unit/server_helpers/excerpt_spec.js
+++ b/core/test/unit/server_helpers/excerpt_spec.js
@@ -38,6 +38,16 @@ describe('{{excerpt}} Helper', function () {
         rendered.string.should.equal(expected);
     });
 
+    it('strips style and script tags and their contents', function () {
+        var html = '<script type="text/javascript>console.log("testing");</script>' +
+                '<style type="text/css">\n.content{color:red;}\n</style>This should be output',
+            expected = 'This should be output',
+            rendered = helpers.excerpt.call({html: html});
+
+        should.exist(rendered);
+        rendered.string.should.equal(expected);
+    });
+
     it('strips multiple inline footnotes', function () {
         var html = '<p>Testing<sup id="fnref:1"><a href="#fn:1" rel="footnote">1</a></sup>, my footnotes. And stuff. Footnote<sup id="fnref:2"><a href="#fn:2" rel="footnote">2</a></sup><a href="http://google.com">with a link</a> right after.',
             expected = 'Testing, my footnotes. And stuff. Footnotewith a link right after.',


### PR DESCRIPTION
closes #5620
- improve regexp in excerpt helper to remove contents of script and style tags
- fixes tests to test script and style tags
