### PR TITLE
Fix new tags disappearing in PSM when saving post

### DIFF
--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -493,6 +493,10 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                     tagToAdd = self.get('store').createRecord('tag', {
                         name: tagName
                     });
+
+                    // we need to set a UUID so that selectize has a unique value
+                    // it will be ignored when sent to the server
+                    tagToAdd.set('uuid', Ember.guidFor(tagToAdd));
                 }
 
                 // push tag onto post relationship

--- a/core/client/app/models/post.js
+++ b/core/client/app/models/post.js
@@ -59,6 +59,7 @@ export default DS.Model.extend(ValidationEngine, {
     // remove client-generated tags, which have `id: null`.
     // Ember Data won't recognize/update them automatically
     // when returned from the server with ids.
+    // https://github.com/emberjs/data/issues/1829
     updateTags: function () {
         var tags = this.get('tags'),
             oldTags = tags.filterBy('id', null);

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -40,7 +40,7 @@
                     multiple=true
                     selection=model.tags
                     content=availableTags
-                    optionValuePath="content.name"
+                    optionValuePath="content.uuid"
                     optionLabelPath="content.name"
                     create-item="addTag"
                     remove-item="removeTag"}}


### PR DESCRIPTION
closes #5708
- when adding a tag give it a throwaway UUID so that every selected/available tag object has a unique identifier for use with selectize
