### PR TITLE
Add meta tags for client_id & client_secret

### DIFF
--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -11,7 +11,15 @@ flagIsSet = function flagIsSet(flag) {
             return setting.key === 'labs';
         });
 
-        labsValue = JSON.parse(labs.value);
+        if (!labs || !labs.value) {
+            return false;
+        }
+
+        try {
+            labsValue = JSON.parse(labs.value);
+        } catch (e) {
+            return false;
+        }
 
         return !!labsValue[flag] && labsValue[flag] === true;
     });


### PR DESCRIPTION
This PR adds the meta tags which will contain `client_id` and `client_secret`. Three conditions must be met for this to appear:
1. there must be a client with the slug `ghost-frontend`
2. the client must have `status === 'enabled'`
3. the public API labs flag must be checked

Here's what it looks like:
![](http://puu.sh/l9avJ.png)

There are 2 additional meta tags:

```
<meta property="ghost:client_id" content="ghost-frontend">
<meta property="ghost:client_secret" content="c6deeb75cfe5">
```

With this, using the public API via ajax no longer requires you to go fishing in your database. Assuming you have `<ul id="result"></ul>` somewhere on your page, the following will fetch a list of your tags:

```
<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
<script type="text/javascript">
var apiUrl = 'http://localhost:2368/blog/ghost/api/v0.1/',
        clientId = $('[property="ghost:client_id"]').attr('content'),
        clientSecret = $('[property="ghost:client_secret"]').attr('content'),
        url = apiUrl + 'tags/?limit=all&client_id=' + clientId + '&client_secret=' + clientSecret;

function onSuccess(data) {
    var $result = $('#result');
    $.each(data.tags, function (i, tag) {
        $result.append('<li><a href="/tag/' + tag.slug + '/">' + tag.name + '</a>&nbsp;</li>');
    });
}
$(document).ready(function () {
    $.ajax({url: url, type: 'get'}).done(onSuccess);
});
```

---

refs #5942
- refactor ghost_head to use Promise.props (settle is going away and this is easier)
- add a new call to fetch the frontend client, if it exists
- add meta tags for the client_id and client_secret on all pages
- don't include the meta tags if the client is not enabled, or if the labs flag is not set
