### PR TITLE
Set a higher maxListeners value

### DIFF
--- a/core/server/events/index.js
+++ b/core/server/events/index.js
@@ -1,9 +1,12 @@
 var events  = require('events'),
     util    = require('util'),
-    EventRegistry;
+    EventRegistry,
+    EventRegistryInstance;
 
 EventRegistry = function () {};
-
 util.inherits(EventRegistry, events.EventEmitter);
 
-module.exports = new EventRegistry();
+EventRegistryInstance = new EventRegistry();
+EventRegistryInstance.setMaxListeners(100);
+
+module.exports = EventRegistryInstance;


### PR DESCRIPTION
According to the link @acburdine posted (https://github.com/nodejs/node-v0.x-archive/issues/5108) the 11 listeners message is expected on node 12 - it always outputs if you set more than 10, basically.

We can either apply this fix to quieten the noise, or alternatively just ignore it and close the issue as a won't fix.

fixes #5373
- Set Max Listeners on our Event Emitter to 100
- Stops the '11 listeners added' error on node 0.12 during tests
