### PR TITLE
Uncapitalise respects subdirectories & no encoding

### DIFF
--- a/core/server/middleware/uncapitalise.js
+++ b/core/server/middleware/uncapitalise.js
@@ -24,9 +24,14 @@ uncapitalise = function uncapitalise(req, res, next) {
         pathToTest = isAPI[1];
     }
 
-    if (/[A-Z]/.test(pathToTest)) {
+    /**
+     * In node < 0.11.1 req.path is not encoded, afterwards, it is always encoded such that | becomes %7C etc.
+     * That encoding isn't useful here, as it triggers an extra uncapitalise redirect, so we decode the path first
+     */
+    if (/[A-Z]/.test(decodeURIComponent(pathToTest))) {
         res.set('Cache-Control', 'public, max-age=' + utils.ONE_YEAR_S);
-        res.redirect(301, req.url.replace(pathToTest, pathToTest.toLowerCase()));
+        // Adding baseUrl ensures subdirectories are kept
+        res.redirect(301, (req.baseUrl ? req.baseUrl : '') + req.url.replace(pathToTest, pathToTest.toLowerCase()));
     } else {
         next();
     }

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -94,6 +94,14 @@ describe('Frontend Routing', function () {
                     .expect(/Page not found/)
                     .end(doEnd(done));
             });
+
+            it('should 404 for encoded char not 301 from uncapitalise', function (done) {
+                request.get('/|/')
+                    .expect('Cache-Control', testUtils.cacheRules['private'])
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
         });
 
         describe('Home', function () {
@@ -146,6 +154,7 @@ describe('Frontend Routing', function () {
             it('should redirect uppercase', function (done) {
                 request.get('/Welcome-To-Ghost/')
                     .expect('Location', '/welcome-to-ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
                     .end(doEnd(done));
             });
@@ -321,6 +330,7 @@ describe('Frontend Routing', function () {
             request.get('/p/2ac6b4f6-e1f3-406c-9247-c94a0496d39d/')
                 .expect(301)
                 .expect('Location', '/short-and-sweet/')
+                .expect('Cache-Control', testUtils.cacheRules.public)
                 .end(doEnd(done));
         });
 
@@ -763,6 +773,7 @@ describe('Frontend Routing', function () {
             request.get('/blog/welcome-to-ghost')
                 .expect(301)
                 .expect('Location', '/blog/welcome-to-ghost/')
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .end(doEnd(done));
         });
 
@@ -776,6 +787,7 @@ describe('Frontend Routing', function () {
             request.get('/blog/tag/getting-started')
                 .expect(301)
                 .expect('Location', '/blog/tag/getting-started/')
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .end(doEnd(done));
         });
 
@@ -837,6 +849,7 @@ describe('Frontend Routing', function () {
             request.get('/blog/welcome-to-ghost')
                 .expect(301)
                 .expect('Location', '/blog/welcome-to-ghost/')
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .end(doEnd(done));
         });
 
@@ -850,12 +863,21 @@ describe('Frontend Routing', function () {
             request.get('/blog/tag/getting-started')
                 .expect(301)
                 .expect('Location', '/blog/tag/getting-started/')
+                .expect('Cache-Control', testUtils.cacheRules.year)
                 .end(doEnd(done));
         });
 
         it('/blog/tag/getting-started/ should 200', function (done) {
             request.get('/blog/tag/getting-started/')
                 .expect(200)
+                .end(doEnd(done));
+        });
+
+        it('should uncapitalise correctly with 301 to subdir', function (done) {
+            request.get('/blog/AAA/')
+                .expect('Location', '/blog/aaa/')
+                .expect('Cache-Control', testUtils.cacheRules.year)
+                .expect(301)
                 .end(doEnd(done));
         });
     });

--- a/core/test/unit/middleware/uncapitalise_spec.js
+++ b/core/test/unit/middleware/uncapitalise_spec.js
@@ -1,7 +1,10 @@
 /*globals describe, beforeEach, afterEach, it*/
 /*jshint expr:true*/
 var sinon           = require('sinon'),
+    should       = require('should'),
     uncapitalise    = require('../../../server/middleware/uncapitalise');
+
+should.equal(true, true);
 
 describe('Middleware: uncapitalise', function () {
     var sandbox,


### PR DESCRIPTION
no issue but this PR is required to fix #5858
- Uncapitalise was dropping the subdirectory when redirecting - so the base url has been added where present
- Uncapitalise was also working differently in node 0.10 and 0.12 - so the path is decoded before testing for uppercase
- Adds some test coverage
