### PR TITLE
Change reset page errors to match sign-in page

### DIFF
--- a/core/client/app/controllers/reset.js
+++ b/core/client/app/controllers/reset.js
@@ -7,6 +7,7 @@ export default Ember.Controller.extend(ValidationEngine, {
     ne2Password: '',
     token: '',
     submitting: false,
+    flowErrors: '',
 
     validationType: 'reset',
 
@@ -32,7 +33,7 @@ export default Ember.Controller.extend(ValidationEngine, {
         submit: function () {
             var credentials = this.getProperties('newPassword', 'ne2Password', 'token'),
                 self = this;
-
+            this.set('flowErrors', '');
             this.validate().then(function () {
                 self.toggleProperty('submitting');
                 ajax({
@@ -52,6 +53,14 @@ export default Ember.Controller.extend(ValidationEngine, {
                     self.get('notifications').showAPIError(response);
                     self.toggleProperty('submitting');
                 });
+            }).catch(function () {
+                if (self.get('errors.newPassword')) {
+                    self.set('flowErrors', self.get('errors.newPassword')[0].message);
+                }
+
+                if (self.get('errors.ne2Password')) {
+                    self.set('flowErrors', self.get('errors.ne2Password')[0].message);
+                }
             });
         }
     }

--- a/core/client/app/templates/reset.hbs
+++ b/core/client/app/templates/reset.hbs
@@ -3,22 +3,16 @@
         <section class="gh-flow-content fade-in">
             <form id="reset" class="gh-signin" method="post" novalidate="novalidate" {{action "submit" on="submit"}}>
                 {{#gh-form-group errors=errors property="newPassword"}}
-                    {{input value=newPassword class="gh-input password" type="password" placeholder="Password" name="newpassword" autofocus="autofocus" focusOut=(action "validate" "newPassword")}}
-                    <div class="pw-strength">
-                        <div class="pw-strength-dot"></div>
-                        <div class="pw-strength-dot"></div>
-                        <div class="pw-strength-dot"></div>
-                        <div class="pw-strength-dot"></div>
-                        <div class="pw-strength-dot <!--pw-strength-activedot-->"></div>
-                    </div>
-                    {{gh-error-message errors=errors property="newPassword"}}
+                    {{gh-input type="password" name="newpassword" placeholder="Password" class="password" autocorrect="off" autofocus="autofocus"  value=newPassword}}
                 {{/gh-form-group}}
                 {{#gh-form-group errors=errors property="ne2Password"}}
-                    {{input value=ne2Password class="gh-input password" type="password" placeholder="Confirm Password" name="ne2password" focusOut=(action "validate" "ne2Password")}}
-                    {{gh-error-message errors=errors property="ne2Password"}}
+                    {{gh-input type="password" name="ne2password" placeholder="Confirm Password" class="password" autocorrect="off" autofocus="autofocus" value=ne2Password}}
                 {{/gh-form-group}}
+
                 {{gh-spin-button class="btn btn-blue btn-block" type="submit" submitting=submitting buttonText="Reset Password" autoWidth=false}}
             </form>
+
+            <p class="main-error">{{{flowErrors}}}</p>
         </section>
     </div>
 </div>

--- a/core/client/app/templates/signin.hbs
+++ b/core/client/app/templates/signin.hbs
@@ -6,14 +6,12 @@
                     <span class="input-icon icon-mail">
                         {{gh-trim-focus-input class="gh-input email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" value=model.identification}}
                     </span>
-                    {{gh-error-message errors=model.errors property="identification"}}
                 {{/gh-form-group}}
                 {{#gh-form-group errors=model.errors property="password"}}
                     <span class="input-icon icon-lock forgotten-wrap">
                         {{input class="gh-input password" type="password" placeholder="Password" name="password" tabindex="2" value=model.password}}
                         <button type="button" {{action "forgotten"}} class="forgotten-link btn btn-link"  tabindex="4" disabled={{submitting}}>Forgot?</button>
                     </span>
-                    {{gh-error-message errors=model.errors property="password"}}
                 {{/gh-form-group}}
                 {{gh-spin-button class="login btn btn-blue btn-block" type="submit" tabindex="3" buttonText="Sign in" submitting=loggingIn autoWidth=false}}
             </form>

--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -19,12 +19,12 @@ var SigninValidator = BaseValidator.create({
         model.get('errors').clear();
 
         if (validator.empty(id)) {
-            model.get('errors').add('identification', '');
+            model.get('errors').add('identification', 'Please enter an email');
             this.invalidate();
         }
 
         if (validator.empty(password)) {
-            model.get('errors').add('password', '');
+            model.get('errors').add('password', 'Please enter a password');
             this.invalidate();
         }
     },
@@ -35,7 +35,7 @@ var SigninValidator = BaseValidator.create({
         model.get('errors').clear();
 
         if (validator.empty(id) || !validator.isEmail(id)) {
-            model.get('errors').add('identification', '');
+            model.get('errors').add('identification', 'Invalid email');
             this.invalidate();
         }
     }

--- a/core/test/functional/client/signin_test.js
+++ b/core/test/functional/client/signin_test.js
@@ -136,7 +136,7 @@ CasperTest.begin('Validates unknown email for sign-in', 5, function suite(test) 
         test.assert(true, 'Unknown email error was shown');
         test.assertExists('.form-group.error input[name="identification"]', 'email field was not highlighted');
         test.assertDoesntExist('.form-group.error input[name="password"]', 'password field was highlighted');
-    }, casper.failOnTimeout(test, 'Uknown email error was not shown'));
+    }, casper.failOnTimeout(test, 'Unknown email error was not shown'));
 }, true);
 
 CasperTest.begin('Validates missing details for sign-in', 11, function suite(test) {
@@ -242,5 +242,5 @@ CasperTest.begin('Validates unknown email for forgotten password', 5, function s
         test.assert(true, 'Unknown email error was shown');
         test.assertExists('.form-group.error input[name="identification"]', 'email field was not highlighted');
         test.assertDoesntExist('.form-group.error input[name="password"]', 'password field was highlighted');
-    }, casper.failOnTimeout(test, 'Uknown email error was not shown'));
+    }, casper.failOnTimeout(test, 'Unknown email error was not shown'));
 }, true);


### PR DESCRIPTION
No Issue
- Takes the inline validation messages and displays below form
- Removes unnecessary gh-error-message components from signin and reset pages
  - Returns error messages to sign-in validations
