### PR TITLE
Fix auth token refresh failing on app-boot with expired access_token

### DIFF
--- a/core/client/app/authenticators/oauth2.js
+++ b/core/client/app/authenticators/oauth2.js
@@ -1,0 +1,8 @@
+import Authenticator from 'simple-auth-oauth2/authenticators/oauth2';
+
+export default Authenticator.extend({
+    makeRequest: function (url, data) {
+        data.client_id = 'ghost-admin';
+        return this._super(url, data);
+    }
+});

--- a/core/client/app/controllers/modals/signin.js
+++ b/core/client/app/controllers/modals/signin.js
@@ -15,7 +15,7 @@ export default Ember.Controller.extend(ValidationEngine, {
     actions: {
         authenticate: function () {
             var appController = this.get('application'),
-                authStrategy = 'simple-auth-authenticator:oauth2-password-grant',
+                authStrategy = 'ghost-authenticator:oauth2-password-grant',
                 data = this.getProperties('identification', 'password'),
                 self = this;
 

--- a/core/client/app/controllers/reset.js
+++ b/core/client/app/controllers/reset.js
@@ -45,7 +45,7 @@ export default Ember.Controller.extend(ValidationEngine, {
                 }).then(function (resp) {
                     self.toggleProperty('submitting');
                     self.get('notifications').showAlert(resp.passwordreset[0].message, {type: 'warn', delayed: true});
-                    self.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', {
+                    self.get('session').authenticate('ghost-authenticator:oauth2-password-grant', {
                         identification: self.get('email'),
                         password: credentials.newPassword
                     });

--- a/core/client/app/controllers/setup/two.js
+++ b/core/client/app/controllers/setup/two.js
@@ -75,7 +75,7 @@ export default Ember.Controller.extend(ValidationEngine, {
                     config.set('blogTitle', data.blogTitle);
                     // Don't call the success handler, otherwise we will be redirected to admin
                     self.get('application').set('skipAuthSuccessHandler', true);
-                    self.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', {
+                    self.get('session').authenticate('ghost-authenticator:oauth2-password-grant', {
                         identification: self.get('email'),
                         password: self.get('password')
                     }).then(function () {

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -17,7 +17,7 @@ export default Ember.Controller.extend(ValidationEngine, {
         authenticate: function () {
             var self = this,
                 model = this.get('model'),
-                authStrategy = 'simple-auth-authenticator:oauth2-password-grant',
+                authStrategy = 'ghost-authenticator:oauth2-password-grant',
                 data = model.getProperties('identification', 'password');
 
             this.get('session').authenticate(authStrategy, data).then(function () {

--- a/core/client/app/controllers/signup.js
+++ b/core/client/app/controllers/signup.js
@@ -64,7 +64,7 @@ export default Ember.Controller.extend(ValidationEngine, {
                         }]
                     }
                 }).then(function () {
-                    self.get('session').authenticate('simple-auth-authenticator:oauth2-password-grant', {
+                    self.get('session').authenticate('ghost-authenticator:oauth2-password-grant', {
                         identification: self.get('model.email'),
                         password: self.get('model.password')
                     }).then(function () {

--- a/core/client/app/initializers/ghost-authenticator.js
+++ b/core/client/app/initializers/ghost-authenticator.js
@@ -1,0 +1,12 @@
+import GhostOauth2Authenticator from 'ghost/authenticators/oauth2';
+
+export default {
+    name: 'ghost-authentictor',
+
+    initialize: function (container) {
+        container.register(
+            'ghost-authenticator:oauth2-password-grant',
+            GhostOauth2Authenticator
+        );
+    }
+};

--- a/core/client/app/instance-initializers/authentication.js
+++ b/core/client/app/instance-initializers/authentication.js
@@ -5,20 +5,12 @@ var AuthenticationInitializer = {
 
     initialize: function (instance) {
         var store = instance.container.lookup('store:main'),
-            Session = instance.container.lookup('simple-auth-session:main'),
-            OAuth2 = instance.container.lookup('simple-auth-authenticator:oauth2-password-grant');
+            Session = instance.container.lookup('simple-auth-session:main');
 
         Session.reopen({
             user: Ember.computed(function () {
                 return store.find('user', 'me');
             })
-        });
-
-        OAuth2.reopen({
-            makeRequest: function (url, data) {
-                data.client_id = 'ghost-admin';
-                return this._super(url, data);
-            }
         });
     }
 };


### PR DESCRIPTION
issue #5751
- moves `makeRequest` override of simple-auth's OAuth authenticator into our own custom authenticator (previously our override was not taking effect until after ember-simple-auth's initial authentication routines, hence why it was working for post-login token refreshes but failing on app-boot)
