### PR TITLE
Further split up frontend controller & improve tests

### DIFF
--- a/core/server/controllers/frontend/error.js
+++ b/core/server/controllers/frontend/error.js
@@ -1,0 +1,12 @@
+function handleError(next) {
+    return function handleError(err) {
+        // If we've thrown an error message of type: 'NotFound' then we found no path match.
+        if (err.errorType === 'NotFoundError') {
+            return next();
+        }
+
+        return next(err);
+    };
+}
+
+module.exports = handleError;

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -1,0 +1,17 @@
+var api = require('../../api');
+
+function fetchData(options) {
+    return api.settings.read('postsPerPage').then(function then(response) {
+        var postPP = response.settings[0],
+            postsPerPage = parseInt(postPP.value, 10);
+
+        // No negative posts per page, must be number
+        if (!isNaN(postsPerPage) && postsPerPage > 0) {
+            options.limit = postsPerPage;
+        }
+        options.include = 'author,tags,fields';
+        return api.posts.browse(options);
+    });
+}
+
+module.exports = fetchData;

--- a/core/server/controllers/frontend/format-response.js
+++ b/core/server/controllers/frontend/format-response.js
@@ -1,0 +1,31 @@
+var _   = require('lodash');
+
+/**
+ * formats variables for handlebars in multi-post contexts.
+ * If extraValues are available, they are merged in the final value
+ * @return {Object} containing page variables
+ */
+function formatPageResponse(posts, page, extraValues) {
+    extraValues = extraValues || {};
+
+    var resp = {
+        posts: posts,
+        pagination: page.meta.pagination
+    };
+    return _.extend(resp, extraValues);
+}
+
+/**
+ * similar to formatPageResponse, but for single post pages
+ * @return {Object} containing page variables
+ */
+function formatResponse(post) {
+    return {
+        post: post
+    };
+}
+
+module.exports = {
+    channel: formatPageResponse,
+    single: formatResponse
+};

--- a/core/server/controllers/frontend/secure.js
+++ b/core/server/controllers/frontend/secure.js
@@ -1,0 +1,10 @@
+// TODO: figure out how to remove the need for this
+// Add Request context parameter to the data object
+// to be passed down to the templates
+function setRequestIsSecure(req, data) {
+    (Array.isArray(data) ? data : [data]).forEach(function forEach(d) {
+        d.secure = req.secure;
+    });
+}
+
+module.exports = setRequestIsSecure;

--- a/core/server/controllers/frontend/theme-paths.js
+++ b/core/server/controllers/frontend/theme-paths.js
@@ -1,0 +1,22 @@
+var api         = require('../../api'),
+    config      = require('../../config');
+
+/**
+ * Returns the paths object of the active theme via way of a promise.
+ * @return {Promise} The promise resolves with the value of the paths.
+ */
+function getActiveThemePaths() {
+    return api.settings.read({
+        key: 'activeTheme',
+        context: {
+            internal: true
+        }
+    }).then(function then(response) {
+        var activeTheme = response.settings[0],
+            paths = config.paths.availableThemes[activeTheme.value];
+
+        return paths;
+    });
+}
+
+module.exports = getActiveThemePaths;

--- a/core/test/unit/controllers/frontend/context_spec.js
+++ b/core/test/unit/controllers/frontend/context_spec.js
@@ -245,4 +245,17 @@ describe('Contexts', function () {
             res.locals.context[0].should.eql('page');
         });
     });
+
+    describe('Private', function () {
+        it('should correctly identify `/private/` as the private route', function () {
+            // Setup test by setting relativeUrl
+            res.locals.relativeUrl = '/private/?r=';
+
+            setResponseContext(req, res, data);
+
+            should.exist(res.locals.context);
+            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context[0].should.eql('private');
+        });
+    });
 });

--- a/core/test/unit/controllers/frontend/error_spec.js
+++ b/core/test/unit/controllers/frontend/error_spec.js
@@ -1,0 +1,43 @@
+/*globals describe, beforeEach, afterEach, it*/
+/*jshint expr:true*/
+var should   = require('should'),
+    sinon    = require('sinon'),
+    errors   = require('../../../../server/errors'),
+
+// Stuff we are testing
+    handleError = require('../../../../server/controllers/frontend/error'),
+
+    sandbox = sinon.sandbox.create();
+
+// To stop jshint complaining
+should.equal(true, true);
+
+describe('handleError', function () {
+    var next;
+    beforeEach(function () {
+        next = sandbox.spy();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('should call next with no args for 404 errors', function () {
+        var notFoundError = new errors.NotFoundError('Something wasn\'t found');
+        handleError(next)(notFoundError);
+
+        next.calledOnce.should.be.true;
+        next.firstCall.args.should.be.empty;
+    });
+
+    it('should call next with error for other errors', function () {
+        var otherError = new errors.MethodNotAllowedError('Something wasn\'t allowed');
+
+        handleError(next)(otherError);
+
+        next.calledOnce.should.be.true;
+        next.firstCall.args.should.have.lengthOf(1);
+        next.firstCall.args[0].should.be.an.Object;
+        next.firstCall.args[0].should.be.instanceof(Error);
+    });
+});

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -1,0 +1,79 @@
+/*globals describe, beforeEach, afterEach, it*/
+/*jshint expr:true*/
+var should   = require('should'),
+    sinon    = require('sinon'),
+    Promise  = require('bluebird'),
+
+    // Stuff we are testing
+    api      = require('../../../../server/api'),
+    fetchData = require('../../../../server/controllers/frontend/fetch-data'),
+
+    sandbox = sinon.sandbox.create();
+
+describe('fetchData', function () {
+    var apiSettingsStub,
+        apiPostsStub;
+
+    beforeEach(function () {
+        apiPostsStub = sandbox.stub(api.posts, 'browse').returns(new Promise.resolve({}));
+        apiSettingsStub = sandbox.stub(api.settings, 'read');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('valid postsPerPage', function () {
+        beforeEach(function () {
+            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
+                settings: [{
+                    key: 'postsPerPage',
+                    value: '10'
+                }]
+            }));
+        });
+
+        it('Adds limit & includes to options by default', function (done) {
+            fetchData({}).then(function () {
+                apiSettingsStub.calledOnce.should.be.true;
+                apiPostsStub.calledOnce.should.be.true;
+                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.firstCall.args[0].should.have.property('include');
+                apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
+                done();
+            }).catch(done);
+        });
+
+        it('Throws error if no options are passed', function (done) {
+            fetchData().then(function () {
+                done('Should have thrown an error here');
+            }).catch(function (err) {
+                should.exist(err);
+                done();
+            });
+        });
+    });
+
+    describe('invalid postsPerPage', function () {
+        beforeEach(function () {
+            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
+                settings: [{
+                    key: 'postsPerPage',
+                    value: '-1'
+                }]
+            }));
+        });
+
+        it('Will not add limit if postsPerPage is not valid', function (done) {
+            fetchData({}).then(function () {
+                apiSettingsStub.calledOnce.should.be.true;
+                apiPostsStub.calledOnce.should.be.true;
+                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.firstCall.args[0].should.have.property('include');
+                apiPostsStub.firstCall.args[0].should.not.have.property('limit');
+
+                done();
+            }).catch(done);
+        });
+    });
+});


### PR DESCRIPTION
This PR is prep work for other changes that are needed in future, like changing the controller to make different requests once `filter` is merged.

It splits out some of the helper functions into their own files. Each file that is split out has 100% test coverage. Where coverage was missing new test files have been added, for files that were already 100% covered I've not added separate tests as I'm planning on doing significant further refactoring and I think many of these files are likely to die again in future.

![](http://puu.sh/kSj17.png)

The big set of changes in the final commit which refactor how most of the frontend tests work remove some ugly test code based on changing config, which wasn't working properly and so settings from some tests were inadvertently affecting other tests.

It significantly reduces how much code is needed for the tests, and hopefully improves how robust they are. All testing of contexts has moved to the context tests.

Hopefully this will make the next bits of work, where behaviour needs to change, much easier to do.

Once this gets a general :+1: I'll squash
