### PR TITLE
Don't run Casper.js tests by default

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -613,7 +613,7 @@ var _              = require('lodash'),
         // details of each of the test suites.
         //
         grunt.registerTask('test-all', 'Run tests and lint code',
-            ['test-routes', 'test-module', 'test-unit', 'test-integration', 'test-ember', 'test-functional']);
+            ['test-routes', 'test-module', 'test-unit', 'test-integration', 'test-ember']);
 
         // ### Lint
         //


### PR DESCRIPTION
This PR proposes that we no longer run our Casper.js tests on travis or as part of the default `grunt validate` step. Those tests take forever, fail randomly and are delivering minimal value in terms of catching genuine bugs, whilst holding up development.

After this PR is merged, the tests can still be run with `grunt test-functional`
- remove casper tests from `grunt validate`
- the tests are still in the codebase & runnable manually for now
