### PR TITLE
Fix for non-unique partial files shadowing each other

### DIFF
--- a/core/server/utils/validate-themes.js
+++ b/core/server/utils/validate-themes.js
@@ -4,12 +4,14 @@
 
 var readThemes = require('./read-themes'),
     Promise = require('bluebird'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    path = require('path');
 
 /**
  * Validate themes:
  *
  *   1. Check if theme has package.json
+ *   2. Check if all partials are unique and do not shadow others.
  */
 
 function validateThemes(dir) {
@@ -18,22 +20,56 @@ function validateThemes(dir) {
         errors: []
     };
 
+    function packagePresentCheck(theme, name, result) {
+        var hasPackageJson, warning;
+
+        hasPackageJson = !!theme['package.json'];
+
+        if (!hasPackageJson) {
+            warning = {
+                message: 'Found a theme with no package.json file',
+                context: 'Theme name: ' + name,
+                help: 'This will be required in future. Please see http://docs.ghost.org/themes/'
+            };
+
+            result.warnings.push(warning);
+        }
+    }
+
+    function ambiguousPartialCheck(theme, name, result) {
+        var partials, partialsHistogram, isUnique, warning;
+
+        if (_.isUndefined(theme.partials)) {
+            return;
+        }
+
+        partials = _.keys(theme.partials);
+        partialsHistogram = _(partials)
+            .map(function (key) { return path.basename(key, path.extname(key)); })
+            .countBy(_.identity).value();
+
+        _.each(partialsHistogram, function (count, partial) {
+            isUnique = count < 2;
+
+            if (isUnique) {
+                return;
+            }
+
+            warning = {
+                message: 'Found a partial (' + partial + ') that is not unique',
+                context: 'Theme name: ' + name,
+                help: 'Check for files sharing the same name but different extensions.'
+            };
+
+            result.warnings.push(warning);
+        });
+    }
+
     return readThemes(dir)
         .tap(function (themes) {
             _.each(themes, function (theme, name) {
-                var hasPackageJson, warning;
-
-                hasPackageJson = !!theme['package.json'];
-
-                if (!hasPackageJson) {
-                    warning = {
-                        message: 'Found a theme with no package.json file',
-                        context: 'Theme name: ' + name,
-                        help: 'This will be required in future. Please see http://docs.ghost.org/themes/'
-                    };
-
-                    result.warnings.push(warning);
-                }
+                packagePresentCheck(theme, name, result);
+                ambiguousPartialCheck(theme, name, result);
             });
         })
         .then(function () {

--- a/core/test/unit/server_utils_spec.js
+++ b/core/test/unit/server_utils_spec.js
@@ -348,5 +348,43 @@ describe('Server Utilities', function () {
                     done();
                 });
         });
+
+        it('should return warnings for themes with ambiguous partial filename', function (done) {
+            var themesPath, pkgJson;
+
+            themesPath = tempfile();
+            pkgJson = JSON.stringify({
+                name: 'casper',
+                version: '1.0.0'
+            });
+
+            fs.mkdirSync(themesPath);
+
+            fs.mkdirSync(join(themesPath, 'casper'));
+
+            fs.writeFileSync(join(themesPath, 'casper', 'package.json'), pkgJson);
+
+            fs.mkdirSync(join(themesPath, 'casper', 'partials'));
+
+            fs.writeFileSync(join(themesPath, 'casper', 'partials', 'loop.hbs'), '');
+            fs.writeFileSync(join(themesPath, 'casper', 'partials', 'loop.hbs~'), '');
+            fs.writeFileSync(join(themesPath, 'casper', 'partials', 'loop.hab.hbs~'), '');
+
+            validateThemes(themesPath)
+                .then(function () {
+                    done(new Error('validateThemes succeeded, but should\'ve failed'));
+                })
+                .catch(function (result) {
+                    result.errors.length.should.equal(0);
+
+                    result.warnings.should.eql([{
+                        message: 'Found a partial (loop) that is not unique',
+                        context: 'Theme name: casper',
+                        help: 'Check for files sharing the same name but different extensions.'
+                    }]);
+
+                    done();
+                });
+        });
     });
 });


### PR DESCRIPTION
closes #2459

Current behaviour of express-hbs is to load all partials with _._ filter
which allows files with same name but different extensions to be mapped
to the same name. This way one partial is shadowing the other.

Fix now is to give a warning at start up if more than one file resolves
to the same name.
