### PR TITLE
fix for page deletion not updating sitemap-page.xml

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -104,7 +104,7 @@ Post = ghostBookshelf.Model.extend({
             }
         });
 
-        this.on('destroyed', function onDestroyed(model) {
+        this.on('destroying', function onDestroying(model) {
             if (model.previous('status') === 'published') {
                 model.emitChange('unpublished');
             }


### PR DESCRIPTION
closes #5913

Sitemap deletion is based on the page.unpublished event. The previous
logic was always sending post.unpublished instead. If page or post
event is triggered is based on the ‘page’ attribute of the model. When
the destroyed handler all attributes are already cleared from the model
which makes this logic always fall back to post.

The fix is to move to the destroying event which still has all the
model values in place.
