### PR TITLE
Add replacement for zero in plural helper

### DIFF
--- a/core/server/helpers/plural.js
+++ b/core/server/helpers/plural.js
@@ -20,7 +20,7 @@ plural = function (context, options) {
     }
 
     if (context === 0) {
-        return new hbs.handlebars.SafeString(options.hash.empty);
+        return new hbs.handlebars.SafeString(options.hash.empty.replace('%', context));
     } else if (context === 1) {
         return new hbs.handlebars.SafeString(options.hash.singular.replace('%', context));
     } else if (context >= 2) {

--- a/core/test/unit/server_helpers/plural_spec.js
+++ b/core/test/unit/server_helpers/plural_spec.js
@@ -31,6 +31,20 @@ describe('{{plural}} helper', function () {
         rendered.string.should.equal(expected);
     });
 
+    it('will show no-value string with placement', function () {
+        var expected = '0 Posts',
+            rendered = helpers.plural.call({}, 0, {
+                hash: {
+                    empty: '% Posts',
+                    singular: '% Post',
+                    plural: '% Posts'
+                }
+            });
+
+        should.exist(rendered);
+        rendered.string.should.equal(expected);
+    });
+
     it('will show singular string', function () {
         var expected = '1 Post',
             rendered = helpers.plural.call({}, 1, {


### PR DESCRIPTION
- currently, the plural helper doesn't replace % with the number when the number is zero, which is inconsistent
- this change ensures that theme developers can choose to show the number or a plain string
