### PR TITLE
Prevent enter button reloading page when focus is on meta-title in PSM

### DIFF
--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -201,6 +201,10 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
     },
 
     actions: {
+        discardEnter: function () {
+            return false;
+        },
+
         togglePage: function () {
             var self = this;
 

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -105,7 +105,7 @@
         </div>
 
         <div class="settings-menu-content">
-            <form>
+            <form {{action "discardEnter" on="submit"}}>
             {{#gh-form-group errors=model.errors property="meta_title"}}
                 <label for="meta-title">Meta Title</label>
                 {{gh-input class="post-setting-meta-title" id="meta-title" value=metaTitleScratch name="post-setting-meta-title" focus-out="setMetaTitle" stopEnterKeyDownPropagation="true"}}


### PR DESCRIPTION
closes #5854
- adds an action that returns false on form submission
