### PR TITLE
Add `/author/:slug/edit/` route to frontend

### DIFF
--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -66,6 +66,9 @@ frontendRoutes = function frontendRoutes(middleware) {
 
     // Authors
     authorRouter.route('/').get(frontend.author);
+    authorRouter.route('/edit?').get(function redirect(req, res) {
+        res.redirect(subdir + '/ghost/team/' + req.params.slug + '/');
+    });
     authorRouter.route('/' + routeKeywords.page + '/:page/').get(frontend.author);
     authorRouter.use(rssRouter);
 

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -575,6 +575,32 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
         });
+
+        describe('Author edit', function () {
+            it('should redirect without slash', function (done) {
+                request.get('/author/ghost-owner/edit')
+                    .expect('Location', '/author/ghost-owner/edit/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEnd(done));
+            });
+
+            it('should redirect to editor', function (done) {
+                request.get('/author/ghost-owner/edit/')
+                    .expect('Location', '/ghost/team/ghost-owner/')
+                    .expect('Cache-Control', testUtils.cacheRules['public'])
+                    .expect(302)
+                    .end(doEnd(done));
+            });
+
+            it('should 404 for something that isn\'t edit', function (done) {
+                request.get('/author/ghost-owner/notedit/')
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+        });
     });
 
     describe('Tag pages', function () {


### PR DESCRIPTION
no issue

Adds a new route that redirects to '/ghost/team/:slug/' from the frontend.
