### PR TITLE
Add underscores to general validation

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -126,7 +126,7 @@ utils = {
                     errors = errors.concat(validation.validate(value, key, globalValidations[key]));
                 } else {
                     // all other keys should be an alphanumeric string + -, like slug, tag, author, status, etc
-                    errors = errors.concat(validation.validate(value, key, {matches: /^[a-z0-9\-]+$/}));
+                    errors = errors.concat(validation.validate(value, key, {matches: /^[a-z0-9\-_]+$/}));
                 }
             }
         });

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -217,9 +217,9 @@ describe('API Utils', function () {
             check('limit', valid, invalid);
         });
 
-        it('can validate `slug` or `status` or `author` etc as a-z, 0-9 and -', function () {
-            valid = ['hello-world', 'hello', '1-2-3', 1, '-1', -1];
-            invalid = ['hello_world', '!things', '?other-things', 'thing"', '`ticks`'];
+        it('can validate `slug` or `status` or `author` etc as a-z, 0-9, - and _', function () {
+            valid = ['hello-world', 'hello', '1-2-3', 1, '-1', -1, 'hello_world'];
+            invalid = ['hello~world', '!things', '?other-things', 'thing"', '`ticks`'];
 
             check('slug', valid, invalid);
             check('status', valid, invalid);


### PR DESCRIPTION
This is just a fix for the incorrect removal of `_` from what's considered a valid slug. It doesn't yet fix the fact that the API is returning 500 instead of 422 or 404 when a slug is invalid, that should be handled in #5808.

fixes #5816 
- general slugs and other fields should permit underscores as well as dashes
