### PR TITLE
Fix DB export throwing access denied errors

### DIFF
--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -19,6 +19,8 @@ function isBearerAutorizationHeader(req) {
 
     if (req.headers && req.headers.authorization) {
         parts = req.headers.authorization.split(' ');
+    } else if (req.query && req.query.access_token) {
+        return true;
     } else {
         return false;
     }

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -47,4 +47,20 @@ describe('DB API', function () {
                 done();
             });
     });
+
+    it('should work with access token set as query parameter', function (done) {
+        request.get(testUtils.API.getApiQuery('db/?access_token=' + accesstoken))
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                var jsonResponse = res.body;
+                should.exist(jsonResponse.db);
+                jsonResponse.db.should.have.length(1);
+                done();
+            });
+    });
 });


### PR DESCRIPTION
closes #6040
- adds check for access token query parameter in auth middleware

@ErisDS turns out it wasn't the pipeline, it was the public api refactor :smile:

If you want me to add tests for this I can do that as well, but for the moment I though I'd get the fix pushed.
