### PR TITLE
Add Menu to About Ghost Page

### DIFF
--- a/core/client/app/templates/about.hbs
+++ b/core/client/app/templates/about.hbs
@@ -1,4 +1,7 @@
 <section class="gh-view js-settings-content">
+    <header class="view-header">
+        {{#gh-view-title openMobileMenu="openMobileMenu"}}<span>About Ghost</span>{{/gh-view-title}}
+    </header>
     <section class="view-content">
         <header class="gh-about-header">
             <img class="gh-logo" src="{{gh-path 'admin' '/img/ghost-logo.png'}}" alt="Ghost" />


### PR DESCRIPTION
Partial of #5483 

Header on About Page was still missing, so added it in
- Added the header to the about.hbs
