### PR TITLE
Fix selected search item appearing as multi-select item in search input

### DIFF
--- a/core/client/app/components/gh-search-input.js
+++ b/core/client/app/components/gh-search-input.js
@@ -78,6 +78,12 @@ export default Ember.Component.extend({
         });
     },
 
+    _keepSelectionClear: Ember.observer('selection', function () {
+        if (this.get('selection') !== null) {
+            this.set('selection', null);
+        }
+    }),
+
     _setKeymasterScope: function () {
         key.setScope('search-input');
     },
@@ -105,7 +111,6 @@ export default Ember.Component.extend({
                 transition = self.get('_routing.router').transitionTo('team.user', selected.id);
             }
 
-            self.set('selection', '');
             transition.then(function () {
                 if (self.get('_selectize').$control_input.is(':focus')) {
                     self._setKeymasterScope();


### PR DESCRIPTION
no issue
- adds an observer to the component's `selection` property that always clears it if it's assigned a value

Fixes this:
![pasted image at 2015_09_02 14_50](https://cloud.githubusercontent.com/assets/415/9640528/f9b06928-51a9-11e5-95d2-aa224e005e82.png)
