### PR TITLE
Add user config option to disable the Admin

### DIFF
--- a/core/server/middleware/disable-admin.js
+++ b/core/server/middleware/disable-admin.js
@@ -1,0 +1,22 @@
+// # DisableAdmin Middleware
+// Usage: disableAdmin(request, result, next)
+// After: decideIsAdmin
+// Before:
+// App: Blog
+//
+// Disables the Admin if the user config explicitly says to.
+
+var config = require('../config'),
+    errors = require('../errors'),
+
+    disableAdmin;
+
+disableAdmin = function disableAdmin(req, res, next) {
+    if (res.isAdmin && config.disableAdmin === true) {
+        return errors.error404(req, res, next);
+    }
+
+    next();
+};
+
+module.exports = disableAdmin;

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -20,6 +20,7 @@ var bodyParser      = require('body-parser'),
     cacheControl     = require('./cache-control'),
     checkSSL         = require('./check-ssl'),
     decideIsAdmin    = require('./decide-is-admin'),
+    disableAdmin     = require('./disable-admin'),
     privateBlogging  = require('./private-blogging'),
     redirectToSetup  = require('./redirect-to-setup'),
     serveSharedFile  = require('./serve-shared-file'),
@@ -88,6 +89,8 @@ setupMiddleware = function setupMiddleware(blogAppInstance, adminApp) {
 
     // First determine whether we're serving admin or theme content
     blogApp.use(decideIsAdmin);
+    // Enable Admin by default
+    blogApp.use(disableAdmin);
     blogApp.use(themeHandler(blogApp).updateActiveTheme);
     blogApp.use(themeHandler(blogApp).configHbsForContext);
 


### PR DESCRIPTION
Hello.

I don't have https/ssl on my server, so I prefer to just disable the admin in production. Something like this worked with my modified Ghost builds in the past.

You can merge this if it looks OK, but I just wanted to throw the idea out there.

Also, Ghost has come quite a long way! Congratulations to the team.
