### PR TITLE
Standardize ember test names and file names

### DIFF
--- a/core/client/tests/integration/components/gh-navigation-test.js
+++ b/core/client/tests/integration/components/gh-navigation-test.js
@@ -9,7 +9,7 @@ const { run } = Ember;
 
 describeComponent(
     'gh-navigation',
-    'Integration : Component : gh-navigation',
+    'Integration: Component: gh-navigation',
     {
         integration: true
     },

--- a/core/client/tests/integration/components/gh-navitem-test.js
+++ b/core/client/tests/integration/components/gh-navitem-test.js
@@ -9,7 +9,7 @@ const { run } = Ember;
 
 describeComponent(
     'gh-navitem',
-    'Integration : Component : gh-navitem',
+    'Integration: Component: gh-navitem',
     {
         integration: true
     },

--- a/core/client/tests/integration/components/gh-navitem-url-input-test.js
+++ b/core/client/tests/integration/components/gh-navitem-url-input-test.js
@@ -14,7 +14,7 @@ const { run } = Ember,
 
 describeComponent(
     'gh-navitem-url-input',
-    'Integration : Component : gh-navitem-url-input', {
+    'Integration: Component: gh-navitem-url-input', {
         integration: true
     },
     function () {

--- a/core/client/tests/unit/components/gh-alert-test.js
+++ b/core/client/tests/unit/components/gh-alert-test.js
@@ -9,7 +9,9 @@ import sinon from 'sinon';
 
 describeComponent(
     'gh-alert',
-    'GhAlertComponent', {
+    'Unit: Component: gh-alert',
+    {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-alerts-test.js
+++ b/core/client/tests/unit/components/gh-alerts-test.js
@@ -10,7 +10,9 @@ import sinon from 'sinon';
 
 describeComponent(
     'gh-alerts',
-    'GhAlertsComponent', {
+    'Unit: Component: gh-alerts',
+    {
+        unit: true,
         // specify the other units that are required for this test
         needs: ['component:gh-alert']
     },

--- a/core/client/tests/unit/components/gh-app-test.js
+++ b/core/client/tests/unit/components/gh-app-test.js
@@ -7,10 +7,11 @@ import {
 
 describeComponent(
     'gh-app',
-    'GhAppComponent',
+    'Unit: Component: gh-app',
     {
-    // specify the other units that are required for this test
-    // needs: ['component:foo', 'helper:bar']
+        unit: true
+        // specify the other units that are required for this test
+        // needs: ['component:foo', 'helper:bar']
     },
     function () {
         it('renders', function () {

--- a/core/client/tests/unit/components/gh-content-preview-content-test.js
+++ b/core/client/tests/unit/components/gh-content-preview-content-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-content-preview-content',
-    'GhContentPreviewContentComponent',
+    'Unit: Component: gh-content-preview-content',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-editor-save-button-test.js
+++ b/core/client/tests/unit/components/gh-editor-save-button-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-editor-save-button',
-    'GhEditorSaveButtonComponent',
+    'Unit: Component: gh-editor-save-button',
     {
+        unit: true,
         needs: [
             'component:gh-dropdown-button',
             'component:gh-dropdown',

--- a/core/client/tests/unit/components/gh-editor-test.js
+++ b/core/client/tests/unit/components/gh-editor-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-editor',
-    'GhEditorComponent',
+    'Unit: Component: gh-editor',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-infinite-scroll-box-test.js
+++ b/core/client/tests/unit/components/gh-infinite-scroll-box-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-infinite-scroll-box',
-    'GhInfiniteScrollBoxComponent',
+    'Unit: Component: gh-infinite-scroll-box',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-infinite-scroll-test.js
+++ b/core/client/tests/unit/components/gh-infinite-scroll-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-infinite-scroll',
-    'GhInfiniteScrollComponent',
+    'Unit: Component: gh-infinite-scroll',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-navitem-url-input-test.js
+++ b/core/client/tests/unit/components/gh-navitem-url-input-test.js
@@ -8,8 +8,10 @@ import {
 
 describeComponent(
     'gh-navitem-url-input',
-    'GhNavitemUrlInputComponent',
-    {},
+    'Unit: Component: gh-navitem-url-input',
+    {
+        unit: true
+    },
     function () {
         it('identifies a URL as the base URL', function () {
             var component = this.subject({

--- a/core/client/tests/unit/components/gh-notification-test.js
+++ b/core/client/tests/unit/components/gh-notification-test.js
@@ -9,7 +9,9 @@ import sinon from 'sinon';
 
 describeComponent(
     'gh-notification',
-    'GhNotificationComponent', {
+    'Unit: Component: gh-notification',
+    {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-notifications-test.js
+++ b/core/client/tests/unit/components/gh-notifications-test.js
@@ -9,8 +9,8 @@ from 'ember-mocha';
 
 describeComponent(
     'gh-notifications',
-    'GhNotificationsComponent', {
-        // specify the other units that are required for this test
+    'Unit: Component: gh-notifications', {
+        unit: true,
         needs: ['component:gh-notification']
     },
     function () {

--- a/core/client/tests/unit/components/gh-posts-list-item-test.js
+++ b/core/client/tests/unit/components/gh-posts-list-item-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-posts-list-item',
-    'GhPostsListItemComponent',
+    'Unit: Component: gh-posts-list-item',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-profile-image-test.js
+++ b/core/client/tests/unit/components/gh-profile-image-test.js
@@ -6,9 +6,14 @@ import {
     it
 } from 'ember-mocha';
 
-describeComponent('gh-profile-image', 'GhProfileImageComponent', {
+describeComponent(
+    'gh-profile-image',
+    'Unit: Component: gh-profile-image',
+    {
+        unit: true,
         needs: ['service:ghost-paths']
-    }, function () {
+    },
+    function () {
         it('renders', function () {
             // creates the component instance
             var component = this.subject();

--- a/core/client/tests/unit/components/gh-search-input-test.js
+++ b/core/client/tests/unit/components/gh-search-input-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-search-input',
-    'GhSearchInputComponent',
+    'Unit: Component: gh-search-input',
     {
+        unit: true,
         needs: ['component:gh-selectize']
     },
     function () {

--- a/core/client/tests/unit/components/gh-select-native-test.js
+++ b/core/client/tests/unit/components/gh-select-native-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-select-native',
-    'GhSelectNativeComponent',
+    'Unit: Component: gh-select-native',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-spin-button-test.js
+++ b/core/client/tests/unit/components/gh-spin-button-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-spin-button',
-    'GhSpinButtonComponent',
+    'Unit: Component: gh-spin-button',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-trim-focus-input_test.js
+++ b/core/client/tests/unit/components/gh-trim-focus-input_test.js
@@ -4,37 +4,44 @@ import {
     it
 } from 'ember-mocha';
 
-describeComponent('gh-trim-focus-input', function () {
-    it('trims value on focusOut', function () {
-        var component = this.subject({
-            value: 'some random stuff   '
+describeComponent(
+    'gh-trim-focus-input',
+    'Unit: Component: gh-trim-focus-input',
+    {
+        unit: true
+    },
+    function () {
+        it('trims value on focusOut', function () {
+            var component = this.subject({
+                value: 'some random stuff   '
+            });
+
+            this.render();
+
+            component.$().focusout();
+            expect(component.$().val()).to.equal('some random stuff');
         });
 
-        this.render();
+        it('does not have the autofocus attribute if not set to focus', function () {
+            var component = this.subject({
+                value: 'some text',
+                focus: false
+            });
 
-        component.$().focusout();
-        expect(component.$().val()).to.equal('some random stuff');
-    });
+            this.render();
 
-    it('does not have the autofocus attribute if not set to focus', function () {
-        var component = this.subject({
-            value: 'some text',
-            focus: false
+            expect(component.$().attr('autofocus')).to.not.be.ok;
         });
 
-        this.render();
+        it('has the autofocus attribute if set to focus', function () {
+            var component = this.subject({
+                value: 'some text',
+                focus: true
+            });
 
-        expect(component.$().attr('autofocus')).to.not.be.ok;
-    });
+            this.render();
 
-    it('has the autofocus attribute if set to focus', function () {
-        var component = this.subject({
-            value: 'some text',
-            focus: true
+            expect(component.$().attr('autofocus')).to.be.ok;
         });
-
-        this.render();
-
-        expect(component.$().attr('autofocus')).to.be.ok;
-    });
-});
+    }
+);

--- a/core/client/tests/unit/components/gh-url-preview_test.js
+++ b/core/client/tests/unit/components/gh-url-preview_test.js
@@ -3,7 +3,12 @@ import {
     it
 } from 'ember-mocha';
 
-describeComponent('gh-url-preview',
+describeComponent(
+    'gh-url-preview',
+    'Unit: Component: gh-url-preview',
+    {
+        unit: true
+    },
     function () {
         it('generates the correct preview URL with a prefix', function () {
             var component = this.subject({

--- a/core/client/tests/unit/components/gh-user-active-test.js
+++ b/core/client/tests/unit/components/gh-user-active-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-user-active',
-    'GhUserActiveComponent',
+    'Unit: Component: gh-user-active',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/components/gh-user-invited-test.js
+++ b/core/client/tests/unit/components/gh-user-invited-test.js
@@ -7,8 +7,9 @@ import {
 
 describeComponent(
     'gh-user-invited',
-    'GhUserInvitedComponent',
+    'Unit: Component: gh-user-invited',
     {
+        unit: true
         // specify the other units that are required for this test
         // needs: ['component:foo', 'helper:bar']
     },

--- a/core/client/tests/unit/controllers/post-settings-menu-test.js
+++ b/core/client/tests/unit/controllers/post-settings-menu-test.js
@@ -6,6 +6,7 @@ import {
 
 describeModule(
     'controller:post-settings-menu',
+    'Unit: Controller: post-settings-menu',
     {
         needs: ['controller:application', 'service:notifications']
     },

--- a/core/client/tests/unit/controllers/settings/general-test.js
+++ b/core/client/tests/unit/controllers/settings/general-test.js
@@ -6,6 +6,7 @@ import {
 
 describeModule(
     'controller:settings/general',
+    'Unit: Controller: settings/general',
     {
         needs: ['service:notifications']
     },

--- a/core/client/tests/unit/controllers/settings/navigation-test.js
+++ b/core/client/tests/unit/controllers/settings/navigation-test.js
@@ -19,7 +19,7 @@ var navSettingJSON = `[
 
 describeModule(
     'controller:settings/navigation',
-    'Unit : Controller : settings/navigation',
+    'Unit: Controller: settings/navigation',
     {
         // Specify the other units that are required for this test.
         needs: ['service:config', 'service:notifications']

--- a/core/client/tests/unit/helpers/gh-user-can-admin-test.js
+++ b/core/client/tests/unit/helpers/gh-user-can-admin-test.js
@@ -6,7 +6,7 @@ import {
     ghUserCanAdmin
 } from 'ghost/helpers/gh-user-can-admin';
 
-describe ('GhUserCanAdminHelper', function () {
+describe ('Unit: Helper: gh-user-can-admin', function () {
     // Mock up roles and test for truthy
     describe ('Owner role', function () {
         var user = {get: function (role) {

--- a/core/client/tests/unit/helpers/is-equal-test.js
+++ b/core/client/tests/unit/helpers/is-equal-test.js
@@ -8,7 +8,7 @@ import {
     isEqual
 } from 'ghost/helpers/is-equal';
 
-describe('IsEqualHelper', function () {
+describe('Unit: Helper: is-equal', function () {
     // Replace this with your real tests.
     it('works', function () {
         var result = isEqual([42, 42]);

--- a/core/client/tests/unit/helpers/is-not-test.js
+++ b/core/client/tests/unit/helpers/is-not-test.js
@@ -8,7 +8,7 @@ import {
     isNot
 } from 'ghost/helpers/is-not';
 
-describe('IsNotHelper', function () {
+describe('Unit: Helper: is-not', function () {
     // Replace this with your real tests.
     it('works', function () {
         var result = isNot(false);

--- a/core/client/tests/unit/helpers/read-path-test.js
+++ b/core/client/tests/unit/helpers/read-path-test.js
@@ -7,7 +7,7 @@ import {
 import {readPath} from 'ghost/helpers/read-path';
 import Ember from 'ember';
 
-describe('ReadPathHelper', function () {
+describe('Unit: Helper: read-path', function () {
     // Replace this with your real tests.
     it('works', function () {
         var result = readPath([Ember.Object.create({hi: 'there'}), 'hi']);

--- a/core/client/tests/unit/mixins/infinite-scroll-test.js
+++ b/core/client/tests/unit/mixins/infinite-scroll-test.js
@@ -7,7 +7,7 @@ import {
 import Ember from 'ember';
 import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
 
-describe('InfiniteScrollMixin', function () {
+describe('Unit: Mixin: infinite-scroll', function () {
     // Replace this with your real tests.
     it('works', function () {
         var InfiniteScrollObject = Ember.Object.extend(InfiniteScrollMixin),

--- a/core/client/tests/unit/models/post-test.js
+++ b/core/client/tests/unit/models/post-test.js
@@ -4,7 +4,9 @@ import {
     it
 } from 'ember-mocha';
 
-describeModel('post',
+describeModel(
+    'post',
+    'Unit: Model: post',
     {
         needs:['model:user', 'model:tag', 'model:role']
     },

--- a/core/client/tests/unit/models/role-test.js
+++ b/core/client/tests/unit/models/role-test.js
@@ -4,7 +4,7 @@ import {
     it
 } from 'ember-mocha';
 
-describeModel('role', function () {
+describeModel('role', 'Unit: Model: role', function () {
     it('provides a lowercase version of the name', function () {
         var model = this.subject({
             name: 'Author'

--- a/core/client/tests/unit/models/setting-test.js
+++ b/core/client/tests/unit/models/setting-test.js
@@ -3,7 +3,7 @@ import {
     it
 } from 'ember-mocha';
 
-describeModel('setting', function () {
+describeModel('setting', 'Unit: Model: setting', function () {
     it('has a validation type of "setting"', function () {
         var model = this.subject();
 

--- a/core/client/tests/unit/models/tag-test.js
+++ b/core/client/tests/unit/models/tag-test.js
@@ -3,7 +3,7 @@ import {
     it
 } from 'ember-mocha';
 
-describeModel('tag', function () {
+describeModel('tag', 'Unit: Model: tag', function () {
     it('has a validation type of "tag"', function () {
         var model = this.subject();
 

--- a/core/client/tests/unit/models/user-test.js
+++ b/core/client/tests/unit/models/user-test.js
@@ -4,7 +4,9 @@ import {
     it
 } from 'ember-mocha';
 
-describeModel('user',
+describeModel(
+    'user',
+    'Unit: Model: user',
     {
         needs: ['model:role']
     },

--- a/core/client/tests/unit/services/config-test.js
+++ b/core/client/tests/unit/services/config-test.js
@@ -9,7 +9,7 @@ import Ember from 'ember';
 
 describeModule(
     'service:config',
-    'ConfigService',
+    'Unit: Service: config',
     {
         // Specify the other units that are required for this test.
         // needs: ['service:foo']

--- a/core/client/tests/unit/services/notifications-test.js
+++ b/core/client/tests/unit/services/notifications-test.js
@@ -9,7 +9,7 @@ import {
 
 describeModule(
     'service:notifications',
-    'NotificationsService',
+    'Unit: Service: notifications',
     {
         // Specify the other units that are required for this test.
         // needs: ['model:notification']

--- a/core/client/tests/unit/utils/ghost-paths-test.js
+++ b/core/client/tests/unit/utils/ghost-paths-test.js
@@ -1,6 +1,6 @@
 import ghostPaths from 'ghost/utils/ghost-paths';
 
-describe('ghost-paths', function () {
+describe('Unit: Util: ghost-paths', function () {
     describe('join', function () {
         var join = ghostPaths().url.join;
 

--- a/core/client/tests/unit/validators/nav-item-test.js
+++ b/core/client/tests/unit/validators/nav-item-test.js
@@ -32,7 +32,7 @@ testValidUrl = function (url) {
     expect(navItem.get('hasValidated')).to.include('url');
 };
 
-describe('Unit : Validator : nav-item', function () {
+describe('Unit: Validator: nav-item', function () {
     it('requires label presence', function () {
         let navItem = NavItem.create();
 


### PR DESCRIPTION
no issue
- standardize on "{TestType}: {ModuleType}: {module-name}" for test description strings
- standardize on `{module-name}-test.js` for test file names
- fix deprecation notices for ember component unit tests without explicit `unit: true` or `needs: []`
