### PR TITLE
remove console log for passing test

### DIFF
--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -77,7 +77,6 @@ describe('Public API', function () {
             .expect('Cache-Control', testUtils.cacheRules.private)
             .expect(200)
             .end(function (err, res) {
-                console.log(res.body);
                 if (err) {
                     return done(err);
                 }


### PR DESCRIPTION
I was browsing the TravisCI build output and noticed this response was being logged 
