### PR TITLE
Don't eager load relations on tag update

### DIFF
--- a/core/server/data/fixtures/index.js
+++ b/core/server/data/fixtures/index.js
@@ -283,27 +283,36 @@ to004 = function to004() {
 
     // Add post_tag order
     upgradeOp = function () {
-        return models.Post.findAll(_.extend({}, options, {withRelated: ['tags']})).then(function (posts) {
-            var tagOps = [];
+        var tagOps = [];
+        logInfo('Collecting data on tag order for posts...');
+        return models.Post.findAll(_.extend({}, options)).then(function (posts) {
             if (posts) {
-                posts.each(function (post) {
-                    var order = 0;
-                    post.related('tags').each(function (tag) {
-                        tagOps.push((function (order) {
-                            var sortOrder = order;
-                            return function () {
-                                return post.tags().updatePivot(
-                                    {sort_order: sortOrder}, _.extend({}, options, {query: {where: {tag_id: tag.id}}})
-                                );
-                            };
-                        }(order)));
-                        order += 1;
-                    });
+                return posts.mapThen(function (post) {
+                    return post.load(['tags']);
                 });
             }
+            return [];
+        }).then(function (posts) {
+            _.each(posts, function (post) {
+                var order = 0;
+                post.related('tags').each(function (tag) {
+                    tagOps.push((function (order) {
+                        var sortOrder = order;
+                        return function () {
+                            return post.tags().updatePivot(
+                                {sort_order: sortOrder}, _.extend({}, options, {query: {where: {tag_id: tag.id}}})
+                            );
+                        };
+                    }(order)));
+                    order += 1;
+                });
+            });
+
             if (tagOps.length > 0) {
-                logInfo('Updating order on ' + tagOps.length + ' tags');
-                return sequence(tagOps);
+                logInfo('Updating order on ' + tagOps.length + ' tag relationships (could take a while)...');
+                return sequence(tagOps).then(function () {
+                    logInfo('Tag order successfully updated');
+                });
             }
         });
     };


### PR DESCRIPTION
This is a first, very quick stab at a fix for this - maybe a few people could verify that running this works and the `sort_order` on the `posts_tags` table does get populated correctly? 

DO backup first, please!

This solution should work but very slowly. It may be worth considering a different approach in order to get speed, but then everyone only has to run this once. Thoughts?

closes #5810 
- switch from using bookshelf's eager loading, to loading separately
- should resolve the TOO MANY SQL VARIABLES error
