### PR TITLE
Make grunt test fail if no filename provided

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -586,7 +586,7 @@ var _              = require('lodash'),
 
         grunt.registerTask('test', function (test) {
             if (!test) {
-                grunt.log.write('no test provided');
+                grunt.fail.fatal('No test provided. `grunt test` expects a filename. e.g.: `grunt test:unit/apps_spec.js`. Did you mean `npm test` or `grunt validate`?');
             }
 
             grunt.task.run('test-setup', 'shell:test:' + test);


### PR DESCRIPTION
Closes #5885

Instead of hiding a notice in a sea of printed stack traces among the
eventual error, this change will cause grunt test to halt and output an
error message with some helpful info as to what went wrong.
