### PR TITLE
Don't allow published_by override

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -140,14 +140,22 @@ Post = ghostBookshelf.Model.extend({
         // this.set('title', this.sanitize('title').trim());
         this.set('title', this.get('title').trim());
 
-        if ((this.hasChanged('status') || !this.get('published_at')) && this.get('status') === 'published') {
-            if (!this.get('published_at')) {
-                this.set('published_at', new Date());
-            }
+        // ### Business logic for published_at and published_by
+        // If the current status is 'published' and published_at is not set, set it to now
+        if (this.get('status') === 'published' && !this.get('published_at')) {
+            this.set('published_at', new Date());
+        }
 
+        // If the current status is 'published' and the status has just changed ensure published_by is set correctly
+        if (this.get('status') === 'published' && this.hasChanged('status')) {
             // unless published_by is set and we're importing, set published_by to contextUser
             if (!(this.get('published_by') && options.importing)) {
                 this.set('published_by', this.contextUser(options));
+            }
+        } else {
+            // In any other case (except import), `published_by` should not be changed
+            if (this.hasChanged('published_by') && !options.importing) {
+                this.set('published_by', this.previous('published_by'));
             }
         }
 

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -389,7 +389,6 @@ describe('Users API', function () {
                 {users: [{name: 'newname', password: 'newpassword'}]}, _.extend({}, context.author, {id: userIdFor.author})
             ).then(function () {
                 return ModelUser.User.findOne({id: userIdFor.author}).then(function (response) {
-                    console.log(response);
                     response.get('name').should.eql('newname');
                     response.get('password').should.not.eql('newpassword');
                     done();


### PR DESCRIPTION
- published_by should be set by business logic, rather than by users

Credits: An anonymous researcher working with Beyond Security's SecuriTeam Secure Disclosure program
