### PR TITLE
Fix occasional issue with editor not rendering

### DIFF
--- a/core/client/app/components/gh-editor.js
+++ b/core/client/app/components/gh-editor.js
@@ -41,7 +41,7 @@ export default Ember.Component.extend({
     // scrollPosition value such that when either scrolling or typing-at-the-end of the text editor the preview pane
     // stays in sync
     scrollPosition: Ember.computed('editorScrollInfo', 'height', function () {
-        if (!this.get('editorScrollInfo')) {
+        if (!this.get('editorScrollInfo') || !this.get('$previewContent') || !this.get('$previewViewPort')) {
             return 0;
         }
 


### PR DESCRIPTION
issue #5659
- guard against missing $previewContent/ViewPort in gh-editor.scrollPosition
- fixes occasional issue with editor not rendering due to scrollPosition being requested before the relevant jquery elements have been set
