### PR TITLE
Add access rules bookshelf plugin

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -137,13 +137,14 @@ utils = {
     },
 
     /**
-     * ## Is Public Context?
-     * If this is a public context, return true
+     * ## Detect Public Context
+     * Calls parse context to expand the options.context object
      * @param {Object} options
      * @returns {Boolean}
      */
-    isPublicContext: function isPublicContext(options) {
-        return permissions.parseContext(options.context).public;
+    detectPublicContext: function detectPublicContext(options) {
+        options.context = permissions.parseContext(options.context);
+        return options.context.public;
     },
     /**
      * ## Apply Public Permissions
@@ -174,7 +175,7 @@ utils = {
         return function doHandlePublicPermissions(options) {
             var permsPromise;
 
-            if (utils.isPublicContext(options)) {
+            if (utils.detectPublicContext(options)) {
                 permsPromise = utils.applyPublicPermissions(docName, method, options);
             } else {
                 permsPromise = permissions.canThis(options.context)[method][singular](options.data);

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -30,6 +30,9 @@ ghostBookshelf = bookshelf(config.database.knex);
 // Load the Bookshelf registry plugin, which helps us avoid circular dependencies
 ghostBookshelf.plugin('registry');
 
+// Load the Ghost access rules plugin, which handles passing permissions/context through the model layer
+ghostBookshelf.plugin(plugins.accessRules);
+
 // Load the Ghost include count plugin, which allows for the inclusion of cross-table counts
 ghostBookshelf.plugin(plugins.includeCount);
 
@@ -268,7 +271,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         options = options || {};
 
         var self = this,
-            itemCollection = this.forge(),
+            itemCollection = this.forge(null, {context: options.context}),
             tableName      = _.result(this.prototype, 'tableName');
 
         // Filter options so that only permitted ones remain

--- a/core/server/models/plugins/access-rules.js
+++ b/core/server/models/plugins/access-rules.js
@@ -1,0 +1,45 @@
+// # Access Rules
+//
+// Extends Bookshelf.Model.force to take a 'context' option which provides information on how this query should
+// be treated in terms of data access rules - currently just detecting public requests
+module.exports = function (Bookshelf) {
+    var model = Bookshelf.Model,
+        Model;
+
+    Model = Bookshelf.Model.extend({
+        /**
+         * Cached copy of the context setup for this model instance
+         */
+        _context: null,
+        /**
+         * ## Is Public Context?
+         * A helper to determine if this is a public request or not
+         * @returns {boolean}
+         */
+        isPublicContext: function isPublicContext() {
+            return !!(this._context && this._context.public);
+        }
+    },
+    {
+        /**
+         * ## Forge
+         * Ensure that context gets set as part of the forge
+         *
+         * @param {object} attributes
+         * @param {object} options
+         * @returns {Bookshelf.Model} model
+         */
+        forge: function forge(attributes, options) {
+            var self = model.forge.apply(this, arguments);
+
+            if (options && options.context) {
+                self._context = options.context;
+                delete options.context;
+            }
+
+            return self;
+        }
+    });
+
+    Bookshelf.Model = Model;
+};

--- a/core/server/models/plugins/index.js
+++ b/core/server/models/plugins/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+    accessRules: require('./access-rules'),
     includeCount: require('./include-count'),
     pagination: require('./pagination')
 };

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -406,7 +406,7 @@ describe('API Utils', function () {
     describe('isPublicContext', function () {
         it('should call out to permissions', function () {
             var permsStub = sandbox.stub(permissions, 'parseContext').returns({public: true});
-            apiUtils.isPublicContext({context: 'test'}).should.be.true;
+            apiUtils.detectPublicContext({context: 'test'}).should.be.true;
             permsStub.called.should.be.true;
             permsStub.calledWith('test').should.be.true;
         });
@@ -424,7 +424,7 @@ describe('API Utils', function () {
     describe('handlePublicPermissions', function () {
         it('should return empty options if passed empty options', function (done) {
             apiUtils.handlePublicPermissions('tests', 'test')({}).then(function (options) {
-                options.should.eql({});
+                options.should.eql({context: {app: null, internal: false, public: true, user: null}});
                 done();
             }).catch(done);
         });
@@ -433,7 +433,7 @@ describe('API Utils', function () {
             var aPPStub = sandbox.stub(apiUtils, 'applyPublicPermissions').returns(Promise.resolve({}));
             apiUtils.handlePublicPermissions('tests', 'test')({}).then(function (options) {
                 aPPStub.calledOnce.should.eql(true);
-                options.should.eql({});
+                options.should.eql({context: {app: null, internal: false, public: true, user: null}});
                 done();
             }).catch(done);
         });
@@ -449,7 +449,7 @@ describe('API Utils', function () {
             apiUtils.handlePublicPermissions('tests', 'test')({context: {user: 1}}).then(function (options) {
                 cTStub.calledOnce.should.eql(true);
                 cTMethodStub.test.test.calledOnce.should.eql(true);
-                options.should.eql({context: {user: 1}});
+                options.should.eql({context: {app: null, internal: false, public: false, user: 1}});
                 done();
             }).catch(done);
         });

--- a/core/test/unit/models_plugins/access-rules_spec.js
+++ b/core/test/unit/models_plugins/access-rules_spec.js
@@ -1,0 +1,54 @@
+/*globals describe, it, beforeEach, afterEach */
+/*jshint expr:true*/
+var should = require('should'),
+    sinon = require('sinon'),
+
+// Thing we're testing
+    // accessRules = require('../../../server/models/plugins/access-rules'),
+    models = require('../../../server/models'),
+    ghostBookshelf,
+
+    sandbox = sinon.sandbox.create();
+
+// To stop jshint complaining
+should.equal(true, true);
+
+describe('Access Rules', function () {
+    beforeEach(function () {
+        return models.init().then(function () {
+            ghostBookshelf = models.Base;
+        });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('Base Model', function () {
+        it('should assign isPublicContext to prototype', function () {
+            ghostBookshelf.Model.prototype.isPublicContext.should.be.a.Function;
+        });
+
+        it('should get called when a model is forged', function () {
+            ghostBookshelf.Model.forge(null, {context: 'test'})._context.should.eql('test');
+        });
+
+        describe('isPublicContext', function () {
+            it('should isPublicContext false if no context is set', function () {
+                ghostBookshelf.Model.forge().isPublicContext().should.be.false;
+            });
+
+            it('should return false if context has no `public` property', function () {
+                ghostBookshelf.Model.forge(null, {context: 'test'}).isPublicContext().should.be.false;
+            });
+
+            it('should return false if context.public is false', function () {
+                ghostBookshelf.Model.forge(null, {context: {public: false}}).isPublicContext().should.be.false;
+            });
+
+            it('should return true if context.public is true', function () {
+                ghostBookshelf.Model.forge(null, {context: {public: true}}).isPublicContext().should.be.true;
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR, along with #6068, the pagination and includeCount plugins, and work on the 'filter' api functionality that I'm hoping to raise a PR for later, is all working towards trying to improve the maintainability of the model layer in Ghost.

At the moment, `models/base/index.js` and the individual model files in `models/` all contain a big mix of configuration and logic which is very hard to follow. It's also very 'hard coded' meaning every new feature we add needs more code somewhere, and keeps adding to the surface area. Meanwhile, this code is only tested using integration tests, which do little more than test the use-cases we care about for the admin UI.

My aim is to start composing more of the business logic for models by building up our plugins, moving code from the base model and individual model files. Each plugin should have some business logic, be unit tested, and provide for configuring if and how it works for a particular model if deviation from the standard is needed. In this way, each of the individual model files should start to become much more readable, containing mostly configuration and small pieces of custom logic.

E.g. the way bookshelf models define their relations - we should be able to use this to automatically configure joins, nested updates, nested deletes, and other complex logic based on the information we already have or with some small extra definitions.

There are also community plugins which we could be leveraging to provide some complex logic: https://github.com/ericclemmons/bookshelf-manager/pull/7. If our own plugins become generic enough, then they can be split out into separate repos with their tests. 

The aim being to reduce the weight of the code in Ghost itself, and defer complex logic elsewhere so that we don't have to think about it or maintain it as we add new features :)

---

Note: the new functionality in this PR doesn't get used yet :)

refs #5614
- change isPublicContext to detectPublicContext
  - behaviour now expands the context object out
  - this is a bit of a sideeffect, but this is the simplest change
    that makes it possible to use the context in the model layer without
    significant wider changes
- add new access rules plugin
  - takes a context object as part of `forge()` & caches it on the model instance
  - provides helper functions for testing access rules later on
