### PR TITLE
Scheduled posts publisher

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -16,6 +16,7 @@ var express     = require('express'),
     errors      = require('./errors'),
     helpers     = require('./helpers'),
     mailer      = require('./mail'),
+    publisher   = require('./publisher'),
     middleware  = require('./middleware'),
     migrations  = require('./data/migration'),
     models      = require('./models'),
@@ -175,6 +176,8 @@ function init(options) {
         return Promise.join(
             // Check for or initialise a dbHash.
             initDbHashAndFirstRun(),
+            // Initialize scheduled posts publisher
+            publisher.init(),
             // Initialize mail
             mailer.init(),
             // Initialize apps

--- a/core/server/publisher.js
+++ b/core/server/publisher.js
@@ -1,0 +1,49 @@
+var Promise      = require('bluebird'),
+    api          = require('./api'),
+    CronJob      = require('cron').CronJob,
+    moment       = require('moment');
+
+function GhostPublisher() {}
+
+// *This promise should always resolve to avoid halting Ghost::init*.
+GhostPublisher.prototype.init = function () {
+    // Set a cronjob task which publishes posts (currently with status = "draft")
+    // with expired publish datetime.
+    // Because publish datetime is usually set per minutes (with seconds being set
+    // to "00") we will cover good auto-publish timing by running the task
+    // on second "02" of every minute.
+    var job = new CronJob({
+        cronTime: '01 * * * * *',
+        onTick: function () {
+            // Note context: {intenal: true} there in both `.browse` and `.edit` calls?
+            // It's done so that to avoid authorization check
+            api.posts.browse({status: 'draft', context: {internal: true}}).then(function (response) {
+                response.posts.forEach(function (post) {
+                    // Normalize both post publish datetime and current datetime to
+                    // Universal Time in Unix Timestamp format so that they could be
+                    // numerically compared
+                    var publishedTimestamp = moment(post.published_at).utc().format('X'),
+                        currentTimestamp = moment().utc().format('X');
+
+                    if (publishedTimestamp < currentTimestamp) {
+                        console.log('Publishing post #' + post.id);
+
+                        api.posts.edit({
+                            posts: [{status: 'published'}]
+                        }, {
+                            id: post.id,
+                            context: {internal: true}
+                        });
+                    }
+                });
+            });
+        },
+        start: false,
+        timeZone: 'GMT'
+    });
+    job.start();
+
+    return Promise.resolve();
+};
+
+module.exports = new GhostPublisher();

--- a/package.json
+++ b/package.json
@@ -63,7 +63,9 @@
     "sqlite3": "3.0.8",
     "unidecode": "0.1.3",
     "validator": "3.40.0",
-    "xml": "1.0.0"
+    "xml": "1.0.0",
+    "cron": "1.0.9",
+    "moment": "2.10.6"
   },
   "optionalDependencies": {
     "mysql": "2.1.1",


### PR DESCRIPTION
Hi,

I hope this PR finds you in good time. I can imagine that scheduled posts feature would've been introduced longer before if there was a single good way to implement it. Although this PR is far from being production ready it is what I came up with regarding scheduled posts mechanism and I'm super glad to share it with you.

It's worth noting that I only provide back-end implementation here, which currently publishes all drafts with expired publish date. You can easily demo that by creating a draft and it will be auto-published on second second of next minute. Although @ErisDS made a great suggestion via Slack on introducing 3rd status for posts: "scheduled" in addition to "published" and "daft" I decided to first share with you my vision of server-side solution and then try myself in introducing "scheduled" status for posts mostly on front-end if it will be relevant at all.

Thank you for your time.

Best Regards,
Sergey
