### PR TITLE
Prevents partial tab view when using keyboard navigation in tag settings

### DIFF
--- a/core/client/app/templates/settings/tags/settings-menu.hbs
+++ b/core/client/app/templates/settings/tags/settings-menu.hbs
@@ -46,6 +46,7 @@
 
         <div class="{{if isViewingSubview 'settings-menu-pane-in' 'settings-menu-pane-out-right'}} settings-menu settings-menu-pane tag-meta-settings-pane">
             {{#gh-tab-pane}}
+                {{#if isViewingSubview}}
                 <div class="settings-menu-header subview">
                     <button {{action "closeSubview"}} class="back icon-arrow-left settings-menu-header-action"><span class="hidden">Back</span></button>
                     <h4>Meta Data</h4>
@@ -78,6 +79,7 @@
                     </div>
                     </form>
                 </div>{{! .settings-menu-content }}
+                {{/if}}
             {{/gh-tab-pane}}
         </div>{{! .settings-menu-pane }}
     {{/gh-tabs-manager}}


### PR DESCRIPTION
refs #5652
- Mimics behaviour of post-settings-menu
- Surrounded the subnavpage with a conditional to check if the page is active before focusing on it
