### PR TITLE
Update public API labs flag text

### DIFF
--- a/core/client/app/styles/patterns/forms.css
+++ b/core/client/app/styles/patterns/forms.css
@@ -58,6 +58,11 @@ input {
     font-size: 1.3rem;
 }
 
+.form-group h3 {
+    margin-bottom: 1.6em;
+    font-size: 1.5rem;
+}
+
 .form-group label {
     margin-bottom: 4px;
 }

--- a/core/client/app/templates/settings/labs.hbs
+++ b/core/client/app/templates/settings/labs.hbs
@@ -46,13 +46,12 @@
         <form>
             <fieldset>
                 <div class="form-group for-checkbox">
-                    <label for="labs-publicAPI">Public API</label>
+                    <h3>Enable Beta Features</h3>
                     <label class="checkbox" for="labs-publicAPI">
                         {{input id="labs-publicAPI" name="labs[publicAPI]" type="checkbox" checked=usePublicAPI}}
                         <span class="input-toggle-component"></span>
-                        <p>Enable public API access.</p>
+                        <p>Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.</p>
                     </label>
-                    <p>Allow access to the publicly available Ghost API using JavaScript.</p>
                 </div>
             </fieldset>
         </form>


### PR DESCRIPTION
There are 3 key pieces of information I think we need to convey on this page:
1. that 'public api access' = get helper & ajax in themes
2. a link to http://support.ghost.org/public-api-beta/ - which is a page containing all of the whats, whys and how-tos + links to all the other documentation that is available - it's a 'hub' for information.
3. a link to https://ghost.org/slack to encourage people to give feedback - should we add an email address too??

Here's what this PR looks like:

![](http://puu.sh/lac7L.png)

I think it can probably be improved?
