### PR TITLE
Switch RSS to use new filter param

### DIFF
--- a/core/server/controllers/frontend/channel-config.js
+++ b/core/server/controllers/frontend/channel-config.js
@@ -1,0 +1,42 @@
+var config = require('../../config'),
+    defaults;
+
+defaults = {
+    index: {
+        name: 'home',
+        route: '/',
+        firstPageTemplate: 'home'
+    },
+    tag: {
+        name: 'tag',
+        route: '/' + config.routeKeywords.tag + '/:slug/',
+        postOptions: {
+            filter: 'tags:%s'
+        },
+        data: {
+            tag: {
+                type: 'read',
+                resource: 'tags',
+                options: {slug: '%s'}
+            }
+        },
+        slugTemplate: true
+    },
+    author: {
+        name: 'author',
+        route: '/' + config.routeKeywords.author + '/:slug/',
+        postOptions: {
+            filter: 'author:%s'
+        },
+        data: {
+            author: {
+                type: 'read',
+                resource: 'users',
+                options: {slug: '%s'}
+            }
+        },
+        slugTemplate: true
+    }
+};
+
+module.exports = defaults;

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -86,7 +86,17 @@ function processQuery(query, slugParam) {
  * @returns {Promise} response
  */
 function fetchData(channelOptions, slugParam) {
-    return fetchPostsPerPage(channelOptions.postOptions).then(function fetchData(pageOptions) {
+    // Temporary workaround to make RSS work, moving towards dynamic channels will provide opportunities to
+    // improve this, I hope :)
+    function handlePostsPerPage(channelOptions) {
+        if (channelOptions.isRSS) {
+            return Promise.resolve({options: channelOptions.postOptions});
+        } else {
+            return fetchPostsPerPage(channelOptions.postOptions);
+        }
+    }
+
+    return handlePostsPerPage(channelOptions).then(function fetchData(pageOptions) {
         var postQuery,
             props = {};
 

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -1,13 +1,14 @@
 var _        = require('lodash'),
-    Promise  = require('bluebird'),
     cheerio  = require('cheerio'),
     crypto   = require('crypto'),
     downsize = require('downsize'),
     RSS      = require('rss'),
     url      = require('url'),
     config   = require('../../../config'),
-    api      = require('../../../api'),
     filters  = require('../../../filters'),
+
+    // Really ugly temporary hack for location of things
+    fetchData = require('../../../controllers/frontend/fetch-data'),
 
     generate,
     generateFeed,
@@ -28,37 +29,30 @@ function handleError(next) {
     };
 }
 
-function getOptions(req, pageParam, slugParam) {
-    var options = {};
-
-    if (pageParam) { options.page = pageParam; }
-    if (isTag(req)) { options.tag = slugParam; }
-    if (isAuthor(req)) { options.author = slugParam; }
-
-    options.include = 'author,tags,fields';
-
-    return options;
-}
-
-function getData(options) {
-    var ops = {
-        title: api.settings.read('title'),
-        description: api.settings.read('description'),
-        permalinks: api.settings.read('permalinks'),
-        results: api.posts.browse(options)
+function getData(channelOpts, slugParam) {
+    channelOpts.data = channelOpts.data || {};
+    channelOpts.data.permalinks = {
+        type: 'read',
+        resource: 'settings',
+        options: 'permalinks'
     };
 
-    return Promise.props(ops).then(function (result) {
-        var titleStart = '';
-        if (options.tag) { titleStart = result.results.meta.filters.tags[0].name + ' - ' || ''; }
-        if (options.author) { titleStart = result.results.meta.filters.author.name + ' - ' || ''; }
+    return fetchData(channelOpts, slugParam).then(function (result) {
+        var response = {},
+            titleStart = '';
 
-        return {
-            title: titleStart + result.title.settings[0].value,
-            description: result.description.settings[0].value,
-            permalinks: result.permalinks.settings[0],
-            results: result.results
+        if (result.data.tag) { titleStart = result.data.tag[0].name + ' - ' || ''; }
+        if (result.data.author) { titleStart = result.data.author[0].name + ' - ' || ''; }
+
+        response.title = titleStart + config.theme.title;
+        response.description = config.theme.description;
+        response.permalinks = result.data.permalinks[0];
+        response.results = {
+            posts: result.posts,
+            meta: result.meta
         };
+
+        return response;
     });
 }
 
@@ -198,15 +192,19 @@ generate = function generate(req, res, next) {
     // Initialize RSS
     var pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
         slugParam = req.params.slug,
-        baseUrl   = getBaseUrl(req, slugParam),
-        options   = getOptions(req, pageParam, slugParam);
+        baseUrl   = getBaseUrl(req, slugParam);
+
+    // Ensure we at least have an empty object for postOptions
+    req.channelConfig.postOptions = req.channelConfig.postOptions || {};
+    // Set page on postOptions for the query made later
+    req.channelConfig.postOptions.page = pageParam;
 
     // No negative pages, or page 1
     if (isNaN(pageParam) || pageParam < 1 || (req.params.page !== undefined && pageParam === 1)) {
         return res.redirect(baseUrl);
     }
 
-    return getData(options).then(function then(data) {
+    return getData(req.channelConfig, slugParam).then(function then(data) {
         var maxPage = data.results.meta.pagination.pages;
 
         // If page is greater than number of pages we have, redirect to last page

--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -55,8 +55,8 @@ frontendRoutes = function frontendRoutes(middleware) {
     });
 
     // Index
-    indexRouter.route('/').get(frontend.homepage);
-    indexRouter.route('/' + routeKeywords.page + '/:page/').get(frontend.homepage);
+    indexRouter.route('/').get(frontend.index);
+    indexRouter.route('/' + routeKeywords.page + '/:page/').get(frontend.index);
     indexRouter.use(rssRouter);
 
     // Tags

--- a/core/test/unit/controllers/frontend/index_spec.js
+++ b/core/test/unit/controllers/frontend/index_spec.js
@@ -37,7 +37,7 @@ describe('Frontend Controller', function () {
         };
     }
 
-    describe('homepage redirects', function () {
+    describe('index redirects', function () {
         var res,
             req;
 
@@ -68,7 +68,7 @@ describe('Frontend Controller', function () {
         it('Redirects to home if page number is -1', function () {
             req.params.page = -1;
 
-            frontend.homepage(req, res, null);
+            frontend.index(req, res, null);
 
             res.redirect.called.should.be.true;
             res.redirect.calledWith('/').should.be.true;
@@ -78,7 +78,7 @@ describe('Frontend Controller', function () {
         it('Redirects to home if page number is 0', function () {
             req.params.page = 0;
 
-            frontend.homepage(req, res, null);
+            frontend.index(req, res, null);
 
             res.redirect.called.should.be.true;
             res.redirect.calledWith('/').should.be.true;
@@ -88,7 +88,7 @@ describe('Frontend Controller', function () {
         it('Redirects to home if page number is 1', function () {
             req.params.page = 1;
 
-            frontend.homepage(req, res, null);
+            frontend.index(req, res, null);
 
             res.redirect.called.should.be.true;
             res.redirect.calledWith('/').should.be.true;
@@ -102,7 +102,7 @@ describe('Frontend Controller', function () {
 
             req.params.page = 0;
 
-            frontend.homepage(req, res, null);
+            frontend.index(req, res, null);
 
             res.redirect.called.should.be.true;
             res.redirect.calledWith('/blog/').should.be.true;
@@ -116,7 +116,7 @@ describe('Frontend Controller', function () {
 
             req.params.page = 1;
 
-            frontend.homepage(req, res, null);
+            frontend.index(req, res, null);
 
             res.redirect.called.should.be.true;
             res.redirect.calledWith('/blog/').should.be.true;
@@ -126,7 +126,7 @@ describe('Frontend Controller', function () {
         it('Redirects to last page if page number too big', function (done) {
             req.params.page = 4;
 
-            frontend.homepage(req, res, done).then(function () {
+            frontend.index(req, res, done).then(function () {
                 res.redirect.called.should.be.true;
                 res.redirect.calledWith('/page/3/').should.be.true;
                 res.render.called.should.be.false;
@@ -141,7 +141,7 @@ describe('Frontend Controller', function () {
 
             req.params.page = 4;
 
-            frontend.homepage(req, res, done).then(function () {
+            frontend.index(req, res, done).then(function () {
                 res.redirect.calledOnce.should.be.true;
                 res.redirect.calledWith('/blog/page/3/').should.be.true;
                 res.render.called.should.be.false;
@@ -150,7 +150,7 @@ describe('Frontend Controller', function () {
         });
     });
 
-    describe('homepage', function () {
+    describe('index', function () {
         var req, res;
 
         beforeEach(function () {
@@ -200,7 +200,7 @@ describe('Frontend Controller', function () {
                 done();
             };
 
-            frontend.homepage(req, res, failTest(done));
+            frontend.index(req, res, failTest(done));
         });
 
         it('Renders index.hbs template on 2nd page when home.hbs exists', function (done) {
@@ -218,7 +218,7 @@ describe('Frontend Controller', function () {
                 done();
             };
 
-            frontend.homepage(req, res, failTest(done));
+            frontend.index(req, res, failTest(done));
         });
 
         it('Renders index.hbs template when home.hbs doesn\'t exist', function (done) {
@@ -231,7 +231,7 @@ describe('Frontend Controller', function () {
                 done();
             };
 
-            frontend.homepage(req, res, failTest(done));
+            frontend.index(req, res, failTest(done));
         });
     });
 
@@ -1165,18 +1165,6 @@ describe('Frontend Controller', function () {
             apiUsersStub = sandbox.stub(api.users, 'read').returns(Promise.resolve({}));
 
             apiSettingsStub = sandbox.stub(api.settings, 'read');
-            apiSettingsStub.withArgs('title').returns(Promise.resolve({
-                settings: [{
-                    key: 'title',
-                    value: 'Test'
-                }]
-            }));
-            apiSettingsStub.withArgs('description').returns(Promise.resolve({
-                settings: [{
-                    key: 'description',
-                    value: 'Some Text'
-                }]
-            }));
             apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
                 settings: [{
                     key: 'permalinks',


### PR DESCRIPTION
This PR is a follow-up to #6000. #6000 updates the frontend controllers to handle multiple queries and provides handling & formatting tools for the data that is returned.

This PR builds on this, splitting out the channel config, reducing the number of API queries needed, and then updating the RSS feed generation to be built on top of this new multiple-query handling.

All of this is slowly working towards making dynamic channels work (#5091) but in this case, this PR does the absolute bare-minimum of reworking to get RSS working again. This means there is some code and concept duplication which can and will be reworked at a later date.

This PR allows us to remove the old-style filtering so that we can do our first Public API release without those parameters being available. 

refs #5943, #5091
- split out channel config
- use config.theme instead of api calls to grab title & desc
- wrap rss call in a function which sets channel config for RSS feeds
- change rss `getData` function to use the new multiple-query-handling fetchData functionality
- make sure channelConfig is set in all tests
