### PR TITLE
Validate leading commas in tag names

### DIFF
--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -476,6 +476,8 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 availableTagNames = null,
                 tagToAdd = null;
 
+            tagName = tagName.trim();
+
             // abort if tag is already selected
             if (currentTagNames.contains(tagName.toLowerCase())) {
                 return;

--- a/core/client/app/validators/tag-settings.js
+++ b/core/client/app/validators/tag-settings.js
@@ -8,6 +8,9 @@ var TagSettingsValidator = BaseValidator.create({
         if (validator.empty(name)) {
             model.get('errors').add('name', 'You must specify a name for the tag.');
             this.invalidate();
+        } else if (name.match(/^,/)) {
+            model.get('errors').add('name', 'Tag names can\'t start with commas.');
+            this.invalidate();
         }
     },
     metaTitle: function (model) {

--- a/core/server/data/schema.js
+++ b/core/server/data/schema.js
@@ -100,7 +100,7 @@ var db = {
         tags: {
             id: {type: 'increments', nullable: false, primary: true},
             uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
-            name: {type: 'string', maxlength: 150, nullable: false},
+            name: {type: 'string', maxlength: 150, nullable: false, validations: {matches: /^([^,]|$)/}},
             slug: {type: 'string', maxlength: 150, nullable: false, unique: true},
             description: {type: 'string', maxlength: 200, nullable: true},
             image: {type: 'text', maxlength: 2000, nullable: true},

--- a/core/test/functional/client/tags_test.js
+++ b/core/test/functional/client/tags_test.js
@@ -17,7 +17,7 @@ CasperTest.begin('Tags screen is correct', 6, function suite(test) {
     });
 });
 
-CasperTest.begin('Tag creation', 14, function suite(test) {
+CasperTest.begin('Tag creation', 16, function suite(test) {
     casper.thenOpenAndWaitForPageLoad('settings.tags');
 
     casper.thenClick('.view-actions .btn-green');
@@ -44,7 +44,7 @@ CasperTest.begin('Tag creation', 14, function suite(test) {
         test.assertSelectorHasText('.settings-tags .tags-count', '0');
     });
 
-    casper.then(function testNameValidation() {
+    casper.then(function testMissingNameValidation() {
         casper.fill('.tag-settings-pane form', {
             name: ''
         });
@@ -53,6 +53,18 @@ CasperTest.begin('Tag creation', 14, function suite(test) {
             test.assert(true, 'Error displayed for missing tag name');
         }, function doneWaiting() {
             test.fail('Error not displayed for missing tag name');
+        });
+    });
+
+    casper.then(function testNameStartsWithCommaValidation() {
+        casper.fill('.tag-settings-pane form', {
+            name: ',, commas'
+        });
+        casper.waitForText('Tag names can\'t start with commas.', function onSuccess() {
+            test.assertExists('.form-group.error input[name="name"]');
+            test.assert(true, 'Error displayed for tag name starting with comma');
+        }, function doneWaiting() {
+            test.fail('Error not displayed for tag name starting with comma');
         });
     });
 

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -52,6 +52,20 @@ describe('Tags API', function () {
                 done();
             }).catch(done);
         });
+
+        it('rejects invalid names with ValidationError', function (done) {
+            var invalidTag = _.clone(newTag);
+
+            invalidTag.name = ', starts with a comma';
+
+            TagAPI.add({tags: [invalidTag]}, testUtils.context.admin)
+                .then(function () {
+                    done(new Error('Adding a tag with an invalid name is not rejected.'));
+                }).catch(function (errors) {
+                    errors.should.have.enumerable(0).with.property('errorType', 'ValidationError');
+                    done();
+                }).catch(done);
+        });
     });
 
     describe('Edit', function () {
@@ -85,6 +99,18 @@ describe('Tags API', function () {
             }, function () {
                 done();
             }).catch(done);
+        });
+
+        it('rejects invalid names with ValidationError', function (done) {
+            var invalidTagName = ', starts with a comma';
+
+            TagAPI.edit({tags: [{name: invalidTagName}]}, _.extend({}, context.editor, {id: firstTag}))
+                .then(function () {
+                    done(new Error('Adding a tag with an invalid name is not rejected.'));
+                }).catch(function (errors) {
+                    errors.should.have.enumerable(0).with.property('errorType', 'ValidationError');
+                    done();
+                }).catch(done);
         });
     });
 


### PR DESCRIPTION
closes #5685
- Adds client and server-side validation for tag names starting with commas
- Trim tag names before adding in PSM (tag attributes are already trimmed before saving in TSM)

TODO:
- [x] Migration to remove leading commas in existing tags (see #5706)
