### PR TITLE
Adds rudimentary validation to user invite

### DIFF
--- a/core/client/app/controllers/modals/invite-new-user.js
+++ b/core/client/app/controllers/modals/invite-new-user.js
@@ -1,7 +1,10 @@
 import Ember from 'ember';
+import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(ValidationEngine, {
     notifications: Ember.inject.service(),
+
+    validationType: 'signup',
 
     role: null,
     authorRole: null,
@@ -42,13 +45,13 @@ export default Ember.Controller.extend({
         confirmAccept: function () {
             var email = this.get('email'),
                 role = this.get('role'),
+                validationErrors = this.get('errors.messages'),
                 self = this,
                 newUser;
 
             // reset the form and close the modal
-            self.set('email', '');
-            self.set('role', self.get('authorRole'));
-            self.send('closeModal');
+            this.set('email', '');
+            this.set('role', self.get('authorRole'));
 
             this.store.find('user').then(function (result) {
                 var invitedUser = result.findBy('email', email);
@@ -82,7 +85,13 @@ export default Ember.Controller.extend({
                         // save is overridden in order to validate, we probably
                         // want to use inline-validations here and only show an
                         // alert if we have an actual error
-                        self.get('notifications').showErrors(errors);
+                        if (errors) {
+                            self.get('notifications').showErrors(errors);
+                        } else if (validationErrors) {
+                            self.get('notifications').showAlert(validationErrors.toString(), {type: 'error'});
+                        }
+                    }).finally(function () {
+                        self.get('errors').clear();
                     });
                 }
             });

--- a/core/client/app/routes/team/user.js
+++ b/core/client/app/routes/team/user.js
@@ -46,10 +46,16 @@ var TeamUserRoute = AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
             model.rollback();
         }
 
+        model.get('errors').clear();
+
         this._super();
     },
 
     actions: {
+        didTransition: function () {
+            this.modelFor('team.user').get('errors').clear();
+        },
+
         save: function () {
             this.get('controller').send('save');
         }

--- a/core/client/app/templates/modals/invite-new-user.hbs
+++ b/core/client/app/templates/modals/invite-new-user.hbs
@@ -2,11 +2,12 @@
     title="Invite a New User" confirm=confirm class="invite-new-user"}}
 
     <fieldset>
-        <div class="form-group">
+        {{#gh-form-group errors=errors hasValidated=hasValidated property="email"}}
             <label for="new-user-email">Email Address</label>
-            {{input enter="confirmAccept" class="gh-input email" id="new-user-email" type="email" placeholder="Email Address" name="email" autofocus="autofocus"
-            autocapitalize="off" autocorrect="off" value=email}}
-        </div>
+            {{gh-input enter="confirmAccept" class="email" id="new-user-email" type="email" placeholder="Email Address" name="email" autofocus="autofocus"
+            autocapitalize="off" autocorrect="off" value=email focusOut=(action "validate" "email")}}
+            {{gh-error-message errors=errors property="email"}}
+        {{/gh-form-group}}
 
         <div class="form-group for-select">
             <label for="new-user-role">Role</label>


### PR DESCRIPTION
Currently, there is no validation on the user invite screen.

This PR adds basic validation (enter an email, validity). 

Adding that validation caused a problem whereby, if you left an error in the modal and then closed it (by any means) and navigated to a user page, the error would show or stick for all users.

Additionally, modals aren't wired up to support validations preventing them being closed, so this has been worked around by showing an alert after the modal closes. This DEFINITELY needs revisiting but at least provides some user feedback for now.

refs #5652
- with these changes, validation appears, but doesn't properly prevent closing the modal
- this needs revisiting at some point
