### PR TITLE
Fix occasional `Cannot read property 'val' of undefined` errors in console

### DIFF
--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -248,6 +248,13 @@ export default Ember.Mixin.create({
 
             options = options || {};
 
+            // when navigating quickly between pages autoSave will occasionally
+            // try to run after the editor has been torn down so bail out here
+            // before we throw errors
+            if (!this.get('editor').$()) {
+                return 0;
+            }
+
             this.toggleProperty('submitting');
 
             if (options.backgroundSave) {


### PR DESCRIPTION
issue #5659
- Guard against missing editor element in editor-base-controller.save
- Fixes occasional issue with `Uncaught TypeError: Cannot read property 'val' of undefined` errors appearing when navigating quickly to/from the editor. I traced the `save` action calls back to the `autoSave` method - it may warrant further investigation to find out why the throttled/debounced calls are sometimes made when the editor element is non-existent.
