### PR TITLE
Refactor old processOptions/where to use GQL JSON

### DIFF
--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -59,16 +59,17 @@ Tag = ghostBookshelf.Model.extend({
     }
 }, {
     findPageDefaultOptions: function findPageDefaultOptions() {
-        return {
-            where: {}
-        };
+        return {};
     },
 
     orderDefaultOptions: function orderDefaultOptions() {
         return {};
     },
 
-    processOptions: function processOptions(itemCollection, options) {
+    /**
+     * @deprecated in favour of filter
+     */
+    processOptions: function processOptions(options) {
         return options;
     },
 


### PR DESCRIPTION
refs #5943
- no longer assume the options in processOptions are set
- set where to a new GQL JSON-like statement object
- rather than setting options, add statements which can be understood by knexify
- pass the statements through knexify to build the query
