### PR TITLE
Add titles to key icons

### DIFF
--- a/core/client/app/templates/editor/edit.hbs
+++ b/core/client/app/templates/editor/edit.hbs
@@ -5,7 +5,7 @@
         tabindex="1" focus=shouldFocusTitle}}
         {{/gh-view-title}}
         <section class="view-actions">
-            <button type="button" class="post-settings" {{action "openSettingsMenu"}}>
+            <button type="button" class="post-settings" title="Post Settings" {{action "openSettingsMenu"}}>
                 <i class="icon-settings"></i>
             </button>
             {{gh-editor-save-button
@@ -29,7 +29,7 @@
                     <a href="#" {{action 'selectTab' 'markdown' target=ghEditor}} class="{{if ghEditor.markdownActive 'active'}}">Markdown</a>
                     <a href="#" {{action 'selectTab' 'preview' target=ghEditor}} class="{{if ghEditor.previewActive 'active'}}">Preview</a>
                 </span>
-                <a class="markdown-help" href="" {{action "openModal" "markdown"}}><i class="icon-markdown"></i></a>
+                <a class="markdown-help" href="" title="Markdown Help" {{action "openModal" "markdown"}}><i class="icon-markdown"></i></a>
             </header>
             <section id="entry-markdown-content" class="entry-markdown-content">
                 {{gh-ed-editor classNames="markdown-editor js-markdown-editor" tabindex="1" spellcheck="true" value=model.scratch setEditor="setEditor" updateScrollInfo="updateEditorScrollInfo" openModal="openModal" onFocusIn="autoSaveNew" height=height focus=shouldFocusEditor}}

--- a/core/client/app/templates/posts/post.hbs
+++ b/core/client/app/templates/posts/post.hbs
@@ -1,5 +1,5 @@
 <section class="post-controls">
-    {{#link-to "editor.edit" model.id class="btn btn-minor post-edit"}}<i class="icon-edit"></i>{{/link-to}}
+    {{#link-to "editor.edit" model.id class="btn btn-minor post-edit" title="Edit this post"}}<i class="icon-edit"></i>{{/link-to}}
 </section>
 
 {{#gh-content-preview-content tagName="section" content=model}}


### PR DESCRIPTION
This is in no way comprehensive, but it adds a couple of titles to key icons in the main editing flow, which do not otherwise have any text indicating what they are.

This can be used to close #5931, or otherwise that issue can be closed without this addition as the cursor has already been changed to the help cursor.

A full audit of accessibility would be great, these amends are just a starter for the 3 most obvious places where there is no text.

closes #5931, refs #3964 
- add 'Markdown Help' title to markdown logo
- add 'Post Settings' title to post settings cog
- add 'Edit this post' title to edit icon on content screen
