### PR TITLE
Use 'updated_at' to prevent overwriting new data with old data.

### DIFF
--- a/core/server/errors/conflict-error.js
+++ b/core/server/errors/conflict-error.js
@@ -1,0 +1,14 @@
+// # Conflict error
+// Custom error class with status code and type prefilled.
+
+function ConflictError(message) {
+    this.message = message;
+    this.stack = new Error().stack;
+    this.code = 409;
+    this.errorType = this.name;
+}
+
+ConflictError.prototype = Object.create(Error.prototype);
+ConflictError.prototype.name = 'ConflictError';
+
+module.exports = ConflictError;

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -6,6 +6,7 @@ var _                          = require('lodash'),
     Promise                    = require('bluebird'),
     hbs                        = require('express-hbs'),
     NotFoundError              = require('./not-found-error'),
+    ConflictError              = require('./conflict-error'),
     BadRequestError            = require('./bad-request-error'),
     InternalServerError        = require('./internal-server-error'),
     NoPermissionError          = require('./no-permission-error'),
@@ -384,6 +385,7 @@ _.each([
 
 module.exports                            = errors;
 module.exports.NotFoundError              = NotFoundError;
+module.exports.ConflictError              = ConflictError;
 module.exports.BadRequestError            = BadRequestError;
 module.exports.InternalServerError        = InternalServerError;
 module.exports.NoPermissionError          = NoPermissionError;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "compression": "1.6.0",
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",
+    "deep-diff": "^0.3.2",
     "downsize": "0.0.8",
     "express": "4.13.3",
     "express-hbs": "0.8.4",


### PR DESCRIPTION
#5599
- refactored `models/base/index#edit` to return a transaction
- added `safeToSave` validation method to check `updated_at` in client and DB objects
- if client-side `updated_at` is behind DB, and other changes have been made, throw `409 Conflict` error
- added `deep-diff` module for calculating changes between objects

Marked WIP because differences in tags currently aren't tracked when updating posts. Input regarding next steps will be appreciated!
