### PR TITLE
Fix release build issues.

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -27,7 +27,7 @@ app = new EmberApp({
         source: './app/styles/app.css',
         inputFile: 'app.css',
         browsers: 'last 2 versions',
-        outputFile: 'ghost.css'
+        outputFile: isProduction ? 'ghost.min.css' : 'ghost.css'
     },
     hinting: false,
     fingerprint: disabled

--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -1,7 +1,9 @@
 /* global require, module */
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app'),
-    isProduction = EmberApp.env() === 'production',
+    environment = EmberApp.env(),
+    isProduction = environment === 'production',
+    mythCompress = isProduction || environment === 'test',
     disabled = {enabled: false},
     assetLocation,
     app;
@@ -27,6 +29,8 @@ app = new EmberApp({
         source: './app/styles/app.css',
         inputFile: 'app.css',
         browsers: 'last 2 versions',
+        sourcemap: !mythCompress,
+        compress: mythCompress,
         outputFile: isProduction ? 'ghost.min.css' : 'ghost.css'
     },
     hinting: false,

--- a/core/client/config/environment.js
+++ b/core/client/config/environment.js
@@ -41,9 +41,6 @@ module.exports = function (environment) {
         ENV.APP.LOG_TRANSITIONS = true;
         ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
         ENV.APP.LOG_VIEW_LOOKUPS = true;
-        ENV.mythOptions = {
-            sourcemap: true
-        };
     }
 
     if (environment === 'test') {
@@ -56,17 +53,6 @@ module.exports = function (environment) {
         ENV.APP.LOG_VIEW_LOOKUPS = false;
 
         ENV.APP.rootElement = '#ember-testing';
-        ENV.mythOptions = {
-            compress: true,
-            outputFile: 'ghost.min.css'
-        };
-    }
-
-    if (environment === 'production') {
-        ENV.mythOptions = {
-            compress: true,
-            outputFile: 'ghost.min.css'
-        };
     }
 
     return ENV;

--- a/core/client/lib/asset-delivery/index.js
+++ b/core/client/lib/asset-delivery/index.js
@@ -2,15 +2,20 @@ module.exports = {
     name: 'asset-delivery',
     postBuild: function (results) {
         var fs = this.project.require('fs-extra'),
-            cpd = this.project.require('ember-cli-copy-dereference'),
+            walkSync = this.project.require('walk-sync'),
+            assetsIn = results.directory + '/assets',
             templateOut = '../server/views/default.hbs',
-            assetsOut = '../built/assets';
+            assetsOut = '../built/assets',
+            assets = walkSync(assetsIn);
 
-        fs.removeSync(templateOut);
-        fs.removeSync(assetsOut);
         fs.ensureDirSync(assetsOut);
 
-        cpd.sync(results.directory + '/index.html', templateOut);
-        cpd.sync(results.directory + '/assets', assetsOut);
+        fs.copySync(results.directory + '/index.html', templateOut, {clobber: true});
+
+        assets.forEach(function (relativePath) {
+            if (relativePath.slice(-1) === '/') { return; }
+
+            fs.copySync(assetsIn + '/' + relativePath, assetsOut + '/' + relativePath, {clobber:true});
+        });
     }
 };

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -24,7 +24,6 @@
     "ember-cli-app-version": "0.3.3",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-copy-dereference": "1.0.0",
     "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-fastclick": "1.0.3",
     "ember-cli-htmlbars": "0.7.6",
@@ -39,7 +38,8 @@
     "ember-myth": "0.1.1",
     "ember-sinon": "0.2.1",
     "fs-extra": "0.16.3",
-    "glob": "^4.0.5"
+    "glob": "^4.0.5",
+    "walk-sync": "^0.1.3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
Fixes #5695.

https://github.com/TryGhost/Ghost/pull/5382 changed the initial intent of the asset delivery addon, from merging the output of each build to clearing the `core/built/` dir.  This lead to one of the issues described in #5695 (where both min and non-min files are not present in `core/built/assets`).
