### PR TITLE
Fix teardown of resize handler in content management screen

### DIFF
--- a/core/client/app/components/gh-content-view-container.js
+++ b/core/client/app/components/gh-content-view-container.js
@@ -8,6 +8,8 @@ export default Ember.Component.extend({
 
     resizeService: Ember.inject.service(),
 
+    _resizeListener: null,
+
     calculatePreviewIsHidden: function () {
         if (this.$('.content-preview').length) {
             this.set('previewIsHidden', !this.$('.content-preview').is(':visible'));
@@ -16,8 +18,12 @@ export default Ember.Component.extend({
 
     didInsertElement: function () {
         this._super(...arguments);
+        this._resizeListener = Ember.run.bind(this, this.calculatePreviewIsHidden);
+        this.get('resizeService').on('debouncedDidResize', this._resizeListener);
         this.calculatePreviewIsHidden();
-        this.get('resizeService').on('debouncedDidResize',
-            Ember.run.bind(this, this.calculatePreviewIsHidden));
+    },
+
+    willDestroy: function () {
+        this.get('resizeService').off('debouncedDidResize', this._resizeListener);
     }
 });


### PR DESCRIPTION
refs #5659 ([comment](https://github.com/TryGhost/Ghost/issues/5659#issuecomment-137114898))
- cleans up resize handler on willDestroy hook of gh-content-view-container
