### PR TITLE
Fix config service bug causing client secrets to be rendered as infinite numbers

### DIFF
--- a/core/client/app/services/config.js
+++ b/core/client/app/services/config.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 function isNumeric(num) {
-    return !isNaN(num);
+    return Ember.$.isNumeric(num);
 }
 
 function _mapType(val) {

--- a/core/client/tests/unit/services/config-test.js
+++ b/core/client/tests/unit/services/config-test.js
@@ -1,0 +1,34 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+    describeModule,
+    it
+} from 'ember-mocha';
+
+import Ember from 'ember';
+
+describeModule(
+    'service:config',
+    'ConfigService',
+    {
+        // Specify the other units that are required for this test.
+        // needs: ['service:foo']
+    },
+    function () {
+        // Replace this with your real tests.
+        it('exists', function () {
+            var service = this.subject();
+            expect(service).to.be.ok;
+        });
+
+        it('correctly parses a client secret', function () {
+            Ember.$('<meta>').attr('name', 'env-clientSecret')
+                .attr('content', '23e435234423')
+                .appendTo('head');
+
+            var service = this.subject();
+
+            expect(service.get('clientSecret')).to.equal('23e435234423');
+        });
+    }
+);


### PR DESCRIPTION
closes #5815 

@kevinansfield @ErisDS This fixed the issue, the only part I was unsure of is if there are actually any valid cases of infinite numbers client side. If so, this will likely have to be changed to explicitly take `clientSecret` as a string.
