### PR TITLE
Number formatting function for download counter

### DIFF
--- a/core/client/app/routes/setup/one.js
+++ b/core/client/app/routes/setup/one.js
@@ -27,7 +27,14 @@ var DownloadCountPoller = Ember.Object.extend({
         var self = this;
 
         ajax(this.get('url')).then(function (data) {
-            self.set('count', data.count.toLocaleString());
+            var count = data.count.toString(),
+                pattern = /(-?\d+)(\d{3})/;
+
+            while (pattern.test(count)) {
+                count = count.replace(pattern, '$1,$2');
+            }
+
+            self.set('count', count);
         }).catch(function () {
             self.set('count', 'many, many');
         });


### PR DESCRIPTION
refs #5652
- safari doesn't support the nice toLocaleString function
- this adds a manual, cross-browser way of adding commas in the right places to long number strings
