### PR TITLE
Use PhantomJS 2.1.1 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ matrix:
     - node_js: "0.10"
       env: TEST_SUITE=lint
 before_install:
+  # - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_testing'; fi
   - if [ $DB == "pg" ]; then psql -c 'create database ghost_testing;' -U postgres; fi
 before_script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ requests](#pull-requests), but please respect the following restrictions:
 * Please **search for existing issues**. Help us keep duplicate issues to a minimum by checking to see if someone
 has already reported your problem or requested your idea.
 
-* Please **do not** use the issue tracker for personal support requests (use [slack](http://ghost.org/slack) or 
+* Please **do not** use the issue tracker for personal support requests (use [slack](http://ghost.org/slack) or
 [stackoverflow](http://stackoverflow.com/questions/tagged/ghost-blog) if you prefer).
 
 * Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
@@ -194,7 +194,7 @@ Looking to get setup to work on Ghost? AWESOME! The [Ghost-Vagrant](https://gith
 **What you'll need:**
 
 - Node version 0.10.x & npm
-- phantomjs 1.9.x
+- phantomjs 2.1.x
 ([instructions](https://github.com/TryGhost/Ghost/wiki/Functional-testing-with-PhantomJS-and-CasperJS)) for running tests
 
 

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -26,7 +26,6 @@
     "ember-cli-babel": "5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "1.1.0",
-    "ember-cli-es5-shim": "0.1.1",
     "ember-cli-fastclick": "1.0.3",
     "ember-cli-htmlbars": "1.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.1",


### PR DESCRIPTION
no issue
- download phantomjs 2.1.1 in Travis' `before_install` step and update the `PATH` export to so the downloaded version is used
- remove the now no-longer needed `ember-cli-es5-shim` dependency
- update documentation references to match new phantomjs version

---

Seeing as we've now dropped the Casper.js suite I figured we should try upgrading to phantomjs 2.0 as it's recommended by Ember, uses a much newer version of webkit and is supposedly faster.

I don't think it's quite ready for general use yet as I ran into a couple of issues when trying this out:
- <strike>Travis does not yet support phantomjs 2.0 by default but that should be coming soon - https://github.com/travis-ci/travis-ci/issues/3225</strike> - easily resolved by downloading/building the version we want in Travis' `before_install` hook
- <strike>Phantomjs won't currently install via homebrew on OS X versions later than Yosemite, there is a 2.0.1 preview with the issues fixed which should make it's way through the pipeline shortly. Binaries are available for install at https://github.com/Vitallium/phantomjs/releases/tag/2.0.1</strike> - The newly released version 2.1.x is now installable via homebrew
