### PR TITLE
Serve theme's favicon.ico and fallback to a default one

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -74,9 +74,6 @@ setupMiddleware = function setupMiddleware(blogApp, adminApp) {
         }
     }
 
-    // Favicon
-    blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
-
     // Static assets
     blogApp.use('/shared', express.static(path.join(corePath, '/shared'), {maxAge: utils.ONE_HOUR_MS}));
     blogApp.use('/content/images', storage.getStorage().serve());
@@ -99,6 +96,9 @@ setupMiddleware = function setupMiddleware(blogApp, adminApp) {
 
     // Theme only config
     blogApp.use(staticTheme());
+
+    // Default favicon
+    blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
 
     // Check if password protected blog
     blogApp.use(privateBlogging.checkIsPrivate); // check if the blog is protected


### PR DESCRIPTION
When a direct request to `/favicon.ico` is sent, serve theme's favicon.ico (if it exists) and fallback to a default favicon.ico in `/shared`.

closes #4869
- reorder middleware, making theme's favicon.ico favorable over a default one
