### PR TITLE
Fix alerts disappearing when navigating

### DIFF
--- a/core/client/app/controllers/modals/signin.js
+++ b/core/client/app/controllers/modals/signin.js
@@ -44,7 +44,6 @@ export default Ember.Controller.extend(ValidationEngine, {
             $('#login').find('input').trigger('change');
 
             this.validate({format: false}).then(function () {
-                self.get('notifications').closeNotifications();
                 self.send('authenticate');
             }).catch(function (errors) {
                 self.get('notifications').showErrors(errors);

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -37,7 +37,6 @@ export default Ember.Controller.extend({
 
             this.set('uploadButtonText', 'Importing');
             this.set('importErrors', '');
-            notifications.closeNotifications();
 
             formData.append('importfile', file);
 

--- a/core/client/app/controllers/settings/navigation.js
+++ b/core/client/app/controllers/settings/navigation.js
@@ -107,8 +107,6 @@ export default Ember.Controller.extend(SettingsSaveMixin, {
         // we need to have navigationItems recomputed.
         this.get('model').notifyPropertyChange('navigation');
 
-        notifications.closeNotifications();
-
         return this.get('model').save().catch(function (err) {
             notifications.showErrors(err);
         });

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -50,7 +50,6 @@ export default Ember.Controller.extend(ValidationEngine, {
             $('#login').find('input').trigger('change');
 
             this.validate({property: 'signin'}).then(function () {
-                self.get('notifications').closeNotifications();
                 self.toggleProperty('loggingIn');
                 self.send('authenticate');
             }).catch(function (error) {

--- a/core/client/app/controllers/signup.js
+++ b/core/client/app/controllers/signup.js
@@ -48,7 +48,6 @@ export default Ember.Controller.extend(ValidationEngine, {
                 notifications = this.get('notifications');
 
             this.set('flowErrors', '');
-            notifications.closeNotifications();
 
             this.validate().then(function () {
                 self.toggleProperty('submitting');

--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -243,8 +243,7 @@ export default Ember.Mixin.create({
                 timedSaveId = this.get('timedSaveId'),
                 self = this,
                 psmController = this.get('postSettingsMenuController'),
-                promise,
-                notifications = this.get('notifications');
+                promise;
 
             options = options || {};
 
@@ -273,8 +272,6 @@ export default Ember.Mixin.create({
                 Ember.run.cancel(timedSaveId);
                 this.set('timedSaveId', null);
             }
-
-            notifications.closeNotifications();
 
             // Set the properties that are indirected
             // set markdown equal to what's in the editor, minus the image markers.

--- a/core/client/app/router.js
+++ b/core/client/app/router.js
@@ -8,11 +8,8 @@ var Router = Ember.Router.extend({
 
     notifications: Ember.inject.service(),
 
-    clearNotifications: Ember.on('didTransition', function () {
-        var notifications = this.get('notifications');
-
-        notifications.closeNotifications();
-        notifications.displayDelayed();
+    displayDelayedNotifications: Ember.on('didTransition', function () {
+        this.get('notifications').displayDelayed();
     })
 });
 

--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -40,7 +40,6 @@ export default Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
 
         closeMenus: function () {
             this.get('dropdown').closeDropdowns();
-            this.get('notifications').closeAll();
             this.send('closeModal');
             this.controller.setProperties({
                 showSettingsMenu: false,


### PR DESCRIPTION
closes #5707
- fix disappearing alerts after transitions by not clearing all alerts/notifications when closing menus
- remove `notifications.closeNotifications()` calls left over from needing to clear validation notifications
