### PR TITLE
Increase timeout in ember tests

### DIFF
--- a/core/client/tests/test-helper.js
+++ b/core/client/tests/test-helper.js
@@ -5,7 +5,7 @@ setResolver(resolver);
 
 /* jshint ignore:start */
 mocha.setup({
-    timeout: 5000,
+    timeout: 15000,
     slow: 500
 });
 /* jshint ignore:end */


### PR DESCRIPTION
no issue
- increases individual test timeout from 5sec to 10sec

It seems Travis is occasionally _very_ slow and will timeout on heavier acceptance tests resulting in random failures. Hopefully this will reduce the number of random test failures we see.
