### PR TITLE
Move cross-table api counts into plugin

### DIFF
--- a/core/server/models/base/include-count.js
+++ b/core/server/models/base/include-count.js
@@ -1,0 +1,53 @@
+var _ = require('lodash');
+
+module.exports = function (Bookshelf) {
+    var modelProto = Bookshelf.Model.prototype,
+        Model,
+        countQueryBuilder;
+
+    countQueryBuilder = {
+        tags: {
+            posts: function addPostCountToTags(model) {
+                model.query('columns', 'tags.*', function (qb) {
+                    qb.count('posts_tags.post_id')
+                        .from('posts_tags')
+                        .whereRaw('tag_id = tags.id')
+                        .as('post_count');
+                });
+            }
+        }
+    };
+
+    Model = Bookshelf.Model.extend({
+        addCounts: function (options) {
+            if (!options) {
+                return;
+            }
+
+            var tableName = _.result(this, 'tableName');
+
+            if (options.include && options.include.indexOf('post_count') > -1) {
+                // remove post_count from withRelated and include
+                options.withRelated = _.pull([].concat(options.withRelated), 'post_count');
+                options.include = _.pull([].concat(options.include), 'post_count');
+
+                // Call the query builder
+                countQueryBuilder[tableName].posts(this);
+            }
+        },
+        fetch: function () {
+            this.addCounts.apply(this, arguments);
+
+            // Call parent fetch
+            return modelProto.fetch.apply(this, arguments);
+        },
+        fetchAll: function () {
+            this.addCounts.apply(this, arguments);
+
+            // Call parent fetchAll
+            return modelProto.fetchAll.apply(this, arguments);
+        }
+    });
+
+    Bookshelf.Model = Model;
+};

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -18,6 +18,7 @@ var _          = require('lodash'),
     uuid       = require('node-uuid'),
     validation = require('../../data/validation'),
     baseUtils  = require('./utils'),
+    includeCount = require('./include-count'),
     pagination = require('./pagination'),
     gql        = require('ghost-gql'),
 
@@ -29,6 +30,9 @@ ghostBookshelf = bookshelf(config.database.knex);
 
 // Load the Bookshelf registry plugin, which helps us avoid circular dependencies
 ghostBookshelf.plugin('registry');
+
+// Load the Ghost include count plugin, which allows for the inclusion of cross-table counts
+ghostBookshelf.plugin(includeCount);
 
 // Load the Ghost pagination plugin, which gives us the `fetchPage` method on Models
 ghostBookshelf.plugin(pagination);
@@ -313,7 +317,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             data.meta = {pagination: response.pagination};
 
             return data;
-        }).catch(errors.logAndThrowError);
+        });
     },
 
     /**

--- a/core/server/models/base/pagination.js
+++ b/core/server/models/base/pagination.js
@@ -3,7 +3,6 @@
 // Extends Bookshelf.Model with a `fetchPage` method. Handles everything to do with paginated requests.
 var _          = require('lodash'),
     Promise    = require('bluebird'),
-    baseUtils  = require('./utils'),
 
     defaults,
     paginationUtils,
@@ -172,9 +171,6 @@ pagination = function pagination(bookshelf) {
                     self.query('groupBy', group);
                 });
             }
-
-            // Apply count options if they are present
-            baseUtils.collectionQuery.count(self, options);
 
             // Setup the promise to do a fetch on our collection, running the specified query
             // @TODO: ensure option handling is done using an explicit pick elsewhere

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -3,27 +3,8 @@
  * Parts of the model code which can be split out and unit tested
  */
 var _ = require('lodash'),
-    collectionQuery,
     processGQLResult,
-    addPostCount,
     tagUpdate;
-
-addPostCount = function addPostCount(options, model) {
-    if (options.include && options.include.indexOf('post_count') > -1) {
-        model.query('columns', 'tags.*', function (qb) {
-            qb.count('posts_tags.post_id').from('posts_tags').whereRaw('tag_id = tags.id').as('post_count');
-        });
-
-        options.withRelated = _.pull([].concat(options.withRelated), 'post_count');
-        options.include = _.pull([].concat(options.include), 'post_count');
-    }
-};
-
-collectionQuery = {
-    count: function count(model, options) {
-        addPostCount(options, model);
-    }
-};
 
 processGQLResult = function processGQLResult(itemCollection, options) {
     var joinTables = options.filter.joins,
@@ -126,6 +107,4 @@ tagUpdate = {
 };
 
 module.exports.processGQLResult = processGQLResult;
-module.exports.collectionQuery = collectionQuery;
-module.exports.addPostCount = addPostCount;
 module.exports.tagUpdate = tagUpdate;

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -1,7 +1,6 @@
 var _              = require('lodash'),
     ghostBookshelf = require('./base'),
     events         = require('../events'),
-    baseUtils      = require('./base/utils'),
     Tag,
     Tags;
 
@@ -100,8 +99,6 @@ Tag = ghostBookshelf.Model.extend({
         data = this.filterData(data, 'findOne');
 
         var tag = this.forge(data);
-
-        baseUtils.addPostCount(options, tag);
 
         // Add related objects
         options.withRelated = _.union(options.withRelated, options.include);


### PR DESCRIPTION
Another piece of refactoring work on the way to making it possible to add cross-table counts etc.

The key thing here, is that rather than having a util that is then called inside the pagination plugin and the tag.read function, and would reasonably have to be called at other points too, we now have a plugin that automatically gets called at the right times.

This makes it easier to add support for counts on other models / relationships. Although, I still need to figure out how to add the behaviour so that only the correct posts are counted (what I'm working on next...)

---

One thing that has occurred to me is to use this fetch/fetchAll override pattern to create a query-building hook system into fetch/fetchAll and allow for the registering of functions to be called by that hook if certain options exist.

E.g. 
- if there is a count property in an include, call count handling
- if there is an order property in the options, call order handling
- if there is an group property in the options, call group handling
## I think this could work to further simplify our code for building queries.

refs #6009, #5615
- minimal refactor to remove the addition of count from pagination and other various points
- create a include count plugin that overrides fetch and fetchAll
- this ensures that counts get added at the right points
