### PR TITLE
Add nodejs v4.0.0 and up as usable engines. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
+  - "4.2.0"
+  - "4.0.0"
 sudo: false
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2.0"
   - "4.0.0"
+  - "4.2.0"
 sudo: false
 cache:
   directories:
@@ -34,7 +34,7 @@ before_script:
 after_success:
   - |
       if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        if [[ "$DB" = "sqlite3" && "$TRAVIS_NODE_VERSION" = "0.10" ]]; then
+        if [[ "$DB" = "sqlite3" && "$TRAVIS_NODE_VERSION" ]]; then
           echo "Generate coverage..."
           grunt coverage
           npm install -g codeclimate-test-reporter

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -22,11 +22,7 @@ describe('DB API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
-    });
+    after(testUtils.teardown);
 
     it('attaches the Content-Disposition header on export', function (done) {
         request.get(testUtils.API.getApiQuery('db/'))

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -13,7 +13,9 @@ describe('Notifications API', function () {
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
+        testUtils.clearData()
+        .then(ghost)
+        .then(function (ghostServer) {
             request = supertest.agent(ghostServer.rootApp);
         }).then(function () {
             return testUtils.doAuth(request);
@@ -23,11 +25,7 @@ describe('Notifications API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
-    });
+    after(testUtils.teardown);
 
     describe('Add', function () {
         var newNotification = {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0",
+    "node": "~0.10.0 || ~0.12.0 || ^4.0.0",
     "iojs": "~1.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
chore(package.json):  Add node ^4.0.0 as usable engines. 

closes #6002
- Adds node v4.0.0 and up as usable engines in package.json
