### PR TITLE
Ensure public api can uses limit parameter

### DIFF
--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -76,6 +76,10 @@ auth = {
                     origin = url.parse(req.headers.origin).hostname;
                 }
 
+                // req.body needs to be null for GET requests to build options correctly
+                delete req.body.client_id;
+                delete req.body.client_secret;
+
                 if (!origin && client && client.type === 'ua') {
                     res.header('Access-Control-Allow-Origin', config.url);
                     req.client = client;


### PR DESCRIPTION
No Issue
- removes client id and secret after authentication
- adds tests to check default limit, all and integer
