### PR TITLE
[SPIKE] Display a loading template for long transitions

### DIFF
--- a/core/client/app/routes/loading.js
+++ b/core/client/app/routes/loading.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    renderTemplate: function () {
+        Ember.run.later(this, function () {
+            this.render();
+        }, 250);
+    }
+});


### PR DESCRIPTION
no issue
- adds a blank (for now) loading template that is displayed if a transition takes more than 250ms
