### PR TITLE
Fix random ember test failures

### DIFF
--- a/core/client/testem.json
+++ b/core/client/testem.json
@@ -1,5 +1,5 @@
 {
-  "framework": "qunit",
+  "framework": "mocha",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [

--- a/core/client/tests/acceptance/settings/navigation-test.js
+++ b/core/client/tests/acceptance/settings/navigation-test.js
@@ -141,8 +141,8 @@ describe('Acceptance: Settings - Navigation', function () {
 
     it('redirects to team page when authenticated as author', function () {
         run(() => {
-            let role = store.createRecord('role', {name: 'Author'});
-            store.createRecord('user', {id: 'me', roles: [role]});
+            let role = store.push('role', {id: 1, name: 'Author'});
+            store.push('user', {id: 'me', roles: [role]});
         });
 
         authenticateSession();
@@ -156,8 +156,8 @@ describe('Acceptance: Settings - Navigation', function () {
     describe('when logged in', function () {
         beforeEach(function () {
             run(() => {
-                let role = store.createRecord('role', {name: 'Administrator'});
-                store.createRecord('user', {id: 'me', roles: [role]});
+                let role = store.push('role', {id: 1, name: 'Administrator'});
+                store.push('user', {id: 'me', roles: [role]});
             });
 
             authenticateSession();
@@ -185,16 +185,20 @@ describe('Acceptance: Settings - Navigation', function () {
                 // TODO: Test for successful save here once we have a visual
                 // indication. For now we know the save happened because
                 // Pretender doesn't complain about an unknown URL
-                expect($('.error').length).to.equal(0);
-                expect($('.gh-alert').length).to.equal(0);
+
+                // don't test against .error directly as it will pick up failed
+                // tests "pre.error" elements
+                expect($('span.error').length, 'error fields count').to.equal(0);
+                expect($('.gh-alert').length, 'alerts count').to.equal(0);
             });
         });
 
         it('clears unsaved settings when navigating away', function () {
             visit('/settings/navigation');
+            fillIn('.gh-blognav-label:first input', 'Test');
+            triggerEvent('.gh-blognav-label:first input', 'blur');
 
             andThen(function () {
-                $('.gh-blognav-label input').val('Test');
                 expect($('.gh-blognav-label:first input').val()).to.equal('Test');
             });
 

--- a/core/client/tests/test-helper.js
+++ b/core/client/tests/test-helper.js
@@ -2,3 +2,10 @@ import resolver from './helpers/resolver';
 import { setResolver } from 'ember-mocha';
 
 setResolver(resolver);
+
+/* jshint ignore:start */
+mocha.setup({
+    timeout: 5000,
+    slow: 500
+});
+/* jshint ignore:end */

--- a/core/client/tests/unit/models/user-test.js
+++ b/core/client/tests/unit/models/user-test.js
@@ -4,6 +4,8 @@ import {
     it
 } from 'ember-mocha';
 
+const { run } = Ember;
+
 describeModel(
     'user',
     'Unit: Model: user',
@@ -26,24 +28,15 @@ describeModel(
             expect(model.get('active')).to.be.ok;
 
             ['warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'].forEach(function (status) {
-                Ember.run(function () {
-                    model.set('status', status);
-
-                    expect(model.get('status')).to.be.ok;
-                });
+                run(() => { model.set('status', status); });
+                expect(model.get('status')).to.be.ok;
             });
 
-            Ember.run(function () {
-                model.set('status', 'inactive');
+            run(() => { model.set('status', 'inactive'); });
+            expect(model.get('active')).to.not.be.ok;
 
-                expect(model.get('active')).to.not.be.ok;
-            });
-
-            Ember.run(function () {
-                model.set('status', 'invited');
-
-                expect(model.get('active')).to.not.be.ok;
-            });
+            run(() => { model.set('status', 'invited'); });
+            expect(model.get('active')).to.not.be.ok;
         });
 
         it('invited property is correct', function () {
@@ -53,23 +46,14 @@ describeModel(
 
             expect(model.get('invited')).to.be.ok;
 
-            Ember.run(function () {
-                model.set('status', 'invited-pending');
+            run(() => { model.set('status', 'invited-pending'); });
+            expect(model.get('invited')).to.be.ok;
 
-                expect(model.get('invited')).to.be.ok;
-            });
+            run(() => { model.set('status', 'active'); });
+            expect(model.get('invited')).to.not.be.ok;
 
-            Ember.run(function () {
-                model.set('status', 'active');
-
-                expect(model.get('invited')).to.not.be.ok;
-            });
-
-            Ember.run(function () {
-                model.set('status', 'inactive');
-
-                expect(model.get('invited')).to.not.be.ok;
-            });
+            run(() => { model.set('status', 'inactive'); });
+            expect(model.get('invited')).to.not.be.ok;
         });
 
         it('pending property is correct', function () {
@@ -79,100 +63,79 @@ describeModel(
 
             expect(model.get('pending')).to.be.ok;
 
-            Ember.run(function () {
-                model.set('status', 'invited');
+            run(() => { model.set('status', 'invited'); });
+            expect(model.get('pending')).to.not.be.ok;
 
-                expect(model.get('pending')).to.not.be.ok;
-            });
-
-            Ember.run(function () {
-                model.set('status', 'inactive');
-
-                expect(model.get('pending')).to.not.be.ok;
-            });
+            run(() => { model.set('status', 'inactive'); });
+            expect(model.get('pending')).to.not.be.ok;
         });
 
         it('role property is correct', function () {
-            var model,
-                role;
+            var model = this.subject();
 
-            model = this.subject();
-
-            Ember.run(this, function () {
-                role = this.store().createRecord('role', {name: 'Author'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Author'});
                 model.get('roles').pushObject(role);
-
-                expect(model.get('role.name')).to.equal('Author');
             });
+            expect(model.get('role.name')).to.equal('Author');
 
-            Ember.run(this, function () {
-                role = this.store().createRecord('role', {name: 'Editor'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Editor'});
                 model.set('role', role);
-
-                expect(model.get('role.name')).to.equal('Editor');
             });
+            expect(model.get('role.name')).to.equal('Editor');
         });
 
         it('isAuthor property is correct', function () {
             var model = this.subject();
 
-            Ember.run(this, function () {
-                var role = this.store().createRecord('role', {name: 'Author'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Author'});
                 model.set('role', role);
-
-                expect(model.get('isAuthor')).to.be.ok;
-                expect(model.get('isEditor')).to.not.be.ok;
-                expect(model.get('isAdmin')).to.not.be.ok;
-                expect(model.get('isOwner')).to.not.be.ok;
             });
+            expect(model.get('isAuthor')).to.be.ok;
+            expect(model.get('isEditor')).to.not.be.ok;
+            expect(model.get('isAdmin')).to.not.be.ok;
+            expect(model.get('isOwner')).to.not.be.ok;
         });
 
         it('isEditor property is correct', function () {
             var model = this.subject();
 
-            Ember.run(this, function () {
-                var role = this.store().createRecord('role', {name: 'Editor'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Editor'});
                 model.set('role', role);
-
-                expect(model.get('isEditor')).to.be.ok;
-                expect(model.get('isAuthor')).to.not.be.ok;
-                expect(model.get('isAdmin')).to.not.be.ok;
-                expect(model.get('isOwner')).to.not.be.ok;
             });
+            expect(model.get('isEditor')).to.be.ok;
+            expect(model.get('isAuthor')).to.not.be.ok;
+            expect(model.get('isAdmin')).to.not.be.ok;
+            expect(model.get('isOwner')).to.not.be.ok;
         });
 
         it('isAdmin property is correct', function () {
             var model = this.subject();
 
-            Ember.run(this, function () {
-                var role = this.store().createRecord('role', {name: 'Administrator'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Administrator'});
                 model.set('role', role);
-
-                expect(model.get('isAdmin')).to.be.ok;
-                expect(model.get('isAuthor')).to.not.be.ok;
-                expect(model.get('isEditor')).to.not.be.ok;
-                expect(model.get('isOwner')).to.not.be.ok;
             });
+            expect(model.get('isAdmin')).to.be.ok;
+            expect(model.get('isAuthor')).to.not.be.ok;
+            expect(model.get('isEditor')).to.not.be.ok;
+            expect(model.get('isOwner')).to.not.be.ok;
         });
 
         it('isOwner property is correct', function () {
             var model = this.subject();
 
-            Ember.run(this, function () {
-                var role = this.store().createRecord('role', {name: 'Owner'});
-
+            run(() => {
+                let role = this.store().push('role', {id: 1, name: 'Owner'});
                 model.set('role', role);
-
-                expect(model.get('isOwner')).to.be.ok;
-                expect(model.get('isAuthor')).to.not.be.ok;
-                expect(model.get('isAdmin')).to.not.be.ok;
-                expect(model.get('isEditor')).to.not.be.ok;
             });
+            expect(model.get('isOwner')).to.be.ok;
+            expect(model.get('isAuthor')).to.not.be.ok;
+            expect(model.get('isAdmin')).to.not.be.ok;
+            expect(model.get('isEditor')).to.not.be.ok;
         });
     }
 );


### PR DESCRIPTION
no issue
- increases the timeout because acceptance tests sometimes hit the previous 2sec limit which then caused a knock-on effect through other tests
- fix settings/navigation acceptance tests where it picked up previous test failure error messages
