### PR TITLE
Dep: Remove typeahead

### DIFF
--- a/core/client/Brocfile.js
+++ b/core/client/Brocfile.js
@@ -64,7 +64,6 @@ app.import('bower_components/codemirror/mode/javascript/javascript.js');
 app.import('bower_components/xregexp/xregexp-all.js');
 app.import('bower_components/password-generator/lib/password-generator.js');
 app.import('bower_components/blueimp-md5/js/md5.js');
-app.import('bower_components/typeahead.js/dist/typeahead.bundle.js');
 
 // 'dem Styles
 app.import('bower_components/codemirror/lib/codemirror.css');

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -28,7 +28,6 @@
     "selectize": "~0.12.1",
     "showdown-ghost": "0.3.6",
     "sinonjs": "1.14.1",
-    "typeahead.js": "0.11.1",
     "validator-js": "3.39.0",
     "xregexp": "2.0.0"
   }


### PR DESCRIPTION
refs  #5682
- we're now using selectize instead of typeahead, so it isn't needed
