### PR TITLE
Switch frontend controller to use new filter param

### DIFF
--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -1,16 +1,122 @@
-var api = require('../../api');
+/**
+ * # Fetch Data
+ * Dynamically build and execute queries on the API for channels
+ */
+var api = require('../../api'),
+    _   = require('lodash'),
+    Promise = require('bluebird'),
+    queryDefaults,
+    defaultPostQuery = {};
 
-function fetchData(options) {
+// The default settings for a default post query
+queryDefaults = {
+    type: 'browse',
+    resource: 'posts',
+    options: {}
+};
+
+// Default post query needs to always include author & tags
+_.extend(defaultPostQuery, queryDefaults, {
+    options: {
+        include: 'author,tags,fields'
+    }
+});
+
+/**
+ * ## Fetch Posts Per page
+ * Grab the postsPerPage setting from the database
+ *
+ * @param {Object} options
+ * @returns {Object} postOptions
+ */
+function fetchPostsPerPage(options) {
+    options = options || {};
+
     return api.settings.read('postsPerPage').then(function then(response) {
-        var postPP = response.settings[0],
-            postsPerPage = parseInt(postPP.value, 10);
+        var postsPerPage = parseInt(response.settings[0].value);
 
         // No negative posts per page, must be number
         if (!isNaN(postsPerPage) && postsPerPage > 0) {
             options.limit = postsPerPage;
         }
-        options.include = 'author,tags,fields';
-        return api.posts.browse(options);
+
+        // Ensure the options key is present, so this can be merged with other options
+        return {options: options};
+    });
+}
+
+/**
+ * @typedef query
+ * @
+ */
+
+/**
+ * ## Process Query
+ * Takes a 'query' object, ensures that type, resource and options are set
+ * Replaces occurrences of `%s` in options with slugParam
+ * Converts the query config to a promise for the result
+ *
+ * @param {{type: String, resource: String, options: Object}} query
+ * @param {String} slugParam
+ * @returns {Promise} promise for an API call
+ */
+function processQuery(query, slugParam) {
+    query = _.cloneDeep(query);
+
+    // Ensure that all the properties are filled out
+    _.defaultsDeep(query, queryDefaults);
+
+    // Replace any slugs
+    _.each(query.options, function (option, name) {
+        query.options[name] = _.isString(option) ? option.replace(/%s/g, slugParam) : option;
+    });
+
+    // Return a promise for the api query
+    return api[query.resource][query.type](query.options);
+}
+
+/**
+ * ## Fetch Data
+ * Calls out to get posts per page, builds the final posts query & builds any additional queries
+ * Wraps the queries using Promise.props to ensure it gets named responses
+ * Does a first round of formatting on the response, and returns
+ *
+ * @param {Object} channelOptions
+ * @param {String} slugParam
+ * @returns {Promise} response
+ */
+function fetchData(channelOptions, slugParam) {
+    return fetchPostsPerPage(channelOptions.postOptions).then(function fetchData(pageOptions) {
+        var postQuery,
+            props = {};
+
+        // All channels must have a posts query, use the default if not provided
+        postQuery = _.defaultsDeep({}, pageOptions, defaultPostQuery);
+        props.posts = processQuery(postQuery, slugParam);
+
+        _.each(channelOptions.data, function (query, name) {
+            props[name] = processQuery(query, slugParam);
+        });
+
+        return Promise.props(props).then(function formatResponse(results) {
+            var response = _.cloneDeep(results.posts);
+            delete results.posts;
+
+            // process any remaining data
+            if (!_.isEmpty(results)) {
+                response.data = {};
+
+                _.each(results, function (result, name) {
+                    if (channelOptions.data[name].type === 'browse') {
+                        response.data[name] = result;
+                    } else {
+                        response.data[name] = result[channelOptions.data[name].resource];
+                    }
+                });
+            }
+
+            return response;
+        });
     });
 }
 

--- a/core/server/controllers/frontend/format-response.js
+++ b/core/server/controllers/frontend/format-response.js
@@ -5,14 +5,25 @@ var _   = require('lodash');
  * If extraValues are available, they are merged in the final value
  * @return {Object} containing page variables
  */
-function formatPageResponse(posts, page, extraValues) {
-    extraValues = extraValues || {};
-
-    var resp = {
-        posts: posts,
-        pagination: page.meta.pagination
+function formatPageResponse(result) {
+    var response = {
+        posts: result.posts,
+        pagination: result.meta.pagination
     };
-    return _.extend(resp, extraValues);
+
+    _.each(result.data, function (data, name) {
+        if (data.meta) {
+            // Move pagination to be a top level key
+            response[name] = data;
+            response[name].pagination = data.meta.pagination;
+            delete response[name].meta;
+        } else {
+            // This is a single object, don't wrap it in an array
+            response[name] = data[0];
+        }
+    });
+
+    return response;
 }
 
 /**

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -516,6 +516,8 @@ describe('Frontend Routing', function () {
                 // we initialise data, but not a user. No user should be required for navigating the frontend
                 return testUtils.initData();
             }).then(function () {
+                return testUtils.fixtures.overrideOwnerUser('ghost-owner');
+            }).then(function () {
                 return testUtils.fixtures.insertPosts();
             }).then(function () {
                 return testUtils.fixtures.insertMorePosts(9);

--- a/core/test/unit/controllers/frontend/format-response_spec.js
+++ b/core/test/unit/controllers/frontend/format-response_spec.js
@@ -1,0 +1,71 @@
+/*globals describe, it*/
+var should   = require('should'),
+
+    // Stuff we are testing
+    formatResponse = require('../../../../server/controllers/frontend/format-response');
+
+// To stop jshint complaining
+should.equal(true, true);
+
+describe('formatResponse', function () {
+    describe('single', function () {
+        it('should return the post object wrapped in a post key', function () {
+            var formatted,
+                postObject = {slug: 'sluggy-thing'};
+
+            formatted = formatResponse.single(postObject);
+
+            formatted.should.be.an.Object.with.property('post');
+            formatted.post.should.eql(postObject);
+        });
+    });
+
+    describe('channel', function () {
+        it('should return posts and posts pagination as top level keys', function () {
+            var formatted,
+                data = {
+                    posts: [{slug: 'a-post'}],
+                    meta: {pagination: {}}
+                };
+
+            formatted = formatResponse.channel(data);
+
+            formatted.should.be.an.Object.with.properties('posts', 'pagination');
+            formatted.posts.should.eql(data.posts);
+            formatted.pagination.should.eql(data.meta.pagination);
+        });
+
+        it('should flatten api read responses which have no pagination data', function () {
+            var formatted,
+                data = {
+                    posts: [{slug: 'a-post'}],
+                    meta: {pagination: {}},
+                    data: {tag: [{name: 'video', slug: 'video', id: 1}]}
+                };
+
+            formatted = formatResponse.channel(data);
+
+            formatted.should.be.an.Object.with.properties('posts', 'pagination', 'tag');
+            formatted.tag.should.eql(data.data.tag[0]);
+        });
+
+        it('should remove the meta key from api browse responses', function () {
+            var formatted,
+                data = {
+                    posts: [{slug: 'a-post'}],
+                    meta: {pagination: {}},
+                    data: {
+                        featured: {
+                            posts: [{id: 1, title: 'featured post 1', slug: 'featured-1'}],
+                            meta: {pagination: {}}
+                        }
+                    }
+                };
+
+            formatted = formatResponse.channel(data);
+
+            formatted.should.be.an.Object.with.properties('posts', 'pagination', 'featured');
+            formatted.featured.should.be.an.Object.with.properties('posts', 'pagination');
+        });
+    });
+});

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -215,11 +215,14 @@ fixtures = {
         });
     },
 
-    overrideOwnerUser: function overrideOwnerUser() {
+    overrideOwnerUser: function overrideOwnerUser(slug) {
         var user,
             knex = config.database.knex;
 
         user = DataGenerator.forKnex.createUser(DataGenerator.Content.users[0]);
+        if (slug) {
+            user.slug = slug;
+        }
 
         return knex('users')
             .where('id', '=', '1')


### PR DESCRIPTION
In order to get the frontend controller working with the new filter parameters, it was necessary to refactor the channel rendering code to handle sending multiple queries.

The old `/posts/?tag=getting-started` style queries had a bit of hackery to them, in that they would get and return the tag being filtered on inside the `meta.filter.tag` property of the result. Equally `/posts/?author=leslie` would include a user object nested in `meta.filter.author`.

The new filter parameter doesn't figure out what objects might be related to the filter in order to include them, if you want more data, you need to fetch it.

So now, to fetch a list of posts for a tag or author we have to do a post browse query with a filter, and an additional query to get the related object. We could change this again in future if wanting the extra data turns out to be a common usecase, but expanding channels out to cope with multiple queries is pretty useful IMO anyway.

Every channel always has a base 'posts' query, although it might be filtered. Then extra data can be fetched by providing a query config inside a `data` key. Each query gets a name, which informs us on how to structure the response. So much like `?author=leslie` resulted in a user object being returned but named `author`, having an `author` query results in much the same.

The fetch-data method which turns the query config into actual api calls does a basic level of formatting to return the result in a similar structure, with posts as top-level, and the additional queries inside a `data` key.

The channel rendering code then calls out to `formatResponse.channel` to do a second level of formatting. This two-level approach could be factored out, I kept it this way as I could imagine channels wanting to provide their own formatting functions so that they can determine the names of the keys their templates get handed.

The structure of the query config isn't particularly great, but it works for now. I can see this being reworked before fully channels channels are made possible.

Hopefully this all makes sense, it seems to working well :grin: 

refs #5943
- updated fetch-data to handle multiple api queries
- using named keys for queries so that the names of items in the result are correct (tag instead of tags etc)
- updated channel configs in frontend controller
- removed old filter code from frontend controller
- added test coverage for fetch-data and format-response
- fixes / removes tests which are broken by the refactor
