### PR TITLE
Add email validation back to signin

### DIFF
--- a/core/client/app/templates/signin.hbs
+++ b/core/client/app/templates/signin.hbs
@@ -4,7 +4,7 @@
             <form id="login" class="gh-signin" method="post" novalidate="novalidate">
                 {{#gh-form-group errors=model.errors property="identification"}}
                     <span class="input-icon icon-mail">
-                        {{gh-trim-focus-input class="gh-input email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" value=model.identification}}
+                        {{gh-trim-focus-input class="gh-input email" type="email" placeholder="Email Address" name="identification" autocapitalize="off" autocorrect="off" tabindex="1" focusOut=(action "validate" "identification") value=model.identification}}
                     </span>
                 {{/gh-form-group}}
                 {{#gh-form-group errors=model.errors property="password"}}

--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -2,12 +2,13 @@ import BaseValidator from './base';
 
 var SigninValidator = BaseValidator.create({
     properties: ['identification', 'signin', 'forgotPassword'],
+    invalidMessage: 'Email address is not valid',
 
     identification: function (model) {
         var id = model.get('identification');
 
         if (!validator.empty(id) && !validator.isEmail(id)) {
-            model.get('errors').add('identification', 'Invalid email');
+            model.get('errors').add('identification', this.get('invalidMessage'));
             this.invalidate();
         }
     },
@@ -23,6 +24,11 @@ var SigninValidator = BaseValidator.create({
             this.invalidate();
         }
 
+        if (!validator.empty(id) && !validator.isEmail(id)) {
+            model.get('errors').add('identification', this.get('invalidMessage'));
+            this.invalidate();
+        }
+
         if (validator.empty(password)) {
             model.get('errors').add('password', 'Please enter a password');
             this.invalidate();
@@ -35,7 +41,7 @@ var SigninValidator = BaseValidator.create({
         model.get('errors').clear();
 
         if (validator.empty(id) || !validator.isEmail(id)) {
-            model.get('errors').add('identification', 'Invalid email');
+            model.get('errors').add('identification', this.get('invalidMessage'));
             this.invalidate();
         }
     }


### PR DESCRIPTION
David raised an issue in #5745 that signin is no longer validating that email addresses are correctly formatted. This is a separate issue & higher priority than #5745 so I've added the fix separately

refs #5745 
- signin form was not checking email address was valid
