### PR TITLE
Apply pipeline to notifications API endpoints

### DIFF
--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -5,6 +5,7 @@ var Promise            = require('bluebird'),
     canThis            = require('../permissions').canThis,
     errors             = require('../errors'),
     utils              = require('./utils'),
+    pipeline           = require('../utils/pipeline'),
 
     // Holds the persistent notifications
     notificationsStore = [],
@@ -47,31 +48,59 @@ notifications = {
      * ```
      */
     add: function add(object, options) {
-        var defaults = {
-                dismissible: true,
-                location: 'bottom',
-                status: 'alert'
-            },
-            addedNotifications = [];
+        var tasks;
 
-        return canThis(options.context).add.notification().then(function () {
-            return utils.checkObject(object, 'notifications').then(function (checkedNotificationData) {
-                _.each(checkedNotificationData.notifications, function (notification) {
-                    notificationCounter = notificationCounter + 1;
+        /**
+         * ### Handle Permissions
+         * We need to be an authorised user to perform this action
+         * @param {Object} options
+         * @returns {Object} options
+         */
+        function handlePermissions(options) {
+            return canThis(options.context).add.notification().then(function () {
+                return options;
+            }, function () {
+                return Promise.reject(new errors.NoPermissionError('You do not have permission to add notifications.'));
+            });
+        }
 
-                    notification = _.assign(defaults, notification, {
-                        id: notificationCounter
-                        // status: 'alert'
-                    });
+        /**
+         * ### Save Notifications
+         * Save the notifications
+         * @param {Object} options
+         * @returns {Object} options
+         */
+        function saveNotifications(options) {
+            var defaults = {
+                    dismissible: true,
+                    location: 'bottom',
+                    status: 'alert'
+                },
+                addedNotifications = [];
 
-                    notificationsStore.push(notification);
-                    addedNotifications.push(notification);
+            _.each(options.data.notifications, function (notification) {
+                notificationCounter = notificationCounter + 1;
+
+                notification = _.assign(defaults, notification, {
+                    id: notificationCounter
+                    // status: 'alert'
                 });
 
-                return {notifications: addedNotifications};
+                notificationsStore.push(notification);
+                addedNotifications.push(notification);
             });
-        }, function () {
-            return Promise.reject(new errors.NoPermissionError('You do not have permission to add notifications.'));
+
+            return addedNotifications;
+        }
+
+        tasks = [
+            utils.validate('notifications'),
+            handlePermissions,
+            saveNotifications
+        ];
+
+        return pipeline(tasks, object, options).then(function formatResponse(result) {
+            return {notifications: result};
         });
     },
 
@@ -83,7 +112,23 @@ notifications = {
      * @returns {Promise(Notifications)}
      */
     destroy: function destroy(options) {
-        return canThis(options.context).destroy.notification().then(function () {
+        var tasks;
+
+        /**
+         * ### Handle Permissions
+         * We need to be an authorised user to perform this action
+         * @param {Object} options
+         * @returns {Object} options
+         */
+        function handlePermissions(options) {
+            return canThis(options.context).destroy.notification().then(function () {
+                return options;
+            }, function () {
+                return Promise.reject(new errors.NoPermissionError('You do not have permission to destroy notifications.'));
+            });
+        }
+
+        function destroyNotification(options) {
             var notification = _.find(notificationsStore, function (element) {
                 return element.id === parseInt(options.id, 10);
             });
@@ -101,9 +146,19 @@ notifications = {
             notificationsStore = _.reject(notificationsStore, function (element) {
                 return element.id === parseInt(options.id, 10);
             });
-            return {notifications: [notification]};
-        }, function () {
-            return Promise.reject(new errors.NoPermissionError('You do not have permission to destroy notifications.'));
+            notificationCounter = notificationCounter - 1;
+
+            return notification;
+        }
+
+        tasks = [
+            utils.validate('notifications', {opts: utils.idDefaultOptions}),
+            handlePermissions,
+            destroyNotification
+        ];
+
+        return pipeline(tasks, options).then(function formatResponse(result) {
+            return {notifications: [result]};
         });
     },
 


### PR DESCRIPTION
refs #5508
- adds pipeline to the add and destroy methods of the notifications api

@ErisDS it seemed to me that the `browse` and `destroyAll` methods were simple enough/had nothing beyond a simple permissions check that adding pipeline to them would unnecessarily add code.
