### PR TITLE
Prevent invite action in step 3 of setup being triggered at wrong time

### DIFF
--- a/core/client/app/templates/setup/three.hbs
+++ b/core/client/app/templates/setup/three.hbs
@@ -5,13 +5,13 @@
 
 <img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" />
 
-<form class="gh-flow-invite" {{action 'invite'}}>
+<form class="gh-flow-invite">
     {{#gh-form-group errors=errors property="users"}}
         <label>Enter one email address per line, we’ll handle the rest! <i class="icon-mail"></i></label>
-        {{gh-textarea name="users" value=users required="required"}}
+        {{gh-textarea name="users" value=users required="required" focusOut=(action "validate")}}
     {{/gh-form-group}}
 
-    {{#gh-spin-button type="submit" classNameBindings=":btn :btn-default :btn-lg :btn-block buttonClass" submitting=submitting autoWidth="false"}}{{buttonText}}{{/gh-spin-button}}
+    {{#gh-spin-button type="submit" action="invite" classNameBindings=":btn :btn-default :btn-lg :btn-block buttonClass" submitting=submitting autoWidth="false"}}{{buttonText}}{{/gh-spin-button}}
 </form>
 
 <button class="gh-flow-skip" {{action "skipInvite"}}>


### PR DESCRIPTION
closes #5757
- validates text on focusOut
- prevent invite action being triggered every time text field gets focus.
