### PR TITLE
Update admin area queries to use new `filter` parameter

### DIFF
--- a/core/client/app/controllers/modals/delete-user.js
+++ b/core/client/app/controllers/modals/delete-user.js
@@ -6,7 +6,7 @@ export default Ember.Controller.extend({
     userPostCount: Ember.computed('model.id', function () {
         var promise,
             query = {
-                author: this.get('model.slug'),
+                filter: `author:${this.get('model.slug')}`,
                 status: 'all'
             };
 


### PR DESCRIPTION
refs #6005
- updates use of the query params removed in #6005 to use new `filter` param
