### PR TITLE
Dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node-uuid": "1.4.3",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.0.1",
-    "passport": "0.2.2",
+    "passport": "0.3.0",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "knex": "0.7.3",
     "lodash": "3.10.1",
     "moment": "2.10.6",
-    "morgan": "1.5.3",
+    "morgan": "1.6.1",
     "node-uuid": "1.4.3",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "iojs": "~1.2.0"
   },
   "dependencies": {
-    "bcryptjs": "2.1.0",
+    "bcryptjs": "2.3.0",
     "bluebird": "2.9.27",
     "body-parser": "1.12.4",
     "bookshelf": "0.7.9",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.3",
-    "request": "2.57.0",
+    "request": "2.65.0",
     "rss": "1.1.1",
     "semver": "4.3.6",
     "showdown-ghost": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "passport": "0.3.0",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
-    "path-match": "1.2.2",
+    "path-match": "1.2.3",
     "request": "2.57.0",
     "rss": "1.1.1",
     "semver": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "intl-messageformat": "1.1.0",
     "knex": "0.7.3",
     "lodash": "3.10.1",
-    "moment": "2.10.3",
+    "moment": "2.10.6",
     "morgan": "1.5.3",
     "node-uuid": "1.4.3",
     "nodemailer": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "semver": "5.0.3",
     "showdown-ghost": "0.3.6",
     "sqlite3": "3.1.0",
-    "unidecode": "0.1.3",
+    "unidecode": "0.1.7",
     "validator": "3.40.0",
     "xml": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cheerio": "0.19.0",
     "compression": "1.6.0",
     "connect-slashes": "1.3.1",
-    "cookie-session": "1.1.0",
+    "cookie-session": "1.2.0",
     "downsize": "0.0.8",
     "express": "4.12.4",
     "express-hbs": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rss": "1.1.1",
     "semver": "5.0.3",
     "showdown-ghost": "0.3.6",
-    "sqlite3": "3.0.8",
+    "sqlite3": "3.1.0",
     "unidecode": "0.1.3",
     "validator": "3.40.0",
     "xml": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "showdown-ghost": "0.3.6",
     "sqlite3": "3.1.0",
     "unidecode": "0.1.7",
-    "validator": "3.40.0",
+    "validator": "4.1.0",
     "xml": "1.0.0"
   },
   "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "intl": "1.0.0",
     "intl-messageformat": "1.1.0",
     "knex": "0.7.3",
-    "lodash": "3.10.0",
+    "lodash": "3.10.1",
     "moment": "2.10.3",
     "morgan": "1.5.3",
     "node-uuid": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "downsize": "0.0.8",
     "express": "4.13.3",
     "express-hbs": "0.8.4",
-    "extract-zip": "1.0.3",
+    "extract-zip": "1.1.1",
     "fs-extra": "0.18.4",
     "glob": "4.3.2",
     "html-to-text": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bcryptjs": "2.3.0",
-    "bluebird": "2.9.27",
+    "bluebird": "2.10.2",
     "body-parser": "1.12.4",
     "bookshelf": "0.7.9",
     "busboy": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "path-match": "1.2.3",
     "request": "2.65.0",
     "rss": "1.1.1",
-    "semver": "4.3.6",
+    "semver": "5.0.3",
     "showdown-ghost": "0.3.6",
     "sqlite3": "3.0.8",
     "unidecode": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "express-hbs": "0.8.4",
     "extract-zip": "1.1.1",
     "fs-extra": "0.24.0",
-    "glob": "4.3.2",
+    "glob": "5.0.15",
     "html-to-text": "1.3.0",
     "intl": "1.0.0",
     "intl-messageformat": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",
     "downsize": "0.0.8",
-    "express": "4.12.4",
+    "express": "4.13.3",
     "express-hbs": "0.8.4",
     "extract-zip": "1.0.3",
     "fs-extra": "0.18.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "busboy": "0.2.11",
     "chalk": "1.1.1",
     "cheerio": "0.19.0",
-    "compression": "1.4.4",
+    "compression": "1.6.0",
     "connect-slashes": "1.3.1",
     "cookie-session": "1.1.0",
     "downsize": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "express": "4.13.3",
     "express-hbs": "0.8.4",
     "extract-zip": "1.1.1",
-    "fs-extra": "0.18.4",
+    "fs-extra": "0.24.0",
     "glob": "4.3.2",
     "html-to-text": "1.3.0",
     "intl": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "body-parser": "1.14.1",
     "bookshelf": "0.7.9",
     "busboy": "0.2.11",
-    "chalk": "1.0.0",
+    "chalk": "1.1.1",
     "cheerio": "0.19.0",
     "compression": "1.4.4",
     "connect-slashes": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "extract-zip": "1.1.1",
     "fs-extra": "0.24.0",
     "glob": "5.0.15",
-    "html-to-text": "1.3.0",
+    "html-to-text": "1.3.2",
     "intl": "1.0.0",
     "intl-messageformat": "1.1.0",
     "knex": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "2.10.2",
     "body-parser": "1.14.1",
     "bookshelf": "0.7.9",
-    "busboy": "0.2.9",
+    "busboy": "0.2.11",
     "chalk": "1.0.0",
     "cheerio": "0.19.0",
     "compression": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bcryptjs": "2.3.0",
     "bluebird": "2.10.2",
-    "body-parser": "1.12.4",
+    "body-parser": "1.14.1",
     "bookshelf": "0.7.9",
     "busboy": "0.2.9",
     "chalk": "1.0.0",


### PR DESCRIPTION
This PR updates all of our main dependencies which can be updated without any code changes. The 3 which are excluded due to needing extra changes are bookshelf, knex, and rss. 

Only stable updates are included, so express is bumped to 4.13.3, not 5.0.0-alpha.2.

I have run the standard & casper.js tests against this locally with no failures.

I think the biggest, most likely to be accidentally impactful changes are in glob and validator. I did think twice about updating validator, but there are some good bug fixes in there.

I'm marking this as a WIP as, although all the dependencies are updated, I'm still working through testing things will all these increased versions. If anyone else has time to pull this down and also test it - in particular the little-loved flows like user invites and password resets, that would be much appreciated.
