### PR TITLE
Show a single 422 error for invalid values

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -89,7 +89,8 @@ utils = {
                     return Promise.resolve(options);
                 }
 
-                return errors.logAndRejectError(validationErrors);
+                // For now, we can only handle showing the first validation error
+                return errors.logAndRejectError(validationErrors[0]);
             }
 
             // If we got an object, check that too
@@ -110,6 +111,7 @@ utils = {
         var globalValidations = {
                 id: {matches: /^\d+|me$/},
                 uuid: {isUUID: true},
+                slug: {isSlug: true},
                 page: {matches: /^\d+$/},
                 limit: {matches: /^\d+|all$/},
                 fields: {matches: /^[a-z0-9_,]+$/},
@@ -125,8 +127,8 @@ utils = {
                 if (globalValidations[key]) {
                     errors = errors.concat(validation.validate(value, key, globalValidations[key]));
                 } else {
-                    // all other keys should be an alphanumeric string + -, like slug, tag, author, status, etc
-                    errors = errors.concat(validation.validate(value, key, {matches: /^[a-z0-9\-_]+$/}));
+                    // all other keys should be alpha-numeric with dashes/underscores, like tag, author, status, etc
+                    errors = errors.concat(validation.validate(value, key, globalValidations.slug));
                 }
             }
         });

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -27,6 +27,10 @@ validator.extend('isEmptyOrURL', function isEmptyOrURL(str) {
     return (_.isEmpty(str) || validator.isURL(str, {require_protocol: false}));
 });
 
+validator.extend('isSlug', function isSlug(str) {
+    return validator.matches(str, /^[a-z0-9\-_]+$/);
+});
+
 // Validation against schema attributes
 // values are checked against the validation objects from schema.js
 validateSchema = function validateSchema(tableName, model) {

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -336,7 +336,7 @@ errors = {
             if (!err || !(err instanceof Error)) {
                 next();
             }
-            errors.renderErrorPage(err.status || 500, err, req, res, next);
+            errors.renderErrorPage(err.status || err.code || 500, err, req, res, next);
         } else {
             var statusCode = 500,
                 returnErrors = [];

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -63,6 +63,14 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
 
+            it('should 404 for unknown post with invalid characters', function (done) {
+                request.get('/$pec+acular~/')
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+
             it('should 404 for unknown frontend route', function (done) {
                 request.get('/spectacular/marvellous/')
                     .expect('Cache-Control', testUtils.cacheRules['private'])
@@ -97,6 +105,14 @@ describe('Frontend Routing', function () {
 
             it('should 404 for encoded char not 301 from uncapitalise', function (done) {
                 request.get('/|/')
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+
+            it('should 404 for unknown author with invalid characters', function (done) {
+                request.get('/author/ghost!user^/')
                     .expect('Cache-Control', testUtils.cacheRules['private'])
                     .expect(404)
                     .expect(/Page not found/)

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -219,6 +219,28 @@ describe('Post API', function () {
                 done();
             }).catch(done);
         });
+
+        it('cannot fetch all posts for a tag with invalid slug', function (done) {
+            PostAPI.browse({tag: 'invalid!'}).then(function () {
+                done(new Error('Should not return a result with invalid tag'));
+            }).catch(function (err) {
+                should.exist(err);
+                err.message.should.eql('Validation (isSlug) failed for tag');
+                err.code.should.eql(422);
+                done();
+            });
+        });
+
+        it('cannot fetch all posts for an author with invalid slug', function (done) {
+            PostAPI.browse({author: 'invalid!'}).then(function () {
+                done(new Error('Should not return a result with invalid author'));
+            }).catch(function (err) {
+                should.exist(err);
+                err.message.should.eql('Validation (isSlug) failed for author');
+                err.code.should.eql(422);
+                done();
+            });
+        });
     });
 
     describe('Read', function () {
@@ -371,6 +393,18 @@ describe('Post API', function () {
                 results.posts[0].previous.author.name.should.eql('Joe Bloggs');
                 done();
             }).catch(done);
+        });
+
+        // TODO: this should be a 422?
+        it('cannot fetch a post with an invalid slug', function (done) {
+            PostAPI.read({slug: 'invalid!'}).then(function () {
+                done(new Error('Should not return a result with invalid slug'));
+            }).catch(function (err) {
+                should.exist(err);
+                err.message.should.eql('Post not found.');
+
+                done();
+            });
         });
     });
 });

--- a/core/test/integration/api/api_slugs_spec.js
+++ b/core/test/integration/api/api_slugs_spec.js
@@ -77,7 +77,7 @@ describe('Slug API', function () {
         .then(function () {
             done(new Error('Generate a slug for an unknown type is not rejected.'));
         }).catch(function (errors) {
-            errors.should.have.enumerable(0).with.property('errorType', 'ValidationError');
+            errors.should.have.property('errorType', 'ValidationError');
             done();
         }).catch(done);
     });

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -296,5 +296,17 @@ describe('Tags API', function () {
                 done();
             }).catch(done);
         });
+
+        // TODO: this should be a 422?
+        it('cannot fetch a tag with an invalid slug', function (done) {
+            TagAPI.read({slug: 'invalid!'}).then(function () {
+                done(new Error('Should not return a result with invalid slug'));
+            }).catch(function (err) {
+                should.exist(err);
+                err.message.should.eql('Tag not found.');
+
+                done();
+            });
+        });
     });
 });

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -194,6 +194,18 @@ describe('Users API', function () {
                 done();
             }).catch(done);
         });
+
+        // TODO: this should be a 422?
+        it('cannot fetch a user with an invalid slug', function (done) {
+            UserAPI.read({slug: 'invalid!'}).then(function () {
+                done(new Error('Should not return a result with invalid slug'));
+            }).catch(function (err) {
+                should.exist(err);
+                err.message.should.eql('User not found.');
+
+                done();
+            });
+        });
     });
 
     describe('Edit', function () {

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -163,7 +163,7 @@ describe('API Utils', function () {
             ).then(function () {
                 done(new Error('Should have thrown a validation error'));
             }).catch(function (err) {
-                err.should.have.enumerable('0').with.property('errorType', 'ValidationError');
+                err.should.have.property('errorType', 'ValidationError');
                 done();
             });
         });


### PR DESCRIPTION
This is an additional fix on top of #5851.

The idea is that the API should return a 422 Validation Error for requests with invalid values for parameters. The controller layer has already been updated in #5851 to ensure that it only looks for valid values from the API, meaning it only ever serves 404

refs #5808
