### PR TITLE
Mobile nav menu fixes

### DIFF
--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -48,6 +48,10 @@ export default Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
             });
         },
 
+        didTransition: function () {
+            this.send('closeMenus');
+        },
+
         signedIn: function () {
             this.send('loadServerNotifications', true);
         },

--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -5,7 +5,7 @@
 
     <div class="gh-viewport {{if autoNav 'gh-autonav'}} {{if showSettingsMenu 'settings-menu-expanded'}} {{if showMobileMenu 'mobile-menu-expanded'}}">
         {{#unless signedOut}}
-            {{gh-nav-menu open=autoNavOpen onMouseEnter="openAutoNav" toggleMaximise="toggleAutoNav" openModal="openModal"}}
+            {{gh-nav-menu open=autoNavOpen onMouseEnter="openAutoNav" toggleMaximise="toggleAutoNav" openModal="openModal" closeMobileMenu="closeMobileMenu"}}
         {{/unless}}
 
         {{#gh-main onMouseEnter="closeAutoNav" data-notification-count=topNotificationCount}}


### PR DESCRIPTION
issue #5483 & #5652
- trigger the close menus action every time a route transition is successful
- close nav menu when clicking "collapse sidebar" button (action chain was incomplete)
