### PR TITLE
Don't return from sending welcome mail

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -269,7 +269,7 @@ authentication = {
                     }]
                 };
 
-            return mail.send(payload, {context: {internal: true}}).catch(function (error) {
+            mail.send(payload, {context: {internal: true}}).catch(function (error) {
                 errors.logError(
                     error.message,
                     'Unable to send welcome email, your blog will continue to function.',


### PR DESCRIPTION
Following on from my comment [here](https://github.com/TryGhost/Ghost/issues/5675#issuecomment-134369639), I believe this is the best we can do?

closes #5675
- welcome mail is non-critical, invalid mail setups shouldn't interfere with setting up a blog
