### PR TITLE
Optimize release dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -351,6 +351,10 @@ var _              = require('lodash'),
                     command: 'npm shrinkwrap'
                 },
 
+                dedupe: {
+                    command: 'npm dedupe'
+                },
+
                 csscombfix: {
                     command: path.resolve(cwd + '/node_modules/.bin/csscomb -c core/client/app/styles/csscomb.json -v core/client/app/styles')
                 },
@@ -926,7 +930,7 @@ var _              = require('lodash'),
             ' - Copy files to release-folder/#/#{version} directory\n' +
             ' - Clean out unnecessary files (travis, .git*, etc)\n' +
             ' - Zip files in release-folder to dist-folder/#{version} directory',
-            ['init', 'shell:ember:prod', 'clean:release',  'shell:shrinkwrap', 'copy:release', 'compress:release']);
+            ['init', 'shell:ember:prod', 'clean:release',  'shell:dedupe', 'shell:shrinkwrap', 'copy:release', 'compress:release']);
     };
 
 module.exports = configureGrunt;


### PR DESCRIPTION
no issue
- added a new grunt task for npm dedupe
- added shell:dedupe to realease task

This reduces the number of modules that need to be installed with `npm install`. New `npm-shrinkwrap.json` files will be 30 % smaller (0.7.0: 3500 lines, New: 2000 lines).
