### PR TITLE
Small messaging improvements

### DIFF
--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -166,7 +166,7 @@ GhostServer.prototype.logStartMessages = function () {
     // Startup & Shutdown messages
     if (process.env.NODE_ENV === 'production') {
         console.log(
-            chalk.green('Ghost is running...'),
+            chalk.green('Ghost is running in ' + process.env.NODE_ENV + '...'),
             '\nYour blog is now available on',
             config.url,
             chalk.gray('\nCtrl+C to shut down')


### PR DESCRIPTION
These two text updates are based on things we've seen users struggle with in slack/support etc. 

The first is a recurring issue with people setting their blog to private and not realising this disables the RSS feed. 

The second is that when on the CLI it's only possible to know you're in production mode by the absence of a mode message, making this explicit makes it easier to debug as you always know what mode you started in.

no issue
- update private blogging description to explicitly mention RSS
- change startup message to explicitly mention production
