### PR TITLE
Standardize on var-less `export default` across ember app

### DIFF
--- a/core/client/app/adapters/application.js
+++ b/core/client/app/adapters/application.js
@@ -1,5 +1,3 @@
 import EmbeddedRelationAdapter from 'ghost/adapters/embedded-relation-adapter';
 
-var ApplicationAdapter = EmbeddedRelationAdapter.extend();
-
-export default ApplicationAdapter;
+export default EmbeddedRelationAdapter.extend();

--- a/core/client/app/adapters/base.js
+++ b/core/client/app/adapters/base.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 import ghostPaths from 'ghost/utils/ghost-paths';
 
-var BaseAdapter = DS.RESTAdapter.extend({
+export default DS.RESTAdapter.extend({
     host: window.location.origin,
     namespace: ghostPaths().apiRoot.slice(1),
 
@@ -41,5 +41,3 @@ var BaseAdapter = DS.RESTAdapter.extend({
         });
     }
 });
-
-export default BaseAdapter;

--- a/core/client/app/adapters/embedded-relation-adapter.js
+++ b/core/client/app/adapters/embedded-relation-adapter.js
@@ -11,7 +11,7 @@ import BaseAdapter from 'ghost/adapters/base';
 // If a model has an embedded hasMany relation, the related type will be included:
 // roles: DS.hasMany('role', { embedded: 'always' }) => ?include=roles
 
-var EmbeddedRelationAdapter = BaseAdapter.extend({
+export default BaseAdapter.extend({
     find: function (store, type, id) {
         return this.ajax(this.buildIncludeURL(store, type, id), 'GET');
     },
@@ -119,5 +119,3 @@ var EmbeddedRelationAdapter = BaseAdapter.extend({
         return ret;
     }
 });
-
-export default EmbeddedRelationAdapter;

--- a/core/client/app/adapters/setting.js
+++ b/core/client/app/adapters/setting.js
@@ -1,6 +1,6 @@
 import ApplicationAdapter from 'ghost/adapters/application';
 
-var SettingAdapter = ApplicationAdapter.extend({
+export default ApplicationAdapter.extend({
     updateRecord: function (store, type, record) {
         var data = {},
             serializer = store.serializerFor(type.modelName);
@@ -17,5 +17,3 @@ var SettingAdapter = ApplicationAdapter.extend({
         return this.ajax(this.buildURL(type.modelName), 'PUT', {data: data});
     }
 });
-
-export default SettingAdapter;

--- a/core/client/app/adapters/user.js
+++ b/core/client/app/adapters/user.js
@@ -1,9 +1,7 @@
 import ApplicationAdapter from 'ghost/adapters/application';
 
-var UserAdapter = ApplicationAdapter.extend({
+export default ApplicationAdapter.extend({
     find: function (store, type, id) {
         return this.findQuery(store, type, {id: id, status: 'all'});
     }
 });
-
-export default UserAdapter;

--- a/core/client/app/assets/lib/uploader.js
+++ b/core/client/app/assets/lib/uploader.js
@@ -1,7 +1,6 @@
 import ghostPaths from 'ghost/utils/ghost-paths';
 
 var UploadUi,
-    upload,
     Ghost = ghostPaths();
 
 UploadUi = function ($dropzone, settings) {
@@ -248,7 +247,7 @@ UploadUi = function ($dropzone, settings) {
     });
 };
 
-upload = function (options) {
+export default function (options) {
     var settings = $.extend({
         progressbar: true,
         editor: false,
@@ -263,6 +262,4 @@ upload = function (options) {
         this.uploaderUi = ui;
         ui.init();
     });
-};
-
-export default upload;
+}

--- a/core/client/app/components/gh-blog-url.js
+++ b/core/client/app/components/gh-blog-url.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
-var blogUrl = Ember.Component.extend({
+export default Ember.Component.extend({
     tagName: '',
     config: Ember.inject.service()
 });
-
-export default blogUrl;

--- a/core/client/app/components/gh-cm-editor.js
+++ b/core/client/app/components/gh-cm-editor.js
@@ -1,7 +1,7 @@
 /* global CodeMirror */
 import Ember from 'ember';
 
-var CodeMirrorEditor = Ember.Component.extend({
+export default Ember.Component.extend({
 
     // DOM stuff
     classNameBindings: ['isFocused:focused'],
@@ -44,5 +44,3 @@ var CodeMirrorEditor = Ember.Component.extend({
     }
 
 });
-
-export default CodeMirrorEditor;

--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import uploader from 'ghost/assets/lib/uploader';
 
-var Preview = Ember.Component.extend({
+export default Ember.Component.extend({
     config: Ember.inject.service(),
 
     didInsertElement: function () {
@@ -41,5 +41,3 @@ var Preview = Ember.Component.extend({
         Ember.run.scheduleOnce('afterRender', this, this.dropzoneHandler);
     })
 });
-
-export default Preview;

--- a/core/client/app/components/gh-input.js
+++ b/core/client/app/components/gh-input.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import TextInputMixin from 'ghost/mixins/text-input';
 
-var Input = Ember.TextField.extend(TextInputMixin, {
+export default Ember.TextField.extend(TextInputMixin, {
     classNames: 'gh-input'
 });
-
-export default Input;

--- a/core/client/app/components/gh-modal-dialog.js
+++ b/core/client/app/components/gh-modal-dialog.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var ModalDialog = Ember.Component.extend({
+
+export default Ember.Component.extend({
     didInsertElement: function () {
         this.$('.js-modal-container, .js-modal-background').addClass('fade-in open');
         this.$('.js-modal').addClass('open');
@@ -56,5 +57,3 @@ var ModalDialog = Ember.Component.extend({
         return this.get('confirm.reject.buttonClass') ? this.get('confirm.reject.buttonClass') : 'btn btn-red';
     })
 });
-
-export default ModalDialog;

--- a/core/client/app/components/gh-tab-pane.js
+++ b/core/client/app/components/gh-tab-pane.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+
 // See gh-tabs-manager.js for use
-var TabPane = Ember.Component.extend({
+export default Ember.Component.extend({
     classNameBindings: ['active'],
 
     tabsManager: Ember.computed(function () {
@@ -26,5 +27,3 @@ var TabPane = Ember.Component.extend({
         this.get('tabsManager').unregisterTabPane(this);
     }
 });
-
-export default TabPane;

--- a/core/client/app/components/gh-tab.js
+++ b/core/client/app/components/gh-tab.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
+
 // See gh-tabs-manager.js for use
-var Tab = Ember.Component.extend({
+export default Ember.Component.extend({
     tabsManager: Ember.computed(function () {
         return this.nearestWithProperty('isTabsManager');
     }),
@@ -28,5 +29,3 @@ var Tab = Ember.Component.extend({
         this.get('tabsManager').unregisterTab(this);
     }
 });
-
-export default Tab;

--- a/core/client/app/components/gh-tabs-manager.js
+++ b/core/client/app/components/gh-tabs-manager.js
@@ -48,7 +48,7 @@ Both tab and tab-pane elements have an "active"
 class applied when they are active.
 
 */
-var TabsManager = Ember.Component.extend({
+export default Ember.Component.extend({
     activeTab: null,
     tabs: [],
     tabPanes: [],
@@ -80,5 +80,3 @@ var TabsManager = Ember.Component.extend({
         this.get('tabPanes').removeObject(tabPane);
     }
 });
-
-export default TabsManager;

--- a/core/client/app/components/gh-textarea.js
+++ b/core/client/app/components/gh-textarea.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import TextInputMixin from 'ghost/mixins/text-input';
 
-var TextArea = Ember.TextArea.extend(TextInputMixin, {
+export default Ember.TextArea.extend(TextInputMixin, {
     classNames: 'gh-input'
 });
-
-export default TextArea;

--- a/core/client/app/components/gh-trim-focus-input.js
+++ b/core/client/app/components/gh-trim-focus-input.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 /*global device*/
-var TrimFocusInput = Ember.TextField.extend({
+
+export default Ember.TextField.extend({
     focus: true,
     classNames: 'gh-input',
     attributeBindings: ['autofocus'],
@@ -26,5 +27,3 @@ var TrimFocusInput = Ember.TextField.extend({
         this.$().val(text.trim());
     })
 });
-
-export default TrimFocusInput;

--- a/core/client/app/components/gh-upload-modal.js
+++ b/core/client/app/components/gh-upload-modal.js
@@ -3,7 +3,7 @@ import ModalDialog from 'ghost/components/gh-modal-dialog';
 import upload from 'ghost/assets/lib/uploader';
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-var UploadModal = ModalDialog.extend({
+export default ModalDialog.extend({
     layoutName: 'components/gh-modal-dialog',
 
     config: Ember.inject.service(),
@@ -73,5 +73,3 @@ var UploadModal = ModalDialog.extend({
         }
     }
 });
-
-export default UploadModal;

--- a/core/client/app/components/gh-url-preview.js
+++ b/core/client/app/components/gh-url-preview.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 Example usage:
 {{gh-url-preview prefix="tag" slug=theSlugValue tagName="p" classNames="description"}}
 */
-var urlPreview = Ember.Component.extend({
+export default Ember.Component.extend({
     classNames: 'ghost-url-preview',
     prefix: null,
     slug: null,
@@ -25,5 +25,3 @@ var urlPreview = Ember.Component.extend({
         return theUrl;
     })
 });
-
-export default urlPreview;

--- a/core/client/app/controllers/about.js
+++ b/core/client/app/controllers/about.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var AboutController = Ember.Controller.extend({
+
+export default Ember.Controller.extend({
     updateNotificationCount: 0,
 
     actions: {
@@ -8,5 +9,3 @@ var AboutController = Ember.Controller.extend({
         }
     }
 });
-
-export default AboutController;

--- a/core/client/app/controllers/editor/new.js
+++ b/core/client/app/controllers/editor/new.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
 
-var EditorNewController = Ember.Controller.extend(EditorControllerMixin, {
+export default Ember.Controller.extend(EditorControllerMixin, {
     // Overriding autoSave on the base controller, as the new controller shouldn't be autosaving
     autoSave: Ember.K,
     actions: {
@@ -18,5 +18,3 @@ var EditorNewController = Ember.Controller.extend(EditorControllerMixin, {
         }
     }
 });
-
-export default EditorNewController;

--- a/core/client/app/controllers/error.js
+++ b/core/client/app/controllers/error.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var ErrorController = Ember.Controller.extend({
+
+export default Ember.Controller.extend({
     code: Ember.computed('content.status', function () {
         return this.get('content.status') > 200 ? this.get('content.status') : 500;
     }),
@@ -12,5 +13,3 @@ var ErrorController = Ember.Controller.extend({
     }),
     stack: false
 });
-
-export default ErrorController;

--- a/core/client/app/controllers/feature.js
+++ b/core/client/app/controllers/feature.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var FeatureController = Ember.Controller.extend(Ember.PromiseProxyMixin, {
+
+export default Ember.Controller.extend(Ember.PromiseProxyMixin, {
     init: function () {
         var promise;
 
@@ -26,5 +27,3 @@ var FeatureController = Ember.Controller.extend(Ember.PromiseProxyMixin, {
         return value;
     })
 });
-
-export default FeatureController;

--- a/core/client/app/helpers/gh-count-characters.js
+++ b/core/client/app/helpers/gh-count-characters.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var countCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     var el = document.createElement('span'),
         length,
         content;
@@ -23,5 +24,3 @@ var countCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams
 
     return Ember.String.htmlSafe(el.outerHTML);
 });
-
-export default countCharacters;

--- a/core/client/app/helpers/gh-count-down-characters.js
+++ b/core/client/app/helpers/gh-count-down-characters.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var countDownCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     var el = document.createElement('span'),
         content,
         maxCharacters,
@@ -25,5 +26,3 @@ var countDownCharacters = Ember.HTMLBars.makeBoundHelper(function (arr /* hashPa
 
     return Ember.String.htmlSafe(el.outerHTML);
 });
-
-export default countDownCharacters;

--- a/core/client/app/helpers/gh-count-words.js
+++ b/core/client/app/helpers/gh-count-words.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import counter from 'ghost/utils/word-count';
 
-var countWords = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     if (!arr || !arr.length) {
         return;
     }
@@ -19,5 +19,3 @@ var countWords = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) 
 
     return count + (count === 1 ? ' word' : ' words');
 });
-
-export default countWords;

--- a/core/client/app/helpers/gh-format-html.js
+++ b/core/client/app/helpers/gh-format-html.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 /* global html_sanitize*/
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-var formatHTML = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     if (!arr || !arr.length) {
         return;
     }
@@ -22,5 +22,3 @@ var formatHTML = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) 
 
     return Ember.String.htmlSafe(escapedhtml);
 });
-
-export default formatHTML;

--- a/core/client/app/helpers/gh-format-markdown.js
+++ b/core/client/app/helpers/gh-format-markdown.js
@@ -2,12 +2,9 @@ import Ember from 'ember';
 /* global Showdown, html_sanitize*/
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-var showdown,
-    formatMarkdown;
+var showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
 
-showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
-
-formatMarkdown = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     if (!arr || !arr.length) {
         return;
     }
@@ -31,5 +28,3 @@ formatMarkdown = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) 
 
     return Ember.String.htmlSafe(escapedhtml);
 });
-
-export default formatMarkdown;

--- a/core/client/app/helpers/gh-format-timeago.js
+++ b/core/client/app/helpers/gh-format-timeago.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var formatTimeago = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
+
+export default Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams */) {
     if (!arr || !arr.length) {
         return;
     }
@@ -11,5 +12,3 @@ var formatTimeago = Ember.HTMLBars.makeBoundHelper(function (arr /* hashParams *
     // For large numbers moment sucks => single Ember.Object based clock better
     // https://github.com/manuelmitasch/ghost-admin-ember-demo/commit/fba3ab0a59238290c85d4fa0d7c6ed1be2a8a82e#commitcomment-5396524
 });
-
-export default formatTimeago;

--- a/core/client/app/initializers/trailing-history.js
+++ b/core/client/app/initializers/trailing-history.js
@@ -1,10 +1,7 @@
 import Ember from 'ember';
 /*global Ember */
 
-var trailingHistory,
-    registerTrailingLocationHistory;
-
-trailingHistory = Ember.HistoryLocation.extend({
+var trailingHistory = Ember.HistoryLocation.extend({
     formatURL: function () {
         // jscs: disable
         return this._super.apply(this, arguments).replace(/\/?$/, '/');
@@ -12,12 +9,10 @@ trailingHistory = Ember.HistoryLocation.extend({
     }
 });
 
-registerTrailingLocationHistory = {
+export default {
     name: 'registerTrailingLocationHistory',
 
     initialize: function (container, application) {
         application.register('location:trailing-history', trailingHistory);
     }
 };
-
-export default registerTrailingLocationHistory;

--- a/core/client/app/instance-initializers/authentication.js
+++ b/core/client/app/instance-initializers/authentication.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-var AuthenticationInitializer = {
+export default {
     name: 'authentication',
 
     initialize: function (instance) {
@@ -14,5 +14,3 @@ var AuthenticationInitializer = {
         });
     }
 };
-
-export default AuthenticationInitializer;

--- a/core/client/app/mixins/body-event-listener.js
+++ b/core/client/app/mixins/body-event-listener.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 // Code modified from Addepar/ember-widgets
 // https://github.com/Addepar/ember-widgets/blob/master/src/mixins.coffee#L39
 
-var BodyEventListener = Ember.Mixin.create({
+export default Ember.Mixin.create({
     bodyElementSelector: 'html',
     bodyClick: Ember.K,
 
@@ -43,5 +43,3 @@ var BodyEventListener = Ember.Mixin.create({
         return event.stopPropagation();
     }
 });
-
-export default BodyEventListener;

--- a/core/client/app/mixins/current-user-settings.js
+++ b/core/client/app/mixins/current-user-settings.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var CurrentUserSettings = Ember.Mixin.create({
+
+export default Ember.Mixin.create({
     transitionAuthor: function () {
         var self = this;
 
@@ -24,5 +25,3 @@ var CurrentUserSettings = Ember.Mixin.create({
         };
     }
 });
-
-export default CurrentUserSettings;

--- a/core/client/app/mixins/dropdown-mixin.js
+++ b/core/client/app/mixins/dropdown-mixin.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 /*
   Dropdowns and their buttons are evented and do not propagate clicks.
 */
-var DropdownMixin = Ember.Mixin.create(Ember.Evented, {
+export default Ember.Mixin.create(Ember.Evented, {
     classNameBindings: ['isOpen:open:closed'],
     isOpen: false,
 
@@ -12,5 +12,3 @@ var DropdownMixin = Ember.Mixin.create(Ember.Evented, {
         return event.stopPropagation();
     }
 });
-
-export default DropdownMixin;

--- a/core/client/app/mixins/ed-editor-api.js
+++ b/core/client/app/mixins/ed-editor-api.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-var EditorAPI = Ember.Mixin.create({
+export default Ember.Mixin.create({
     /**
      * Get Value
      *
@@ -132,5 +132,3 @@ var EditorAPI = Ember.Mixin.create({
         this.sendAction('onChange');
     }
 });
-
-export default EditorAPI;

--- a/core/client/app/mixins/ed-editor-scroll.js
+++ b/core/client/app/mixins/ed-editor-scroll.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
 
-var EditorScroll = Ember.Mixin.create({
+export default Ember.Mixin.create({
     /**
      * Determine if the cursor is at the end of the textarea
      */
@@ -102,5 +101,3 @@ var EditorScroll = Ember.Mixin.create({
         this.detachScrollHandlers();
     }
 });
-
-export default EditorScroll;

--- a/core/client/app/mixins/ed-editor-shortcuts.js
+++ b/core/client/app/mixins/ed-editor-shortcuts.js
@@ -3,8 +3,7 @@ import Ember from 'ember';
 import titleize from 'ghost/utils/titleize';
 
 var simpleShortcutSyntax,
-    shortcuts,
-    EditorShortcuts;
+    shortcuts;
 
 // Used for simple, noncomputational replace-and-go! shortcuts.
 // See default case in shortcut function below.
@@ -137,7 +136,7 @@ shortcuts = {
     }
 };
 
-EditorShortcuts = Ember.Mixin.create({
+export default Ember.Mixin.create({
     shortcut: function (type) {
         var selection = this.getSelection(),
             replacement = {
@@ -171,5 +170,3 @@ EditorShortcuts = Ember.Mixin.create({
         }
     }
 });
-
-export default EditorShortcuts;

--- a/core/client/app/mixins/editor-base-route.js
+++ b/core/client/app/mixins/editor-base-route.js
@@ -3,7 +3,7 @@ import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import styleBody from 'ghost/mixins/style-body';
 import editorShortcuts from 'ghost/utils/editor-shortcuts';
 
-var EditorBaseRoute = Ember.Mixin.create(styleBody, ShortcutsRoute, {
+export default Ember.Mixin.create(styleBody, ShortcutsRoute, {
     classNames: ['editor'],
 
     actions: {
@@ -135,5 +135,3 @@ var EditorBaseRoute = Ember.Mixin.create(styleBody, ShortcutsRoute, {
         this.attachModelHooks(controller, model);
     }
 });
-
-export default EditorBaseRoute;

--- a/core/client/app/mixins/pagination-route.js
+++ b/core/client/app/mixins/pagination-route.js
@@ -1,13 +1,11 @@
 import Ember from 'ember';
-var defaultPaginationSettings,
-    PaginationRoute;
 
-defaultPaginationSettings = {
+var defaultPaginationSettings = {
     page: 1,
     limit: 15
 };
 
-PaginationRoute = Ember.Mixin.create({
+export default Ember.Mixin.create({
     /**
      * Sets up pagination details
      * @param {object} settings specifies additional pagination details
@@ -26,5 +24,3 @@ PaginationRoute = Ember.Mixin.create({
         this.controller.set('paginationSettings', settings);
     }
 });
-
-export default PaginationRoute;

--- a/core/client/app/mixins/shortcuts-route.js
+++ b/core/client/app/mixins/shortcuts-route.js
@@ -42,7 +42,7 @@ key.setScope('default');
  * To have all your shortcut work in all scopes, give it the scope "all".
  * Find out more at the keymaster docs
  */
-var ShortcutsRoute = Ember.Mixin.create({
+export default Ember.Mixin.create({
     registerShortcuts: function () {
         var self = this,
             shortcuts = this.get('shortcuts');
@@ -84,5 +84,3 @@ var ShortcutsRoute = Ember.Mixin.create({
         this.removeShortcuts();
     }
 });
-
-export default ShortcutsRoute;

--- a/core/client/app/mixins/style-body.js
+++ b/core/client/app/mixins/style-body.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 // mixin used for routes that need to set a css className on the body tag
 
-var styleBody = Ember.Mixin.create({
+export default Ember.Mixin.create({
     activate: function () {
         this._super();
 
@@ -28,5 +28,3 @@ var styleBody = Ember.Mixin.create({
         });
     }
 });
-
-export default styleBody;

--- a/core/client/app/mixins/text-input.js
+++ b/core/client/app/mixins/text-input.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var BlurField = Ember.Mixin.create({
+
+export default Ember.Mixin.create({
     selectOnClick: false,
     stopEnterKeyDownPropagation: false,
 
@@ -20,5 +21,3 @@ var BlurField = Ember.Mixin.create({
         }
     }
 });
-
-export default BlurField;

--- a/core/client/app/models/notification.js
+++ b/core/client/app/models/notification.js
@@ -1,9 +1,8 @@
 import DS from 'ember-data';
-var Notification = DS.Model.extend({
+
+export default DS.Model.extend({
     dismissible: DS.attr('boolean'),
     status: DS.attr('string'),
     type: DS.attr('string'),
     message: DS.attr('string')
 });
-
-export default Notification;

--- a/core/client/app/models/role.js
+++ b/core/client/app/models/role.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-var Role = DS.Model.extend({
+
+export default DS.Model.extend({
     uuid: DS.attr('string'),
     name: DS.attr('string'),
     description: DS.attr('string'),
@@ -13,5 +14,3 @@ var Role = DS.Model.extend({
         return this.get('name').toLocaleLowerCase();
     })
 });
-
-export default Role;

--- a/core/client/app/models/setting.js
+++ b/core/client/app/models/setting.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var Setting = DS.Model.extend(ValidationEngine, {
+export default DS.Model.extend(ValidationEngine, {
     validationType: 'setting',
 
     title: DS.attr('string'),
@@ -21,5 +21,3 @@ var Setting = DS.Model.extend(ValidationEngine, {
     isPrivate: DS.attr('boolean'),
     password: DS.attr('string')
 });
-
-export default Setting;

--- a/core/client/app/models/tag.js
+++ b/core/client/app/models/tag.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-var Tag = DS.Model.extend(ValidationEngine, {
+export default DS.Model.extend(ValidationEngine, {
     validationType: 'tag',
 
     uuid: DS.attr('string'),
@@ -19,5 +19,3 @@ var Tag = DS.Model.extend(ValidationEngine, {
     updated_by: DS.attr(),
     post_count: DS.attr('number')
 });
-
-export default Tag;

--- a/core/client/app/routes/authenticated.js
+++ b/core/client/app/routes/authenticated.js
@@ -1,6 +1,4 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixin';
 
-var AuthenticatedRoute = Ember.Route.extend(AuthenticatedRouteMixin);
-
-export default AuthenticatedRoute;
+export default Ember.Route.extend(AuthenticatedRouteMixin);

--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -3,7 +3,7 @@ import base from 'ghost/mixins/editor-base-route';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
-var EditorEditRoute = AuthenticatedRoute.extend(base, {
+export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
     beforeModel: function (transition) {
@@ -62,5 +62,3 @@ var EditorEditRoute = AuthenticatedRoute.extend(base, {
         }
     }
 });
-
-export default EditorEditRoute;

--- a/core/client/app/routes/editor/index.js
+++ b/core/client/app/routes/editor/index.js
@@ -1,8 +1,7 @@
 import Ember from 'ember';
-var EditorRoute = Ember.Route.extend({
+
+export default Ember.Route.extend({
     beforeModel: function () {
         this.transitionTo('editor.new');
     }
 });
-
-export default EditorRoute;

--- a/core/client/app/routes/error404.js
+++ b/core/client/app/routes/error404.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var Error404Route = Ember.Route.extend({
+
+export default Ember.Route.extend({
     controllerName: 'error',
     templateName: 'error',
     titleToken: 'Error',
@@ -10,5 +11,3 @@ var Error404Route = Ember.Route.extend({
         };
     }
 });
-
-export default Error404Route;

--- a/core/client/app/routes/mobile-index-route.js
+++ b/core/client/app/routes/mobile-index-route.js
@@ -4,7 +4,7 @@ import mobileQuery from 'ghost/utils/mobile';
 // Routes that extend MobileIndexRoute need to implement
 // desktopTransition, a function which is called when
 // the user resizes to desktop levels.
-var MobileIndexRoute = Ember.Route.extend({
+export default Ember.Route.extend({
     desktopTransition: Ember.K,
 
     activate: function attachDesktopTransition() {
@@ -26,5 +26,3 @@ var MobileIndexRoute = Ember.Route.extend({
         });
     })
 });
-
-export default MobileIndexRoute;

--- a/core/client/app/routes/posts/index.js
+++ b/core/client/app/routes/posts/index.js
@@ -2,7 +2,7 @@ import AuthenticatedRouteMixin from 'simple-auth/mixins/authenticated-route-mixi
 import MobileIndexRoute from 'ghost/routes/mobile-index-route';
 import mobileQuery from 'ghost/utils/mobile';
 
-var PostsIndexRoute = MobileIndexRoute.extend(AuthenticatedRouteMixin, {
+export default MobileIndexRoute.extend(AuthenticatedRouteMixin, {
     noPosts: false,
 
     // Transition to a specific post if we're not on mobile
@@ -46,5 +46,3 @@ var PostsIndexRoute = MobileIndexRoute.extend(AuthenticatedRouteMixin, {
         this.goToPost();
     }
 });
-
-export default PostsIndexRoute;

--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -3,7 +3,7 @@ import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
-var PostsPostRoute = AuthenticatedRoute.extend(ShortcutsRoute, {
+export default AuthenticatedRoute.extend(ShortcutsRoute, {
     model: function (params) {
         var self = this,
             post,
@@ -75,5 +75,3 @@ var PostsPostRoute = AuthenticatedRoute.extend(ShortcutsRoute, {
         }
     }
 });
-
-export default PostsPostRoute;

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -2,7 +2,7 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
 
-var NavigationRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
+export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Navigation',
 
     classNames: ['settings-view-navigation'],
@@ -29,5 +29,3 @@ var NavigationRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, 
         }
     }
 });
-
-export default NavigationRoute;

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -2,8 +2,7 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import PaginationRouteMixin from 'ghost/mixins/pagination-route';
 
-var TagsRoute,
-    paginationSettings;
+var paginationSettings;
 
 paginationSettings = {
     page: 1,
@@ -11,7 +10,7 @@ paginationSettings = {
     limit: 15
 };
 
-TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
+export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin, {
     titleToken: 'Settings - Tags',
 
     beforeModel: function (transition) {
@@ -45,5 +44,3 @@ TagsRoute = AuthenticatedRoute.extend(CurrentUserSettings, PaginationRouteMixin,
         this.controller.send('resetPagination');
     }
 });
-
-export default TagsRoute;

--- a/core/client/app/routes/setup/index.js
+++ b/core/client/app/routes/setup/index.js
@@ -1,9 +1,7 @@
 import Ember from 'ember';
 
-var SetupRoute = Ember.Route.extend({
+export default Ember.Route.extend({
     beforeModel: function () {
         this.transitionTo('setup.one');
     }
 });
-
-export default SetupRoute;

--- a/core/client/app/routes/signin.js
+++ b/core/client/app/routes/signin.js
@@ -3,7 +3,7 @@ import Configuration from 'simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 import DS from 'ember-data';
 
-var SigninRoute = Ember.Route.extend(styleBody, {
+export default Ember.Route.extend(styleBody, {
     titleToken: 'Sign In',
 
     classNames: ['ghost-login'],
@@ -33,5 +33,3 @@ var SigninRoute = Ember.Route.extend(styleBody, {
         controller.set('model.password', '');
     }
 });
-
-export default SigninRoute;

--- a/core/client/app/routes/team/user.js
+++ b/core/client/app/routes/team/user.js
@@ -2,7 +2,7 @@ import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
 
-var TeamUserRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
+export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Team - User',
 
     classNames: ['team-view-user'],
@@ -61,5 +61,3 @@ var TeamUserRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
         }
     }
 });
-
-export default TeamUserRoute;

--- a/core/client/app/serializers/application.js
+++ b/core/client/app/serializers/application.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import DS from 'ember-data';
-var ApplicationSerializer = DS.RESTSerializer.extend({
+
+export default DS.RESTSerializer.extend({
     serializeIntoHash: function (hash, type, record, options) {
         // Our API expects an id on the posted object
         options = options || {};
@@ -16,5 +17,3 @@ var ApplicationSerializer = DS.RESTSerializer.extend({
         hash[root] = [data];
     }
 });
-
-export default ApplicationSerializer;

--- a/core/client/app/serializers/post.js
+++ b/core/client/app/serializers/post.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
     // settings for the EmbeddedRecordsMixin.
     attrs: {
         tags: {embedded: 'always'}
@@ -52,5 +52,3 @@ var PostSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         hash[root] = [data];
     }
 });
-
-export default PostSerializer;

--- a/core/client/app/serializers/setting.js
+++ b/core/client/app/serializers/setting.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-var SettingSerializer = ApplicationSerializer.extend({
+export default ApplicationSerializer.extend({
     serializeIntoHash: function (hash, type, record, options) {
         // Settings API does not want ids
         options = options || {};
@@ -36,5 +36,3 @@ var SettingSerializer = ApplicationSerializer.extend({
         return this.extractArray(store, type, payload).pop();
     }
 });
-
-export default SettingSerializer;

--- a/core/client/app/serializers/tag.js
+++ b/core/client/app/serializers/tag.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-var TagSerializer = ApplicationSerializer.extend({
+export default ApplicationSerializer.extend({
     serializeIntoHash: function (hash, type, record, options) {
         options = options || {};
         options.includeId = true;
@@ -17,5 +17,3 @@ var TagSerializer = ApplicationSerializer.extend({
         hash[root] = [data];
     }
 });
-
-export default TagSerializer;

--- a/core/client/app/serializers/user.js
+++ b/core/client/app/serializers/user.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-var UserSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
     attrs: {
         roles: {embedded: 'always'}
     },
@@ -17,5 +17,3 @@ var UserSerializer = ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         return this._super.apply(this, arguments);
     }
 });
-
-export default UserSerializer;

--- a/core/client/app/transforms/moment-date.js
+++ b/core/client/app/transforms/moment-date.js
@@ -1,6 +1,7 @@
 import DS from 'ember-data';
 /* global moment */
-var MomentDate = DS.Transform.extend({
+
+export default DS.Transform.extend({
     deserialize: function (serialized) {
         if (serialized) {
             return moment(serialized);
@@ -14,4 +15,3 @@ var MomentDate = DS.Transform.extend({
         return deserialized;
     }
 });
-export default MomentDate;

--- a/core/client/app/utils/bind.js
+++ b/core/client/app/utils/bind.js
@@ -1,6 +1,6 @@
 var slice = Array.prototype.slice;
 
-function bind(/* func, args, thisArg */) {
+export default function (/* func, args, thisArg */) {
     var args = slice.call(arguments),
         func = args.shift(),
         thisArg = args.pop();
@@ -11,5 +11,3 @@ function bind(/* func, args, thisArg */) {
 
     return bound;
 }
-
-export default bind;

--- a/core/client/app/utils/bound-one-way.js
+++ b/core/client/app/utils/bound-one-way.js
@@ -9,7 +9,7 @@ import Ember from 'ember';
  * @param {*} upstream
  * @param {function} transform a function to transform the **upstream** value.
  */
-var BoundOneWay = function (upstream, transform) {
+export default function (upstream, transform) {
     if (typeof transform !== 'function') {
         // default to the identity function
         transform = function (value) { return value; };
@@ -23,6 +23,4 @@ var BoundOneWay = function (upstream, transform) {
             return value;
         }
     });
-};
-
-export default BoundOneWay;
+}

--- a/core/client/app/utils/ctrl-or-cmd.js
+++ b/core/client/app/utils/ctrl-or-cmd.js
@@ -1,3 +1,1 @@
-var ctrlOrCmd = navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';
-
-export default ctrlOrCmd;
+export default navigator.userAgent.indexOf('Mac') !== -1 ? 'command' : 'ctrl';

--- a/core/client/app/utils/document-title.js
+++ b/core/client/app/utils/document-title.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-var documentTitle = function () {
+
+export default function () {
     Ember.Route.reopen({
         // `titleToken` can either be a static string or a function
         // that accepts a model object and returns a string (or array
@@ -56,6 +57,4 @@ var documentTitle = function () {
             }
         }
     });
-};
-
-export default documentTitle;
+}

--- a/core/client/app/utils/ghost-paths.js
+++ b/core/client/app/utils/ghost-paths.js
@@ -17,7 +17,7 @@ var makeRoute = function (root, args) {
     return route += '/';
 };
 
-function ghostPaths() {
+export default function () {
     var path = window.location.pathname,
         subdir = path.substr(0, path.search('/ghost/')),
         adminRoot = subdir + '/ghost',
@@ -57,5 +57,3 @@ function ghostPaths() {
         count: 'https://ghost.org/count/'
     };
 }
-
-export default ghostPaths;

--- a/core/client/app/utils/isFinite.js
+++ b/core/client/app/utils/isFinite.js
@@ -2,8 +2,6 @@
 
 // isFinite function from lodash
 
-function isFinite(value) {
+export default function (value) {
     return window.isFinite(value) && !window.isNaN(parseFloat(value));
 }
-
-export default isFinite;

--- a/core/client/app/utils/isNumber.js
+++ b/core/client/app/utils/isNumber.js
@@ -2,9 +2,7 @@
 
 var toString = Object.prototype.toString;
 
-function isNumber(value) {
+export default function (value) {
     return typeof value === 'number' ||
       value && typeof value === 'object' && toString.call(value) === '[object Number]' || false;
 }
-
-export default isNumber;

--- a/core/client/app/utils/mobile.js
+++ b/core/client/app/utils/mobile.js
@@ -1,3 +1,1 @@
-var mobileQuery = matchMedia('(max-width: 800px)');
-
-export default mobileQuery;
+export default matchMedia('(max-width: 800px)');

--- a/core/client/app/utils/random-password.js
+++ b/core/client/app/utils/random-password.js
@@ -1,10 +1,8 @@
 /* global generatePassword */
 
-function randomPassword() {
+export default function () {
     var word = generatePassword(6),
         randomN   = Math.floor(Math.random() * 1000);
 
     return word + randomN;
 }
-
-export default randomPassword;

--- a/core/client/app/utils/set-scroll-classname.js
+++ b/core/client/app/utils/set-scroll-classname.js
@@ -4,7 +4,7 @@
 // **target:** The element in which the class is applied. Defaults to scrolled element.
 // **class-name:** The class which is applied.
 // **offset:** How far the user has to scroll before the class is applied.
-var setScrollClassName = function (options) {
+export default function (options) {
     var $target = options.target || this,
         offset = options.offset,
         className = options.className || 'scrolling';
@@ -14,6 +14,4 @@ var setScrollClassName = function (options) {
     } else {
         $target.removeClass(className);
     }
-};
-
-export default setScrollClassName;
+}

--- a/core/client/app/utils/text-field.js
+++ b/core/client/app/utils/text-field.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+
 Ember.TextField.reopen({
     attributeBindings: ['autofocus']
 });

--- a/core/client/app/utils/titleize.js
+++ b/core/client/app/utils/titleize.js
@@ -3,7 +3,7 @@ var lowerWords = ['of', 'a', 'the', 'and', 'an', 'or', 'nor', 'but', 'is', 'if',
                   'then', 'else', 'when', 'at', 'from', 'by', 'on', 'off', 'for',
                   'in', 'out', 'over', 'to', 'into', 'with'];
 
-function titleize(input) {
+export default function (input) {
     var words = input.split(' ').map(function (word, index) {
         if (index === 0 || lowerWords.indexOf(word) === -1) {
             word = Ember.String.capitalize(word);
@@ -14,5 +14,3 @@ function titleize(input) {
 
     return words.join(' ');
 }
-
-export default titleize;

--- a/core/client/app/utils/validator-extensions.js
+++ b/core/client/app/utils/validator-extensions.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+
 function init() {
     // Provide a few custom validators
     //

--- a/core/client/app/utils/word-count.js
+++ b/core/client/app/utils/word-count.js
@@ -1,7 +1,7 @@
 // jscs: disable
 /* global XRegExp */
 
-function wordCount(s) {
+export default function (s) {
 
     var nonANumLetters = new XRegExp("[^\\s\\d\\p{L}]", "g"); // all non-alphanumeric letters regexp
 
@@ -14,5 +14,3 @@ function wordCount(s) {
 
     return s.split(' ').length;
 }
-
-export default wordCount;

--- a/core/client/app/validators/base.js
+++ b/core/client/app/validators/base.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
  * Base validator that all validators should extend
  * Handles checking of individual properties or the entire model
  */
-var BaseValidator = Ember.Object.extend({
+export default Ember.Object.extend({
     properties: [],
     passed: false,
 
@@ -36,5 +36,3 @@ var BaseValidator = Ember.Object.extend({
         this.set('passed', false);
     }
 });
-
-export default BaseValidator;

--- a/core/client/app/validators/new-user.js
+++ b/core/client/app/validators/new-user.js
@@ -1,6 +1,6 @@
 import BaseValidator from './base';
 
-var NewUserValidator = BaseValidator.extend({
+export default BaseValidator.extend({
     properties: ['name', 'email', 'password'],
 
     name: function (model) {
@@ -31,5 +31,3 @@ var NewUserValidator = BaseValidator.extend({
         }
     }
 });
-
-export default NewUserValidator;

--- a/core/client/app/validators/post.js
+++ b/core/client/app/validators/post.js
@@ -1,6 +1,6 @@
 import BaseValidator from './base';
 
-var PostValidator = BaseValidator.create({
+export default BaseValidator.create({
     properties: ['title', 'metaTitle', 'metaDescription'],
 
     title: function (model) {
@@ -35,5 +35,3 @@ var PostValidator = BaseValidator.create({
         }
     }
 });
-
-export default PostValidator;

--- a/core/client/app/validators/reset.js
+++ b/core/client/app/validators/reset.js
@@ -1,5 +1,6 @@
 import BaseValidator from './base';
-var ResetValidator = BaseValidator.create({
+
+export default BaseValidator.create({
     properties: ['newPassword'],
     newPassword: function (model) {
         var p1 = model.get('newPassword'),
@@ -17,5 +18,3 @@ var ResetValidator = BaseValidator.create({
         }
     }
 });
-
-export default ResetValidator;

--- a/core/client/app/validators/setting.js
+++ b/core/client/app/validators/setting.js
@@ -1,6 +1,6 @@
 import BaseValidator from './base';
 
-var SettingValidator = BaseValidator.create({
+export default BaseValidator.create({
     properties: ['title', 'description', 'password', 'postsPerPage'],
     title: function (model) {
         var title = model.get('title');
@@ -42,5 +42,3 @@ var SettingValidator = BaseValidator.create({
         }
     }
 });
-
-export default SettingValidator;

--- a/core/client/app/validators/setup.js
+++ b/core/client/app/validators/setup.js
@@ -1,6 +1,6 @@
 import NewUserValidator from 'ghost/validators/new-user';
 
-var SetupValidator = NewUserValidator.create({
+export default NewUserValidator.create({
     properties: ['name', 'email', 'password', 'blogTitle'],
 
     blogTitle: function (model) {
@@ -12,5 +12,3 @@ var SetupValidator = NewUserValidator.create({
         }
     }
 });
-
-export default SetupValidator;

--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -1,6 +1,6 @@
 import BaseValidator from './base';
 
-var SigninValidator = BaseValidator.create({
+export default BaseValidator.create({
     properties: ['identification', 'signin', 'forgotPassword'],
     invalidMessage: 'Email address is not valid',
 
@@ -46,5 +46,3 @@ var SigninValidator = BaseValidator.create({
         }
     }
 });
-
-export default SigninValidator;

--- a/core/client/app/validators/tag-settings.js
+++ b/core/client/app/validators/tag-settings.js
@@ -1,6 +1,6 @@
 import BaseValidator from './base';
 
-var TagSettingsValidator = BaseValidator.create({
+export default BaseValidator.create({
     properties: ['name', 'metaTitle', 'metaDescription'],
     name: function (model) {
         var name = model.get('name');
@@ -33,5 +33,3 @@ var TagSettingsValidator = BaseValidator.create({
         }
     }
 });
-
-export default TagSettingsValidator;

--- a/core/client/app/validators/user.js
+++ b/core/client/app/validators/user.js
@@ -1,7 +1,7 @@
 import BaseValidator from './base';
 import Ember from 'ember';
 
-var UserValidator = BaseValidator.create({
+export default BaseValidator.create({
     properties: ['name', 'bio', 'email', 'location', 'website', 'roles'],
     isActive: function (model) {
         return (model.get('status') === 'active');
@@ -70,5 +70,3 @@ var UserValidator = BaseValidator.create({
         }
     }
 });
-
-export default UserValidator;


### PR DESCRIPTION
no issue
- drops the `var Foo = Ember.Thing.extend({}); export default Foo;` syntax in favour of exporting directly, eg: `export default Ember.Thing.extend({})`
- discussion on this change [here](https://github.com/TryGhost/Ghost/pull/5340#issuecomment-105828423) and [here](https://github.com/TryGhost/Ghost/pull/5694#discussion-diff-37511606)
