### PR TITLE
Support pattern matching for both posts with and without a date in the URL

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -281,13 +281,23 @@ frontendControllers = {
             var permalink = response.settings[0].value,
                 editFormat,
                 postLookup,
-                match;
+                match,
+                urlPattern;
 
             editFormat = permalink.substr(permalink.length - 1) === '/' ? ':edit?' : '/:edit?';
 
+            urlPattern = permalink;
             // Convert saved permalink into a path-match function
             permalink = routeMatch(permalink + editFormat);
             match = permalink(postPath);
+
+            if (match === false) {
+                permalink = urlPattern === '/:year/:month/:day/:slug/' ?
+                  '/:slug/' :
+                  '/:year/:month/:day/:slug/';
+                permalink = routeMatch(permalink + editFormat);
+                match = permalink(postPath);
+            }
 
             // Check if the path matches the permalink structure.
             //
@@ -353,6 +363,8 @@ frontendControllers = {
             // Check if the url provided with the post object matches req.path
             // If it does, render the post
             // If not, return 404
+            // TODO - find best approach to by pass this check since the post URL might not match the
+            // requested URL since we are matching with and without the date
             if (post.url && post.url === postUrl) {
                 return render();
             } else {


### PR DESCRIPTION
issue #5673
-added an extra check for the URL with and without the date pre-pended
-TODO find a way to by pass the check on the post URL and the requested URL
