### PR TITLE
Returns 404 page instead of crashing when special chars are used in tag slugs

### DIFF
--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -14,6 +14,7 @@ var _           = require('lodash'),
     Promise     = require('bluebird'),
     template    = require('../helpers/template'),
     routeMatch  = require('path-match')(),
+    safeString  = require('../utils/index').safeString,
 
     frontendControllers,
     staticPostPermalink = routeMatch('/:slug/:edit?');
@@ -160,8 +161,8 @@ function renderChannel(channelOpts) {
             filter, filterKey;
 
         // Add the slug if it exists in the route
-        if (channelOpts.route.indexOf(':slug') !== -1) {
-            options[channelOpts.name] = req.params.slug;
+        if (channelOpts.route.indexOf(':slug') !== -1 && req.params.slug) {
+            options[channelOpts.name] = safeString(req.params.slug);
             hasSlug = true;
         }
 

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -79,6 +79,14 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
 
+            it('should 404 for unknown tag with invalid characters', function (done) {
+                request.get('/tag/~$pectacular~/')
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+
             it('should 404 for unknown author', function (done) {
                 request.get('/author/spectacular/')
                     .expect('Cache-Control', testUtils.cacheRules['private'])


### PR DESCRIPTION
Returns 404 page instead of crashing a server whenever special characters are used for tag filtering

closes #5808
refs #5816
- adds additional filtering any 'slug' containing content in `renderChannel` for frontend
- adds test for invalid characters in tag slug
