### PR TITLE
Add <enclosure> element to Ghost RSS feeds containing post cover image

### DIFF
--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -177,10 +177,10 @@ generateFeed = function generateFeed(data) {
             var imageContentType = "image/jpeg";
             
             // Support for png, gif, webp and svg images
-            imageContentType = ( imageUrl.toLowerCase().indexOf(".png") != -1 ) ? "image/png" : imageContentType;
-            imageContentType = ( imageUrl.toLowerCase().indexOf(".gif") != -1 ) ? "image/gif" : imageContentType;
-            imageContentType = ( imageUrl.toLowerCase().indexOf(".webp") != -1 ) ? "image/webp" : imageContentType;
-            imageContentType = ( imageUrl.toLowerCase().indexOf(".svg") != -1 ) ? "image/svg+xml" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".png") !== -1 ) ? "image/png" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".gif") !== -1 ) ? "image/gif" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".webp") !== -1 ) ? "image/webp" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".svg") !== -1 ) ? "image/svg+xml" : imageContentType;
 
             // Add an additional enclosure tag, because not all readers support media:content
             item.custom_elements.push({

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -172,8 +172,28 @@ generateFeed = function generateFeed(data) {
                     }
                 }
             });
+            
+            /// Detect image content type, jpeg by default
+            var imageContentType = "image/jpeg";
+            
+            // Support for png, gif, webp and svg images
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".png") != -1 ) ? "image/png" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".gif") != -1 ) ? "image/gif" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".webp") != -1 ) ? "image/webp" : imageContentType;
+            imageContentType = ( imageUrl.toLowerCase().indexOf(".svg") != -1 ) ? "image/svg+xml" : imageContentType;
 
-            // Also add the image to the content, because not all readers support media:content
+            // Add an additional enclosure tag, because not all readers support media:content
+            item.custom_elements.push({
+                'enclosure': {
+                    _attr: {
+                        length: 0,
+                        url: imageUrl,
+                        type: imageContentType
+                    }
+                }
+            });
+
+            // Also add the image to the content, because not all readers support media:content and the enclosure tag
             htmlContent('p').first().before('<img src="' + imageUrl + '" />');
             htmlContent('img').attr('alt', post.title);
         }


### PR DESCRIPTION
References #4888
- Adds the &lt;enclosure&gt; element to Ghost RSS feeds containing the post cover image if one is available. Some RSS readers don't support media:content but they do support enclosure for post images. [Here is an example.](http://help.campaignmonitor.com/topic.aspx?t=277)

Since the <enclosure> tag requires a mime type, I added some basic code to detect it based on the image URL's extension -- let me know if there's a better way to achieve this.

Also, I used the W3C XML validator with the new <enclosure> tag and it validates.
