### PR TITLE
Public is the default schema but if you use different name your are

### DIFF
--- a/core/server/data/utils/clients/pg.js
+++ b/core/server/data/utils/clients/pg.js
@@ -17,7 +17,7 @@ doRawFlattenAndPluck = function doRaw(query, name) {
 
 getTables = function getTables() {
     return doRawFlattenAndPluck(
-        'SELECT table_name FROM information_schema.tables WHERE table_schema = \'public\' and table_name not like \'pg_%\'', 'table_name'
+        'SELECT table_name FROM information_schema.tables WHERE table_schema = CURRENT_SCHEMA()', 'table_name'
     );
 };
 


### PR DESCRIPTION
Unable to start the upgrade process.
This new SQL command exclude 'information_schema' instead of 'public'

This PR fix the issue #5891
