### PR TITLE
Pagination cleanup & improvements

### DIFF
--- a/core/server/models/base/pagination.js
+++ b/core/server/models/base/pagination.js
@@ -48,12 +48,12 @@ paginationUtils = {
     /**
      * ### Query
      * Apply the necessary parameters to paginate the query
-     * @param {Bookshelf.Model|Bookshelf.Collection} itemCollection
+     * @param {bookshelf.Model} model
      * @param {options} options
      */
-    addLimitAndOffset: function addLimitAndOffset(itemCollection, options) {
+    addLimitAndOffset: function addLimitAndOffset(model, options) {
         if (_.isNumber(options.limit)) {
-            itemCollection
+            model
                 .query('limit', options.limit)
                 .query('offset', options.limit * (options.page - 1));
         }
@@ -97,26 +97,26 @@ paginationUtils = {
 /**
  * ### Pagination Object
  * @typedef {Object} pagination
- * @property {Number} `page` \- page in set to display
- * @property {Number|String} `limit` \- no. results per page, or 'all'
- * @property {Number} `pages` \- total no. pages in the full set
- * @property {Number} `total` \- total no. items in the full set
- * @property {Number|null} `next` \- next page
- * @property {Number|null} `prev` \- previous page
+ * @property {Number} page \- page in set to display
+ * @property {Number|String} limit \- no. results per page, or 'all'
+ * @property {Number} pages \- total no. pages in the full set
+ * @property {Number} total \- total no. items in the full set
+ * @property {Number|null} next \- next page
+ * @property {Number|null} prev \- previous page
  */
 
 /**
  * ### Fetch Page Options
  * @typedef {Object} options
- * @property {Number} `page` \- page in set to display
- * @property {Number|String} `limit` \- no. results per page, or 'all'
- * @property {Object} `order` \- set of order by params and directions
+ * @property {Number} page \- page in set to display
+ * @property {Number|String} limit \- no. results per page, or 'all'
+ * @property {Object} order \- set of order by params and directions
  */
 
 /**
  * ### Fetch Page Response
  * @typedef {Object} paginatedResult
- * @property {Array} `collection` \- set of results
+ * @property {Array} collection \- set of results
  * @property {pagination} pagination \- pagination metadata
  */
 
@@ -141,8 +141,6 @@ pagination = function pagination(bookshelf) {
             // Get the table name and idAttribute for this model
             var tableName = _.result(this.constructor.prototype, 'tableName'),
                 idAttribute = _.result(this.constructor.prototype, 'idAttribute'),
-            // Create a new collection for running `this` query, ensuring we're using collection, rather than model
-                collection = this.constructor.collection(),
                 countPromise,
                 collectionPromise,
                 self = this;
@@ -156,48 +154,31 @@ pagination = function pagination(bookshelf) {
                 bookshelf.knex.raw('count(distinct ' + tableName + '.' + idAttribute + ') as aggregate')
             );
 
-            // Clone the base query into our collection
-            collection._knex = this.query().clone();
-
             // #### Post count clauses
             // Add any where or join clauses which need to NOT be included with the aggregate query
 
             // Setup the pagination parameters so that we return the correct items from the set
-            paginationUtils.addLimitAndOffset(collection, options);
+            paginationUtils.addLimitAndOffset(self, options);
 
             // Apply ordering options if they are present
             if (options.order && !_.isEmpty(options.order)) {
                 _.forOwn(options.order, function (direction, property) {
-                    collection.query('orderBy', tableName + '.' + property, direction);
+                    self.query('orderBy', tableName + '.' + property, direction);
                 });
             }
 
             if (options.groups && !_.isEmpty(options.groups)) {
                 _.each(options.groups, function (group) {
-                    collection.query('groupBy', group);
+                    self.query('groupBy', group);
                 });
             }
 
             // Apply count options if they are present
-            baseUtils.collectionQuery.count(collection, options);
-
-            this.resetQuery();
-            if (this.relatedData) {
-                collection.relatedData = this.relatedData;
-            }
-
-            // ensure that our model (self) gets the correct events fired upon it
-            collection
-                .on('fetching', function (collection, columns, options) {
-                    return self.triggerThen('fetching:collection', collection, columns, options);
-                })
-                .on('fetched', function (collection, resp, options) {
-                    return self.triggerThen('fetched:collection', collection, resp, options);
-                });
+            baseUtils.collectionQuery.count(self, options);
 
             // Setup the promise to do a fetch on our collection, running the specified query
             // @TODO: ensure option handling is done using an explicit pick elsewhere
-            collectionPromise = collection.fetch(_.omit(options, ['page', 'limit']));
+            collectionPromise = self.fetchAll(_.omit(options, ['page', 'limit']));
 
             // Resolve the two promises
             return Promise.join(collectionPromise, countPromise).then(function formatResponse(results) {

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -8,9 +8,9 @@ var _ = require('lodash'),
     addPostCount,
     tagUpdate;
 
-addPostCount = function addPostCount(options, itemCollection) {
+addPostCount = function addPostCount(options, model) {
     if (options.include && options.include.indexOf('post_count') > -1) {
-        itemCollection.query('columns', 'tags.*', function (qb) {
+        model.query('columns', 'tags.*', function (qb) {
             qb.count('posts_tags.post_id').from('posts_tags').whereRaw('tag_id = tags.id').as('post_count');
         });
 
@@ -20,8 +20,8 @@ addPostCount = function addPostCount(options, itemCollection) {
 };
 
 collectionQuery = {
-    count: function count(collection, options) {
-        addPostCount(options, collection);
+    count: function count(model, options) {
+        addPostCount(options, model);
     }
 };
 

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -512,5 +512,35 @@ describe('Filter Param Spec', function () {
                 done();
             });
         });
+
+        describe('Empty results', function () {
+            it('Will return empty result if tag has no posts', function (done) {
+                PostAPI.browse({filter: 'tag:no-posts', include: 'tag,author'}).then(function (result) {
+                    // 1. Result should have the correct base structure
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+
+                    // 2. The data part of the response should be correct
+                    // We should have 4 matching items
+                    result.posts.should.be.an.Array.with.lengthOf(0);
+
+                    // 3. The meta object should contain the right details
+                    result.meta.should.have.property('pagination');
+                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.page.should.eql(1);
+                    result.meta.pagination.limit.should.eql(15);
+                    result.meta.pagination.pages.should.eql(1);
+                    result.meta.pagination.total.should.eql(0);
+                    should.equal(result.meta.pagination.next, null);
+                    should.equal(result.meta.pagination.prev, null);
+
+                    // NOTE: new query does not have meta filter
+                    result.meta.should.not.have.property('filters');
+
+                    done();
+                }).catch(done);
+            });
+        });
     });
 });


### PR DESCRIPTION
Some more improvements I found whilst looking at how to add cross table joins/counts. My original `fetchPage` method was modelled after bookshelf's own [fetchAll](https://github.com/tgriesser/bookshelf/blob/bbf5b9c2b3dae50002aec20a6e96f0b6c3b0f348/lib/model.js#L121), which I did as I thought I would need access to the features of collections.

However, it turns out this is unnecessary, and that changing `fetchPage` to call `fetchAll` instead of `fetch` means that we can simplify the code quite significantly, or rather just leave the additional complexity to the `fetchAll` method and let `fetchPage` just do the things it needs to do: namely add an aggregate count and ensure that page & limit are applied to the main query correctly.

The tests have also been simplified somewhat, and I've increased the coverage back to 100%.

no issue
- switching from using fetch to fetch all means some code can be removed from the fetchPage method
- updating tests to reflect cleaner code
- ensure coverage is at 100%
