### PR TITLE
Separate the client/server test suites on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,17 @@ env:
   global:
     - GITHUB_OAUTH_KEY=003a44d58f12089d0c0261338298af3813330949
     - GHOST_NODE_VERSION_CHECK=false
+    - TEST_SUITE=server
   matrix:
     - DB=sqlite3 NODE_ENV=testing
     - DB=mysql NODE_ENV=testing-mysql
     - DB=pg NODE_ENV=testing-pg
+matrix:
+  include:
+    - node_js: "0.10"
+      env: TEST_SUITE=client
+    - node_js: "0.10"
+      env: TEST_SUITE=lint
 before_install:
   - git clone git://github.com/n1k0/casperjs.git ~/casperjs
   - cd ~/casperjs


### PR DESCRIPTION
no issue
- add separate grunt tasks for validating all/client/server test suites
- modify `grunt validate` to respect the `TEST_SUITE` env var if present
- default to `TEST_SUITE=server` on Travis
- add an individual build to the Travis matrix that tests the client

Previously we were duplicating the client tests for every node and database version in our build matrix. Duplicating client tests is now a waste of time/resources as the tests are now completely isolated from the server and so different node/database versions have no effect. This PR is an attempt at removing the duplication to speed up our Travis runs.

Other things that would be nice to implement:
- [x] Run the linting as a separate build - the files won't change between builds so re-running linting for every build in the matrix is wasteful (it may also give more visibility when it's just linting that has failed?)

I think the above would dramatically speed up our Travis runs - the build and lint steps typically mean our actual test suites don't start until 2+ minutes for every matrix build.
