### PR TITLE
Adds 'button' role to toggle menu icon for better a11y

### DIFF
--- a/core/client/app/templates/components/gh-menu-toggle.hbs
+++ b/core/client/app/templates/components/gh-menu-toggle.hbs
@@ -1,1 +1,1 @@
-<i class="{{iconClass}}"></i>
+<i class="{{iconClass}}" role="button"></i>


### PR DESCRIPTION
closes #5696
- adds button role to toggle icon on new zelda menu

new experience using `vimperator`:
![ghost-i11y-toggle-fixed](https://cloud.githubusercontent.com/assets/675397/9381737/5d088764-473a-11e5-9c69-4d9a830b49db.gif)
