### PR TITLE
Fix settings menu issue with devices that are less than 350px wide

### DIFF
--- a/core/client/app/styles/components/settings-menu.css
+++ b/core/client/app/styles/components/settings-menu.css
@@ -12,6 +12,7 @@
     bottom: 0;
     z-index: 500;
     overflow: hidden;
+    max-width: 100%;
     width: 350px;
     border-left: #dfe1e3 1px solid;
     background: #fff;


### PR DESCRIPTION
fixes #5933 

This seemed to fix the issue, however, if there's a device with a screen size much less than 300px, it might cause issues, although from what I was able to find, 320px is likely the smallest resolution size that we should tailor to, so this _shouldn't_ cause any issues.

cc @kevinansfield
