### PR TITLE
Fix gh-validation-settings-container throwing error on tag settings page

### DIFF
--- a/core/client/app/components/gh-validation-status-container.js
+++ b/core/client/app/components/gh-validation-status-container.js
@@ -11,8 +11,11 @@ import ValidationStateMixin from 'ghost/mixins/validation-state';
 export default Ember.Component.extend(ValidationStateMixin, {
     classNameBindings: ['errorClass'],
 
-    errorClass: Ember.computed('hasError', 'hasValidated.[]', function () {
-        if (this.hasValidated.contains(this.get('property'))) {
+    errorClass: Ember.computed('property', 'hasError', 'hasValidated.[]', function () {
+        let hasValidated = this.get('hasValidated'),
+            property = this.get('property');
+
+        if (hasValidated && hasValidated.contains(property)) {
             return this.get('hasError') ? 'error' : 'success';
         } else {
             return '';

--- a/core/client/tests/integration/components/gh-validation-status-container-test.js
+++ b/core/client/tests/integration/components/gh-validation-status-container-test.js
@@ -1,0 +1,72 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+    describeComponent,
+    it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import DS from 'ember-data';
+
+describeComponent(
+    'gh-validation-status-container',
+    'Integration: Component: gh-validation-status-container',
+    {
+        integration: true
+    },
+    function () {
+        beforeEach(function () {
+            let testObject = new Ember.Object();
+            testObject.set('name', 'Test');
+            testObject.set('hasValidated', []);
+            testObject.set('errors', DS.Errors.create());
+
+            this.set('testObject', testObject);
+        });
+
+        it('has no success/error class by default', function () {
+            this.render(hbs`
+                {{#gh-validation-status-container class="gh-test" property="name" errors=testObject.errors hasValidated=testObject.hasValidated}}
+                {{/gh-validation-status-container}}
+            `);
+            expect(this.$('.gh-test')).to.have.length(1);
+            expect(this.$('.gh-test').hasClass('success')).to.be.false;
+            expect(this.$('.gh-test').hasClass('error')).to.be.false;
+        });
+
+        it('has success class when valid', function () {
+            this.get('testObject.hasValidated').push('name');
+
+            this.render(hbs`
+                {{#gh-validation-status-container class="gh-test" property="name" errors=testObject.errors hasValidated=testObject.hasValidated}}
+                {{/gh-validation-status-container}}
+            `);
+            expect(this.$('.gh-test')).to.have.length(1);
+            expect(this.$('.gh-test').hasClass('success')).to.be.true;
+            expect(this.$('.gh-test').hasClass('error')).to.be.false;
+        });
+
+        it('has error class when invalid', function () {
+            this.get('testObject.hasValidated').push('name');
+            this.get('testObject.errors').add('name', 'has error');
+
+            this.render(hbs`
+                {{#gh-validation-status-container class="gh-test" property="name" errors=testObject.errors hasValidated=testObject.hasValidated}}
+                {{/gh-validation-status-container}}
+            `);
+            expect(this.$('.gh-test')).to.have.length(1);
+            expect(this.$('.gh-test').hasClass('success')).to.be.false;
+            expect(this.$('.gh-test').hasClass('error')).to.be.true;
+        });
+
+        it('still renders if hasValidated is undefined', function () {
+            this.set('testObject.hasValidated', undefined);
+
+            this.render(hbs`
+                {{#gh-validation-status-container class="gh-test" property="name" errors=testObject.errors hasValidated=testObject.hasValidated}}
+                {{/gh-validation-status-container}}
+            `);
+            expect(this.$('.gh-test')).to.have.length(1);
+        });
+    }
+);


### PR DESCRIPTION
no issue
- check that gh-validation-settings-container component's `hasValidated` property exists
- add tests for `gh-validation-settings-container`
