### PR TITLE
Add order parameter

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -23,7 +23,7 @@ utils = {
     // ### Manual Default Options
     // These must be provided by the endpoint
     // browseDefaultOptions - valid for all browse api endpoints
-    browseDefaultOptions: ['page', 'limit', 'fields', 'filter'],
+    browseDefaultOptions: ['page', 'limit', 'fields', 'filter', 'order'],
     // idDefaultOptions - valid whenever an id is valid
     idDefaultOptions: ['id'],
 
@@ -114,6 +114,7 @@ utils = {
                 page: {matches: /^\d+$/},
                 limit: {matches: /^\d+|all$/},
                 fields: {matches: /^[a-z0-9_,]+$/},
+                order: {matches: /^[a-z0-9_,\. ]+$/i},
                 name: {}
             },
             // these values are sanitised/validated separately

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -400,7 +400,7 @@ Post = ghostBookshelf.Model.extend({
             // these are the only options that can be passed to Bookshelf / Knex.
             validOptions = {
                 findOne: ['importing', 'withRelated'],
-                findPage: ['page', 'limit', 'columns', 'filter', 'status', 'staticPages', 'featured'],
+                findPage: ['page', 'limit', 'columns', 'filter', 'order', 'status', 'staticPages', 'featured'],
                 add: ['importing']
             };
 

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -278,6 +278,54 @@ describe('Post API', function () {
                 done();
             }).catch(done);
         });
+
+        it('can order posts using asc', function (done) {
+            var posts, expectedTitles;
+
+            posts = _(testUtils.DataGenerator.Content.posts).reject('page').value();
+            expectedTitles = _(posts).pluck('title').sortBy().value();
+
+            PostAPI.browse({context: {user: 1}, status: 'all', order: 'title asc', fields: 'title'}).then(function (results) {
+                should.exist(results.posts);
+
+                var titles = _.pluck(results.posts, 'title');
+                titles.should.eql(expectedTitles);
+
+                done();
+            }).catch(done);
+        });
+
+        it('can order posts using desc', function (done) {
+            var posts, expectedTitles;
+
+            posts = _(testUtils.DataGenerator.Content.posts).reject('page').value();
+            expectedTitles = _(posts).pluck('title').sortBy().reverse().value();
+
+            PostAPI.browse({context: {user: 1}, status: 'all', order: 'title DESC', fields: 'title'}).then(function (results) {
+                should.exist(results.posts);
+
+                var titles = _.pluck(results.posts, 'title');
+                titles.should.eql(expectedTitles);
+
+                done();
+            }).catch(done);
+        });
+
+        it('can order posts and filter disallowed attributes', function (done) {
+            var posts, expectedTitles;
+
+            posts = _(testUtils.DataGenerator.Content.posts).reject('page').value();
+            expectedTitles = _(posts).pluck('title').sortBy().value();
+
+            PostAPI.browse({context: {user: 1}, status: 'all', order: 'bunny DESC, title ASC', fields: 'title'}).then(function (results) {
+                should.exist(results.posts);
+
+                var titles = _.pluck(results.posts, 'title');
+                titles.should.eql(expectedTitles);
+
+                done();
+            }).catch(done);
+        });
     });
 
     describe('Read', function () {

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -18,7 +18,7 @@ describe('API Utils', function () {
     describe('Default Options', function () {
         it('should provide a set of default options', function () {
             apiUtils.globalDefaultOptions.should.eql(['context', 'include']);
-            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields', 'filter']);
+            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields', 'filter', 'order']);
             apiUtils.dataDefaultOptions.should.eql(['data']);
             apiUtils.idDefaultOptions.should.eql(['id']);
         });


### PR DESCRIPTION
This PR adds `order` parameter to `browse` endpoints. 

Closes #5602.

Supplied input string (e.g. `title desc`) is converted to the same format as produced by `orderDefaultOptions()`:

``` js
{
    title: 'DESC'
}
```
#### Example

``` js
PostAPI.browse({ order: 'title desc, updated_at asc' });
```

Upper-cased `DESC` and `ASC` are also allowed. Spaces after commas are not required, this input is also valid: `title desc, updated_at asc`.

**Note**: If order parameter contains attributes, that do not belong to the current model, they will be ignored: `bunny desc, title asc` (`bunny` is skipped).
#### Todo
- [ ] test fields with dots in them, e.g. `posts.title desc`
- [ ] tests for other models (not sure this is needed)
- [ ] decide, if custom order option should completely overwrite or merge with default order options (`orderDefaultOptions()`)
