### PR TITLE
Don't alter password from User.edit endpoint

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -156,6 +156,11 @@ users = {
             options.editRoles = true;
         }
 
+        // The password should never be set via this endpoint, if it is passed, ignore it
+        if (object.users && object.users[0] && object.users[0].password) {
+            delete object.users[0].password;
+        }
+
         /**
          * ### Handle Permissions
          * We need to be an authorised user to perform this action

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -383,6 +383,19 @@ describe('Users API', function () {
                 done();
             }).catch(done);
         });
+
+        it('Does not allow password to be set', function (done) {
+            UserAPI.edit(
+                {users: [{name: 'newname', password: 'newpassword'}]}, _.extend({}, context.author, {id: userIdFor.author})
+            ).then(function () {
+                return ModelUser.User.findOne({id: userIdFor.author}).then(function (response) {
+                    console.log(response);
+                    response.get('name').should.eql('newname');
+                    response.get('password').should.not.eql('newpassword');
+                    done();
+                });
+            }).catch(done);
+        });
     });
 
     describe('Add', function () {


### PR DESCRIPTION
- password changes should only be possible from the password change endpoint

Credits: An anonymous researcher working with Beyond Security's SecuriTeam Secure Disclosure program
