### PR TITLE
Support for more URL schemes in url helpers

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -210,7 +210,8 @@ function urlFor(context, data, absolute) {
     }
 
     // This url already has a protocol so is likely an external url to be returned
-    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.indexOf('mailto:') === 0)) {
+    // or it is an anchor-only path
+    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.match(/^(\/\/|#|[a-zA-Z0-9-]*:)/))) {
         return urlPath;
     }
 

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -210,8 +210,8 @@ function urlFor(context, data, absolute) {
     }
 
     // This url already has a protocol so is likely an external url to be returned
-    // or it is an anchor-only path
-    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.match(/^(\/\/|#|[a-zA-Z0-9-]*:)/))) {
+    // or it is an alternative scheme, protocol-less, or an anchor-only path
+    if (urlPath && (urlPath.indexOf('://') !== -1 || urlPath.match(/^(\/\/|#|[a-zA-Z0-9\-]+:)/))) {
         return urlPath;
     }
 

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -379,6 +379,15 @@ describe('Config', function () {
                 testData = {nav: {url: 'http://sub.my-ghost-blog.com/'}};
                 config.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
 
+                testData = {nav: {url: '//sub.my-ghost-blog.com/'}};
+                config.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/');
+
+                testData = {nav: {url: 'mailto:sub@my-ghost-blog.com/'}};
+                config.urlFor(testContext, testData).should.equal('mailto:sub@my-ghost-blog.com/');
+
+                testData = {nav: {url: '#this-anchor'}};
+                config.urlFor(testContext, testData).should.equal('#this-anchor');
+
                 config.set({url: 'http://my-ghost-blog.com/blog'});
                 testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
                 config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -151,4 +151,10 @@ describe('{{url}} helper', function () {
         should.exist(rendered);
         rendered.should.equal('http://casper.website/baz');
     });
+
+    it('should pass through protocol-relative URLs');
+
+    it('should pass through URLs with alternative schemes');
+
+    it('should pass through anchor-only URLs');
 });

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -12,7 +12,7 @@ var should         = require('should'),
     api            = require('../../../server/api');
 
 describe('{{url}} helper', function () {
-    var sandbox;
+    var sandbox, rendered;
 
     before(function () {
         sandbox = sinon.sandbox.create();
@@ -21,6 +21,7 @@ describe('{{url}} helper', function () {
     });
 
     beforeEach(function () {
+        rendered = null;
         sandbox.stub(api.settings, 'read', function () {
             return Promise.resolve({settings: [{value: '/:slug/'}]});
         });
@@ -39,7 +40,7 @@ describe('{{url}} helper', function () {
     });
 
     it('should return the slug with a prefix slash if the context is a post', function () {
-        var rendered = helpers.url.call({
+        rendered = helpers.url.call({
             html: 'content',
             markdown: 'ff',
             title: 'title',
@@ -53,7 +54,7 @@ describe('{{url}} helper', function () {
     });
 
     it('should output an absolute URL if the option is present', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {html: 'content', markdown: 'ff', title: 'title', slug: 'slug', url: '/slug/', created_at: new Date(0)},
             {hash: {absolute: 'true'}}
         );
@@ -63,7 +64,7 @@ describe('{{url}} helper', function () {
     });
 
     it('should return the slug with a prefixed /tag/ if the context is a tag', function () {
-        var rendered = helpers.url.call({
+        rendered = helpers.url.call({
             name: 'the tag',
             slug: 'the-tag',
             description: null,
@@ -75,8 +76,6 @@ describe('{{url}} helper', function () {
     });
 
     it('should return / if not a post or tag', function () {
-        var rendered;
-
         rendered = helpers.url.call({markdown: 'ff', title: 'title', slug: 'slug'});
         should.exist(rendered);
         rendered.should.equal('/');
@@ -95,14 +94,14 @@ describe('{{url}} helper', function () {
     });
 
     it('should return a relative url if passed through a nav context', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {url: '/foo', label: 'Foo', slug: 'foo', current: true});
         should.exist(rendered);
         rendered.should.equal('/foo');
     });
 
     it('should return an absolute url if passed through a nav context', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {url: '/bar', label: 'Bar', slug: 'bar', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -110,7 +109,7 @@ describe('{{url}} helper', function () {
     });
 
     it('external urls should be retained in a nav context', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -118,7 +117,7 @@ describe('{{url}} helper', function () {
     });
 
     it('should handle hosted urls in a nav context', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {url: 'http://testurl.com/qux', label: 'Qux', slug: 'qux', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -126,35 +125,85 @@ describe('{{url}} helper', function () {
     });
 
     it('should handle hosted urls with the wrong protocol in a nav context', function () {
-        var rendered = helpers.url.call(
+        rendered = helpers.url.call(
             {url: 'https://testurl.com/quux', label: 'Quux', slug: 'quux', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
         rendered.should.equal('http://testurl.com/quux');
     });
 
-    it('should handle subdir being set in nav context', function () {
-        utils.overrideConfig({url: 'http://testurl.com/blog'});
+    it('should pass through protocol-less URLs regardless of absolute setting', function () {
+        rendered = helpers.url.call(
+            {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
+            {hash: {}});
+        should.exist(rendered);
+        rendered.should.equal('//casper.website/baz');
 
-        var rendered = helpers.url.call(
-            {url: '/xyzzy', label: 'xyzzy', slug: 'xyzzy', current: true},
+        rendered = helpers.url.call(
+            {url: '//casper.website/baz', label: 'Baz', slug: 'baz', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
-        rendered.should.equal('http://testurl.com/blog/xyzzy');
+        rendered.should.equal('//casper.website/baz');
     });
 
-    it('external urls should be retained in a nav context with subdir', function () {
-        utils.overrideConfig({url: 'http://testurl.com/blog'});
-        var rendered = helpers.url.call(
-            {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
+    it('should pass through URLs with alternative schemes regardless of absolute setting', function () {
+        rendered = helpers.url.call(
+            {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
+            {hash: {}});
+        should.exist(rendered);
+        rendered.should.equal('tel:01234567890');
+
+        rendered = helpers.url.call(
+            {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
+            {hash: {}});
+        should.exist(rendered);
+        rendered.should.equal('mailto:example@ghost.org');
+
+        rendered = helpers.url.call(
+            {url: 'tel:01234567890', label: 'Baz', slug: 'baz', current: true},
             {hash: {absolute: 'true'}});
         should.exist(rendered);
-        rendered.should.equal('http://casper.website/baz');
+        rendered.should.equal('tel:01234567890');
+
+        rendered = helpers.url.call(
+            {url: 'mailto:example@ghost.org', label: 'Baz', slug: 'baz', current: true},
+            {hash: {absolute: 'true'}});
+        should.exist(rendered);
+        rendered.should.equal('mailto:example@ghost.org');
     });
 
-    it('should pass through protocol-relative URLs');
+    it('should pass through anchor-only URLs  regardless of absolute setting', function () {
+        rendered = helpers.url.call(
+            {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
+            {hash: {}});
+        should.exist(rendered);
+        rendered.should.equal('#thatsthegoodstuff');
 
-    it('should pass through URLs with alternative schemes');
+        rendered = helpers.url.call(
+            {url: '#thatsthegoodstuff', label: 'Baz', slug: 'baz', current: true},
+            {hash: {absolute: 'true'}});
+        should.exist(rendered);
+        rendered.should.equal('#thatsthegoodstuff');
+    });
 
-    it('should pass through anchor-only URLs');
+    describe('with subdir', function () {
+        it('external urls should be retained in a nav context with subdir', function () {
+            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            rendered = helpers.url.call(
+                {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
+                {hash: {absolute: 'true'}});
+            should.exist(rendered);
+            rendered.should.equal('http://casper.website/baz');
+        });
+
+        it('should handle subdir being set in nav context', function () {
+            utils.overrideConfig({url: 'http://testurl.com/blog'});
+
+            rendered = helpers.url.call(
+                {url: '/xyzzy', label: 'xyzzy', slug: 'xyzzy', current: true},
+                {hash: {absolute: 'true'}});
+            should.exist(rendered);
+            rendered.should.equal('http://testurl.com/blog/xyzzy');
+        });
+    });
 });


### PR DESCRIPTION
Refs #5801, needed for #5843
- Allows direct pass-through of protocol-relative (`//host`), alternate-scheme (`tel:`), and anchor-only urls (`#contact`)
- Tests both the `urlFor` function and the `{{url}}` helper apply the rules correctly
