### PR TITLE
Minor validations fixes

### DIFF
--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -58,6 +58,7 @@ export default Ember.Controller.extend(SettingsSaveMixin, {
     }).readOnly(),
 
     generatePassword: Ember.observer('model.isPrivate', function () {
+        this.get('model.errors').remove('password');
         if (this.get('model.isPrivate') && this.get('model.isDirty')) {
             this.get('model').set('password', randomPassword());
         }

--- a/core/client/app/controllers/settings/tags.js
+++ b/core/client/app/controllers/settings/tags.js
@@ -111,10 +111,12 @@ export default Ember.Controller.extend(PaginationMixin, SettingsMenuMixin, {
     actions: {
         newTag: function () {
             this.set('activeTag', this.store.createRecord('tag', {post_count: 0}));
+            this.get('activeTag.errors').clear();
             this.send('openSettingsMenu');
         },
 
         editTag: function (tag) {
+            tag.validate();
             this.set('activeTag', tag);
             this.send('openSettingsMenu');
         },

--- a/core/client/app/validators/tag-settings.js
+++ b/core/client/app/validators/tag-settings.js
@@ -11,6 +11,9 @@ var TagSettingsValidator = BaseValidator.create({
         } else if (name.match(/^,/)) {
             model.get('errors').add('name', 'Tag names can\'t start with commas.');
             this.invalidate();
+        } else if (!validator.isLength(name, 0, 150)) {
+            model.get('errors').add('name', 'Tag names cannot be longer than 150 characters.');
+            this.invalidate();
         }
     },
     metaTitle: function (model) {


### PR DESCRIPTION
no issue
- clear private blog password validation errors on enable/disable
- validate maximum tag name length
- fix sticky validations when moving between tags or navigating to/from tags manager
