### PR TITLE
Fixed transparent PNG gravatars preview on setup.

### DIFF
--- a/core/client/app/templates/components/gh-profile-image.hbs
+++ b/core/client/app/templates/components/gh-profile-image.hbs
@@ -1,11 +1,11 @@
 <figure class="account-image js-file-upload">
     {{#unless hasUploadedImage}}
-        <div class="placeholder-img" style={{defaultImage}}></div>
-
         {{#if hasEmail}}
             <div id="account-image" class="gravatar-img" style={{imageBackground}}>
                 <span class="sr-only">User image</span>
             </div>
+        {{else}}
+            <div class="placeholder-img" style={{defaultImage}}></div>
         {{/if}}
     {{/unless}}
 


### PR DESCRIPTION
closes #5882

Updated profile image helper, so that when users that have gravatar images that are PNGs with transparency, the default image no longer shows underneath, when on the /ghost/setup/two/ page.
