### PR TITLE
Fix /author/ pages crashing & permit /tag/

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -212,7 +212,7 @@ ConfigManager.prototype.set = function (config) {
             // Used by generateSlug to generate slugs for posts, tags, users, ..
             // reserved slugs are reserved but can be extended/removed by apps
             // protected slugs cannot be changed or removed
-            reserved: ['admin', 'app', 'apps', 'archive', 'archives', 'categories', 'category', 'dashboard', 'feed', 'ghost-admin', 'login', 'logout', 'page', 'pages', 'post', 'posts', 'public', 'register', 'setup', 'signin', 'signout', 'signup', 'tag', 'tags', 'user', 'users', 'wp-admin', 'wp-login'],
+            reserved: ['admin', 'app', 'apps', 'archive', 'archives', 'categories', 'category', 'dashboard', 'feed', 'ghost-admin', 'login', 'logout', 'page', 'pages', 'post', 'posts', 'public', 'register', 'setup', 'signin', 'signout', 'signup', 'user', 'users', 'wp-admin', 'wp-login'],
             protected: ['ghost', 'rss']
         },
         uploads: {

--- a/core/server/controllers/frontend.js
+++ b/core/server/controllers/frontend.js
@@ -72,8 +72,8 @@ function handleError(next) {
 function setResponseContext(req, res, data) {
     var contexts = [],
         pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
-        tagPattern = new RegExp('^\\/' + config.routeKeywords.tag + '\\/'),
-        authorPattern = new RegExp('^\\/' + config.routeKeywords.author + '\\/'),
+        tagPattern = new RegExp('^\\/' + config.routeKeywords.tag + '\\/.+'),
+        authorPattern = new RegExp('^\\/' + config.routeKeywords.author + '\\/.+'),
         privatePattern = new RegExp('^\\/' + config.routeKeywords.private + '\\/'),
         indexPattern = new RegExp('^\\/' + config.routeKeywords.page + '\\/'),
         homePattern = new RegExp('^\\/$');

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -526,6 +526,14 @@ describe('Frontend Routing', function () {
 
         after(testUtils.teardown);
 
+        it('should 404 for /author/ route', function (done) {
+            request.get('/author/')
+                .expect('Cache-Control', testUtils.cacheRules['private'])
+                .expect(404)
+                .expect(/Page not found/)
+                .end(doEnd(done));
+        });
+
         it('should redirect without slash', function (done) {
             request.get('/author/ghost-owner/page/2')
                 .expect('Location', '/author/ghost-owner/page/2/')
@@ -652,6 +660,14 @@ describe('Frontend Routing', function () {
         });
 
         after(testUtils.teardown);
+
+        it('should 404 for /tag/ route', function (done) {
+            request.get('/tag/')
+                .expect('Cache-Control', testUtils.cacheRules['private'])
+                .expect(404)
+                .expect(/Page not found/)
+                .end(doEnd(done));
+        });
 
         it('should redirect without slash', function (done) {
             request.get('/tag/injection/page/2')


### PR DESCRIPTION
fixes #5905
- update context patterns to correctly match author & tag pages
- remove 'tag' and 'tags' from reserved slugs - we'll handle this in terms of overrides in future
