### PR TITLE
Fix over-sized editor pane widths

### DIFF
--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -24,6 +24,11 @@
     background: #fff;
 }
 
+/*  Flexbox fix. https://github.com/TryGhost/Ghost/issues/5804#issuecomment-141416812 */
+.gh-main > section {
+    width: 1px;
+}
+
 
 /* Global Nav
 /* ---------------------------------------------------------- */

--- a/core/test/functional/base.js
+++ b/core/test/functional/base.js
@@ -206,6 +206,12 @@ casper.thenOpenAndWaitForPageLoad = function (screen, then, timeout) {
     timeout = timeout || casper.failOnTimeout(casper.test, 'Unable to load ' + screen);
 
     return casper.thenOpen(url + screens[screen].url).then(function () {
+        // HACK: phantomjs + flexbox = nope. Fix offending styles here.
+        casper.evaluate(function () {
+            var style = document.createElement('style');
+            style.innerHTML = '.gh-main > section { width: auto; }';
+            document.body.appendChild(style);
+        });
         return casper.waitForScreenLoad(screen, then, timeout);
     });
 };


### PR DESCRIPTION
closes #5804
- adds a fixed width that flexbox can expand from to prevent flexbox content dictating the width (see https://github.com/TryGhost/Ghost/issues/5804#issuecomment-141416812)
- adds a hack to the casperjs tests reverting the CSS change because phantomjs and flexbox don't get along
