### PR TITLE
Add Node.js 4.0 stable to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
NodeJS v4 was just released [NodeJS v4 announcement](https://nodejs.org/en/blog/release/v4.0.0/). This updates the CI build script to accommodate the release.
