### PR TITLE
Move get helper behind labs flag

### DIFF
--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -3,7 +3,7 @@ var _           = require('lodash'),
     url         = require('url'),
     errors      = require('../errors'),
     config      = require('../config'),
-    api         = require('../api'),
+    labs        = require('../utils/labs'),
     oauthServer,
 
     auth;
@@ -133,17 +133,8 @@ auth = {
 
     // ### Require user depending on public API being activated.
     requiresAuthorizedUserPublicAPI: function requiresAuthorizedUserPublicAPI(req, res, next) {
-        return api.settings.read({key: 'labs', context: {internal: true}}).then(function (response) {
-            var labs,
-                labsValue;
-
-            labs = _.find(response.settings, function (setting) {
-                return setting.key === 'labs';
-            });
-
-            labsValue = JSON.parse(labs.value);
-
-            if (labsValue.publicAPI && labsValue.publicAPI === true) {
+        return labs.isSet('publicAPI').then(function (publicAPI) {
+            if (publicAPI === true) {
                 return next();
             } else {
                 if (req.user) {

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -1,0 +1,20 @@
+var _   = require('lodash'),
+    api = require('../api'),
+    flagIsSet;
+
+flagIsSet = function flagIsSet(flag) {
+    return api.settings.read({key: 'labs', context: {internal: true}}).then(function (response) {
+        var labs,
+            labsValue;
+
+        labs = _.find(response.settings, function (setting) {
+            return setting.key === 'labs';
+        });
+
+        labsValue = JSON.parse(labs.value);
+
+        return !!labsValue[flag] && labsValue[flag] === true;
+    });
+};
+
+module.exports.isSet = flagIsSet;

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -11,6 +11,8 @@ var should         = require('should'),
     helpers        = require('../../../server/helpers'),
     api            = require('../../../server/api'),
 
+    labs           = require('../../../server/utils/labs'),
+
     sandbox = sinon.sandbox.create();
 
 describe('{{#get}} helper', function () {
@@ -23,6 +25,7 @@ describe('{{#get}} helper', function () {
     beforeEach(function () {
         fn = sandbox.spy();
         inverse = sandbox.spy();
+        sandbox.stub(labs, 'isSet').returns(new Promise.resolve(true));
     });
 
     afterEach(function () {


### PR DESCRIPTION
This PR has a couple of key parts, but I think it all makes sense together.

First, I split the code from `middleware/auth.js` out into `utils/labs.js`, so we have a one-size-fits-all utility for finding out if a labs flag is set.

Secondly, I had to do a bit of a weird dance in the get helper to be able to depend on this flag in a way that live updates.

The get helper is wrapped in a function that checks the labs flag, if the flag is set, then the get helper is called using `.call` to bind to the original `this`. 

If the flag is not set, doing nothing results in 'undefined' being printed out to the page - not ideal. With normal unregistered helpers you get a 500 error printed on screen in the browser and usually also in the server console. In this case, that behaviour is somewhat undesirable.

Therefore, I did a little extra work, setup a 'nice' error message and made it so that this would be output on both the client and server console:

![](http://puu.sh/l8brA.png)

![](http://puu.sh/l8cjj.png)

The intention is to be informative and not destructive, in this case. I think that is sane?

issue #5976 
- break out the labs check into a utility
- wrap the get helper in a labs check, so it only works if the checkbox is checked
- make the get helper output an error to both the server and browser console if used when not enabled
