### PR TITLE
[SPIKE] Loading event example

### DIFF
--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -30,6 +30,17 @@ export default Ember.Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     },
 
     actions: {
+        loading: function () {
+            var timer = Ember.run.later(this, function () {
+                $('.gh-main').prepend('<div id="gh-main-loading"><h1>Loading all the things!</h1></div>');
+            }, 250);
+
+            this.router.one('didTransition', function () {
+                Ember.run.cancel(timer);
+                $('#gh-main-loading').remove();
+            });
+        },
+
         openMobileMenu: function () {
             this.controller.set('showMobileMenu', true);
         },

--- a/core/client/app/styles/app.css
+++ b/core/client/app/styles/app.css
@@ -27,6 +27,7 @@
 @import "components/popovers.css";
 @import "components/settings-menu.css";
 @import "components/selectize.css";
+@import "components/loading.css";
 
 
 /* Layouts: Groups of Components

--- a/core/client/app/styles/components/loading.css
+++ b/core/client/app/styles/components/loading.css
@@ -1,0 +1,7 @@
+#gh-main-loading {
+    position: absolute;
+    z-index: 9999;
+    width: 100%;
+    height: 100%;
+    background-color: white;
+}


### PR DESCRIPTION
no issue
- example of using the `loading` event instead of ember's loading routes to avoid the white flash for quick transitions but still show a loading screen for those on slow connections
