### PR TITLE
Prevent gh-spin-button from infinite spin

### DIFF
--- a/core/client/app/components/gh-spin-button.js
+++ b/core/client/app/components/gh-spin-button.js
@@ -31,8 +31,8 @@ export default Ember.Component.extend({
             this.set('showSpinnerTimeout', Ember.run.later(this, function () {
                 if (!this.get('submitting')) {
                     this.set('showSpinner', false);
-                    this.set('showSpinnerTimeout', null);
                 }
+                this.set('showSpinnerTimeout', null);
             }, 1000));
         } else if (!submitting && timeout === null) {
             this.set('showSpinner', false);


### PR DESCRIPTION
closes #5768
- Always set showSpinnerTimeout back to null after 1 second.
