### PR TITLE
Don't clear password field on transition

### DIFF
--- a/core/client/app/controllers/setup/three.js
+++ b/core/client/app/controllers/setup/three.js
@@ -123,7 +123,7 @@ export default Ember.Controller.extend({
 
                             notifications.showAlert(successCount + ' ' + invitationsString + ' sent!', {type: 'success', delayed: true});
                             self.send('loadServerNotifications');
-                            self.transitionTo('posts.index');
+                            self.transitionToRoute('posts.index');
                         }
 
                         self.toggleProperty('submitting');
@@ -143,7 +143,7 @@ export default Ember.Controller.extend({
         },
         skipInvite: function () {
             this.send('loadServerNotifications');
-            this.transitionTo('posts.index');
+            this.transitionToRoute('posts.index');
         }
     }
 });

--- a/core/client/app/controllers/setup/two.js
+++ b/core/client/app/controllers/setup/two.js
@@ -79,7 +79,6 @@ export default Ember.Controller.extend(ValidationEngine, {
                         identification: self.get('email'),
                         password: self.get('password')
                     }).then(function () {
-                        self.set('password', '');
                         self.set('blogCreated', true);
                         if (data.image) {
                             self.sendImage(result.users[0])

--- a/core/client/app/routes/setup.js
+++ b/core/client/app/routes/setup.js
@@ -31,5 +31,9 @@ export default Ember.Route.extend(styleBody, {
                 return self.transitionTo('signin');
             }
         });
+    },
+    deactivate: function () {
+        this._super();
+        this.controllerFor('setup/two').set('password', '');
     }
 });


### PR DESCRIPTION
This change resolves the issue with the password field being unpopulated when clicking back.

It was originally put in place, I believe, because we were using the user model and keeping it around meant it was in the ember inspector in plain text until you ended your session? 

I don't think this issue is a problem any more, but if it is, I can clear the password from the controller on success on step 3 cc @kevinansfield 

ref #5652
- resolves issues with setup flow for the time being
