### PR TITLE
Zelda audit

### DIFF
--- a/core/client/app/styles/components/dropdowns.css
+++ b/core/client/app/styles/components/dropdowns.css
@@ -22,7 +22,7 @@
     background-color: #fff;
     background-clip: padding-box;
     border-radius: 4px;
-    box-shadow: rgba(0, 0, 0, 0.175) 0 2px 6px;
+    box-shadow: rgba(0, 0, 0, 0.10) 0 2px 6px;
     list-style: none;
     text-align: left;
     text-transform: none;

--- a/core/client/app/styles/components/notifications.css
+++ b/core/client/app/styles/components/notifications.css
@@ -128,13 +128,13 @@
     font-size: 1.4rem;
     line-height: 1.3em;
     font-weight: 200;
-    user-select: all;
+    user-select: text;
 }
 
 .gh-alert a {
     text-decoration: underline;
     font-weight: 400;
-    user-select: all;
+    user-select: text;
 }
 
 .gh-alert-close {

--- a/core/client/app/styles/layouts/content.css
+++ b/core/client/app/styles/layouts/content.css
@@ -216,11 +216,12 @@
 
 .content-preview .post-controls {
     position: absolute;
-    top: 25px;
+    top: 5px;
     right: 25px;
 }
 
-.content-preview .post-controls .btn {
+.content-preview .post-controls .post-edit {
+    padding-top: 0;
     padding-right: 0;
     border: none;
     font-size: 18px;

--- a/core/client/app/styles/layouts/editor.css
+++ b/core/client/app/styles/layouts/editor.css
@@ -156,7 +156,7 @@
 
 .entry-preview-content *,
 .content-preview-content * {
-    user-select: all;
+    user-select: text;
 }
 
 .entry-preview-content a,

--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -192,7 +192,7 @@
 .gh-nav-footer-sitelink {
     flex-grow: 1;
     padding: 12px;
-    color: var(--midgrey);
+    color: color(var(--midgrey) lightness(-10%));
     text-align: center;
     text-transform: uppercase;
     font-size: 1rem;
@@ -327,13 +327,12 @@
 .gh-help-menu {
     display: flex;
     align-items: center;
-    padding: 5px 10px;
     border-left: #dfe1e3 1px solid;
     cursor: pointer;
 }
 
 .gh-help-button {
-    padding: 0 5px;
+    padding: 5px 15px;
     color: var(--midgrey);
     text-align: center;
     font-size: 1.4rem;

--- a/core/client/app/styles/layouts/tags.css
+++ b/core/client/app/styles/layouts/tags.css
@@ -109,7 +109,7 @@
 
 .settings-tag .tag-description {
     margin: 0;
-    color: #dfe1e3;
+    color: color(#dfe1e3 lightness(-10%));
     font-size: 13px;
 }
 
@@ -117,6 +117,6 @@
     position: absolute;
     top: 20px;
     right: 12px;
-    color: #dfe1e3;
+    color: color(#dfe1e3 lightness(-10%));
     font-size: 16px;
 }

--- a/core/client/app/styles/patterns/buttons.css
+++ b/core/client/app/styles/patterns/buttons.css
@@ -3,9 +3,6 @@
 
 /* Base button style */
 .btn {
-    display: flex;
-    justify-content: center;
-    align-items: center;
     margin-bottom: 0;
     padding: 9px 15px;
     border: #dfe1e3 1px solid;
@@ -163,6 +160,7 @@ fieldset[disabled] .btn {
 .btn-minor:focus {
     border-color: #c1c1c1;
     background: #fff;
+    box-shadow: none;
     color: #808284;
 }
 

--- a/core/client/app/templates/about.hbs
+++ b/core/client/app/templates/about.hbs
@@ -2,7 +2,7 @@
     <section class="view-content">
         <header class="gh-about-header">
             <img class="gh-logo" src="{{gh-path 'admin' '/img/ghost-logo.png'}}" alt="Ghost" />
-            <!-- TODO: fix about notifications -->
+            {{!-- TODO: fix about notifications --}}
             {{gh-notifications location="about-upgrade" notify="updateNotificationChange"}}
         </header>
 

--- a/core/client/app/templates/components/gh-modal-dialog.hbs
+++ b/core/client/app/templates/components/gh-modal-dialog.hbs
@@ -8,13 +8,8 @@
             </section>
             {{#if confirm}}
             <footer class="modal-footer">
-                <button type="button" class="{{rejectButtonClass}} btn-minor js-button-reject" {{action "confirm" "reject"}}>
-                    {{confirm.reject.text}}
-                </button><!--
-                Required to strip the white-space between buttons
-                --><button type="button" class="{{acceptButtonClass}} js-button-accept" {{action "confirm" "accept"}}>
-                    {{confirm.accept.text}}
-                </button>
+                {{! Buttons must be on one line to prevent white-space errors }}
+                <button type="button" class="{{rejectButtonClass}} btn-minor js-button-reject" {{action "confirm" "reject"}}>{{confirm.reject.text}}</button><button type="button" class="{{acceptButtonClass}} js-button-accept" {{action "confirm" "accept"}}>{{confirm.accept.text}}</button>
             </footer>
             {{/if}}
         </section>

--- a/core/client/app/templates/posts.hbs
+++ b/core/client/app/templates/posts.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view content-view-container">
 <header class="view-header">
-    {{#gh-view-title openMobileMenu="openMobileMenu"}}Content{{/gh-view-title}}
+    {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Content</span>{{/gh-view-title}}
     <section class="view-actions">
         {{#link-to "editor.new" class="btn btn-green" title="New Post"}}New Post{{/link-to}}
     </section>

--- a/core/client/app/templates/settings/code-injection.hbs
+++ b/core/client/app/templates/settings/code-injection.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view">
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}Code Injection{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Code Injection</span>{{/gh-view-title}}
         <section class="view-actions">
             {{gh-spin-button type="button" class="btn btn-blue" action="save" buttonText="Save" submitting=submitting}}
         </section>

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view">
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}General{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>General</span>{{/gh-view-title}}
         <section class="view-actions">
             {{gh-spin-button type="button" class="btn btn-blue" action="save" buttonText="Save" submitting=submitting}}
         </section>

--- a/core/client/app/templates/settings/labs.hbs
+++ b/core/client/app/templates/settings/labs.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view">
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}Labs{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Labs</span>{{/gh-view-title}}
     </header>
 
     <section class="view-content settings-debug">

--- a/core/client/app/templates/settings/navigation.hbs
+++ b/core/client/app/templates/settings/navigation.hbs
@@ -1,6 +1,6 @@
 {{#gh-navigation moveItem="moveItem"}}
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}Navigation{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Navigation</span>{{/gh-view-title}}
         <section class="view-actions">
             {{gh-spin-button type="button" class="btn btn-blue" action="save" buttonText="Save" submitting=submitting}}
         </section>

--- a/core/client/app/templates/settings/tags.hbs
+++ b/core/client/app/templates/settings/tags.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view">
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}Tags{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Tags</span>{{/gh-view-title}}
         <section class="view-actions">
             <button type="button" class="btn btn-green" {{action "newTag"}}>New Tag</button>
         </section>

--- a/core/client/app/templates/team/index.hbs
+++ b/core/client/app/templates/team/index.hbs
@@ -1,6 +1,6 @@
 <section class="gh-view">
     <header class="view-header">
-        {{#gh-view-title openMobileMenu="openMobileMenu"}}Team{{/gh-view-title}}
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>Team</span>{{/gh-view-title}}
         {{!-- Do not show Invite user button to authors --}}
         {{#unless session.user.isAuthor}}
             <section class="view-actions">

--- a/core/client/app/templates/team/user.hbs
+++ b/core/client/app/templates/team/user.hbs
@@ -2,7 +2,7 @@
     <header class="view-header">
         {{#gh-view-title openMobileMenu="openMobileMenu"}}
             {{link-to "Team" "team"}}
-            <i class="icon-arrow-right"></i> {{user.name}}
+            <i class="icon-arrow-right"></i> <span>{{user.name}}</span>
         {{/gh-view-title}}
         <section class="view-actions">
             {{#if userActionsAreVisible}}


### PR DESCRIPTION
- Fixed view title cutoff in safari
- Lighter dropdown shadow
- Removed display:flex from .btn because safari can't handle it on <button> elements, where it will immediately set all text-alignment to "left" with no way to change. I haven't been able to find any regressions for this change so far. Can't remember why buttons were supposed to be flexbox anyway. Maybe for icon alignment within buttons, but I can't find any such examples within the app.
- Safari thinks that user-select: all; means a single click should SELECT ALL THE THINGS. Removed/replaced with user-select: text; which makes it behave like Chrome; click and drag to select.
- Increased hit area for "?" button
- Removed :active style for post-edit button on content management screen, adjusted position
- Increased contrast on tag description, tag count, and view blog links
