### PR TITLE
Remove unnecessary API lookup for activeTheme

### DIFF
--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -1,7 +1,6 @@
 var _       = require('lodash'),
     express = require('express'),
     path    = require('path'),
-    api     = require('../api'),
     config  = require('../config'),
     utils   = require('../utils');
 
@@ -12,11 +11,10 @@ function isBlackListedFileType(file) {
 }
 
 function forwardToExpressStatic(req, res, next) {
-    api.settings.read({context: {internal: true}, key: 'activeTheme'}).then(function then(response) {
-        var activeTheme = response.settings[0];
-
-        express['static'](path.join(config.paths.themePath, activeTheme.value), {maxAge: utils.ONE_YEAR_MS})(req, res, next);
-    });
+    express['static'](
+        path.join(config.paths.themePath, req.app.get('activeTheme')),
+        {maxAge: utils.ONE_YEAR_MS}
+    )(req, res, next);
 }
 
 function staticTheme() {

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -2,9 +2,7 @@
 /*jshint expr:true*/
 var sinon        = require('sinon'),
     should       = require('should'),
-    Promise      = require('bluebird'),
 
-    api          = require('../../../server/api'),
     express      = require('express'),
     staticTheme  = require('../../../server/middleware/static-theme');
 
@@ -46,23 +44,22 @@ describe('staticTheme', function () {
 
     it('should call express.static if valid file type', function (done) {
         var req = {
-                url: 'myvalidfile.css'
+                url: 'myvalidfile.css',
+                app: {
+                    get: function () { return 'casper'; }
+                }
             },
-            settingsStub,
+            activeThemeStub,
             sandbox = sinon.sandbox.create(),
             expressStatic = sinon.spy(express, 'static');
 
-        settingsStub = sandbox.stub(api.settings, 'read').withArgs(sinon.match.has('key', 'activeTheme')).returns(Promise.resolve({
-            settings: [{
-                key: 'activeKey',
-                value: 'casper'
-            }]
-        }));
+        activeThemeStub = sandbox.spy(req.app, 'get');
 
         staticTheme(null)(req, null, function (reqArg, res, next2) {
             /*jshint unused:false */
             sandbox.restore();
             next.called.should.be.false;
+            activeThemeStub.called.should.be.true;
             expressStatic.called.should.be.true;
             expressStatic.args[0][1].maxAge.should.exist;
             done();


### PR DESCRIPTION
- the active theme is already managed and kept up to date as a property
  of the express app
- this can be accessed via `req.app` inside of middleware
