### PR TITLE
[WIP] Fix front-end URL output for more URL schemes

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -210,7 +210,8 @@ function urlFor(context, data, absolute) {
     }
 
     // This url already has a protocol so is likely an external url to be returned
-    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.indexOf('mailto:') === 0)) {
+    // or it is an anchor-only path
+    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.match(/^(\/\/|#|[a-zA-Z0-9-]*:)/))) {
         return urlPath;
     }
 

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -151,4 +151,10 @@ describe('{{url}} helper', function () {
         should.exist(rendered);
         rendered.should.equal('http://casper.website/baz');
     });
+
+    it('should pass through protocol-relative URLs');
+
+    it('should pass through URLs with alternative schemes');
+
+    it('should pass through anchor-only URLs');
 });


### PR DESCRIPTION
- allows direct pass-through of protocol-relative (`//host`), alternate-scheme (`tel:`), and anchor-only urls (`#contact`)
