### PR TITLE
Fix double-click & enter/o editing shortcuts

### DIFF
--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -61,6 +61,8 @@ var PostsPostRoute = AuthenticatedRoute.extend(ShortcutsRoute, {
 
     actions: {
         openEditor: function (post) {
+            post = post || this.get('controller.model');
+
             if (!post) {
                 return;
             }

--- a/core/client/app/templates/posts.hbs
+++ b/core/client/app/templates/posts.hbs
@@ -11,7 +11,7 @@
         {{#gh-infinite-scroll-box tagName="section" classNames="content-list-content js-content-scrollbox" fetch="loadNextPage"}}
             <ol class="posts-list">
                 {{#each sortedPosts key="id" as |post|}}
-                    {{#gh-posts-list-item post=post active=(is-equal post currentPost) previewIsHidden=container.previewIsHidden as |component|}}
+                    {{#gh-posts-list-item post=post active=(is-equal post currentPost) onDoubleClick="openEditor" previewIsHidden=container.previewIsHidden as |component|}}
                         {{#link-to component.viewOrEdit post.id class="permalink" title="Edit this post"}}
                             <h3 class="entry-title">{{post.title}}</h3>
                             <section class="entry-meta">


### PR DESCRIPTION
closes #5767
- readd action for double click
- use model for openEditor
