### PR TITLE
Fix auto width and height of spin button

### DIFF
--- a/core/client/app/components/gh-spin-button.js
+++ b/core/client/app/components/gh-spin-button.js
@@ -4,6 +4,7 @@ export default Ember.Component.extend({
     tagName: 'button',
     buttonText: '',
     submitting: false,
+    showSpinner: false,
     autoWidth: true,
 
     // Disable Button when isLoading equals true
@@ -20,19 +21,14 @@ export default Ember.Component.extend({
         return true;
     },
 
-    setSize: function () {
-        if (!this.get('submitting') && this.get('autoWidth')) {
-            // this exists so that the spinner doesn't change the size of the button
-            this.$().width(this.$().width()); // sets width of button
-            this.$().height(this.$().height()); // sets height of button
+    setSize: Ember.observer('submitting', function () {
+        if (this.get('submitting') && this.get('autoWidth')) {
+            this.$().width(this.$().width());
+            this.$().height(this.$().height());
+        } else {
+            this.$().width('');
+            this.$().height('');
         }
-    },
-
-    width: Ember.observer('buttonText', 'autoWidth', function () {
-        this.setSize();
-    }),
-
-    didInsertElement: function () {
-        this.setSize();
-    }
+        this.set('showSpinner', this.get('submitting'));
+    })
 });

--- a/core/client/app/templates/components/gh-spin-button.hbs
+++ b/core/client/app/templates/components/gh-spin-button.hbs
@@ -1,9 +1,9 @@
-{{#unless submitting}}
+{{#if showSpinner}}
+    <span class="spinner"></span>
+{{else}}
     {{#if buttonText}}
         {{buttonText}}
     {{else}}
         {{{yield}}}
     {{/if}}
-{{else}}
-    <span class="spinner"></span>
-{{/unless}}
+{{/if}}


### PR DESCRIPTION
refs #5652
- changes the spin-button so that it only sets the size when the button is submitting instead of all of the time

@JohnONolan this might also fix the random spinning that you've seen occurring on the editor page. Also, I noticed a slight discrepancy between the height of the button and the height of the dropdown toggle box in the editor save button, which seems to exist on master.
