### PR TITLE
Fix "revoke invite" feature on /team page

### DIFF
--- a/core/client/app/adapters/user.js
+++ b/core/client/app/adapters/user.js
@@ -5,6 +5,17 @@ export default ApplicationAdapter.extend({
         return this.findQuery(store, type, {id: id, status: 'all'});
     },
 
+    // TODO: This is needed because the API currently expects you to know the
+    // status of the record before retrieving by ID. Quick fix is to always
+    // include status=all in the query
+    findRecord: function (store, type, id, snapshot) {
+        let url = this.buildIncludeURL(store, type.modelName, id, snapshot, 'findRecord');
+
+        url += '&status=all';
+
+        return this.ajax(url, 'GET');
+    },
+
     findAll: function (store, type, id) {
         return this.query(store, type, {id: id, status: 'all'});
     }


### PR DESCRIPTION
refs #5947
- override the `findRecord` method of the user adapter to always include "status=all" when querying by ID
