### PR TITLE
Form default error class to none

### DIFF
--- a/core/client/app/components/gh-validation-status-container.js
+++ b/core/client/app/components/gh-validation-status-container.js
@@ -11,7 +11,11 @@ import ValidationStateMixin from 'ghost/mixins/validation-state';
 export default Ember.Component.extend(ValidationStateMixin, {
     classNameBindings: ['errorClass'],
 
-    errorClass: Ember.computed('hasError', function () {
-        return this.get('hasError') ? 'error' : 'success';
+    errorClass: Ember.computed('hasError', 'hasValidated.[]', function () {
+        if (this.hasValidated.contains(this.get('property'))) {
+            return this.get('hasError') ? 'error' : 'success';
+        } else {
+            return '';
+        }
     })
 });


### PR DESCRIPTION
fixes #5884 
prevents unvalidated forms from showing up as success

![ghost signup](https://cloud.githubusercontent.com/assets/4482399/10265890/3f1324e8-69ff-11e5-83e0-98811f7a5b91.gif)

I could use some help figuring out where/how to test this change. Is that something I should ask about in slack or can we talk about it over this PR?

Also, I know I will have to squash commits before merge, but I am hoping for some feedback first.
