### PR TITLE
Revert to using findAll for internal tools

### DIFF
--- a/core/server/data/import/data-importer.js
+++ b/core/server/data/import/data-importer.js
@@ -23,13 +23,13 @@ DataImporter.prototype.loadRoles = function () {
 
 DataImporter.prototype.loadUsers = function () {
     var users = {all: {}},
-        options = _.extend({}, {include: ['roles'], limit: 'all'}, internal);
+        options = _.extend({}, {include: ['roles']}, internal);
 
-    return models.User.findPage(options).then(function (data) {
-        data.users.forEach(function (user) {
-            users.all[user.email] = {realId: user.id};
-            if (user.roles[0] && user.roles[0].name === 'Owner') {
-                users.owner = user;
+    return models.User.findAll(options).then(function (_users) {
+        _users.forEach(function (user) {
+            users.all[user.get('email')] = {realId: user.get('id')};
+            if (user.related('roles').toJSON(options)[0] && user.related('roles').toJSON(options)[0].name === 'Owner') {
+                users.owner = user.toJSON(options);
             }
         });
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -187,7 +187,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     /**
      * Returns an array of keys permitted in every method's `options` hash.
      * Can be overridden and added to by a model's `permittedOptions` method.
-     * @return {Array} Keys allowed in the `options` hash of every model's method.
+     * @return {Object} Keys allowed in the `options` hash of every model's method.
      */
     permittedOptions: function permittedOptions() {
         // terms to whitelist for all methods.
@@ -229,6 +229,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     findAll: function findAll(options) {
         options = this.filterOptions(options, 'findAll');
+        options.withRelated = _.union(options.withRelated, options.include);
         return this.forge().fetchAll(options).then(function then(result) {
             if (options.include) {
                 _.each(result.models, function each(item) {

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -44,13 +44,13 @@ models = {
     deleteAllContent: function deleteAllContent() {
         var self = this;
 
-        return self.Post.findPage({limit: 'all'}).then(function then(data) {
-            return Promise.all(_.map(data.posts, function mapper(post) {
+        return self.Post.findAll().then(function then(posts) {
+            return Promise.all(_.map(posts.toJSON(), function mapper(post) {
                 return self.Post.destroy({id: post.id});
             }));
         }).then(function () {
-            return self.Tag.findPage({limit: 'all'}).then(function then(data) {
-                return Promise.all(_.map(data.tags, function mapper(tag) {
+            return self.Tag.findAll().then(function then(tags) {
+                return Promise.all(_.map(tags.toJSON(), function mapper(tag) {
                     return self.Tag.destroy({id: tag.id});
                 }));
             });

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -513,7 +513,7 @@ describe('Post Model', function () {
                 }).catch(done);
             });
 
-            it.only('can save a draft without setting published_by or published_at', function (done) {
+            it('can save a draft without setting published_by or published_at', function (done) {
                 var newPost = testUtils.DataGenerator.forModel.posts[2],
                     postId;
 


### PR DESCRIPTION
This was an error with the original spec for #4577 - although the `findAll` methods can be removed from individual models as the specific versions are no longer needed, we still need to use the base `findAll` method when importing or removing all content as findPage has special logic.

In the case of posts and users, `findPage({limit: 'all'})` doesn't have quite the same meaning as `findAll` as there are filters based on status and other attributes. `findAll` fetches all records without filters.

The result was that `deleteAllContent` was only deleting published posts, and the importer would also have had problems with matching up inactive users.

The reason this wasn't flagged up by the tests in #5909 is that I had accidentally left an `.only` statement behind from testing something else, disabling the pertinent tests. This PR fixes that too.

refs #5909, #4577 
- removes accidental '.only' which was hiding issues with the findAll changes
- deleteAllContent and importer still need to use a hard 'findAll' as findPage({limit: 'all'}) doesn't have the same behaviour
