### PR TITLE
Fix post tag input so it keeps the tag order

### DIFF
--- a/core/client/app/components/gh-selectize.js
+++ b/core/client/app/components/gh-selectize.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import EmberSelectizeComponent from 'ember-cli-selectize/components/ember-selectize';
+
+export default EmberSelectizeComponent.extend({
+
+    /**
+    * Event callback that is triggered when user creates a tag
+    * - modified to pass the caret position to the action
+    */
+    _create(input, callback) {
+        var caret = this._selectize.caretPos;
+
+        // Delete user entered text
+        this._selectize.setTextboxValue('');
+        // Send create action
+
+        // allow the observers and computed properties to run first
+        Ember.run.schedule('actions', this, function () {
+            this.sendAction('create-item', input, caret);
+        });
+        // We cancel the creation here, so it's up to you to include the created element
+        // in the content and selection property
+        callback(null);
+    }
+
+});

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -469,7 +469,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             });
         },
 
-        addTag: function (tagName) {
+        addTag: function (tagName, index) {
             var self = this,
                 currentTags = this.get('model.tags'),
                 currentTagNames = currentTags.map(function (tag) { return tag.get('name').toLowerCase(); }),
@@ -500,7 +500,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 }
 
                 // push tag onto post relationship
-                if (tagToAdd) { self.get('model.tags').pushObject(tagToAdd); }
+                if (tagToAdd) { self.get('model.tags').insertAt(index, tagToAdd); }
             });
         },
 

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -35,7 +35,7 @@
 
             <div class="form-group">
                 <label for="tag-input">Tags</label>
-                {{ember-selectize
+                {{gh-selectize
                     id="tag-input"
                     multiple=true
                     selection=model.tags


### PR DESCRIPTION
refs #5732
- patches ember-selectize to send the caret position to the create-item action handler
- updates `addTag` method in PSM controller to insert new tags in the correct position

When testing #5732 we found that new tags added at any position in the tag input were always pushed to the end of the tags array causing a re-shuffle on save and mitigating the (re)ordering benefit. Neither the `ember-cli-selectize` addon nor the `selectize.js` plugin pass any position data to their item creation handlers by default so it was necessary to patch the addon's functionality.
