### PR TITLE
[WIP] Tags input (again) this time using bootstrap-tokenfield plugin

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -60,6 +60,11 @@ app.import('bower_components/xregexp/xregexp-all.js');
 app.import('bower_components/password-generator/lib/password-generator.js');
 app.import('bower_components/blueimp-md5/js/md5.js');
 app.import('bower_components/typeahead.js/dist/typeahead.bundle.js');
+app.import('bower_components/typeahead.js/dist/bloodhound.js');
+app.import('bower_components/typeahead.js-es6-shim/typeahead-shim.js', {
+  exports: { 'bloodhound': ['default'] }
+});
+
 
 // 'dem Styles
 app.import('bower_components/codemirror/lib/codemirror.css');

--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -62,9 +62,8 @@ app.import('bower_components/blueimp-md5/js/md5.js');
 app.import('bower_components/typeahead.js/dist/typeahead.bundle.js');
 app.import('bower_components/typeahead.js/dist/bloodhound.js');
 app.import('bower_components/typeahead.js-es6-shim/typeahead-shim.js', {
-  exports: { 'bloodhound': ['default'] }
+    exports: {bloodhound: ['default']}
 });
-
 
 // 'dem Styles
 app.import('bower_components/codemirror/lib/codemirror.css');

--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -44,7 +44,7 @@ app.import('bower_components/showdown-ghost/src/extensions/highlight.js');
 app.import('bower_components/moment/moment.js');
 app.import('bower_components/keymaster/keymaster.js');
 app.import('bower_components/devicejs/lib/device.js');
-app.import('bower_components/jquery-ui/ui/jquery-ui.js');
+app.import('bower_components/jquery-ui/jquery-ui.js');
 app.import('bower_components/jquery-file-upload/js/jquery.fileupload.js');
 app.import('bower_components/blueimp-load-image/js/load-image.all.min.js');
 app.import('bower_components/jquery-file-upload/js/jquery.fileupload-process.js');

--- a/core/client/app/components/gh-post-tags-input.js
+++ b/core/client/app/components/gh-post-tags-input.js
@@ -1,0 +1,159 @@
+import Ember from 'ember';
+import TokenFieldInput from 'ember-cli-styleless-tokenfield/components/input-tokenfield';
+import Bloodhound from 'bloodhound';
+
+export default TokenFieldInput.extend({
+
+    selectedTags: null, // tags array
+    availableTags: null, // tags query promise
+
+    // _availableTagsData: null,
+
+    didInsertElement: function() {
+        this._setTokensFromSelectedTags();
+        this._consumeAvailableTagsPromise();
+        this._super();
+    },
+
+    setupEventHandlers: Ember.on('didInsertElement', function() {
+        // this.$().on('tokenfield:createtoken', Ember.run.bind(this, this.preventDuplicateToken));
+        this.$().on('tokenfield:createtoken', Ember.run.bind(this, this.createToken));
+        this.$().on('tokenfield:removetoken', Ember.run.bind(this, this.removeToken));
+    }),
+
+    createToken: function(event) {
+        // var availableTags = this.get('_availableTagsData'),
+        //     matchingTag = null;
+        //
+        // if (availableTags) {
+        //     matchingTag = availableTags.find(function(tag) {
+        //         return tag.get('name').toLowerCase() === event.attrs.value.toLowerCase();
+        //     });
+        //
+        //     if (matchingTag) {
+        //         // change values directly rather than assigning a new object
+        //         // as we want to keep the reference that's used by tokenfield's
+        //         // actual createToken function
+        //         event.attrs.value = matchingTag.get('id');
+        //         event.attrs.label = matchingTag.get('name');
+        //     } else {
+        //         this.attrs.addTag(event.attrs.value);
+        //         this.$().data('bs.tokenfield').$input.val('');
+        //         event.preventDefault();
+        //     }
+        // } else if (this._userHasEnteredText()) {
+        //     // user is trying to create a new tag but we can't do that without
+        //     // knowing the available tags. log and halt process for now
+        //     console.warn('Attempted to create tag before available tags have loaded');
+        //     event.preventDefault();
+        // }
+
+        // avoid sending action on initial startup by checking for user text
+        if (this._userHasEnteredText()) {
+            this.attrs.addTag(event.attrs.value);
+            this.$().data('bs.tokenfield').$input.val('');
+            event.preventDefault();
+        }
+    },
+
+    removeToken: function(event) {
+        var self = this,
+            // event.attrs is an array if multiple tokens are selected
+            tokens = Array.isArray(event.attrs) ? event.attrs : [event.attrs];
+
+        tokens.forEach(function(token) {
+            self.attrs.removeTag(token.value);
+        });
+
+        // can't prevent default here because bootstrap-tokenfield will exit
+        // before preventing the default click action which causes a redirect
+        // to the blog homepage
+        // event.preventDefault();
+    },
+
+    _setTokensFromSelectedTags: function() {
+        var selectedTags = this.get('selectedTags'),
+            tokens = selectedTags.mapBy('name'),
+            tokensPromise = null;
+
+        // there's a quirk in ember-cli-bootstrap-tokenfield where the
+        // tokenfield's tokens property isn't reset unless a promise is passed
+        tokensPromise = new Ember.RSVP.Promise(function(resolve) {
+            resolve(tokens);
+        });
+
+        this.set('tokens', tokensPromise);
+    },
+
+    _observeSelectedTags: Ember.observer('selectedTags.[]', function() {
+        this._setTokensFromSelectedTags();
+    }),
+
+    _consumeAvailableTagsPromise: function() {
+        var self = this,
+            availableTagsPromise = this.get('availableTags'),
+            engine = null;
+
+        if (!availableTagsPromise || typeof availableTagsPromise.then !== 'function') {
+            // TODO: handle a non-promise availableTags property
+            return;
+        }
+
+        // pre-fetch available tags for use in token creation handler
+        // availableTagsPromise.then(function(tags) {
+        //     self.set('_availableTagsData', tags);
+        // });
+
+        engine = new Bloodhound({
+            datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+            queryTokenizer: Bloodhound.tokenizers.whitespace,
+            remote: {
+                url: '%QUERY',
+                transport: function(url, options, onSuccess, onError) {
+                    // intercept the remote query and return our own promise
+                    // data instead of the usual AJAX call
+                    self.get('availableTags').then(function(availableTags) {
+                        onSuccess(availableTags);
+                    }).catch(function(error) {
+                        onError(error);
+                    });
+                },
+                filter: function(tags) {
+                    // convert tags into typeahead-compatible structure and
+                    // filter out already selected tags
+                    var datums = tags.map(function(tag) {
+                        return { value: tag.get('name') };
+                    });
+                    var selectedTokenNames = self.$().tokenfield('getTokens').mapBy('label');
+
+                    return datums.reject(function(datum) {
+                        return selectedTokenNames.contains(datum.value);
+                    });
+                }
+            }
+        });
+
+        engine.initialize();
+
+        this.set('typeahead', [{highlight: true, hint: true}, { source: engine.ttAdapter() }]);
+    },
+
+    // preventDuplicateToken: function(event) {
+    //     var existingTokens = this.$().tokenfield('getTokens'),
+    //         self = this;
+    //
+    //     if (typeof existingTokens.forEach === 'function') {
+    //         existingTokens.forEach(function(token) {
+    //             if (token.label.toLowerCase() === event.attrs.value.toLowerCase()) {
+    //                 event.preventDefault();
+    //                 self.$().data('bs.tokenfield').$input.val('');
+    //             }
+    //         });
+    //     }
+    // },
+
+    _userHasEnteredText: function() {
+        return this.$().data('bs.tokenfield') &&
+            this.$().data('bs.tokenfield').$input.val() !== '';
+    }
+});

--- a/core/client/app/components/gh-post-tags-input.js
+++ b/core/client/app/components/gh-post-tags-input.js
@@ -7,18 +7,18 @@ export default TokenFieldInput.extend({
     selectedTags: null, // tags array
     availableTags: null, // tags query promise
 
-    didInsertElement: function() {
+    didInsertElement: function () {
         this._setTokensFromSelectedTags();
         this._consumeAvailableTagsPromise();
         this._super();
     },
 
-    setupEventHandlers: Ember.on('didInsertElement', function() {
+    setupEventHandlers: Ember.on('didInsertElement', function () {
         this.$().on('tokenfield:createtoken', Ember.run.bind(this, this.createToken));
         this.$().on('tokenfield:removetoken', Ember.run.bind(this, this.removeToken));
     }),
 
-    createToken: function(event) {
+    createToken: function (event) {
         // avoid sending action on initial startup by checking for user text
         if (this._userHasEnteredText()) {
             this.attrs.addTag(event.attrs.value);
@@ -27,12 +27,12 @@ export default TokenFieldInput.extend({
         }
     },
 
-    removeToken: function(event) {
+    removeToken: function (event) {
         var self = this,
             // event.attrs is an array if multiple tokens are selected
             tokens = Array.isArray(event.attrs) ? event.attrs : [event.attrs];
 
-        tokens.forEach(function(token) {
+        tokens.forEach(function (token) {
             self.attrs.removeTag(token.value);
         });
 
@@ -42,25 +42,25 @@ export default TokenFieldInput.extend({
         // event.preventDefault();
     },
 
-    _setTokensFromSelectedTags: function() {
+    _setTokensFromSelectedTags: function () {
         var selectedTags = this.get('selectedTags'),
             tokens = selectedTags.mapBy('name'),
             tokensPromise = null;
 
         // there's a quirk in ember-cli-bootstrap-tokenfield where the
         // tokenfield's tokens property isn't reset unless a promise is passed
-        tokensPromise = new Ember.RSVP.Promise(function(resolve) {
+        tokensPromise = new Ember.RSVP.Promise(function (resolve) {
             resolve(tokens);
         });
 
         this.set('tokens', tokensPromise);
     },
 
-    _observeSelectedTags: Ember.observer('selectedTags.[]', function() {
+    _observeSelectedTags: Ember.observer('selectedTags.[]', function () {
         this._setTokensFromSelectedTags();
     }),
 
-    _consumeAvailableTagsPromise: function() {
+    _consumeAvailableTagsPromise: function () {
         var self = this,
             availableTagsPromise = this.get('availableTags'),
             engine = null;
@@ -75,24 +75,26 @@ export default TokenFieldInput.extend({
             queryTokenizer: Bloodhound.tokenizers.whitespace,
             remote: {
                 url: '%QUERY',
-                transport: function(url, options, onSuccess, onError) {
+                transport: function (url, options, onSuccess, onError) {
                     // intercept the remote query and return our own promise
                     // data instead of the usual AJAX call
-                    self.get('availableTags').then(function(availableTags) {
+                    self.get('availableTags').then(function (availableTags) {
                         onSuccess(availableTags);
-                    }).catch(function(error) {
+                    }).catch(function (error) {
                         onError(error);
                     });
                 },
-                filter: function(tags) {
+                filter: function (tags) {
+                    var datums, selectedTokenNames = null;
+
                     // convert tags into typeahead-compatible structure and
                     // filter out already selected tags
-                    var datums = tags.map(function(tag) {
-                        return { value: tag.get('name') };
+                    datums = tags.map(function (tag) {
+                        return {value: tag.get('name')};
                     });
-                    var selectedTokenNames = self.$().tokenfield('getTokens').mapBy('value');
+                    selectedTokenNames = self.$().tokenfield('getTokens').mapBy('value');
 
-                    return datums.reject(function(datum) {
+                    return datums.reject(function (datum) {
                         return selectedTokenNames.contains(datum.value);
                     });
                 }
@@ -101,10 +103,10 @@ export default TokenFieldInput.extend({
 
         engine.initialize();
 
-        this.set('typeahead', [{highlight: true, hint: true}, { source: engine.ttAdapter() }]);
+        this.set('typeahead', [{highlight: true, hint: true}, {source: engine.ttAdapter()}]);
     },
 
-    _userHasEnteredText: function() {
+    _userHasEnteredText: function () {
         return this.$().data('bs.tokenfield') &&
             this.$().data('bs.tokenfield').$input.val() !== '';
     }

--- a/core/client/app/components/gh-post-tags-input.js
+++ b/core/client/app/components/gh-post-tags-input.js
@@ -7,8 +7,6 @@ export default TokenFieldInput.extend({
     selectedTags: null, // tags array
     availableTags: null, // tags query promise
 
-    // _availableTagsData: null,
-
     didInsertElement: function() {
         this._setTokensFromSelectedTags();
         this._consumeAvailableTagsPromise();
@@ -16,38 +14,11 @@ export default TokenFieldInput.extend({
     },
 
     setupEventHandlers: Ember.on('didInsertElement', function() {
-        // this.$().on('tokenfield:createtoken', Ember.run.bind(this, this.preventDuplicateToken));
         this.$().on('tokenfield:createtoken', Ember.run.bind(this, this.createToken));
         this.$().on('tokenfield:removetoken', Ember.run.bind(this, this.removeToken));
     }),
 
     createToken: function(event) {
-        // var availableTags = this.get('_availableTagsData'),
-        //     matchingTag = null;
-        //
-        // if (availableTags) {
-        //     matchingTag = availableTags.find(function(tag) {
-        //         return tag.get('name').toLowerCase() === event.attrs.value.toLowerCase();
-        //     });
-        //
-        //     if (matchingTag) {
-        //         // change values directly rather than assigning a new object
-        //         // as we want to keep the reference that's used by tokenfield's
-        //         // actual createToken function
-        //         event.attrs.value = matchingTag.get('id');
-        //         event.attrs.label = matchingTag.get('name');
-        //     } else {
-        //         this.attrs.addTag(event.attrs.value);
-        //         this.$().data('bs.tokenfield').$input.val('');
-        //         event.preventDefault();
-        //     }
-        // } else if (this._userHasEnteredText()) {
-        //     // user is trying to create a new tag but we can't do that without
-        //     // knowing the available tags. log and halt process for now
-        //     console.warn('Attempted to create tag before available tags have loaded');
-        //     event.preventDefault();
-        // }
-
         // avoid sending action on initial startup by checking for user text
         if (this._userHasEnteredText()) {
             this.attrs.addTag(event.attrs.value);
@@ -99,11 +70,6 @@ export default TokenFieldInput.extend({
             return;
         }
 
-        // pre-fetch available tags for use in token creation handler
-        // availableTagsPromise.then(function(tags) {
-        //     self.set('_availableTagsData', tags);
-        // });
-
         engine = new Bloodhound({
             datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
             queryTokenizer: Bloodhound.tokenizers.whitespace,
@@ -124,7 +90,7 @@ export default TokenFieldInput.extend({
                     var datums = tags.map(function(tag) {
                         return { value: tag.get('name') };
                     });
-                    var selectedTokenNames = self.$().tokenfield('getTokens').mapBy('label');
+                    var selectedTokenNames = self.$().tokenfield('getTokens').mapBy('value');
 
                     return datums.reject(function(datum) {
                         return selectedTokenNames.contains(datum.value);
@@ -137,20 +103,6 @@ export default TokenFieldInput.extend({
 
         this.set('typeahead', [{highlight: true, hint: true}, { source: engine.ttAdapter() }]);
     },
-
-    // preventDuplicateToken: function(event) {
-    //     var existingTokens = this.$().tokenfield('getTokens'),
-    //         self = this;
-    //
-    //     if (typeof existingTokens.forEach === 'function') {
-    //         existingTokens.forEach(function(token) {
-    //             if (token.label.toLowerCase() === event.attrs.value.toLowerCase()) {
-    //                 event.preventDefault();
-    //                 self.$().data('bs.tokenfield').$input.val('');
-    //             }
-    //         });
-    //     }
-    // },
 
     _userHasEnteredText: function() {
         return this.$().data('bs.tokenfield') &&

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -189,7 +189,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
     },
 
     // query for all existing tags applicable to tag input's autocomplete
-    availableTags: Ember.computed(function() {
+    availableTags: Ember.computed(function () {
         return this.get('store').find('tag', {limit: 'all'});
     }),
 
@@ -467,10 +467,10 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             });
         },
 
-        addTag: function(tagName) {
+        addTag: function (tagName) {
             var self = this,
                 currentTags = this.get('model.tags'),
-                currentTagNames = currentTags.map(function(tag) { return tag.get('name').toLowerCase(); }),
+                currentTagNames = currentTags.map(function (tag) { return tag.get('name').toLowerCase(); }),
                 availableTagNames = null,
                 tagToAdd = null;
 
@@ -479,12 +479,12 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('availableTags').then(function(availableTags) {
-                availableTagNames = availableTags.map(function(tag) { return tag.get('name').toLowerCase(); });
+            this.get('availableTags').then(function (availableTags) {
+                availableTagNames = availableTags.map(function (tag) { return tag.get('name').toLowerCase(); });
 
                 // find existing tag or create new
                 if (availableTagNames.contains(tagName.toLowerCase())) {
-                    tagToAdd = availableTags.find(function(tag) {
+                    tagToAdd = availableTags.find(function (tag) {
                         return tag.get('name').toLowerCase() === tagName.toLowerCase();
                     });
                 } else {
@@ -498,13 +498,13 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             });
         },
 
-        removeTag: function(tagName) {
-            var tagName = tagName.toLowerCase(),
+        removeTag: function (tagName) {
+            var lowercaseTagName = tagName.toLowerCase(),
                 currentTags = this.get('model.tags'),
                 tagToRemove = null;
 
-            tagToRemove = currentTags.find(function(tag) {
-                return tag.get('name').toLowerCase() === tagName;
+            tagToRemove = currentTags.find(function (tag) {
+                return tag.get('name').toLowerCase() === lowercaseTagName;
             });
 
             currentTags.removeObject(tagToRemove);

--- a/core/client/app/styles/app.css
+++ b/core/client/app/styles/app.css
@@ -26,6 +26,7 @@
 @import "components/badges.css";
 @import "components/popovers.css";
 @import "components/settings-menu.css";
+@import "components/tokenfield.css";
 
 
 /* Layouts: Groups of Components

--- a/core/client/app/styles/components/tokenfield.css
+++ b/core/client/app/styles/components/tokenfield.css
@@ -1,0 +1,415 @@
+.form-control {
+    display: block;
+    padding: 6px 12px;
+    width: 100%;
+    height: 34px;
+    border: 1px solid #ccc;
+    background-color: #fff;
+    background-image: none;
+    border-radius: 4px;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    color: #555;
+    font-size: 14px;
+    line-height: 1.42857143;
+    transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+    -webkit-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
+}
+
+.form-control:focus {
+    outline: 0;
+    border-color: #66afe9;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+
+.form-control::-moz-placeholder {
+    color: #999;
+    opacity: 1;
+}
+
+.form-control:-ms-input-placeholder {
+    color: #999;
+}
+
+.form-control::-webkit-input-placeholder {
+    color: #999;
+}
+
+.form-control[disabled],
+.form-control[readonly],
+fieldset[disabled] .form-control {
+    background-color: #eee;
+    opacity: 1;
+    cursor: not-allowed;
+}
+
+/*!
+ * bootstrap-tokenfield
+ * https://github.com/sliptree/bootstrap-tokenfield
+ * Copyright 2013-2014 Sliptree and other contributors; Licensed MIT
+ */
+@-webkit-keyframes blink {
+    0% {
+        border-color: #ededed;
+    }
+    100% {
+        border-color: #b94a48;
+    }
+}
+@-moz-keyframes blink {
+    0% {
+        border-color: #ededed;
+    }
+    100% {
+        border-color: #b94a48;
+    }
+}
+@keyframes blink {
+    0% {
+        border-color: #ededed;
+    }
+    100% {
+        border-color: #b94a48;
+    }
+}
+.tokenfield {
+    padding-bottom: 0;
+    min-height: 34px;
+    height: auto;
+}
+.tokenfield.focus {
+    outline: 0;
+    border-color: #66afe9;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px rgba(102, 175, 233, 0.6);
+}
+.tokenfield .token {
+    display: inline-block;
+    box-sizing: border-box;
+    margin: -1px 5px 5px 0;
+    height: 22px;
+    border: 1px solid #d9d9d9;
+    background-color: #ededed;
+    border-radius: 3px;
+    vertical-align: top;
+    white-space: nowrap;
+    cursor: default;
+
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+}
+.tokenfield .token:hover {
+    border-color: #b9b9b9;
+}
+.tokenfield .token.active {
+    border-color: #52a8ec;
+    border-color: rgba(82, 168, 236, 0.8);
+}
+.tokenfield .token.duplicate {
+    border-color: #ebccd1;
+    animation-name: blink;
+    animation-duration: 0.1s;
+    animation-timing-function: ease;
+    animation-iteration-count: infinite;
+    animation-direction: normal;
+
+    -webkit-animation-name: blink;
+    -webkit-animation-duration: 0.1s;
+    -webkit-animation-direction: normal;
+    -webkit-animation-timing-function: ease;
+    -webkit-animation-iteration-count: infinite;
+}
+.tokenfield .token.invalid {
+    border: 1px solid transparent;
+    border-bottom: 1px dotted #d9534f;
+    background: none;
+    border-radius: 0;
+
+    -webkit-border-radius: 0;
+    -moz-border-radius: 0;
+}
+.tokenfield .token.invalid.active {
+    border: 1px solid #ededed;
+    background: #ededed;
+    border-radius: 3px;
+
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+}
+.tokenfield .token .token-label {
+    display: inline-block;
+    overflow: hidden;
+    padding-left: 4px;
+    vertical-align: top;
+    text-overflow: ellipsis;
+}
+.tokenfield .token .close {
+    display: inline-block;
+    float: none;
+    margin-left: 5px;
+    padding-right: 4px;
+    height: 100%;
+    vertical-align: top;
+    font-family: Arial;
+    font-size: 1.1em;
+    line-height: 100%;
+    line-height: 1.49em;
+}
+.tokenfield .token-input {
+    margin-bottom: 6px;
+    padding: 0;
+    min-width: 60px;
+    width: 60px;
+    height: 20px;
+    border: 0;
+    background: none;
+    box-shadow: none;
+
+    -webkit-box-shadow: none;
+}
+.tokenfield .token-input:focus {
+    outline: 0;
+    border-color: transparent;
+    box-shadow: none;
+    /* IE6-9 */
+
+    -webkit-box-shadow: none;
+}
+.tokenfield.disabled {
+    background-color: #eee;
+    cursor: not-allowed;
+}
+.tokenfield.disabled .token-input {
+    cursor: not-allowed;
+}
+.tokenfield.disabled .token:hover {
+    border-color: #d9d9d9;
+    cursor: not-allowed;
+}
+.tokenfield.disabled .token:hover .close {
+    opacity: 0.2;
+    filter: alpha(opacity=20);
+    cursor: not-allowed;
+}
+.has-warning .tokenfield.focus {
+    border-color: #66512c;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #c0a16b;
+}
+.has-error .tokenfield.focus {
+    border-color: #843534;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ce8483;
+}
+.has-success .tokenfield.focus {
+    border-color: #2b542c;
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+
+    -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #67b168;
+}
+.tokenfield.input-sm,
+.input-group-sm .tokenfield {
+    padding-bottom: 0;
+    min-height: 30px;
+}
+.input-group-sm .token,
+.tokenfield.input-sm .token {
+    margin-bottom: 4px;
+    height: 20px;
+}
+.input-group-sm .token-input,
+.tokenfield.input-sm .token-input {
+    margin-bottom: 5px;
+    height: 18px;
+}
+.tokenfield.input-lg,
+.input-group-lg .tokenfield {
+    padding-bottom: 4px;
+    min-height: 45px;
+    height: auto;
+}
+.input-group-lg .token,
+.tokenfield.input-lg .token {
+    height: 25px;
+}
+.input-group-lg .token-label,
+.tokenfield.input-lg .token-label {
+    line-height: 23px;
+}
+.input-group-lg .token .close,
+.tokenfield.input-lg .token .close {
+    line-height: 1.3em;
+}
+.input-group-lg .token-input,
+.tokenfield.input-lg .token-input {
+    margin-bottom: 6px;
+    height: 23px;
+    vertical-align: top;
+    line-height: 23px;
+}
+.tokenfield.rtl {
+    text-align: right;
+    direction: rtl;
+}
+.tokenfield.rtl .token {
+    margin: -1px 0 5px 5px;
+}
+.tokenfield.rtl .token .token-label {
+    padding-right: 4px;
+    padding-left: 0;
+}
+
+/*!
+ * bootstrap-tokenfield
+ * https://github.com/sliptree/bootstrap-tokenfield
+ * Copyright 2013-2014 Sliptree and other contributors; Licensed MIT
+ */
+/* General Typeahead styling, from http://jsfiddle.net/ragulka/Dy9au/1/ */
+.twitter-typeahead {
+    position: relative;
+    width: 100%;
+    vertical-align: top;
+}
+.twitter-typeahead .tt-input,
+.twitter-typeahead .tt-hint {
+    margin: 0;
+    width: 100%;
+    background-color: #fff;
+    vertical-align: middle;
+}
+.twitter-typeahead .tt-hint {
+    z-index: 1;
+    /*border: 1px solid transparent;*/
+    color: #999;
+}
+.twitter-typeahead .tt-input {
+    z-index: 2;
+    color: #555;
+}
+.twitter-typeahead .tt-input,
+.twitter-typeahead .tt-hint {
+    padding: 6px 4px;
+    /*height: 34px;*/
+    font-size: 14px;
+    line-height: 1.428571429;
+}
+.twitter-typeahead .input-sm.tt-input,
+.twitter-typeahead .hint-sm.tt-hint {
+    border-radius: 3px;
+}
+.twitter-typeahead .input-lg.tt-input,
+.twitter-typeahead .hint-lg.tt-hint {
+    border-radius: 6px;
+}
+.input-group .twitter-typeahead:first-child .tt-input,
+.input-group .twitter-typeahead:first-child .tt-hint {
+    border-radius: 4px 0 0 4px !important;
+}
+.input-group .twitter-typeahead:last-child .tt-input,
+.input-group .twitter-typeahead:last-child .tt-hint {
+    border-radius: 0 4px 4px 0 !important;
+}
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:first-child .tt-hint {
+    border-radius: 3px 0 0 3px !important;
+}
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-sm .twitter-typeahead:last-child .tt-hint {
+    border-radius: 0 3px 3px 0 !important;
+}
+.input-sm.tt-input,
+.hint-sm.tt-hint,
+.input-group.input-group-sm .tt-input,
+.input-group.input-group-sm .tt-hint {
+    padding: 5px 10px;
+    height: 30px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:first-child .tt-hint {
+    border-radius: 6px 0 0 6px !important;
+}
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-input,
+.input-group.input-group-lg .twitter-typeahead:last-child .tt-hint {
+    border-radius: 0 6px 6px 0 !important;
+}
+.input-lg.tt-input,
+.hint-lg.tt-hint,
+.input-group.input-group-lg .tt-input,
+.input-group.input-group-lg .tt-hint {
+    padding: 10px 16px;
+    height: 45px;
+    font-size: 18px;
+    line-height: 1.33;
+}
+.tt-dropdown-menu {
+    margin-top: 2px;
+    padding: 5px 0;
+    min-width: 160px;
+    width: 100%;
+    border: 1px solid #ccc;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    background-color: #fff;
+    background-clip: padding-box;
+    border-radius: 6px;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+
+    *border-right-width: 2px;
+    *border-bottom-width: 2px;
+    -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+    -webkit-background-clip: padding-box;
+    -moz-background-clip: padding;
+}
+.tt-suggestion {
+    display: block;
+    padding: 3px 20px;
+}
+.tt-suggestion.tt-cursor,
+.tt-suggestion:hover {
+    background-image: -webkit-linear-gradient(top, #f5f5f5 0%, #e8e8e8 100%);
+    background-image: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 100%);
+    background-repeat: repeat-x;
+    color: #262626;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff5f5f5', endColorstr='#ffe8e8e8', GradientType=0);
+    cursor: pointer;
+}
+.tt-suggestion.tt-cursor a {
+    color: #fff;
+}
+.tt-suggestion p {
+    margin: 0;
+}
+/* Tokenfield-specific Typeahead styling */
+.tokenfield .twitter-typeahead {
+    width: auto;
+}
+/*
+.tokenfield .twitter-typeahead .tt-hint {
+    padding: 0;
+    height: 20px;
+}
+*/
+.tokenfield.input-sm .twitter-typeahead .tt-input,
+.tokenfield.input-sm .twitter-typeahead .tt-hint {
+    height: 18px;
+    font-size: 12px;
+    line-height: 1.5;
+}
+.tokenfield.input-lg .twitter-typeahead .tt-input,
+.tokenfield.input-lg .twitter-typeahead .tt-hint {
+    height: 23px;
+    font-size: 18px;
+    line-height: 1.33;
+}
+.tokenfield .twitter-typeahead .tt-suggestions {
+    font-size: 14px;
+}

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -35,7 +35,12 @@
 
             <div class="form-group">
                 <label for="tag-input">Tags</label>
-                {{gh-tags-input post=model}}
+                {{gh-post-tags-input
+                    selectedTags=model.tags
+                    availableTags=availableTags
+                    addTag=(action 'addTag')
+                    removeTag=(action 'removeTag')
+                    placeholder="Type something and hit enter"}}
             </div>
 
             {{#unless session.user.isAuthor}}

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -14,7 +14,7 @@
     "ember-simple-auth": "0.8.0",
     "fastclick": "1.0.6",
     "google-caja": "5669.0.0",
-    "jquery": "1.11.2",
+    "jquery": "2.1.4",
     "jquery-file-upload": "9.5.6",
     "jquery-hammerjs": "1.0.1",
     "jquery-ui": "1.11.4",

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -17,7 +17,7 @@
     "jquery": "1.11.2",
     "jquery-file-upload": "9.5.6",
     "jquery-hammerjs": "1.0.1",
-    "jquery-ui": "1.10.4",
+    "jquery-ui": "1.11.4",
     "jqueryui-touch-punch": "furf/jquery-ui-touch-punch",
     "keymaster": "1.6.3",
     "loader.js": "3.2.1",

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -2,6 +2,7 @@
   "name": "ghost",
   "dependencies": {
     "blueimp-md5": "1.1.0",
+    "bootstrap-tokenfield": "0.12.1",
     "codemirror": "5.2.0",
     "devicejs": "0.2.7",
     "ember": "1.13.2",
@@ -27,7 +28,8 @@
     "rangyinputs": "1.2.0",
     "showdown-ghost": "0.3.6",
     "sinonjs": "1.14.1",
-    "typeahead.js": "0.11.1",
+    "typeahead.js": "0.10.5",
+    "typeahead.js-es6-shim": "0.10.5",
     "validator-js": "3.39.0",
     "xregexp": "2.0.0"
   }

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -33,6 +33,7 @@
     "ember-cli-mocha": "^0.7.0",
     "ember-cli-simple-auth": "0.8.0",
     "ember-cli-simple-auth-oauth2": "0.8.0",
+    "ember-cli-styleless-tokenfield": "https://github.com/kevinansfield/ember-cli-styleless-tokenfield/tarball/55b6f81253d5e65bbfa5f6b972393e74db56f5e9",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",
     "ember-export-application-global": "^1.0.2",


### PR DESCRIPTION
@acburdine did some excellent work re-working the old tag input however there were still a number of edge cases and UI inconsistencies.

This is an attempt to leverage the existing bootstrap-tokenfield plugin with typeahead support and to further separate post/tags/input concerns.

TODO:
- [ ] Fix occasional issues arising from the async add/remove tag behaviour
- [ ] Fix issue with only the first autocomplete item appearing as a typeahead hint
- [ ] Fix previously added tag name re-appearing in the input field (introduced after delegating tag management to action)
- [ ] Fix issue with autocomplete list showing items with no matches (introduced after delegating tag management to action)
- [ ] Clean up the CSS
- [ ] Split re-usable elements of the token field into a separate component (ie. `gh-tags-input` and `gh-tokenfield-input`)
- [ ] Tests
- [ ] Remove old tag input code
