### PR TITLE
fixes transparent gravatar images

### DIFF
--- a/core/client/app/styles/layouts/flow.css
+++ b/core/client/app/styles/layouts/flow.css
@@ -305,6 +305,7 @@
     width: 90px;
     height: 90px;
     border: #fff 4px solid;
+    background-color: #fff;
     background-position: center center;
     background-size: cover;
     border-radius: 100%;

--- a/core/client/app/templates/components/gh-profile-image.hbs
+++ b/core/client/app/templates/components/gh-profile-image.hbs
@@ -2,7 +2,7 @@
     {{#unless hasUploadedImage}}
         <div class="placeholder-img" style={{defaultImage}}></div>
 
-        {{#if hasEmail}}
+        {{#if hasImageBackground}}
             <div id="account-image" class="gravatar-img" style={{imageBackground}}>
                 <span class="sr-only">User image</span>
             </div>

--- a/core/client/tests/unit/components/gh-profile-image-test.js
+++ b/core/client/tests/unit/components/gh-profile-image-test.js
@@ -23,17 +23,21 @@ describeComponent(
             this.render();
             expect(component._state).to.equal('inDOM');
         });
-        it('renders the gravatar image background if email is supplied', function () {
+        it('renders the gravatar image background if valid gravatar email is supplied', function () {
             var component = this.subject(),
                 testEmail = 'test@example.com',
-                style, size;
+                size = component.get('size'),
+                imageUrl = 'http://www.gravatar.com/avatar/' + md5(testEmail) + '?s=' + size + '&d=404',
+                style;
 
             component.set('email', testEmail);
+            component.set('imageBackgroundUrl', {
+                value: imageUrl
+            });
+
             this.render();
 
-            size = component.get('size');
-
-            style = 'url(http://www.gravatar.com/avatar/' + md5(testEmail) + '?s=' + size + '&d=blank)';
+            style = 'url(' + imageUrl + ')';
 
             expect(component.$('#account-image').css('background-image')).to.equal(style);
         });


### PR DESCRIPTION
closes #5882

Updated gh-profile-image component, so that it checks if the email is linked to a valid gravatar and only then it will update the background image. The xhr request will return a 404 if the gravatar doesn’t exist

Note: 
My unit test is kind of hack-ish. I couldn't find an example that would show me how to properly fake an ajax request using Ghost's test suite 
