### PR TITLE
Use ember-suave and standardise client's es6 usage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,8 +126,7 @@ var _              = require('lodash'),
 
                 client: {
                     options: {
-                        esnext: true,
-                        disallowObjectController: true
+                        config: 'core/client/.jscsrc'
                     },
 
                     files: {
@@ -135,9 +134,22 @@ var _              = require('lodash'),
                             'core/client/**/*.js',
                             '!core/client/node_modules/**/*.js',
                             '!core/client/bower_components/**/*.js',
+                            '!core/client/tests/**/*.js',
                             '!core/client/tmp/**/*.js',
                             '!core/client/dist/**/*.js',
                             '!core/client/vendor/**/*.js'
+                        ]
+                    }
+                },
+
+                client_tests: {
+                    options: {
+                        config: 'core/client/tests/.jscsrc'
+                    },
+
+                    files: {
+                        src: [
+                            'core/client/tests/**/*.js'
                         ]
                     }
                 },

--- a/core/client/.jscsrc
+++ b/core/client/.jscsrc
@@ -1,0 +1,14 @@
+{
+    "preset": "ember-suave",
+    "validateIndentation": 4,
+    "disallowSpacesInFunction": null,
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "disallowSpacesInsideObjectBrackets": "all",
+    "requireCommentsToIncludeAccess": null,
+    "requireSpacesInsideObjectBrackets": null
+}

--- a/core/client/app/adapters/application.js
+++ b/core/client/app/adapters/application.js
@@ -2,7 +2,7 @@ import EmbeddedRelationAdapter from 'ghost/adapters/embedded-relation-adapter';
 
 export default EmbeddedRelationAdapter.extend({
 
-    shouldBackgroundReloadRecord: function () {
+    shouldBackgroundReloadRecord() {
         return false;
     }
 

--- a/core/client/app/adapters/base.js
+++ b/core/client/app/adapters/base.js
@@ -1,21 +1,22 @@
+import Ember from 'ember';
 import DS from 'ember-data';
 import ghostPaths from 'ghost/utils/ghost-paths';
-import Ember from 'ember';
 
 const {inject} = Ember;
+const {RESTAdapter} = DS;
 
-export default DS.RESTAdapter.extend({
+export default RESTAdapter.extend({
     host: window.location.origin,
     namespace: ghostPaths().apiRoot.slice(1),
 
     session: inject.service('session'),
 
-    shouldBackgroundReloadRecord: function () {
+    shouldBackgroundReloadRecord() {
         return false;
     },
 
-    query: function (store, type, query) {
-        var id;
+    query(store, type, query) {
+        let id;
 
         if (query.id) {
             id = query.id;
@@ -25,9 +26,9 @@ export default DS.RESTAdapter.extend({
         return this.ajax(this.buildURL(type.modelName, id), 'GET', {data: query});
     },
 
-    buildURL: function (type, id) {
+    buildURL(type, id) {
         // Ensure trailing slashes
-        var url = this._super(type, id);
+        let url = this._super(type, id);
 
         if (url.slice(-1) !== '/') {
             url += '/';
@@ -42,15 +43,15 @@ export default DS.RESTAdapter.extend({
     // response body for successful DELETEs.
     // Non-2xx (failure) responses will still work correctly as Ember will turn
     // them into rejected promises.
-    deleteRecord: function () {
-        var response = this._super.apply(this, arguments);
+    deleteRecord() {
+        let response = this._super(...arguments);
 
-        return response.then(function () {
+        return response.then(() => {
             return null;
         });
     },
 
-    handleResponse: function (status) {
+    handleResponse(status) {
         if (status === 401) {
             if (this.get('session.isAuthenticated')) {
                 this.get('session').invalidate();

--- a/core/client/app/adapters/setting.js
+++ b/core/client/app/adapters/setting.js
@@ -1,9 +1,9 @@
 import ApplicationAdapter from 'ghost/adapters/application';
 
 export default ApplicationAdapter.extend({
-    updateRecord: function (store, type, record) {
-        var data = {},
-            serializer = store.serializerFor(type.modelName);
+    updateRecord(store, type, record) {
+        let data = {};
+        let serializer = store.serializerFor(type.modelName);
 
         // remove the fake id that we added onto the model.
         delete record.id;
@@ -14,6 +14,6 @@ export default ApplicationAdapter.extend({
 
         // use the ApplicationAdapter's buildURL method but do not
         // pass in an id.
-        return this.ajax(this.buildURL(type.modelName), 'PUT', {data: data});
+        return this.ajax(this.buildURL(type.modelName), 'PUT', {data});
     }
 });

--- a/core/client/app/adapters/user.js
+++ b/core/client/app/adapters/user.js
@@ -2,14 +2,14 @@ import ApplicationAdapter from 'ghost/adapters/application';
 import SlugUrl from 'ghost/mixins/slug-url';
 
 export default ApplicationAdapter.extend(SlugUrl, {
-    find: function (store, type, id) {
-        return this.findQuery(store, type, {id: id, status: 'all'});
+    find(store, type, id) {
+        return this.findQuery(store, type, {id, status: 'all'});
     },
 
     // TODO: This is needed because the API currently expects you to know the
     // status of the record before retrieving by ID. Quick fix is to always
     // include status=all in the query
-    findRecord: function (store, type, id, snapshot) {
+    findRecord(store, type, id, snapshot) {
         let url = this.buildIncludeURL(store, type.modelName, id, snapshot, 'findRecord');
 
         url += '&status=all';
@@ -17,7 +17,7 @@ export default ApplicationAdapter.extend(SlugUrl, {
         return this.ajax(url, 'GET');
     },
 
-    findAll: function (store, type, id) {
-        return this.query(store, type, {id: id, status: 'all'});
+    findAll(store, type, id) {
+        return this.query(store, type, {id, status: 'all'});
     }
 });

--- a/core/client/app/app.js
+++ b/core/client/app/app.js
@@ -5,12 +5,14 @@ import 'ghost/utils/link-component';
 import 'ghost/utils/text-field';
 import config from './config/environment';
 
+const {Application} = Ember;
+
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
-var App = Ember.Application.extend({
+let App = Application.extend({
+    Resolver,
     modulePrefix: config.modulePrefix,
-    podModulePrefix: config.podModulePrefix,
-    Resolver: Resolver
+    podModulePrefix: config.podModulePrefix
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/core/client/app/assets/lib/uploader.js
+++ b/core/client/app/assets/lib/uploader.js
@@ -1,12 +1,11 @@
 import ghostPaths from 'ghost/utils/ghost-paths';
 
-var UploadUi,
-    Ghost = ghostPaths();
+let Ghost = ghostPaths();
 
-UploadUi = function ($dropzone, settings) {
-    var $url = '<div class="js-url"><input class="url js-upload-url gh-input" type="url" placeholder="http://"/></div>',
-        $cancel = '<a class="image-cancel icon-trash js-cancel" title="Delete"><span class="hidden">Delete</span></a>',
-        $progress =  $('<div />', {
+let UploadUi = function ($dropzone, settings) {
+    let $url = '<div class="js-url"><input class="url js-upload-url gh-input" type="url" placeholder="http://"/></div>';
+    let $cancel = '<a class="image-cancel icon-trash js-cancel" title="Delete"><span class="hidden">Delete</span></a>';
+    let $progress =  $('<div />', {
             class: 'js-upload-progress progress progress-success active',
             role: 'progressbar',
             'aria-valuemin': '0',
@@ -17,38 +16,36 @@ UploadUi = function ($dropzone, settings) {
         }));
 
     $.extend(this, {
-        complete: function (result) {
-            var self = this;
-
+        complete(result) {
             function showImage(width, height) {
-                $dropzone.find('img.js-upload-target').attr({width: width, height: height}).css({display: 'block'});
+                $dropzone.find('img.js-upload-target').attr({width, height}).css({display: 'block'});
                 $dropzone.find('.fileupload-loading').remove();
                 $dropzone.css({height: 'auto'});
-                $dropzone.delay(250).animate({opacity: 100}, 1000, function () {
+                $dropzone.delay(250).animate({opacity: 100}, 1000, () => {
                     $('.js-button-accept').prop('disabled', false);
-                    self.init();
+                    this.init();
                 });
             }
 
             function animateDropzone($img) {
-                $dropzone.animate({opacity: 0}, 250, function () {
+                $dropzone.animate({opacity: 0}, 250, () => {
                     $dropzone.removeClass('image-uploader').addClass('pre-image-uploader');
                     $dropzone.css({minHeight: 0});
-                    self.removeExtras();
-                    $dropzone.animate({height: $img.height()}, 250, function () {
+                    this.removeExtras();
+                    $dropzone.animate({height: $img.height()}, 250, () => {
                         showImage($img.width(), $img.height());
                     });
                 });
             }
 
             function preLoadImage() {
-                var $img = $dropzone.find('img.js-upload-target')
+                let $img = $dropzone.find('img.js-upload-target')
                     .attr({src: '', width: 'auto', height: 'auto'});
 
-                $progress.animate({opacity: 0}, 250, function () {
-                    $dropzone.find('span.media').after('<img class="fileupload-loading"  src="' + Ghost.subdir + '/ghost/img/loadingcat.gif" />');
+                $progress.animate({opacity: 0}, 250, () => {
+                    $dropzone.find('span.media').after(`<img class="fileupload-loading" src="${Ghost.subdir}/ghost/img/loadingcat.gif" />`);
                 });
-                $img.one('load', function () {
+                $img.one('load', () => {
                     $dropzone.trigger('uploadsuccess', [result]);
                     animateDropzone($img);
                 }).attr('src', result);
@@ -56,12 +53,10 @@ UploadUi = function ($dropzone, settings) {
             preLoadImage();
         },
 
-        bindFileUpload: function () {
-            var self = this;
-
+        bindFileUpload() {
             $dropzone.find('.js-fileupload').fileupload().fileupload('option', {
-                url: Ghost.apiRoot + '/uploads/',
-                add: function (e, data) {
+                url: `${Ghost.apiRoot}/uploads/`,
+                add(e, data) {
                     /*jshint unused:false*/
                     $('.js-button-accept').prop('disabled', true);
                     $dropzone.find('.js-fileupload').removeClass('right');
@@ -69,7 +64,7 @@ UploadUi = function ($dropzone, settings) {
                     $progress.find('.js-upload-progress-bar').removeClass('fail');
                     $dropzone.trigger('uploadstart', [$dropzone.attr('id')]);
                     $dropzone.find('span.media, div.description, a.image-url, a.image-webcam')
-                        .animate({opacity: 0}, 250, function () {
+                        .animate({opacity: 0}, 250, () => {
                             $dropzone.find('div.description').hide().css({opacity: 100});
                             if (settings.progressbar) {
                                 $dropzone.find('div.js-fail').after($progress);
@@ -79,15 +74,15 @@ UploadUi = function ($dropzone, settings) {
                         });
                 },
                 dropZone: settings.fileStorage ? $dropzone : null,
-                progressall: function (e, data) {
+                progressall(e, data) {
                     /*jshint unused:false*/
-                    var progress = parseInt(data.loaded / data.total * 100, 10);
+                    let progress = parseInt(data.loaded / data.total * 100, 10);
                     if (settings.progressbar) {
                         $dropzone.trigger('uploadprogress', [progress, data]);
-                        $progress.find('.js-upload-progress-bar').css('width', progress + '%');
+                        $progress.find('.js-upload-progress-bar').css('width', `${progress}%`);
                     }
                 },
-                fail: function (e, data) {
+                fail(e, data) {
                     /*jshint unused:false*/
                     $('.js-button-accept').prop('disabled', false);
                     $dropzone.trigger('uploadfailure', [data.result]);
@@ -100,21 +95,21 @@ UploadUi = function ($dropzone, settings) {
                         $dropzone.find('div.js-fail').text('Something went wrong :(');
                     }
                     $dropzone.find('div.js-fail, button.js-fail').fadeIn(1500);
-                    $dropzone.find('button.js-fail').on('click', function () {
+                    $dropzone.find('button.js-fail').on('click', () => {
                         $dropzone.css({minHeight: 0});
                         $dropzone.find('div.description').show();
-                        self.removeExtras();
-                        self.init();
+                        this.removeExtras();
+                        this.init();
                     });
                 },
-                done: function (e, data) {
+                done(e, data) {
                     /*jshint unused:false*/
-                    self.complete(data.result);
+                    this.complete(data.result);
                 }
             });
         },
 
-        buildExtras: function () {
+        buildExtras() {
             if (!$dropzone.find('span.media')[0]) {
                 $dropzone.prepend('<span class="media"><span class="hidden">Image Upload</span></span>');
             }
@@ -135,13 +130,11 @@ UploadUi = function ($dropzone, settings) {
             // }
         },
 
-        removeExtras: function () {
+        removeExtras() {
             $dropzone.find('span.media, div.js-upload-progress, a.image-url, a.image-upload, a.image-webcam, div.js-fail, button.js-fail, a.js-cancel').remove();
         },
 
-        initWithDropzone: function () {
-            var self = this;
-
+        initWithDropzone() {
             // This is the start point if no image exists
             $dropzone.find('img.js-upload-target').css({display: 'none'});
             $dropzone.find('div.description').show();
@@ -150,24 +143,23 @@ UploadUi = function ($dropzone, settings) {
             this.buildExtras();
             this.bindFileUpload();
             if (!settings.fileStorage) {
-                self.initUrl();
+                this.initUrl();
                 return;
             }
-            $dropzone.find('a.image-url').on('click', function () {
-                self.initUrl();
+            $dropzone.find('a.image-url').on('click', () => {
+                this.initUrl();
             });
         },
-        initUrl: function () {
-            var self = this, val;
+        initUrl() {
             this.removeExtras();
             $dropzone.addClass('image-uploader-url').removeClass('pre-image-uploader');
             $dropzone.find('.js-fileupload').addClass('right');
-            $dropzone.find('.js-cancel').on('click', function () {
+            $dropzone.find('.js-cancel').on('click', () => {
                 $dropzone.find('.js-url').remove();
                 $dropzone.find('.js-fileupload').removeClass('right');
                 $dropzone.trigger('imagecleared');
-                self.removeExtras();
-                self.initWithDropzone();
+                this.removeExtras();
+                this.initWithDropzone();
             });
 
             $dropzone.find('div.description').before($url);
@@ -177,16 +169,17 @@ UploadUi = function ($dropzone, settings) {
                 $dropzone.find('div.description').hide();
             }
 
-            $dropzone.find('.js-button-accept').on('click', function () {
-                val = $dropzone.find('.js-upload-url').val();
+            $dropzone.find('.js-button-accept').on('click', () => {
+                let val = $dropzone.find('.js-upload-url').val();
+
                 $dropzone.find('div.description').hide();
                 $dropzone.find('.js-fileupload').removeClass('right');
                 $dropzone.find('.js-url').remove();
                 if (val === '') {
                     $dropzone.trigger('uploadsuccess', 'http://');
-                    self.initWithDropzone();
+                    this.initWithDropzone();
                 } else {
-                    self.complete(val);
+                    this.complete(val);
                 }
             });
 
@@ -195,37 +188,35 @@ UploadUi = function ($dropzone, settings) {
                 $dropzone.append('<a class="image-upload icon-photos" title="Add image"><span class="hidden">Upload</span></a>');
             }
 
-            $dropzone.find('a.image-upload').on('click', function () {
+            $dropzone.find('a.image-upload').on('click', () => {
                 $dropzone.find('.js-url').remove();
                 $dropzone.find('.js-fileupload').removeClass('right');
-                self.initWithDropzone();
+                this.initWithDropzone();
             });
         },
 
-        initWithImage: function () {
-            var self = this;
-
+        initWithImage() {
             // This is the start point if an image already exists
             this.removeExtras();
             $dropzone.removeClass('image-uploader image-uploader-url').addClass('pre-image-uploader');
             $dropzone.find('div.description').hide();
             $dropzone.find('img.js-upload-target').show();
             $dropzone.append($cancel);
-            $dropzone.find('.js-cancel').on('click', function () {
+            $dropzone.find('.js-cancel').on('click', () => {
                 $dropzone.find('img.js-upload-target').attr({src: ''});
                 $dropzone.find('div.description').show();
                 $dropzone.trigger('imagecleared');
-                $dropzone.delay(250).animate({opacity: 100}, 1000, function () {
-                    self.init();
+                $dropzone.delay(250).animate({opacity: 100}, 1000, () => {
+                    this.init();
                 });
 
                 $dropzone.trigger('uploadsuccess', 'http://');
-                self.initWithDropzone();
+                this.initWithDropzone();
             });
         },
 
-        init: function () {
-            var imageTarget = $dropzone.find('img.js-upload-target');
+        init() {
+            let imageTarget = $dropzone.find('img.js-upload-target');
             // First check if field image is defined by checking for js-upload-target class
             if (!imageTarget[0]) {
                 // This ensures there is an image we can hook into to display uploaded image
@@ -239,7 +230,7 @@ UploadUi = function ($dropzone, settings) {
             }
         },
 
-        reset: function () {
+        reset() {
             $dropzone.find('.js-url').remove();
             $dropzone.find('.js-fileupload').removeClass('right');
             this.removeExtras();
@@ -249,17 +240,15 @@ UploadUi = function ($dropzone, settings) {
 };
 
 export default function (options) {
-    var settings = $.extend({
+    let settings = $.extend({
         progressbar: true,
         editor: false,
         fileStorage: true
     }, options);
 
     return this.each(function () {
-        var $dropzone = $(this),
-            ui;
-
-        ui = new UploadUi($dropzone, settings);
+        let $dropzone = $(this);
+        let ui = new UploadUi($dropzone, settings);
         $(this).attr('data-uploaderui', true);
         this.uploaderUi = ui;
         ui.init();

--- a/core/client/app/authenticators/oauth2.js
+++ b/core/client/app/authenticators/oauth2.js
@@ -1,21 +1,25 @@
 import Ember from 'ember';
 import Authenticator from 'ember-simple-auth/authenticators/oauth2-password-grant';
 
+const {computed, inject} = Ember;
+
 export default Authenticator.extend({
-    config: Ember.inject.service(),
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    config: inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
 
-    serverTokenEndpoint: Ember.computed('ghostPaths.apiRoot', function () {
-        return this.get('ghostPaths.apiRoot') + '/authentication/token';
+    serverTokenEndpoint: computed('ghostPaths.apiRoot', function () {
+        return `${this.get('ghostPaths.apiRoot')}/authentication/token`;
     }),
 
-    serverTokenRevocationEndpoint: Ember.computed('ghostPaths.apiRoot', function () {
-        return this.get('ghostPaths.apiRoot') + '/authentication/revoke';
+    serverTokenRevocationEndpoint: computed('ghostPaths.apiRoot', function () {
+        return `${this.get('ghostPaths.apiRoot')}/authentication/revoke`;
     }),
 
-    makeRequest: function (url, data) {
+    makeRequest(url, data) {
+        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
         data.client_id = this.get('config.clientId');
         data.client_secret = this.get('config.clientSecret');
+        /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
         return this._super(url, data);
     }
 });

--- a/core/client/app/components/gh-activating-list-item.js
+++ b/core/client/app/components/gh-activating-list-item.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, on, run} = Ember;
+
+export default Component.extend({
     tagName: 'li',
     classNameBindings: ['active'],
     active: false,
     linkClasses: null,
 
-    unfocusLink: Ember.on('click', function () {
+    unfocusLink: on('click', function () {
         this.$('a').blur();
     }),
 
     actions: {
-        setActive: function (value) {
-            Ember.run.schedule('afterRender', this, function () {
+        setActive(value) {
+            run.schedule('afterRender', this, function () {
                 this.set('active', value);
             });
         }

--- a/core/client/app/components/gh-alert.js
+++ b/core/client/app/components/gh-alert.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+
+export default Component.extend({
     tagName: 'article',
     classNames: ['gh-alert'],
     classNameBindings: ['typeClass'],
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    typeClass: Ember.computed('message.type', function () {
-        var classes = '',
-            type = this.get('message.type'),
-            typeMapping;
+    typeClass: computed('message.type', function () {
+        let type = this.get('message.type');
+        let classes = '';
+        let typeMapping;
 
         typeMapping = {
             success: 'green',
@@ -20,14 +22,14 @@ export default Ember.Component.extend({
         };
 
         if (typeMapping[type] !== undefined) {
-            classes += 'gh-alert-' + typeMapping[type];
+            classes += `gh-alert-${typeMapping[type]}`;
         }
 
         return classes;
     }),
 
     actions: {
-        closeNotification: function () {
+        closeNotification() {
             this.get('notifications').closeNotification(this.get('message'));
         }
     }

--- a/core/client/app/components/gh-alerts.js
+++ b/core/client/app/components/gh-alerts.js
@@ -1,14 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject, observer} = Ember;
+const {alias} = computed;
+
+export default Component.extend({
     tagName: 'aside',
     classNames: 'gh-alerts',
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    messages: Ember.computed.alias('notifications.alerts'),
+    messages: alias('notifications.alerts'),
 
-    messageCountObserver: Ember.observer('messages.[]', function () {
+    messageCountObserver: observer('messages.[]', function () {
         this.sendAction('notify', this.get('messages').length);
     })
 });

--- a/core/client/app/components/gh-app.js
+++ b/core/client/app/components/gh-app.js
@@ -1,12 +1,14 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, observer} = Ember;
+
+export default Component.extend({
     classNames: ['gh-app'],
 
     showSettingsMenu: false,
 
-    toggleSettingsMenuBodyClass: Ember.observer('showSettingsMenu', function () {
-        var showSettingsMenu = this.get('showSettingsMenu');
+    toggleSettingsMenuBodyClass: observer('showSettingsMenu', function () {
+        let showSettingsMenu = this.get('showSettingsMenu');
 
         Ember.$('body').toggleClass('settings-menu-expanded', showSettingsMenu);
     })

--- a/core/client/app/components/gh-blog-url.js
+++ b/core/client/app/components/gh-blog-url.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, inject} = Ember;
+
+export default Component.extend({
     tagName: '',
-    config: Ember.inject.service()
+
+    config: inject.service()
 });

--- a/core/client/app/components/gh-cm-editor.js
+++ b/core/client/app/components/gh-cm-editor.js
@@ -1,14 +1,13 @@
 /* global CodeMirror */
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component} = Ember;
 
-    // DOM stuff
+export default Component.extend({
     classNameBindings: ['isFocused:focused'],
-    isFocused: false,
 
     value: '', // make sure a value exists
-    _editor: null, // reference to CodeMirror editor
+    isFocused: false,
 
     // options for the editor
     lineNumbers: true,
@@ -16,9 +15,11 @@ export default Ember.Component.extend({
     mode: 'htmlmixed',
     theme: 'xq-light',
 
-    didInsertElement: function () {
-        var options = this.getProperties('lineNumbers', 'indentUnit', 'mode', 'theme'),
-            editor = new CodeMirror(this.get('element'), options);
+    _editor: null, // reference to CodeMirror editor
+
+    didInsertElement() {
+        let options = this.getProperties('lineNumbers', 'indentUnit', 'mode', 'theme');
+        let editor = new CodeMirror(this.get('element'), options);
 
         editor.getDoc().setValue(this.get('value'));
 
@@ -34,10 +35,9 @@ export default Ember.Component.extend({
         this._editor = editor;
     },
 
-    willDestroyElement: function () {
-        var editor = this._editor.getWrapperElement();
+    willDestroyElement() {
+        let editor = this._editor.getWrapperElement();
         editor.parentNode.removeChild(editor);
         this._editor = null;
     }
-
 });

--- a/core/client/app/components/gh-content-cover.js
+++ b/core/client/app/components/gh-content-cover.js
@@ -12,17 +12,19 @@ Example:
 
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component} = Ember;
+
+export default Component.extend({
     classNames: ['content-cover'],
 
     onClick: null,
     onMouseEnter: null,
 
-    click: function () {
+    click() {
         this.sendAction('onClick');
     },
 
-    mouseEnter: function () {
+    mouseEnter() {
         this.sendAction('onMouseEnter');
     }
 });

--- a/core/client/app/components/gh-content-preview-content.js
+++ b/core/client/app/components/gh-content-preview-content.js
@@ -1,21 +1,23 @@
 import Ember from 'ember';
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
 
-export default Ember.Component.extend({
+const {Component, run} = Ember;
+
+export default Component.extend({
     classNames: ['content-preview-content'],
 
     content: null,
 
-    didInsertElement: function () {
-        var el = this.$();
+    didInsertElement() {
+        let el = this.$();
 
-        el.on('scroll', Ember.run.bind(el, setScrollClassName, {
+        el.on('scroll', run.bind(el, setScrollClassName, {
             target: el.closest('.content-preview'),
             offset: 10
         }));
     },
 
-    didReceiveAttrs: function (options) {
+    didReceiveAttrs(options) {
         // adjust when didReceiveAttrs gets both newAttrs and oldAttrs
         if (options.newAttrs.content && this.get('content') !== options.newAttrs.content.value) {
             let el = this.$();
@@ -26,8 +28,8 @@ export default Ember.Component.extend({
         }
     },
 
-    willDestroyElement: function () {
-        var el = this.$();
+    willDestroyElement() {
+        let el = this.$();
 
         el.off('scroll');
     }

--- a/core/client/app/components/gh-content-view-container.js
+++ b/core/client/app/components/gh-content-view-container.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+
+export default Component.extend({
     tagName: 'section',
     classNames: ['gh-view', 'content-view-container'],
 
-    mediaQueries: Ember.inject.service(),
-    previewIsHidden: Ember.computed.reads('mediaQueries.maxWidth900')
+    mediaQueries: inject.service(),
+    previewIsHidden: computed.reads('mediaQueries.maxWidth900')
 });

--- a/core/client/app/components/gh-dropdown-button.js
+++ b/core/client/app/components/gh-dropdown-button.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import DropdownMixin from 'ghost/mixins/dropdown-mixin';
 
-export default Ember.Component.extend(DropdownMixin, {
+const {Component, inject} = Ember;
+
+export default Component.extend(DropdownMixin, {
     tagName: 'button',
     attributeBindings: 'role',
     role: 'button',
@@ -9,10 +11,10 @@ export default Ember.Component.extend(DropdownMixin, {
     // matches with the dropdown this button toggles
     dropdownName: null,
 
-    dropdown: Ember.inject.service(),
+    dropdown: inject.service(),
 
     // Notify dropdown service this dropdown should be toggled
-    click: function (event) {
+    click(event) {
         this._super(event);
         this.get('dropdown').toggleDropdown(this.get('dropdownName'), this);
     }

--- a/core/client/app/components/gh-dropdown.js
+++ b/core/client/app/components/gh-dropdown.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import DropdownMixin from 'ghost/mixins/dropdown-mixin';
 
-export default Ember.Component.extend(DropdownMixin, {
+const {Component, computed, inject} = Ember;
+
+export default Component.extend(DropdownMixin, {
     classNames: 'dropdown',
     classNameBindings: ['fadeIn:fade-in-scale:fade-out', 'isOpen:open:closed'],
 
@@ -15,29 +17,28 @@ export default Ember.Component.extend(DropdownMixin, {
     isOpen: false,
 
     // Managed the toggle between the fade-in and fade-out classes
-    fadeIn: Ember.computed('isOpen', 'closing', function () {
+    fadeIn: computed('isOpen', 'closing', function () {
         return this.get('isOpen') && !this.get('closing');
     }),
 
-    dropdown: Ember.inject.service(),
+    dropdown: inject.service(),
 
-    open: function () {
+    open() {
         this.set('isOpen', true);
         this.set('closing', false);
         this.set('button.isOpen', true);
     },
 
-    close: function () {
-        var self = this;
-
+    close() {
         this.set('closing', true);
 
         if (this.get('button')) {
             this.set('button.isOpen', false);
         }
-        this.$().on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', function (event) {
+
+        this.$().on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', (event) => {
             if (event.originalEvent.animationName === 'fade-out') {
-                Ember.run(self, function () {
+                Ember.run(this, function () {
                     if (this.get('closing')) {
                         this.set('isOpen', false);
                         this.set('closing', false);
@@ -48,12 +49,12 @@ export default Ember.Component.extend(DropdownMixin, {
     },
 
     // Called by the dropdown service when any dropdown button is clicked.
-    toggle: function (options) {
-        var isClosing = this.get('closing'),
-            isOpen = this.get('isOpen'),
-            name = this.get('name'),
-            button = this.get('button'),
-            targetDropdownName = options.target;
+    toggle(options) {
+        let isClosing = this.get('closing');
+        let isOpen = this.get('isOpen');
+        let name = this.get('name');
+        let targetDropdownName = options.target;
+        let button = this.get('button');
 
         if (name === targetDropdownName && (!isOpen || isClosing)) {
             if (!button) {
@@ -66,7 +67,7 @@ export default Ember.Component.extend(DropdownMixin, {
         }
     },
 
-    click: function (event) {
+    click(event) {
         this._super(event);
 
         if (this.get('closeOnClick')) {
@@ -74,19 +75,19 @@ export default Ember.Component.extend(DropdownMixin, {
         }
     },
 
-    didInsertElement: function () {
-        this._super();
+    didInsertElement() {
+        let dropdownService = this.get('dropdown');
 
-        var dropdownService = this.get('dropdown');
+        this._super(...arguments);
 
         dropdownService.on('close', this, this.close);
         dropdownService.on('toggle', this, this.toggle);
     },
 
-    willDestroyElement: function () {
-        this._super();
+    willDestroyElement() {
+        let dropdownService = this.get('dropdown');
 
-        var dropdownService = this.get('dropdown');
+        this._super(...arguments);
 
         dropdownService.off('close', this, this.close);
         dropdownService.off('toggle', this, this.toggle);

--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -3,20 +3,22 @@ import EditorAPI from 'ghost/mixins/ed-editor-api';
 import EditorShortcuts from 'ghost/mixins/ed-editor-shortcuts';
 import EditorScroll from 'ghost/mixins/ed-editor-scroll';
 
-export default Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
+const {TextArea, run} = Ember;
+
+export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
     focus: false,
 
     /**
      * Tell the controller about focusIn events, will trigger an autosave on a new document
      */
-    focusIn: function () {
+    focusIn() {
         this.sendAction('onFocusIn');
     },
 
     /**
      * Sets the focus of the textarea if needed
      */
-    setFocus: function () {
+    setFocus() {
         if (this.get('focus')) {
             this.$().val(this.$().val()).focus();
         }
@@ -25,17 +27,17 @@ export default Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
     /**
      * Sets up properties at render time
      */
-    didInsertElement: function () {
-        this._super();
+    didInsertElement() {
+        this._super(...arguments);
 
         this.setFocus();
 
         this.sendAction('setEditor', this);
 
-        Ember.run.scheduleOnce('afterRender', this, this.afterRenderEvent);
+        run.scheduleOnce('afterRender', this, this.afterRenderEvent);
     },
 
-    afterRenderEvent: function () {
+    afterRenderEvent() {
         if (this.get('focus') && this.get('focusCursorAtEnd')) {
             this.setSelection('end');
         }
@@ -44,16 +46,16 @@ export default Ember.TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
     /**
      * Disable editing in the textarea (used while an upload is in progress)
      */
-    disable: function () {
-        var textarea = this.get('element');
+    disable() {
+        let textarea = this.get('element');
         textarea.setAttribute('readonly', 'readonly');
     },
 
     /**
      * Reenable editing in the textarea
      */
-    enable: function () {
-        var textarea = this.get('element');
+    enable() {
+        let textarea = this.get('element');
         textarea.removeAttribute('readonly');
     }
 });

--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -1,39 +1,43 @@
 import Ember from 'ember';
 import uploader from 'ghost/assets/lib/uploader';
 
-export default Ember.Component.extend({
-    config: Ember.inject.service(),
+const {Component, inject, run} = Ember;
+
+export default Component.extend({
+    config: inject.service(),
 
     _scrollWrapper: null,
 
-    didInsertElement: function () {
+    didInsertElement() {
         this._scrollWrapper = this.$().closest('.entry-preview-content');
         this.adjustScrollPosition(this.get('scrollPosition'));
-        Ember.run.scheduleOnce('afterRender', this, this.dropzoneHandler);
+        run.scheduleOnce('afterRender', this, this.dropzoneHandler);
     },
 
-    didReceiveAttrs: function (attrs) {
-        if (!attrs.oldAttrs) { return; }
+    didReceiveAttrs(attrs) {
+        if (!attrs.oldAttrs) {
+            return;
+        }
 
         if (attrs.newAttrs.scrollPosition && attrs.newAttrs.scrollPosition.value !== attrs.oldAttrs.scrollPosition.value) {
             this.adjustScrollPosition(attrs.newAttrs.scrollPosition.value);
         }
 
         if (attrs.newAttrs.markdown.value !== attrs.oldAttrs.markdown.value) {
-            Ember.run.scheduleOnce('afterRender', this, this.dropzoneHandler);
+            run.scheduleOnce('afterRender', this, this.dropzoneHandler);
         }
     },
 
-    adjustScrollPosition: function (scrollPosition) {
-        var scrollWrapper = this._scrollWrapper;
+    adjustScrollPosition(scrollPosition) {
+        let scrollWrapper = this._scrollWrapper;
 
         if (scrollWrapper) {
             scrollWrapper.scrollTop(scrollPosition);
         }
     },
 
-    dropzoneHandler: function () {
-        var dropzones = $('.js-drop-zone[data-uploaderui!="true"]');
+    dropzoneHandler() {
+        let dropzones = $('.js-drop-zone[data-uploaderui!="true"]');
 
         if (dropzones.length) {
             uploader.call(dropzones, {
@@ -41,10 +45,10 @@ export default Ember.Component.extend({
                 fileStorage: this.get('config.fileStorage')
             });
 
-            dropzones.on('uploadstart', Ember.run.bind(this, 'sendAction', 'uploadStarted'));
-            dropzones.on('uploadfailure', Ember.run.bind(this, 'sendAction', 'uploadFinished'));
-            dropzones.on('uploadsuccess', Ember.run.bind(this, 'sendAction', 'uploadFinished'));
-            dropzones.on('uploadsuccess', Ember.run.bind(this, 'sendAction', 'uploadSuccess'));
+            dropzones.on('uploadstart', run.bind(this, 'sendAction', 'uploadStarted'));
+            dropzones.on('uploadfailure', run.bind(this, 'sendAction', 'uploadFinished'));
+            dropzones.on('uploadsuccess', run.bind(this, 'sendAction', 'uploadFinished'));
+            dropzones.on('uploadsuccess', run.bind(this, 'sendAction', 'uploadSuccess'));
 
             // Set the current height so we can listen
             this.sendAction('updateHeight', this.$().height());

--- a/core/client/app/components/gh-editor-save-button.js
+++ b/core/client/app/components/gh-editor-save-button.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed} = Ember;
+
+export default Component.extend({
     tagName: 'section',
     classNames: ['splitbtn', 'js-publish-splitbutton'],
     classNameBindings: ['isNew:unsaved'],
@@ -12,36 +14,36 @@ export default Ember.Component.extend({
     submitting: false,
 
     // Tracks whether we're going to change the state of the post on save
-    isDangerous: Ember.computed('isPublished', 'willPublish', function () {
+    isDangerous: computed('isPublished', 'willPublish', function () {
         return this.get('isPublished') !== this.get('willPublish');
     }),
 
-    publishText: Ember.computed('isPublished', 'postOrPage', function () {
-        return this.get('isPublished') ? 'Update ' + this.get('postOrPage') : 'Publish Now';
+    publishText: computed('isPublished', 'postOrPage', function () {
+        return this.get('isPublished') ? `Update ${this.get('postOrPage')}` : 'Publish Now';
     }),
 
-    draftText: Ember.computed('isPublished', function () {
+    draftText: computed('isPublished', function () {
         return this.get('isPublished') ? 'Unpublish' : 'Save Draft';
     }),
 
-    deleteText: Ember.computed('postOrPage', function () {
-        return 'Delete ' + this.get('postOrPage');
+    deleteText: computed('postOrPage', function () {
+        return `Delete ${this.get('postOrPage')}`;
     }),
 
-    saveText: Ember.computed('willPublish', 'publishText', 'draftText', function () {
+    saveText: computed('willPublish', 'publishText', 'draftText', function () {
         return this.get('willPublish') ? this.get('publishText') : this.get('draftText');
     }),
 
     actions: {
-        save: function () {
+        save() {
             this.sendAction('save');
         },
 
-        setSaveType: function (saveType) {
+        setSaveType(saveType) {
             this.sendAction('setSaveType', saveType);
         },
 
-        delete: function () {
+        delete() {
             this.sendAction('delete');
         }
     }

--- a/core/client/app/components/gh-editor.js
+++ b/core/client/app/components/gh-editor.js
@@ -1,54 +1,37 @@
 import Ember from 'ember';
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
 
-export default Ember.Component.extend({
+const {Component, computed, run} = Ember;
+const {equal} = computed;
+
+export default Component.extend({
     tagName: 'section',
     classNames: ['gh-view'],
-
-    scheduleAfterRender: function () {
-        Ember.run.scheduleOnce('afterRender', this, this.afterRenderEvent);
-    },
-
-    didInsertElement: function () {
-        this.scheduleAfterRender();
-    },
-
-    afterRenderEvent: function () {
-        var $previewViewPort = this.$('.js-entry-preview-content');
-
-        // cache these elements for use in other methods
-        this.set('$previewViewPort', $previewViewPort);
-        this.set('$previewContent', this.$('.js-rendered-markdown'));
-
-        $previewViewPort.on('scroll', Ember.run.bind($previewViewPort, setScrollClassName, {
-            target: this.$('.js-entry-preview'),
-            offset: 10
-        }));
-    },
-
-    willDestroyElement: function () {
-        // removes scroll handlers from the view
-        this.get('$previewViewPort').off('scroll');
-    },
 
     // updated when gh-ed-editor component scrolls
     editorScrollInfo: null,
     // updated when markdown is rendered
     height: null,
+    activeTab: 'markdown',
+
+    markdownActive: equal('activeTab', 'markdown'),
+    previewActive: equal('activeTab', 'preview'),
 
     // HTML Preview listens to scrollPosition and updates its scrollTop value
     // This property receives scrollInfo from the textEditor, and height from the preview pane, and will update the
     // scrollPosition value such that when either scrolling or typing-at-the-end of the text editor the preview pane
     // stays in sync
-    scrollPosition: Ember.computed('editorScrollInfo', 'height', function () {
-        if (!this.get('editorScrollInfo') || !this.get('$previewContent') || !this.get('$previewViewPort')) {
+    scrollPosition: computed('editorScrollInfo', 'height', function () {
+        let scrollInfo = this.get('editorScrollInfo');
+        let $previewContent = this.get('$previewContent');
+        let $previewViewPort = this.get('$previewViewPort');
+
+        if (!scrollInfo || !$previewContent || !$previewViewPort) {
             return 0;
         }
 
-        var scrollInfo = this.get('editorScrollInfo'),
-            previewHeight = this.get('$previewContent').height() - this.get('$previewViewPort').height(),
-            previewPosition,
-            ratio;
+        let previewHeight = $previewContent.height() - $previewViewPort.height();
+        let previewPosition, ratio;
 
         ratio = previewHeight / scrollInfo.diff;
         previewPosition = scrollInfo.top * ratio;
@@ -56,12 +39,34 @@ export default Ember.Component.extend({
         return previewPosition;
     }),
 
-    activeTab: 'markdown',
-    markdownActive: Ember.computed.equal('activeTab', 'markdown'),
-    previewActive: Ember.computed.equal('activeTab', 'preview'),
+    scheduleAfterRender() {
+        run.scheduleOnce('afterRender', this, this.afterRenderEvent);
+    },
+
+    didInsertElement() {
+        this.scheduleAfterRender();
+    },
+
+    afterRenderEvent() {
+        let $previewViewPort = this.$('.js-entry-preview-content');
+
+        // cache these elements for use in other methods
+        this.set('$previewViewPort', $previewViewPort);
+        this.set('$previewContent', this.$('.js-rendered-markdown'));
+
+        $previewViewPort.on('scroll', run.bind($previewViewPort, setScrollClassName, {
+            target: this.$('.js-entry-preview'),
+            offset: 10
+        }));
+    },
+
+    willDestroyElement() {
+        // removes scroll handlers from the view
+        this.get('$previewViewPort').off('scroll');
+    },
 
     actions: {
-        selectTab: function (tab) {
+        selectTab(tab) {
             this.set('activeTab', tab);
         }
     }

--- a/core/client/app/components/gh-error-message.js
+++ b/core/client/app/components/gh-error-message.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const {Component, computed, isEmpty} = Ember;
+
 /**
  * Renders one random error message when passed a DS.Errors object
  * and a property name. The message will be one of the ones associated with
@@ -8,23 +10,23 @@ import Ember from 'ember';
  * @param  {DS.Errors} errors   The DS.Errors object
  * @param  {string} property    The property name
  */
-export default Ember.Component.extend({
+export default Component.extend({
     tagName: 'p',
     classNames: ['response'],
 
     errors: null,
     property: '',
 
-    isVisible: Ember.computed.notEmpty('errors'),
+    isVisible: computed.notEmpty('errors'),
 
-    message: Ember.computed('errors.[]', 'property', function () {
-        var property = this.get('property'),
-            errors = this.get('errors'),
-            messages = [],
-            index;
+    message: computed('errors.[]', 'property', function () {
+        let property = this.get('property');
+        let errors = this.get('errors');
+        let messages = [];
+        let index;
 
-        if (!Ember.isEmpty(errors) && errors.get(property)) {
-            errors.get(property).forEach(function (error) {
+        if (!isEmpty(errors) && errors.get(property)) {
+            errors.get(property).forEach((error) => {
                 messages.push(error);
             });
             index = Math.floor(Math.random() * messages.length);

--- a/core/client/app/components/gh-file-upload.js
+++ b/core/client/app/components/gh-file-upload.js
@@ -1,10 +1,11 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component} = Ember;
+
+export default Component.extend({
     _file: null,
 
     uploadButtonText: 'Text',
-
     uploadButtonDisabled: true,
 
     onUpload: null,
@@ -12,14 +13,14 @@ export default Ember.Component.extend({
 
     shouldResetForm: true,
 
-    change: function (event) {
+    change(event) {
         this.set('uploadButtonDisabled', false);
         this.sendAction('onAdd');
         this._file = event.target.files[0];
     },
 
     actions: {
-        upload: function () {
+        upload() {
             if (!this.get('uploadButtonDisabled') && this._file) {
                 this.sendAction('onUpload', this._file);
             }
@@ -29,7 +30,7 @@ export default Ember.Component.extend({
 
             // Reset form
             if (this.get('shouldResetForm')) {
-                this.$().closest('form').get(0).reset();
+                this.$().closest('form')[0].reset();
             }
         }
     }

--- a/core/client/app/components/gh-infinite-scroll-box.js
+++ b/core/client/app/components/gh-infinite-scroll-box.js
@@ -2,21 +2,22 @@ import Ember from 'ember';
 import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
 
-export default Ember.Component.extend(InfiniteScrollMixin, {
-    didRender: function () {
-        this._super();
+const {Component, run} = Ember;
 
-        var el = this.$();
+export default Component.extend(InfiniteScrollMixin, {
+    didRender() {
+        let el = this.$();
 
-        el.on('scroll', Ember.run.bind(el, setScrollClassName, {
+        this._super(...arguments);
+
+        el.on('scroll', run.bind(el, setScrollClassName, {
             target: el.closest('.content-list'),
             offset: 10
         }));
     },
 
-    willDestroyElement: function () {
-        this._super();
-
+    willDestroyElement() {
+        this._super(...arguments);
         this.$().off('scroll');
     }
 });

--- a/core/client/app/components/gh-infinite-scroll.js
+++ b/core/client/app/components/gh-infinite-scroll.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
 
-export default Ember.Component.extend(InfiniteScrollMixin);
+const {Component} = Ember;
+
+export default Component.extend(InfiniteScrollMixin);

--- a/core/client/app/components/gh-input.js
+++ b/core/client/app/components/gh-input.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import TextInputMixin from 'ghost/mixins/text-input';
 
-export default Ember.TextField.extend(TextInputMixin, {
+const {TextField} = Ember;
+
+export default TextField.extend(TextInputMixin, {
     classNames: 'gh-input'
 });

--- a/core/client/app/components/gh-main.js
+++ b/core/client/app/components/gh-main.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component} = Ember;
+
+export default Component.extend({
     tagName: 'main',
     classNames: ['gh-main'],
     ariaRole: 'main',
 
-    mouseEnter: function () {
+    mouseEnter() {
         this.sendAction('onMouseEnter');
     }
 });

--- a/core/client/app/components/gh-menu-toggle.js
+++ b/core/client/app/components/gh-menu-toggle.js
@@ -1,24 +1,25 @@
-/*
-This cute little component has two jobs.
-
-On desktop, it toggles autoNav behaviour. It tracks
-that state via the maximise property, and uses the
-state to render the appropriate icon.
-
-On mobile, it renders a closing icon, and clicking it
-closes the mobile menu
-*/
-
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+
+/*
+    This cute little component has two jobs.
+
+    On desktop, it toggles autoNav behaviour. It tracks
+    that state via the maximise property, and uses the
+    state to render the appropriate icon.
+
+    On mobile, it renders a closing icon, and clicking it
+    closes the mobile menu
+*/
+export default Component.extend({
     classNames: ['gh-menu-toggle'],
 
-    mediaQueries: Ember.inject.service(),
-    isMobile: Ember.computed.reads('mediaQueries.isMobile'),
+    mediaQueries: inject.service(),
+    isMobile: computed.reads('mediaQueries.isMobile'),
     maximise: false,
 
-    iconClass: Ember.computed('maximise', 'isMobile', function () {
+    iconClass: computed('maximise', 'isMobile', function () {
         if (this.get('maximise') && !this.get('isMobile')) {
             return 'icon-maximise';
         } else {
@@ -26,7 +27,7 @@ export default Ember.Component.extend({
         }
     }),
 
-    click: function () {
+    click() {
         if (this.get('isMobile')) {
             this.sendAction('mobileAction');
         } else {

--- a/core/client/app/components/gh-modal-dialog.js
+++ b/core/client/app/components/gh-modal-dialog.js
@@ -1,59 +1,66 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
-    didInsertElement: function () {
-        this.$('.js-modal-container, .js-modal-background').addClass('fade-in open');
-        this.$('.js-modal').addClass('open');
-    },
+const {Component, computed} = Ember;
 
-    close: function () {
-        var self = this;
+function K() {
+    return this;
+}
 
-        this.$('.js-modal, .js-modal-background').removeClass('fade-in').addClass('fade-out');
-
-        // The background should always be the last thing to fade out, so check on that instead of the content
-        this.$('.js-modal-background').on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', function (event) {
-            if (event.originalEvent.animationName === 'fade-out') {
-                self.$('.js-modal, .js-modal-background').removeClass('open');
-            }
-        });
-
-        this.sendAction();
-    },
+export default Component.extend({
 
     confirmaccept: 'confirmAccept',
     confirmreject: 'confirmReject',
 
-    actions: {
-        closeModal: function () {
-            this.close();
-        },
-        confirm: function (type) {
-            this.sendAction('confirm' + type);
-            this.close();
-        },
-        noBubble: Ember.K
-    },
+    klass: computed('type', 'style', function () {
+        let classNames = [];
 
-    klass: Ember.computed('type', 'style', function () {
-        var classNames = [];
-
-        classNames.push(this.get('type') ? 'modal-' + this.get('type') : 'modal');
+        classNames.push(this.get('type') ? `modal-${this.get('type')}` : 'modal');
 
         if (this.get('style')) {
-            this.get('style').split(',').forEach(function (style) {
-                classNames.push('modal-style-' + style);
+            this.get('style').split(',').forEach((style) => {
+                classNames.push(`modal-style-${style}`);
             });
         }
 
         return classNames.join(' ');
     }),
 
-    acceptButtonClass: Ember.computed('confirm.accept.buttonClass', function () {
+    acceptButtonClass: computed('confirm.accept.buttonClass', function () {
         return this.get('confirm.accept.buttonClass') ? this.get('confirm.accept.buttonClass') : 'btn btn-green';
     }),
 
-    rejectButtonClass: Ember.computed('confirm.reject.buttonClass', function () {
+    rejectButtonClass: computed('confirm.reject.buttonClass', function () {
         return this.get('confirm.reject.buttonClass') ? this.get('confirm.reject.buttonClass') : 'btn btn-red';
-    })
+    }),
+
+    didInsertElement() {
+        this.$('.js-modal-container, .js-modal-background').addClass('fade-in open');
+        this.$('.js-modal').addClass('open');
+    },
+
+    close() {
+        this.$('.js-modal, .js-modal-background').removeClass('fade-in').addClass('fade-out');
+
+        // The background should always be the last thing to fade out, so check on that instead of the content
+        this.$('.js-modal-background').on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', (event) => {
+            if (event.originalEvent.animationName === 'fade-out') {
+                this.$('.js-modal, .js-modal-background').removeClass('open');
+            }
+        });
+
+        this.sendAction();
+    },
+
+    actions: {
+        closeModal() {
+            this.close();
+        },
+
+        confirm(type) {
+            this.sendAction(`confirm${type}`);
+            this.close();
+        },
+
+        noBubble: K
+    }
 });

--- a/core/client/app/components/gh-nav-menu.js
+++ b/core/client/app/components/gh-nav-menu.js
@@ -1,33 +1,35 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, inject} = Ember;
+
+export default Component.extend({
     tagName: 'nav',
     classNames: ['gh-nav'],
     classNameBindings: ['open'],
 
-    config: Ember.inject.service(),
-    session: Ember.inject.service(),
-
     open: false,
 
-    mouseEnter: function () {
+    config: inject.service(),
+    session: inject.service(),
+
+    mouseEnter() {
         this.sendAction('onMouseEnter');
     },
 
     actions: {
-        toggleAutoNav: function () {
+        toggleAutoNav() {
             this.sendAction('toggleMaximise');
         },
 
-        openModal: function (modal) {
+        openModal(modal) {
             this.sendAction('openModal', modal);
         },
 
-        closeMobileMenu: function () {
+        closeMobileMenu() {
             this.sendAction('closeMobileMenu');
         },
 
-        openAutoNav: function () {
+        openAutoNav() {
             this.sendAction('openAutoNav');
         }
     }

--- a/core/client/app/components/gh-navigation.js
+++ b/core/client/app/components/gh-navigation.js
@@ -1,13 +1,14 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, run} = Ember;
+
+export default Component.extend({
     tagName: 'section',
     classNames: 'gh-view',
 
-    didInsertElement: function () {
-        var navContainer = this.$('.js-gh-blognav'),
-            navElements = '.gh-blognav-item:not(.gh-blognav-item:last-child)',
-            self = this;
+    didInsertElement() {
+        let navContainer = this.$('.js-gh-blognav');
+        let navElements = '.gh-blognav-item:not(.gh-blognav-item:last-child)';
 
         this._super(...arguments);
 
@@ -15,21 +16,21 @@ export default Ember.Component.extend({
             handle: '.gh-blognav-grab',
             items: navElements,
 
-            start: function (event, ui) {
-                Ember.run(function () {
+            start(event, ui) {
+                run(() => {
                     ui.item.data('start-index', ui.item.index());
                 });
             },
 
-            update: function (event, ui) {
-                Ember.run(function () {
-                    self.sendAction('moveItem', ui.item.data('start-index'), ui.item.index());
+            update(event, ui) {
+                run(() => {
+                    this.sendAction('moveItem', ui.item.data('start-index'), ui.item.index());
                 });
             }
         });
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         this.$('.ui-sortable').sortable('destroy');
     }
 });

--- a/core/client/app/components/gh-navitem-url-input.js
+++ b/core/client/app/components/gh-navitem-url-input.js
@@ -1,11 +1,10 @@
 import Ember from 'ember';
 
-var joinUrlParts,
-    isRelative;
+const {TextField, computed, run} = Ember;
 
-joinUrlParts = function (url, path) {
+let joinUrlParts = function (url, path) {
     if (path[0] !== '/' && url.slice(-1) !== '/') {
-        path = '/' + path;
+        path = `/${path}`;
     } else if (path[0] === '/' && url.slice(-1) === '/') {
         path = path.slice(1);
     }
@@ -13,19 +12,27 @@ joinUrlParts = function (url, path) {
     return url + path;
 };
 
-isRelative = function (url) {
+let isRelative = function (url) {
     // "protocol://", "//example.com", "scheme:", "#anchor", & invalid paths
     // should all be treated as absolute
     return !url.match(/\s/) && !validator.isURL(url) && !url.match(/^(\/\/|#|[a-zA-Z0-9\-]+:)/);
 };
 
-export default Ember.TextField.extend({
+export default TextField.extend({
     classNames: 'gh-input',
     classNameBindings: ['fakePlaceholder'],
 
-    didReceiveAttrs: function () {
-        var url = this.get('url'),
-            baseUrl = this.get('baseUrl');
+    isBaseUrl: computed('baseUrl', 'value', function () {
+        return this.get('baseUrl') === this.get('value');
+    }),
+
+    fakePlaceholder: computed('isBaseUrl', 'hasFocus', function () {
+        return this.get('isBaseUrl') && this.get('last') && !this.get('hasFocus');
+    }),
+
+    didReceiveAttrs() {
+        let baseUrl = this.get('baseUrl');
+        let url = this.get('url');
 
         // if we have a relative url, create the absolute url to be displayed in the input
         if (isRelative(url)) {
@@ -35,28 +42,20 @@ export default Ember.TextField.extend({
         this.set('value', url);
     },
 
-    isBaseUrl: Ember.computed('baseUrl', 'value', function () {
-        return this.get('baseUrl') === this.get('value');
-    }),
-
-    fakePlaceholder: Ember.computed('isBaseUrl', 'hasFocus', function () {
-        return this.get('isBaseUrl') && this.get('last') && !this.get('hasFocus');
-    }),
-
-    focusIn: function (event) {
+    focusIn(event) {
         this.set('hasFocus', true);
 
         if (this.get('isBaseUrl')) {
             // position the cursor at the end of the input
-            Ember.run.next(function (el) {
-                var length = el.value.length;
+            run.next(function (el) {
+                let {length} = el.value;
 
                 el.setSelectionRange(length, length);
             }, event.target);
         }
     },
 
-    keyDown: function (event) {
+    keyDown(event) {
         // delete the "placeholder" value all at once
         if (this.get('isBaseUrl') && (event.keyCode === 8 || event.keyCode === 46)) {
             this.set('value', '');
@@ -70,7 +69,7 @@ export default Ember.TextField.extend({
         }
     },
 
-    keyPress: function (event) {
+    keyPress(event) {
         // enter key
         if (event.keyCode === 13) {
             event.preventDefault();
@@ -80,19 +79,21 @@ export default Ember.TextField.extend({
         return true;
     },
 
-    focusOut: function () {
+    focusOut() {
         this.set('hasFocus', false);
 
         this.notifyUrlChanged();
     },
 
-    notifyUrlChanged: function () {
-        this.set('value', this.get('value').trim());
+    notifyUrlChanged() {
+        let value = this.get('value').trim();
+        let urlParts = document.createElement('a');
+        let baseUrl = this.get('baseUrl');
+        let baseUrlParts = document.createElement('a');
+        let url = value;
 
-        var url = this.get('value'),
-            urlParts = document.createElement('a'),
-            baseUrl = this.get('baseUrl'),
-            baseUrlParts = document.createElement('a');
+        // ensure value property is trimmed
+        this.set('value', value);
 
         // leverage the browser's native URI parsing
         urlParts.href = url;
@@ -117,7 +118,7 @@ export default Ember.TextField.extend({
             url = url.replace(baseUrlParts.host, '');
             url = url.replace(baseUrlParts.pathname, '');
             if (!url.match(/^\//)) {
-                url = '/' + url;
+                url = `/${url}`;
             }
         }
 

--- a/core/client/app/components/gh-navitem.js
+++ b/core/client/app/components/gh-navitem.js
@@ -1,21 +1,23 @@
 import Ember from 'ember';
 import ValidationStateMixin from 'ghost/mixins/validation-state';
 
-export default Ember.Component.extend(ValidationStateMixin, {
+const {Component, computed} = Ember;
+
+export default Component.extend(ValidationStateMixin, {
     classNames: 'gh-blognav-item',
     classNameBindings: ['errorClass'],
 
     attributeBindings: ['order:data-order'],
-    order: Ember.computed.readOnly('navItem.order'),
-    errors: Ember.computed.readOnly('navItem.errors'),
+    order: computed.readOnly('navItem.order'),
+    errors: computed.readOnly('navItem.errors'),
 
-    errorClass: Ember.computed('hasError', function () {
+    errorClass: computed('hasError', function () {
         if (this.get('hasError')) {
             return 'gh-blognav-item--error';
         }
     }),
 
-    keyPress: function (event) {
+    keyPress(event) {
         // enter key
         if (event.keyCode === 13) {
             event.preventDefault();
@@ -26,15 +28,15 @@ export default Ember.Component.extend(ValidationStateMixin, {
     },
 
     actions: {
-        addItem: function () {
+        addItem() {
             this.sendAction('addItem');
         },
 
-        deleteItem: function (item) {
+        deleteItem(item) {
             this.sendAction('deleteItem', item);
         },
 
-        updateUrl: function (value) {
+        updateUrl(value) {
             this.sendAction('updateUrl', value, this.get('navItem'));
         }
     }

--- a/core/client/app/components/gh-notification.js
+++ b/core/client/app/components/gh-notification.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+
+export default Component.extend({
     tagName: 'article',
     classNames: ['gh-notification', 'gh-notification-passive'],
     classNameBindings: ['typeClass'],
 
     message: null,
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    typeClass: Ember.computed('message.type', function () {
-        var classes = '',
-            type = this.get('message.type'),
-            typeMapping;
+    typeClass: computed('message.type', function () {
+        let type = this.get('message.type');
+        let classes = '';
+        let typeMapping;
 
         typeMapping = {
             success: 'green',
@@ -21,28 +23,26 @@ export default Ember.Component.extend({
         };
 
         if (typeMapping[type] !== undefined) {
-            classes += 'gh-notification-' + typeMapping[type];
+            classes += `gh-notification-${typeMapping[type]}`;
         }
 
         return classes;
     }),
 
-    didInsertElement: function () {
-        var self = this;
-
-        self.$().on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', function (event) {
+    didInsertElement() {
+        this.$().on('animationend webkitAnimationEnd oanimationend MSAnimationEnd', (event) => {
             if (event.originalEvent.animationName === 'fade-out') {
-                self.get('notifications').closeNotification(self.get('message'));
+                this.get('notifications').closeNotification(this.get('message'));
             }
         });
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         this.$().off('animationend webkitAnimationEnd oanimationend MSAnimationEnd');
     },
 
     actions: {
-        closeNotification: function () {
+        closeNotification() {
             this.get('notifications').closeNotification(this.get('message'));
         }
     }

--- a/core/client/app/components/gh-notifications.js
+++ b/core/client/app/components/gh-notifications.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+const {alias} = computed;
+
+export default Component.extend({
     tagName: 'aside',
     classNames: 'gh-notifications',
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    messages: Ember.computed.alias('notifications.notifications')
+    messages: alias('notifications.notifications')
 });

--- a/core/client/app/components/gh-popover-button.js
+++ b/core/client/app/components/gh-popover-button.js
@@ -1,18 +1,24 @@
 import Ember from 'ember';
 import DropdownButton from 'ghost/components/gh-dropdown-button';
 
+const {inject} = Ember;
+
+function K() {
+    return this;
+}
+
 export default DropdownButton.extend({
-    dropdown: Ember.inject.service(),
+    dropdown: inject.service(),
 
-    click: Ember.K,
+    click: K,
 
-    mouseEnter: function (event) {
-        this._super(event);
+    mouseEnter() {
+        this._super(...arguments);
         this.get('dropdown').toggleDropdown(this.get('popoverName'), this);
     },
 
-    mouseLeave: function (event) {
-        this._super(event);
+    mouseLeave() {
+        this._super(...arguments);
         this.get('dropdown').toggleDropdown(this.get('popoverName'), this);
     }
 });

--- a/core/client/app/components/gh-popover.js
+++ b/core/client/app/components/gh-popover.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 import GhostDropdown from 'ghost/components/gh-dropdown';
 
+const {inject} = Ember;
+
 export default GhostDropdown.extend({
     classNames: 'ghost-popover',
-    dropdown: Ember.inject.service()
+    dropdown: inject.service()
 });

--- a/core/client/app/components/gh-posts-list-item.js
+++ b/core/client/app/components/gh-posts-list-item.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+const {alias, equal} = computed;
+
+export default Component.extend({
     tagName: 'li',
     classNameBindings: ['active', 'isFeatured:featured', 'isPage:page'],
 
@@ -8,60 +11,56 @@ export default Ember.Component.extend({
     active: false,
     previewIsHidden: false,
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    isFeatured: alias('post.featured'),
+    isPage: alias('post.page'),
+    isPublished: equal('post.status', 'published'),
 
-    isFeatured: Ember.computed.alias('post.featured'),
+    ghostPaths: inject.service('ghost-paths'),
 
-    isPage: Ember.computed.alias('post.page'),
-
-    isPublished: Ember.computed.equal('post.status', 'published'),
-
-    authorName: Ember.computed('post.author.name', 'post.author.email', function () {
+    authorName: computed('post.author.name', 'post.author.email', function () {
         return this.get('post.author.name') || this.get('post.author.email');
     }),
 
-    authorAvatar: Ember.computed('post.author.image', function () {
+    authorAvatar: computed('post.author.image', function () {
         return this.get('post.author.image') || this.get('ghostPaths.url').asset('/shared/img/user-image.png');
     }),
 
-    authorAvatarBackground: Ember.computed('authorAvatar', function () {
+    authorAvatarBackground: computed('authorAvatar', function () {
         return Ember.String.htmlSafe(`background-image: url(${this.get('authorAvatar')})`);
     }),
 
-    viewOrEdit: Ember.computed('previewIsHidden', function () {
+    viewOrEdit: computed('previewIsHidden', function () {
         return this.get('previewIsHidden') ? 'editor.edit' : 'posts.post';
     }),
 
-    click: function () {
+    click() {
         this.sendAction('onClick', this.get('post'));
     },
 
-    doubleClick: function () {
+    doubleClick() {
         this.sendAction('onDoubleClick', this.get('post'));
     },
 
-    didInsertElement: function () {
+    didInsertElement() {
         this.addObserver('active', this, this.scrollIntoView);
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         this.removeObserver('active', this, this.scrollIntoView);
     },
 
-    scrollIntoView: function () {
+    scrollIntoView() {
         if (!this.get('active')) {
             return;
         }
 
-        var element = this.$(),
-            offset = element.offset().top,
-            elementHeight = element.height(),
-            container = Ember.$('.js-content-scrollbox'),
-            containerHeight = container.height(),
-            currentScroll = container.scrollTop(),
-            isBelowTop,
-            isAboveBottom,
-            isOnScreen;
+        let element = this.$();
+        let offset = element.offset().top;
+        let elementHeight = element.height();
+        let container = $('.js-content-scrollbox');
+        let containerHeight = container.height();
+        let currentScroll = container.scrollTop();
+        let isBelowTop, isAboveBottom, isOnScreen;
 
         isAboveBottom = offset < containerHeight;
         isBelowTop = offset > elementHeight;

--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
 
+const {Component, computed, inject, run} = Ember;
+const {notEmpty} = computed;
+
 /**
  * A component to manage a user profile image. By default it just handles picture uploads,
  * but if passed a bound 'email' property it will render the user's gravatar image
@@ -14,7 +17,7 @@ import Ember from 'ember';
  * @property  {String}      defaultImage      String containing the background-image css property of the default user profile image
  * @property  {String}      imageBackground   String containing the background-image css property with the gravatar url
  */
-export default Ember.Component.extend({
+export default Component.extend({
     email: '',
     size: 90,
     debounce: 300,
@@ -23,35 +26,35 @@ export default Ember.Component.extend({
     hasUploadedImage: false,
     fileStorage: true,
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    displayGravatar: Ember.computed.notEmpty('validEmail'),
+    ghostPaths: inject.service('ghost-paths'),
+    displayGravatar: notEmpty('validEmail'),
 
-    init: function () {
+    init() {
         this._super(...arguments);
         // Fire this immediately in case we're initialized with a valid email
         this.trySetValidEmail();
     },
 
-    defaultImage: Ember.computed('ghostPaths', function () {
-        const url = this.get('ghostPaths.url').asset('/shared/img/user-image.png');
+    defaultImage: computed('ghostPaths', function () {
+        let url = this.get('ghostPaths.url').asset('/shared/img/user-image.png');
         return Ember.String.htmlSafe(`background-image: url(${url})`);
     }),
 
-    trySetValidEmail: function () {
+    trySetValidEmail() {
         if (!this.get('isDestroyed')) {
-            const email = this.get('email');
+            let email = this.get('email');
             this.set('validEmail', validator.isEmail(email) ? email : '');
         }
     },
 
-    didReceiveAttrs: function (attrs) {
-        const timeout = parseInt(attrs.newAttrs.throttle || this.get('debounce'));
-        Ember.run.debounce(this, 'trySetValidEmail', timeout);
+    didReceiveAttrs(attrs) {
+        let timeout = parseInt(attrs.newAttrs.throttle || this.get('debounce'));
+        run.debounce(this, 'trySetValidEmail', timeout);
     },
 
-    imageBackground: Ember.computed('validEmail', 'size', function () {
-        const email = this.get('validEmail'),
-              size = this.get('size');
+    imageBackground: computed('validEmail', 'size', function () {
+        let email = this.get('validEmail');
+        let size = this.get('size');
 
         let style = '';
         if (email) {
@@ -61,9 +64,9 @@ export default Ember.Component.extend({
         return Ember.String.htmlSafe(style);
     }),
 
-    didInsertElement: function () {
-        var size = this.get('size'),
-            uploadElement = this.$('.js-file-input');
+    didInsertElement() {
+        let size = this.get('size');
+        let uploadElement = this.$('.js-file-input');
 
         // while theoretically the 'add' and 'processalways' functions could be
         // added as properties of the hash passed to fileupload(), for some reason
@@ -77,26 +80,27 @@ export default Ember.Component.extend({
             maxNumberOfFiles: 1,
             autoUpload: false
         })
-        .on('fileuploadadd', Ember.run.bind(this, this.queueFile))
-        .on('fileuploadprocessalways', Ember.run.bind(this, this.triggerPreview));
+        .on('fileuploadadd', run.bind(this, this.queueFile))
+        .on('fileuploadprocessalways', run.bind(this, this.triggerPreview));
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         if (this.$('.js-file-input').data()['blueimp-fileupload']) {
             this.$('.js-file-input').fileupload('destroy');
         }
     },
 
-    queueFile: function (e, data) {
-        const fileName = data.files[0].name;
+    queueFile(e, data) {
+        let fileName = data.files[0].name;
 
         if ((/\.(gif|jpe?g|png|svg?z)$/i).test(fileName)) {
             this.sendAction('setImage', data);
         }
     },
 
-    triggerPreview: function (e, data) {
-        const file = data.files[data.index];
+    triggerPreview(e, data) {
+        let file = data.files[data.index];
+
         if (file.preview) {
             this.set('hasUploadedImage', true);
             // necessary jQuery code because file.preview is a raw DOM object

--- a/core/client/app/components/gh-search-input.js
+++ b/core/client/app/components/gh-search-input.js
@@ -1,8 +1,12 @@
+/* global key */
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
-/* global key */
 
-export default Ember.Component.extend({
+const {Component, RSVP, computed, inject, observer} = Ember;
+const {filterBy} = computed;
+
+export default Component.extend({
 
     selection: null,
     content: [],
@@ -10,48 +14,49 @@ export default Ember.Component.extend({
     contentExpiry: 10 * 1000,
     contentExpiresAt: false,
 
-    posts: Ember.computed.filterBy('content', 'category', 'Posts'),
-    pages: Ember.computed.filterBy('content', 'category', 'Pages'),
-    users: Ember.computed.filterBy('content', 'category', 'Users'),
-    tags: Ember.computed.filterBy('content', 'category', 'Tags'),
+    posts: filterBy('content', 'category', 'Posts'),
+    pages: filterBy('content', 'category', 'Pages'),
+    users: filterBy('content', 'category', 'Users'),
+    tags:  filterBy('content', 'category', 'Tags'),
 
-    _store: Ember.inject.service('store'),
-    _routing: Ember.inject.service('-routing'),
-    _selectize: Ember.computed(function () {
+    _store: inject.service('store'),
+    _routing: inject.service('-routing'),
+
+    _selectize: computed(function () {
         return this.$('select')[0].selectize;
     }),
 
-    refreshContent: function () {
-        var promises = [],
-            now = new Date(),
-            contentExpiry = this.get('contentExpiry'),
-            contentExpiresAt = this.get('contentExpiresAt'),
-            self = this;
+    refreshContent() {
+        let promises = [];
+        let now = new Date();
+        let contentExpiry = this.get('contentExpiry');
+        let contentExpiresAt = this.get('contentExpiresAt');
 
-        if (self.get('isLoading') || contentExpiresAt > now) { return; }
+        if (this.get('isLoading') || contentExpiresAt > now) {
+            return;
+        }
 
-        self.set('isLoading', true);
+        this.set('isLoading', true);
         promises.pushObject(this._loadPosts());
         promises.pushObject(this._loadUsers());
         promises.pushObject(this._loadTags());
 
-        Ember.RSVP.all(promises).then(function () { }).finally(function () {
-            self.set('isLoading', false);
-            self.set('contentExpiresAt', new Date(now.getTime() + contentExpiry));
+        RSVP.all(promises).then(() => { }).finally(() => {
+            this.set('isLoading', false);
+            this.set('contentExpiresAt', new Date(now.getTime() + contentExpiry));
         });
     },
 
-    _loadPosts: function () {
-        var store = this.get('_store'),
-            postsUrl = store.adapterFor('post').urlForQuery({}, 'post') + '/',
-            postsQuery = {fields: 'id,title,page', limit: 'all', status: 'all', staticPages: 'all'},
-            content = this.get('content'),
-            self = this;
+    _loadPosts() {
+        let store = this.get('_store');
+        let postsUrl = `${store.adapterFor('post').urlForQuery({}, 'post')}/`;
+        let postsQuery = {fields: 'id,title,page', limit: 'all', status: 'all', staticPages: 'all'};
+        let content = this.get('content');
 
-        return ajax(postsUrl, {data: postsQuery}).then(function (posts) {
-            content.removeObjects(self.get('posts'));
-            content.removeObjects(self.get('pages'));
-            content.pushObjects(posts.posts.map(function (post) {
+        return ajax(postsUrl, {data: postsQuery}).then((posts) => {
+            content.removeObjects(this.get('posts'));
+            content.removeObjects(this.get('pages'));
+            content.pushObjects(posts.posts.map((post) => {
                 return {
                     id: `post.${post.id}`,
                     title: post.title,
@@ -61,16 +66,15 @@ export default Ember.Component.extend({
         });
     },
 
-    _loadUsers: function () {
-        var store = this.get('_store'),
-            usersUrl = store.adapterFor('user').urlForQuery({}, 'user') + '/',
-            usersQuery = {fields: 'name,slug', limit: 'all'},
-            content = this.get('content'),
-            self = this;
+    _loadUsers() {
+        let store = this.get('_store');
+        let usersUrl = `${store.adapterFor('user').urlForQuery({}, 'user')}/`;
+        let usersQuery = {fields: 'name,slug', limit: 'all'};
+        let content = this.get('content');
 
-        return ajax(usersUrl, {data: usersQuery}).then(function (users) {
-            content.removeObjects(self.get('users'));
-            content.pushObjects(users.users.map(function (user) {
+        return ajax(usersUrl, {data: usersQuery}).then((users) => {
+            content.removeObjects(this.get('users'));
+            content.pushObjects(users.users.map((user) => {
                 return {
                     id: `user.${user.slug}`,
                     title: user.name,
@@ -80,16 +84,15 @@ export default Ember.Component.extend({
         });
     },
 
-    _loadTags: function () {
-        var store = this.get('_store'),
-            tagsUrl = store.adapterFor('tag').urlForQuery({}, 'tag') + '/',
-            tagsQuery = {fields: 'name,slug', limit: 'all'},
-            content = this.get('content'),
-            self = this;
+    _loadTags() {
+        let store = this.get('_store');
+        let tagsUrl = `${store.adapterFor('tag').urlForQuery({}, 'tag')}/`;
+        let tagsQuery = {fields: 'name,slug', limit: 'all'};
+        let content = this.get('content');
 
-        return ajax(tagsUrl, {data: tagsQuery}).then(function (tags) {
-            content.removeObjects(self.get('tags'));
-            content.pushObjects(tags.tags.map(function (tag) {
+        return ajax(tagsUrl, {data: tagsQuery}).then((tags) => {
+            content.removeObjects(this.get('tags'));
+            content.pushObjects(tags.tags.map((tag) => {
                 return {
                     id: `tag.${tag.slug}`,
                     title: tag.name,
@@ -99,80 +102,81 @@ export default Ember.Component.extend({
         });
     },
 
-    _keepSelectionClear: Ember.observer('selection', function () {
+    _keepSelectionClear: observer('selection', function () {
         if (this.get('selection') !== null) {
             this.set('selection', null);
         }
     }),
 
-    _setKeymasterScope: function () {
+    _setKeymasterScope() {
         key.setScope('search-input');
     },
 
-    _resetKeymasterScope: function () {
+    _resetKeymasterScope() {
         key.setScope('default');
     },
 
-    willDestroy: function () {
+    willDestroy() {
         this._resetKeymasterScope();
     },
 
     actions: {
-        openSelected: function (selected) {
-            var transition = null,
-                self = this;
+        openSelected(selected) {
+            let transition = null;
 
-            if (!selected) { return; }
+            if (!selected) {
+                return;
+            }
 
             if (selected.category === 'Posts' || selected.category === 'Pages') {
                 let id = selected.id.replace('post.', '');
-                transition = self.get('_routing.router').transitionTo('editor.edit', id);
+                transition = this.get('_routing.router').transitionTo('editor.edit', id);
             }
 
             if (selected.category === 'Users') {
                 let id = selected.id.replace('user.', '');
-                transition = self.get('_routing.router').transitionTo('team.user', id);
+                transition = this.get('_routing.router').transitionTo('team.user', id);
             }
 
             if (selected.category === 'Tags') {
                 let id = selected.id.replace('tag.', '');
-                transition = self.get('_routing.router').transitionTo('settings.tags.tag', id);
+                transition = this.get('_routing.router').transitionTo('settings.tags.tag', id);
             }
 
-            transition.then(function () {
-                if (self.get('_selectize').$control_input.is(':focus')) {
-                    self._setKeymasterScope();
+            transition.then(() => {
+                if (this.get('_selectize').$control_input.is(':focus')) {
+                    this._setKeymasterScope();
                 }
             });
         },
 
-        focusInput: function () {
+        focusInput() {
             this.get('_selectize').focus();
         },
 
-        onInit: function () {
-            var selectize = this.get('_selectize'),
-                html = '<div class="dropdown-empty-message">Nothing found&hellip;</div>';
+        onInit() {
+            let selectize = this.get('_selectize');
+            let html = '<div class="dropdown-empty-message">Nothing found&hellip;</div>';
 
             selectize.$empty_results_container = $(html);
             selectize.$empty_results_container.hide();
             selectize.$dropdown.append(selectize.$empty_results_container);
         },
 
-        onFocus: function () {
+        onFocus() {
             this._setKeymasterScope();
             this.refreshContent();
         },
 
-        onBlur: function () {
-            var selectize = this.get('_selectize');
+        onBlur() {
+            let selectize = this.get('_selectize');
 
             this._resetKeymasterScope();
             selectize.$empty_results_container.hide();
         },
 
-        onType: function () {
-            var selectize = this.get('_selectize');
+        onType() {
+            let selectize = this.get('_selectize');
 
             if (!selectize.hasOptions) {
                 selectize.open();

--- a/core/client/app/components/gh-select-native.js
+++ b/core/client/app/components/gh-select-native.js
@@ -1,28 +1,34 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed} = Ember;
+const {reads} = computed;
+
+function K() {
+    return this;
+}
+
+export default Component.extend({
     content: null,
     prompt: null,
     optionValuePath: 'id',
     optionLabelPath: 'title',
     selection: null,
-    action: Ember.K, // action to fire on change
+    action: K, // action to fire on change
 
     // shadow the passed-in `selection` to avoid
     // leaking changes to it via a 2-way binding
-    _selection: Ember.computed.reads('selection'),
+    _selection: reads('selection'),
 
     actions: {
-        change: function () {
-            var selectEl = this.$('select')[0],
-                selectedIndex = selectEl.selectedIndex,
-                content = this.get('content'),
+        change() {
+            let [selectEl] = this.$('select');
+            let {selectedIndex} = selectEl;
 
-                // decrement index by 1 if we have a prompt
-                hasPrompt = !!this.get('prompt'),
-                contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex,
+            // decrement index by 1 if we have a prompt
+            let hasPrompt = !!this.get('prompt');
+            let contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
 
-                selection = content.objectAt(contentIndex);
+            let selection = this.get('content').objectAt(contentIndex);
 
             // set the local, shadowed selection to avoid leaking
             // changes to `selection` out via 2-way binding

--- a/core/client/app/components/gh-selectize.js
+++ b/core/client/app/components/gh-selectize.js
@@ -1,30 +1,34 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import EmberSelectizeComponent from 'ember-cli-selectize/components/ember-selectize';
 
+const {computed, isBlank, get, on, run} = Ember;
+const emberA = Ember.A;
+
 export default EmberSelectizeComponent.extend({
 
-    selectizeOptions: Ember.computed(function () {
-        const options = this._super(...arguments);
+    selectizeOptions: computed(function () {
+        let options = this._super(...arguments);
 
-        options.onChange = Ember.run.bind(this, '_onChange');
+        options.onChange = run.bind(this, '_onChange');
 
         return options;
     }),
 
-    _dontOpenWhenBlank: Ember.on('didInsertElement', function () {
-        var openOnFocus = this.get('openOnFocus');
+    _dontOpenWhenBlank: on('didInsertElement', function () {
+        let openOnFocus = this.get('openOnFocus');
 
         if (!openOnFocus) {
-            Ember.run.schedule('afterRender', this, function () {
-                var selectize = this._selectize;
+            run.schedule('afterRender', this, function () {
+                let selectize = this._selectize;
                 if (selectize) {
                     selectize.on('dropdown_open', function () {
-                        if (Ember.isBlank(selectize.$control_input.val())) {
+                        if (isBlank(selectize.$control_input.val())) {
                             selectize.close();
                         }
                     });
                     selectize.on('type', function (filter) {
-                        if (Ember.isBlank(filter)) {
+                        if (isBlank(filter)) {
                             selectize.close();
                         }
                     });
@@ -37,15 +41,15 @@ export default EmberSelectizeComponent.extend({
     * Event callback that is triggered when user creates a tag
     * - modified to pass the caret position to the action
     */
-    _create: function (input, callback) {
-        var caret = this._selectize.caretPos;
+    _create(input, callback) {
+        let caret = this._selectize.caretPos;
 
         // Delete user entered text
         this._selectize.setTextboxValue('');
         // Send create action
 
         // allow the observers and computed properties to run first
-        Ember.run.schedule('actions', this, function () {
+        run.schedule('actions', this, function () {
             this.sendAction('create-item', input, caret);
         });
         // We cancel the creation here, so it's up to you to include the created element
@@ -53,10 +57,10 @@ export default EmberSelectizeComponent.extend({
         callback(null);
     },
 
-    _addSelection: function (obj) {
-        var _valuePath = this.get('_valuePath'),
-            val = Ember.get(obj, _valuePath),
-            caret = this._selectize.caretPos;
+    _addSelection(obj) {
+        let _valuePath = this.get('_valuePath');
+        let val = get(obj, _valuePath);
+        let caret = this._selectize.caretPos;
 
         // caret position is always 1 more than the desired index as this method
         // is called after selectize has inserted the item and the caret has moved
@@ -65,15 +69,15 @@ export default EmberSelectizeComponent.extend({
 
         this.get('selection').insertAt(caret, obj);
 
-        Ember.run.schedule('actions', this, function () {
+        run.schedule('actions', this, function () {
             this.sendAction('add-item', obj);
             this.sendAction('add-value', val);
         });
     },
 
-    _onChange: function (args) {
-        const selection = Ember.get(this, 'selection'),
-              valuePath = Ember.get(this, '_valuePath');
+    _onChange(args) {
+        let selection = Ember.get(this, 'selection');
+        let valuePath = Ember.get(this, '_valuePath');
 
         if (!args || !selection || !Ember.isArray(selection) || args.length !== selection.length) {
             return;
@@ -87,11 +91,13 @@ export default EmberSelectizeComponent.extend({
             return;
         }
 
-        let reorderedSelection = Ember.A([]);
+        let reorderedSelection = emberA([]);
 
-        args.forEach(function (value) {
-            const obj = selection.find(function (item) {
-                return (Ember.get(item, valuePath) + '') === value;
+        args.forEach((value) => {
+            let obj = selection.find(function (item) {
+                // jscs:disable
+                return (get(item, valuePath) + '') === value;
+                // jscs:enable
             });
 
             if (obj) {

--- a/core/client/app/components/gh-skip-link.js
+++ b/core/client/app/components/gh-skip-link.js
@@ -1,7 +1,9 @@
 /*jshint scripturl:true*/
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, on} = Ember;
+
+export default Component.extend({
     tagName: 'a',
     anchor: '',
     classNames: ['sr-only', 'sr-only-focusable'],
@@ -13,9 +15,9 @@ export default Ember.Component.extend({
     // anchor behaviors or ignored
     href: Ember.String.htmlSafe('javascript:;'),
 
-    scrollTo: Ember.on('click', function () {
-        var anchor = this.get('anchor'),
-            $el = Ember.$(anchor);
+    scrollTo: on('click', function () {
+        let anchor = this.get('anchor');
+        let $el = Ember.$(anchor);
 
         if ($el) {
             // Scrolls to the top of main content or whatever

--- a/core/client/app/components/gh-spin-button.js
+++ b/core/client/app/components/gh-spin-button.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, observer, run} = Ember;
+const {equal} = computed;
+
+export default Component.extend({
     tagName: 'button',
     buttonText: '',
     submitting: false,
@@ -12,9 +15,9 @@ export default Ember.Component.extend({
     attributeBindings: ['disabled', 'type', 'tabindex'],
 
     // Must be set on the controller
-    disabled: Ember.computed.equal('showSpinner', true),
+    disabled: equal('showSpinner', true),
 
-    click: function () {
+    click() {
         if (this.get('action')) {
             this.sendAction('action');
             return false;
@@ -22,13 +25,13 @@ export default Ember.Component.extend({
         return true;
     },
 
-    toggleSpinner: Ember.observer('submitting', function () {
-        var submitting = this.get('submitting'),
-            timeout = this.get('showSpinnerTimeout');
+    toggleSpinner: observer('submitting', function () {
+        let submitting = this.get('submitting');
+        let timeout = this.get('showSpinnerTimeout');
 
         if (submitting) {
             this.set('showSpinner', true);
-            this.set('showSpinnerTimeout', Ember.run.later(this, function () {
+            this.set('showSpinnerTimeout', run.later(this, function () {
                 if (!this.get('submitting')) {
                     this.set('showSpinner', false);
                 }
@@ -39,7 +42,7 @@ export default Ember.Component.extend({
         }
     }),
 
-    setSize: Ember.observer('showSpinner', function () {
+    setSize: observer('showSpinner', function () {
         if (this.get('showSpinner') && this.get('autoWidth')) {
             this.$().width(this.$().width());
             this.$().height(this.$().height());
@@ -49,7 +52,7 @@ export default Ember.Component.extend({
         }
     }),
 
-    willDestroy: function () {
-        Ember.run.cancel(this.get('showSpinnerTimeout'));
+    willDestroy() {
+        run.cancel(this.get('showSpinnerTimeout'));
     }
 });

--- a/core/client/app/components/gh-tab-pane.js
+++ b/core/client/app/components/gh-tab-pane.js
@@ -1,28 +1,31 @@
 import Ember from 'ember';
 
+const {Component, computed} = Ember;
+const {alias} = computed;
+
 // See gh-tabs-manager.js for use
-export default Ember.Component.extend({
+export default Component.extend({
     classNameBindings: ['active'],
 
-    tabsManager: Ember.computed(function () {
+    tabsManager: computed(function () {
         return this.nearestWithProperty('isTabsManager');
     }),
 
-    tab: Ember.computed('tabsManager.tabs.[]', 'tabsManager.tabPanes.[]', function () {
-        var index = this.get('tabsManager.tabPanes').indexOf(this),
-            tabs = this.get('tabsManager.tabs');
+    tab: computed('tabsManager.tabs.[]', 'tabsManager.tabPanes.[]', function () {
+        let index = this.get('tabsManager.tabPanes').indexOf(this);
+        let tabs = this.get('tabsManager.tabs');
 
         return tabs && tabs.objectAt(index);
     }),
 
-    active: Ember.computed.alias('tab.active'),
+    active: alias('tab.active'),
 
-    willRender: function () {
+    willRender() {
         // Register with the tabs manager
         this.get('tabsManager').registerTabPane(this);
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         // Deregister with the tabs manager
         this.get('tabsManager').unregisterTabPane(this);
     }

--- a/core/client/app/components/gh-tab.js
+++ b/core/client/app/components/gh-tab.js
@@ -1,30 +1,32 @@
 import Ember from 'ember';
 
+const {Component, computed} = Ember;
+
 // See gh-tabs-manager.js for use
-export default Ember.Component.extend({
-    tabsManager: Ember.computed(function () {
+export default Component.extend({
+    tabsManager: computed(function () {
         return this.nearestWithProperty('isTabsManager');
     }),
 
-    active: Ember.computed('tabsManager.activeTab', function () {
+    active: computed('tabsManager.activeTab', function () {
         return this.get('tabsManager.activeTab') === this;
     }),
 
-    index: Ember.computed('tabsManager.tabs.[]', function () {
+    index: computed('tabsManager.tabs.[]', function () {
         return this.get('tabsManager.tabs').indexOf(this);
     }),
 
     // Select on click
-    click: function () {
+    click() {
         this.get('tabsManager').select(this);
     },
 
-    willRender: function () {
+    willRender() {
         // register the tabs with the tab manager
         this.get('tabsManager').registerTab(this);
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         // unregister the tabs with the tab manager
         this.get('tabsManager').unregisterTab(this);
     }

--- a/core/client/app/components/gh-tabs-manager.js
+++ b/core/client/app/components/gh-tabs-manager.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
+
+const {Component} = Ember;
+
 /**
 Heavily inspired by ic-tabs (https://github.com/instructure/ic-tabs)
 
@@ -48,35 +51,35 @@ Both tab and tab-pane elements have an "active"
 class applied when they are active.
 
 */
-export default Ember.Component.extend({
+export default Component.extend({
     activeTab: null,
     tabs: [],
     tabPanes: [],
 
+    // Used by children to find this tabsManager
+    isTabsManager: true,
+
     // Called when a gh-tab is clicked.
-    select: function (tab) {
+    select(tab) {
         this.set('activeTab', tab);
         this.sendAction('selected');
     },
 
-    // Used by children to find this tabsManager
-    isTabsManager: true,
-
     // Register tabs and their panes to allow for
     // interaction between components.
-    registerTab: function (tab) {
+    registerTab(tab) {
         this.get('tabs').addObject(tab);
     },
 
-    unregisterTab: function (tab) {
+    unregisterTab(tab) {
         this.get('tabs').removeObject(tab);
     },
 
-    registerTabPane: function (tabPane) {
+    registerTabPane(tabPane) {
         this.get('tabPanes').addObject(tabPane);
     },
 
-    unregisterTabPane: function (tabPane) {
+    unregisterTabPane(tabPane) {
         this.get('tabPanes').removeObject(tabPane);
     }
 });

--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -2,9 +2,9 @@
 import Ember from 'ember';
 import boundOneWay from 'ghost/utils/bound-one-way';
 
-const {get} = Ember;
+const {Component, Handlebars, computed, get, inject} = Ember;
 
-export default Ember.Component.extend({
+export default Component.extend({
 
     tag: null,
 
@@ -16,12 +16,12 @@ export default Ember.Component.extend({
 
     isViewingSubview: false,
 
-    config: Ember.inject.service(),
+    config: inject.service(),
 
     mediaQueries: Ember.inject.service(),
     isMobile: Ember.computed.reads('mediaQueries.maxWidth600'),
 
-    title: Ember.computed('tag.isNew', function () {
+    title: computed('tag.isNew', function () {
         if (this.get('tag.isNew')) {
             return 'New Tag';
         } else {
@@ -29,25 +29,25 @@ export default Ember.Component.extend({
         }
     }),
 
-    seoTitle: Ember.computed('scratchName', 'scratchMetaTitle', function () {
+    seoTitle: computed('scratchName', 'scratchMetaTitle', function () {
         let metaTitle = this.get('scratchMetaTitle') || '';
 
         metaTitle = metaTitle.length > 0 ? metaTitle : this.get('scratchName');
 
         if (metaTitle && metaTitle.length > 70) {
             metaTitle = metaTitle.substring(0, 70).trim();
-            metaTitle = Ember.Handlebars.Utils.escapeExpression(metaTitle);
-            metaTitle = Ember.String.htmlSafe(metaTitle + '&hellip;');
+            metaTitle = Handlebars.Utils.escapeExpression(metaTitle);
+            metaTitle = Ember.String.htmlSafe(`${metaTitle}&hellip;`);
         }
 
         return metaTitle;
     }),
 
-    seoURL: Ember.computed('scratchSlug', function () {
-        const blogUrl = this.get('config.blogUrl'),
-              seoSlug = this.get('scratchSlug') || '';
+    seoURL: computed('scratchSlug', function () {
+        let blogUrl = this.get('config.blogUrl');
+        let seoSlug = this.get('scratchSlug') || '';
 
-        let seoURL = blogUrl + '/tag/' + seoSlug;
+        let seoURL = `${blogUrl}/tag/${seoSlug}`;
 
         // only append a slash to the URL if the slug exists
         if (seoSlug) {
@@ -56,73 +56,73 @@ export default Ember.Component.extend({
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
-            seoURL = Ember.String.htmlSafe(seoURL + '&hellip;');
+            seoURL = Ember.String.htmlSafe(`${seoURL}&hellip;`);
         }
 
         return seoURL;
     }),
 
-    seoDescription: Ember.computed('scratchDescription', 'scratchMetaDescription', function () {
+    seoDescription: computed('scratchDescription', 'scratchMetaDescription', function () {
         let metaDescription = this.get('scratchMetaDescription') || '';
 
         metaDescription = metaDescription.length > 0 ? metaDescription : this.get('scratchDescription');
 
         if (metaDescription && metaDescription.length > 156) {
             metaDescription = metaDescription.substring(0, 156).trim();
-            metaDescription = Ember.Handlebars.Utils.escapeExpression(metaDescription);
-            metaDescription = Ember.String.htmlSafe(metaDescription + '&hellip;');
+            metaDescription = Handlebars.Utils.escapeExpression(metaDescription);
+            metaDescription = Ember.String.htmlSafe(`${metaDescription}&hellip;`);
         }
 
         return metaDescription;
     }),
 
-    didReceiveAttrs: function (attrs) {
+    didReceiveAttrs(attrs) {
         if (get(attrs, 'newAttrs.tag.value.id') !== get(attrs, 'oldAttrs.tag.value.id')) {
             this.reset();
         }
     },
 
-    reset: function () {
+    reset() {
         this.set('isViewingSubview', false);
         if (this.$()) {
             this.$('.settings-menu-pane').scrollTop(0);
         }
     },
 
-    focusIn: function () {
+    focusIn() {
         key.setScope('tag-settings-form');
     },
 
-    focusOut: function () {
+    focusOut() {
         key.setScope('default');
     },
 
     actions: {
-        setProperty: function (property, value) {
+        setProperty(property, value) {
             this.attrs.setProperty(property, value);
         },
 
-        setCoverImage: function (image) {
+        setCoverImage(image) {
             this.attrs.setProperty('image', image);
         },
 
-        clearCoverImage: function () {
+        clearCoverImage() {
             this.attrs.setProperty('image', '');
         },
 
-        setUploaderReference: function () {
+        setUploaderReference() {
             // noop
         },
 
-        openMeta: function () {
+        openMeta() {
             this.set('isViewingSubview', true);
         },
 
-        closeMeta: function () {
+        closeMeta() {
             this.set('isViewingSubview', false);
         },
 
-        deleteTag: function () {
+        deleteTag() {
             this.sendAction('openModal', 'delete-tag', this.get('tag'));
         }
     }

--- a/core/client/app/components/gh-tags-management-container.js
+++ b/core/client/app/components/gh-tags-management-container.js
@@ -1,28 +1,29 @@
 import Ember from 'ember';
 
-const {isBlank} = Ember;
+const {Component, computed, inject, isBlank, observer, run} = Ember;
+const {equal, reads} = computed;
 
-export default Ember.Component.extend({
+export default Component.extend({
     classNames: ['view-container'],
     classNameBindings: ['isMobile'],
 
-    mediaQueries: Ember.inject.service(),
+    mediaQueries: inject.service(),
 
     tags: null,
     selectedTag: null,
 
-    isMobile: Ember.computed.reads('mediaQueries.maxWidth600'),
-    isEmpty: Ember.computed.equal('tags.length', 0),
+    isMobile: reads('mediaQueries.maxWidth600'),
+    isEmpty: equal('tags.length', 0),
 
-    init: function () {
+    init() {
         this._super(...arguments);
-        Ember.run.schedule('actions', this, this.fireMobileChangeActions);
+        run.schedule('actions', this, this.fireMobileChangeActions);
     },
 
-    displaySettingsPane: Ember.computed('isEmpty', 'selectedTag', 'isMobile', function () {
-        const isEmpty = this.get('isEmpty'),
-              selectedTag = this.get('selectedTag'),
-              isMobile = this.get('isMobile');
+    displaySettingsPane: computed('isEmpty', 'selectedTag', 'isMobile', function () {
+        let isEmpty = this.get('isEmpty');
+        let selectedTag = this.get('selectedTag');
+        let isMobile = this.get('isMobile');
 
         // always display settings pane for blank-slate on mobile
         if (isMobile && isEmpty) {
@@ -38,7 +39,7 @@ export default Ember.Component.extend({
         return true;
     }),
 
-    fireMobileChangeActions: Ember.observer('isMobile', function () {
+    fireMobileChangeActions: observer('isMobile', function () {
         if (!this.get('isMobile')) {
             this.sendAction('leftMobile');
         }

--- a/core/client/app/components/gh-textarea.js
+++ b/core/client/app/components/gh-textarea.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import TextInputMixin from 'ghost/mixins/text-input';
 
-export default Ember.TextArea.extend(TextInputMixin, {
+const {TextArea} = Ember;
+
+export default TextArea.extend(TextInputMixin, {
     classNames: 'gh-input'
 });

--- a/core/client/app/components/gh-trim-focus-input.js
+++ b/core/client/app/components/gh-trim-focus-input.js
@@ -1,12 +1,14 @@
-import Ember from 'ember';
 /*global device*/
+import Ember from 'ember';
 
-export default Ember.TextField.extend({
+const {TextField, computed, on} = Ember;
+
+export default TextField.extend({
     focus: true,
     classNames: 'gh-input',
     attributeBindings: ['autofocus'],
 
-    autofocus: Ember.computed(function () {
+    autofocus: computed(function () {
         if (this.get('focus')) {
             return (device.ios()) ? false : 'autofocus';
         }
@@ -14,7 +16,7 @@ export default Ember.TextField.extend({
         return false;
     }),
 
-    focusField: Ember.on('didInsertElement', function () {
+    focusField: on('didInsertElement', function () {
         // This fix is required until Mobile Safari has reliable
         // autofocus, select() or focus() support
         if (this.get('focus') && !device.ios()) {
@@ -22,8 +24,8 @@ export default Ember.TextField.extend({
         }
     }),
 
-    trimValue: Ember.on('focusOut', function () {
-        var text = this.$().val();
+    trimValue: on('focusOut', function () {
+        let text = this.$().val();
         this.$().val(text.trim());
     })
 });

--- a/core/client/app/components/gh-upload-modal.js
+++ b/core/client/app/components/gh-upload-modal.js
@@ -3,44 +3,50 @@ import ModalDialog from 'ghost/components/gh-modal-dialog';
 import upload from 'ghost/assets/lib/uploader';
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
+const {inject, isEmpty} = Ember;
+
 export default ModalDialog.extend({
     layoutName: 'components/gh-modal-dialog',
 
-    config: Ember.inject.service(),
+    config: inject.service(),
 
-    didInsertElement: function () {
-        this._super();
+    didInsertElement() {
+        this._super(...arguments);
         upload.call(this.$('.js-drop-zone'), {fileStorage: this.get('config.fileStorage')});
     },
-    keyDown: function () {
+
+    keyDown() {
         this.setErrorState(false);
     },
-    setErrorState: function (state) {
+
+    setErrorState(state) {
         if (state) {
             this.$('.js-upload-url').addClass('error');
         } else {
             this.$('.js-upload-url').removeClass('error');
         }
     },
+
     confirm: {
         reject: {
-            func: function () { // The function called on rejection
-                return true;
-            },
             buttonClass: 'btn btn-default',
-            text: 'Cancel' // The reject button text
+            text: 'Cancel', // The reject button text
+            func() { // The function called on rejection
+                return true;
+            }
         },
+
         accept: {
             buttonClass: 'btn btn-blue right',
             text: 'Save', // The accept button text: 'Save'
-            func: function () {
-                var imageType = 'model.' + this.get('imageType'),
-                    value;
+            func() {
+                let imageType = `model.${this.get('imageType')}`;
+                let value;
 
                 if (this.$('.js-upload-url').val()) {
                     value = this.$('.js-upload-url').val();
 
-                    if (!Ember.isEmpty(value) && !cajaSanitizers.url(value)) {
+                    if (!isEmpty(value) && !cajaSanitizers.url(value)) {
                         this.setErrorState(true);
                         return {message: 'Image URI is not valid'};
                     }
@@ -55,12 +61,13 @@ export default ModalDialog.extend({
     },
 
     actions: {
-        closeModal: function () {
+        closeModal() {
             this.sendAction();
         },
-        confirm: function (type) {
-            var result,
-                func = this.get('confirm.' + type + '.func');
+
+        confirm(type) {
+            let func = this.get(`confirm.${type}.func`);
+            let result;
 
             if (typeof func === 'function') {
                 result = func.apply(this);
@@ -68,7 +75,7 @@ export default ModalDialog.extend({
 
             if (!result.message) {
                 this.sendAction();
-                this.sendAction('confirm' + type);
+                this.sendAction(`confirm${type}`);
             }
         }
     }

--- a/core/client/app/components/gh-uploader.js
+++ b/core/client/app/components/gh-uploader.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 import uploader from 'ghost/assets/lib/uploader';
 
-export default Ember.Component.extend({
+const {Component, computed, get, inject, isEmpty, run} = Ember;
+
+export default Component.extend({
     classNames: ['image-uploader', 'js-post-image-upload'],
 
-    config: Ember.inject.service(),
+    config: inject.service(),
 
-    imageSource: Ember.computed('image', function () {
+    imageSource: computed('image', function () {
         return this.get('image') || '';
     }),
 
     // removes event listeners from the uploader
-    removeListeners: function () {
-        var $this = this.$();
+    removeListeners() {
+        let $this = this.$();
 
         $this.off();
         $this.find('.js-cancel').off();
@@ -22,20 +24,19 @@ export default Ember.Component.extend({
     // between transitions Glimmer will re-use the existing elements including
     // those that arealready decorated by jQuery. The following works around
     // situations where the image is changed without a full teardown/rebuild
-    didReceiveAttrs: function (attrs) {
-        var oldValue = attrs.oldAttrs && Ember.get(attrs.oldAttrs, 'image.value'),
-            newValue = attrs.newAttrs && Ember.get(attrs.newAttrs, 'image.value'),
-            self = this;
+    didReceiveAttrs(attrs) {
+        let oldValue = attrs.oldAttrs && get(attrs.oldAttrs, 'image.value');
+        let newValue = attrs.newAttrs && get(attrs.newAttrs, 'image.value');
 
         // always reset when we receive a blank image
         // - handles navigating to populated image from blank image
-        if (Ember.isEmpty(newValue) && !Ember.isEmpty(oldValue)) {
-            self.$()[0].uploaderUi.reset();
+        if (isEmpty(newValue) && !isEmpty(oldValue)) {
+            this.$()[0].uploaderUi.reset();
         }
 
         // re-init if we receive a new image but the uploader is blank
         // - handles back button navigating from blank image to populated image
-        if (!Ember.isEmpty(newValue) && this.$()) {
+        if (!isEmpty(newValue) && this.$()) {
             if (this.$('.js-upload-target').attr('src') === '') {
                 this.$()[0].uploaderUi.reset();
                 this.$()[0].uploaderUi.initWithImage();
@@ -43,34 +44,31 @@ export default Ember.Component.extend({
         }
     },
 
-    didInsertElement: function () {
+    didInsertElement() {
         this.send('initUploader');
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         this.removeListeners();
     },
 
     actions: {
-        initUploader: function () {
-            var ref,
-                el = this.$(),
-                self = this;
-
-            ref = uploader.call(el, {
+        initUploader() {
+            let el = this.$();
+            let ref = uploader.call(el, {
                 editor: true,
                 fileStorage: this.get('config.fileStorage')
             });
 
-            el.on('uploadsuccess', function (event, result) {
+            el.on('uploadsuccess', (event, result) => {
                 if (result && result !== '' && result !== 'http://') {
-                    Ember.run(self, function () {
+                    run(this, function () {
                         this.sendAction('uploaded', result);
                     });
                 }
             });
 
-            el.on('imagecleared', Ember.run.bind(self, 'sendAction', 'canceled'));
+            el.on('imagecleared', run.bind(this, 'sendAction', 'canceled'));
 
             this.sendAction('initUploader', ref);
         }

--- a/core/client/app/components/gh-url-preview.js
+++ b/core/client/app/components/gh-url-preview.js
@@ -1,26 +1,30 @@
 import Ember from 'ember';
+
+const {Component, computed, inject} = Ember;
+
 /*
 Example usage:
 {{gh-url-preview prefix="tag" slug=theSlugValue tagName="p" classNames="description"}}
 */
-export default Ember.Component.extend({
+export default Component.extend({
     classNames: 'ghost-url-preview',
     prefix: null,
     slug: null,
 
-    config: Ember.inject.service(),
+    config: inject.service(),
 
-    url: Ember.computed('slug', function () {
+    url: computed('slug', function () {
         // Get the blog URL and strip the scheme
-        var blogUrl = this.get('config.blogUrl'),
-            noSchemeBlogUrl = blogUrl.substr(blogUrl.indexOf('://') + 3), // Remove `http[s]://`
+        let blogUrl = this.get('config.blogUrl');
+        // Remove `http[s]://`
+        let noSchemeBlogUrl = blogUrl.substr(blogUrl.indexOf('://') + 3);
 
-            // Get the prefix and slug values
-            prefix = this.get('prefix') ? this.get('prefix') + '/' : '',
-            slug = this.get('slug') ? this.get('slug') + '/' : '',
+        // Get the prefix and slug values
+        let prefix = this.get('prefix') ? `${this.get('prefix')}/` : '';
+        let slug = this.get('slug') ? `${this.get('slug')}/` : '';
 
-            // Join parts of the URL together with slashes
-            theUrl = noSchemeBlogUrl + '/' + prefix + slug;
+        // Join parts of the URL together with slashes
+        let theUrl = `${noSchemeBlogUrl}/${prefix}${slug}`;
 
         return theUrl;
     })

--- a/core/client/app/components/gh-user-active.js
+++ b/core/client/app/components/gh-user-active.js
@@ -1,24 +1,26 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component, computed, inject} = Ember;
+
+export default Component.extend({
     tagName: '',
 
     user: null,
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    ghostPaths: inject.service('ghost-paths'),
 
-    userDefault: Ember.computed('ghostPaths', function () {
+    userDefault: computed('ghostPaths', function () {
         return this.get('ghostPaths.url').asset('/shared/img/user-image.png');
     }),
 
-    userImageBackground: Ember.computed('user.image', 'userDefault', function () {
-        var url = this.get('user.image') || this.get('userDefault');
+    userImageBackground: computed('user.image', 'userDefault', function () {
+        let url = this.get('user.image') || this.get('userDefault');
 
         return Ember.String.htmlSafe(`background-image: url(${url})`);
     }),
 
-    lastLogin: Ember.computed('user.last_login', function () {
-        var lastLogin = this.get('user.last_login');
+    lastLogin: computed('user.last_login', function () {
+        let lastLogin = this.get('user.last_login');
 
         return lastLogin ? lastLogin.fromNow() : '(Never)';
     })

--- a/core/client/app/components/gh-validation-status-container.js
+++ b/core/client/app/components/gh-validation-status-container.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import ValidationStateMixin from 'ghost/mixins/validation-state';
 
+const {Component, computed} = Ember;
+
 /**
  * Handles the CSS necessary to show a specific property state. When passed a
  * DS.Errors object and a property name, if the DS.Errors object has errors for
@@ -8,12 +10,12 @@ import ValidationStateMixin from 'ghost/mixins/validation-state';
  * @param  {DS.Errors} errors   The DS.Errors object
  * @param  {string} property    Name of the property
  */
-export default Ember.Component.extend(ValidationStateMixin, {
+export default Component.extend(ValidationStateMixin, {
     classNameBindings: ['errorClass'],
 
-    errorClass: Ember.computed('property', 'hasError', 'hasValidated.[]', function () {
-        let hasValidated = this.get('hasValidated'),
-            property = this.get('property');
+    errorClass: computed('property', 'hasError', 'hasValidated.[]', function () {
+        let hasValidated = this.get('hasValidated');
+        let property = this.get('property');
 
         if (hasValidated && hasValidated.contains(property)) {
             return this.get('hasError') ? 'error' : 'success';

--- a/core/client/app/components/gh-view-title.js
+++ b/core/client/app/components/gh-view-title.js
@@ -1,10 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+const {Component} = Ember;
+
+export default Component.extend({
     tagName: 'h2',
     classNames: ['view-title'],
+
     actions: {
-        openMobileMenu: function () {
+        openMobileMenu() {
             this.sendAction('openMobileMenu');
         }
     }

--- a/core/client/app/controllers/about.js
+++ b/core/client/app/controllers/about.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const {Controller} = Ember;
+
+export default Controller.extend({
     updateNotificationCount: 0,
 
     actions: {
-        updateNotificationChange: function (count) {
+        updateNotificationChange(count) {
             this.set('updateNotificationCount', count);
         }
     }

--- a/core/client/app/controllers/application.js
+++ b/core/client/app/controllers/application.js
@@ -1,22 +1,22 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    dropdown: Ember.inject.service(),
+const {Controller, computed, inject} = Ember;
 
-    // jscs: disable
-    signedOut: Ember.computed.match('currentPath', /(signin|signup|setup|reset)/),
-    // jscs: enable
+export default Controller.extend({
+    dropdown: inject.service(),
+
+    signedOut: computed.match('currentPath', /(signin|signup|setup|reset)/),
 
     topNotificationCount: 0,
     showMobileMenu: false,
     showSettingsMenu: false,
 
     autoNav: false,
-    autoNavOpen: Ember.computed('autoNav', {
-        get: function () {
+    autoNavOpen: computed('autoNav', {
+        get() {
             return false;
         },
-        set: function (key, value) {
+        set(key, value) {
             if (this.get('autoNav')) {
                 return value;
             }
@@ -25,23 +25,23 @@ export default Ember.Controller.extend({
     }),
 
     actions: {
-        topNotificationChange: function (count) {
+        topNotificationChange(count) {
             this.set('topNotificationCount', count);
         },
 
-        toggleAutoNav: function () {
+        toggleAutoNav() {
             this.toggleProperty('autoNav');
         },
 
-        openAutoNav: function () {
+        openAutoNav() {
             this.set('autoNavOpen', true);
         },
 
-        closeAutoNav: function () {
+        closeAutoNav() {
             this.set('autoNavOpen', false);
         },
 
-        closeMobileMenu: function () {
+        closeMobileMenu() {
             this.set('showMobileMenu', false);
         }
     }

--- a/core/client/app/controllers/editor/edit.js
+++ b/core/client/app/controllers/editor/edit.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
 
-export default Ember.Controller.extend(EditorControllerMixin, {
+const {Controller} = Ember;
+
+export default Controller.extend(EditorControllerMixin, {
     actions: {
-        openDeleteModal: function () {
+        openDeleteModal() {
             this.send('openModal', 'delete-post', this.get('model'));
         }
     }

--- a/core/client/app/controllers/editor/new.js
+++ b/core/client/app/controllers/editor/new.js
@@ -1,18 +1,23 @@
 import Ember from 'ember';
 import EditorControllerMixin from 'ghost/mixins/editor-base-controller';
 
-export default Ember.Controller.extend(EditorControllerMixin, {
+const {Controller} = Ember;
+
+function K() {
+    return this;
+}
+
+export default Controller.extend(EditorControllerMixin, {
     // Overriding autoSave on the base controller, as the new controller shouldn't be autosaving
-    autoSave: Ember.K,
+    autoSave: K,
     actions: {
         /**
           * Redirect to editor after the first save
           */
-        save: function (options) {
-            var self = this;
-            return this._super(options).then(function (model) {
+        save(options) {
+            return this._super(options).then((model) => {
                 if (model.get('id')) {
-                    self.replaceRoute('editor.edit', model);
+                    this.replaceRoute('editor.edit', model);
                 }
             });
         }

--- a/core/client/app/controllers/error.js
+++ b/core/client/app/controllers/error.js
@@ -1,15 +1,20 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    code: Ember.computed('content.status', function () {
+const {Controller, computed} = Ember;
+
+export default Controller.extend({
+
+    stack: false,
+
+    code: computed('content.status', function () {
         return this.get('content.status') > 200 ? this.get('content.status') : 500;
     }),
-    message: Ember.computed('content.statusText', function () {
+
+    message: computed('content.statusText', function () {
         if (this.get('code') === 404) {
             return 'Page not found';
         }
 
         return this.get('content.statusText') !== 'error' ? this.get('content.statusText') : 'Internal Server Error';
-    }),
-    stack: false
+    })
 });

--- a/core/client/app/controllers/feature.js
+++ b/core/client/app/controllers/feature.js
@@ -1,20 +1,14 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend(Ember.PromiseProxyMixin, {
-    init: function () {
-        var promise;
+const {Controller, PromiseProxyMixin, computed} = Ember;
+const {alias} = computed;
 
-        promise = this.store.query('setting', {type: 'blog,theme'}).then(function (settings) {
-            return settings.get('firstObject');
-        });
+export default Controller.extend(PromiseProxyMixin, {
 
-        this.set('promise', promise);
-    },
+    setting: alias('content'),
 
-    setting: Ember.computed.alias('content'),
-
-    labs: Ember.computed('isSettled', 'setting.labs', function () {
-        var value = {};
+    labs: computed('isSettled', 'setting.labs', function () {
+        let value = {};
 
         if (this.get('isFulfilled')) {
             try {
@@ -27,7 +21,15 @@ export default Ember.Controller.extend(Ember.PromiseProxyMixin, {
         return value;
     }),
 
-    publicAPI: Ember.computed('config.publicAPI', 'labs.publicAPI', function () {
+    publicAPI: computed('config.publicAPI', 'labs.publicAPI', function () {
         return this.get('config.publicAPI') || this.get('labs.publicAPI');
-    })
+    }),
+
+    init() {
+        let promise = this.store.query('setting', {type: 'blog,theme'}).then((settings) => {
+            return settings.get('firstObject');
+        });
+
+        this.set('promise', promise);
+    }
 });

--- a/core/client/app/controllers/modals/copy-html.js
+++ b/core/client/app/controllers/modals/copy-html.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    generatedHTML: Ember.computed.alias('model.generatedHTML')
+const {Controller, computed} = Ember;
+const {alias} = computed;
+
+export default Controller.extend({
+    generatedHTML: alias('model.generatedHTML')
 });

--- a/core/client/app/controllers/modals/delete-all.js
+++ b/core/client/app/controllers/modals/delete-all.js
@@ -1,29 +1,11 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-export default Ember.Controller.extend({
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
+const {Controller, inject} = Ember;
 
-    actions: {
-        confirmAccept: function () {
-            var self = this;
-
-            ajax(this.get('ghostPaths.url').api('db'), {
-                type: 'DELETE'
-            }).then(function () {
-                self.get('notifications').showAlert('All content deleted from database.', {type: 'success', key: 'all-content.delete.success'});
-                self.store.unloadAll('post');
-                self.store.unloadAll('tag');
-            }).catch(function (response) {
-                self.get('notifications').showAPIError(response, {key: 'all-content.delete'});
-            });
-        },
-
-        confirmReject: function () {
-            return false;
-        }
-    },
+export default Controller.extend({
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
 
     confirm: {
         accept: {
@@ -33,6 +15,24 @@ export default Ember.Controller.extend({
         reject: {
             text: 'Cancel',
             buttonClass: 'btn btn-default btn-minor'
+        }
+    },
+
+    actions: {
+        confirmAccept() {
+            ajax(this.get('ghostPaths.url').api('db'), {
+                type: 'DELETE'
+            }).then(() => {
+                this.get('notifications').showAlert('All content deleted from database.', {type: 'success', key: 'all-content.delete.success'});
+                this.store.unloadAll('post');
+                this.store.unloadAll('tag');
+            }).catch((response) => {
+                this.get('notifications').showAPIError(response, {key: 'all-content.delete'});
+            });
+        },
+
+        confirmReject() {
+            return false;
         }
     }
 });

--- a/core/client/app/controllers/modals/delete-post.js
+++ b/core/client/app/controllers/modals/delete-post.js
@@ -1,30 +1,10 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    dropdown: Ember.inject.service(),
-    notifications: Ember.inject.service(),
+const {Controller, inject} = Ember;
 
-    actions: {
-        confirmAccept: function () {
-            var self = this,
-                model = this.get('model');
-
-            // definitely want to clear the data store and post of any unsaved, client-generated tags
-            model.updateTags();
-
-            model.destroyRecord().then(function () {
-                self.get('dropdown').closeDropdowns();
-                self.get('notifications').closeAlerts('post.delete');
-                self.transitionToRoute('posts.index');
-            }, function () {
-                self.get('notifications').showAlert('Your post could not be deleted. Please try again.', {type: 'error', key: 'post.delete.failed'});
-            });
-        },
-
-        confirmReject: function () {
-            return false;
-        }
-    },
+export default Controller.extend({
+    dropdown: inject.service(),
+    notifications: inject.service(),
 
     confirm: {
         accept: {
@@ -34,6 +14,27 @@ export default Ember.Controller.extend({
         reject: {
             text: 'Cancel',
             buttonClass: 'btn btn-default btn-minor'
+        }
+    },
+
+    actions: {
+        confirmAccept() {
+            let model = this.get('model');
+
+            // definitely want to clear the data store and post of any unsaved, client-generated tags
+            model.updateTags();
+
+            model.destroyRecord().then(() => {
+                this.get('dropdown').closeDropdowns();
+                this.get('notifications').closeAlerts('post.delete');
+                this.transitionToRoute('posts.index');
+            }, () => {
+                this.get('notifications').showAlert('Your post could not be deleted. Please try again.', {type: 'error', key: 'post.delete.failed'});
+            });
+        },
+
+        confirmReject() {
+            return false;
         }
     }
 });

--- a/core/client/app/controllers/modals/delete-tag.js
+++ b/core/client/app/controllers/modals/delete-tag.js
@@ -11,7 +11,7 @@ export default Controller.extend({
     }),
 
     actions: {
-        confirmAccept: function () {
+        confirmAccept() {
             let tag = this.get('model');
 
             this.send('closeMenus');
@@ -27,7 +27,7 @@ export default Controller.extend({
             });
         },
 
-        confirmReject: function () {
+        confirmReject() {
             return false;
         }
     },

--- a/core/client/app/controllers/modals/invite-new-user.js
+++ b/core/client/app/controllers/modals/invite-new-user.js
@@ -1,29 +1,29 @@
 import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default Ember.Controller.extend(ValidationEngine, {
-    notifications: Ember.inject.service(),
+const {Controller, computed, inject, observer} = Ember;
+
+export default Controller.extend(ValidationEngine, {
+    notifications: inject.service(),
 
     validationType: 'signup',
 
     role: null,
     authorRole: null,
 
-    roles: Ember.computed(function () {
+    roles: computed(function () {
         return this.store.query('role', {permissions: 'assign'});
     }),
 
     // Used to set the initial value for the dropdown
-    authorRoleObserver: Ember.observer('roles.@each.role', function () {
-        var self = this;
+    authorRoleObserver: observer('roles.@each.role', function () {
+        this.get('roles').then((roles) => {
+            let authorRole = roles.findBy('name', 'Author');
 
-        this.get('roles').then(function (roles) {
-            var authorRole = roles.findBy('name', 'Author');
+            this.set('authorRole', authorRole);
 
-            self.set('authorRole', authorRole);
-
-            if (!self.get('role')) {
-                self.set('role', authorRole);
+            if (!this.get('role')) {
+                this.set('role', authorRole);
             }
         });
     }),
@@ -37,69 +37,68 @@ export default Ember.Controller.extend(ValidationEngine, {
         }
     },
 
+    confirmReject() {
+        return false;
+    },
+
     actions: {
-        setRole: function (role) {
+        setRole(role) {
             this.set('role', role);
         },
 
-        confirmAccept: function () {
-            var email = this.get('email'),
-                role = this.get('role'),
-                validationErrors = this.get('errors.messages'),
-                self = this,
-                newUser;
+        confirmAccept() {
+            let email = this.get('email');
+            let role = this.get('role');
+            let validationErrors = this.get('errors.messages');
+            let newUser;
 
             // reset the form and close the modal
             this.set('email', '');
-            this.set('role', self.get('authorRole'));
+            this.set('role', this.get('authorRole'));
 
-            this.store.findAll('user', {reload: true}).then(function (result) {
-                var invitedUser = result.findBy('email', email);
+            this.store.findAll('user', {reload: true}).then((result) => {
+                let invitedUser = result.findBy('email', email);
 
                 if (invitedUser) {
                     if (invitedUser.get('status') === 'invited' || invitedUser.get('status') === 'invited-pending') {
-                        self.get('notifications').showAlert('A user with that email address was already invited.', {type: 'warn', key: 'invite.send.already-invited'});
+                        this.get('notifications').showAlert('A user with that email address was already invited.', {type: 'warn', key: 'invite.send.already-invited'});
                     } else {
-                        self.get('notifications').showAlert('A user with that email address already exists.', {type: 'warn', key: 'invite.send.user-exists'});
+                        this.get('notifications').showAlert('A user with that email address already exists.', {type: 'warn', key: 'invite.send.user-exists'});
                     }
                 } else {
-                    newUser = self.store.createRecord('user', {
-                        email: email,
-                        status: 'invited',
-                        role: role
+                    newUser = this.store.createRecord('user', {
+                        email,
+                        role,
+                        status: 'invited'
                     });
 
-                    newUser.save().then(function () {
-                        var notificationText = 'Invitation sent! (' + email + ')';
+                    newUser.save().then(() => {
+                        let notificationText = `Invitation sent! (${email})`;
 
                         // If sending the invitation email fails, the API will still return a status of 201
                         // but the user's status in the response object will be 'invited-pending'.
                         if (newUser.get('status') === 'invited-pending') {
-                            self.get('notifications').showAlert('Invitation email was not sent.  Please try resending.', {type: 'error', key: 'invite.send.failed'});
+                            this.get('notifications').showAlert('Invitation email was not sent.  Please try resending.', {type: 'error', key: 'invite.send.failed'});
                         } else {
-                            self.get('notifications').closeAlerts('invite.send');
-                            self.get('notifications').showNotification(notificationText);
+                            this.get('notifications').closeAlerts('invite.send');
+                            this.get('notifications').showNotification(notificationText);
                         }
-                    }).catch(function (errors) {
+                    }).catch((errors) => {
                         newUser.deleteRecord();
                         // TODO: user model includes ValidationEngine mixin so
                         // save is overridden in order to validate, we probably
                         // want to use inline-validations here and only show an
                         // alert if we have an actual error
                         if (errors) {
-                            self.get('notifications').showErrors(errors, {key: 'invite.send'});
+                            this.get('notifications').showErrors(errors, {key: 'invite.send'});
                         } else if (validationErrors) {
-                            self.get('notifications').showAlert(validationErrors.toString(), {type: 'error', key: 'invite.send.validation-error'});
+                            this.get('notifications').showAlert(validationErrors.toString(), {type: 'error', key: 'invite.send.validation-error'});
                         }
-                    }).finally(function () {
-                        self.get('errors').clear();
+                    }).finally(() => {
+                        this.get('errors').clear();
                     });
                 }
             });
-        },
-
-        confirmReject: function () {
-            return false;
         }
     }
 });

--- a/core/client/app/controllers/modals/leave-editor.js
+++ b/core/client/app/controllers/modals/leave-editor.js
@@ -1,18 +1,32 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    notifications: Ember.inject.service(),
+const {Controller, computed, inject, isArray} = Ember;
+const {alias} = computed;
 
-    args: Ember.computed.alias('model'),
+export default Controller.extend({
+    notifications: inject.service(),
+
+    args: alias('model'),
+
+    confirm: {
+        accept: {
+            text: 'Leave',
+            buttonClass: 'btn btn-red'
+        },
+        reject: {
+            text: 'Stay',
+            buttonClass: 'btn btn-default btn-minor'
+        }
+    },
 
     actions: {
-        confirmAccept: function () {
-            var args = this.get('args'),
-                editorController,
+        confirmAccept() {
+            let args = this.get('args');
+            let editorController,
                 model,
                 transition;
 
-            if (Ember.isArray(args)) {
+            if (isArray(args)) {
                 editorController = args[0];
                 transition = args[1];
                 model = editorController.get('model');
@@ -44,18 +58,7 @@ export default Ember.Controller.extend({
             transition.retry();
         },
 
-        confirmReject: function () {
-        }
-    },
-
-    confirm: {
-        accept: {
-            text: 'Leave',
-            buttonClass: 'btn btn-red'
-        },
-        reject: {
-            text: 'Stay',
-            buttonClass: 'btn btn-default btn-minor'
+        confirmReject() {
         }
     }
 });

--- a/core/client/app/controllers/modals/signin.js
+++ b/core/client/app/controllers/modals/signin.js
@@ -1,57 +1,56 @@
 import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default Ember.Controller.extend(ValidationEngine, {
+const {Controller, computed, inject} = Ember;
+
+export default Controller.extend(ValidationEngine, {
     validationType: 'signin',
     submitting: false,
 
-    application: Ember.inject.controller(),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
+    application: inject.controller(),
+    notifications: inject.service(),
+    session: inject.service(),
 
-    identification: Ember.computed('session.user.email', function () {
+    identification: computed('session.user.email', function () {
         return this.get('session.user.email');
     }),
 
     actions: {
-        authenticate: function () {
-            var appController = this.get('application'),
-                authStrategy = 'authenticator:oauth2',
-                self = this;
+        authenticate() {
+            let appController = this.get('application');
+            let authStrategy = 'authenticator:oauth2';
 
             appController.set('skipAuthSuccessHandler', true);
 
-            this.get('session').authenticate(authStrategy, this.get('identification'), this.get('password')).then(function () {
-                self.send('closeModal');
-                self.set('password', '');
-                self.get('notifications').closeAlerts('post.save');
-            }).catch(function () {
+            this.get('session').authenticate(authStrategy, this.get('identification'), this.get('password')).then(() => {
+                this.send('closeModal');
+                this.set('password', '');
+                this.get('notifications').closeAlerts('post.save');
+            }).catch(() => {
                 // if authentication fails a rejected promise will be returned.
                 // it needs to be caught so it doesn't generate an exception in the console,
                 // but it's actually "handled" by the sessionAuthenticationFailed action handler.
-            }).finally(function () {
-                self.toggleProperty('submitting');
+            }).finally(() => {
+                this.toggleProperty('submitting');
                 appController.set('skipAuthSuccessHandler', undefined);
             });
         },
 
-        validateAndAuthenticate: function () {
-            var self = this;
-
+        validateAndAuthenticate() {
             this.toggleProperty('submitting');
 
             // Manually trigger events for input fields, ensuring legacy compatibility with
             // browsers and password managers that don't send proper events on autofill
             $('#login').find('input').trigger('change');
 
-            this.validate({format: false}).then(function () {
-                self.send('authenticate');
-            }).catch(function (errors) {
-                self.get('notifications').showErrors(errors);
+            this.validate({format: false}).then(() => {
+                this.send('authenticate');
+            }).catch((errors) => {
+                this.get('notifications').showErrors(errors);
             });
         },
 
-        confirmAccept: function () {
+        confirmAccept() {
             this.send('validateAndAuthenticate');
         }
     }

--- a/core/client/app/controllers/modals/transfer-owner.js
+++ b/core/client/app/controllers/modals/transfer-owner.js
@@ -1,48 +1,12 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-export default Ember.Controller.extend({
-    dropdown: Ember.inject.service(),
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
+const {Controller, inject, isArray} = Ember;
 
-    actions: {
-        confirmAccept: function () {
-            var user = this.get('model'),
-                url = this.get('ghostPaths.url').api('users', 'owner'),
-                self = this;
-
-            self.get('dropdown').closeDropdowns();
-
-            ajax(url, {
-                type: 'PUT',
-                data: {
-                    owner: [{
-                        id: user.get('id')
-                    }]
-                }
-            }).then(function (response) {
-                // manually update the roles for the users that just changed roles
-                // because store.pushPayload is not working with embedded relations
-                if (response && Ember.isArray(response.users)) {
-                    response.users.forEach(function (userJSON) {
-                        var user = self.store.peekRecord('user', userJSON.id),
-                            role = self.store.peekRecord('role', userJSON.roles[0].id);
-
-                        user.set('role', role);
-                    });
-                }
-
-                self.get('notifications').showAlert('Ownership successfully transferred to ' + user.get('name'), {type: 'success', key: 'owner.transfer.success'});
-            }).catch(function (error) {
-                self.get('notifications').showAPIError(error, {key: 'owner.transfer'});
-            });
-        },
-
-        confirmReject: function () {
-            return false;
-        }
-    },
+export default Controller.extend({
+    dropdown: inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
 
     confirm: {
         accept: {
@@ -52,6 +16,43 @@ export default Ember.Controller.extend({
         reject: {
             text: 'Cancel',
             buttonClass: 'btn btn-default btn-minor'
+        }
+    },
+
+    actions: {
+        confirmAccept() {
+            let user = this.get('model');
+            let url = this.get('ghostPaths.url').api('users', 'owner');
+
+            this.get('dropdown').closeDropdowns();
+
+            ajax(url, {
+                type: 'PUT',
+                data: {
+                    owner: [{
+                        id: user.get('id')
+                    }]
+                }
+            }).then((response) => {
+                // manually update the roles for the users that just changed roles
+                // because store.pushPayload is not working with embedded relations
+                if (response && isArray(response.users)) {
+                    response.users.forEach((userJSON) => {
+                        let user = this.store.peekRecord('user', userJSON.id);
+                        let role = this.store.peekRecord('role', userJSON.roles[0].id);
+
+                        user.set('role', role);
+                    });
+                }
+
+                this.get('notifications').showAlert(`Ownership successfully transferred to ${user.get('name')}`, {type: 'success', key: 'owner.transfer.success'});
+            }).catch((error) => {
+                this.get('notifications').showAPIError(error, {key: 'owner.transfer'});
+            });
+        },
+
+        confirmReject() {
+            return false;
         }
     }
 });

--- a/core/client/app/controllers/modals/upload.js
+++ b/core/client/app/controllers/modals/upload.js
@@ -1,22 +1,24 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    notifications: Ember.inject.service(),
+const {Controller, inject} = Ember;
+
+export default Controller.extend({
+    notifications: inject.service(),
 
     acceptEncoding: 'image/*',
 
     actions: {
-        confirmAccept: function () {
-            var notifications = this.get('notifications');
+        confirmAccept() {
+            let notifications = this.get('notifications');
 
-            this.get('model').save().then(function (model) {
+            this.get('model').save().then((model) => {
                 return model;
-            }).catch(function (err) {
+            }).catch((err) => {
                 notifications.showAPIError(err, {key: 'image.upload'});
             });
         },
 
-        confirmReject: function () {
+        confirmReject() {
             return false;
         }
     }

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -5,48 +5,48 @@ import SlugGenerator from 'ghost/models/slug-generator';
 import boundOneWay from 'ghost/utils/bound-one-way';
 import isNumber from 'ghost/utils/isNumber';
 
-export default Ember.Controller.extend(SettingsMenuMixin, {
+const {ArrayProxy, Controller, Handlebars, PromiseProxyMixin, RSVP, computed, guidFor, inject, isArray, observer, run} = Ember;
+
+export default Controller.extend(SettingsMenuMixin, {
     debounceId: null,
     lastPromise: null,
     selectedAuthor: null,
     uploaderReference: null,
 
-    application: Ember.inject.controller(),
-    config: Ember.inject.service(),
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
+    application: inject.controller(),
+    config: inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
+    session: inject.service(),
 
-    initializeSelectedAuthor: Ember.observer('model', function () {
-        var self = this;
-
-        return this.get('model.author').then(function (author) {
-            self.set('selectedAuthor', author);
+    initializeSelectedAuthor: observer('model', function () {
+        return this.get('model.author').then((author) => {
+            this.set('selectedAuthor', author);
             return author;
         });
     }),
 
-    authors: Ember.computed(function () {
+    authors: computed(function () {
         // Loaded asynchronously, so must use promise proxies.
-        var deferred = {};
+        let deferred = {};
 
-        deferred.promise = this.store.query('user', {limit: 'all'}).then(function (users) {
+        deferred.promise = this.store.query('user', {limit: 'all'}).then((users) => {
             return users.rejectBy('id', 'me').sortBy('name');
-        }).then(function (users) {
-            return users.filter(function (user) {
+        }).then((users) => {
+            return users.filter((user) => {
                 return user.get('active');
             });
         });
 
-        return Ember.ArrayProxy
-            .extend(Ember.PromiseProxyMixin)
+        return ArrayProxy
+            .extend(PromiseProxyMixin)
             .create(deferred);
     }),
 
     /*jshint unused:false */
-    publishedAtValue: Ember.computed('model.published_at', {
-        get: function () {
-            var pubDate = this.get('model.published_at');
+    publishedAtValue: computed('model.published_at', {
+        get() {
+            let pubDate = this.get('model.published_at');
 
             if (pubDate) {
                 return formatDate(pubDate);
@@ -54,7 +54,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
 
             return formatDate(moment());
         },
-        set: function (key, value) {
+        set(key, value) {
             // We're using a fake setter to reset
             // the cache for this property
             return formatDate(moment());
@@ -65,7 +65,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
     slugValue: boundOneWay('model.slug'),
 
     // Lazy load the slug generator
-    slugGenerator: Ember.computed(function () {
+    slugGenerator: computed(function () {
         return SlugGenerator.create({
             ghostPaths: this.get('ghostPaths'),
             slugType: 'post'
@@ -73,21 +73,20 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
     }),
 
     // Requests slug from title
-    generateAndSetSlug: function (destination) {
-        var self = this,
-            title = this.get('model.titleScratch'),
-            afterSave = this.get('lastPromise'),
-            promise;
+    generateAndSetSlug(destination) {
+        let title = this.get('model.titleScratch');
+        let afterSave = this.get('lastPromise');
+        let promise;
 
         // Only set an "untitled" slug once per post
         if (title === '(Untitled)' && this.get('model.slug')) {
             return;
         }
 
-        promise = Ember.RSVP.resolve(afterSave).then(function () {
-            return self.get('slugGenerator').generateSlug(title).then(function (slug) {
-                self.set(destination, slug);
-            }).catch(function () {
+        promise = RSVP.resolve(afterSave).then(() => {
+            return this.get('slugGenerator').generateSlug(title).then((slug) => {
+                this.set(destination, slug);
+            }).catch(() => {
                 // Nothing to do (would be nice to log this somewhere though),
                 // but a rejected promise needs to be handled here so that a resolved
                 // promise is returned.
@@ -100,25 +99,24 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
     metaTitleScratch: boundOneWay('model.meta_title'),
     metaDescriptionScratch: boundOneWay('model.meta_description'),
 
-    seoTitle: Ember.computed('model.titleScratch', 'metaTitleScratch', function () {
-        var metaTitle = this.get('metaTitleScratch') || '';
+    seoTitle: computed('model.titleScratch', 'metaTitleScratch', function () {
+        let metaTitle = this.get('metaTitleScratch') || '';
 
         metaTitle = metaTitle.length > 0 ? metaTitle : this.get('model.titleScratch');
 
         if (metaTitle.length > 70) {
             metaTitle = metaTitle.substring(0, 70).trim();
-            metaTitle = Ember.Handlebars.Utils.escapeExpression(metaTitle);
-            metaTitle = Ember.String.htmlSafe(metaTitle + '&hellip;');
+            metaTitle = Handlebars.Utils.escapeExpression(metaTitle);
+            metaTitle = Ember.String.htmlSafe(`${metaTitle}&hellip;`);
         }
 
         return metaTitle;
     }),
 
-    seoDescription: Ember.computed('model.scratch', 'metaDescriptionScratch', function () {
-        var metaDescription = this.get('metaDescriptionScratch') || '',
-            el,
-            html = '',
-            placeholder;
+    seoDescription: computed('model.scratch', 'metaDescriptionScratch', function () {
+        let metaDescription = this.get('metaDescriptionScratch') || '';
+        let html = '';
+        let el, placeholder;
 
         if (metaDescription.length > 0) {
             placeholder = metaDescription;
@@ -133,27 +131,25 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             }
 
             // Strip HTML
-            placeholder = $('<div />', {html: html}).text();
+            placeholder = $('<div />', {html}).text();
             // Replace new lines and trim
-            // jscs: disable
             placeholder = placeholder.replace(/\n+/g, ' ').trim();
-            // jscs: enable
         }
 
         if (placeholder.length > 156) {
             // Limit to 156 characters
             placeholder = placeholder.substring(0, 156).trim();
-            placeholder = Ember.Handlebars.Utils.escapeExpression(placeholder);
-            placeholder = Ember.String.htmlSafe(placeholder + '&hellip;');
+            placeholder = Handlebars.Utils.escapeExpression(placeholder);
+            placeholder = Ember.String.htmlSafe(`${placeholder}&hellip;`);
         }
 
         return placeholder;
     }),
 
-    seoURL: Ember.computed('model.slug', 'config.blogUrl', function () {
-        var blogUrl = this.get('config.blogUrl'),
-            seoSlug = this.get('model.slug') ? this.get('model.slug') : '',
-            seoURL = blogUrl + '/' + seoSlug;
+    seoURL: computed('model.slug', 'config.blogUrl', function () {
+        let blogUrl = this.get('config.blogUrl');
+        let seoSlug = this.get('model.slug') ? this.get('model.slug') : '';
+        let seoURL = `${blogUrl}/${seoSlug}`;
 
         // only append a slash to the URL if the slug exists
         if (seoSlug) {
@@ -162,7 +158,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
 
         if (seoURL.length > 70) {
             seoURL = seoURL.substring(0, 70).trim();
-            seoURL = Ember.String.htmlSafe(seoURL + '&hellip;');
+            seoURL = Ember.String.htmlSafe(`${seoURL}&hellip;`);
         }
 
         return seoURL;
@@ -170,61 +166,58 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
 
     // observe titleScratch, keeping the post's slug in sync
     // with it until saved for the first time.
-    addTitleObserver: Ember.observer('model', function () {
+    addTitleObserver: observer('model', function () {
         if (this.get('model.isNew') || this.get('model.title') === '(Untitled)') {
             this.addObserver('model.titleScratch', this, 'titleObserver');
         }
     }),
 
-    titleObserver: function () {
-        var debounceId,
-            title = this.get('model.title');
+    titleObserver() {
+        let title = this.get('model.title');
+        let debounceId;
 
         // generate a slug if a post is new and doesn't have a title yet or
         // if the title is still '(Untitled)' and the slug is unaltered.
         if ((this.get('model.isNew') && !title) || title === '(Untitled)') {
-            debounceId = Ember.run.debounce(this, 'generateAndSetSlug', 'model.slug', 700);
+            debounceId = run.debounce(this, 'generateAndSetSlug', 'model.slug', 700);
         }
 
         this.set('debounceId', debounceId);
     },
 
     // live-query of all tags for tag input autocomplete
-    availableTags: Ember.computed(function () {
-        return this.get('store').filter('tag', {limit: 'all'}, function () {
+    availableTags: computed(function () {
+        return this.get('store').filter('tag', {limit: 'all'}, () => {
             return true;
         });
     }),
 
-    showErrors: function (errors) {
-        errors = Ember.isArray(errors) ? errors : [errors];
+    showErrors(errors) {
+        errors = isArray(errors) ? errors : [errors];
         this.get('notifications').showErrors(errors);
     },
 
     actions: {
-        discardEnter: function () {
+        discardEnter() {
             return false;
         },
 
-        togglePage: function () {
-            var self = this;
-
+        togglePage() {
             this.toggleProperty('model.page');
+
             // If this is a new post.  Don't save the model.  Defer the save
             // to the user pressing the save button
             if (this.get('model.isNew')) {
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+            this.get('model').save().catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
-        toggleFeatured: function () {
-            var self = this;
-
+        toggleFeatured() {
             this.toggleProperty('model.featured');
 
             // If this is a new post.  Don't save the model.  Defer the save
@@ -233,21 +226,19 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save(this.get('saveOptions')).catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+            this.get('model').save(this.get('saveOptions')).catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
         /**
          * triggered by user manually changing slug
          */
-        updateSlug: function (newSlug) {
-            var slug = this.get('model.slug'),
-                self = this;
+        updateSlug(newSlug) {
+            let slug = this.get('model.slug');
 
             newSlug = newSlug || slug;
-
             newSlug = newSlug && newSlug.trim();
 
             // Ignore unchanged slugs or candidate slugs that are empty
@@ -258,7 +249,7 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('slugGenerator').generateSlug(newSlug).then(function (serverSlug) {
+            this.get('slugGenerator').generateSlug(newSlug).then((serverSlug) => {
                 // If after getting the sanitized and unique slug back from the API
                 // we end up with a slug that matches the existing slug, abort the change
                 if (serverSlug === slug) {
@@ -272,35 +263,35 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 // the trailing incrementor (e.g., this-is-a-slug and this-is-a-slug-2)
 
                 // get the last token out of the slug candidate and see if it's a number
-                var slugTokens = serverSlug.split('-'),
-                    check = Number(slugTokens.pop());
+                let slugTokens = serverSlug.split('-');
+                let check = Number(slugTokens.pop());
 
                 // if the candidate slug is the same as the existing slug except
                 // for the incrementor then the existing slug should be used
                 if (isNumber(check) && check > 0) {
                     if (slug === slugTokens.join('-') && serverSlug !== newSlug) {
-                        self.set('slugValue', slug);
+                        this.set('slugValue', slug);
 
                         return;
                     }
                 }
 
-                self.set('model.slug', serverSlug);
+                this.set('model.slug', serverSlug);
 
-                if (self.hasObserverFor('model.titleScratch')) {
-                    self.removeObserver('model.titleScratch', self, 'titleObserver');
+                if (this.hasObserverFor('model.titleScratch')) {
+                    this.removeObserver('model.titleScratch', this, 'titleObserver');
                 }
 
                 // If this is a new post.  Don't save the model.  Defer the save
                 // to the user pressing the save button
-                if (self.get('model.isNew')) {
+                if (this.get('model.isNew')) {
                     return;
                 }
 
-                return self.get('model').save();
-            }).catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+                return this.get('model').save();
+            }).catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
@@ -309,11 +300,10 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
          * Action sent by post settings menu view.
          * (#1351)
          */
-        setPublishedAt: function (userInput) {
-            var errMessage = '',
-                newPublishedAt = parseDateString(userInput),
-                publishedAt = this.get('model.published_at'),
-                self = this;
+        setPublishedAt(userInput) {
+            let newPublishedAt = parseDateString(userInput);
+            let publishedAt = this.get('model.published_at');
+            let errMessage = '';
 
             if (!userInput) {
                 // Clear out the published_at field for a draft
@@ -354,16 +344,16 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+            this.get('model').save().catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
-        setMetaTitle: function (metaTitle) {
-            var property = 'meta_title',
-                model = this.get('model'),
-                currentTitle = model.get(property) || '';
+        setMetaTitle(metaTitle) {
+            let property = 'meta_title';
+            let model = this.get('model');
+            let currentTitle = model.get(property) || '';
 
             // Only update if the title has changed
             if (currentTitle === metaTitle) {
@@ -381,10 +371,10 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             model.save();
         },
 
-        setMetaDescription: function (metaDescription) {
-            var property = 'meta_description',
-                model = this.get('model'),
-                currentDescription = model.get(property) || '';
+        setMetaDescription(metaDescription) {
+            let property = 'meta_description';
+            let model = this.get('model');
+            let currentDescription = model.get(property) || '';
 
             // Only update if the description has changed
             if (currentDescription === metaDescription) {
@@ -402,56 +392,51 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
             model.save();
         },
 
-        setCoverImage: function (image) {
-            var self = this;
-
+        setCoverImage(image) {
             this.set('model.image', image);
 
             if (this.get('model.isNew')) {
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+            this.get('model').save().catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
-        clearCoverImage: function () {
-            var self = this;
-
+        clearCoverImage() {
             this.set('model.image', '');
 
             if (this.get('model.isNew')) {
                 return;
             }
 
-            this.get('model').save().catch(function (errors) {
-                self.showErrors(errors);
-                self.get('model').rollbackAttributes();
+            this.get('model').save().catch((errors) => {
+                this.showErrors(errors);
+                this.get('model').rollbackAttributes();
             });
         },
 
-        resetUploader: function () {
-            var uploader = this.get('uploaderReference');
+        resetUploader() {
+            let uploader = this.get('uploaderReference');
 
             if (uploader && uploader[0]) {
                 uploader[0].uploaderUi.reset();
             }
         },
 
-        resetPubDate: function () {
+        resetPubDate() {
             this.set('publishedAtValue', '');
         },
 
-        closeNavMenu: function () {
+        closeNavMenu() {
             this.get('application').send('closeNavMenu');
         },
 
-        changeAuthor: function (newAuthor) {
-            var author = this.get('model.author'),
-                model = this.get('model'),
-                self = this;
+        changeAuthor(newAuthor) {
+            let author = this.get('model.author');
+            let model = this.get('model');
 
             // return if nothing changed
             if (newAuthor.get('id') === author.get('id')) {
@@ -465,19 +450,20 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            model.save().catch(function (errors) {
-                self.showErrors(errors);
-                self.set('selectedAuthor', author);
+            model.save().catch((errors) => {
+                this.showErrors(errors);
+                this.set('selectedAuthor', author);
                 model.rollbackAttributes();
             });
         },
 
-        addTag: function (tagName, index) {
-            var self = this,
-                currentTags = this.get('model.tags'),
-                currentTagNames = currentTags.map(function (tag) { return tag.get('name').toLowerCase(); }),
-                availableTagNames = null,
-                tagToAdd = null;
+        addTag(tagName, index) {
+            let currentTags = this.get('model.tags');
+            let currentTagNames = currentTags.map((tag) => {
+                return tag.get('name').toLowerCase();
+            });
+            let availableTagNames,
+                tagToAdd;
 
             tagName = tagName.trim();
 
@@ -486,30 +472,34 @@ export default Ember.Controller.extend(SettingsMenuMixin, {
                 return;
             }
 
-            this.get('availableTags').then(function (availableTags) {
-                availableTagNames = availableTags.map(function (tag) { return tag.get('name').toLowerCase(); });
+            this.get('availableTags').then((availableTags) => {
+                availableTagNames = availableTags.map((tag) => {
+                    return tag.get('name').toLowerCase();
+                });
 
                 // find existing tag or create new
                 if (availableTagNames.contains(tagName.toLowerCase())) {
-                    tagToAdd = availableTags.find(function (tag) {
+                    tagToAdd = availableTags.find((tag) => {
                         return tag.get('name').toLowerCase() === tagName.toLowerCase();
                     });
                 } else {
-                    tagToAdd = self.get('store').createRecord('tag', {
+                    tagToAdd = this.get('store').createRecord('tag', {
                         name: tagName
                     });
 
                     // we need to set a UUID so that selectize has a unique value
                     // it will be ignored when sent to the server
-                    tagToAdd.set('uuid', Ember.guidFor(tagToAdd));
+                    tagToAdd.set('uuid', guidFor(tagToAdd));
                 }
 
                 // push tag onto post relationship
-                if (tagToAdd) { self.get('model.tags').insertAt(index, tagToAdd); }
+                if (tagToAdd) {
+                    this.get('model.tags').insertAt(index, tagToAdd);
+                }
             });
         },
 
-        removeTag: function (tag) {
+        removeTag(tag) {
             this.get('model.tags').removeObject(tag);
 
             if (tag.get('isNew')) {

--- a/core/client/app/controllers/posts.js
+++ b/core/client/app/controllers/posts.js
@@ -1,17 +1,20 @@
 import Ember from 'ember';
 
+const {Controller, compare, computed} = Ember;
+const {equal} = computed;
+
 // a custom sort function is needed in order to sort the posts list the same way the server would:
 //     status: ASC
 //     published_at: DESC
 //     updated_at: DESC
 //     id: DESC
 function comparator(item1, item2) {
-    var updated1 = item1.get('updated_at'),
-        updated2 = item2.get('updated_at'),
-        idResult,
+    let updated1 = item1.get('updated_at');
+    let updated2 = item2.get('updated_at');
+    let idResult,
+        publishedAtResult,
         statusResult,
-        updatedAtResult,
-        publishedAtResult;
+        updatedAtResult;
 
     // when `updated_at` is undefined, the model is still
     // being written to with the results from the server
@@ -23,9 +26,9 @@ function comparator(item1, item2) {
         return 1;
     }
 
-    idResult = Ember.compare(parseInt(item1.get('id')), parseInt(item2.get('id')));
-    statusResult = Ember.compare(item1.get('status'), item2.get('status'));
-    updatedAtResult = Ember.compare(updated1.valueOf(), updated2.valueOf());
+    idResult = compare(parseInt(item1.get('id')), parseInt(item2.get('id')));
+    statusResult = compare(item1.get('status'), item2.get('status'));
+    updatedAtResult = compare(updated1.valueOf(), updated2.valueOf());
     publishedAtResult = publishedAtCompare(item1, item2);
 
     if (statusResult === 0) {
@@ -45,8 +48,8 @@ function comparator(item1, item2) {
 }
 
 function publishedAtCompare(item1, item2) {
-    var published1 = item1.get('published_at'),
-        published2 = item2.get('published_at');
+    let published1 = item1.get('published_at');
+    let published2 = item2.get('published_at');
 
     if (!published1 && !published2) {
         return 0;
@@ -60,23 +63,23 @@ function publishedAtCompare(item1, item2) {
         return 1;
     }
 
-    return Ember.compare(published1.valueOf(), published2.valueOf());
+    return compare(published1.valueOf(), published2.valueOf());
 }
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 
     // See PostsRoute's shortcuts
-    postListFocused: Ember.computed.equal('keyboardFocus', 'postList'),
-    postContentFocused: Ember.computed.equal('keyboardFocus', 'postContent'),
+    postListFocused: equal('keyboardFocus', 'postList'),
+    postContentFocused: equal('keyboardFocus', 'postContent'),
 
-    sortedPosts: Ember.computed('model.@each.status', 'model.@each.published_at', 'model.@each.isNew', 'model.@each.updated_at', function () {
-        var postsArray = this.get('model').toArray();
+    sortedPosts: computed('model.@each.status', 'model.@each.published_at', 'model.@each.isNew', 'model.@each.updated_at', function () {
+        let postsArray = this.get('model').toArray();
 
         return postsArray.sort(comparator);
     }),
 
     actions: {
-        showPostContent: function (post) {
+        showPostContent(post) {
             if (!post) {
                 return;
             }

--- a/core/client/app/controllers/reset.js
+++ b/core/client/app/controllers/reset.js
@@ -2,7 +2,9 @@ import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default Ember.Controller.extend(ValidationEngine, {
+const {Controller, computed, inject} = Ember;
+
+export default Controller.extend(ValidationEngine, {
     newPassword: '',
     ne2Password: '',
     token: '',
@@ -11,18 +13,18 @@ export default Ember.Controller.extend(ValidationEngine, {
 
     validationType: 'reset',
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
+    session: inject.service(),
 
-    email: Ember.computed('token', function () {
+    email: computed('token', function () {
         // The token base64 encodes the email (and some other stuff),
         // each section is divided by a '|'. Email comes second.
         return atob(this.get('token')).split('|')[1];
     }),
 
     // Used to clear sensitive information
-    clearData: function () {
+    clearData() {
         this.setProperties({
             newPassword: '',
             ne2Password: '',
@@ -31,34 +33,34 @@ export default Ember.Controller.extend(ValidationEngine, {
     },
 
     actions: {
-        submit: function () {
-            var credentials = this.getProperties('newPassword', 'ne2Password', 'token'),
-                self = this;
+        submit() {
+            let credentials = this.getProperties('newPassword', 'ne2Password', 'token');
+
             this.set('flowErrors', '');
             this.get('hasValidated').addObjects((['newPassword', 'ne2Password']));
-            this.validate().then(function () {
-                self.toggleProperty('submitting');
+            this.validate().then(() => {
+                this.toggleProperty('submitting');
                 ajax({
-                    url: self.get('ghostPaths.url').api('authentication', 'passwordreset'),
+                    url: this.get('ghostPaths.url').api('authentication', 'passwordreset'),
                     type: 'PUT',
                     data: {
                         passwordreset: [credentials]
                     }
-                }).then(function (resp) {
-                    self.toggleProperty('submitting');
-                    self.get('notifications').showAlert(resp.passwordreset[0].message, {type: 'warn', delayed: true, key: 'password.reset'});
-                    self.get('session').authenticate('authenticator:oauth2', self.get('email'), credentials.newPassword);
-                }).catch(function (response) {
-                    self.get('notifications').showAPIError(response, {key: 'password.reset'});
-                    self.toggleProperty('submitting');
+                }).then((resp) => {
+                    this.toggleProperty('submitting');
+                    this.get('notifications').showAlert(resp.passwordreset[0].message, {type: 'warn', delayed: true, key: 'password.reset'});
+                    this.get('session').authenticate('authenticator:oauth2', this.get('email'), credentials.newPassword);
+                }).catch((response) => {
+                    this.get('notifications').showAPIError(response, {key: 'password.reset'});
+                    this.toggleProperty('submitting');
                 });
-            }).catch(function () {
-                if (self.get('errors.newPassword')) {
-                    self.set('flowErrors', self.get('errors.newPassword')[0].message);
+            }).catch(() => {
+                if (this.get('errors.newPassword')) {
+                    this.set('flowErrors', this.get('errors.newPassword')[0].message);
                 }
 
-                if (self.get('errors.ne2Password')) {
-                    self.set('flowErrors', self.get('errors.ne2Password')[0].message);
+                if (this.get('errors.ne2Password')) {
+                    this.set('flowErrors', this.get('errors.ne2Password')[0].message);
                 }
             });
         }

--- a/core/client/app/controllers/settings/code-injection.js
+++ b/core/client/app/controllers/settings/code-injection.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 import SettingsSaveMixin from 'ghost/mixins/settings-save';
 
-export default Ember.Controller.extend(SettingsSaveMixin, {
-    notifications: Ember.inject.service(),
+const {Controller, inject} = Ember;
 
-    save: function () {
-        var notifications = this.get('notifications');
+export default Controller.extend(SettingsSaveMixin, {
+    notifications: inject.service(),
 
-        return this.get('model').save().catch(function (error) {
+    save() {
+        let notifications = this.get('notifications');
+
+        return this.get('model').save().catch((error) => {
             notifications.showAPIError(error, {key: 'code-injection.save'});
         });
     }

--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -2,16 +2,18 @@ import Ember from 'ember';
 import SettingsSaveMixin from 'ghost/mixins/settings-save';
 import randomPassword from 'ghost/utils/random-password';
 
-export default Ember.Controller.extend(SettingsSaveMixin, {
-    notifications: Ember.inject.service(),
-    config: Ember.inject.service(),
+const {Controller, computed, inject, observer} = Ember;
 
-    selectedTheme: Ember.computed('model.activeTheme', 'themes', function () {
-        var activeTheme = this.get('model.activeTheme'),
-            themes = this.get('themes'),
-            selectedTheme;
+export default Controller.extend(SettingsSaveMixin, {
+    notifications: inject.service(),
+    config: inject.service(),
 
-        themes.forEach(function (theme) {
+    selectedTheme: computed('model.activeTheme', 'themes', function () {
+        let activeTheme = this.get('model.activeTheme');
+        let themes = this.get('themes');
+        let selectedTheme;
+
+        themes.forEach((theme) => {
             if (theme.name === activeTheme) {
                 selectedTheme = theme;
             }
@@ -20,34 +22,35 @@ export default Ember.Controller.extend(SettingsSaveMixin, {
         return selectedTheme;
     }),
 
-    logoImageSource: Ember.computed('model.logo', function () {
+    logoImageSource: computed('model.logo', function () {
         return this.get('model.logo') || '';
     }),
 
-    coverImageSource: Ember.computed('model.cover', function () {
+    coverImageSource: computed('model.cover', function () {
         return this.get('model.cover') || '';
     }),
 
-    isDatedPermalinks: Ember.computed('model.permalinks', {
-        set: function (key, value) {
+    isDatedPermalinks: computed('model.permalinks', {
+        set(key, value) {
             this.set('model.permalinks', value ? '/:year/:month/:day/:slug/' : '/:slug/');
 
-            var slugForm = this.get('model.permalinks');
+            let slugForm = this.get('model.permalinks');
             return slugForm !== '/:slug/';
         },
-        get: function () {
-            var slugForm = this.get('model.permalinks');
+
+        get() {
+            let slugForm = this.get('model.permalinks');
 
             return slugForm !== '/:slug/';
         }
     }),
 
-    themes: Ember.computed(function () {
+    themes: computed(function () {
         return this.get('model.availableThemes').reduce(function (themes, t) {
-            var theme = {};
+            let theme = {};
 
             theme.name = t.name;
-            theme.label = t.package ? t.package.name + ' - ' + t.package.version : t.name;
+            theme.label = t.package ? `${t.package.name} - ${t.package.version}` : t.name;
             theme.package = t.package;
             theme.active = !!t.active;
 
@@ -57,22 +60,22 @@ export default Ember.Controller.extend(SettingsSaveMixin, {
         }, []);
     }).readOnly(),
 
-    generatePassword: Ember.observer('model.isPrivate', function () {
+    generatePassword: observer('model.isPrivate', function () {
         this.get('model.errors').remove('password');
         if (this.get('model.isPrivate') && this.get('model.hasDirtyAttributes')) {
             this.get('model').set('password', randomPassword());
         }
     }),
 
-    save: function () {
-        var notifications = this.get('notifications'),
-            config = this.get('config');
+    save() {
+        let notifications = this.get('notifications');
+        let config = this.get('config');
 
-        return this.get('model').save().then(function (model) {
+        return this.get('model').save().then((model) => {
             config.set('blogTitle', model.get('title'));
 
             return model;
-        }).catch(function (error) {
+        }).catch((error) => {
             if (error) {
                 notifications.showAPIError(error, {key: 'settings.save'});
             }
@@ -80,19 +83,19 @@ export default Ember.Controller.extend(SettingsSaveMixin, {
     },
 
     actions: {
-        validate: function (property) {
-            this.get('model').validate({property: property});
+        validate(property) {
+            this.get('model').validate({property});
         },
 
-        checkPostsPerPage: function () {
-            var postsPerPage = this.get('model.postsPerPage');
+        checkPostsPerPage() {
+            let postsPerPage = this.get('model.postsPerPage');
 
             if (postsPerPage < 1 || postsPerPage > 1000 || isNaN(postsPerPage)) {
                 this.set('model.postsPerPage', 5);
             }
         },
 
-        setTheme: function (theme) {
+        setTheme(theme) {
             this.set('model.activeTheme', theme.name);
         }
     }

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -1,51 +1,51 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-export default Ember.Controller.extend({
+const {Controller, computed, inject} = Ember;
+
+export default Controller.extend({
     uploadButtonText: 'Import',
     importErrors: '',
     submitting: false,
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
-    feature: Ember.inject.controller(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
+    session: inject.service(),
+    feature: inject.controller(),
 
-    labsJSON: Ember.computed('model.labs', function () {
+    labsJSON: computed('model.labs', function () {
         return JSON.parse(this.get('model.labs') || {});
     }),
 
-    saveLabs: function (optionName, optionValue) {
-        var self = this,
-            labsJSON =  this.get('labsJSON');
+    saveLabs(optionName, optionValue) {
+        let labsJSON =  this.get('labsJSON');
 
         // Set new value in the JSON object
         labsJSON[optionName] = optionValue;
 
         this.set('model.labs', JSON.stringify(labsJSON));
 
-        this.get('model').save().catch(function (errors) {
-            self.showErrors(errors);
-            self.get('model').rollbackAttributes();
+        this.get('model').save().catch((errors) => {
+            this.showErrors(errors);
+            this.get('model').rollbackAttributes();
         });
     },
 
-    usePublicAPI: Ember.computed('feature.publicAPI', {
-        get: function () {
+    usePublicAPI: computed('feature.publicAPI', {
+        get() {
             return this.get('feature.publicAPI');
         },
-        set: function (key, value) {
+        set(key, value) {
             this.saveLabs('publicAPI', value);
             return value;
         }
     }),
 
     actions: {
-        onUpload: function (file) {
-            var self = this,
-                formData = new FormData(),
-                notifications = this.get('notifications'),
-                currentUserId = this.get('session.user.id');
+        onUpload(file) {
+            let formData = new FormData();
+            let notifications = this.get('notifications');
+            let currentUserId = this.get('session.user.id');
 
             this.set('uploadButtonText', 'Importing');
             this.set('importErrors', '');
@@ -59,29 +59,30 @@ export default Ember.Controller.extend({
                 cache: false,
                 contentType: false,
                 processData: false
-            }).then(function () {
+            }).then(() => {
                 // Clear the store, so that all the new data gets fetched correctly.
-                self.store.unloadAll();
+                this.store.unloadAll();
                 // Reload currentUser and set session
-                self.set('session.user', self.store.findRecord('user', currentUserId));
+                this.set('session.user', this.store.findRecord('user', currentUserId));
                 // TODO: keep as notification, add link to view content
                 notifications.showNotification('Import successful.');
                 notifications.closeAlerts('import.upload');
-            }).catch(function (response) {
+            }).catch((response) => {
                 if (response && response.jqXHR && response.jqXHR.responseJSON && response.jqXHR.responseJSON.errors) {
-                    self.set('importErrors', response.jqXHR.responseJSON.errors);
+                    this.set('importErrors', response.jqXHR.responseJSON.errors);
                 }
 
                 notifications.showAlert('Import Failed', {type: 'error', key: 'import.upload.failed'});
-            }).finally(function () {
-                self.set('uploadButtonText', 'Import');
+            }).finally(() => {
+                this.set('uploadButtonText', 'Import');
             });
         },
 
-        exportData: function () {
-            var iframe = $('#iframeDownload'),
-                downloadURL = this.get('ghostPaths.url').api('db') +
-                    '?access_token=' + this.get('session.data.authenticated.access_token');
+        exportData() {
+            let dbUrl = this.get('ghostPaths.url').api('db');
+            let accessToken = this.get('session.data.authenticated.access_token');
+            let downloadURL = `${dbUrl}?access_token=${accessToken}`;
+            let iframe = $('#iframeDownload');
 
             if (iframe.length === 0) {
                 iframe = $('<iframe>', {id: 'iframeDownload'}).hide().appendTo('body');
@@ -90,24 +91,23 @@ export default Ember.Controller.extend({
             iframe.attr('src', downloadURL);
         },
 
-        sendTestEmail: function () {
-            var notifications = this.get('notifications'),
-                self = this;
+        sendTestEmail() {
+            let notifications = this.get('notifications');
 
             this.toggleProperty('submitting');
 
             ajax(this.get('ghostPaths.url').api('mail', 'test'), {
                 type: 'POST'
-            }).then(function () {
+            }).then(() => {
                 notifications.showAlert('Check your email for the test message.', {type: 'info', key: 'test-email.send.success'});
-                self.toggleProperty('submitting');
-            }).catch(function (error) {
+                this.toggleProperty('submitting');
+            }).catch((error) => {
                 if (typeof error.jqXHR !== 'undefined') {
                     notifications.showAPIError(error, {key: 'test-email.send'});
                 } else {
                     notifications.showErrors(error, {key: 'test-email.send'});
                 }
-                self.toggleProperty('submitting');
+                this.toggleProperty('submitting');
             });
         }
     }

--- a/core/client/app/controllers/settings/tags.js
+++ b/core/client/app/controllers/settings/tags.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-const {computed, inject} = Ember,
-      {alias, equal, sort} = computed;
+const {computed, inject} = Ember;
+const {alias, equal, sort} = computed;
 
 export default Ember.Controller.extend({
 
@@ -14,8 +14,8 @@ export default Ember.Controller.extend({
 
     // TODO: replace with ordering by page count once supported by the API
     tags: sort('model', function (a, b) {
-        const idA = +a.get('id'),
-              idB = +b.get('id');
+        let idA = +a.get('id');
+        let idB = +b.get('id');
 
         if (idA > idB) {
             return 1;
@@ -27,7 +27,7 @@ export default Ember.Controller.extend({
     }),
 
     actions: {
-        leftMobile: function () {
+        leftMobile() {
             let firstTag = this.get('tags.firstObject');
             // redirect to first tag if possible so that you're not left with
             // tag settings blank slate when switching from portrait to landscape

--- a/core/client/app/controllers/settings/tags/tag.js
+++ b/core/client/app/controllers/settings/tags/tag.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 
-const {computed, inject} = Ember,
-      {alias} = computed;
+const {Controller, computed, inject} = Ember;
+const {alias} = computed;
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 
     tag: alias('model'),
     isMobile: alias('tagsController.isMobile'),
@@ -11,9 +11,9 @@ export default Ember.Controller.extend({
     tagsController: inject.controller('settings.tags'),
     notifications: inject.service(),
 
-    saveTagProperty: function (propKey, newValue) {
-        const tag = this.get('tag'),
-              currentValue = tag.get(propKey);
+    saveTagProperty(propKey, newValue) {
+        let tag = this.get('tag');
+        let currentValue = tag.get(propKey);
 
         newValue = newValue.trim();
 
@@ -37,7 +37,7 @@ export default Ember.Controller.extend({
     },
 
     actions: {
-        setProperty: function (propKey, value) {
+        setProperty(propKey, value) {
             this.saveTagProperty(propKey, value);
         }
     }

--- a/core/client/app/controllers/setup.js
+++ b/core/client/app/controllers/setup.js
@@ -1,14 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    appController: Ember.inject.controller('application'),
-    ghostPaths: Ember.inject.service('ghost-paths'),
+const {Controller, computed, get, inject} = Ember;
+const {match} = computed;
 
-    showBackLink: Ember.computed.match('appController.currentRouteName', /^setup\.(two|three)$/),
+export default Controller.extend({
+    appController: inject.controller('application'),
+    ghostPaths: inject.service('ghost-paths'),
 
-    backRoute: Ember.computed('appController.currentRouteName', function () {
-        var appController = this.get('appController'),
-            currentRoute = Ember.get(appController, 'currentRouteName');
+    showBackLink: match('appController.currentRouteName', /^setup\.(two|three)$/),
+
+    backRoute: computed('appController.currentRouteName', function () {
+        let appController = this.get('appController');
+        let currentRoute = get(appController, 'currentRouteName');
 
         return currentRoute === 'setup.two' ? 'setup.one' : 'setup.two';
     })

--- a/core/client/app/controllers/setup/three.js
+++ b/core/client/app/controllers/setup/three.js
@@ -1,19 +1,24 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default Ember.Controller.extend({
-    notifications: Ember.inject.service(),
-    two: Ember.inject.controller('setup/two'),
+const {Controller, RSVP, computed, inject} = Ember;
+const {Errors} = DS;
+const {alias} = computed;
+const emberA = Ember.A;
 
-    errors: DS.Errors.create(),
-    hasValidated: Ember.A(),
+export default Controller.extend({
+    notifications: inject.service(),
+    two: inject.controller('setup/two'),
+
+    errors: Errors.create(),
+    hasValidated: emberA(),
     users: '',
-    ownerEmail: Ember.computed.alias('two.email'),
+    ownerEmail: alias('two.email'),
     submitting: false,
 
-    usersArray: Ember.computed('users', function () {
-        var errors = this.get('errors'),
-            users = this.get('users').split('\n').filter(function (email) {
+    usersArray: computed('users', function () {
+        let errors = this.get('errors');
+        let users = this.get('users').split('\n').filter(function (email) {
             return email.trim().length > 0;
         });
 
@@ -27,28 +32,28 @@ export default Ember.Controller.extend({
         return users.uniq();
     }),
 
-    validUsersArray: Ember.computed('usersArray', 'ownerEmail', function () {
-        var ownerEmail = this.get('ownerEmail');
+    validUsersArray: computed('usersArray', 'ownerEmail', function () {
+        let ownerEmail = this.get('ownerEmail');
 
         return this.get('usersArray').filter(function (user) {
             return validator.isEmail(user) && user !== ownerEmail;
         });
     }),
 
-    invalidUsersArray: Ember.computed('usersArray', 'ownerEmail', function () {
-        var ownerEmail = this.get('ownerEmail');
+    invalidUsersArray: computed('usersArray', 'ownerEmail', function () {
+        let ownerEmail = this.get('ownerEmail');
 
-        return this.get('usersArray').reject(function (user) {
+        return this.get('usersArray').reject((user) => {
             return validator.isEmail(user) || user === ownerEmail;
         });
     }),
 
-    validationResult: Ember.computed('invalidUsersArray', function () {
-        var errors = [];
+    validationResult: computed('invalidUsersArray', function () {
+        let errors = [];
 
-        this.get('invalidUsersArray').forEach(function (user) {
+        this.get('invalidUsersArray').forEach((user) => {
             errors.push({
-                user: user,
+                user,
                 error: 'email'
             });
         });
@@ -62,34 +67,36 @@ export default Ember.Controller.extend({
         }
     }),
 
-    validate: function () {
-        var errors = this.get('errors'),
-            validationResult = this.get('validationResult'),
-            property = 'users';
+    validate() {
+        let errors = this.get('errors');
+        let validationResult = this.get('validationResult');
+        let property = 'users';
 
         errors.clear();
 
         // If property isn't in the `hasValidated` array, add it to mark that this field can show a validation result
         this.get('hasValidated').addObject(property);
 
-        if (validationResult === true) { return true; }
+        if (validationResult === true) {
+            return true;
+        }
 
-        validationResult.forEach(function (error) {
+        validationResult.forEach((error) => {
             // Only one error type here so far, but one day the errors might be more detailed
             switch (error.error) {
             case 'email':
-                errors.add(property, error.user + ' is not a valid email.');
+                errors.add(property, `${error.user} is not a valid email.`);
             }
         });
 
         return false;
     },
 
-    buttonText: Ember.computed('errors.users', 'validUsersArray', 'invalidUsersArray', function () {
-        var usersError = this.get('errors.users.firstObject.message'),
-            validNum = this.get('validUsersArray').length,
-            invalidNum = this.get('invalidUsersArray').length,
-            userCount;
+    buttonText: computed('errors.users', 'validUsersArray', 'invalidUsersArray', function () {
+        let usersError = this.get('errors.users.firstObject.message');
+        let validNum = this.get('validUsersArray').length;
+        let invalidNum = this.get('invalidUsersArray').length;
+        let userCount;
 
         if (usersError && usersError.match(/no users/i)) {
             return usersError;
@@ -102,15 +109,15 @@ export default Ember.Controller.extend({
 
         if (validNum > 0) {
             userCount = validNum === 1 ? 'user' : 'users';
-            userCount = validNum + ' ' + userCount;
+            userCount = `${validNum} ${userCount}`;
         } else {
             userCount = 'some users';
         }
 
-        return 'Invite ' + userCount;
+        return `Invite ${userCount}`;
     }),
 
-    buttonClass: Ember.computed('validationResult', 'usersArray.length', function () {
+    buttonClass: computed('validationResult', 'usersArray.length', function () {
         if (this.get('validationResult') === true && this.get('usersArray.length') > 0) {
             return 'btn-green';
         } else {
@@ -118,52 +125,51 @@ export default Ember.Controller.extend({
         }
     }),
 
-    authorRole: Ember.computed(function () {
-        return this.store.findAll('role', {reload: true}).then(function (roles) {
+    authorRole: computed(function () {
+        return this.store.findAll('role', {reload: true}).then((roles) => {
             return roles.findBy('name', 'Author');
         });
     }),
 
     actions: {
-        validate: function () {
+        validate() {
             this.validate();
         },
 
-        invite: function () {
-            var self = this,
-                users = this.get('usersArray'),
-                notifications = this.get('notifications'),
-                invitationsString;
+        invite() {
+            let users = this.get('usersArray');
+            let notifications = this.get('notifications');
+            let invitationsString;
 
             if (this.validate() && users.length > 0) {
                 this.toggleProperty('submitting');
-                this.get('authorRole').then(function (authorRole) {
-                    Ember.RSVP.Promise.all(
-                        users.map(function (user) {
-                            var newUser = self.store.createRecord('user', {
+                this.get('authorRole').then((authorRole) => {
+                    RSVP.Promise.all(
+                        users.map((user) => {
+                            let newUser = this.store.createRecord('user', {
                                 email: user,
                                 status: 'invited',
                                 role: authorRole
                             });
 
-                            return newUser.save().then(function () {
+                            return newUser.save().then(() => {
                                 return {
                                     email: user,
                                     success: newUser.get('status') === 'invited'
                                 };
-                            }).catch(function () {
+                            }).catch(() => {
                                 return {
                                     email: user,
                                     success: false
                                 };
                             });
                         })
-                    ).then(function (invites) {
-                        var successCount = 0,
-                            erroredEmails = [],
-                            message;
+                    ).then((invites) => {
+                        let erroredEmails = [];
+                        let successCount = 0;
+                        let message;
 
-                        invites.forEach(function (invite) {
+                        invites.forEach((invite) => {
                             if (invite.success) {
                                 successCount++;
                             } else {
@@ -173,7 +179,7 @@ export default Ember.Controller.extend({
 
                         if (erroredEmails.length > 0) {
                             invitationsString = erroredEmails.length > 1 ? ' invitations: ' : ' invitation: ';
-                            message = 'Failed to send ' + erroredEmails.length + invitationsString;
+                            message = `Failed to send ${erroredEmails.length} ${invitationsString}`;
                             message += erroredEmails.join(', ');
                             notifications.showAlert(message, {type: 'error', delayed: successCount > 0, key: 'signup.send-invitations.failed'});
                         }
@@ -181,11 +187,11 @@ export default Ember.Controller.extend({
                         if (successCount > 0) {
                             // pluralize
                             invitationsString = successCount > 1 ? 'invitations' : 'invitation';
-                            notifications.showAlert(successCount + ' ' + invitationsString + ' sent!', {type: 'success', delayed: true, key: 'signup.send-invitations.success'});
+                            notifications.showAlert(`${successCount} ${invitationsString} sent!`, {type: 'success', delayed: true, key: 'signup.send-invitations.success'});
                         }
-                        self.send('loadServerNotifications');
-                        self.toggleProperty('submitting');
-                        self.transitionToRoute('posts.index');
+                        this.send('loadServerNotifications');
+                        this.toggleProperty('submitting');
+                        this.transitionToRoute('posts.index');
                     });
                 });
             } else if (users.length === 0) {
@@ -193,7 +199,7 @@ export default Ember.Controller.extend({
             }
         },
 
-        skipInvite: function () {
+        skipInvite() {
             this.send('loadServerNotifications');
             this.transitionToRoute('posts.index');
         }

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -2,53 +2,53 @@ import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 import {request as ajax} from 'ic-ajax';
 
-export default Ember.Controller.extend(ValidationEngine, {
+const {Controller, inject} = Ember;
+
+export default Controller.extend(ValidationEngine, {
     submitting: false,
     loggingIn: false,
     authProperties: ['identification', 'password'],
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
-    application: Ember.inject.controller(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
+    session: inject.service(),
+    application: inject.controller(),
     flowErrors: '',
 
     // ValidationEngine settings
     validationType: 'signin',
 
     actions: {
-        authenticate: function () {
-            var self = this,
-                model = this.get('model'),
-                authStrategy = 'authenticator:oauth2';
+        authenticate() {
+            let model = this.get('model');
+            let authStrategy = 'authenticator:oauth2';
 
             // Authentication transitions to posts.index, we can leave spinner running unless there is an error
-            this.get('session').authenticate(authStrategy, model.get('identification'), model.get('password')).catch(function (error) {
-                self.toggleProperty('loggingIn');
+            this.get('session').authenticate(authStrategy, model.get('identification'), model.get('password')).catch((error) => {
+                this.toggleProperty('loggingIn');
 
                 if (error && error.errors) {
-                    error.errors.forEach(function (err) {
+                    error.errors.forEach((err) => {
                         err.message = err.message.htmlSafe();
                     });
 
-                    self.set('flowErrors', error.errors[0].message.string);
+                    this.set('flowErrors', error.errors[0].message.string);
 
                     if (error.errors[0].message.string.match(/user with that email/)) {
-                        self.get('model.errors').add('identification', '');
+                        this.get('model.errors').add('identification', '');
                     }
 
                     if (error.errors[0].message.string.match(/password is incorrect/)) {
-                        self.get('model.errors').add('password', '');
+                        this.get('model.errors').add('password', '');
                     }
                 } else {
                     // Connection errors don't return proper status message, only req.body
-                    self.get('notifications').showAlert('There was a problem on the server.', {type: 'error', key: 'session.authenticate.failed'});
+                    this.get('notifications').showAlert('There was a problem on the server.', {type: 'error', key: 'session.authenticate.failed'});
                 }
             });
         },
 
-        validateAndAuthenticate: function () {
-            var self = this;
+        validateAndAuthenticate() {
             this.set('flowErrors', '');
             // Manually trigger events for input fields, ensuring legacy compatibility with
             // browsers and password managers that don't send proper events on autofill
@@ -56,56 +56,54 @@ export default Ember.Controller.extend(ValidationEngine, {
 
             // This is a bit dirty, but there's no other way to ensure the properties are set as well as 'signin'
             this.get('hasValidated').addObjects(this.authProperties);
-            this.validate({property: 'signin'}).then(function () {
-                self.toggleProperty('loggingIn');
-                self.send('authenticate');
-            }).catch(function (error) {
+            this.validate({property: 'signin'}).then(() => {
+                this.toggleProperty('loggingIn');
+                this.send('authenticate');
+            }).catch((error) => {
                 if (error) {
-                    self.get('notifications').showAPIError(error, {key: 'signin.authenticate'});
+                    this.get('notifications').showAPIError(error, {key: 'signin.authenticate'});
                 } else {
-                    self.set('flowErrors', 'Please fill out the form to sign in.');
+                    this.set('flowErrors', 'Please fill out the form to sign in.');
                 }
             });
         },
 
-        forgotten: function () {
-            var email = this.get('model.identification'),
-                notifications = this.get('notifications'),
-                self = this;
+        forgotten() {
+            let email = this.get('model.identification');
+            let notifications = this.get('notifications');
 
             this.set('flowErrors', '');
             // This is a bit dirty, but there's no other way to ensure the properties are set as well as 'forgotPassword'
             this.get('hasValidated').addObject('identification');
-            this.validate({property: 'forgotPassword'}).then(function () {
-                self.toggleProperty('submitting');
+            this.validate({property: 'forgotPassword'}).then(() => {
+                this.toggleProperty('submitting');
 
                 ajax({
-                    url: self.get('ghostPaths.url').api('authentication', 'passwordreset'),
+                    url: this.get('ghostPaths.url').api('authentication', 'passwordreset'),
                     type: 'POST',
                     data: {
-                        passwordreset: [{
-                            email: email
-                        }]
+                        passwordreset: [{email}]
                     }
-                }).then(function () {
-                    self.toggleProperty('submitting');
+                }).then(() => {
+                    this.toggleProperty('submitting');
                     notifications.showAlert('Please check your email for instructions.', {type: 'info', key: 'forgot-password.send.success'});
-                }).catch(function (resp) {
-                    self.toggleProperty('submitting');
+                }).catch((resp) => {
+                    this.toggleProperty('submitting');
                     if (resp && resp.jqXHR && resp.jqXHR.responseJSON && resp.jqXHR.responseJSON.errors) {
-                        var message = resp.jqXHR.responseJSON.errors[0].message;
+                        let [error] = resp.jqXHR.responseJSON.errors;
+                        let {message} = error;
 
-                        self.set('flowErrors', message);
+                        this.set('flowErrors', message);
 
                         if (message.match(/no user with that email/)) {
-                            self.get('model.errors').add('identification', '');
+                            this.get('model.errors').add('identification', '');
                         }
                     } else {
                         notifications.showAPIError(resp, {defaultErrorText: 'There was a problem with the reset, please try again.', key: 'forgot-password.send'});
                     }
                 });
-            }).catch(function () {
-                self.set('flowErrors', 'We need your email address to reset your password!');
+            }).catch(() => {
+                this.set('flowErrors', 'We need your email address to reset your password!');
             });
         }
     }

--- a/core/client/app/controllers/team/index.js
+++ b/core/client/app/controllers/team/index.js
@@ -1,17 +1,20 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
+const {Controller, computed, inject} = Ember;
+const {alias, filter} = computed;
 
-    session: Ember.inject.service(),
+export default Controller.extend({
 
-    users: Ember.computed.alias('model'),
+    session: inject.service(),
 
-    activeUsers: Ember.computed.filter('users', function (user) {
+    users: alias('model'),
+
+    activeUsers: filter('users', function (user) {
         return /^active|warn-[1-4]|locked$/.test(user.get('status'));
     }),
 
-    invitedUsers: Ember.computed.filter('users', function (user) {
-        var status = user.get('status');
+    invitedUsers: filter('users', function (user) {
+        let status = user.get('status');
 
         return status === 'invited' || status === 'invited-pending';
     })

--- a/core/client/app/helpers/gh-count-characters.js
+++ b/core/client/app/helpers/gh-count-characters.js
@@ -1,16 +1,15 @@
 import Ember from 'ember';
 
-export default Ember.Helper.helper(function (params) {
-    var el = document.createElement('span'),
-        length,
-        content;
+const {Helper} = Ember;
 
+export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
 
-    content = params[0] || '';
-    length = content.length;
+    let el = document.createElement('span');
+    let content = params[0] || '';
+    let {length} = content;
 
     el.className = 'word-count';
 

--- a/core/client/app/helpers/gh-count-down-characters.js
+++ b/core/client/app/helpers/gh-count-down-characters.js
@@ -1,17 +1,17 @@
 import Ember from 'ember';
 
-export default Ember.Helper.helper(function (params) {
-    var el = document.createElement('span'),
-        content,
-        maxCharacters,
-        length;
+const {Helper} = Ember;
 
+export default Helper.helper(function (params) {
     if (!params || params.length < 2) {
         return;
     }
 
-    content = params[0] || '';
-    maxCharacters = params[1];
+    let el = document.createElement('span');
+    let [content, maxCharacters] = params;
+    let length;
+
+    content = content || '';
     length = content.length;
 
     el.className = 'word-count';

--- a/core/client/app/helpers/gh-count-words.js
+++ b/core/client/app/helpers/gh-count-words.js
@@ -1,21 +1,20 @@
 import Ember from 'ember';
 import counter from 'ghost/utils/word-count';
 
-export default Ember.Helper.helper(function (params) {
+const {Helper} = Ember;
+
+export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
 
-    var markdown,
-        count;
-
-    markdown = params[0] || '';
+    let markdown = params[0] || '';
 
     if (/^\s*$/.test(markdown)) {
         return '0 words';
     }
 
-    count = counter(markdown);
+    let count = counter(markdown);
 
     return count + (count === 1 ? ' word' : ' words');
 });

--- a/core/client/app/helpers/gh-format-html.js
+++ b/core/client/app/helpers/gh-format-html.js
@@ -1,13 +1,15 @@
-import Ember from 'ember';
 /* global html_sanitize*/
+import Ember from 'ember';
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-export default Ember.Helper.helper(function (params) {
+const {Helper} = Ember;
+
+export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
 
-    var escapedhtml = params[0] || '';
+    let escapedhtml = params[0] || '';
 
     // replace script and iFrame
     escapedhtml = escapedhtml.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,

--- a/core/client/app/helpers/gh-format-markdown.js
+++ b/core/client/app/helpers/gh-format-markdown.js
@@ -1,16 +1,18 @@
-import Ember from 'ember';
 /* global Showdown, html_sanitize*/
+import Ember from 'ember';
 import cajaSanitizers from 'ghost/utils/caja-sanitizers';
 
-var showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
+const {Helper} = Ember;
 
-export default Ember.Helper.helper(function (params) {
+let showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
+
+export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
 
-    var escapedhtml = '',
-        markdown = params[0] || '';
+    let markdown = params[0] || '';
+    let escapedhtml = '';
 
     // convert markdown to HTML
     escapedhtml = showdown.makeHtml(markdown);

--- a/core/client/app/helpers/gh-format-timeago.js
+++ b/core/client/app/helpers/gh-format-timeago.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Helper.helper(function (params) {
+const {Helper} = Ember;
+
+export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
 
-    var timeago = params[0];
+    let [timeago] = params;
 
     return moment(timeago).fromNow();
     // stefanpenner says cool for small number of timeagos.

--- a/core/client/app/helpers/gh-path.js
+++ b/core/client/app/helpers/gh-path.js
@@ -8,10 +8,12 @@ import ghostPaths from 'ghost/utils/ghost-paths';
 // {{gh-path 'api'}} for Ghost's api root (/myblog/ghost/api/v0.1/)
 // {{gh-path 'admin' '/assets/hi.png'}} for resolved url (/myblog/ghost/assets/hi.png)
 
-export default Ember.Helper.helper(function (params) {
-    var base,
-        paths = ghostPaths(),
-        [path, url] = params;
+const {Helper} = Ember;
+
+export default Helper.helper(function (params) {
+    let paths = ghostPaths();
+    let [path, url] = params;
+    let base;
 
     if (!path) {
         path = 'blog';
@@ -39,7 +41,7 @@ export default Ember.Helper.helper(function (params) {
 
     // handle leading and trailing slashes
 
-    base = base[base.length - 1] !== '/' ? base + '/' : base;
+    base = base[base.length - 1] !== '/' ? `${base}/` : base;
 
     if (url && url.length > 0) {
         if (url[0] === '/') {

--- a/core/client/app/helpers/gh-user-can-admin.js
+++ b/core/client/app/helpers/gh-user-can-admin.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
+
+const {Helper} = Ember;
+
 // Handlebars Helper {{gh-user-can-admin}} group users by admin and owner using if, or group them author using unless
 // Usage: call helper as with aparameter of session.user
 // e.g - {{#if (gh-user-can-admin session.user)}} 'block content' {{/if}}
@@ -8,6 +11,6 @@ export function ghUserCanAdmin(params) {
     return !!(params[0].get('isOwner') || params[0].get('isAdmin'));
 }
 
-export default Ember.Helper.helper(function (params) {
+export default Helper.helper(function (params) {
     return ghUserCanAdmin(params);
 });

--- a/core/client/app/helpers/is-equal.js
+++ b/core/client/app/helpers/is-equal.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
+const {Helper} = Ember;
+
 export function isEqual(params) {
-    var [lhs, rhs] = params;
+    let [lhs, rhs] = params;
 
     return lhs === rhs;
 }
 
-export default Ember.Helper.helper(function (params) {
+export default Helper.helper(function (params) {
     return isEqual(params);
 });

--- a/core/client/app/helpers/is-not.js
+++ b/core/client/app/helpers/is-not.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
+const {Helper} = Ember;
+
 export function isNot(params) {
     return !params;
 }
 
-export default Ember.Helper.helper(function (params) {
+export default Helper.helper(function (params) {
     return isNot(params);
 });

--- a/core/client/app/helpers/read-path.js
+++ b/core/client/app/helpers/read-path.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export function readPath(params) {
-    var [obj, path] = params;
+const {Helper, get} = Ember;
 
-    return Ember.get(obj, path);
+export function readPath(params) {
+    let [obj, path] = params;
+
+    return get(obj, path);
 }
 
-export default Ember.Helper.helper(function (params) {
+export default Helper.helper(function (params) {
     return readPath(params);
 });

--- a/core/client/app/initializers/ember-simple-auth.js
+++ b/core/client/app/initializers/ember-simple-auth.js
@@ -6,8 +6,8 @@ import setupSessionService from 'ember-simple-auth/initializers/setup-session-se
 
 export default {
     name: 'ember-simple-auth',
-    initialize: function (registry) {
-        const config   = ENV['ember-simple-auth'] || {};
+    initialize(registry) {
+        let config   = ENV['ember-simple-auth'] || {};
         config.baseURL = ghostPaths().adminRoot;
         Configuration.load(config);
 

--- a/core/client/app/initializers/trailing-history.js
+++ b/core/client/app/initializers/trailing-history.js
@@ -1,17 +1,17 @@
 import Ember from 'ember';
 
-var trailingHistory = Ember.HistoryLocation.extend({
-    formatURL: function () {
-        // jscs: disable
+const {HistoryLocation} = Ember;
+
+let trailingHistory = HistoryLocation.extend({
+    formatURL() {
         return this._super.apply(this, arguments).replace(/\/?$/, '/');
-        // jscs: enable
     }
 });
 
 export default {
     name: 'registerTrailingLocationHistory',
 
-    initialize: function (registry, application) {
+    initialize(registry, application) {
         application.register('location:trailing-history', trailingHistory);
     }
 };

--- a/core/client/app/instance-initializers/oauth-prefilter.js
+++ b/core/client/app/instance-initializers/oauth-prefilter.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 
+const {merge} = Ember;
+
 export default {
     name: 'oauth-prefilter',
     after: 'ember-simple-auth',
 
-    initialize: function (application) {
-        var session = application.container.lookup('service:session');
+    initialize(application) {
+        let session = application.container.lookup('service:session');
 
         Ember.$.ajaxPrefilter(function (options) {
             session.authorize('authorizer:oauth2', function (headerName, headerValue) {
-                var headerObject = {};
+                let headerObject = {};
 
                 headerObject[headerName] = headerValue;
-                options.headers = Ember.merge(options.headers || {}, headerObject);
+                options.headers = merge(options.headers || {}, headerObject);
             });
         });
     }

--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -1,6 +1,7 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 
-let {isBlank} = Ember;
+const {isBlank} = Ember;
 
 function paginatedResponse(modelName, allModels, request) {
     let page = +request.queryParams.page || 1;
@@ -15,8 +16,8 @@ function paginatedResponse(modelName, allModels, request) {
     } else {
         limit = +limit;
 
-        let start = (page - 1) * limit,
-            end = start + limit;
+        let start = (page - 1) * limit;
+        let end = start + limit;
 
         models = allModels.slice(start, end);
         pages = Math.ceil(allModels.length / limit);
@@ -33,9 +34,9 @@ function paginatedResponse(modelName, allModels, request) {
     return {
         meta: {
             pagination: {
-                page: page,
-                limit: limit,
-                pages: pages,
+                page,
+                limit,
+                pages,
                 total: allModels.length,
                 next: next || null,
                 prev: prev || null
@@ -109,17 +110,17 @@ export default function () {
         let filters = request.queryParams.type.split(',');
         let settings = [];
 
-        filters.forEach(filter => {
+        filters.forEach((filter) => {
             settings.pushObjects(db.settings.where({type: filter}));
         });
 
         return {
+            settings,
             meta: {
                 filters: {
                     type: request.queryParams.type
                 }
-            },
-            settings: settings
+            }
         };
     });
 
@@ -194,7 +195,7 @@ export default function () {
         tag = db.tags.insert(attrs);
 
         return {
-            tag: tag
+            tag
         };
     });
 
@@ -210,12 +211,12 @@ export default function () {
         // TODO: remove post_count unless requested?
 
         return {
-            tag: tag
+            tag
         };
     });
 
     this.put('/tags/:id/', function (db, request) {
-        let id = request.params.id;
+        let {id} = request.params;
         let [attrs] = JSON.parse(request.requestBody).tags;
         let record = db.tags.update(id, attrs);
 

--- a/core/client/app/mirage/fixtures/roles.js
+++ b/core/client/app/mirage/fixtures/roles.js
@@ -1,3 +1,4 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 export default [
     {
         id: 1,

--- a/core/client/app/mirage/fixtures/settings.js
+++ b/core/client/app/mirage/fixtures/settings.js
@@ -1,3 +1,4 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 export default [
     {
         created_at: '2015-09-11T09:44:30.805Z',

--- a/core/client/app/mixins/body-event-listener.js
+++ b/core/client/app/mixins/body-event-listener.js
@@ -1,45 +1,49 @@
 import Ember from 'ember';
 
+const {Mixin, run} = Ember;
+
+function K() {
+    return this;
+}
+
 // Code modified from Addepar/ember-widgets
 // https://github.com/Addepar/ember-widgets/blob/master/src/mixins.coffee#L39
 
-export default Ember.Mixin.create({
+export default Mixin.create({
     bodyElementSelector: 'html',
-    bodyClick: Ember.K,
+    bodyClick: K,
 
-    init: function () {
-        this._super();
+    init() {
+        this._super(...arguments);
 
-        return Ember.run.next(this, this._setupDocumentHandlers);
+        return run.next(this, this._setupDocumentHandlers);
     },
 
-    willDestroy: function () {
-        this._super();
+    willDestroy() {
+        this._super(...arguments);
 
         return this._removeDocumentHandlers();
     },
 
-    _setupDocumentHandlers: function () {
+    _setupDocumentHandlers() {
         if (this._clickHandler) {
             return;
         }
 
-        var self = this;
-
-        this._clickHandler = function () {
-            return self.bodyClick();
+        this._clickHandler = () => {
+            return this.bodyClick();
         };
 
         return $(this.get('bodyElementSelector')).on('click', this._clickHandler);
     },
 
-    _removeDocumentHandlers: function () {
+    _removeDocumentHandlers() {
         $(this.get('bodyElementSelector')).off('click', this._clickHandler);
         this._clickHandler = null;
     },
 
     // http://stackoverflow.com/questions/152975/how-to-detect-a-click-outside-an-element
-    click: function (event) {
+    click(event) {
         return event.stopPropagation();
     }
 });

--- a/core/client/app/mixins/current-user-settings.js
+++ b/core/client/app/mixins/current-user-settings.js
@@ -1,24 +1,22 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
-    transitionAuthor: function () {
-        var self = this;
+const {Mixin} = Ember;
 
-        return function (user) {
+export default Mixin.create({
+    transitionAuthor() {
+        return (user) => {
             if (user.get('isAuthor')) {
-                return self.transitionTo('team.user', user);
+                return this.transitionTo('team.user', user);
             }
 
             return user;
         };
     },
 
-    transitionEditor: function () {
-        var self = this;
-
-        return function (user) {
+    transitionEditor() {
+        return (user) => {
             if (user.get('isEditor')) {
-                return self.transitionTo('team');
+                return this.transitionTo('team');
             }
 
             return user;

--- a/core/client/app/mixins/dropdown-mixin.js
+++ b/core/client/app/mixins/dropdown-mixin.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
+
+const {Evented, Mixin} = Ember;
+
 /*
   Dropdowns and their buttons are evented and do not propagate clicks.
 */
-export default Ember.Mixin.create(Ember.Evented, {
+export default Mixin.create(Evented, {
     classNameBindings: ['isOpen:open:closed'],
     isOpen: false,
 
-    click: function (event) {
+    click(event) {
         this._super(event);
 
         return event.stopPropagation();

--- a/core/client/app/mixins/ed-editor-api.js
+++ b/core/client/app/mixins/ed-editor-api.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+const {Mixin} = Ember;
+
+export default Mixin.create({
     /**
      * Get Value
      *
@@ -8,7 +10,7 @@ export default Ember.Mixin.create({
      *
      * @returns {String}
      */
-    getValue: function () {
+    getValue() {
         return this.$().val();
     },
 
@@ -19,7 +21,7 @@ export default Ember.Mixin.create({
      *
      * @returns {Selection}
      */
-    getSelection: function () {
+    getSelection() {
         return this.$().getSelection();
     },
 
@@ -29,10 +31,10 @@ export default Ember.Mixin.create({
      * Fetch the string of characters from the start of the given line up to the cursor
      * @returns {{text: string, start: number}}
      */
-    getLineToCursor: function () {
-        var selection = this.$().getSelection(),
-            value = this.getValue(),
-            lineStart;
+    getLineToCursor() {
+        let selection = this.$().getSelection();
+        let value = this.getValue();
+        let lineStart;
 
         // Normalise newlines
         value = value.replace('\r\n', '\n');
@@ -53,10 +55,10 @@ export default Ember.Mixin.create({
      *
      * @returns {{text: string, start: number, end: number}}
      */
-    getLine: function () {
-        var selection = this.$().getSelection(),
-            value = this.getValue(),
-            lineStart,
+    getLine() {
+        let selection = this.$().getSelection();
+        let value = this.getValue();
+        let lineStart,
             lineEnd;
 
         // Normalise newlines
@@ -84,8 +86,8 @@ export default Ember.Mixin.create({
      * @param {number} start
      * @param {number} end
      */
-    setSelection: function (start, end) {
-        var $textarea = this.$();
+    setSelection(start, end) {
+        let $textarea = this.$();
 
         if (start === 'end') {
             start = $textarea.val().length;
@@ -108,8 +110,8 @@ export default Ember.Mixin.create({
      * Providing selectionStart only will cause the cursor to be placed there, or alternatively a range can be selected
      * by providing selectionEnd.
      */
-    replaceSelection: function (replacement, replacementStart, replacementEnd, cursorPosition) {
-        var $textarea = this.$();
+    replaceSelection(replacement, replacementStart, replacementEnd, cursorPosition) {
+        let $textarea = this.$();
 
         cursorPosition = cursorPosition || 'collapseToEnd';
         replacementEnd = replacementEnd || replacementStart;

--- a/core/client/app/mixins/ed-editor-scroll.js
+++ b/core/client/app/mixins/ed-editor-scroll.js
@@ -1,21 +1,21 @@
 import Ember from 'ember';
 import setScrollClassName from 'ghost/utils/set-scroll-classname';
 
-export default Ember.Mixin.create({
+const {Mixin, run} = Ember;
+
+export default Mixin.create({
     /**
      * Determine if the cursor is at the end of the textarea
      */
-    isCursorAtEnd: function () {
-        var selection = this.$().getSelection(),
-            value = this.getValue(),
-            linesAtEnd = 3,
-            stringAfterCursor,
-            match;
+    isCursorAtEnd() {
+        let selection = this.$().getSelection();
+        let value = this.getValue();
+        let linesAtEnd = 3;
+        let match,
+            stringAfterCursor;
 
         stringAfterCursor = value.substring(selection.end);
-        /* jscs: disable */
         match = stringAfterCursor.match(/\n/g);
-        /* jscs: enable */
 
         if (!match || match.length < linesAtEnd) {
             return true;
@@ -27,9 +27,9 @@ export default Ember.Mixin.create({
     /**
      * Build an object that represents the scroll state
      */
-    getScrollInfo: function () {
-        var scroller = this.get('element'),
-            scrollInfo = {
+    getScrollInfo() {
+        let scroller = this.get('element');
+        let scrollInfo = {
                 top: scroller.scrollTop,
                 height: scroller.scrollHeight,
                 clientHeight: scroller.clientHeight,
@@ -44,10 +44,11 @@ export default Ember.Mixin.create({
     /**
      * Calculate if we're within scrollInfo.padding of the end of the document, and scroll the rest of the way
      */
-    adjustScrollPosition: function () {
+    adjustScrollPosition() {
         // If we're receiving change events from the end of the document, i.e the user is typing-at-the-end, update the
         // scroll position to ensure both panels stay in view and in sync
-        var scrollInfo = this.getScrollInfo();
+        let scrollInfo = this.getScrollInfo();
+
         if (scrollInfo.isCursorAtEnd && (scrollInfo.diff >= scrollInfo.top) &&
             (scrollInfo.diff < scrollInfo.top + scrollInfo.padding)) {
             scrollInfo.top += scrollInfo.padding;
@@ -59,8 +60,8 @@ export default Ember.Mixin.create({
     /**
      * Send the scrollInfo for scrollEvents to the view so that the preview pane can be synced
      */
-    scrollHandler: function () {
-        this.set('scrollThrottle', Ember.run.throttle(this, function () {
+    scrollHandler() {
+        this.set('scrollThrottle', run.throttle(this, () => {
             this.sendAction('updateScrollInfo', this.getScrollInfo());
         }, 10));
     },
@@ -68,13 +69,13 @@ export default Ember.Mixin.create({
     /**
      * once the element is in the DOM bind to the events which control scroll behaviour
      */
-    attachScrollHandlers: function () {
-        var $el = this.$();
+    attachScrollHandlers() {
+        let $el = this.$();
 
-        $el.on('keypress', Ember.run.bind(this, this.adjustScrollPosition));
+        $el.on('keypress', run.bind(this, this.adjustScrollPosition));
 
-        $el.on('scroll', Ember.run.bind(this, this.scrollHandler));
-        $el.on('scroll', Ember.run.bind($el, setScrollClassName, {
+        $el.on('scroll', run.bind(this, this.scrollHandler));
+        $el.on('scroll', run.bind($el, setScrollClassName, {
             target: Ember.$('.js-entry-markdown'),
             offset: 10
         }));
@@ -83,20 +84,20 @@ export default Ember.Mixin.create({
     /**
      * once the element has been removed from the DOM unbind from the events which control scroll behaviour
      */
-    detachScrollHandlers: function () {
+    detachScrollHandlers() {
         this.$().off('keypress');
         this.$().off('scroll');
-        Ember.run.cancel(this.get('scrollThrottle'));
+        run.cancel(this.get('scrollThrottle'));
     },
 
-    didInsertElement: function () {
-        this._super();
+    didInsertElement() {
+        this._super(...arguments);
 
         this.attachScrollHandlers();
     },
 
-    willDestroyElement: function () {
-        this._super();
+    willDestroyElement() {
+        this._super(...arguments);
 
         this.detachScrollHandlers();
     }

--- a/core/client/app/mixins/ed-editor-shortcuts.js
+++ b/core/client/app/mixins/ed-editor-shortcuts.js
@@ -2,12 +2,11 @@
 import Ember from 'ember';
 import titleize from 'ghost/utils/titleize';
 
-var simpleShortcutSyntax,
-    shortcuts;
+const {Mixin} = Ember;
 
 // Used for simple, noncomputational replace-and-go! shortcuts.
 // See default case in shortcut function below.
-simpleShortcutSyntax = {
+let simpleShortcutSyntax = {
     bold: {
         regex: '**|**',
         cursor: '|'
@@ -46,10 +45,10 @@ simpleShortcutSyntax = {
     }
 };
 
-shortcuts = {
-    simple: function (type, replacement, selection, line) {
-        var shortcut,
-            startIndex = 0;
+let shortcuts = {
+    simple(type, replacement, selection, line) {
+        let startIndex = 0;
+        let shortcut;
 
         if (simpleShortcutSyntax.hasOwnProperty(type)) {
             shortcut = simpleShortcutSyntax[type];
@@ -59,7 +58,7 @@ shortcuts = {
             // add a newline if needed
             if (shortcut.newline && line.text !== '') {
                 startIndex = 1;
-                replacement.text = '\n' + replacement.text;
+                replacement.text = `\n${replacement.text}`;
             }
 
             // handle cursor position
@@ -77,11 +76,10 @@ shortcuts = {
 
         return replacement;
     },
-    cycleHeaderLevel: function (replacement, line) {
-        // jscs:disable
-        var match = line.text.match(/^#+/),
-        // jscs:enable
-            currentHeaderLevel,
+
+    cycleHeaderLevel(replacement, line) {
+        let match = line.text.match(/^#+/);
+        let currentHeaderLevel,
             hashPrefix;
 
         if (!match) {
@@ -96,18 +94,17 @@ shortcuts = {
 
         hashPrefix = new Array(currentHeaderLevel + 2).join('#');
 
-        // jscs:disable
-        replacement.text = hashPrefix + ' ' + line.text.replace(/^#* /, '');
-        // jscs:enable
+        replacement.text = `${hashPrefix} ${line.text.replace(/^#* /, '')}`;
 
         replacement.start = line.start;
         replacement.end = line.end;
 
         return replacement;
     },
-    copyHTML: function (editor, selection) {
-        var converter = new Showdown.converter(),
-            generatedHTML;
+
+    copyHTML(editor, selection) {
+        let converter = new Showdown.converter();
+        let generatedHTML;
 
         if (selection.text) {
             generatedHTML = converter.makeHtml(selection.text);
@@ -116,34 +113,38 @@ shortcuts = {
         }
 
         // Talk to the editor
-        editor.sendAction('openModal', 'copy-html', {generatedHTML: generatedHTML});
+        editor.sendAction('openModal', 'copy-html', {generatedHTML});
     },
-    currentDate: function (replacement) {
+
+    currentDate(replacement) {
         replacement.text = moment(new Date()).format('D MMMM YYYY');
         return replacement;
     },
-    uppercase: function (replacement, selection) {
+
+    uppercase(replacement, selection) {
         replacement.text = selection.text.toLocaleUpperCase();
         return replacement;
     },
-    lowercase: function (replacement, selection) {
+
+    lowercase(replacement, selection) {
         replacement.text = selection.text.toLocaleLowerCase();
         return replacement;
     },
-    titlecase: function (replacement, selection) {
+
+    titlecase(replacement, selection) {
         replacement.text = titleize(selection.text);
         return replacement;
     }
 };
 
-export default Ember.Mixin.create({
-    shortcut: function (type) {
-        var selection = this.getSelection(),
-            replacement = {
-                start: selection.start,
-                end: selection.end,
-                position: 'collapseToEnd'
-            };
+export default Mixin.create({
+    shortcut(type) {
+        let selection = this.getSelection();
+        let replacement = {
+            start: selection.start,
+            end: selection.end,
+            position: 'collapseToEnd'
+        };
 
         switch (type) {
             // This shortcut is special as it needs to send an action

--- a/core/client/app/mixins/editor-base-route.js
+++ b/core/client/app/mixins/editor-base-route.js
@@ -3,48 +3,50 @@ import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
 import styleBody from 'ghost/mixins/style-body';
 import editorShortcuts from 'ghost/utils/editor-shortcuts';
 
-export default Ember.Mixin.create(styleBody, ShortcutsRoute, {
+const {Mixin, RSVP, run} = Ember;
+
+export default Mixin.create(styleBody, ShortcutsRoute, {
     classNames: ['editor'],
 
     actions: {
-        save: function () {
+        save() {
             this.get('controller').send('save');
         },
 
-        publish: function () {
-            var controller = this.get('controller');
+        publish() {
+            let controller = this.get('controller');
 
             controller.send('setSaveType', 'publish');
             controller.send('save');
         },
 
-        toggleZenMode: function () {
+        toggleZenMode() {
             Ember.$('body').toggleClass('zen');
         },
 
         // The actual functionality is implemented in utils/ed-editor-shortcuts
-        editorShortcut: function (options) {
+        editorShortcut(options) {
             // Only fire editor shortcuts when the editor has focus.
             if (this.get('controller.editor').$().is(':focus')) {
                 this.get('controller.editor').shortcut(options.type);
             }
         },
 
-        willTransition: function (transition) {
-            var controller = this.get('controller'),
-                scratch = controller.get('model.scratch'),
-                controllerIsDirty = controller.get('hasDirtyAttributes'),
-                model = controller.get('model'),
-                state = model.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew'),
-                fromNewToEdit,
-                deletedWithoutChanges;
+        willTransition(transition) {
+            let controller = this.get('controller');
+            let scratch = controller.get('model.scratch');
+            let controllerIsDirty = controller.get('hasDirtyAttributes');
+            let model = controller.get('model');
+            let state = model.getProperties('isDeleted', 'isSaving', 'hasDirtyAttributes', 'isNew');
+            let deletedWithoutChanges,
+                fromNewToEdit;
 
             // if a save is in-flight we don't know whether or not it's safe to leave
             // so we abort the transition and retry after the save has completed.
             if (state.isSaving) {
                 transition.abort();
-                return Ember.run.later(this, function () {
-                    Ember.RSVP.resolve(controller.get('lastPromise')).then(function () {
+                return run.later(this, function () {
+                    RSVP.resolve(controller.get('lastPromise')).then(() => {
                         transition.retry();
                     });
                 }, 100);
@@ -85,19 +87,19 @@ export default Ember.Mixin.create(styleBody, ShortcutsRoute, {
         }
     },
 
-    renderTemplate: function (controller, model) {
+    renderTemplate(controller, model) {
         this._super(controller, model);
 
         this.render('post-settings-menu', {
+            model,
             into: 'application',
-            outlet: 'settings-menu',
-            model: model
+            outlet: 'settings-menu'
         });
     },
 
     shortcuts: editorShortcuts,
 
-    attachModelHooks: function (controller, model) {
+    attachModelHooks(controller, model) {
         // this will allow us to track when the model is saved and update the controller
         // so that we can be sure controller.hasDirtyAttributes is correct, without having to update the
         // controller on each instance of `model.save()`.
@@ -112,17 +114,18 @@ export default Ember.Mixin.create(styleBody, ShortcutsRoute, {
         model.on('didUpdate', controller, controller.get('modelSaved'));
     },
 
-    detachModelHooks: function (controller, model) {
+    detachModelHooks(controller, model) {
         model.off('didCreate', controller, controller.get('modelSaved'));
         model.off('didUpdate', controller, controller.get('modelSaved'));
     },
 
-    setupController: function (controller, model) {
+    setupController(controller, model) {
+        let tags = model.get('tags');
+
         model.set('scratch', model.get('markdown'));
         model.set('titleScratch', model.get('title'));
 
         this._super(controller, model);
-        var tags = model.get('tags');
 
         if (tags) {
             // used to check if anything has changed in the editor

--- a/core/client/app/mixins/infinite-scroll.js
+++ b/core/client/app/mixins/infinite-scroll.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+const {Mixin, run} = Ember;
+
+export default Mixin.create({
     isLoading: false,
     triggerPoint: 100,
 
@@ -8,10 +10,10 @@ export default Ember.Mixin.create({
      * Determines if we are past a scroll point where we need to fetch the next page
      * @param {object} event The scroll event
      */
-    checkScroll: function (event) {
-        var element = event.target,
-            triggerPoint = this.get('triggerPoint'),
-            isLoading = this.get('isLoading');
+    checkScroll(event) {
+        let element = event.target;
+        let triggerPoint = this.get('triggerPoint');
+        let isLoading = this.get('isLoading');
 
         // If we haven't passed our threshold or we are already fetching content, exit
         if (isLoading || (element.scrollTop + element.clientHeight + triggerPoint <= element.scrollHeight)) {
@@ -21,17 +23,17 @@ export default Ember.Mixin.create({
         this.sendAction('fetch');
     },
 
-    didInsertElement: function () {
-        var el = this.get('element');
+    didInsertElement() {
+        let el = this.get('element');
 
-        el.onscroll = Ember.run.bind(this, this.checkScroll);
+        el.onscroll = run.bind(this, this.checkScroll);
 
         if (el.scrollHeight <= el.clientHeight) {
             this.sendAction('fetch');
         }
     },
 
-    willDestroyElement: function () {
+    willDestroyElement() {
         // turn off the scroll handler
         this.get('element').onscroll = null;
     }

--- a/core/client/app/mixins/pagination-route.js
+++ b/core/client/app/mixins/pagination-route.js
@@ -1,21 +1,23 @@
 import Ember from 'ember';
 import getRequestErrorMessage from 'ghost/utils/ajax';
 
-var defaultPaginationSettings = {
+const {Mixin, inject} = Ember;
+
+let defaultPaginationSettings = {
     page: 1,
     limit: 15
 };
 
-export default Ember.Mixin.create({
-    notifications: Ember.inject.service(),
+export default Mixin.create({
+    notifications: inject.service(),
 
     paginationModel: null,
     paginationSettings: null,
     paginationMeta: null,
 
-    init: function () {
-        var paginationSettings = this.get('paginationSettings'),
-            settings = Ember.$.extend({}, defaultPaginationSettings, paginationSettings);
+    init() {
+        let paginationSettings = this.get('paginationSettings');
+        let settings = Ember.$.extend({}, defaultPaginationSettings, paginationSettings);
 
         this._super(...arguments);
         this.set('paginationSettings', settings);
@@ -27,12 +29,12 @@ export default Ember.Mixin.create({
      * @param {jqXHR} response The jQuery ajax reponse object.
      * @return
      */
-    reportLoadError: function (response) {
-        var message = 'A problem was encountered while loading more records';
+    reportLoadError(response) {
+        let message = 'A problem was encountered while loading more records';
 
         if (response) {
             // Get message from response
-            message += ': ' + getRequestErrorMessage(response, true);
+            message += `: ${getRequestErrorMessage(response, true)}`;
         } else {
             message += '.';
         }
@@ -40,23 +42,22 @@ export default Ember.Mixin.create({
         this.get('notifications').showAlert(message, {type: 'error', key: 'pagination.load.failed'});
     },
 
-    loadFirstPage: function () {
-        var paginationSettings = this.get('paginationSettings'),
-            modelName = this.get('paginationModel'),
-            self = this;
+    loadFirstPage() {
+        let paginationSettings = this.get('paginationSettings');
+        let modelName = this.get('paginationModel');
 
         paginationSettings.page = 1;
 
-        return this.get('store').query(modelName, paginationSettings).then(function (results) {
-            self.set('paginationMeta', results.meta);
+        return this.get('store').query(modelName, paginationSettings).then((results) => {
+            this.set('paginationMeta', results.meta);
             return results;
-        }, function (response) {
-            self.reportLoadError(response);
+        }, (response) => {
+            this.reportLoadError(response);
         });
     },
 
     actions: {
-        loadFirstPage: function () {
+        loadFirstPage() {
             return this.loadFirstPage();
         },
 
@@ -64,29 +65,28 @@ export default Ember.Mixin.create({
          * Loads the next paginated page of posts into the ember-data store. Will cause the posts list UI to update.
          * @return
          */
-        loadNextPage: function () {
-            var self = this,
-                store = this.get('store'),
-                modelName = this.get('paginationModel'),
-                metadata = this.get('paginationMeta'),
-                nextPage = metadata.pagination && metadata.pagination.next,
-                paginationSettings = this.get('paginationSettings');
+        loadNextPage() {
+            let store = this.get('store');
+            let modelName = this.get('paginationModel');
+            let metadata = this.get('paginationMeta');
+            let nextPage = metadata.pagination && metadata.pagination.next;
+            let paginationSettings = this.get('paginationSettings');
 
             if (nextPage) {
                 this.set('isLoading', true);
                 this.set('paginationSettings.page', nextPage);
 
-                store.query(modelName, paginationSettings).then(function (results) {
-                    self.set('isLoading', false);
-                    self.set('paginationMeta', results.meta);
+                store.query(modelName, paginationSettings).then((results) => {
+                    this.set('isLoading', false);
+                    this.set('paginationMeta', results.meta);
                     return results;
-                }, function (response) {
-                    self.reportLoadError(response);
+                }, (response) => {
+                    this.reportLoadError(response);
                 });
             }
         },
 
-        resetPagination: function () {
+        resetPagination() {
             this.set('paginationSettings.page', 1);
         }
     }

--- a/core/client/app/mixins/settings-menu-controller.js
+++ b/core/client/app/mixins/settings-menu-controller.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
-    application: Ember.inject.controller(),
+const {Mixin, computed, inject} = Ember;
 
-    isViewingSubview: Ember.computed('application.showSettingsMenu', {
-        get: function () {
+export default Mixin.create({
+    application: inject.controller(),
+
+    isViewingSubview: computed('application.showSettingsMenu', {
+        get() {
             return false;
         },
-        set: function (key, value) {
+        set(key, value) {
             // Not viewing a subview if we can't even see the PSM
             if (!this.get('application.showSettingsMenu')) {
                 return false;
@@ -17,11 +19,11 @@ export default Ember.Mixin.create({
     }),
 
     actions: {
-        showSubview: function () {
+        showSubview() {
             this.set('isViewingSubview', true);
         },
 
-        closeSubview: function () {
+        closeSubview() {
             this.set('isViewingSubview', false);
         }
     }

--- a/core/client/app/mixins/settings-save.js
+++ b/core/client/app/mixins/settings-save.js
@@ -1,16 +1,16 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+const {Mixin} = Ember;
+
+export default Mixin.create({
     submitting: false,
 
     actions: {
-        save: function () {
-            var self = this;
-
+        save() {
             this.set('submitting', true);
 
-            this.save().then(function () {
-                self.set('submitting', false);
+            this.save().then(() => {
+                this.set('submitting', false);
             });
         }
     }

--- a/core/client/app/mixins/shortcuts-route.js
+++ b/core/client/app/mixins/shortcuts-route.js
@@ -1,5 +1,7 @@
-import Ember from 'ember';
 /* global key */
+import Ember from 'ember';
+
+const {Mixin, run, typeOf} = Ember;
 
 // Configure KeyMaster to respond to all shortcuts,
 // even inside of
@@ -42,46 +44,45 @@ key.setScope('default');
  * To have all your shortcut work in all scopes, give it the scope "all".
  * Find out more at the keymaster docs
  */
-export default Ember.Mixin.create({
-    registerShortcuts: function () {
-        var self = this,
-            shortcuts = this.get('shortcuts');
+export default Mixin.create({
+    registerShortcuts() {
+        let shortcuts = this.get('shortcuts');
 
-        Object.keys(shortcuts).forEach(function (shortcut) {
-            var scope = shortcuts[shortcut].scope || 'default',
-                action = shortcuts[shortcut],
-                options;
+        Object.keys(shortcuts).forEach((shortcut) => {
+            let scope = shortcuts[shortcut].scope || 'default';
+            let action = shortcuts[shortcut];
+            let options;
 
-            if (Ember.typeOf(action) !== 'string') {
+            if (typeOf(action) !== 'string') {
                 options = action.options;
                 action = action.action;
             }
 
-            key(shortcut, scope, function (event) {
+            key(shortcut, scope, (event) => {
                 // stop things like ctrl+s from actually opening a save dialogue
                 event.preventDefault();
-                Ember.run(self, function () {
+                run(this, function () {
                     this.send(action, options);
                 });
             });
         });
     },
 
-    removeShortcuts: function () {
-        var shortcuts = this.get('shortcuts');
+    removeShortcuts() {
+        let shortcuts = this.get('shortcuts');
 
-        Object.keys(shortcuts).forEach(function (shortcut) {
-            var scope = shortcuts[shortcut].scope || 'default';
+        Object.keys(shortcuts).forEach((shortcut) => {
+            let scope = shortcuts[shortcut].scope || 'default';
             key.unbind(shortcut, scope);
         });
     },
 
-    activate: function () {
+    activate() {
         this._super();
         this.registerShortcuts();
     },
 
-    deactivate: function () {
+    deactivate() {
         this._super();
         this.removeShortcuts();
     }

--- a/core/client/app/mixins/slug-url.js
+++ b/core/client/app/mixins/slug-url.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 const {isBlank} = Ember;
 
 export default Ember.Mixin.create({
-    buildURL: function (_modelName, _id, _snapshot, _requestType, query) {
+    buildURL(_modelName, _id, _snapshot, _requestType, query) {
         let url = this._super(...arguments);
 
         if (query && !isBlank(query.slug)) {

--- a/core/client/app/mixins/style-body.js
+++ b/core/client/app/mixins/style-body.js
@@ -1,28 +1,30 @@
 import Ember from 'ember';
+
+const {Mixin, run} = Ember;
+
 // mixin used for routes that need to set a css className on the body tag
+export default Mixin.create({
+    activate() {
+        let cssClasses = this.get('classNames');
 
-export default Ember.Mixin.create({
-    activate: function () {
-        this._super();
-
-        var cssClasses = this.get('classNames');
+        this._super(...arguments);
 
         if (cssClasses) {
-            Ember.run.schedule('afterRender', null, function () {
-                cssClasses.forEach(function (curClass) {
+            run.schedule('afterRender', null, function () {
+                cssClasses.forEach((curClass) => {
                     Ember.$('body').addClass(curClass);
                 });
             });
         }
     },
 
-    deactivate: function () {
-        this._super();
+    deactivate() {
+        let cssClasses = this.get('classNames');
 
-        var cssClasses = this.get('classNames');
+        this._super(...arguments);
 
-        Ember.run.schedule('afterRender', null, function () {
-            cssClasses.forEach(function (curClass) {
+        run.schedule('afterRender', null, function () {
+            cssClasses.forEach((curClass) => {
                 Ember.$('body').removeClass(curClass);
             });
         });

--- a/core/client/app/mixins/text-input.js
+++ b/core/client/app/mixins/text-input.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+const {Mixin} = Ember;
+
+export default Mixin.create({
     selectOnClick: false,
     stopEnterKeyDownPropagation: false,
 
-    click: function (event) {
+    click(event) {
         if (this.get('selectOnClick')) {
             event.currentTarget.select();
         }
     },
 
-    keyDown: function (event) {
+    keyDown(event) {
         // stop event propagation when pressing "enter"
         // most useful in the case when undesired (global) keyboard shortcuts are getting triggered while interacting
         // with this particular input element.

--- a/core/client/app/mixins/validation-engine.js
+++ b/core/client/app/mixins/validation-engine.js
@@ -13,6 +13,10 @@ import UserValidator from 'ghost/validators/user';
 import TagSettingsValidator from 'ghost/validators/tag-settings';
 import NavItemValidator from 'ghost/validators/nav-item';
 
+const {Mixin, RSVP, isArray} = Ember;
+const {Errors, Model} = DS;
+const emberA = Ember.A;
+
 // our extensions to the validator library
 ValidatorExtensions.init();
 
@@ -21,7 +25,7 @@ ValidatorExtensions.init();
 * It will be able to validate any properties on itself (or the model it passes to validate())
 * with the use of a declared validator.
 */
-export default Ember.Mixin.create({
+export default Mixin.create({
     // these validators can be passed a model to validate when the class that
     // mixes in the ValidationEngine declares a validationType equal to a key on this object.
     // the model is either passed in via `this.validate({ model: object })`
@@ -42,11 +46,11 @@ export default Ember.Mixin.create({
 
     // This adds the Errors object to the validation engine, and shouldn't affect
     // ember-data models because they essentially use the same thing
-    errors: DS.Errors.create(),
+    errors: Errors.create(),
 
     // Store whether a property has been validated yet, so that we know whether or not
     // to show error / success validation for a field
-    hasValidated: Ember.A(),
+    hasValidated: emberA(),
 
     /**
     * Passes the model to the validator specified by validationType.
@@ -60,34 +64,33 @@ export default Ember.Mixin.create({
     * 					   no property is specified, the entire model will be
     * 					   validated
     */
-    validate: function (opts) {
-        // jscs:disable safeContextKeyword
-        opts = opts || {};
-
-        var model = this,
+    validate(opts) {
+        let model = this;
+        let hasValidated,
             type,
-            validator,
-            hasValidated;
+            validator;
+
+        opts = opts || {};
 
         if (opts.model) {
             model = opts.model;
-        } else if (this instanceof DS.Model) {
+        } else if (this instanceof Model) {
             model = this;
         } else if (this.get('model')) {
             model = this.get('model');
         }
 
         type = this.get('validationType') || model.get('validationType');
-        validator = this.get('validators.' + type) || model.get('validators.' + type);
+        validator = this.get(`validators.${type}`) || model.get(`validators.${type}`);
         hasValidated = this.get('hasValidated');
 
         opts.validationType = type;
 
-        return new Ember.RSVP.Promise(function (resolve, reject) {
-            var passed;
+        return new RSVP.Promise((resolve, reject) => {
+            let passed;
 
             if (!type || !validator) {
-                return reject(['The validator specified, "' + type + '", did not exist!']);
+                return reject([`The validator specified, "${type}", did not exist!`]);
             }
 
             if (opts.property) {
@@ -109,11 +112,10 @@ export default Ember.Mixin.create({
     * This allows us to run validation before actually trying to save the model to the server.
     * You can supply options to be passed into the `validate` method, since the ED `save` method takes no options.
     */
-    save: function (options) {
-        var self = this,
-            // this is a hack, but needed for async _super calls.
-            // ref: https://github.com/emberjs/ember.js/pull/4301
-            _super = this.__nextSuper;
+    save(options) {
+        // this is a hack, but needed for async _super calls.
+        // ref: https://github.com/emberjs/ember.js/pull/4301
+        let _super = this.__nextSuper;
 
         options = options || {};
         options.wasSave = true;
@@ -122,26 +124,27 @@ export default Ember.Mixin.create({
         // in that case, we don't need validation checks or error propagation,
         // because the model itself is being destroyed.
         if (this.get('isDeleted')) {
-            return this._super();
+            return this._super(...arguments);
         }
 
         // If validation fails, reject with validation errors.
         // If save to the server fails, reject with server response.
-        return this.validate(options).then(function () {
-            return _super.call(self, options);
-        }).catch(function (result) {
+        return this.validate(options).then(() => {
+            return _super.call(this, options);
+        }).catch((result) => {
             // server save failed or validator type doesn't exist
-            if (result && !Ember.isArray(result)) {
+            if (result && !isArray(result)) {
                 // return the array of errors from the server
                 result = getRequestErrorMessage(result);
             }
 
-            return Ember.RSVP.reject(result);
+            return RSVP.reject(result);
         });
     },
+
     actions: {
-        validate: function (property) {
-            this.validate({property: property});
+        validate(property) {
+            this.validate({property});
         }
     }
 });

--- a/core/client/app/mixins/validation-state.js
+++ b/core/client/app/mixins/validation-state.js
@@ -1,18 +1,21 @@
 import Ember from 'ember';
 
-export default Ember.Mixin.create({
+const {Mixin, computed, isEmpty} = Ember;
+const emberA = Ember.A;
+
+export default Mixin.create({
 
     errors: null,
     property: '',
-    hasValidated: Ember.A(),
+    hasValidated: emberA(),
 
-    hasError: Ember.computed('errors.[]', 'property', 'hasValidated.[]', function () {
-        var property = this.get('property'),
-            errors = this.get('errors'),
-            hasValidated = this.get('hasValidated');
+    hasError: computed('errors.[]', 'property', 'hasValidated.[]', function () {
+        let property = this.get('property');
+        let errors = this.get('errors');
+        let hasValidated = this.get('hasValidated');
 
         // if we aren't looking at a specific property we always want an error class
-        if (!property && !Ember.isEmpty(errors)) {
+        if (!property && !isEmpty(errors)) {
             return true;
         }
 

--- a/core/client/app/models/notification.js
+++ b/core/client/app/models/notification.js
@@ -1,8 +1,10 @@
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-    dismissible: DS.attr('boolean'),
-    status: DS.attr('string'),
-    type: DS.attr('string'),
-    message: DS.attr('string')
+const {Model, attr} = DS;
+
+export default Model.extend({
+    dismissible: attr('boolean'),
+    status: attr('string'),
+    type: attr('string'),
+    message: attr('string')
 });

--- a/core/client/app/models/post.js
+++ b/core/client/app/models/post.js
@@ -1,49 +1,54 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default DS.Model.extend(ValidationEngine, {
+const {computed, inject} = Ember;
+const {equal} = computed;
+const {Model, attr, belongsTo, hasMany} = DS;
+
+export default Model.extend(ValidationEngine, {
     validationType: 'post',
 
-    uuid: DS.attr('string'),
-    title: DS.attr('string', {defaultValue: ''}),
-    slug: DS.attr('string'),
-    markdown: DS.attr('string', {defaultValue: ''}),
-    html: DS.attr('string'),
-    image: DS.attr('string'),
-    featured: DS.attr('boolean', {defaultValue: false}),
-    page: DS.attr('boolean', {defaultValue: false}),
-    status: DS.attr('string', {defaultValue: 'draft'}),
-    language: DS.attr('string', {defaultValue: 'en_US'}),
-    meta_title: DS.attr('string'),
-    meta_description: DS.attr('string'),
-    author: DS.belongsTo('user', {async: true}),
-    author_id: DS.attr('number'),
-    updated_at: DS.attr('moment-date'),
-    updated_by: DS.attr(),
-    published_at: DS.attr('moment-date'),
-    published_by: DS.belongsTo('user', {async: true}),
-    created_at: DS.attr('moment-date'),
-    created_by: DS.attr(),
-    tags: DS.hasMany('tag', {
+    uuid: attr('string'),
+    title: attr('string', {defaultValue: ''}),
+    slug: attr('string'),
+    markdown: attr('string', {defaultValue: ''}),
+    html: attr('string'),
+    image: attr('string'),
+    featured: attr('boolean', {defaultValue: false}),
+    page: attr('boolean', {defaultValue: false}),
+    status: attr('string', {defaultValue: 'draft'}),
+    language: attr('string', {defaultValue: 'en_US'}),
+    meta_title: attr('string'),
+    meta_description: attr('string'),
+    author: belongsTo('user', {async: true}),
+    author_id: attr('number'),
+    updated_at: attr('moment-date'),
+    updated_by: attr(),
+    published_at: attr('moment-date'),
+    published_by: belongsTo('user', {async: true}),
+    created_at: attr('moment-date'),
+    created_by: attr(),
+    tags: hasMany('tag', {
         embedded: 'always',
         async: false
     }),
-    url: DS.attr('string'),
+    url: attr('string'),
 
-    config: Ember.inject.service(),
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    config: inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
 
-    absoluteUrl: Ember.computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
-        var blogUrl = this.get('config.blogUrl'),
-            postUrl = this.get('url');
+    absoluteUrl: computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
+        let blogUrl = this.get('config.blogUrl');
+        let postUrl = this.get('url');
         return this.get('ghostPaths.url').join(blogUrl, postUrl);
     }),
 
-    previewUrl: Ember.computed('uuid', 'ghostPaths.url', 'config.blogUrl', 'config.routeKeywords.preview', function () {
-        var blogUrl = this.get('config.blogUrl'),
-            uuid = this.get('uuid'),
-            previewKeyword = this.get('config.routeKeywords.preview');
+    previewUrl: computed('uuid', 'ghostPaths.url', 'config.blogUrl', 'config.routeKeywords.preview', function () {
+        let blogUrl = this.get('config.blogUrl');
+        let uuid = this.get('uuid');
+        let previewKeyword = this.get('config.routeKeywords.preview');
         // New posts don't have a preview
         if (!uuid) {
             return '';
@@ -56,22 +61,22 @@ export default DS.Model.extend(ValidationEngine, {
 
     // Computed post properties
 
-    isPublished: Ember.computed.equal('status', 'published'),
-    isDraft: Ember.computed.equal('status', 'draft'),
+    isPublished: equal('status', 'published'),
+    isDraft: equal('status', 'draft'),
 
     // remove client-generated tags, which have `id: null`.
     // Ember Data won't recognize/update them automatically
     // when returned from the server with ids.
     // https://github.com/emberjs/data/issues/1829
-    updateTags: function () {
-        var tags = this.get('tags'),
-            oldTags = tags.filterBy('id', null);
+    updateTags() {
+        let tags = this.get('tags');
+        let oldTags = tags.filterBy('id', null);
 
         tags.removeObjects(oldTags);
         oldTags.invoke('deleteRecord');
     },
 
-    isAuthoredByUser: function (user) {
+    isAuthoredByUser(user) {
         return parseInt(user.get('id'), 10) === parseInt(this.get('author_id'), 10);
     }
 

--- a/core/client/app/models/role.js
+++ b/core/client/app/models/role.js
@@ -1,16 +1,20 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default DS.Model.extend({
-    uuid: DS.attr('string'),
-    name: DS.attr('string'),
-    description: DS.attr('string'),
-    created_at: DS.attr('moment-date'),
-    updated_at: DS.attr('moment-date'),
-    created_by: DS.attr(),
-    updated_by: DS.attr(),
+const {computed} = Ember;
+const {Model, attr} = DS;
 
-    lowerCaseName: Ember.computed('name', function () {
+export default Model.extend({
+    uuid: attr('string'),
+    name: attr('string'),
+    description: attr('string'),
+    created_at: attr('moment-date'),
+    updated_at: attr('moment-date'),
+    created_by: attr(),
+    updated_by: attr(),
+
+    lowerCaseName: computed('name', function () {
         return this.get('name').toLocaleLowerCase();
     })
 });

--- a/core/client/app/models/setting.js
+++ b/core/client/app/models/setting.js
@@ -1,23 +1,26 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default DS.Model.extend(ValidationEngine, {
+const {Model, attr} = DS;
+
+export default Model.extend(ValidationEngine, {
     validationType: 'setting',
 
-    title: DS.attr('string'),
-    description: DS.attr('string'),
-    logo: DS.attr('string'),
-    cover: DS.attr('string'),
-    defaultLang: DS.attr('string'),
-    postsPerPage: DS.attr('number'),
-    forceI18n: DS.attr('boolean'),
-    permalinks: DS.attr('string'),
-    activeTheme: DS.attr('string'),
-    availableThemes: DS.attr(),
-    ghost_head: DS.attr('string'),
-    ghost_foot: DS.attr('string'),
-    labs: DS.attr('string'),
-    navigation: DS.attr('string'),
-    isPrivate: DS.attr('boolean'),
-    password: DS.attr('string')
+    title: attr('string'),
+    description: attr('string'),
+    logo: attr('string'),
+    cover: attr('string'),
+    defaultLang: attr('string'),
+    postsPerPage: attr('number'),
+    forceI18n: attr('boolean'),
+    permalinks: attr('string'),
+    activeTheme: attr('string'),
+    availableThemes: attr(),
+    ghost_head: attr('string'),
+    ghost_foot: attr('string'),
+    labs: attr('string'),
+    navigation: attr('string'),
+    isPrivate: attr('boolean'),
+    password: attr('string')
 });

--- a/core/client/app/models/slug-generator.js
+++ b/core/client/app/models/slug-generator.js
@@ -1,32 +1,34 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
+const {RSVP, inject} = Ember;
+
 export default Ember.Object.extend({
     slugType: null,
     value: null,
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    ghostPaths: inject.service('ghost-paths'),
 
-    toString: function () {
+    toString() {
         return this.get('value');
     },
 
-    generateSlug: function (textToSlugify) {
-        var self = this,
-            url;
+    generateSlug(textToSlugify) {
+        let url;
 
         if (!textToSlugify) {
-            return Ember.RSVP.resolve('');
+            return RSVP.resolve('');
         }
 
         url = this.get('ghostPaths.url').api('slugs', this.get('slugType'), encodeURIComponent(textToSlugify));
 
         return ajax(url, {
             type: 'GET'
-        }).then(function (response) {
-            var slug = response.slugs[0].slug;
+        }).then((response) => {
+            let [firstSlug] = response.slugs;
+            let {slug} = firstSlug;
 
-            self.set('value', slug);
+            this.set('value', slug);
 
             return slug;
         });

--- a/core/client/app/models/tag.js
+++ b/core/client/app/models/tag.js
@@ -1,21 +1,24 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default DS.Model.extend(ValidationEngine, {
+const {Model, attr} = DS;
+
+export default Model.extend(ValidationEngine, {
     validationType: 'tag',
 
-    uuid: DS.attr('string'),
-    name: DS.attr('string'),
-    slug: DS.attr('string'),
-    description: DS.attr('string'),
-    parent: DS.attr(),
-    meta_title: DS.attr('string'),
-    meta_description: DS.attr('string'),
-    image: DS.attr('string'),
-    hidden: DS.attr('boolean'),
-    created_at: DS.attr('moment-date'),
-    updated_at: DS.attr('moment-date'),
-    created_by: DS.attr(),
-    updated_by: DS.attr(),
-    count: DS.attr('raw')
+    uuid: attr('string'),
+    name: attr('string'),
+    slug: attr('string'),
+    description: attr('string'),
+    parent: attr(),
+    meta_title: attr('string'),
+    meta_description: attr('string'),
+    image: attr('string'),
+    hidden: attr('boolean'),
+    created_at: attr('moment-date'),
+    updated_at: attr('moment-date'),
+    created_by: attr(),
+    updated_by: attr(),
+    count: attr('raw')
 });

--- a/core/client/app/models/user.js
+++ b/core/client/app/models/user.js
@@ -1,42 +1,80 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import DS from 'ember-data';
 import {request as ajax} from 'ic-ajax';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-export default DS.Model.extend(ValidationEngine, {
+const {computed, inject} = Ember;
+const {equal, empty} = computed;
+const {Model, attr, hasMany} = DS;
+
+export default Model.extend(ValidationEngine, {
     validationType: 'user',
 
-    uuid: DS.attr('string'),
-    name: DS.attr('string'),
-    slug: DS.attr('string'),
-    email: DS.attr('string'),
-    image: DS.attr('string'),
-    cover: DS.attr('string'),
-    bio: DS.attr('string'),
-    website: DS.attr('string'),
-    location: DS.attr('string'),
-    accessibility: DS.attr('string'),
-    status: DS.attr('string'),
-    language: DS.attr('string', {defaultValue: 'en_US'}),
-    meta_title: DS.attr('string'),
-    meta_description: DS.attr('string'),
-    last_login: DS.attr('moment-date'),
-    created_at: DS.attr('moment-date'),
-    created_by: DS.attr('number'),
-    updated_at: DS.attr('moment-date'),
-    updated_by: DS.attr('number'),
-    roles: DS.hasMany('role', {
+    uuid: attr('string'),
+    name: attr('string'),
+    slug: attr('string'),
+    email: attr('string'),
+    image: attr('string'),
+    cover: attr('string'),
+    bio: attr('string'),
+    website: attr('string'),
+    location: attr('string'),
+    accessibility: attr('string'),
+    status: attr('string'),
+    language: attr('string', {defaultValue: 'en_US'}),
+    meta_title: attr('string'),
+    meta_description: attr('string'),
+    last_login: attr('moment-date'),
+    created_at: attr('moment-date'),
+    created_by: attr('number'),
+    updated_at: attr('moment-date'),
+    updated_by: attr('number'),
+    roles: hasMany('role', {
         embedded: 'always',
         async: false
     }),
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    ghostPaths: inject.service('ghost-paths'),
 
-    role: Ember.computed('roles', {
-        get: function () {
+    // TODO: Once client-side permissions are in place,
+    // remove the hard role check.
+    isAuthor: equal('role.name', 'Author'),
+    isEditor: equal('role.name', 'Editor'),
+    isAdmin: equal('role.name', 'Administrator'),
+    isOwner: equal('role.name', 'Owner'),
+
+    isPasswordValid: empty('passwordValidationErrors.[]'),
+
+    active: computed('status', function () {
+        return ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'].indexOf(this.get('status')) > -1;
+    }),
+
+    invited: computed('status', function () {
+        return ['invited', 'invited-pending'].indexOf(this.get('status')) > -1;
+    }),
+
+    pending: equal('status', 'invited-pending').property('status'),
+
+    passwordValidationErrors: computed('password', 'newPassword', 'ne2Password', function () {
+        let validationErrors = [];
+
+        if (!validator.equals(this.get('newPassword'), this.get('ne2Password'))) {
+            validationErrors.push({message: 'Your new passwords do not match'});
+        }
+
+        if (!validator.isLength(this.get('newPassword'), 8)) {
+            validationErrors.push({message: 'Your password is not long enough. It must be at least 8 characters long.'});
+        }
+
+        return validationErrors;
+    }),
+
+    role: computed('roles', {
+        get() {
             return this.get('roles.firstObject');
         },
-        set: function (key, value) {
+        set(key, value) {
             // Only one role per user, so remove any old data.
             this.get('roles').clear();
             this.get('roles').pushObject(value);
@@ -45,15 +83,8 @@ export default DS.Model.extend(ValidationEngine, {
         }
     }),
 
-    // TODO: Once client-side permissions are in place,
-    // remove the hard role check.
-    isAuthor: Ember.computed.equal('role.name', 'Author'),
-    isEditor: Ember.computed.equal('role.name', 'Editor'),
-    isAdmin: Ember.computed.equal('role.name', 'Administrator'),
-    isOwner: Ember.computed.equal('role.name', 'Owner'),
-
-    saveNewPassword: function () {
-        var url = this.get('ghostPaths.url').api('users', 'password');
+    saveNewPassword() {
+        let url = this.get('ghostPaths.url').api('users', 'password');
 
         return ajax(url, {
             type: 'PUT',
@@ -68,43 +99,17 @@ export default DS.Model.extend(ValidationEngine, {
         });
     },
 
-    resendInvite: function () {
-        var fullUserData = this.toJSON(),
-            userData = {
-                email: fullUserData.email,
-                roles: fullUserData.roles
-            };
+    resendInvite() {
+        let fullUserData = this.toJSON();
+        let userData = {
+            email: fullUserData.email,
+            roles: fullUserData.roles
+        };
 
         return ajax(this.get('ghostPaths.url').api('users'), {
             type: 'POST',
             data: JSON.stringify({users: [userData]}),
             contentType: 'application/json'
         });
-    },
-
-    passwordValidationErrors: Ember.computed('password', 'newPassword', 'ne2Password', function () {
-        var validationErrors = [];
-
-        if (!validator.equals(this.get('newPassword'), this.get('ne2Password'))) {
-            validationErrors.push({message: 'Your new passwords do not match'});
-        }
-
-        if (!validator.isLength(this.get('newPassword'), 8)) {
-            validationErrors.push({message: 'Your password is not long enough. It must be at least 8 characters long.'});
-        }
-
-        return validationErrors;
-    }),
-
-    isPasswordValid: Ember.computed.empty('passwordValidationErrors.[]'),
-
-    active: Ember.computed('status', function () {
-        return ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'].indexOf(this.get('status')) > -1;
-    }),
-
-    invited: Ember.computed('status', function () {
-        return ['invited', 'invited-pending'].indexOf(this.get('status')) > -1;
-    }),
-
-    pending: Ember.computed.equal('status', 'invited-pending').property('status')
+    }
 });

--- a/core/client/app/router.js
+++ b/core/client/app/router.js
@@ -3,13 +3,15 @@ import ghostPaths from 'ghost/utils/ghost-paths';
 import documentTitle from 'ghost/utils/document-title';
 import config from './config/environment';
 
-var Router = Ember.Router.extend({
+const {inject, on} = Ember;
+
+let Router = Ember.Router.extend({
     location: config.locationType, // use HTML5 History API instead of hash-tag based URLs
     rootURL: ghostPaths().adminRoot, // admin interface lives under sub-directory /ghost
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    displayDelayedNotifications: Ember.on('didTransition', function () {
+    displayDelayedNotifications: on('didTransition', function () {
         this.get('notifications').displayDelayed();
     })
 });

--- a/core/client/app/routes/about.js
+++ b/core/client/app/routes/about.js
@@ -3,32 +3,33 @@ import {request as ajax} from 'ic-ajax';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import styleBody from 'ghost/mixins/style-body';
 
+const {inject} = Ember;
+
 export default AuthenticatedRoute.extend(styleBody, {
     titleToken: 'About',
 
     classNames: ['view-about'],
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
+    ghostPaths: inject.service('ghost-paths'),
 
     cachedConfig: false,
 
-    model: function () {
-        var cachedConfig = this.get('cachedConfig'),
-            self = this;
+    model() {
+        let cachedConfig = this.get('cachedConfig');
 
         if (cachedConfig) {
             return cachedConfig;
         }
 
         return ajax(this.get('ghostPaths.url').api('configuration'))
-            .then(function (configurationResponse) {
-                var configKeyValues = configurationResponse.configuration;
+            .then((configurationResponse) => {
+                let configKeyValues = configurationResponse.configuration;
 
                 cachedConfig = {};
-                configKeyValues.forEach(function (configKeyValue) {
+                configKeyValues.forEach((configKeyValue) => {
                     cachedConfig[configKeyValue.key] = configKeyValue.value;
                 });
-                self.set('cachedConfig', cachedConfig);
+                this.set('cachedConfig', cachedConfig);
 
                 return cachedConfig;
             });

--- a/core/client/app/routes/authenticated.js
+++ b/core/client/app/routes/authenticated.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 
-export default Ember.Route.extend(AuthenticatedRouteMixin);
+const {Route} = Ember;
+
+export default Route.extend(AuthenticatedRouteMixin);

--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -1,3 +1,4 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import base from 'ghost/mixins/editor-base-route';
 import isNumber from 'ghost/utils/isNumber';
@@ -6,21 +7,20 @@ import isFinite from 'ghost/utils/isFinite';
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
-    beforeModel: function (transition) {
+    beforeModel(transition) {
         this.set('_transitionedFromNew', transition.data.fromNew);
 
         this._super(...arguments);
     },
 
-    model: function (params) {
-        var self = this,
-            postId,
+    model(params) {
+        let postId,
             query;
 
         postId = Number(params.post_id);
 
         if (!isNumber(postId) || !isFinite(postId) || postId % 1 !== 0 || postId <= 0) {
-            return this.transitionTo('error404', 'editor/' + params.post_id);
+            return this.transitionTo('error404', `editor/${params.post_id}`);
         }
 
         query = {
@@ -29,35 +29,33 @@ export default AuthenticatedRoute.extend(base, {
             staticPages: 'all'
         };
 
-        return self.store.query('post', query).then(function (records) {
-            var post = records.get('firstObject');
+        return this.store.query('post', query).then((records) => {
+            let post = records.get('firstObject');
 
             if (post) {
                 return post;
             }
 
-            return self.replaceRoute('posts.index');
+            return this.replaceRoute('posts.index');
         });
     },
 
-    afterModel: function (post) {
-        var self = this;
-
-        return self.get('session.user').then(function (user) {
+    afterModel(post) {
+        return this.get('session.user').then((user) => {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
-                return self.replaceRoute('posts.index');
+                return this.replaceRoute('posts.index');
             }
         });
     },
 
-    setupController: function (controller/*, model */) {
+    setupController(controller) {
         this._super(...arguments);
 
         controller.set('shouldFocusEditor', this.get('_transitionedFromNew'));
     },
 
     actions: {
-        authorizationFailed: function () {
+        authorizationFailed() {
             this.send('openModal', 'signin');
         }
     }

--- a/core/client/app/routes/editor/index.js
+++ b/core/client/app/routes/editor/index.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
-    beforeModel: function () {
+const {Route} = Ember;
+
+export default Route.extend({
+    beforeModel() {
         this.transitionTo('editor.new');
     }
 });

--- a/core/client/app/routes/editor/new.js
+++ b/core/client/app/routes/editor/new.js
@@ -4,30 +4,29 @@ import base from 'ghost/mixins/editor-base-route';
 export default AuthenticatedRoute.extend(base, {
     titleToken: 'Editor',
 
-    model: function () {
-        var self = this;
-        return this.get('session.user').then(function (user) {
-            return self.store.createRecord('post', {
+    model() {
+        return this.get('session.user').then((user) => {
+            return this.store.createRecord('post', {
                 author: user
             });
         });
     },
 
-    renderTemplate: function (controller, model) {
+    renderTemplate(controller, model) {
         this.render('editor/edit', {
-            controller: controller,
-            model: model
+            controller,
+            model
         });
 
         this.render('post-settings-menu', {
+            model,
             into: 'application',
-            outlet: 'settings-menu',
-            model: model
+            outlet: 'settings-menu'
         });
     },
 
-    setupController: function (controller, model) {
-        var psm = this.controllerFor('post-settings-menu');
+    setupController(controller, model) {
+        let psm = this.controllerFor('post-settings-menu');
 
         // make sure there are no titleObserver functions hanging around
         // from previous posts
@@ -41,7 +40,7 @@ export default AuthenticatedRoute.extend(base, {
     },
 
     actions: {
-        willTransition: function (transition) {
+        willTransition(transition) {
             // decorate the transition object so the editor.edit route
             // knows this was the previous active route
             transition.data.fromNew = true;

--- a/core/client/app/routes/error404.js
+++ b/core/client/app/routes/error404.js
@@ -1,11 +1,13 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
+const {Route} = Ember;
+
+export default Route.extend({
     controllerName: 'error',
     templateName: 'error',
     titleToken: 'Error',
 
-    model: function () {
+    model() {
         return {
             status: 404
         };

--- a/core/client/app/routes/mobile-index-route.js
+++ b/core/client/app/routes/mobile-index-route.js
@@ -1,28 +1,29 @@
 import Ember from 'ember';
 
+const {Route, addObserver, inject, removeObserver} = Ember;
+
 // Routes that extend MobileIndexRoute need to implement
 // desktopTransition, a function which is called when
 // the user resizes to desktop levels.
-export default Ember.Route.extend({
+export default Route.extend({
     desktopTransition: Ember.K,
     _callDesktopTransition: null,
 
-    mediaQueries: Ember.inject.service(),
+    mediaQueries: inject.service(),
 
-    activate: function () {
+    activate() {
         this._callDesktopTransition = () => {
             if (!this.get('mediaQueries.isMobile')) {
                 this.desktopTransition();
             }
         };
-        Ember.addObserver(this, 'mediaQueries.isMobile', this._callDesktopTransition);
+        addObserver(this, 'mediaQueries.isMobile', this._callDesktopTransition);
     },
 
-    deactivate: function () {
+    deactivate() {
         if (this._callDesktopTransition) {
-            Ember.removeObserver(this, 'mediaQueries.isMobile', this._callDesktopTransition);
+            removeObserver(this, 'mediaQueries.isMobile', this._callDesktopTransition);
             this._callDesktopTransition = null;
         }
     }
-
 });

--- a/core/client/app/routes/posts.js
+++ b/core/client/app/routes/posts.js
@@ -12,20 +12,19 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
         staticPages: 'all'
     },
 
-    model: function () {
-        var paginationSettings = this.get('paginationSettings'),
-            self = this;
+    model() {
+        let paginationSettings = this.get('paginationSettings');
 
-        return this.get('session.user').then(function (user) {
+        return this.get('session.user').then((user) => {
             if (user.get('isAuthor')) {
                 paginationSettings.filter = paginationSettings.filter ?
                     `${paginationSettings.filter}+author:${user.get('slug')}` : `author:${user.get('slug')}`;
             }
 
-            return self.loadFirstPage().then(function () {
+            return this.loadFirstPage().then(() => {
                 // using `.filter` allows the template to auto-update when new models are pulled in from the server.
                 // we just need to 'return true' to allow all models by default.
-                return self.store.filter('post', function (post) {
+                return this.store.filter('post', (post) => {
                     if (user.get('isAuthor')) {
                         return post.isAuthoredByUser(user);
                     }
@@ -36,13 +35,11 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
         });
     },
 
-    stepThroughPosts: function (step) {
-        var currentPost = this.get('controller.currentPost'),
-            posts = this.get('controller.sortedPosts'),
-            length = posts.get('length'),
-            newPosition;
-
-        newPosition = posts.indexOf(currentPost) + step;
+    stepThroughPosts(step) {
+        let currentPost = this.get('controller.currentPost');
+        let posts = this.get('controller.sortedPosts');
+        let length = posts.get('length');
+        let newPosition = posts.indexOf(currentPost) + step;
 
         // if we are on the first or last item
         // just do nothing (desired behavior is to not
@@ -56,9 +53,9 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
         this.transitionTo('posts.post', posts.objectAt(newPosition));
     },
 
-    scrollContent: function (amount) {
-        var content = Ember.$('.js-content-preview'),
-            scrolled = content.scrollTop();
+    scrollContent(amount) {
+        let content = Ember.$('.js-content-preview');
+        let scrolled = content.scrollTop();
 
         content.scrollTop(scrolled + 50 * amount);
     },
@@ -72,17 +69,19 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
     },
 
     actions: {
-        focusList: function () {
+        focusList() {
             this.controller.set('keyboardFocus', 'postList');
         },
-        focusContent: function () {
+
+        focusContent() {
             this.controller.set('keyboardFocus', 'postContent');
         },
-        newPost: function () {
+
+        newPost() {
             this.transitionTo('editor.new');
         },
 
-        moveUp: function () {
+        moveUp() {
             if (this.controller.get('postContentFocused')) {
                 this.scrollContent(-1);
             } else {
@@ -90,7 +89,7 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
             }
         },
 
-        moveDown: function () {
+        moveDown() {
             if (this.controller.get('postContentFocused')) {
                 this.scrollContent(1);
             } else {

--- a/core/client/app/routes/posts/index.js
+++ b/core/client/app/routes/posts/index.js
@@ -2,30 +2,32 @@ import Ember from 'ember';
 import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import MobileIndexRoute from 'ghost/routes/mobile-index-route';
 
+const {computed, inject} = Ember;
+const {reads} = computed;
+
 export default MobileIndexRoute.extend(AuthenticatedRouteMixin, {
     noPosts: false,
 
-    mediaQueries: Ember.inject.service(),
-    isMobile: Ember.computed.reads('mediaQueries.isMobile'),
+    mediaQueries: inject.service(),
+    isMobile: reads('mediaQueries.isMobile'),
 
     // Transition to a specific post if we're not on mobile
-    beforeModel: function () {
+    beforeModel() {
         if (!this.get('isMobile')) {
             return this.goToPost();
         }
     },
 
-    setupController: function (controller) {
+    setupController(controller) {
         controller.set('noPosts', this.get('noPosts'));
     },
 
-    goToPost: function () {
-        var self = this,
-            // the store has been populated by PostsRoute
-            posts = this.store.peekAll('post'),
-            post;
+    goToPost() {
+        // the store has been populated by PostsRoute
+        let posts = this.store.peekAll('post');
+        let post;
 
-        return this.get('session.user').then(function (user) {
+        return this.get('session.user').then((user) => {
             post = posts.find(function (post) {
                 // Authors can only see posts they've written
                 if (user.get('isAuthor')) {
@@ -36,15 +38,15 @@ export default MobileIndexRoute.extend(AuthenticatedRouteMixin, {
             });
 
             if (post) {
-                return self.transitionTo('posts.post', post);
+                return this.transitionTo('posts.post', post);
             }
 
-            self.set('noPosts', true);
+            this.set('noPosts', true);
         });
     },
 
     // Mobile posts route callback
-    desktopTransition: function () {
+    desktopTransition() {
         this.goToPost();
     }
 });

--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -4,17 +4,18 @@ import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
 export default AuthenticatedRoute.extend(ShortcutsRoute, {
-    model: function (params) {
-        var self = this,
-            post,
+    model(params) {
+        let post,
             postId,
             query;
 
+        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
         postId = Number(params.post_id);
 
         if (!isNumber(postId) || !isFinite(postId) || postId % 1 !== 0 || postId <= 0) {
             return this.transitionTo('error404', params.post_id);
         }
+        /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
 
         post = this.store.peekRecord('post', postId);
         if (post) {
@@ -27,26 +28,24 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             staticPages: 'all'
         };
 
-        return self.store.queryRecord('post', query).then(function (post) {
+        return this.store.queryRecord('post', query).then((post) => {
             if (post) {
                 return post;
             }
 
-            return self.replaceRoute('posts.index');
+            return this.replaceRoute('posts.index');
         });
     },
 
-    afterModel: function (post) {
-        var self = this;
-
-        return self.get('session.user').then(function (user) {
+    afterModel(post) {
+        return this.get('session.user').then((user) => {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
-                return self.replaceRoute('posts.index');
+                return this.replaceRoute('posts.index');
             }
         });
     },
 
-    setupController: function (controller, model) {
+    setupController(controller, model) {
         this._super(controller, model);
 
         this.controllerFor('posts').set('currentPost', model);
@@ -58,7 +57,7 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
     },
 
     actions: {
-        openEditor: function (post) {
+        openEditor(post) {
             post = post || this.get('controller.model');
 
             if (!post) {
@@ -68,7 +67,7 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             this.transitionTo('editor.edit', post.get('id'));
         },
 
-        deletePost: function () {
+        deletePost() {
             this.send('openModal', 'delete-post', this.get('controller.model'));
         }
     }

--- a/core/client/app/routes/reset.js
+++ b/core/client/app/routes/reset.js
@@ -2,26 +2,28 @@ import Ember from 'ember';
 import Configuration from 'ember-simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 
-export default Ember.Route.extend(styleBody, {
+const {Route, inject} = Ember;
+
+export default Route.extend(styleBody, {
     classNames: ['ghost-reset'],
 
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
+    notifications: inject.service(),
+    session: inject.service(),
 
-    beforeModel: function () {
+    beforeModel() {
         if (this.get('session.isAuthenticated')) {
             this.get('notifications').showAlert('You can\'t reset your password while you\'re signed in.', {type: 'warn', delayed: true, key: 'password.reset.signed-in'});
             this.transitionTo(Configuration.routeAfterAuthentication);
         }
     },
 
-    setupController: function (controller, params) {
+    setupController(controller, params) {
         controller.token = params.token;
     },
 
     // Clear out any sensitive information
-    deactivate: function () {
-        this._super();
+    deactivate() {
+        this._super(...arguments);
         this.controller.clearData();
     }
 });

--- a/core/client/app/routes/settings/code-injection.js
+++ b/core/client/app/routes/settings/code-injection.js
@@ -6,21 +6,21 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Code Injection',
     classNames: ['settings-view-code'],
 
-    beforeModel: function (transition) {
+    beforeModel(transition) {
         this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },
 
-    model: function () {
-        return this.store.query('setting', {type: 'blog,theme'}).then(function (records) {
+    model() {
+        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
             return records.get('firstObject');
         });
     },
 
     actions: {
-        save: function () {
+        save() {
             this.get('controller').send('save');
         }
     }

--- a/core/client/app/routes/settings/general.js
+++ b/core/client/app/routes/settings/general.js
@@ -7,21 +7,21 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['settings-view-general'],
 
-    beforeModel: function (transition) {
+    beforeModel(transition) {
         this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },
 
-    model: function () {
-        return this.store.query('setting', {type: 'blog,theme,private'}).then(function (records) {
+    model() {
+        return this.store.query('setting', {type: 'blog,theme,private'}).then((records) => {
             return records.get('firstObject');
         });
     },
 
     actions: {
-        save: function () {
+        save() {
             this.get('controller').send('save');
         }
     }

--- a/core/client/app/routes/settings/labs.js
+++ b/core/client/app/routes/settings/labs.js
@@ -7,15 +7,15 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['settings'],
 
-    beforeModel: function (transition) {
+    beforeModel(transition) {
         this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor())
             .then(this.transitionEditor());
     },
 
-    model: function () {
-        return this.store.query('setting', {type: 'blog,theme'}).then(function (records) {
+    model() {
+        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
             return records.get('firstObject');
         });
     }

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -7,20 +7,20 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['settings-view-navigation'],
 
-    beforeModel: function (transition) {
+    beforeModel(transition) {
         this._super(transition);
         return this.get('session.user')
             .then(this.transitionAuthor());
     },
 
-    model: function () {
-        return this.store.query('setting', {type: 'blog,theme'}).then(function (records) {
+    model() {
+        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
             return records.get('firstObject');
         });
     },
 
     actions: {
-        save: function () {
+        save() {
             // since shortcuts are run on the route, we have to signal to the components
             // on the page that we're about to save.
             $('.page-actions .btn-blue').focus();
@@ -28,7 +28,7 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
             this.get('controller').send('save');
         },
 
-        willTransition: function () {
+        willTransition() {
             // reset the model so that our CPs re-calc and unsaved changes aren't
             // persisted across transitions
             this.set('controller.model', null);

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -21,14 +21,14 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
         c: 'newTag'
     },
 
-    beforeModel: function () {
+    beforeModel() {
         this._super(...arguments);
 
         return this.get('session.user')
             .then(this.transitionAuthor());
     },
 
-    model: function () {
+    model() {
         this.store.unloadAll('tag');
 
         return this.loadFirstPage().then(() => {
@@ -38,14 +38,14 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
         });
     },
 
-    deactivate: function () {
+    deactivate() {
         this.send('resetPagination');
     },
 
-    stepThroughTags: function (step) {
-        let currentTag = this.modelFor('settings.tags.tag'),
-            tags = this.get('controller.tags'),
-            length = tags.get('length');
+    stepThroughTags(step) {
+        let currentTag = this.modelFor('settings.tags.tag');
+        let tags = this.get('controller.tags');
+        let length = tags.get('length');
 
         if (currentTag && length) {
             let newPosition = tags.indexOf(currentTag) + step;
@@ -60,15 +60,15 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
         }
     },
 
-    scrollContent: function (amount) {
-        let content = Ember.$('.tag-settings-pane'),
-            scrolled = content.scrollTop();
+    scrollContent(amount) {
+        let content = Ember.$('.tag-settings-pane');
+        let scrolled = content.scrollTop();
 
         content.scrollTop(scrolled + 50 * amount);
     },
 
     actions: {
-        moveUp: function () {
+        moveUp() {
             if (this.controller.get('tagContentFocused')) {
                 this.scrollContent(-1);
             } else {
@@ -76,7 +76,7 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
             }
         },
 
-        moveDown: function () {
+        moveDown() {
             if (this.controller.get('tagContentFocused')) {
                 this.scrollContent(1);
             } else {
@@ -84,15 +84,15 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
             }
         },
 
-        focusList: function () {
+        focusList() {
             this.set('controller.keyboardFocus', 'tagList');
         },
 
-        focusContent: function () {
+        focusContent() {
             this.set('controller.keyboardFocus', 'tagContent');
         },
 
-        newTag: function () {
+        newTag() {
             this.transitionTo('settings.tags.new');
         }
     }

--- a/core/client/app/routes/settings/tags/index.js
+++ b/core/client/app/routes/settings/tags/index.js
@@ -1,15 +1,16 @@
 import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 
+const {inject} = Ember;
+
 export default AuthenticatedRoute.extend({
 
-    mediaQueries: Ember.inject.service(),
+    mediaQueries: inject.service(),
 
-    beforeModel: function () {
+    beforeModel() {
         let firstTag = this.modelFor('settings.tags').get('firstObject');
         if (firstTag && !this.get('mediaQueries.maxWidth600')) {
             this.transitionTo('settings.tags.tag', firstTag);
         }
     }
-
 });

--- a/core/client/app/routes/settings/tags/new.js
+++ b/core/client/app/routes/settings/tags/new.js
@@ -4,16 +4,16 @@ export default AuthenticatedRoute.extend({
 
     controllerName: 'settings.tags.tag',
 
-    model: function () {
+    model() {
         return this.store.createRecord('tag');
     },
 
-    renderTemplate: function () {
+    renderTemplate() {
         this.render('settings.tags.tag');
     },
 
     // reset the model so that mobile screens react to an empty selectedTag
-    deactivate: function () {
+    deactivate() {
         this.set('controller.model', null);
     }
 

--- a/core/client/app/routes/settings/tags/tag.js
+++ b/core/client/app/routes/settings/tags/tag.js
@@ -1,17 +1,18 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 
 export default AuthenticatedRoute.extend({
 
-    model: function (params) {
+    model(params) {
         return this.store.queryRecord('tag', {slug: params.tag_slug});
     },
 
-    serialize: function (model) {
+    serialize(model) {
         return {tag_slug: model.get('slug')};
     },
 
     // reset the model so that mobile screens react to an empty selectedTag
-    deactivate: function () {
+    deactivate() {
         this.set('controller.model', null);
     }
 

--- a/core/client/app/routes/setup.js
+++ b/core/client/app/routes/setup.js
@@ -3,19 +3,19 @@ import {request as ajax} from 'ic-ajax';
 import Configuration from 'ember-simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 
-export default Ember.Route.extend(styleBody, {
+const {Route, inject} = Ember;
+
+export default Route.extend(styleBody, {
     titleToken: 'Setup',
 
     classNames: ['ghost-setup'],
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    session: Ember.inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
+    session: inject.service(),
 
     // use the beforeModel hook to check to see whether or not setup has been
     // previously completed.  If it has, stop the transition into the setup page.
-    beforeModel: function () {
-        var self = this;
-
+    beforeModel() {
         if (this.get('session.isAuthenticated')) {
             this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
             return;
@@ -24,16 +24,17 @@ export default Ember.Route.extend(styleBody, {
         // If user is not logged in, check the state of the setup process via the API
         return ajax(this.get('ghostPaths.url').api('authentication/setup'), {
             type: 'GET'
-        }).then(function (result) {
-            var setup = result.setup[0].status;
+        }).then((result) => {
+            let setup = result.setup[0].status;
 
             if (setup) {
-                return self.transitionTo('signin');
+                return this.transitionTo('signin');
             }
         });
     },
-    deactivate: function () {
-        this._super();
+
+    deactivate() {
+        this._super(...arguments);
         this.controllerFor('setup/two').set('password', '');
     }
 });

--- a/core/client/app/routes/setup/index.js
+++ b/core/client/app/routes/setup/index.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
-    beforeModel: function () {
+const {Route} = Ember;
+
+export default Route.extend({
+    beforeModel() {
         this.transitionTo('setup.one');
     }
 });

--- a/core/client/app/routes/setup/one.js
+++ b/core/client/app/routes/setup/one.js
@@ -1,21 +1,21 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-var DownloadCountPoller = Ember.Object.extend({
+const {Route, inject, run} = Ember;
+
+let DownloadCountPoller = Ember.Object.extend({
     url: null,
     count: '',
     runId: null,
 
-    init: function () {
+    init() {
         this.downloadCounter();
         this.poll();
     },
 
-    poll: function () {
-        var interval = Ember.testing ? 20 : 2000,
-            runId;
-
-        runId = Ember.run.later(this, function () {
+    poll() {
+        let interval = Ember.testing ? 20 : 2000;
+        let runId = run.later(this, function () {
             this.downloadCounter();
             if (!Ember.testing) {
                 this.poll();
@@ -25,34 +25,32 @@ var DownloadCountPoller = Ember.Object.extend({
         this.set('runId', runId);
     },
 
-    downloadCounter: function () {
-        var self = this;
-
-        ajax(this.get('url')).then(function (data) {
-            var count = data.count.toString(),
-                pattern = /(-?\d+)(\d{3})/;
+    downloadCounter() {
+        ajax(this.get('url')).then((data) => {
+            let pattern = /(-?\d+)(\d{3})/;
+            let count = data.count.toString();
 
             while (pattern.test(count)) {
                 count = count.replace(pattern, '$1,$2');
             }
 
-            self.set('count', count);
-        }).catch(function () {
-            self.set('count', '');
+            this.set('count', count);
+        }).catch(() => {
+            this.set('count', '');
         });
     }
 });
 
-export default Ember.Route.extend({
-    ghostPaths: Ember.inject.service('ghost-paths'),
+export default Route.extend({
+    ghostPaths: inject.service('ghost-paths'),
 
-    model: function () {
+    model() {
         return DownloadCountPoller.create({url: this.get('ghostPaths.count')});
     },
 
-    resetController: function (controller, isExiting) {
+    resetController(controller, isExiting) {
         if (isExiting) {
-            Ember.run.cancel(controller.get('model.runId'));
+            run.cancel(controller.get('model.runId'));
             controller.set('model', null);
         }
     }

--- a/core/client/app/routes/setup/three.js
+++ b/core/client/app/routes/setup/three.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
-export default Ember.Route.extend({
-    beforeModel: function () {
+const {Route} = Ember;
+
+export default Route.extend({
+    beforeModel() {
         if (!this.controllerFor('setup.two').get('blogCreated')) {
             this.transitionTo('setup.two');
         }

--- a/core/client/app/routes/signin.js
+++ b/core/client/app/routes/signin.js
@@ -3,32 +3,35 @@ import styleBody from 'ghost/mixins/style-body';
 import Configuration from 'ember-simple-auth/configuration';
 import DS from 'ember-data';
 
-export default Ember.Route.extend(styleBody, {
+const {Route, inject} = Ember;
+const {Errors} = DS;
+
+export default Route.extend(styleBody, {
     titleToken: 'Sign In',
 
     classNames: ['ghost-login'],
 
-    session: Ember.inject.service(),
+    session: inject.service(),
 
-    beforeModel: function () {
+    beforeModel() {
         if (this.get('session.isAuthenticated')) {
             this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
         }
     },
 
-    model: function () {
+    model() {
         return Ember.Object.create({
             identification: '',
             password: '',
-            errors: DS.Errors.create()
+            errors: Errors.create()
         });
     },
 
     // the deactivate hook is called after a route has been exited.
-    deactivate: function () {
-        this._super();
+    deactivate() {
+        let controller = this.controllerFor('signin');
 
-        var controller = this.controllerFor('signin');
+        this._super(...arguments);
 
         // clear the properties that hold the credentials when we're no longer on the signin screen
         controller.set('model.identification', '');

--- a/core/client/app/routes/signout.js
+++ b/core/client/app/routes/signout.js
@@ -2,16 +2,18 @@ import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import styleBody from 'ghost/mixins/style-body';
 
+const {canInvoke, inject} = Ember;
+
 export default AuthenticatedRoute.extend(styleBody, {
     titleToken: 'Sign Out',
 
     classNames: ['ghost-signout'],
 
-    notifications: Ember.inject.service(),
+    notifications: inject.service(),
 
-    afterModel: function (model, transition) {
+    afterModel(model, transition) {
         this.get('notifications').clearAll();
-        if (Ember.canInvoke(transition, 'send')) {
+        if (canInvoke(transition, 'send')) {
             transition.send('invalidateSession');
             transition.abort();
         } else {

--- a/core/client/app/routes/signup.js
+++ b/core/client/app/routes/signup.js
@@ -4,32 +4,34 @@ import {request as ajax} from 'ic-ajax';
 import Configuration from 'ember-simple-auth/configuration';
 import styleBody from 'ghost/mixins/style-body';
 
-export default Ember.Route.extend(styleBody, {
+const {Route, RSVP, inject} = Ember;
+const {Errors} = DS;
+
+export default Route.extend(styleBody, {
     classNames: ['ghost-signup'],
 
-    ghostPaths: Ember.inject.service('ghost-paths'),
-    notifications: Ember.inject.service(),
-    session: Ember.inject.service(),
+    ghostPaths: inject.service('ghost-paths'),
+    notifications: inject.service(),
+    session: inject.service(),
 
-    beforeModel: function () {
+    beforeModel() {
         if (this.get('session.isAuthenticated')) {
             this.get('notifications').showAlert('You need to sign out to register as a new user.', {type: 'warn', delayed: true, key: 'signup.create.already-authenticated'});
             this.transitionTo(Configuration.routeIfAlreadyAuthenticated);
         }
     },
 
-    model: function (params) {
-        var self = this,
-            tokenText,
-            email,
-            model = Ember.Object.create(),
-            re = /^(?:[A-Za-z0-9_\-]{4})*(?:[A-Za-z0-9_\-]{2}|[A-Za-z0-9_\-]{3})?$/;
+    model(params) {
+        let model = Ember.Object.create();
+        let re = /^(?:[A-Za-z0-9_\-]{4})*(?:[A-Za-z0-9_\-]{2}|[A-Za-z0-9_\-]{3})?$/;
+        let email,
+            tokenText;
 
-        return new Ember.RSVP.Promise(function (resolve) {
+        return new RSVP.Promise((resolve) => {
             if (!re.test(params.token)) {
-                self.get('notifications').showAlert('Invalid token.', {type: 'error', delayed: true, key: 'signup.create.invalid-token'});
+                this.get('notifications').showAlert('Invalid token.', {type: 'error', delayed: true, key: 'signup.create.invalid-token'});
 
-                return resolve(self.transitionTo('signin'));
+                return resolve(this.transitionTo('signin'));
             }
 
             tokenText = atob(params.token);
@@ -37,31 +39,31 @@ export default Ember.Route.extend(styleBody, {
 
             model.set('email', email);
             model.set('token', params.token);
-            model.set('errors', DS.Errors.create());
+            model.set('errors', Errors.create());
 
             return ajax({
-                url: self.get('ghostPaths.url').api('authentication', 'invitation'),
+                url: this.get('ghostPaths.url').api('authentication', 'invitation'),
                 type: 'GET',
                 dataType: 'json',
                 data: {
-                    email: email
+                    email
                 }
-            }).then(function (response) {
+            }).then((response) => {
                 if (response && response.invitation && response.invitation[0].valid === false) {
-                    self.get('notifications').showAlert('The invitation does not exist or is no longer valid.', {type: 'warn', delayed: true, key: 'signup.create.invalid-invitation'});
+                    this.get('notifications').showAlert('The invitation does not exist or is no longer valid.', {type: 'warn', delayed: true, key: 'signup.create.invalid-invitation'});
 
-                    return resolve(self.transitionTo('signin'));
+                    return resolve(this.transitionTo('signin'));
                 }
 
                 resolve(model);
-            }).catch(function () {
+            }).catch(() => {
                 resolve(model);
             });
         });
     },
 
-    deactivate: function () {
-        this._super();
+    deactivate() {
+        this._super(...arguments);
 
         // clear the properties that hold the sensitive data from the controller
         this.controllerFor('signup').setProperties({email: '', password: '', token: ''});

--- a/core/client/app/routes/team/index.js
+++ b/core/client/app/routes/team/index.js
@@ -14,20 +14,18 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, Paginat
         limit: 20
     },
 
-    model: function () {
-        var self = this;
-
+    model() {
         this.loadFirstPage();
 
-        return self.store.query('user', {limit: 'all', status: 'invited'}).then(function () {
-            return self.store.filter('user', function () {
+        return this.store.query('user', {limit: 'all', status: 'invited'}).then(() => {
+            return this.store.filter('user', () => {
                 return true;
             });
         });
     },
 
     actions: {
-        reload: function () {
+        reload() {
             this.refresh();
         }
     }

--- a/core/client/app/routes/team/user.js
+++ b/core/client/app/routes/team/user.js
@@ -1,3 +1,4 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
@@ -7,30 +8,30 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
     classNames: ['team-view-user'],
 
-    model: function (params) {
+    model(params) {
         return this.store.queryRecord('user', {slug: params.user_slug});
     },
 
-    serialize: function (model) {
+    serialize(model) {
         return {user_slug: model.get('slug')};
     },
 
-    afterModel: function (user) {
-        var self = this;
-        return this.get('session.user').then(function (currentUser) {
-            var isOwnProfile = user.get('id') === currentUser.get('id'),
-                isAuthor = currentUser.get('isAuthor'),
-                isEditor = currentUser.get('isEditor');
+    afterModel(user) {
+        return this.get('session.user').then((currentUser) => {
+            let isOwnProfile = user.get('id') === currentUser.get('id');
+            let isAuthor = currentUser.get('isAuthor');
+            let isEditor = currentUser.get('isEditor');
+
             if (isAuthor && !isOwnProfile) {
-                self.transitionTo('team.user', currentUser);
+                this.transitionTo('team.user', currentUser);
             } else if (isEditor && !isOwnProfile && !user.get('isAuthor')) {
-                self.transitionTo('team');
+                this.transitionTo('team');
             }
         });
     },
 
-    deactivate: function () {
-        var model = this.modelFor('team.user');
+    deactivate() {
+        let model = this.modelFor('team.user');
 
         // we want to revert any unsaved changes on exit
         if (model && model.get('hasDirtyAttributes')) {
@@ -39,15 +40,15 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
 
         model.get('errors').clear();
 
-        this._super();
+        this._super(...arguments);
     },
 
     actions: {
-        didTransition: function () {
+        didTransition() {
             this.modelFor('team.user').get('errors').clear();
         },
 
-        save: function () {
+        save() {
             this.get('controller').send('save');
         }
     }

--- a/core/client/app/serializers/application.js
+++ b/core/client/app/serializers/application.js
@@ -1,18 +1,20 @@
 import Ember from 'ember';
 import DS from 'ember-data';
 
-export default DS.RESTSerializer.extend({
+const {RESTSerializer} = DS;
+
+export default RESTSerializer.extend({
 
     isNewSerializerAPI: true,
 
-    serializeIntoHash: function (hash, type, record, options) {
+    serializeIntoHash(hash, type, record, options) {
         // Our API expects an id on the posted object
         options = options || {};
         options.includeId = true;
 
         // We have a plural root in the API
-        var root = Ember.String.pluralize(type.modelName),
-            data = this.serialize(record, options);
+        let root = Ember.String.pluralize(type.modelName);
+        let data = this.serialize(record, options);
 
         // Don't ever pass uuid's
         delete data.uuid;

--- a/core/client/app/serializers/post.js
+++ b/core/client/app/serializers/post.js
@@ -1,14 +1,17 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+const {EmbeddedRecordsMixin} = DS;
+
+export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // settings for the EmbeddedRecordsMixin.
     attrs: {
         tags: {embedded: 'always'}
     },
 
-    normalize: function (typeClass, hash, prop) {
+    normalize(typeClass, hash, prop) {
         // this is to enable us to still access the raw author_id
         // without requiring an extra get request (since it is an
         // async relationship).
@@ -17,27 +20,27 @@ export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
         return this._super(typeClass, hash, prop);
     },
 
-    normalizeSingleResponse: function (store, primaryModelClass, payload) {
-        var root = this.keyForAttribute(primaryModelClass.modelName),
-            pluralizedRoot = Ember.String.pluralize(primaryModelClass.modelName);
+    normalizeSingleResponse(store, primaryModelClass, payload) {
+        let root = this.keyForAttribute(primaryModelClass.modelName);
+        let pluralizedRoot = Ember.String.pluralize(primaryModelClass.modelName);
 
         payload[root] = payload[pluralizedRoot][0];
         delete payload[pluralizedRoot];
 
-        return this._super.apply(this, arguments);
+        return this._super(...arguments);
     },
 
-    normalizeArrayResponse: function () {
-        return this._super.apply(this, arguments);
+    normalizeArrayResponse() {
+        return this._super(...arguments);
     },
 
-    serializeIntoHash: function (hash, type, record, options) {
+    serializeIntoHash(hash, type, record, options) {
         options = options || {};
         options.includeId = true;
 
         // We have a plural root in the API
-        var root = Ember.String.pluralize(type.modelName),
-            data = this.serialize(record, options);
+        let root = Ember.String.pluralize(type.modelName);
+        let data = this.serialize(record, options);
 
         // Properties that exist on the model but we don't want sent in the payload
 

--- a/core/client/app/serializers/setting.js
+++ b/core/client/app/serializers/setting.js
@@ -2,38 +2,38 @@ import Ember from 'ember';
 import ApplicationSerializer from 'ghost/serializers/application';
 
 export default ApplicationSerializer.extend({
-    serializeIntoHash: function (hash, type, record, options) {
+    serializeIntoHash(hash, type, record, options) {
         // Settings API does not want ids
         options = options || {};
         options.includeId = false;
 
-        var root = Ember.String.pluralize(type.modelName),
-            data = this.serialize(record, options),
-            payload = [];
+        let root = Ember.String.pluralize(type.modelName);
+        let data = this.serialize(record, options);
+        let payload = [];
 
         delete data.id;
 
-        Object.keys(data).forEach(function (k) {
+        Object.keys(data).forEach((k) => {
             payload.push({key: k, value: data[k]});
         });
 
         hash[root] = payload;
     },
 
-    normalizeArrayResponse: function (store, primaryModelClass, _payload, id, requestType) {
-        var payload = {settings: [this._extractObjectFromArrayPayload(_payload)]};
+    normalizeArrayResponse(store, primaryModelClass, _payload, id, requestType) {
+        let payload = {settings: [this._extractObjectFromArrayPayload(_payload)]};
         return this._super(store, primaryModelClass, payload, id, requestType);
     },
 
-    normalizeSingleResponse: function (store, primaryModelClass, _payload, id, requestType) {
-        var payload = {setting: this._extractObjectFromArrayPayload(_payload)};
+    normalizeSingleResponse(store, primaryModelClass, _payload, id, requestType) {
+        let payload = {setting: this._extractObjectFromArrayPayload(_payload)};
         return this._super(store, primaryModelClass, payload, id, requestType);
     },
 
-    _extractObjectFromArrayPayload: function (_payload) {
-        var payload = {id: '0'};
+    _extractObjectFromArrayPayload(_payload) {
+        let payload = {id: '0'};
 
-        _payload.settings.forEach(function (setting) {
+        _payload.settings.forEach((setting) => {
             payload[setting.key] = setting.value;
         });
 

--- a/core/client/app/serializers/tag.js
+++ b/core/client/app/serializers/tag.js
@@ -1,13 +1,14 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import ApplicationSerializer from 'ghost/serializers/application';
 
 export default ApplicationSerializer.extend({
-    serializeIntoHash: function (hash, type, record, options) {
+    serializeIntoHash(hash, type, record, options) {
         options = options || {};
         options.includeId = true;
 
-        var root = Ember.String.pluralize(type.modelName),
-            data = this.serialize(record, options);
+        let root = Ember.String.pluralize(type.modelName);
+        let data = this.serialize(record, options);
 
         // Properties that exist on the model but we don't want sent in the payload
 

--- a/core/client/app/serializers/user.js
+++ b/core/client/app/serializers/user.js
@@ -2,28 +2,30 @@ import Ember from 'ember';
 import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
 
-export default ApplicationSerializer.extend(DS.EmbeddedRecordsMixin, {
+const {EmbeddedRecordsMixin} = DS;
+
+export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     attrs: {
         roles: {embedded: 'always'}
     },
 
-    extractSingle: function (store, primaryType, payload) {
-        var root = this.keyForAttribute(primaryType.modelName),
-            pluralizedRoot = Ember.String.pluralize(primaryType.modelName);
+    extractSingle(store, primaryType, payload) {
+        let root = this.keyForAttribute(primaryType.modelName);
+        let pluralizedRoot = Ember.String.pluralize(primaryType.modelName);
 
         payload[root] = payload[pluralizedRoot][0];
         delete payload[pluralizedRoot];
 
-        return this._super.apply(this, arguments);
+        return this._super(...arguments);
     },
 
-    normalizeSingleResponse: function (store, primaryModelClass, payload) {
-        var root = this.keyForAttribute(primaryModelClass.modelName),
-            pluralizedRoot = Ember.String.pluralize(primaryModelClass.modelName);
+    normalizeSingleResponse(store, primaryModelClass, payload) {
+        let root = this.keyForAttribute(primaryModelClass.modelName);
+        let pluralizedRoot = Ember.String.pluralize(primaryModelClass.modelName);
 
         payload[root] = payload[pluralizedRoot][0];
         delete payload[pluralizedRoot];
 
-        return this._super.apply(this, arguments);
+        return this._super(...arguments);
     }
 });

--- a/core/client/app/services/config.js
+++ b/core/client/app/services/config.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const {Service, _ProxyMixin, computed} = Ember;
+
 function isNumeric(num) {
     return Ember.$.isNumeric(num);
 }
@@ -25,15 +27,15 @@ function _mapType(val) {
     }
 }
 
-export default Ember.Service.extend(Ember._ProxyMixin, {
-    content: Ember.computed(function () {
-        var metaConfigTags = Ember.$('meta[name^="env-"]'),
-        config = {};
+export default Service.extend(_ProxyMixin, {
+    content: computed(function () {
+        let metaConfigTags = Ember.$('meta[name^="env-"]');
+        let config = {};
 
-        metaConfigTags.each(function (i, el) {
-            var key = el.name,
-                value = el.content,
-                propertyName = key.substring(4);
+        metaConfigTags.each((i, el) => {
+            let key = el.name;
+            let value = el.content;
+            let propertyName = key.substring(4);
 
             config[propertyName] = _mapType(value);
         });

--- a/core/client/app/services/dropdown.js
+++ b/core/client/app/services/dropdown.js
@@ -2,17 +2,19 @@ import Ember from 'ember';
 // This is used by the dropdown initializer (and subsequently popovers) to manage closing & toggling
 import BodyEventListener from 'ghost/mixins/body-event-listener';
 
-export default Ember.Service.extend(Ember.Evented, BodyEventListener, {
-    bodyClick: function (event) {
+const {Service, Evented} = Ember;
+
+export default Service.extend(Evented, BodyEventListener, {
+    bodyClick(event) {
         /*jshint unused:false */
         this.closeDropdowns();
     },
 
-    closeDropdowns: function () {
+    closeDropdowns() {
         this.trigger('close');
     },
 
-    toggleDropdown: function (dropdownName, dropdownButton) {
+    toggleDropdown(dropdownName, dropdownButton) {
         this.trigger('toggle', {target: dropdownName, button: dropdownButton});
     }
 });

--- a/core/client/app/services/ghost-paths.js
+++ b/core/client/app/services/ghost-paths.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import ghostPaths from 'ghost/utils/ghost-paths';
 
-export default Ember.Service.extend(Ember._ProxyMixin, {
+const {Service, _ProxyMixin} = Ember;
+
+export default Service.extend(_ProxyMixin, {
     content: ghostPaths()
 });

--- a/core/client/app/services/media-queries.js
+++ b/core/client/app/services/media-queries.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const {Service, run} = Ember;
+
 const MEDIA_QUERIES = {
     maxWidth600: '(max-width: 600px)',
     isMobile: '(max-width: 800px)',
@@ -7,25 +9,25 @@ const MEDIA_QUERIES = {
     maxWidth1000: '(max-width: 1000px)'
 };
 
-export default Ember.Service.extend({
-    init: function () {
+export default Service.extend({
+    init() {
         this._super(...arguments);
         this._handlers = [];
         this.loadQueries(MEDIA_QUERIES);
     },
 
-    loadQueries: function (queries) {
-        Object.keys(queries).forEach(key => {
+    loadQueries(queries) {
+        Object.keys(queries).forEach((key) => {
             this.loadQuery(key, queries[key]);
         });
     },
 
-    loadQuery: function (key, queryString) {
+    loadQuery(key, queryString) {
         let query = window.matchMedia(queryString);
 
         this.set(key, query.matches);
 
-        let handler = Ember.run.bind(this, () => {
+        let handler = run.bind(this, () => {
             let lastValue = this.get(key);
             let newValue = query.matches;
             if (lastValue !== newValue) {
@@ -36,7 +38,7 @@ export default Ember.Service.extend({
         this._handlers.push([query, handler]);
     },
 
-    willDestroy: function () {
+    willDestroy() {
         this._handlers.forEach(([query, handler]) => {
             query.removeListener(handler);
         });

--- a/core/client/app/services/session.js
+++ b/core/client/app/services/session.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import SessionService from 'ember-simple-auth/services/session';
 
-export default SessionService.extend({
-    store: Ember.inject.service(),
+const {computed, inject} = Ember;
 
-    user: Ember.computed(function () {
+export default SessionService.extend({
+    store: inject.service(),
+
+    user: computed(function () {
         return this.get('store').findRecord('user', 'me');
     })
 });

--- a/core/client/app/transforms/moment-date.js
+++ b/core/client/app/transforms/moment-date.js
@@ -1,14 +1,17 @@
-import DS from 'ember-data';
 /* global moment */
+import DS from 'ember-data';
 
-export default DS.Transform.extend({
-    deserialize: function (serialized) {
+const {Transform} = DS;
+
+export default Transform.extend({
+    deserialize(serialized) {
         if (serialized) {
             return moment(serialized);
         }
         return serialized;
     },
-    serialize: function (deserialized) {
+
+    serialize(deserialized) {
         if (deserialized) {
             return moment(deserialized).toDate();
         }

--- a/core/client/app/transforms/raw.js
+++ b/core/client/app/transforms/raw.js
@@ -3,11 +3,11 @@ import DS from 'ember-data';
 const {Transform} = DS;
 
 export default Transform.extend({
-    deserialize: function (serialized) {
+    deserialize(serialized) {
         return serialized;
     },
 
-    serialize: function (deserialized) {
+    serialize(deserialized) {
         return deserialized;
     }
 });

--- a/core/client/app/utils/ajax.js
+++ b/core/client/app/utils/ajax.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
+const {isArray} = Ember;
+
 // Used in API request fail handlers to parse a standard api error
 // response json for the message to display
 export default function getRequestErrorMessage(request, performConcat) {
-    var message,
+    let message,
         msgDetail;
 
     // Can't really continue without a request
@@ -18,20 +20,20 @@ export default function getRequestErrorMessage(request, performConcat) {
     if (request.status !== 200) {
         try {
             // Try to parse out the error, or default to 'Unknown'
-            if (request.responseJSON.errors && Ember.isArray(request.responseJSON.errors)) {
-                message = request.responseJSON.errors.map(function (errorItem) {
+            if (request.responseJSON.errors && isArray(request.responseJSON.errors)) {
+                message = request.responseJSON.errors.map((errorItem) => {
                     return errorItem.message;
                 });
             } else {
                 message =  request.responseJSON.error || 'Unknown Error';
             }
         } catch (e) {
-            msgDetail = request.status ? request.status + ' - ' + request.statusText : 'Server was not available';
-            message = 'The server returned an error (' + msgDetail + ').';
+            msgDetail = request.status ? `${request.status} - ${request.statusText}` : 'Server was not available';
+            message = `The server returned an error (${msgDetail}).`;
         }
     }
 
-    if (performConcat && Ember.isArray(message)) {
+    if (performConcat && isArray(message)) {
         message = message.join('<br />');
     }
 

--- a/core/client/app/utils/bind.js
+++ b/core/client/app/utils/bind.js
@@ -1,9 +1,9 @@
-var slice = Array.prototype.slice;
+const {slice} = Array.prototype;
 
 export default function (/* func, args, thisArg */) {
-    var args = slice.call(arguments),
-        func = args.shift(),
-        thisArg = args.pop();
+    let args = slice.call(arguments);
+    let func = args.shift();
+    let thisArg = args.pop();
 
     function bound() {
         return func.apply(thisArg, args);

--- a/core/client/app/utils/bound-one-way.js
+++ b/core/client/app/utils/bound-one-way.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
+
+const {computed} = Ember;
+
 /**
  * Defines a property similarly to `Ember.computed.oneway`,
  * save that while a `oneway` loses its binding upon being set,
@@ -12,14 +15,16 @@ import Ember from 'ember';
 export default function (upstream, transform) {
     if (typeof transform !== 'function') {
         // default to the identity function
-        transform = function (value) { return value; };
+        transform = function (value) {
+            return value;
+        };
     }
 
-    return Ember.computed(upstream, {
-        get: function () {
+    return computed(upstream, {
+        get() {
             return transform(this.get(upstream));
         },
-        set: function (key, value) {
+        set(key, value) {
             return value;
         }
     });

--- a/core/client/app/utils/caja-sanitizers.js
+++ b/core/client/app/utils/caja-sanitizers.js
@@ -1,14 +1,11 @@
 /**
  * google-caja uses url() and id() to verify if the values are allowed.
  */
-var url,
-    id;
-
 /**
  * Check if URL is allowed
  * URLs are allowed if they start with http://, https://, or /.
  */
-url = function (url) {
+let url = function (url) {
     url = url.toString().replace(/['"]+/g, '');
     if (/^https?:\/\//.test(url) || /^\//.test(url)) {
         return url;
@@ -19,11 +16,11 @@ url = function (url) {
  * Check if ID is allowed
  * All ids are allowed at the moment.
  */
-id = function (id) {
+let id = function (id) {
     return id;
 };
 
 export default {
-    url: url,
-    id: id
+    url,
+    id
 };

--- a/core/client/app/utils/date-formatting.js
+++ b/core/client/app/utils/date-formatting.js
@@ -1,42 +1,39 @@
 /* global moment */
 // jscs: disable disallowSpacesInsideParentheses
 
-var parseDateFormats,
-    displayDateFormat,
-    verifyTimeStamp,
-    parseDateString,
-    formatDate;
+const parseDateFormats = ['DD MMM YY @ HH:mm', 'DD MMM YY HH:mm',
+                          'D MMM YY @ HH:mm', 'D MMM YY HH:mm',
+                          'DD MMM YYYY @ HH:mm', 'DD MMM YYYY HH:mm',
+                          'D MMM YYYY @ HH:mm', 'D MMM YYYY HH:mm',
+                          'DD/MM/YY @ HH:mm', 'DD/MM/YY HH:mm',
+                          'DD/MM/YYYY @ HH:mm', 'DD/MM/YYYY HH:mm',
+                          'DD-MM-YY @ HH:mm', 'DD-MM-YY HH:mm',
+                          'DD-MM-YYYY @ HH:mm', 'DD-MM-YYYY HH:mm',
+                          'YYYY-MM-DD @ HH:mm', 'YYYY-MM-DD HH:mm',
+                          'DD MMM @ HH:mm', 'DD MMM HH:mm',
+                          'D MMM @ HH:mm', 'D MMM HH:mm'];
 
-parseDateFormats = ['DD MMM YY @ HH:mm', 'DD MMM YY HH:mm',
-                        'D MMM YY @ HH:mm', 'D MMM YY HH:mm',
-                        'DD MMM YYYY @ HH:mm', 'DD MMM YYYY HH:mm',
-                        'D MMM YYYY @ HH:mm', 'D MMM YYYY HH:mm',
-                        'DD/MM/YY @ HH:mm', 'DD/MM/YY HH:mm',
-                        'DD/MM/YYYY @ HH:mm', 'DD/MM/YYYY HH:mm',
-                        'DD-MM-YY @ HH:mm', 'DD-MM-YY HH:mm',
-                        'DD-MM-YYYY @ HH:mm', 'DD-MM-YYYY HH:mm',
-                        'YYYY-MM-DD @ HH:mm', 'YYYY-MM-DD HH:mm',
-                        'DD MMM @ HH:mm', 'DD MMM HH:mm',
-                        'D MMM @ HH:mm', 'D MMM HH:mm'];
-
-displayDateFormat = 'DD MMM YY @ HH:mm';
+const displayDateFormat = 'DD MMM YY @ HH:mm';
 
 // Add missing timestamps
-verifyTimeStamp = function (dateString) {
+function verifyTimeStamp(dateString) {
     if (dateString && !dateString.slice(-5).match(/\d+:\d\d/)) {
         dateString += ' 12:00';
     }
     return dateString;
-};
+}
 
 // Parses a string to a Moment
-parseDateString = function (value) {
+function parseDateString(value) {
     return value ? moment(verifyTimeStamp(value), parseDateFormats, true) : undefined;
-};
+}
 
 // Formats a Date or Moment
-formatDate = function (value) {
+function formatDate(value) {
     return verifyTimeStamp(value ? moment(value).format(displayDateFormat) : '');
-};
+}
 
-export {parseDateString, formatDate};
+export {
+    parseDateString,
+    formatDate
+};

--- a/core/client/app/utils/document-title.js
+++ b/core/client/app/utils/document-title.js
@@ -1,7 +1,9 @@
 import Ember from 'ember';
 
+const {Route, Router, isArray, on} = Ember;
+
 export default function () {
-    Ember.Route.reopen({
+    Route.reopen({
         // `titleToken` can either be a static string or a function
         // that accepts a model object and returns a string (or array
         // of strings if there are multiple tokens).
@@ -15,15 +17,15 @@ export default function () {
         title: null,
 
         _actions: {
-            collectTitleTokens: function (tokens) {
-                var titleToken = this.titleToken,
-                    finalTitle;
+            collectTitleTokens(tokens) {
+                let {titleToken} = this;
+                let finalTitle;
 
                 if (typeof this.titleToken === 'function') {
                     titleToken = this.titleToken(this.currentModel);
                 }
 
-                if (Ember.isArray(titleToken)) {
+                if (isArray(titleToken)) {
                     tokens.unshift.apply(this, titleToken);
                 } else if (titleToken) {
                     tokens.unshift(titleToken);
@@ -44,12 +46,12 @@ export default function () {
         }
     });
 
-    Ember.Router.reopen({
-        updateTitle: Ember.on('didTransition', function () {
+    Router.reopen({
+        updateTitle: on('didTransition', function () {
             this.send('collectTitleTokens', []);
         }),
 
-        setTitle: function (title) {
+        setTitle(title) {
             window.document.title = title;
         }
     });

--- a/core/client/app/utils/ed-image-manager.js
+++ b/core/client/app/utils/ed-image-manager.js
@@ -1,8 +1,10 @@
-var imageMarkdownRegex = /^!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?$/gim;
+const imageMarkdownRegex = /^!(?:\[([^\n\]]*)\])(?:\(([^\n\]]*)\))?$/gim;
 
 // Process the markdown content and find all of the locations where there is an image markdown block
 function parse(stringToParse) {
-    var m, images = [];
+    let images = [];
+    let m;
+
     while ((m = imageMarkdownRegex.exec(stringToParse)) !== null) {
         images.push(m);
     }
@@ -12,10 +14,9 @@ function parse(stringToParse) {
 
 // Loop through all dropzones in the preview and find which one was the target of the upload
 function getZoneIndex(element) {
-    var zones = document.querySelectorAll('.js-entry-preview .js-drop-zone'),
-        i;
+    let zones = document.querySelectorAll('.js-entry-preview .js-drop-zone');
 
-    for (i = 0; i < zones.length; i += 1) {
+    for (let i = 0; i < zones.length; i += 1) {
         if (zones.item(i) === element) {
             return i;
         }
@@ -26,9 +27,9 @@ function getZoneIndex(element) {
 
 // Figure out the start and end of the selection range for the src in the markdown, so we know what to replace
 function getSrcRange(content, element) {
-    var images = parse(content),
-        index = getZoneIndex(element),
-        replacement = {};
+    let images = parse(content);
+    let index = getZoneIndex(element);
+    let replacement = {};
 
     if (index > -1) {
         // [1] matches the alt test, and 2 matches the url between the ()
@@ -49,5 +50,5 @@ function getSrcRange(content, element) {
 }
 
 export default {
-    getSrcRange: getSrcRange
+    getSrcRange
 };

--- a/core/client/app/utils/editor-shortcuts.js
+++ b/core/client/app/utils/editor-shortcuts.js
@@ -3,24 +3,24 @@
 // This map is used to ensure the right action is called by each shortcut
 import ctrlOrCmd from 'ghost/utils/ctrl-or-cmd';
 
-var shortcuts = {};
+let shortcuts = {};
 
 // General editor shortcuts
-shortcuts[ctrlOrCmd + '+alt+p'] = 'publish';
+shortcuts[`${ctrlOrCmd}+alt+p`] = 'publish';
 shortcuts['alt+shift+z'] = 'toggleZenMode';
 
 // Markdown Shortcuts
 
 // Text
 shortcuts['ctrl+alt+u'] = {action: 'editorShortcut', options: {type: 'strike'}};
-shortcuts[ctrlOrCmd + '+b'] = {action: 'editorShortcut', options: {type: 'bold'}};
-shortcuts[ctrlOrCmd + '+i'] = {action: 'editorShortcut', options: {type: 'italic'}};
+shortcuts[`${ctrlOrCmd}+b`] = {action: 'editorShortcut', options: {type: 'bold'}};
+shortcuts[`${ctrlOrCmd}+i`] = {action: 'editorShortcut', options: {type: 'italic'}};
 
 shortcuts['ctrl+u'] = {action: 'editorShortcut', options: {type: 'uppercase'}};
 shortcuts['ctrl+shift+u'] = {action: 'editorShortcut', options: {type: 'lowercase'}};
 shortcuts['ctrl+alt+shift+u'] = {action: 'editorShortcut', options: {type: 'titlecase'}};
-shortcuts[ctrlOrCmd + '+shift+c'] = {action: 'editorShortcut', options: {type: 'copyHTML'}};
-shortcuts[ctrlOrCmd + '+h'] = {action: 'editorShortcut', options: {type: 'cycleHeaderLevel'}};
+shortcuts[`${ctrlOrCmd}+shift+c`] = {action: 'editorShortcut', options: {type: 'copyHTML'}};
+shortcuts[`${ctrlOrCmd}+h`] = {action: 'editorShortcut', options: {type: 'cycleHeaderLevel'}};
 
 // Formatting
 shortcuts['ctrl+q'] = {action: 'editorShortcut', options: {type: 'blockquote'}};
@@ -28,8 +28,8 @@ shortcuts['ctrl+l'] = {action: 'editorShortcut', options: {type: 'list'}};
 
 // Insert content
 shortcuts['ctrl+shift+1'] = {action: 'editorShortcut', options: {type: 'currentDate'}};
-shortcuts[ctrlOrCmd + '+k'] = {action: 'editorShortcut', options: {type: 'link'}};
-shortcuts[ctrlOrCmd + '+shift+i'] = {action: 'editorShortcut', options: {type: 'image'}};
-shortcuts[ctrlOrCmd + '+shift+k'] = {action: 'editorShortcut', options: {type: 'code'}};
+shortcuts[`${ctrlOrCmd}+k`] = {action: 'editorShortcut', options: {type: 'link'}};
+shortcuts[`${ctrlOrCmd}+shift+i`] = {action: 'editorShortcut', options: {type: 'image'}};
+shortcuts[`${ctrlOrCmd}+shift+k`] = {action: 'editorShortcut', options: {type: 'code'}};
 
 export default shortcuts;

--- a/core/client/app/utils/ghost-paths.js
+++ b/core/client/app/utils/ghost-paths.js
@@ -1,59 +1,55 @@
-var makeRoute = function (root, args) {
-    var slashAtStart,
-        slashAtEnd,
-        parts,
-        route;
+let makeRoute = function (root, args) {
+    let slashAtStart = /^\//;
+    let slashAtEnd = /\/$/;
+    let parts = Array.prototype.slice.call(args, 0);
+    let route = root.replace(slashAtEnd, '');
 
-    slashAtStart = /^\//;
-    slashAtEnd = /\/$/;
-    route = root.replace(slashAtEnd, '');
-    parts = Array.prototype.slice.call(args, 0);
-
-    parts.forEach(function (part) {
+    parts.forEach((part) => {
         if (part) {
             route = [route, part.replace(slashAtStart, '').replace(slashAtEnd, '')].join('/');
         }
     });
+
     return route += '/';
 };
 
 export default function () {
-    var path = window.location.pathname,
-        subdir = path.substr(0, path.search('/ghost/')),
-        adminRoot = subdir + '/ghost',
-        apiRoot = subdir + '/ghost/api/v0.1';
+    let path = window.location.pathname;
+    let subdir = path.substr(0, path.search('/ghost/'));
+    let adminRoot = `${subdir}/ghost`;
+    let apiRoot = `${subdir}/ghost/api/v0.1`;
 
     function assetUrl(src) {
         return subdir + src;
     }
 
     return {
-        subdir: subdir,
-        blogRoot: subdir + '/',
-        adminRoot: adminRoot,
-        apiRoot: apiRoot,
+        adminRoot,
+        apiRoot,
+        subdir,
+        blogRoot: `${subdir}/`,
+        count: 'https://ghost.org/count/',
 
         url: {
-            admin: function () {
+            admin() {
                 return makeRoute(adminRoot, arguments);
             },
 
-            api: function () {
+            api() {
                 return makeRoute(apiRoot, arguments);
             },
 
-            join: function () {
+            join() {
                 if (arguments.length > 1) {
                     return makeRoute(arguments[0], Array.prototype.slice.call(arguments, 1));
                 } else if (arguments.length === 1) {
-                    var arg = arguments[0];
-                    return arg.slice(-1) === '/' ? arg : arg + '/';
+                    let [arg] = arguments;
+                    return arg.slice(-1) === '/' ? arg : `${arg}/`;
                 }
                 return '/';
             },
 
             asset: assetUrl
-        },
-        count: 'https://ghost.org/count/'
+        }
     };
 }

--- a/core/client/app/utils/isNumber.js
+++ b/core/client/app/utils/isNumber.js
@@ -1,6 +1,6 @@
 // isNumber function from lodash
 
-var toString = Object.prototype.toString;
+const {toString} = Object.prototype;
 
 export default function (value) {
     return typeof value === 'number' ||

--- a/core/client/app/utils/link-component.js
+++ b/core/client/app/utils/link-component.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
 
-Ember.LinkComponent.reopen({
-    active: Ember.computed('attrs.params', '_routing.currentState', function () {
-        var isActive = this._super();
+const {LinkComponent, computed} = Ember;
+
+LinkComponent.reopen({
+    active: computed('attrs.params', '_routing.currentState', function () {
+        let isActive = this._super(...arguments);
 
         if (typeof this.attrs.alternateActive === 'function') {
             this.attrs.alternateActive(isActive);
@@ -11,7 +13,7 @@ Ember.LinkComponent.reopen({
         return isActive;
     }),
 
-    activeClass: Ember.computed('tagName', function () {
+    activeClass: computed('tagName', function () {
         return this.get('tagName') === 'button' ? '' : 'active';
     })
 });

--- a/core/client/app/utils/random-password.js
+++ b/core/client/app/utils/random-password.js
@@ -1,8 +1,8 @@
 /* global generatePassword */
 
 export default function () {
-    var word = generatePassword(6),
-        randomN   = Math.floor(Math.random() * 1000);
+    let word = generatePassword(6);
+    let randomN   = Math.floor(Math.random() * 1000);
 
     return word + randomN;
 }

--- a/core/client/app/utils/set-scroll-classname.js
+++ b/core/client/app/utils/set-scroll-classname.js
@@ -5,9 +5,9 @@
 // **class-name:** The class which is applied.
 // **offset:** How far the user has to scroll before the class is applied.
 export default function (options) {
-    var $target = options.target || this,
-        offset = options.offset,
-        className = options.className || 'scrolling';
+    let $target = options.target || this;
+    let {offset} = options;
+    let className = options.className || 'scrolling';
 
     if (this.scrollTop() > offset) {
         $target.addClass(className);

--- a/core/client/app/utils/text-field.js
+++ b/core/client/app/utils/text-field.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
-Ember.TextField.reopen({
+const {TextField} = Ember;
+
+TextField.reopen({
     attributeBindings: ['autofocus']
 });

--- a/core/client/app/utils/titleize.js
+++ b/core/client/app/utils/titleize.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
-var lowerWords = ['of', 'a', 'the', 'and', 'an', 'or', 'nor', 'but', 'is', 'if',
-                  'then', 'else', 'when', 'at', 'from', 'by', 'on', 'off', 'for',
-                  'in', 'out', 'over', 'to', 'into', 'with'];
+const lowerWords = ['of', 'a', 'the', 'and', 'an', 'or', 'nor', 'but', 'is', 'if',
+                    'then', 'else', 'when', 'at', 'from', 'by', 'on', 'off', 'for',
+                    'in', 'out', 'over', 'to', 'into', 'with'];
 
 export default function (input) {
-    var words = input.split(' ').map(function (word, index) {
+    let words = input.split(' ').map((word, index) => {
         if (index === 0 || lowerWords.indexOf(word) === -1) {
             word = Ember.String.capitalize(word);
         }

--- a/core/client/app/utils/validator-extensions.js
+++ b/core/client/app/utils/validator-extensions.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 
+const {isBlank} = Ember;
+
 function init() {
     // Provide a few custom validators
     //
     validator.extend('empty', function (str) {
-        return Ember.isBlank(str);
+        return isBlank(str);
     });
 
     validator.extend('notContains', function (str, badString) {
@@ -13,5 +15,5 @@ function init() {
 }
 
 export default {
-    init: init
+    init
 };

--- a/core/client/app/utils/window-proxy.js
+++ b/core/client/app/utils/window-proxy.js
@@ -1,9 +1,9 @@
 export default {
-    changeLocation: function (url) {
+    changeLocation(url) {
         window.location = url;
     },
 
-    replaceLocation: function (url) {
+    replaceLocation(url) {
         window.location.replace(url);
     }
 };

--- a/core/client/app/utils/word-count.js
+++ b/core/client/app/utils/word-count.js
@@ -2,8 +2,7 @@
 /* global XRegExp */
 
 export default function (s) {
-
-    var nonANumLetters = new XRegExp("[^\\s\\d\\p{L}]", "g"); // all non-alphanumeric letters regexp
+    let nonANumLetters = new XRegExp("[^\\s\\d\\p{L}]", 'g'); // all non-alphanumeric letters regexp
 
     s = s.replace(/<(.|\n)*?>/g, ' '); // strip tags
     s = s.replace(nonANumLetters, ''); // ignore non-alphanumeric letters

--- a/core/client/app/validators/base.js
+++ b/core/client/app/validators/base.js
@@ -16,23 +16,22 @@ export default Ember.Object.extend({
      * @return {boolean}      True if the model passed all (or one) validation(s),
      *                        false if not
      */
-    check: function (model, prop) {
-        var self = this;
-
+    check(model, prop) {
         this.set('passed', true);
 
         if (prop && this[prop]) {
             this[prop](model);
         } else {
-            this.get('properties').forEach(function (property) {
-                if (self[property]) {
-                    self[property](model);
+            this.get('properties').forEach((property) => {
+                if (this[property]) {
+                    this[property](model);
                 }
             });
         }
         return this.get('passed');
     },
-    invalidate: function () {
+
+    invalidate() {
         this.set('passed', false);
     }
 });

--- a/core/client/app/validators/nav-item.js
+++ b/core/client/app/validators/nav-item.js
@@ -3,11 +3,13 @@ import BaseValidator from './base';
 export default BaseValidator.create({
     properties: ['label', 'url'],
 
-    label: function (model) {
-        var label = model.get('label'),
-            hasValidated = model.get('hasValidated');
+    label(model) {
+        let label = model.get('label');
+        let hasValidated = model.get('hasValidated');
 
-        if (this.canBeIgnored(model)) { return; }
+        if (this.canBeIgnored(model)) {
+            return;
+        }
 
         if (validator.empty(label)) {
             model.get('errors').add('label', 'You must specify a label');
@@ -17,13 +19,17 @@ export default BaseValidator.create({
         hasValidated.addObject('label');
     },
 
-    url: function (model) {
-        var url = model.get('url'),
-            hasValidated = model.get('hasValidated'),
-            validatorOptions = {require_protocol: true},
-            urlRegex = new RegExp(/^(\/|#|[a-zA-Z0-9\-]+:)/);
+    url(model) {
+        let url = model.get('url');
+        let hasValidated = model.get('hasValidated');
+        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+        let validatorOptions = {require_protocol: true};
+        /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
+        let urlRegex = new RegExp(/^(\/|#|[a-zA-Z0-9\-]+:)/);
 
-        if (this.canBeIgnored(model)) { return; }
+        if (this.canBeIgnored(model)) {
+            return;
+        }
 
         if (validator.empty(url)) {
             model.get('errors').add('url', 'You must specify a URL or relative path');
@@ -36,10 +42,10 @@ export default BaseValidator.create({
         hasValidated.addObject('url');
     },
 
-    canBeIgnored: function (model) {
-        var label = model.get('label'),
-            url = model.get('url'),
-            isLast = model.get('last');
+    canBeIgnored(model) {
+        let label = model.get('label');
+        let url = model.get('url');
+        let isLast = model.get('last');
 
         // if nav item is last and completely blank, mark it valid and skip
         if (isLast && (validator.empty(url) || url === '/') && validator.empty(label)) {

--- a/core/client/app/validators/new-user.js
+++ b/core/client/app/validators/new-user.js
@@ -3,16 +3,17 @@ import BaseValidator from './base';
 export default BaseValidator.extend({
     properties: ['name', 'email', 'password'],
 
-    name: function (model) {
-        var name = model.get('name');
+    name(model) {
+        let name = model.get('name');
 
         if (!validator.isLength(name, 1)) {
             model.get('errors').add('name', 'Please enter a name.');
             this.invalidate();
         }
     },
-    email: function (model) {
-        var email = model.get('email');
+
+    email(model) {
+        let email = model.get('email');
 
         if (validator.empty(email)) {
             model.get('errors').add('email', 'Please enter an email.');
@@ -22,8 +23,9 @@ export default BaseValidator.extend({
             this.invalidate();
         }
     },
-    password: function (model) {
-        var password = model.get('password');
+
+    password(model) {
+        let password = model.get('password');
 
         if (!validator.isLength(password, 8)) {
             model.get('errors').add('password', 'Password must be at least 8 characters long');

--- a/core/client/app/validators/post.js
+++ b/core/client/app/validators/post.js
@@ -3,8 +3,8 @@ import BaseValidator from './base';
 export default BaseValidator.create({
     properties: ['title', 'metaTitle', 'metaDescription'],
 
-    title: function (model) {
-        var title = model.get('title');
+    title(model) {
+        let title = model.get('title');
 
         if (validator.empty(title)) {
             model.get('errors').add('title', 'You must specify a title for the post.');
@@ -17,8 +17,8 @@ export default BaseValidator.create({
         }
     },
 
-    metaTitle: function (model) {
-        var metaTitle = model.get('meta_title');
+    metaTitle(model) {
+        let metaTitle = model.get('meta_title');
 
         if (!validator.isLength(metaTitle, 0, 150)) {
             model.get('errors').add('meta_title', 'Meta Title cannot be longer than 150 characters.');
@@ -26,8 +26,8 @@ export default BaseValidator.create({
         }
     },
 
-    metaDescription: function (model) {
-        var metaDescription = model.get('meta_description');
+    metaDescription(model) {
+        let metaDescription = model.get('meta_description');
 
         if (!validator.isLength(metaDescription, 0, 200)) {
             model.get('errors').add('meta_description', 'Meta Description cannot be longer than 200 characters.');

--- a/core/client/app/validators/reset.js
+++ b/core/client/app/validators/reset.js
@@ -2,9 +2,10 @@ import BaseValidator from './base';
 
 export default BaseValidator.create({
     properties: ['newPassword'],
-    newPassword: function (model) {
-        var p1 = model.get('newPassword'),
-            p2 = model.get('ne2Password');
+
+    newPassword(model) {
+        let p1 = model.get('newPassword');
+        let p2 = model.get('ne2Password');
 
         if (validator.empty(p1)) {
             model.get('errors').add('newPassword', 'Please enter a password.');

--- a/core/client/app/validators/setting.js
+++ b/core/client/app/validators/setting.js
@@ -2,33 +2,36 @@ import BaseValidator from './base';
 
 export default BaseValidator.create({
     properties: ['title', 'description', 'password', 'postsPerPage'],
-    title: function (model) {
-        var title = model.get('title');
+    title(model) {
+        let title = model.get('title');
 
         if (!validator.isLength(title, 0, 150)) {
             model.get('errors').add('title', 'Title is too long');
             this.invalidate();
         }
     },
-    description: function (model) {
-        var desc = model.get('description');
+
+    description(model) {
+        let desc = model.get('description');
 
         if (!validator.isLength(desc, 0, 200)) {
             model.get('errors').add('description', 'Description is too long');
             this.invalidate();
         }
     },
-    password: function (model) {
-        var isPrivate = model.get('isPrivate'),
-            password = model.get('password');
+
+    password(model) {
+        let isPrivate = model.get('isPrivate');
+        let password = model.get('password');
 
         if (isPrivate && password === '') {
             model.get('errors').add('password', 'Password must be supplied');
             this.invalidate();
         }
     },
-    postsPerPage: function (model) {
-        var postsPerPage = model.get('postsPerPage');
+
+    postsPerPage(model) {
+        let postsPerPage = model.get('postsPerPage');
 
         if (!validator.isInt(postsPerPage)) {
             model.get('errors').add('postsPerPage', 'Posts per page must be a number');

--- a/core/client/app/validators/setup.js
+++ b/core/client/app/validators/setup.js
@@ -3,8 +3,8 @@ import NewUserValidator from 'ghost/validators/new-user';
 export default NewUserValidator.create({
     properties: ['name', 'email', 'password', 'blogTitle'],
 
-    blogTitle: function (model) {
-        var blogTitle = model.get('blogTitle');
+    blogTitle(model) {
+        let blogTitle = model.get('blogTitle');
 
         if (!validator.isLength(blogTitle, 1)) {
             model.get('errors').add('blogTitle', 'Please enter a blog title.');

--- a/core/client/app/validators/signin.js
+++ b/core/client/app/validators/signin.js
@@ -4,8 +4,8 @@ export default BaseValidator.create({
     properties: ['identification', 'signin', 'forgotPassword'],
     invalidMessage: 'Email address is not valid',
 
-    identification: function (model) {
-        var id = model.get('identification');
+    identification(model) {
+        let id = model.get('identification');
 
         if (!validator.empty(id) && !validator.isEmail(id)) {
             model.get('errors').add('identification', this.get('invalidMessage'));
@@ -13,9 +13,9 @@ export default BaseValidator.create({
         }
     },
 
-    signin: function (model) {
-        var id = model.get('identification'),
-            password = model.get('password');
+    signin(model) {
+        let id = model.get('identification');
+        let password = model.get('password');
 
         model.get('errors').clear();
 
@@ -35,8 +35,8 @@ export default BaseValidator.create({
         }
     },
 
-    forgotPassword: function (model) {
-        var id = model.get('identification');
+    forgotPassword(model) {
+        let id = model.get('identification');
 
         model.get('errors').clear();
 

--- a/core/client/app/validators/tag-settings.js
+++ b/core/client/app/validators/tag-settings.js
@@ -3,8 +3,8 @@ import BaseValidator from './base';
 export default BaseValidator.create({
     properties: ['name', 'slug', 'description', 'metaTitle', 'metaDescription'],
 
-    name: function (model) {
-        var name = model.get('name');
+    name(model) {
+        let name = model.get('name');
 
         if (validator.empty(name)) {
             model.get('errors').add('name', 'You must specify a name for the tag.');
@@ -18,8 +18,8 @@ export default BaseValidator.create({
         }
     },
 
-    slug: function (model) {
-        var slug = model.get('slug');
+    slug(model) {
+        let slug = model.get('slug');
 
         if (!validator.isLength(slug, 0, 150)) {
             model.get('errors').add('slug', 'URL cannot be longer than 150 characters.');
@@ -27,8 +27,8 @@ export default BaseValidator.create({
         }
     },
 
-    description: function (model) {
-        var description = model.get('description');
+    description(model) {
+        let description = model.get('description');
 
         if (!validator.isLength(description, 0, 200)) {
             model.get('errors').add('description', 'Description cannot be longer than 200 characters.');
@@ -36,8 +36,8 @@ export default BaseValidator.create({
         }
     },
 
-    metaTitle: function (model) {
-        var metaTitle = model.get('meta_title');
+    metaTitle(model) {
+        let metaTitle = model.get('meta_title');
 
         if (!validator.isLength(metaTitle, 0, 150)) {
             model.get('errors').add('meta_title', 'Meta Title cannot be longer than 150 characters.');
@@ -45,8 +45,8 @@ export default BaseValidator.create({
         }
     },
 
-    metaDescription: function (model) {
-        var metaDescription = model.get('meta_description');
+    metaDescription(model) {
+        let metaDescription = model.get('meta_description');
 
         if (!validator.isLength(metaDescription, 0, 200)) {
             model.get('errors').add('meta_description', 'Meta Description cannot be longer than 200 characters.');

--- a/core/client/app/validators/user.js
+++ b/core/client/app/validators/user.js
@@ -1,13 +1,14 @@
 import BaseValidator from './base';
-import Ember from 'ember';
 
 export default BaseValidator.create({
     properties: ['name', 'bio', 'email', 'location', 'website', 'roles'],
-    isActive: function (model) {
+
+    isActive(model) {
         return (model.get('status') === 'active');
     },
-    name: function (model) {
-        var name = model.get('name');
+
+    name(model) {
+        let name = model.get('name');
 
         if (this.isActive(model)) {
             if (validator.empty(name)) {
@@ -19,8 +20,9 @@ export default BaseValidator.create({
             }
         }
     },
-    bio: function (model) {
-        var bio = model.get('bio');
+
+    bio(model) {
+        let bio = model.get('bio');
 
         if (this.isActive(model)) {
             if (!validator.isLength(bio, 0, 200)) {
@@ -29,16 +31,18 @@ export default BaseValidator.create({
             }
         }
     },
-    email: function (model) {
-        var email = model.get('email');
+
+    email(model) {
+        let email = model.get('email');
 
         if (!validator.isEmail(email)) {
             model.get('errors').add('email', 'Please supply a valid email address');
             this.invalidate();
         }
     },
-    location: function (model) {
-        var location = model.get('location');
+
+    location(model) {
+        let location = model.get('location');
 
         if (this.isActive(model)) {
             if (!validator.isLength(location, 0, 150)) {
@@ -47,21 +51,26 @@ export default BaseValidator.create({
             }
         }
     },
-    website: function (model) {
-        var website = model.get('website');
 
+    website(model) {
+        let website = model.get('website');
+
+        /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
         if (this.isActive(model)) {
-            if (!Ember.isEmpty(website) &&
+            if (!validator.empty(website) &&
                 (!validator.isURL(website, {require_protocol: false}) ||
                 !validator.isLength(website, 0, 2000))) {
+
                 model.get('errors').add('website', 'Website is not a valid url');
                 this.invalidate();
             }
         }
+        /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
     },
-    roles: function (model) {
+
+    roles(model) {
         if (!this.isActive(model)) {
-            var roles = model.get('roles');
+            let roles = model.get('roles');
 
             if (roles.length < 1) {
                 model.get('errors').add('role', 'Please select a role');

--- a/core/client/config/environment.js
+++ b/core/client/config/environment.js
@@ -1,5 +1,5 @@
 /* jshint node: true */
-/* jscs:disable disallowEmptyBlocks */
+/* jscs:disable */
 
 module.exports = function (environment) {
     var ENV = {

--- a/core/client/ember-cli-build.js
+++ b/core/client/ember-cli-build.js
@@ -1,3 +1,4 @@
+/* jscs:disable */
 /* global require, module */
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app'),

--- a/core/client/lib/asset-delivery/index.js
+++ b/core/client/lib/asset-delivery/index.js
@@ -1,3 +1,4 @@
+/* jscs:disable */
 module.exports = {
     name: 'asset-delivery',
     postBuild: function (results) {

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -45,7 +45,7 @@
     "ember-myth": "0.1.1",
     "ember-simple-auth": "1.0.0",
     "ember-sinon": "0.2.1",
-    "ember-watson": "^0.6.4",
+    "ember-suave": "1.2.2",
     "fs-extra": "0.16.3",
     "glob": "^4.0.5",
     "walk-sync": "^0.1.3"

--- a/core/client/tests/.jscsrc
+++ b/core/client/tests/.jscsrc
@@ -1,0 +1,4 @@
+{
+    "preset": "../.jscsrc",
+    "requireBlocksOnNewline": null
+}

--- a/core/client/tests/acceptance/authentication-test.js
+++ b/core/client/tests/acceptance/authentication-test.js
@@ -34,8 +34,8 @@ describe('Acceptance: Authentication', function () {
             };
 
             server.loadFixtures();
-            const role = server.create('role', {name: 'Administrator'}),
-                  user = server.create('user', {roles: [role], slug: 'test-user'});
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role], slug: 'test-user'});
         });
 
         afterEach(function () {
@@ -43,9 +43,6 @@ describe('Acceptance: Authentication', function () {
         });
 
         it('invalidates session on 401 API response', function () {
-            const role = server.create('role', {name: 'Administrator'}),
-                  user = server.create('user', {roles: [role]});
-
             // return a 401 when attempting to retrieve tags
             server.get('/users/', (db, request) => {
                 return new Mirage.Response(401, {}, {
@@ -75,13 +72,13 @@ describe('Acceptance: Authentication', function () {
         });
 
         it('displays re-auth modal attempting to save with invalid session', function () {
-            const role = server.create('role', {name: 'Administrator'}),
-                  user = server.create('user', {roles: [role]});
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role]});
 
             // simulate an invalid session when saving the edited post
             server.put('/posts/:id/', (db, request) => {
-                let post = db.posts.find(request.params.id),
-                    [attrs] = JSON.parse(request.requestBody).posts;
+                let post = db.posts.find(request.params.id);
+                let [attrs] = JSON.parse(request.requestBody).posts;
 
                 if (attrs.markdown === 'Edited post body') {
                     return new Mirage.Response(401, {}, {

--- a/core/client/tests/acceptance/settings/navigation-test.js
+++ b/core/client/tests/acceptance/settings/navigation-test.js
@@ -1,4 +1,5 @@
 /* jshint expr:true */
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import {
     describe,
     it,
@@ -33,8 +34,8 @@ describe('Acceptance: Settings - Navigation', function () {
     });
 
     it('redirects to team page when authenticated as author', function () {
-        const role = server.create('role', {name: 'Author'}),
-              user = server.create('user', {roles: [role], slug: 'test-user'});
+        let role = server.create('role', {name: 'Author'});
+        let user = server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
         visit('/settings/navigation');
@@ -46,8 +47,8 @@ describe('Acceptance: Settings - Navigation', function () {
 
     describe('when logged in', function () {
         beforeEach(function () {
-            const role = server.create('role', {name: 'Administrator'}),
-                  user = server.create('user', {roles: [role]});
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role]});
 
             // load the settings fixtures
             // TODO: this should always be run for acceptance tests

--- a/core/client/tests/acceptance/settings/tags-test.js
+++ b/core/client/tests/acceptance/settings/tags-test.js
@@ -1,4 +1,5 @@
 /* jshint expr:true */
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import {
     describe,
     it,
@@ -10,33 +11,34 @@ import Ember from 'ember';
 import startApp from '../../helpers/start-app';
 import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
 
-const {run} = Ember,
-    // Grabbed from keymaster's testing code because Ember's `keyEvent` helper
-    // is for some reason not triggering the events in a way that keymaster detects:
-    // https://github.com/madrobby/keymaster/blob/master/test/keymaster.html#L31
-    modifierMap = {
-        16:'shiftKey',
-        18:'altKey',
-        17:'ctrlKey',
-        91:'metaKey'
-    },
-    keydown = function (code, modifiers, el) {
-        let event = document.createEvent('Event');
-        event.initEvent('keydown', true, true);
-        event.keyCode = code;
-        if (modifiers && modifiers.length > 0) {
-            for (let i in modifiers) {
-                event[modifierMap[modifiers[i]]] = true;
-            }
+const {run} = Ember;
+
+// Grabbed from keymaster's testing code because Ember's `keyEvent` helper
+// is for some reason not triggering the events in a way that keymaster detects:
+// https://github.com/madrobby/keymaster/blob/master/test/keymaster.html#L31
+const modifierMap = {
+    16: 'shiftKey',
+    18: 'altKey',
+    17: 'ctrlKey',
+    91: 'metaKey'
+};
+let keydown = function (code, modifiers, el) {
+    let event = document.createEvent('Event');
+    event.initEvent('keydown', true, true);
+    event.keyCode = code;
+    if (modifiers && modifiers.length > 0) {
+        for (let i in modifiers) {
+            event[modifierMap[modifiers[i]]] = true;
         }
-        (el || document).dispatchEvent(event);
-    },
-    keyup = function (code, el) {
-        let event = document.createEvent('Event');
-        event.initEvent('keyup', true, true);
-        event.keyCode = code;
-        (el || document).dispatchEvent(event);
-    };
+    }
+    (el || document).dispatchEvent(event);
+};
+let keyup = function (code, el) {
+    let event = document.createEvent('Event');
+    event.initEvent('keyup', true, true);
+    event.keyCode = code;
+    (el || document).dispatchEvent(event);
+};
 
 describe('Acceptance: Settings - Tags', function () {
     let application;
@@ -59,8 +61,8 @@ describe('Acceptance: Settings - Tags', function () {
     });
 
     it('redirects to team page when authenticated as author', function () {
-        const role = server.create('role', {name: 'Author'}),
-              user = server.create('user', {roles: [role], slug: 'test-user'});
+        let role = server.create('role', {name: 'Author'});
+        let user = server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
         visit('/settings/navigation');
@@ -72,8 +74,8 @@ describe('Acceptance: Settings - Tags', function () {
 
     describe('when logged in', function () {
         beforeEach(function () {
-            const role = server.create('role', {name: 'Administrator'}),
-                  user = server.create('user', {roles: [role]});
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role]});
 
             // load the settings fixtures
             // TODO: this should always be run for acceptance tests
@@ -83,8 +85,8 @@ describe('Acceptance: Settings - Tags', function () {
         });
 
         it('it renders, can be navigated, can edit, create & delete tags', function () {
-            const tag1 = server.create('tag'),
-                  tag2 = server.create('tag');
+            let tag1 = server.create('tag');
+            let tag2 = server.create('tag');
 
             visit('/settings/tags');
 

--- a/core/client/tests/acceptance/setup-test.js
+++ b/core/client/tests/acceptance/setup-test.js
@@ -25,8 +25,8 @@ describe('Acceptance: Setup', function () {
     });
 
     it('redirects if already authenticated', function () {
-        const role = server.create('role', {name: 'Author'}),
-              user = server.create('user', {roles: [role], slug: 'test-user'});
+        let role = server.create('role', {name: 'Author'});
+        let user = server.create('user', {roles: [role], slug: 'test-user'});
 
         authenticateSession(application);
 

--- a/core/client/tests/helpers/resolver.js
+++ b/core/client/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
 import Resolver from 'ember/resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+let resolver = Resolver.create();
 
 resolver.namespace = {
     modulePrefix: config.modulePrefix,

--- a/core/client/tests/helpers/start-app.js
+++ b/core/client/tests/helpers/start-app.js
@@ -2,13 +2,16 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const {merge, run} = Ember;
+
 export default function startApp(attrs) {
-    var application,
-        attributes = Ember.merge({}, config.APP);
+    let attributes = merge({}, config.APP);
+    let application;
 
-    attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+    // use defaults, but you can override;
+    attributes = merge(attributes, attrs);
 
-    Ember.run(function () {
+    run(function () {
         application = Application.create(attributes);
         application.setupForTesting();
         application.injectTestHelpers();

--- a/core/client/tests/integration/components/gh-alerts-test.js
+++ b/core/client/tests/integration/components/gh-alerts-test.js
@@ -7,10 +7,12 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const {run} = Ember,
-    notificationsStub = Ember.Service.extend({
-        alerts: Ember.A()
-    });
+const {run} = Ember;
+const emberA = Ember.A;
+
+let notificationsStub = Ember.Service.extend({
+    alerts: emberA()
+});
 
 describeComponent(
     'gh-alerts',
@@ -34,7 +36,7 @@ describeComponent(
             expect(this.$('.gh-alerts').length).to.equal(1);
             expect(this.$('.gh-alerts').children().length).to.equal(2);
 
-            this.set('notifications.alerts', Ember.A());
+            this.set('notifications.alerts', emberA());
             expect(this.$('.gh-alerts').children().length).to.equal(0);
         });
 
@@ -50,7 +52,7 @@ describeComponent(
             this.get('notifications.alerts').pushObject({message: 'Third', type: 'success'});
 
             expectedCount = 0;
-            this.set('notifications.alerts', Ember.A());
+            this.set('notifications.alerts', emberA());
         });
     }
 );

--- a/core/client/tests/integration/components/gh-navigation-test.js
+++ b/core/client/tests/integration/components/gh-navigation-test.js
@@ -21,9 +21,9 @@ describeComponent(
         });
 
         it('triggers reorder action', function () {
-            let navItems = [],
-                expectedOldIndex = -1,
-                expectedNewIndex = -1;
+            let navItems = [];
+            let expectedOldIndex = -1;
+            let expectedNewIndex = -1;
 
             navItems.pushObject(NavItem.create({label: 'First', url: '/first'}));
             navItems.pushObject(NavItem.create({label: 'Second', url: '/second'}));

--- a/core/client/tests/integration/components/gh-navitem-test.js
+++ b/core/client/tests/integration/components/gh-navitem-test.js
@@ -73,7 +73,9 @@ describeComponent(
             this.set('navItem', NavItem.create({label: 'Test', url: '/url', last: true}));
 
             let addActionCallCount = 0;
-            this.on('add', () => { addActionCallCount++; });
+            this.on('add', () => {
+                addActionCallCount++;
+            });
 
             this.render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl addItem="add"}}`);
             this.$('.gh-blognav-add').trigger('click');
@@ -85,7 +87,9 @@ describeComponent(
             this.set('navItem', NavItem.create({label: 'Test', url: '/url'}));
 
             let updateActionCallCount = 0;
-            this.on('update', () => { updateActionCallCount++; });
+            this.on('update', () => {
+                updateActionCallCount++;
+            });
 
             this.render(hbs`{{gh-navitem navItem=navItem baseUrl=baseUrl updateUrl="update"}}`);
             this.$('.gh-blognav-url input').trigger('blur');

--- a/core/client/tests/integration/components/gh-navitem-url-input-test.js
+++ b/core/client/tests/integration/components/gh-navitem-url-input-test.js
@@ -7,10 +7,11 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const {run} = Ember,
-      // we want baseUrl to match the running domain so relative URLs are
-      // handled as expected (browser auto-sets the domain when using a.href)
-      currentUrl = `${window.location.protocol}//${window.location.host}/`;
+const {run} = Ember;
+
+// we want baseUrl to match the running domain so relative URLs are
+// handled as expected (browser auto-sets the domain when using a.href)
+let currentUrl = `${window.location.protocol}//${window.location.host}/`;
 
 describeComponent(
     'gh-navitem-url-input',
@@ -104,37 +105,53 @@ describeComponent(
         });
 
         it('adds base url to relative urls on blur', function () {
-            this.on('updateUrl', () => { return null; });
+            this.on('updateUrl', () => {
+                return null;
+            });
             this.render(hbs`
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
             `);
             let $input = this.$('input');
 
-            run(() => { $input.val('/about').trigger('input'); });
-            run(() => { $input.trigger('blur'); });
+            run(() => {
+                $input.val('/about').trigger('input');
+            });
+            run(() => {
+                $input.trigger('blur');
+            });
 
             expect($input.val()).to.equal(`${currentUrl}about`);
         });
 
         it('adds "mailto:" to email addresses on blur', function () {
-            this.on('updateUrl', () => { return null; });
+            this.on('updateUrl', () => {
+                return null;
+            });
             this.render(hbs`
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
             `);
             let $input = this.$('input');
 
-            run(() => { $input.val('test@example.com').trigger('input'); });
-            run(() => { $input.trigger('blur'); });
+            run(() => {
+                $input.val('test@example.com').trigger('input');
+            });
+            run(() => {
+                $input.trigger('blur');
+            });
 
             expect($input.val()).to.equal('mailto:test@example.com');
 
             // ensure we don't double-up on the mailto:
-            run(() => { $input.trigger('blur'); });
+            run(() => {
+                $input.trigger('blur');
+            });
             expect($input.val()).to.equal('mailto:test@example.com');
         });
 
         it('doesn\'t add base url to invalid urls on blur', function () {
-            this.on('updateUrl', () => { return null; });
+            this.on('updateUrl', () => {
+                return null;
+            });
             this.render(hbs`
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
             `);
@@ -154,7 +171,9 @@ describeComponent(
         });
 
         it('doesn\'t mangle invalid urls on blur', function () {
-            this.on('updateUrl', () => { return null; });
+            this.on('updateUrl', () => {
+                return null;
+            });
             this.render(hbs`
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
             `);
@@ -176,13 +195,17 @@ describeComponent(
 
             expect($input.hasClass('fake-placeholder')).to.be.true;
 
-            run(() => { $input.trigger('focus'); });
+            run(() => {
+                $input.trigger('focus');
+            });
             expect($input.hasClass('fake-placeholder')).to.be.false;
         });
 
         it('triggers "change" action on blur', function () {
             let changeActionCallCount = 0;
-            this.on('updateUrl', () => { changeActionCallCount++; });
+            this.on('updateUrl', () => {
+                changeActionCallCount++;
+            });
 
             this.render(hbs `
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
@@ -196,7 +219,9 @@ describeComponent(
 
         it('triggers "change" action on enter', function () {
             let changeActionCallCount = 0;
-            this.on('updateUrl', () => { changeActionCallCount++; });
+            this.on('updateUrl', () => {
+                changeActionCallCount++;
+            });
 
             this.render(hbs `
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
@@ -215,7 +240,9 @@ describeComponent(
 
         it('triggers "change" action on CMD-S', function () {
             let changeActionCallCount = 0;
-            this.on('updateUrl', () => { changeActionCallCount++; });
+            this.on('updateUrl', () => {
+                changeActionCallCount++;
+            });
 
             this.render(hbs `
                 {{gh-navitem-url-input baseUrl=baseUrl url=url last=isLast change="updateUrl"}}
@@ -247,8 +274,12 @@ describeComponent(
 
             let testUrl = (url) => {
                 expectedUrl = url;
-                run(() => { $input.val(url).trigger('input'); });
-                run(() => { $input.trigger('blur'); });
+                run(() => {
+                    $input.val(url).trigger('input');
+                });
+                run(() => {
+                    $input.trigger('blur');
+                });
             };
 
             testUrl('http://example.com');
@@ -276,8 +307,12 @@ describeComponent(
 
             let testUrl = (url) => {
                 expectedUrl = `/${url}`;
-                run(() => { $input.val(`${currentUrl}${url}`).trigger('input'); });
-                run(() => { $input.trigger('blur'); });
+                run(() => {
+                    $input.val(`${currentUrl}${url}`).trigger('input');
+                });
+                run(() => {
+                    $input.trigger('blur');
+                });
             };
 
             testUrl('about');
@@ -301,8 +336,12 @@ describeComponent(
 
             let testUrl = (url) => {
                 expectedUrl = url;
-                run(() => { $input.val(`${currentUrl}blog${url}`).trigger('input'); });
-                run(() => { $input.trigger('blur'); });
+                run(() => {
+                    $input.val(`${currentUrl}blog${url}`).trigger('input');
+                });
+                run(() => {
+                    $input.trigger('blur');
+                });
             };
 
             testUrl('/about');
@@ -325,7 +364,9 @@ describeComponent(
             let $input = this.$('input');
 
             expectedUrl = 'http://test.example.com/';
-            run(() => { $input.val(expectedUrl).trigger('input').trigger('blur'); });
+            run(() => {
+                $input.val(expectedUrl).trigger('input').trigger('blur');
+            });
             expect($input.val()).to.equal(expectedUrl);
         });
     }

--- a/core/client/tests/integration/components/gh-notifications-test.js
+++ b/core/client/tests/integration/components/gh-notifications-test.js
@@ -7,10 +7,12 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const {run} = Ember,
-    notificationsStub = Ember.Service.extend({
-        notifications: Ember.A()
-    });
+const {Service, run} = Ember;
+const emberA = Ember.A;
+
+let notificationsStub = Service.extend({
+    notifications: emberA()
+});
 
 describeComponent(
     'gh-notifications',
@@ -35,7 +37,7 @@ describeComponent(
 
             expect(this.$('.gh-notifications').children().length).to.equal(2);
 
-            this.set('notifications.notifications', Ember.A());
+            this.set('notifications.notifications', emberA());
             expect(this.$('.gh-notifications').children().length).to.equal(0);
         });
     }

--- a/core/client/tests/integration/components/gh-profile-image-test.js
+++ b/core/client/tests/integration/components/gh-profile-image-test.js
@@ -8,17 +8,18 @@ import {
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
-const {run} = Ember,
-      pathsStub = Ember.Service.extend({
-          url: {
-              api: function () {
-                  return '';
-              },
-              asset: function (src) {
-                  return src;
-              }
-          }
-      });
+const {run} = Ember;
+
+let pathsStub = Ember.Service.extend({
+    url: {
+        api() {
+            return '';
+        },
+        asset(src) {
+            return src;
+        }
+    }
+});
 
 describeComponent(
     'gh-profile-image',
@@ -43,8 +44,8 @@ describeComponent(
         });
 
         it('immediately renders the gravatar if valid email supplied', function () {
-            let email = 'test@example.com',
-                expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
+            let email = 'test@example.com';
+            let expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
 
             this.set('email', email);
 
@@ -57,8 +58,8 @@ describeComponent(
         });
 
         it('throttles gravatar loading as email is changed', function (done) {
-            let email = 'test@example.com',
-                expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
+            let email = 'test@example.com';
+            let expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
 
             this.set('email', 'test');
 

--- a/core/client/tests/integration/components/gh-tag-settings-form-test.js
+++ b/core/client/tests/integration/components/gh-tag-settings-form-test.js
@@ -1,4 +1,5 @@
 /* jshint expr:true */
+/* jscs:disable requireTemplateStringsForConcatenation */
 import { expect } from 'chai';
 import {
     describeComponent,
@@ -8,10 +9,11 @@ import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 import DS from 'ember-data';
 
-const {run} = Ember,
-      configStub = Ember.Service.extend({
-          blogUrl: 'http://localhost:2368'
-      });
+const {run} = Ember;
+
+let configStub = Ember.Service.extend({
+    blogUrl: 'http://localhost:2368'
+});
 
 describeComponent(
     'gh-tag-settings-form',
@@ -21,6 +23,7 @@ describeComponent(
     },
     function () {
         beforeEach(function () {
+            /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
             let tag = Ember.Object.create({
                 id: 1,
                 name: 'Test',
@@ -31,6 +34,7 @@ describeComponent(
                 errors: DS.Errors.create(),
                 hasValidated: []
             });
+            /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
 
             this.set('tag', tag);
             this.set('actions.setProperty', function (property, value) {
@@ -120,8 +124,8 @@ describeComponent(
         });
 
         it('triggers setProperty action on blur of all fields', function () {
-            let expectedProperty = '',
-                expectedValue = '';
+            let expectedProperty = '';
+            let expectedValue = '';
 
             this.set('actions.setProperty', function (property, value) {
                 expect(property, 'property').to.equal(expectedProperty);
@@ -164,8 +168,8 @@ describeComponent(
         });
 
         it('displays error messages for validated fields', function () {
-            let errors = this.get('tag.errors'),
-                hasValidated = this.get('tag.hasValidated');
+            let errors = this.get('tag.errors');
+            let hasValidated = this.get('tag.hasValidated');
 
             errors.add('name', 'must be present');
             hasValidated.push('name');

--- a/core/client/tests/unit/components/gh-alert-test.js
+++ b/core/client/tests/unit/components/gh-alert-test.js
@@ -17,9 +17,9 @@ describeComponent(
     },
     function () {
         it('closes notification through notifications service', function () {
-            var component = this.subject(),
-                notifications = {},
-                notification = {message: 'Test close', type: 'success'};
+            let component = this.subject();
+            let notifications = {};
+            let notification = {message: 'Test close', type: 'success'};
 
             notifications.closeNotification = sinon.spy();
             component.set('notifications', notifications);

--- a/core/client/tests/unit/components/gh-app-test.js
+++ b/core/client/tests/unit/components/gh-app-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-content-preview-content-test.js
+++ b/core/client/tests/unit/components/gh-content-preview-content-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-editor-save-button-test.js
+++ b/core/client/tests/unit/components/gh-editor-save-button-test.js
@@ -20,7 +20,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-editor-test.js
+++ b/core/client/tests/unit/components/gh-editor-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-infinite-scroll-box-test.js
+++ b/core/client/tests/unit/components/gh-infinite-scroll-box-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-infinite-scroll-test.js
+++ b/core/client/tests/unit/components/gh-infinite-scroll-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-navitem-url-input-test.js
+++ b/core/client/tests/unit/components/gh-navitem-url-input-test.js
@@ -6,6 +6,8 @@ import {
     it
 } from 'ember-mocha';
 
+const {run} = Ember;
+
 describeComponent(
     'gh-navitem-url-input',
     'Unit: Component: gh-navitem-url-input',
@@ -14,20 +16,20 @@ describeComponent(
     },
     function () {
         it('identifies a URL as the base URL', function () {
-            var component = this.subject({
+            let component = this.subject({
                 url: '',
                 baseUrl: 'http://example.com/'
             });
 
             this.render();
 
-            Ember.run(function () {
+            run(function () {
                 component.set('value', 'http://example.com/');
             });
 
             expect(component.get('isBaseUrl')).to.be.ok;
 
-            Ember.run(function () {
+            run(function () {
                 component.set('value', 'http://example.com/go/');
             });
 

--- a/core/client/tests/unit/components/gh-notification-test.js
+++ b/core/client/tests/unit/components/gh-notification-test.js
@@ -17,9 +17,9 @@ describeComponent(
     },
     function () {
         it('closes notification through notifications service', function () {
-            var component = this.subject(),
-                notifications = {},
-                notification = {message: 'Test close', type: 'success'};
+            let component = this.subject();
+            let notifications = {};
+            let notification = {message: 'Test close', type: 'success'};
 
             notifications.closeNotification = sinon.spy();
             component.set('notifications', notifications);
@@ -31,9 +31,9 @@ describeComponent(
         });
 
         it('closes notification when animationend event is triggered', function (done) {
-            var component = this.subject(),
-                notifications = {},
-                notification = {message: 'Test close', type: 'success'};
+            let component = this.subject();
+            let notifications = {};
+            let notification = {message: 'Test close', type: 'success'};
 
             notifications.closeNotification = sinon.spy();
             component.set('notifications', notifications);

--- a/core/client/tests/unit/components/gh-posts-list-item-test.js
+++ b/core/client/tests/unit/components/gh-posts-list-item-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-search-input-test.js
+++ b/core/client/tests/unit/components/gh-search-input-test.js
@@ -15,7 +15,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
             expect(component._state).to.equal('preRender');
 
             // renders the component on the page

--- a/core/client/tests/unit/components/gh-select-native-test.js
+++ b/core/client/tests/unit/components/gh-select-native-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-selectize-test.js
+++ b/core/client/tests/unit/components/gh-selectize-test.js
@@ -7,6 +7,7 @@ import {
 import Ember from 'ember';
 
 const {run} = Ember;
+const emberA = Ember.A;
 
 describeComponent(
     'gh-selectize',
@@ -18,11 +19,11 @@ describeComponent(
     },
     function () {
         it('re-orders selection when selectize order is changed', function () {
-            const component = this.subject();
+            let component = this.subject();
 
             run(() => {
-                component.set('content', Ember.A(['item 1', 'item 2', 'item 3']));
-                component.set('selection', Ember.A(['item 2', 'item 3']));
+                component.set('content', emberA(['item 1', 'item 2', 'item 3']));
+                component.set('selection', emberA(['item 2', 'item 3']));
                 component.set('multiple', true);
             });
 

--- a/core/client/tests/unit/components/gh-spin-button-test.js
+++ b/core/client/tests/unit/components/gh-spin-button-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-trim-focus-input_test.js
+++ b/core/client/tests/unit/components/gh-trim-focus-input_test.js
@@ -12,7 +12,7 @@ describeComponent(
     },
     function () {
         it('trims value on focusOut', function () {
-            var component = this.subject({
+            let component = this.subject({
                 value: 'some random stuff   '
             });
 
@@ -23,7 +23,7 @@ describeComponent(
         });
 
         it('does not have the autofocus attribute if not set to focus', function () {
-            var component = this.subject({
+            let component = this.subject({
                 value: 'some text',
                 focus: false
             });
@@ -34,7 +34,7 @@ describeComponent(
         });
 
         it('has the autofocus attribute if set to focus', function () {
-            var component = this.subject({
+            let component = this.subject({
                 value: 'some text',
                 focus: true
             });

--- a/core/client/tests/unit/components/gh-url-preview_test.js
+++ b/core/client/tests/unit/components/gh-url-preview_test.js
@@ -11,7 +11,7 @@ describeComponent(
     },
     function () {
         it('generates the correct preview URL with a prefix', function () {
-            var component = this.subject({
+            let component = this.subject({
                 prefix: 'tag',
                 slug: 'test-slug',
                 tagName: 'p',
@@ -26,7 +26,7 @@ describeComponent(
         });
 
         it('generates the correct preview URL without a prefix', function () {
-            var component = this.subject({
+            let component = this.subject({
                 slug: 'test-slug',
                 tagName: 'p',
                 classNames: 'test-class',

--- a/core/client/tests/unit/components/gh-user-active-test.js
+++ b/core/client/tests/unit/components/gh-user-active-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/components/gh-user-invited-test.js
+++ b/core/client/tests/unit/components/gh-user-invited-test.js
@@ -16,7 +16,7 @@ describeComponent(
     function () {
         it('renders', function () {
             // creates the component instance
-            var component = this.subject();
+            let component = this.subject();
 
             expect(component._state).to.equal('preRender');
 

--- a/core/client/tests/unit/controllers/post-settings-menu-test.js
+++ b/core/client/tests/unit/controllers/post-settings-menu-test.js
@@ -1,8 +1,15 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 import {
     describeModule,
     it
 } from 'ember-mocha';
+
+const {run} = Ember;
+
+function K() {
+    return this;
+}
 
 describeModule(
     'controller:post-settings-menu',
@@ -13,7 +20,7 @@ describeModule(
 
     function () {
         it('slugValue is one-way bound to model.slug', function () {
-            var controller = this.subject({
+            let controller = this.subject({
                 model: Ember.Object.create({
                     slug: 'a-slug'
                 })
@@ -22,20 +29,20 @@ describeModule(
             expect(controller.get('model.slug')).to.equal('a-slug');
             expect(controller.get('slugValue')).to.equal('a-slug');
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('model.slug', 'changed-slug');
 
                 expect(controller.get('slugValue')).to.equal('changed-slug');
             });
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('slugValue', 'changed-directly');
 
                 expect(controller.get('model.slug')).to.equal('changed-slug');
                 expect(controller.get('slugValue')).to.equal('changed-directly');
             });
 
-            Ember.run(function () {
+            run(function () {
                 // test that the one-way binding is still in place
                 controller.set('model.slug', 'should-update');
 
@@ -44,7 +51,7 @@ describeModule(
         });
 
         it('metaTitleScratch is one-way bound to model.meta_title', function () {
-            var controller = this.subject({
+            let controller = this.subject({
                 model: Ember.Object.create({
                     meta_title: 'a title'
                 })
@@ -53,20 +60,20 @@ describeModule(
             expect(controller.get('model.meta_title')).to.equal('a title');
             expect(controller.get('metaTitleScratch')).to.equal('a title');
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('model.meta_title', 'a different title');
 
                 expect(controller.get('metaTitleScratch')).to.equal('a different title');
             });
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('metaTitleScratch', 'changed directly');
 
                 expect(controller.get('model.meta_title')).to.equal('a different title');
                 expect(controller.get('metaTitleScratch')).to.equal('changed directly');
             });
 
-            Ember.run(function () {
+            run(function () {
                 // test that the one-way binding is still in place
                 controller.set('model.meta_title', 'should update');
 
@@ -75,7 +82,7 @@ describeModule(
         });
 
         it('metaDescriptionScratch is one-way bound to model.meta_description', function () {
-            var controller = this.subject({
+            let controller = this.subject({
                 model: Ember.Object.create({
                     meta_description: 'a description'
                 })
@@ -84,20 +91,20 @@ describeModule(
             expect(controller.get('model.meta_description')).to.equal('a description');
             expect(controller.get('metaDescriptionScratch')).to.equal('a description');
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('model.meta_description', 'a different description');
 
                 expect(controller.get('metaDescriptionScratch')).to.equal('a different description');
             });
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('metaDescriptionScratch', 'changed directly');
 
                 expect(controller.get('model.meta_description')).to.equal('a different description');
                 expect(controller.get('metaDescriptionScratch')).to.equal('changed directly');
             });
 
-            Ember.run(function () {
+            run(function () {
                 // test that the one-way binding is still in place
                 controller.set('model.meta_description', 'should update');
 
@@ -107,7 +114,7 @@ describeModule(
 
         describe('seoTitle', function () {
             it('should be the meta_title if one exists', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         meta_title: 'a meta-title',
                         titleScratch: 'should not be used'
@@ -118,7 +125,7 @@ describeModule(
             });
 
             it('should default to the title if an explicit meta-title does not exist', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         titleScratch: 'should be the meta-title'
                     })
@@ -128,7 +135,7 @@ describeModule(
             });
 
             it('should be the meta_title if both title and meta_title exist', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         meta_title: 'a meta-title',
                         titleScratch: 'a title'
@@ -139,7 +146,7 @@ describeModule(
             });
 
             it('should revert to the title if explicit meta_title is removed', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         meta_title: 'a meta-title',
                         titleScratch: 'a title'
@@ -148,7 +155,7 @@ describeModule(
 
                 expect(controller.get('seoTitle')).to.equal('a meta-title');
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.meta_title', '');
 
                     expect(controller.get('seoTitle')).to.equal('a title');
@@ -156,18 +163,15 @@ describeModule(
             });
 
             it('should truncate to 70 characters with an appended ellipsis', function () {
-                var longTitle,
-                    controller;
-
-                longTitle = new Array(100).join('a');
-                expect(longTitle.length).to.equal(99);
-
-                controller = this.subject({
+                let longTitle = new Array(100).join('a');
+                let controller = this.subject({
                     model: Ember.Object.create()
                 });
 
-                Ember.run(function () {
-                    var expected = longTitle.substr(0, 70) + '&hellip;';
+                expect(longTitle.length).to.equal(99);
+
+                run(function () {
+                    let expected = `${longTitle.substr(0, 70)}&hellip;`;
 
                     controller.set('metaTitleScratch', longTitle);
 
@@ -179,7 +183,7 @@ describeModule(
 
         describe('seoDescription', function () {
             it('should be the meta_description if one exists', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         meta_description: 'a description'
                     })
@@ -194,18 +198,15 @@ describeModule(
             });
 
             it('should truncate to 156 characters with an appended ellipsis', function () {
-                var longDescription,
-                    controller;
-
-                longDescription = new Array(200).join('a');
-                expect(longDescription.length).to.equal(199);
-
-                controller = this.subject({
+                let longDescription = new Array(200).join('a');
+                let controller = this.subject({
                     model: Ember.Object.create()
                 });
 
-                Ember.run(function () {
-                    var expected = longDescription.substr(0, 156) + '&hellip;';
+                expect(longDescription.length).to.equal(199);
+
+                run(function () {
+                    let expected = `${longDescription.substr(0, 156)}&hellip;`;
 
                     controller.set('metaDescriptionScratch', longDescription);
 
@@ -217,7 +218,7 @@ describeModule(
 
         describe('seoURL', function () {
             it('should be the URL of the blog if no post slug exists', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     config: Ember.Object.create({blogUrl: 'http://my-ghost-blog.com'}),
                     model: Ember.Object.create()
                 });
@@ -226,7 +227,7 @@ describeModule(
             });
 
             it('should be the URL of the blog plus the post slug', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     config: Ember.Object.create({blogUrl: 'http://my-ghost-blog.com'}),
                     model: Ember.Object.create({slug: 'post-slug'})
                 });
@@ -235,14 +236,14 @@ describeModule(
             });
 
             it('should update when the post slug changes', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     config: Ember.Object.create({blogUrl: 'http://my-ghost-blog.com'}),
                     model: Ember.Object.create({slug: 'post-slug'})
                 });
 
                 expect(controller.get('seoURL')).to.equal('http://my-ghost-blog.com/post-slug/');
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.slug', 'changed-slug');
 
                     expect(controller.get('seoURL')).to.equal('http://my-ghost-blog.com/changed-slug/');
@@ -250,21 +251,18 @@ describeModule(
             });
 
             it('should truncate a long URL to 70 characters with an appended ellipsis', function () {
-                var longSlug,
-                    blogURL = 'http://my-ghost-blog.com',
-                    expected,
-                    controller;
-
-                longSlug = new Array(75).join('a');
-                expect(longSlug.length).to.equal(74);
-
-                controller = this.subject({
+                let blogURL = 'http://my-ghost-blog.com';
+                let longSlug = new Array(75).join('a');
+                let controller = this.subject({
                     config: Ember.Object.create({blogUrl: blogURL}),
                     model: Ember.Object.create({slug: longSlug})
                 });
+                let expected;
 
-                expected = blogURL + '/' + longSlug + '/';
-                expected = expected.substr(0, 70) + '&hellip;';
+                expect(longSlug.length).to.equal(74);
+
+                expected = `${blogURL}/${longSlug}/`;
+                expected = `${expected.substr(0, 70)}&hellip;`;
 
                 expect(controller.get('seoURL').toString().length).to.equal(78);
                 expect(controller.get('seoURL').toString()).to.equal(expected);
@@ -273,7 +271,7 @@ describeModule(
 
         describe('togglePage', function () {
             it('should toggle the page property', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         page: false,
                         isNew: true
@@ -282,7 +280,7 @@ describeModule(
 
                 expect(controller.get('model.page')).to.not.be.ok;
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('togglePage');
 
                     expect(controller.get('model.page')).to.be.ok;
@@ -290,18 +288,18 @@ describeModule(
             });
 
             it('should not save the post if it is still new', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         page: false,
                         isNew: true,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                             return Ember.RSVP.resolve();
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('togglePage');
 
                     expect(controller.get('model.page')).to.be.ok;
@@ -310,18 +308,18 @@ describeModule(
             });
 
             it('should save the post if it is not new', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         page: false,
                         isNew: false,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                             return Ember.RSVP.resolve();
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('togglePage');
 
                     expect(controller.get('model.page')).to.be.ok;
@@ -332,14 +330,14 @@ describeModule(
 
         describe('toggleFeatured', function () {
             it('should toggle the featured property', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         featured: false,
                         isNew: true
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('toggleFeatured');
 
                     expect(controller.get('model.featured')).to.be.ok;
@@ -347,18 +345,18 @@ describeModule(
             });
 
             it('should not save the post if it is still new', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         featured: false,
                         isNew: true,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                             return Ember.RSVP.resolve();
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('toggleFeatured');
 
                     expect(controller.get('model.featured')).to.be.ok;
@@ -367,18 +365,18 @@ describeModule(
             });
 
             it('should save the post if it is not new', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         featured: false,
                         isNew: false,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                             return Ember.RSVP.resolve();
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.send('toggleFeatured');
 
                     expect(controller.get('model.featured')).to.be.ok;
@@ -389,16 +387,16 @@ describeModule(
 
         describe('generateAndSetSlug', function () {
             it('should generate a slug and set it on the destination', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            return Ember.RSVP.resolve(str + '-slug');
+                        generateSlug(str) {
+                            return Ember.RSVP.resolve(`${str}-slug`);
                         }
                     }),
                     model: Ember.Object.create({slug: ''})
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.titleScratch', 'title');
                     controller.generateAndSetSlug('model.slug');
 
@@ -413,10 +411,10 @@ describeModule(
             });
 
             it('should not set the destination if the title is "(Untitled)" and the post already has a slug', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            return Ember.RSVP.resolve(str + '-slug');
+                        generateSlug(str) {
+                            return Ember.RSVP.resolve(`${str}-slug`);
                         }
                     }),
                     model: Ember.Object.create({
@@ -426,7 +424,7 @@ describeModule(
 
                 expect(controller.get('model.slug')).to.equal('whatever');
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.titleScratch', 'title');
 
                     Ember.RSVP.resolve(controller.get('lastPromise')).then(function () {
@@ -440,10 +438,10 @@ describeModule(
 
         describe('titleObserver', function () {
             it('should invoke generateAndSetSlug if the post is new and a title has not been set', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({isNew: true}),
                     invoked: 0,
-                    generateAndSetSlug: function () {
+                    generateAndSetSlug() {
                         this.incrementProperty('invoked');
                     }
                 });
@@ -451,7 +449,7 @@ describeModule(
                 expect(controller.get('invoked')).to.equal(0);
                 expect(controller.get('model.title')).to.not.be.ok;
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.titleScratch', 'test');
 
                     controller.titleObserver();
@@ -459,7 +457,7 @@ describeModule(
                     // since titleObserver invokes generateAndSetSlug with a delay of 700ms
                     // we need to make sure this assertion runs after that.
                     // probably a better way to handle this?
-                    Ember.run.later(function () {
+                    run.later(function () {
                         expect(controller.get('invoked')).to.equal(1);
 
                         done();
@@ -468,13 +466,13 @@ describeModule(
             });
 
             it('should invoke generateAndSetSlug if the post title is "(Untitled)"', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         isNew: false,
                         title: '(Untitled)'
                     }),
                     invoked: 0,
-                    generateAndSetSlug: function () {
+                    generateAndSetSlug() {
                         this.incrementProperty('invoked');
                     }
                 });
@@ -482,7 +480,7 @@ describeModule(
                 expect(controller.get('invoked')).to.equal(0);
                 expect(controller.get('model.title')).to.equal('(Untitled)');
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.titleScratch', 'test');
 
                     controller.titleObserver();
@@ -490,7 +488,7 @@ describeModule(
                     // since titleObserver invokes generateAndSetSlug with a delay of 700ms
                     // we need to make sure this assertion runs after that.
                     // probably a better way to handle this?
-                    Ember.run.later(function () {
+                    run.later(function () {
                         expect(controller.get('invoked')).to.equal(1);
 
                         done();
@@ -499,13 +497,13 @@ describeModule(
             });
 
             it('should not invoke generateAndSetSlug if the post is new but has a title', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         isNew: true,
                         title: 'a title'
                     }),
                     invoked: 0,
-                    generateAndSetSlug: function () {
+                    generateAndSetSlug() {
                         this.incrementProperty('invoked');
                     }
                 });
@@ -513,7 +511,7 @@ describeModule(
                 expect(controller.get('invoked')).to.equal(0);
                 expect(controller.get('model.title')).to.equal('a title');
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('model.titleScratch', 'test');
 
                     controller.titleObserver();
@@ -521,7 +519,7 @@ describeModule(
                     // since titleObserver invokes generateAndSetSlug with a delay of 700ms
                     // we need to make sure this assertion runs after that.
                     // probably a better way to handle this?
-                    Ember.run.later(function () {
+                    run.later(function () {
                         expect(controller.get('invoked')).to.equal(0);
 
                         done();
@@ -532,13 +530,13 @@ describeModule(
 
         describe('updateSlug', function () {
             it('should reset slugValue to the previous slug when the new slug is blank or unchanged', function () {
-                var controller = this.subject({
+                let controller = this.subject({
                     model: Ember.Object.create({
                         slug: 'slug'
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     // unchanged
                     controller.set('slugValue', 'slug');
                     controller.send('updateSlug', controller.get('slugValue'));
@@ -547,7 +545,7 @@ describeModule(
                     expect(controller.get('slugValue')).to.equal('slug');
                 });
 
-                Ember.run(function () {
+                run(function () {
                     // unchanged after trim
                     controller.set('slugValue', 'slug  ');
                     controller.send('updateSlug', controller.get('slugValue'));
@@ -556,7 +554,7 @@ describeModule(
                     expect(controller.get('slugValue')).to.equal('slug');
                 });
 
-                Ember.run(function () {
+                run(function () {
                     // blank
                     controller.set('slugValue', '');
                     controller.send('updateSlug', controller.get('slugValue'));
@@ -567,11 +565,10 @@ describeModule(
             });
 
             it('should not set a new slug if the server-generated slug matches existing slug', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            var promise;
-                            promise = Ember.RSVP.resolve(str.split('#')[0]);
+                        generateSlug(str) {
+                            let promise = Ember.RSVP.resolve(str.split('#')[0]);
                             this.set('lastPromise', promise);
                             return promise;
                         }
@@ -581,7 +578,7 @@ describeModule(
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('slugValue', 'whatever#slug');
                     controller.send('updateSlug', controller.get('slugValue'));
 
@@ -594,11 +591,11 @@ describeModule(
             });
 
             it('should not set a new slug if the only change is to the appended increment value', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            var promise;
-                            promise = Ember.RSVP.resolve(str.replace(/[^a-zA-Z]/g, '') + '-2');
+                        generateSlug(str) {
+                            let sanitizedStr = str.replace(/[^a-zA-Z]/g, '');
+                            let promise = Ember.RSVP.resolve(`${sanitizedStr}-2`);
                             this.set('lastPromise', promise);
                             return promise;
                         }
@@ -608,7 +605,7 @@ describeModule(
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('slugValue', 'whatever!');
                     controller.send('updateSlug', controller.get('slugValue'));
 
@@ -621,22 +618,21 @@ describeModule(
             });
 
             it('should set the slug if the new slug is different', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            var promise;
-                            promise = Ember.RSVP.resolve(str);
+                        generateSlug(str) {
+                            let promise = Ember.RSVP.resolve(str);
                             this.set('lastPromise', promise);
                             return promise;
                         }
                     }),
                     model: Ember.Object.create({
                         slug: 'whatever',
-                        save: Ember.K
+                        save: K
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('slugValue', 'changed');
                     controller.send('updateSlug', controller.get('slugValue'));
 
@@ -649,11 +645,10 @@ describeModule(
             });
 
             it('should save the post when the slug changes and the post is not new', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            var promise;
-                            promise = Ember.RSVP.resolve(str);
+                        generateSlug(str) {
+                            let promise = Ember.RSVP.resolve(str);
                             this.set('lastPromise', promise);
                             return promise;
                         }
@@ -662,13 +657,13 @@ describeModule(
                         slug: 'whatever',
                         saved: 0,
                         isNew: false,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('slugValue', 'changed');
                     controller.send('updateSlug', controller.get('slugValue'));
 
@@ -682,11 +677,10 @@ describeModule(
             });
 
             it('should not save the post when the slug changes and the post is new', function (done) {
-                var controller = this.subject({
+                let controller = this.subject({
                     slugGenerator: Ember.Object.create({
-                        generateSlug: function (str) {
-                            var promise;
-                            promise = Ember.RSVP.resolve(str);
+                        generateSlug(str) {
+                            let promise = Ember.RSVP.resolve(str);
                             this.set('lastPromise', promise);
                             return promise;
                         }
@@ -695,13 +689,13 @@ describeModule(
                         slug: 'whatever',
                         saved: 0,
                         isNew: true,
-                        save: function () {
+                        save() {
                             this.incrementProperty('saved');
                         }
                     })
                 });
 
-                Ember.run(function () {
+                run(function () {
                     controller.set('slugValue', 'changed');
                     controller.send('updateSlug', controller.get('slugValue'));
 

--- a/core/client/tests/unit/controllers/settings/general-test.js
+++ b/core/client/tests/unit/controllers/settings/general-test.js
@@ -4,6 +4,8 @@ import {
     it
 } from 'ember-mocha';
 
+const {run} = Ember;
+
 describeModule(
     'controller:settings/general',
     'Unit: Controller: settings/general',
@@ -13,7 +15,7 @@ describeModule(
 
     function () {
         it('isDatedPermalinks should be correct', function () {
-            var controller = this.subject({
+            const controller = this.subject({
                 model: Ember.Object.create({
                     permalinks: '/:year/:month/:day/:slug/'
                 })
@@ -21,7 +23,7 @@ describeModule(
 
             expect(controller.get('isDatedPermalinks')).to.be.ok;
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('model.permalinks', '/:slug/');
 
                 expect(controller.get('isDatedPermalinks')).to.not.be.ok;
@@ -29,20 +31,20 @@ describeModule(
         });
 
         it('setting isDatedPermalinks should switch between dated and slug', function () {
-            var controller = this.subject({
+            const controller = this.subject({
                 model: Ember.Object.create({
                     permalinks: '/:year/:month/:day/:slug/'
                 })
             });
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('isDatedPermalinks', false);
 
                 expect(controller.get('isDatedPermalinks')).to.not.be.ok;
                 expect(controller.get('model.permalinks')).to.equal('/:slug/');
             });
 
-            Ember.run(function () {
+            run(function () {
                 controller.set('isDatedPermalinks', true);
 
                 expect(controller.get('isDatedPermalinks')).to.be.ok;
@@ -51,8 +53,8 @@ describeModule(
         });
 
         it('themes should be correct', function () {
-            var controller,
-                themes = [];
+            let themes = [];
+            let controller;
 
             themes.push({
                 name: 'casper',

--- a/core/client/tests/unit/controllers/settings/navigation-test.js
+++ b/core/client/tests/unit/controllers/settings/navigation-test.js
@@ -6,7 +6,7 @@ import { NavItem } from 'ghost/controllers/settings/navigation';
 
 const {run} = Ember;
 
-var navSettingJSON = `[
+const navSettingJSON = `[
     {"label":"Home","url":"/"},
     {"label":"JS Test","url":"javascript:alert('hello');"},
     {"label":"About","url":"/about"},
@@ -26,14 +26,14 @@ describeModule(
     },
     function () {
         it('blogUrl: captures config and ensures trailing slash', function () {
-            var ctrl = this.subject();
+            let ctrl = this.subject();
             ctrl.set('config.blogUrl', 'http://localhost:2368/blog');
             expect(ctrl.get('blogUrl')).to.equal('http://localhost:2368/blog/');
         });
 
         it('navigationItems: generates list of NavItems', function () {
-            var ctrl = this.subject(),
-                lastItem;
+            let ctrl = this.subject();
+            let lastItem;
 
             run(() => {
                 ctrl.set('model', Ember.Object.create({navigation: navSettingJSON}));
@@ -51,8 +51,8 @@ describeModule(
         });
 
         it('navigationItems: adds blank item if navigation setting is empty', function () {
-            var ctrl = this.subject(),
-                lastItem;
+            let ctrl = this.subject();
+            let lastItem;
 
             run(() => {
                 ctrl.set('model', Ember.Object.create({navigation: null}));
@@ -65,8 +65,8 @@ describeModule(
         });
 
         it('updateLastNavItem: correctly sets "last" properties', function () {
-            var ctrl = this.subject(),
-                item1,
+            let ctrl = this.subject();
+            let item1,
                 item2;
 
             run(() => {
@@ -84,7 +84,7 @@ describeModule(
         });
 
         it('save: validates nav items', function (done) {
-            var ctrl = this.subject();
+            let ctrl = this.subject();
 
             run(() => {
                 ctrl.set('model', Ember.Object.create({navigation: `[
@@ -109,14 +109,13 @@ describeModule(
         });
 
         it('save: generates new navigation JSON', function (done) {
-            var ctrl = this.subject(),
-                model = Ember.Object.create({navigation: {}}),
-                expectedJSON = `[{"label":"New","url":"/new"}]`;
+            let ctrl = this.subject();
+            let model = Ember.Object.create({navigation: {}});
+            let expectedJSON = `[{"label":"New","url":"/new"}]`;
 
             model.save = function () {
-                var self = this;
-                return new Ember.RSVP.Promise(function (resolve, reject) {
-                    return resolve(self);
+                return new Ember.RSVP.Promise((resolve, reject) => {
+                    return resolve(this);
                 });
             };
 
@@ -126,7 +125,7 @@ describeModule(
                 // remove inserted blank item so validation works
                 ctrl.get('navigationItems').removeObject(ctrl.get('navigationItems.firstObject'));
                 // add new object
-                ctrl.get('navigationItems').addObject(NavItem.create({label:'New', url:'/new'}));
+                ctrl.get('navigationItems').addObject(NavItem.create({label: 'New', url: '/new'}));
 
                 ctrl.save().then(function success() {
                     expect(ctrl.get('model.navigation')).to.equal(expectedJSON);
@@ -139,7 +138,7 @@ describeModule(
         });
 
         it('action - addItem: adds item to navigationItems', function () {
-            var ctrl = this.subject();
+            let ctrl = this.subject();
 
             run(() => {
                 ctrl.set('navigationItems', [NavItem.create({label: 'First', url: '/first', last: true})]);
@@ -154,7 +153,7 @@ describeModule(
         });
 
         it('action - addItem: doesn\'t insert new item if last object is incomplete', function () {
-            var ctrl = this.subject();
+            let ctrl = this.subject();
 
             run(() => {
                 ctrl.set('navigationItems', [NavItem.create({label: '', url: '', last: true})]);
@@ -165,11 +164,11 @@ describeModule(
         });
 
         it('action - deleteItem: removes item from navigationItems', function () {
-            var ctrl = this.subject(),
-                navItems = [
-                    NavItem.create({label: 'First', url: '/first'}),
-                    NavItem.create({label: 'Second', url: '/second', last: true})
-                ];
+            let ctrl = this.subject();
+            let navItems = [
+                NavItem.create({label: 'First', url: '/first'}),
+                NavItem.create({label: 'Second', url: '/second', last: true})
+            ];
 
             run(() => {
                 ctrl.set('navigationItems', navItems);
@@ -180,11 +179,11 @@ describeModule(
         });
 
         it('action - moveItem: updates navigationItems list', function () {
-            var ctrl = this.subject(),
-                navItems = [
-                    NavItem.create({label: 'First', url: '/first'}),
-                    NavItem.create({label: 'Second', url: '/second', last: true})
-                ];
+            let ctrl = this.subject();
+            let navItems = [
+                NavItem.create({label: 'First', url: '/first'}),
+                NavItem.create({label: 'Second', url: '/second', last: true})
+            ];
 
             run(() => {
                 ctrl.set('navigationItems', navItems);
@@ -195,11 +194,11 @@ describeModule(
         });
 
         it('action - updateUrl: updates URL on navigationItem', function () {
-            var ctrl = this.subject(),
-                navItems = [
-                    NavItem.create({label: 'First', url: '/first'}),
-                    NavItem.create({label: 'Second', url: '/second', last: true})
-                ];
+            let ctrl = this.subject();
+            let navItems = [
+                NavItem.create({label: 'First', url: '/first'}),
+                NavItem.create({label: 'Second', url: '/second', last: true})
+            ];
 
             run(() => {
                 ctrl.set('navigationItems', navItems);

--- a/core/client/tests/unit/helpers/gh-user-can-admin-test.js
+++ b/core/client/tests/unit/helpers/gh-user-can-admin-test.js
@@ -2,14 +2,13 @@ import {
     describeModule,
     it
 } from 'ember-mocha';
-import {
-    ghUserCanAdmin
-} from 'ghost/helpers/gh-user-can-admin';
+import { ghUserCanAdmin } from 'ghost/helpers/gh-user-can-admin';
 
-describe ('Unit: Helper: gh-user-can-admin', function () {
+describe('Unit: Helper: gh-user-can-admin', function () {
     // Mock up roles and test for truthy
-    describe ('Owner role', function () {
-        var user = {get: function (role) {
+    describe('Owner role', function () {
+        let user = {
+            get(role) {
                 if (role === 'isOwner') {
                     return true;
                 } else if (role === 'isAdmin') {
@@ -17,15 +16,16 @@ describe ('Unit: Helper: gh-user-can-admin', function () {
                 }
             }
         };
+
         it(' - can be Admin', function () {
-            var result = ghUserCanAdmin([user]);
+            let result = ghUserCanAdmin([user]);
             expect(result).to.equal(true);
         });
     });
 
-    describe ('Administrator role', function () {
-        var user = {
-            get: function (role) {
+    describe('Administrator role', function () {
+        let user = {
+            get(role) {
                 if (role === 'isOwner') {
                     return false;
                 } else if (role === 'isAdmin') {
@@ -33,15 +33,16 @@ describe ('Unit: Helper: gh-user-can-admin', function () {
                 }
             }
         };
+
         it(' - can be Admin', function () {
-            var result = ghUserCanAdmin([user]);
+            let result = ghUserCanAdmin([user]);
             expect(result).to.equal(true);
         });
     });
 
-    describe ('Editor and Author roles', function () {
-        var user = {
-            get: function (role) {
+    describe('Editor and Author roles', function () {
+        let user = {
+            get(role) {
                 if (role === 'isOwner') {
                     return false;
                 } else if (role === 'isAdmin') {
@@ -49,8 +50,9 @@ describe ('Unit: Helper: gh-user-can-admin', function () {
                 }
             }
         };
+
         it(' - cannot be Admin', function () {
-            var result = ghUserCanAdmin([user]);
+            let result = ghUserCanAdmin([user]);
             expect(result).to.equal(false);
         });
     });

--- a/core/client/tests/unit/helpers/is-equal-test.js
+++ b/core/client/tests/unit/helpers/is-equal-test.js
@@ -11,7 +11,7 @@ import {
 describe('Unit: Helper: is-equal', function () {
     // Replace this with your real tests.
     it('works', function () {
-        var result = isEqual([42, 42]);
+        const result = isEqual([42, 42]);
 
         expect(result).to.be.ok;
     });

--- a/core/client/tests/unit/helpers/is-not-test.js
+++ b/core/client/tests/unit/helpers/is-not-test.js
@@ -11,7 +11,7 @@ import {
 describe('Unit: Helper: is-not', function () {
     // Replace this with your real tests.
     it('works', function () {
-        var result = isNot(false);
+        let result = isNot(false);
 
         expect(result).to.be.ok;
     });

--- a/core/client/tests/unit/helpers/read-path-test.js
+++ b/core/client/tests/unit/helpers/read-path-test.js
@@ -10,7 +10,7 @@ import Ember from 'ember';
 describe('Unit: Helper: read-path', function () {
     // Replace this with your real tests.
     it('works', function () {
-        var result = readPath([Ember.Object.create({hi: 'there'}), 'hi']);
+        let result = readPath([Ember.Object.create({hi: 'there'}), 'hi']);
 
         expect(result).to.equal('there');
     });

--- a/core/client/tests/unit/mixins/infinite-scroll-test.js
+++ b/core/client/tests/unit/mixins/infinite-scroll-test.js
@@ -10,8 +10,8 @@ import InfiniteScrollMixin from 'ghost/mixins/infinite-scroll';
 describe('Unit: Mixin: infinite-scroll', function () {
     // Replace this with your real tests.
     it('works', function () {
-        var InfiniteScrollObject = Ember.Object.extend(InfiniteScrollMixin),
-            subject = InfiniteScrollObject.create();
+        let InfiniteScrollObject = Ember.Object.extend(InfiniteScrollMixin);
+        let subject = InfiniteScrollObject.create();
 
         expect(subject).to.be.ok;
     });

--- a/core/client/tests/unit/models/post-test.js
+++ b/core/client/tests/unit/models/post-test.js
@@ -8,18 +8,18 @@ describeModel(
     'post',
     'Unit: Model: post',
     {
-        needs:['model:user', 'model:tag', 'model:role']
+        needs: ['model:user', 'model:tag', 'model:role']
     },
 
     function () {
         it('has a validation type of "post"', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             expect(model.validationType).to.equal('post');
         });
 
         it('isPublished and isDraft are correct', function () {
-            var model = this.subject({
+            let model = this.subject({
                 status: 'published'
             });
 
@@ -35,10 +35,12 @@ describeModel(
         });
 
         it('isAuthoredByUser is correct', function () {
-            var model = this.subject({
+            /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+            let model = this.subject({
                 author_id: 15
-            }),
-            user = Ember.Object.create({id: '15'});
+            });
+            /* jscs:enable requireCamelCaseOrUpperCaseIdentifiers */
+            let user = Ember.Object.create({id: '15'});
 
             expect(model.isAuthoredByUser(user)).to.be.ok;
 
@@ -50,13 +52,13 @@ describeModel(
         });
 
         it('updateTags removes and deletes old tags', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             Ember.run(this, function () {
-                var modelTags = model.get('tags'),
-                    tag1 = this.store().createRecord('tag', {id: '1'}),
-                    tag2 = this.store().createRecord('tag', {id: '2'}),
-                    tag3 = this.store().createRecord('tag');
+                let modelTags = model.get('tags');
+                let tag1 = this.store().createRecord('tag', {id: '1'});
+                let tag2 = this.store().createRecord('tag', {id: '2'});
+                let tag3 = this.store().createRecord('tag');
 
                 // During testing a record created without an explicit id will get
                 // an id of 'fixture-n' instead of null

--- a/core/client/tests/unit/models/role-test.js
+++ b/core/client/tests/unit/models/role-test.js
@@ -4,16 +4,18 @@ import {
     it
 } from 'ember-mocha';
 
+const {run} = Ember;
+
 describeModel('role', 'Unit: Model: role', function () {
     it('provides a lowercase version of the name', function () {
-        var model = this.subject({
+        const model = this.subject({
             name: 'Author'
         });
 
         expect(model.get('name')).to.equal('Author');
         expect(model.get('lowerCaseName')).to.equal('author');
 
-        Ember.run(function () {
+        run(function () {
             model.set('name', 'Editor');
 
             expect(model.get('name')).to.equal('Editor');

--- a/core/client/tests/unit/models/setting-test.js
+++ b/core/client/tests/unit/models/setting-test.js
@@ -5,7 +5,7 @@ import {
 
 describeModel('setting', 'Unit: Model: setting', function () {
     it('has a validation type of "setting"', function () {
-        var model = this.subject();
+        let model = this.subject();
 
         expect(model.get('validationType')).to.equal('setting');
     });

--- a/core/client/tests/unit/models/tag-test.js
+++ b/core/client/tests/unit/models/tag-test.js
@@ -5,7 +5,7 @@ import {
 
 describeModel('tag', 'Unit: Model: tag', function () {
     it('has a validation type of "tag"', function () {
-        var model = this.subject();
+        let model = this.subject();
 
         expect(model.get('validationType')).to.equal('tag');
     });

--- a/core/client/tests/unit/models/user-test.js
+++ b/core/client/tests/unit/models/user-test.js
@@ -15,13 +15,13 @@ describeModel(
 
     function () {
         it('has a validation type of "user"', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             expect(model.get('validationType')).to.equal('user');
         });
 
         it('active property is correct', function () {
-            var model = this.subject({
+            let model = this.subject({
                 status: 'active'
             });
 
@@ -40,7 +40,7 @@ describeModel(
         });
 
         it('invited property is correct', function () {
-            var model = this.subject({
+            let model = this.subject({
                 status: 'invited'
             });
 
@@ -57,7 +57,7 @@ describeModel(
         });
 
         it('pending property is correct', function () {
-            var model = this.subject({
+            let model = this.subject({
                 status: 'invited-pending'
             });
 
@@ -71,7 +71,7 @@ describeModel(
         });
 
         it('role property is correct', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             run(() => {
                 let role = this.store().push({data: {id: 1, type: 'role', attributes: {name: 'Author'}}});
@@ -87,7 +87,7 @@ describeModel(
         });
 
         it('isAuthor property is correct', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             run(() => {
                 let role = this.store().push({data: {id: 1, type: 'role', attributes: {name: 'Author'}}});
@@ -100,7 +100,7 @@ describeModel(
         });
 
         it('isEditor property is correct', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             run(() => {
                 let role = this.store().push({data: {id: 1, type: 'role', attributes: {name: 'Editor'}}});
@@ -113,7 +113,7 @@ describeModel(
         });
 
         it('isAdmin property is correct', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             run(() => {
                 let role = this.store().push({data: {id: 1, type: 'role', attributes: {name: 'Administrator'}}});
@@ -126,7 +126,7 @@ describeModel(
         });
 
         it('isOwner property is correct', function () {
-            var model = this.subject();
+            let model = this.subject();
 
             run(() => {
                 let role = this.store().push({data: {id: 1, type: 'role', attributes: {name: 'Owner'}}});

--- a/core/client/tests/unit/services/config-test.js
+++ b/core/client/tests/unit/services/config-test.js
@@ -17,7 +17,7 @@ describeModule(
     function () {
         // Replace this with your real tests.
         it('exists', function () {
-            var service = this.subject();
+            const service = this.subject();
             expect(service).to.be.ok;
         });
 
@@ -26,7 +26,7 @@ describeModule(
                 .attr('content', '23e435234423')
                 .appendTo('head');
 
-            var service = this.subject();
+            const service = this.subject();
 
             expect(service.get('clientSecret')).to.equal('23e435234423');
         });

--- a/core/client/tests/unit/services/notifications-test.js
+++ b/core/client/tests/unit/services/notifications-test.js
@@ -8,6 +8,7 @@ import {
 } from 'ember-mocha';
 
 const {run, get} = Ember;
+const emberA = Ember.A;
 
 describeModule(
     'service:notifications',
@@ -18,12 +19,12 @@ describeModule(
     },
     function () {
         beforeEach(function () {
-            this.subject().set('content', Ember.A());
-            this.subject().set('delayedNotifications', Ember.A());
+            this.subject().set('content', emberA());
+            this.subject().set('delayedNotifications', emberA());
         });
 
         it('filters alerts/notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             // wrapped in run-loop to enure alerts/notifications CPs are updated
             run(() => {
@@ -39,8 +40,8 @@ describeModule(
         });
 
         it('#handleNotification deals with DS.Notification notifications', function () {
-            var notifications = this.subject(),
-                notification = Ember.Object.create({message: '<h1>Test</h1>', status: 'alert'});
+            const notifications = this.subject();
+            let notification = Ember.Object.create({message: '<h1>Test</h1>', status: 'alert'});
 
             notification.toJSON = function () {};
 
@@ -53,7 +54,7 @@ describeModule(
         });
 
         it('#handleNotification defaults to notification if no status supplied', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             notifications.handleNotification({message: 'Test'}, false);
 
@@ -62,7 +63,7 @@ describeModule(
         });
 
         it('#showAlert adds POJO alerts', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAlert('Test Alert', {type: 'error'});
@@ -73,7 +74,7 @@ describeModule(
         });
 
         it('#showAlert adds delayed notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('Test Alert', {type: 'error', delayed: true});
@@ -87,7 +88,7 @@ describeModule(
         // we split on the second period and treat the resulting base as
         // the key for duplicate checking
         it('#showAlert clears duplicates', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAlert('Kept');
@@ -105,7 +106,7 @@ describeModule(
         });
 
         it('#showNotification adds POJO notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('Test Notification', {type: 'success'});
@@ -116,7 +117,7 @@ describeModule(
         });
 
         it('#showNotification adds delayed notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('Test Notification', {delayed: true});
@@ -127,7 +128,7 @@ describeModule(
         });
 
         it('#showNotification clears existing notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('First');
@@ -140,7 +141,7 @@ describeModule(
         });
 
         it('#showNotification keeps existing notifications if doNotCloseNotifications option passed', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('First');
@@ -152,7 +153,7 @@ describeModule(
 
         // TODO: review whether this can be removed once it's no longer used by validations
         it('#showErrors adds multiple notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showErrors([
@@ -168,8 +169,8 @@ describeModule(
         });
 
         it('#showAPIError adds single json response error', function () {
-            var notifications = this.subject(),
-                resp = {jqXHR: {responseJSON: {error: 'Single error'}}};
+            const notifications = this.subject();
+            const resp = {jqXHR: {responseJSON: {error: 'Single error'}}};
 
             run(() => {
                 notifications.showAPIError(resp);
@@ -184,8 +185,8 @@ describeModule(
 
         // used to display validation errors returned from the server
         it('#showAPIError adds multiple json response errors', function () {
-            var notifications = this.subject(),
-                resp = {jqXHR: {responseJSON: {errors: ['First error', 'Second error']}}};
+            const notifications = this.subject();
+            const resp = {jqXHR: {responseJSON: {errors: ['First error', 'Second error']}}};
 
             run(() => {
                 notifications.showAPIError(resp);
@@ -198,8 +199,8 @@ describeModule(
         });
 
         it('#showAPIError adds single json response message', function () {
-            var notifications = this.subject(),
-                resp = {jqXHR: {responseJSON: {message: 'Single message'}}};
+            const notifications = this.subject();
+            const resp = {jqXHR: {responseJSON: {message: 'Single message'}}};
 
             run(() => {
                 notifications.showAPIError(resp);
@@ -213,15 +214,15 @@ describeModule(
         });
 
         it('#showAPIError displays default error text if response has no error/message', function () {
-            var notifications = this.subject(),
-                resp = {};
+            const notifications = this.subject();
+            const resp = {};
 
             run(() => { notifications.showAPIError(resp); });
             expect(notifications.get('content')).to.deep.equal([
                 {message: 'There was a problem on the server, please try again.', status: 'alert', type: 'error', key: 'api-error'}
             ]);
 
-            notifications.set('content', Ember.A());
+            notifications.set('content', emberA());
 
             run(() => {
                 notifications.showAPIError(resp, {defaultErrorText: 'Overridden default'});
@@ -232,7 +233,7 @@ describeModule(
         });
 
         it('#showAPIError sets correct key when passed a base key', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAPIError('Test', {key: 'test.alert'});
@@ -242,7 +243,7 @@ describeModule(
         });
 
         it('#showAPIError sets correct key when not passed a key', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAPIError('Test');
@@ -252,7 +253,7 @@ describeModule(
         });
 
         it('#displayDelayed moves delayed notifications into content', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showNotification('First', {delayed: true});
@@ -269,8 +270,8 @@ describeModule(
         });
 
         it('#closeNotification removes POJO notifications', function () {
-            var notification = {message: 'Close test', status: 'notification'},
-                notifications = this.subject();
+            const notification = {message: 'Close test', status: 'notification'};
+            const notifications = this.subject();
 
             run(() => {
                 notifications.handleNotification(notification);
@@ -288,15 +289,17 @@ describeModule(
         });
 
         it('#closeNotification removes and deletes DS.Notification records', function () {
-            var notification = Ember.Object.create({message: 'Close test', status: 'alert'}),
-                notifications = this.subject();
+            const notification = Ember.Object.create({message: 'Close test', status: 'alert'});
+            const notifications = this.subject();
 
             notification.toJSON = function () {};
             notification.deleteRecord = function () {};
             sinon.spy(notification, 'deleteRecord');
             notification.save = function () {
                 return {
-                    finally: function (callback) { return callback(notification); }
+                    finally(callback) {
+                        return callback(notification);
+                    }
                 };
             };
             sinon.spy(notification, 'save');
@@ -314,7 +317,7 @@ describeModule(
         });
 
         it('#closeNotifications only removes notifications', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAlert('First alert');
@@ -332,7 +335,7 @@ describeModule(
         });
 
         it('#closeNotifications only closes notifications with specified key', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             run(() => {
                 notifications.showAlert('First alert');
@@ -354,15 +357,17 @@ describeModule(
         });
 
         it('#clearAll removes everything without deletion', function () {
-            var notifications = this.subject(),
-                notificationModel = Ember.Object.create({message: 'model'});
+            const notifications = this.subject();
+            const notificationModel = Ember.Object.create({message: 'model'});
 
             notificationModel.toJSON = function () {};
             notificationModel.deleteRecord = function () {};
             sinon.spy(notificationModel, 'deleteRecord');
             notificationModel.save = function () {
                 return {
-                    finally: function (callback) { return callback(notificationModel); }
+                    finally(callback) {
+                        return callback(notificationModel);
+                    }
                 };
             };
             sinon.spy(notificationModel, 'save');
@@ -378,7 +383,7 @@ describeModule(
         });
 
         it('#closeAlerts only removes alerts', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             notifications.showNotification('First notification');
             notifications.showAlert('First alert');
@@ -393,7 +398,7 @@ describeModule(
         });
 
         it('#closeAlerts closes only alerts with specified key', function () {
-            var notifications = this.subject();
+            const notifications = this.subject();
 
             notifications.showNotification('First notification');
             notifications.showAlert('First alert', {key: 'test.close'});

--- a/core/client/tests/unit/utils/ghost-paths-test.js
+++ b/core/client/tests/unit/utils/ghost-paths-test.js
@@ -2,10 +2,10 @@ import ghostPaths from 'ghost/utils/ghost-paths';
 
 describe('Unit: Util: ghost-paths', function () {
     describe('join', function () {
-        var join = ghostPaths().url.join;
+        const {join} = ghostPaths().url;
 
         it('should join two or more paths, normalizing slashes', function () {
-            var path;
+            let path;
 
             path = join('/one/', '/two/');
             expect(path).to.equal('/one/two/');
@@ -24,7 +24,7 @@ describe('Unit: Util: ghost-paths', function () {
         });
 
         it('should not change the slash at the beginning', function () {
-            var path;
+            let path;
 
             path = join('one/');
             expect(path).to.equal('one/');
@@ -39,7 +39,7 @@ describe('Unit: Util: ghost-paths', function () {
         });
 
         it('should always return a slash at the end', function () {
-            var path;
+            let path;
 
             path = join();
             expect(path).to.equal('/');

--- a/core/client/tests/unit/validators/nav-item-test.js
+++ b/core/client/tests/unit/validators/nav-item-test.js
@@ -7,11 +7,8 @@ import {
 import validator from 'ghost/validators/nav-item';
 import { NavItem } from 'ghost/controllers/settings/navigation';
 
-var testInvalidUrl,
-    testValidUrl;
-
-testInvalidUrl = function (url) {
-    let navItem = NavItem.create({url: url});
+const testInvalidUrl = function (url) {
+    let navItem = NavItem.create({url});
 
     validator.check(navItem, 'url');
 
@@ -23,8 +20,8 @@ testInvalidUrl = function (url) {
     expect(navItem.get('hasValidated')).to.include('url');
 };
 
-testValidUrl = function (url) {
-    let navItem = NavItem.create({url: url});
+const testValidUrl = function (url) {
+    let navItem = NavItem.create({url});
 
     validator.check(navItem, 'url');
 

--- a/core/client/tests/unit/validators/tag-settings-test.js
+++ b/core/client/tests/unit/validators/tag-settings-test.js
@@ -1,3 +1,4 @@
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 /* jshint expr:true */
 import { expect } from 'chai';
 import {
@@ -9,15 +10,16 @@ import Ember from 'ember';
 // import validator from 'ghost/validators/tag-settings';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-const {run} = Ember,
-    Tag = Ember.Object.extend(ValidationEngine, {
-        validationType: 'tag',
+const {run} = Ember;
 
-        name: null,
-        description: null,
-        meta_title: null,
-        meta_description: null
-    });
+const Tag = Ember.Object.extend(ValidationEngine, {
+    validationType: 'tag',
+
+    name: null,
+    description: null,
+    meta_title: null,
+    meta_description: null
+});
 
 // TODO: These tests have way too much duplication, consider creating test
 // helpers for validations
@@ -27,8 +29,8 @@ const {run} = Ember,
 
 describe('Unit: Validator: tag-settings', function () {
     it('validates all fields by default', function () {
-        let tag = Tag.create({}),
-            properties = tag.get('validators.tag.properties');
+        const tag = Tag.create({});
+        const properties = tag.get('validators.tag.properties');
 
         // TODO: This is checking implementation details rather than expected
         // behaviour. Replace once we have consistent behaviour (see below)
@@ -54,8 +56,8 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with valid name', function () {
         // longest valid name
-        let tag = Tag.create({name: (new Array(151).join('x'))}),
-            passed = false;
+        const tag = Tag.create({name: (new Array(151).join('x'))});
+        let passed = false;
 
         expect(tag.get('name').length, 'name length').to.equal(150);
 
@@ -70,8 +72,9 @@ describe('Unit: Validator: tag-settings', function () {
     });
 
     it('validates name presence', function () {
-        let tag = Tag.create(),
-            passed = false;
+        const tag = Tag.create();
+        let passed = false;
+        let nameErrors;
 
         // TODO: validator is currently a singleton meaning state leaks
         // between all objects that use it. Each object should either
@@ -87,7 +90,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let nameErrors = tag.get('errors').errorsFor('name')[0];
+        nameErrors = tag.get('errors').errorsFor('name').get(0);
         expect(nameErrors.attribute, 'errors.name.attribute').to.equal('name');
         expect(nameErrors.message, 'errors.name.message').to.equal('You must specify a name for the tag.');
 
@@ -96,8 +99,9 @@ describe('Unit: Validator: tag-settings', function () {
     });
 
     it('validates names starting with a comma', function () {
-        let tag = Tag.create({name: ',test'}),
-            passed = false;
+        const tag = Tag.create({name: ',test'});
+        let passed = false;
+        let nameErrors;
 
         run(() => {
             tag.validate({property: 'name'}).then(() => {
@@ -105,7 +109,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let nameErrors = tag.get('errors').errorsFor('name')[0];
+        nameErrors = tag.get('errors').errorsFor('name').get(0);
         expect(nameErrors.attribute, 'errors.name.attribute').to.equal('name');
         expect(nameErrors.message, 'errors.name.message').to.equal('Tag names can\'t start with commas.');
         expect(tag.get('errors.length')).to.equal(1);
@@ -116,8 +120,9 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates name length', function () {
         // shortest invalid name
-        let tag = Tag.create({name: (new Array(152).join('x'))}),
-            passed = false;
+        const tag = Tag.create({name: (new Array(152).join('x'))});
+        let passed = false;
+        let nameErrors;
 
         expect(tag.get('name').length, 'name length').to.equal(151);
 
@@ -127,7 +132,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let nameErrors = tag.get('errors').errorsFor('name')[0];
+        nameErrors = tag.get('errors').errorsFor('name')[0];
         expect(nameErrors.attribute, 'errors.name.attribute').to.equal('name');
         expect(nameErrors.message, 'errors.name.message').to.equal('Tag names cannot be longer than 150 characters.');
 
@@ -137,8 +142,8 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with valid slug', function () {
         // longest valid slug
-        let tag = Tag.create({slug: (new Array(151).join('x'))}),
-            passed = false;
+        const tag = Tag.create({slug: (new Array(151).join('x'))});
+        let passed = false;
 
         expect(tag.get('slug').length, 'slug length').to.equal(150);
 
@@ -154,8 +159,9 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates slug length', function () {
         // shortest invalid slug
-        let tag = Tag.create({slug: (new Array(152).join('x'))}),
-            passed = false;
+        const tag = Tag.create({slug: (new Array(152).join('x'))});
+        let passed = false;
+        let slugErrors;
 
         expect(tag.get('slug').length, 'slug length').to.equal(151);
 
@@ -165,7 +171,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let slugErrors = tag.get('errors').errorsFor('slug')[0];
+        slugErrors = tag.get('errors').errorsFor('slug')[0];
         expect(slugErrors.attribute, 'errors.slug.attribute').to.equal('slug');
         expect(slugErrors.message, 'errors.slug.message').to.equal('URL cannot be longer than 150 characters.');
 
@@ -175,8 +181,8 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('passes with a valid description', function () {
         // longest valid description
-        let tag = Tag.create({description: (new Array(201).join('x'))}),
-            passed = false;
+        const tag = Tag.create({description: (new Array(201).join('x'))});
+        let passed = false;
 
         expect(tag.get('description').length, 'description length').to.equal(200);
 
@@ -192,8 +198,9 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates description length', function () {
         // shortest invalid description
-        let tag = Tag.create({description: (new Array(202).join('x'))}),
-            passed = false;
+        const tag = Tag.create({description: (new Array(202).join('x'))});
+        let passed = false;
+        let errors;
 
         expect(tag.get('description').length, 'description length').to.equal(201);
 
@@ -203,7 +210,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let errors = tag.get('errors').errorsFor('description')[0];
+        errors = tag.get('errors').errorsFor('description')[0];
         expect(errors.attribute, 'errors.description.attribute').to.equal('description');
         expect(errors.message, 'errors.description.message').to.equal('Description cannot be longer than 200 characters.');
 
@@ -221,8 +228,8 @@ describe('Unit: Validator: tag-settings', function () {
     // model/validator respectively - this should be standardised
     it('passes with a valid meta_title', function () {
         // longest valid meta_title
-        let tag = Tag.create({meta_title: (new Array(151).join('x'))}),
-            passed = false;
+        const tag = Tag.create({meta_title: (new Array(151).join('x'))});
+        let passed = false;
 
         expect(tag.get('meta_title').length, 'meta_title length').to.equal(150);
 
@@ -238,8 +245,9 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates meta_title length', function () {
         // shortest invalid meta_title
-        let tag = Tag.create({meta_title: (new Array(152).join('x'))}),
-            passed = false;
+        const tag = Tag.create({meta_title: (new Array(152).join('x'))});
+        let passed = false;
+        let errors;
 
         expect(tag.get('meta_title').length, 'meta_title length').to.equal(151);
 
@@ -249,7 +257,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let errors = tag.get('errors').errorsFor('meta_title')[0];
+        errors = tag.get('errors').errorsFor('meta_title')[0];
         expect(errors.attribute, 'errors.meta_title.attribute').to.equal('meta_title');
         expect(errors.message, 'errors.meta_title.message').to.equal('Meta Title cannot be longer than 150 characters.');
 
@@ -261,8 +269,8 @@ describe('Unit: Validator: tag-settings', function () {
     // the model/validator respectively - this should be standardised
     it('passes with a valid meta_description', function () {
         // longest valid description
-        let tag = Tag.create({meta_description: (new Array(201).join('x'))}),
-            passed = false;
+        const tag = Tag.create({meta_description: (new Array(201).join('x'))});
+        let passed = false;
 
         expect(tag.get('meta_description').length, 'meta_description length').to.equal(200);
 
@@ -278,8 +286,9 @@ describe('Unit: Validator: tag-settings', function () {
 
     it('validates meta_description length', function () {
         // shortest invalid meta_description
-        let tag = Tag.create({meta_description: (new Array(202).join('x'))}),
-            passed = false;
+        const tag = Tag.create({meta_description: (new Array(202).join('x'))});
+        let passed = false;
+        let errors;
 
         expect(tag.get('meta_description').length, 'meta_description length').to.equal(201);
 
@@ -289,7 +298,7 @@ describe('Unit: Validator: tag-settings', function () {
             });
         });
 
-        let errors = tag.get('errors').errorsFor('meta_description')[0];
+        errors = tag.get('errors').errorsFor('meta_description')[0];
         expect(errors.attribute, 'errors.meta_description.attribute').to.equal('meta_description');
         expect(errors.message, 'errors.meta_description.message').to.equal('Meta Description cannot be longer than 200 characters.');
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-docker": "0.0.10",
     "grunt-express-server": "0.5.1",
-    "grunt-jscs": "2.1.0",
+    "grunt-jscs": "2.3.0",
     "grunt-mocha-cli": "1.13.0",
     "grunt-mocha-istanbul": "2.4.0",
     "grunt-shell": "1.1.2",


### PR DESCRIPTION
no issue
- adds [ember-suave](https://github.com/dockyard/ember-suave) dependency to enforce es6 styles
- update files to match Dockyard's [Javascript](https://github.com/dockyard/styleguides/blob/master/engineering/javascript.md) (with slight modifications) and [Ember](https://github.com/dockyard/styleguides/blob/master/engineering/ember.md) style guides

ES6 is seeing rapid adoption across the ember core and community in general, this is an attempt to bring Ghost in line with the accepted coding style.

Aside from the general es6-isms, `Ember.*` and `DS.*` modules are pulled out and defined at the top of the files ready for when these modules are pulled out into ES2015 modules that can be imported directly. I believe there are plans to eventually use this within the build process to only pull in Ember code that our application is using giving us smaller builds and faster download/parsing.

I've created as a quick spike for now in order to gather thoughts and discussion from the rest of the team. Please let me know if there's anything in particular you think is confusing, difficult to parse or too different to the server-side!

Outstanding issues:
- `Ember.Object`, `Ember.String`, `Ember.$` have not yet been moved into the `Ember` object destructuring assignment as they generate warnings about overriding existing vars. Need to decide to skip those for now or find a way to suppress the warnings.
- `Ember.A()` (builds an Ember.NativeArray instance) and `Ember.K()` (empty function that returns `this`) have not been moved to the `Ember` destructuring assignment because I'm not a fan of the one-char function names.
- Have we gone far enough with the fat arrow functions? Currently all methods inside a property method use fat arrows to preserve the `this` scope, should the fat arrow syntax be used anywhere else? Is the non-parens version preferable in certain circumstances?
