### PR TITLE
Check client is enabled before auth

### DIFF
--- a/core/server/middleware/auth-strategies.js
+++ b/core/server/middleware/auth-strategies.js
@@ -17,7 +17,7 @@ strategies = {
             .then(function then(model) {
                 if (model) {
                     var client = model.toJSON({include: ['trustedDomains']});
-                    if (client.secret === clientSecret) {
+                    if (client.status === 'enabled' && client.secret === clientSecret) {
                         return done(null, client);
                     }
                 }

--- a/core/test/unit/middleware/auth-strategies_spec.js
+++ b/core/test/unit/middleware/auth-strategies_spec.js
@@ -12,7 +12,8 @@ var should           = require('should'),
 
     fakeClient =  {
         slug: 'ghost-admin',
-        secret: 'not_available'
+        secret: 'not_available',
+        status: 'enabled'
     },
 
     fakeValidToken = {
@@ -88,6 +89,21 @@ describe('Auth Strategies', function () {
         it('shouldn\'t find client with invalid secret', function (done) {
             var clientId = 'ghost-admin',
                 clientSecret = 'invalid_secret';
+            authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
+                clientStub.calledOnce.should.be.true;
+                clientStub.calledWith({slug: clientId}).should.be.true;
+                next.called.should.be.true;
+                next.calledWith(null, false).should.be.true;
+                done();
+            }).catch(done);
+        });
+
+        it('shouldn\'t auth client that is disabled', function (done) {
+            var clientId = 'ghost-admin',
+                clientSecret = 'not_available';
+
+            fakeClient.status = 'disabled';
+
             authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
                 clientStub.calledOnce.should.be.true;
                 clientStub.calledWith({slug: clientId}).should.be.true;


### PR DESCRIPTION
no issue
- add a check that the client has status 'enabled' to client auth strategy
- this permits the disabling of clients easily
- update tests
