### PR TITLE
Make bodyparser limit configurable to allow for posts larger than 100kB

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -122,8 +122,8 @@ setupMiddleware = function setupMiddleware(blogApp, adminApp) {
     blogApp.use(uncapitalise);
 
     // Body parsing
-    blogApp.use(bodyParser.json());
-    blogApp.use(bodyParser.urlencoded({extended: true}));
+    blogApp.use(bodyParser.json({limit: '1mb'}));
+    blogApp.use(bodyParser.urlencoded({extended: true, limit: '1mb'}));
 
     blogApp.use(passport.initialize());
 


### PR DESCRIPTION
Added support for a config option (under server) that sets the bodyparser limit. Currently this limit is the default of express: 100kB.

`grunt validate` has some trouble with `csscomb` and `shell:ember:test` but this seems to be a problem with my dev environment. Will try to get that fixed and run tests locally again.
