### PR TITLE
Add themes 'ajax' helper

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,7 +130,6 @@ var _              = require('lodash'),
                     '!config*.js', // note: i added this, do we want this linted?
                     'core/*.js',
                     'core/server/**/*.js',
-                    'core/shared/**/*.js',
                     'core/test/**/*.js',
                     '!core/test/coverage/**',
                     '!core/shared/vendor/**/*.js'
@@ -167,7 +166,6 @@ var _              = require('lodash'),
                             '!config*.js', // note: i added this, do we want this linted?
                             'core/*.js',
                             'core/server/**/*.js',
-                            'core/shared/**/*.js',
                             'core/test/**/*.js',
                             '!core/test/coverage/**',
                             '!core/shared/vendor/**/*.js'

--- a/core/shared/ghost-url.js
+++ b/core/shared/ghost-url.js
@@ -1,0 +1,64 @@
+(function () {
+    'use strict';
+
+    function generateQueryString(object) {
+        var url = '?',
+            i;
+
+        if (!object) {
+            return '';
+        }
+
+        for (i in object) {
+            if (object.hasOwnProperty(i) && (!!object[i] || object[i] === false)) {
+                url += i + '=' + encodeURIComponent(object[i]) + '&';
+            }
+        }
+
+        return url.substring(0, url.length - 1);
+    }
+
+    var url = {
+        config: {
+            url: '{{api_url}}',
+            useOrigin: '{{useOrigin}}',
+            origin: '',
+            clientId: '',
+            clientSecret: ''
+        },
+
+        api: function () {
+            var args = Array.prototype.slice.call(arguments),
+                url = ((this.config.useOrigin === 'true')) ? this.config.origin + this.config.url : this.config.url,
+                queryOptions;
+
+            if (args.length && typeof args[args.length - 1] === 'object') {
+                queryOptions = args.pop();
+            } else {
+                queryOptions = {};
+            }
+
+            queryOptions.client_id = this.config.clientId;
+            queryOptions.client_secret = this.config.clientSecret;
+
+            if (args.length) {
+                args.forEach(function (el) {
+                    url += el.replace(/^\/|\/$/g, '') + '/';
+                });
+            }
+
+            return url + generateQueryString(queryOptions);
+        }
+    };
+
+    if (typeof window !== 'undefined') {
+        url.config.origin = window.location.origin;
+        url.config.clientId = document.querySelector('meta[property=\'ghost:client_id\']').content;
+        url.config.clientSecret = document.querySelector('meta[property=\'ghost:client_secret\']').content;
+        window.ghost = window.ghost || {};
+        window.ghost.url = url;
+    }
+    if (typeof module !== 'undefined') {
+        module.exports = url;
+    }
+})();

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -1,0 +1,90 @@
+/* globals describe,  afterEach, it */
+/*jshint expr:true*/
+var url    = require('../../shared/ghost-url');
+
+describe('Ghost Ajax Helper', function () {
+    afterEach(function () {
+        url.config = {};
+    });
+
+    it('renders basic url correctly when no arguments are presented & useOrigin is set to false', function () {
+        url.config = {
+            url: 'http://testblog.com/',
+            useOrigin: 'false',
+            clientId: '',
+            clientSecret: ''
+        };
+
+        url.api().should.equal('http://testblog.com/');
+    });
+
+    it('renders basic url correctly when no arguments are presented & useOrigin is set to true', function () {
+        url.config = {
+            url: '/url/',
+            useOrigin: 'true',
+            origin: 'http://originblog.com',
+            clientId: '',
+            clientSecret: ''
+        };
+
+        url.api().should.equal('http://originblog.com/url/');
+    });
+
+    it('strips arguments of forward and trailing slashes correctly', function () {
+        url.config = {
+            url: 'http://testblog.com/',
+            useOrigin: 'false',
+            clientId: '',
+            clientSecret: ''
+        };
+
+        url.api('a/', '/b', '/c/').should.equal('http://testblog.com/a/b/c/');
+    });
+
+    it('appends client_id & client_secret to query string automatically', function () {
+        url.config = {
+            url: 'http://testblog.com/',
+            useOrigin: 'false',
+            clientId: 'ghost-frontend',
+            clientSecret: 'notasecret'
+        };
+
+        url.api().should.equal('http://testblog.com/?client_id=ghost-frontend&client_secret=notasecret');
+    });
+
+    it('generates query parameters correctly', function () {
+        url.config = {
+            url: 'http://testblog.com/',
+            useOrigin: 'false',
+            clientId: 'ghost-frontend',
+            clientSecret: 'notasecret'
+        };
+
+        var rendered = url.api({a: 'string', b: 5, c: 'en coded'});
+
+        rendered.should.match(/http:\/\/testblog\.com\/\?/);
+        rendered.should.match(/client_id=ghost-frontend/);
+        rendered.should.match(/client_secret=notasecret/);
+        rendered.should.match(/a/);
+        rendered.should.match(/b=5/);
+        rendered.should.match(/c=en\%20coded/);
+    });
+
+    it('generates complex query correctly', function () {
+        url.config = {
+            url: '/blog/ghost/api/v0.1/',
+            useOrigin: 'true',
+            origin: 'https://testblog.com',
+            clientId: 'ghost-frontend',
+            clientSecret: 'notasecret'
+        };
+
+        var rendered = url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
+
+        rendered.should.match(/https:\/\/testblog\.com\/blog\/ghost\/api\/v0\.1\/posts\/tags\/count\/\?/);
+        rendered.should.match(/client_id=ghost-frontend/);
+        rendered.should.match(/client_secret=notasecret/);
+        rendered.should.match(/include=tags%2Ctests/);
+        rendered.should.match(/page=2/);
+    });
+});

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -778,4 +778,104 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
     });
+
+    describe('with Ajax Helper', function () {
+        beforeEach(function () {
+            utils.overrideConfig({
+                url: '',
+                urlSSL: '',
+                forceAdminSSL: false
+            });
+        });
+
+        it('renders script tags with basic configuration', function (done) {
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index'], post: false},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                expectGhostClientMeta(rendered);
+                rendered.string.should.match(/<script type="text\/javascript">\(function \(\) \{/);
+                rendered.string.should.match(/'use strict';/);
+                rendered.string.should.match(/<\/script>/);
+
+                done();
+            });
+        });
+
+        it('renders basic url correctly', function (done) {
+            utils.overrideConfig({
+                url: 'http://testurl.com/'
+            });
+
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index'], post: false},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                expectGhostClientMeta(rendered);
+                rendered.string.should.match(/url: '\/ghost\/api\/v0\.1\/'/);
+                rendered.string.should.match(/useOrigin: 'true'/);
+
+                done();
+            });
+        });
+
+        it('renders basic url correctly with subdirectory', function (done) {
+            utils.overrideConfig({
+                url: 'http://testurl.com/blog/'
+            });
+
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index'], post: false},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                expectGhostClientMeta(rendered);
+                rendered.string.should.match(/url: '\/blog\/ghost\/api\/v0\.1\/'/);
+                rendered.string.should.match(/useOrigin: 'true'/);
+
+                done();
+            });
+        });
+
+        it('renders correct https url with forceAdminSSL set', function (done) {
+            utils.overrideConfig({
+                url: 'http://testurl.com/',
+                forceAdminSSL: true
+            });
+
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index'], post: false},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                expectGhostClientMeta(rendered);
+                rendered.string.should.match(/url: 'https:\/\/testurl\.com\/ghost\/api\/v0\.1\/'/);
+                rendered.string.should.match(/useOrigin: 'false'/);
+
+                done();
+            });
+        });
+
+        it('renders correct https url if urlSSL is set and forceAdminSSL is also set', function (done) {
+            utils.overrideConfig({
+                url: 'http://testurl.com/',
+                urlSSL: 'https://sslurl.com/',
+                forceAdminSSL: true
+            });
+
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index'], post: false},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                expectGhostClientMeta(rendered);
+                rendered.string.should.match(/url: 'https:\/\/sslurl\.com\/ghost\/api\/v0\.1\/'/);
+                rendered.string.should.match(/useOrigin: 'false'/);
+
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
This PR adds a small inline script to the `{{ghost_head}}` helper that includes a utility function (`ghost.url()`) for creating api urls to be called by some form of ajax.

Currently the script itself works, but it can be made better.

Tasks:
- [x] Implement intial script
- [x] Clean up script
- [x] Tests
- [x] :cake:
