### PR TITLE
Force ember browser tests to always use full height of preview container

### DIFF
--- a/core/client/tests/index.html
+++ b/core/client/tests/index.html
@@ -24,6 +24,16 @@
 
     {{content-for 'head-footer'}}
     {{content-for 'test-head-footer'}}
+
+    <style>
+        /* fix to ensure we use full viewport height when testing */
+        #ember-testing {
+            height: 100%;
+        }
+        #ember-testing > div {
+            height: 100%;
+        }
+    </style>
   </head>
   <body>
 


### PR DESCRIPTION
no issue
- adds style to client/tests/index.html to force preview container and inner element to always fill 100% height
- fixes issue with infinite-scroll test failing in browser but passing in phantomjs
