### PR TITLE
Fixes for sign-in error handling

### DIFF
--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -27,6 +27,14 @@ export default Ember.Controller.extend(ValidationEngine, {
 
                 if (err.errors) {
                     self.set('flowErrors', err.errors[0].message.string);
+
+                    if (err.errors[0].message.string.match(/no user with that email/)) {
+                        self.get('model.errors').add('identification', '');
+                    }
+
+                    if (err.errors[0].message.string.match(/password is incorrect/)) {
+                        self.get('model.errors').add('password', '');
+                    }
                 }
                 // if authentication fails a rejected promise will be returned.
                 // it needs to be caught so it doesn't generate an exception in the console,
@@ -41,7 +49,7 @@ export default Ember.Controller.extend(ValidationEngine, {
             // browsers and password managers that don't send proper events on autofill
             $('#login').find('input').trigger('change');
 
-            this.validate().then(function () {
+            this.validate({property: 'signin'}).then(function () {
                 self.get('notifications').closeNotifications();
                 self.toggleProperty('loggingIn');
                 self.send('authenticate');
@@ -60,7 +68,7 @@ export default Ember.Controller.extend(ValidationEngine, {
                 self = this;
 
             this.set('flowErrors', '');
-            this.validate({property: 'identification'}).then(function () {
+            this.validate({property: 'forgotPassword'}).then(function () {
                 self.toggleProperty('submitting');
 
                 ajax({
@@ -77,7 +85,13 @@ export default Ember.Controller.extend(ValidationEngine, {
                 }).catch(function (resp) {
                     self.toggleProperty('submitting');
                     if (resp && resp.jqXHR && resp.jqXHR.responseJSON && resp.jqXHR.responseJSON.errors) {
-                        self.set('flowErrors', resp.jqXHR.responseJSON.errors[0].message);
+                        var message = resp.jqXHR.responseJSON.errors[0].message;
+
+                        self.set('flowErrors', message);
+
+                        if (message.match(/no user with that email/)) {
+                            self.get('model.errors').add('identification', '');
+                        }
                     } else {
                         notifications.showAPIError(resp, {defaultErrorText: 'There was a problem with the reset, please try again.'});
                     }

--- a/core/client/app/styles/layouts/auth.css
+++ b/core/client/app/styles/layouts/auth.css
@@ -26,6 +26,10 @@
     position: relative;
 }
 
+.forgotten-wrap input {
+    padding-right: 7rem;
+}
+
 .forgotten-wrap .forgotten-link {
     position: absolute;
     top: 10px;

--- a/core/client/app/templates/signin.hbs
+++ b/core/client/app/templates/signin.hbs
@@ -4,13 +4,13 @@
             <form id="login" class="gh-signin" method="post" novalidate="novalidate" {{action "validateAndAuthenticate" on="submit"}}>
                 {{#gh-form-group errors=model.errors property="identification"}}
                     <span class="input-icon icon-mail">
-                        {{gh-trim-focus-input class="gh-input email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" value=model.identification focusOut=(action "validate" "identification")}}
+                        {{gh-trim-focus-input class="gh-input email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" value=model.identification}}
                     </span>
                     {{gh-error-message errors=model.errors property="identification"}}
                 {{/gh-form-group}}
                 {{#gh-form-group errors=model.errors property="password"}}
                     <span class="input-icon icon-lock forgotten-wrap">
-                        {{input class="gh-input password" type="password" placeholder="Password" name="password" tabindex="2" value=model.password focusOut=(action "validate" "password")}}
+                        {{input class="gh-input password" type="password" placeholder="Password" name="password" tabindex="2" value=model.password}}
                         <button type="button" {{action "forgotten"}} class="forgotten-link btn btn-link"  tabindex="4" disabled={{submitting}}>Forgot?</button>
                     </span>
                     {{gh-error-message errors=model.errors property="password"}}

--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -1,23 +1,41 @@
 import BaseValidator from './base';
 
 var SigninValidator = BaseValidator.create({
-    properties: ['identification', 'password'],
+    properties: ['identification', 'signin', 'forgotPassword'],
+
     identification: function (model) {
         var id = model.get('identification');
 
-        if (validator.empty(id)) {
-            model.get('errors').add('identification', 'Please enter an email');
-            this.invalidate();
-        } else if (!validator.isEmail(id)) {
+        if (!validator.empty(id) && !validator.isEmail(id)) {
             model.get('errors').add('identification', 'Invalid email');
             this.invalidate();
         }
     },
-    password: function (model) {
-        var password = model.get('password') || '';
 
-        if (!validator.isLength(password, 1)) {
-            model.get('errors').add('password', 'Please enter a password');
+    signin: function (model) {
+        var id = model.get('identification'),
+            password = model.get('password');
+
+        model.get('errors').clear();
+
+        if (validator.empty(id)) {
+            model.get('errors').add('identification', '');
+            this.invalidate();
+        }
+
+        if (validator.empty(password)) {
+            model.get('errors').add('password', '');
+            this.invalidate();
+        }
+    },
+
+    forgotPassword: function (model) {
+        var id = model.get('identification');
+
+        model.get('errors').clear();
+
+        if (validator.empty(id) || !validator.isEmail(id)) {
+            model.get('errors').add('identification', '');
             this.invalidate();
         }
     }


### PR DESCRIPTION
issue #5652, closes #5641

Two of the audit items were about errors showing when fields were empty and there not being enough space for validation messages.

Seeing as for the signup form we have a separate error message below the submit button I've tried to solve both issues by removing the inline messages and creating separate validation functions for sign-in and sign-up so that the relevant fields are still highlighted.

@JohnONolan, @ErisDS: Does this alternative process work for you or do we still want inline messages in some cases?
- removes inline errors for empty fields
- removes on-blur validation, instead only performing validation on submit
- separate validation routines for sign-in and forgot password
- highlight fields with errors when trying to submit
- adds a fix for "forgot" link overlapping long passwords and the new safari keychain icon (#5641)

TODO:
- [x] Update tests
