### PR TITLE
Filter plugin

### DIFF
--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -2,41 +2,8 @@
  * # Utils
  * Parts of the model code which can be split out and unit tested
  */
-var _   = require('lodash'),
-    gql = require('ghost-gql'),
-    processGQLResult,
+var _ = require('lodash'),
     tagUpdate;
-
-processGQLResult = function processGQLResult(itemCollection, options) {
-    var joinTables = options.filter.joins;
-
-    if (joinTables && joinTables.indexOf('tags') > -1) {
-        // We need to use leftOuterJoin to insure we still include posts which don't have tags in the result
-        // The where clause should restrict which items are returned
-        itemCollection
-            .query('leftOuterJoin', 'posts_tags', 'posts_tags.post_id', '=', 'posts.id')
-            .query('leftOuterJoin', 'tags', 'posts_tags.tag_id', '=', 'tags.id');
-
-        // The order override should ONLY happen if we are doing an "IN" query
-        // TODO move the order handling to the query building that is currently inside pagination
-        // TODO make the order handling in pagination handle orderByRaw
-        // TODO extend this handling to all joins
-        if (gql.json.findStatement(options.filter.statements, {prop: /^tags/, op: 'IN'})) {
-            // TODO make this count the number of MATCHING tags, not just the number of tags
-            itemCollection.query('orderByRaw', 'count(tags.id) DESC');
-        }
-
-        // We need to add a group by to counter the double left outer join
-        // TODO improve on th group by handling
-        options.groups = options.groups || [];
-        options.groups.push('posts.id');
-    }
-
-    if (joinTables && joinTables.indexOf('author') > -1) {
-        itemCollection
-            .query('join', 'users as author', 'author.id', '=', 'posts.author_id');
-    }
-};
 
 tagUpdate = {
     fetchCurrentPost: function fetchCurrentPost(PostModel, id, options) {
@@ -100,5 +67,4 @@ tagUpdate = {
     }
 };
 
-module.exports.processGQLResult = processGQLResult;
 module.exports.tagUpdate = tagUpdate;

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -1,0 +1,165 @@
+var _   = require('lodash'),
+    gql = require('ghost-gql'),
+    filter,
+    filterUtils;
+
+filterUtils = {
+    /**
+     * ## Combine Filters
+     * Util to combine the enforced, default and custom filters such that they behave accordingly
+     * @param {String|Object} enforced - filters which must ALWAYS be applied
+     * @param {String|Object} defaults - filters which must be applied if a matching filter isn't provided
+     * @param {...String|Object} [custom] - custom filters which are additional
+     * @returns {*}
+     */
+    combineFilters: function combineFilters(enforced, defaults, custom /* ...custom */) {
+        custom = Array.prototype.slice.call(arguments, 2);
+
+        // Ensure everything has been run through the gql parser
+        enforced = enforced ? (_.isString(enforced) ? gql.parse(enforced) : enforced) : null;
+        defaults = defaults ? (_.isString(defaults) ? gql.parse(defaults) : defaults) : null;
+        custom = _.map(custom, function (arg) {
+            return _.isString(arg) ? gql.parse(arg) : arg;
+        });
+
+        // Merge custom filter options into a single set of statements
+        custom = gql.json.mergeStatements.apply(this, custom);
+
+        // if there is no enforced or default statements, return just the custom statements;
+        if (!enforced && !defaults) {
+            return custom;
+        }
+
+        // Reduce custom filters based on enforced filters
+        if (custom && !_.isEmpty(custom.statements) && enforced && !_.isEmpty(enforced.statements)) {
+            custom.statements = gql.json.rejectStatements(custom.statements, function (customStatement) {
+                return gql.json.findStatement(enforced.statements, customStatement, 'prop');
+            });
+        }
+
+        // Reduce default filters based on custom filters
+        if (defaults && !_.isEmpty(defaults.statements) && custom && !_.isEmpty(custom.statements)) {
+            defaults.statements = gql.json.rejectStatements(defaults.statements, function (defaultStatement) {
+                return gql.json.findStatement(custom.statements, defaultStatement, 'prop');
+            });
+        }
+
+        // Merge enforced and defaults
+        enforced = gql.json.mergeStatements(enforced, defaults);
+
+        if (_.isEmpty(custom.statements)) {
+            return enforced;
+        }
+
+        if (_.isEmpty(enforced.statements)) {
+            return custom;
+        }
+
+        return {
+            statements: [
+                {group: enforced.statements},
+                {group: custom.statements, func: 'and'}
+            ]
+        };
+    }
+};
+
+filter = function filter(Bookshelf) {
+    var Model = Bookshelf.Model.extend({
+        // Cached copy of the filters setup for this model instance
+        _filters: null,
+        // Override these on the various models
+        enforcedFilters: function enforcedFilters() {},
+        defaultFilters: function defaultFilters() {},
+
+        /**
+         * ## Post process Filters
+         * Post Process filters looking for joins etc
+         * @TODO refactor this
+         * @param {object} options
+         */
+        postProcessFilters: function postProcessFilters(options) {
+            var joinTables = this._filters.joins;
+
+            if (joinTables && joinTables.indexOf('tags') > -1) {
+                // We need to use leftOuterJoin to insure we still include posts which don't have tags in the result
+                // The where clause should restrict which items are returned
+                this
+                    .query('leftOuterJoin', 'posts_tags', 'posts_tags.post_id', '=', 'posts.id')
+                    .query('leftOuterJoin', 'tags', 'posts_tags.tag_id', '=', 'tags.id');
+
+                // The order override should ONLY happen if we are doing an "IN" query
+                // TODO move the order handling to the query building that is currently inside pagination
+                // TODO make the order handling in pagination handle orderByRaw
+                // TODO extend this handling to all joins
+                if (gql.json.findStatement(this._filters.statements, {prop: /^tags/, op: 'IN'})) {
+                    // TODO make this count the number of MATCHING tags, not just the number of tags
+                    this.query('orderByRaw', 'count(tags.id) DESC');
+                }
+
+                // We need to add a group by to counter the double left outer join
+                // TODO improve on the group by handling
+                options.groups = options.groups || [];
+                options.groups.push('posts.id');
+            }
+
+            if (joinTables && joinTables.indexOf('author') > -1) {
+                this
+                    .query('join', 'users as author', 'author.id', '=', 'posts.author_id');
+            }
+        },
+        /**
+         * ## fetchAndCombineFilters
+         * Helper method, uses the combineFilters util to apply filters to the current model instance
+         * based on options and the set enforced/default filters for this resource
+         * @param {Object} options
+         * @returns {Bookshelf.Model}
+         */
+        fetchAndCombineFilters: function fetchAndCombineFilters(options) {
+            options = options || {};
+
+            this._filters = filterUtils.combineFilters(
+                this.enforcedFilters(),
+                this.defaultFilters(),
+                options.filter,
+                options.where
+            );
+
+            return this;
+        },
+        /**
+         * ## Apply Filters
+         * Method which makes the necessary query builder calls (through knex) for the filters set
+         * on this model instance
+         * @param {Object} options
+         * @returns {Bookshelf.Model}
+         */
+        applyFilters: function applyFilters(options) {
+            var self = this;
+
+            // @TODO figure out a better place/way to trigger loading filters
+            if (!this._filters) {
+                this.fetchAndCombineFilters(options);
+            }
+
+            if (this._filters) {
+                this.query(function (qb) {
+                    gql.knexify(qb, self._filters);
+                });
+
+                // Replaces processGQLResult
+                this.postProcessFilters(options);
+            }
+
+            return this;
+        }
+    });
+
+    Bookshelf.Model = Model;
+};
+
+/**
+ * ## Export Filter plugin
+ * @api public
+ */
+module.exports = filter;

--- a/core/server/models/plugins/index.js
+++ b/core/server/models/plugins/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     accessRules: require('./access-rules'),
+    filter: require('./filter'),
     includeCount: require('./include-count'),
     pagination: require('./pagination')
 };

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -328,15 +328,14 @@ Post = ghostBookshelf.Model.extend({
         }
 
         return attrs;
+    },
+    enforcedFilters: function enforcedFilters() {
+        return this.isPublicContext() ? 'status:published' : null;
+    },
+    defaultFilters: function defaultFilters() {
+        return this.isPublicContext() ? 'page:false' : 'page:false+status:published';
     }
 }, {
-    findPageDefaultOptions: function findPageDefaultOptions() {
-        return {
-            staticPages: false, // include static pages
-            status: 'published'
-        };
-    },
-
     orderDefaultOptions: function orderDefaultOptions() {
         return {
             status: 'ASC',
@@ -358,7 +357,7 @@ Post = ghostBookshelf.Model.extend({
         options.where = {statements: []};
 
         // Step 4: Setup filters (where clauses)
-        if (options.staticPages !== 'all') {
+        if (options.staticPages && options.staticPages !== 'all') {
             // convert string true/false to boolean
             if (!_.isBoolean(options.staticPages)) {
                 options.staticPages = _.contains(['true', '1'], options.staticPages);
@@ -372,12 +371,12 @@ Post = ghostBookshelf.Model.extend({
 
         // Unless `all` is passed as an option, filter on
         // the status provided.
-        if (options.status !== 'all') {
+        if (options.status && options.status !== 'all') {
             // make sure that status is valid
             options.status = _.contains(['published', 'draft'], options.status) ? options.status : 'published';
             options.where.statements.push({prop: 'status', op: '=', value: options.status});
             delete options.status;
-        } else {
+        } else if (options.status === 'all') {
             options.where.statements.push({prop: 'status', op: 'IN', value: ['published', 'draft']});
             delete options.status;
         }

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -58,10 +58,6 @@ Tag = ghostBookshelf.Model.extend({
         return attrs;
     }
 }, {
-    findPageDefaultOptions: function findPageDefaultOptions() {
-        return {};
-    },
-
     orderDefaultOptions: function orderDefaultOptions() {
         return {};
     },

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -161,15 +161,14 @@ User = ghostBookshelf.Model.extend({
         return roles.some(function getRole(role) {
             return role.get('name') === roleName;
         });
-    }
-
-}, {
-    findPageDefaultOptions: function findPageDefaultOptions() {
-        return {
-            status: 'active'
-        };
     },
-
+    enforcedFilters: function enforcedFilters() {
+        return this.isPublicContext() ? 'status:[' + activeStates.join(',') + ']' : null;
+    },
+    defaultFilters: function defaultFilters() {
+        return this.isPublicContext() ? null : 'status:[' + activeStates.join(',') + ']';
+    }
+}, {
     orderDefaultOptions: function orderDefaultOptions() {
         return {
             last_login: 'DESC',

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -79,10 +79,15 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(10);
+                    result.posts.should.be.an.Array.with.lengthOf(9);
 
                     ids = _.pluck(result.posts, 'id');
-                    ids.should.eql([15, 14, 11, 9, 8, 7, 6, 5, 3, 2]);
+                    ids.should.eql([14, 11, 9, 8, 7, 6, 5, 3, 2]);
+
+                    _.each(result.posts, function (post) {
+                        post.page.should.be.false;
+                        post.status.should.eql('published');
+                    });
 
                     // TODO: Should be in published order
 
@@ -92,7 +97,7 @@ describe('Filter Param Spec', function () {
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
-                    result.meta.pagination.total.should.eql(10);
+                    result.meta.pagination.total.should.eql(9);
                     should.equal(result.meta.pagination.next, null);
                     should.equal(result.meta.pagination.prev, null);
 
@@ -433,7 +438,7 @@ describe('Filter Param Spec', function () {
         });
 
         describe('Handling "page" (staticPages)', function () {
-            it('Will return only posts by default', function (done) {
+            it('Will return only published posts by default', function (done) {
                 PostAPI.browse({limit: 'all'}).then(function (result) {
                     var ids, page;
                     // 1. Result should have the correct base structure
@@ -470,8 +475,8 @@ describe('Filter Param Spec', function () {
                 }).catch(done);
             });
 
-            // TODO: determine if this should be supported via filter, or whether it should only be available via a 'PageAPI'
-            it.skip('Will return only pages when requested', function (done) {
+            // @TODO: determine if this should be supported via filter, or whether it should only be available via a 'PageAPI'
+            it('Will return only pages when requested', function (done) {
                 PostAPI.browse({filter: 'page:true'}).then(function (result) {
                     var ids, page;
                     // 1. Result should have the correct base structure
@@ -541,6 +546,72 @@ describe('Filter Param Spec', function () {
                     done();
                 }).catch(done);
             });
+        });
+    });
+
+    describe('Bad behaviour', function () {
+        it('Try to get draft posts (filter with or)', function (done) {
+            PostAPI.browse({filter: 'status:published,status:draft', limit: 'all'}).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                _.each(result.posts, function (post) {
+                    post.page.should.be.false;
+                    post.status.should.eql('published');
+                });
+
+                done();
+            }).catch(done);
+        });
+
+        it('Try to get draft posts (filter with in)', function (done) {
+            PostAPI.browse({filter: 'status:[published,draft]', limit: 'all'}).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                _.each(result.posts, function (post) {
+                    post.page.should.be.false;
+                    post.status.should.eql('published');
+                });
+
+                done();
+            }).catch(done);
+        });
+
+        it('Try to get draft posts (filter with group)', function (done) {
+            PostAPI.browse({filter: 'page:false,(status:draft)', limit: 'all'}).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                _.each(result.posts, function (post) {
+                    post.page.should.be.false;
+                    post.status.should.eql('published');
+                });
+
+                done();
+            }).catch(done);
+        });
+
+        it('Try to get draft posts (filter with group and in)', function (done) {
+            PostAPI.browse({filter: 'page:false,(status:[draft,published])', limit: 'all'}).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                _.each(result.posts, function (post) {
+                    post.page.should.be.false;
+                    post.status.should.eql('published');
+                });
+
+                done();
+            }).catch(done);
         });
     });
 });

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -99,6 +99,15 @@ describe('Post API', function () {
             }).catch(done);
         });
 
+        it('can fetch static and normal posts (filter version)', function (done) {
+            PostAPI.browse({context: {user: 1}, filter: 'page:[false,true]'}).then(function (results) {
+                // should be the same as the current staticPages: 'all'
+                should.exist(results.posts);
+                results.posts.length.should.eql(5);
+                done();
+            }).catch(done);
+        });
+
         it('can fetch page 1', function (done) {
             PostAPI.browse({context: {user: 1}, page: 1, limit: 2, status: 'all'}).then(function (results) {
                 should.exist(results.posts);

--- a/core/test/unit/apps_filters_spec.js
+++ b/core/test/unit/apps_filters_spec.js
@@ -1,0 +1,147 @@
+/*globals describe, beforeEach, afterEach, it*/
+/*jshint expr:true*/
+var should  = require('should'),
+    sinon   = require('sinon'),
+    Promise = require('bluebird'),
+    _       = require('lodash'),
+
+    // Stuff we are testing
+    Filters = require('../../server/filters').Filters;
+
+describe('Filters', function () {
+    var filters, sandbox;
+
+    beforeEach(function () {
+        filters = new Filters();
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        filters = null;
+        sandbox.restore();
+    });
+
+    it('can register filters with specific priority', function () {
+        var filterName = 'test',
+            filterPriority = 9,
+            testFilterHandler = sandbox.spy();
+
+        filters.registerFilter(filterName, filterPriority, testFilterHandler);
+
+        should.exist(filters.filterCallbacks[filterName]);
+        should.exist(filters.filterCallbacks[filterName][filterPriority]);
+
+        filters.filterCallbacks[filterName][filterPriority].should.containEql(testFilterHandler);
+    });
+
+    it('can register filters with default priority', function () {
+        var filterName = 'test',
+            defaultPriority = 5,
+            testFilterHandler = sandbox.spy();
+
+        filters.registerFilter(filterName, testFilterHandler);
+
+        should.exist(filters.filterCallbacks[filterName]);
+        should.exist(filters.filterCallbacks[filterName][defaultPriority]);
+
+        filters.filterCallbacks[filterName][defaultPriority].should.containEql(testFilterHandler);
+    });
+
+    it('can register filters with priority null with default priority', function () {
+        var filterName = 'test',
+            defaultPriority = 5,
+            testFilterHandler = sandbox.spy();
+
+        filters.registerFilter(filterName, null, testFilterHandler);
+
+        should.exist(filters.filterCallbacks[filterName]);
+        should.exist(filters.filterCallbacks[filterName][defaultPriority]);
+
+        filters.filterCallbacks[filterName][defaultPriority].should.containEql(testFilterHandler);
+    });
+
+    it('executes filters in priority order', function (done) {
+        var filterName = 'testpriority',
+            testFilterHandler1 = sandbox.spy(),
+            testFilterHandler2 = sandbox.spy(),
+            testFilterHandler3 = sandbox.spy();
+
+        filters.registerFilter(filterName, 0, testFilterHandler1);
+        filters.registerFilter(filterName, 2, testFilterHandler2);
+        filters.registerFilter(filterName, 9, testFilterHandler3);
+
+        filters.doFilter(filterName, null).then(function () {
+            testFilterHandler1.calledBefore(testFilterHandler2).should.equal(true);
+            testFilterHandler2.calledBefore(testFilterHandler3).should.equal(true);
+
+            testFilterHandler3.called.should.equal(true);
+
+            done();
+        });
+    });
+
+    it('executes filters that return a promise', function (done) {
+        var filterName = 'testprioritypromise',
+            testFilterHandler1 = sinon.spy(function (args) {
+                return new Promise(function (resolve) {
+                    process.nextTick(function () {
+                        args.filter1 = true;
+
+                        resolve(args);
+                    });
+                });
+            }),
+            testFilterHandler2 = sinon.spy(function (args) {
+                args.filter2 = true;
+
+                return args;
+            }),
+            testFilterHandler3 = sinon.spy(function (args) {
+                return new Promise(function (resolve) {
+                    process.nextTick(function () {
+                        args.filter3 = true;
+
+                        resolve(args);
+                    });
+                });
+            });
+
+        filters.registerFilter(filterName, 0, testFilterHandler1);
+        filters.registerFilter(filterName, 2, testFilterHandler2);
+        filters.registerFilter(filterName, 9, testFilterHandler3);
+
+        filters.doFilter(filterName, {test: true}).then(function (newArgs) {
+            testFilterHandler1.calledBefore(testFilterHandler2).should.equal(true);
+            testFilterHandler2.calledBefore(testFilterHandler3).should.equal(true);
+
+            testFilterHandler3.called.should.equal(true);
+
+            newArgs.filter1.should.equal(true);
+            newArgs.filter2.should.equal(true);
+            newArgs.filter3.should.equal(true);
+
+            done();
+        }).catch(done);
+    });
+
+    it('executes filters with a context', function (done) {
+        var filterName = 'textContext',
+            testFilterHandler1 = sinon.spy(function (args, context) {
+                args.context1 = _.isObject(context);
+                return args;
+            }),
+            testFilterHandler2 = sinon.spy(function (args, context) {
+                args.context2 = _.isObject(context);
+                return args;
+            });
+
+        filters.registerFilter(filterName, 0, testFilterHandler1);
+        filters.registerFilter(filterName, 1, testFilterHandler2);
+
+        filters.doFilter(filterName, {test: true}, {context: true}).then(function (newArgs) {
+            newArgs.context1.should.equal(true);
+            newArgs.context2.should.equal(true);
+            done();
+        }).catch(done);
+    });
+});

--- a/core/test/unit/models_plugins/filter_spec.js
+++ b/core/test/unit/models_plugins/filter_spec.js
@@ -1,0 +1,620 @@
+/*globals describe, it, before, beforeEach, afterEach */
+/*jshint expr:true*/
+var should = require('should'),
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+
+// Thing we're testing
+    filter = rewire('../../../server/models/plugins/filter'),
+    models = require('../../../server/models'),
+    ghostBookshelf,
+
+    sandbox = sinon.sandbox.create();
+
+// To stop jshint complaining
+should.equal(true, true);
+
+describe('Filter', function () {
+    before(function () {
+        return models.init().then(function () {
+            ghostBookshelf = models.Base;
+        });
+    });
+
+    beforeEach(function () {
+        // re-initialise the plugin with the rewired version
+        filter(ghostBookshelf);
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        filter = rewire('../../../server/models/plugins/filter');
+    });
+
+    describe('Base Model', function () {
+        describe('Enforced & Default Filters', function () {
+            it('should add filter functions to prototype', function () {
+                ghostBookshelf.Model.prototype.enforcedFilters.should.be.a.Function;
+                ghostBookshelf.Model.prototype.defaultFilters.should.be.a.Function;
+            });
+
+            it('filter functions should return undefined', function () {
+                should(ghostBookshelf.Model.prototype.enforcedFilters()).be.undefined;
+                should(ghostBookshelf.Model.prototype.defaultFilters()).be.undefined;
+            });
+        });
+
+        describe('Fetch And Combine Filters', function () {
+            var filterUtils;
+
+            beforeEach(function () {
+                filterUtils = filter.__get__('filterUtils');
+                filterUtils.combineFilters = sandbox.stub();
+            });
+
+            it('should add function to prototype', function () {
+                ghostBookshelf.Model.prototype.fetchAndCombineFilters.should.be.a.Function;
+            });
+
+            it('should set _filters to be the result of combineFilters', function () {
+                filterUtils.combineFilters.returns({statements: [
+                    {prop: 'page', op: '=', value: true}
+                ]});
+                var result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
+
+                result._filters.should.eql({statements: [
+                    {prop: 'page', op: '=', value: true}
+                ]});
+            });
+
+            it('should call combineFilters with undefined x4 if passed no options', function () {
+                var result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
+
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, undefined, undefined]);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with enforced filters if set', function () {
+                var filterSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'enforcedFilters')
+                    .returns('status:published'),
+                    result;
+
+                result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
+
+                filterSpy.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql(['status:published', undefined, undefined, undefined]);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with default filters if set', function () {
+                var filterSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'defaultFilters')
+                        .returns('page:false'),
+                    result;
+
+                result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
+
+                filterSpy.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql([undefined, 'page:false', undefined, undefined]);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with custom filters if set', function () {
+                var result = ghostBookshelf.Model.prototype.fetchAndCombineFilters({
+                    filter: 'tag:photo'
+                });
+
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, 'tag:photo', undefined]);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with old-style custom filters if set', function () {
+                var result = ghostBookshelf.Model.prototype.fetchAndCombineFilters({
+                    where: 'author:cameron'
+                });
+
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, undefined, 'author:cameron']);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with enforced and defaults if set', function () {
+                var filterSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'enforcedFilters')
+                        .returns('status:published'),
+                    filterSpy2 = sandbox.stub(ghostBookshelf.Model.prototype, 'defaultFilters')
+                        .returns('page:false'),
+                    result;
+
+                result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
+
+                filterSpy.calledOnce.should.be.true;
+                filterSpy2.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args.should.eql(['status:published', 'page:false', undefined, undefined]);
+                should(result._filters).be.undefined;
+            });
+
+            it('should call combineFilters with all values if set', function () {
+                var filterSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'enforcedFilters')
+                        .returns('status:published'),
+                    filterSpy2 = sandbox.stub(ghostBookshelf.Model.prototype, 'defaultFilters')
+                        .returns('page:false'),
+                    result;
+
+                result = ghostBookshelf.Model.prototype.fetchAndCombineFilters({
+                    filter: 'tag:photo',
+                    where: 'author:cameron'
+                });
+
+                filterSpy.calledOnce.should.be.true;
+                filterSpy2.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.firstCall.args
+                    .should.eql(['status:published', 'page:false', 'tag:photo', 'author:cameron']);
+                should(result._filters).be.undefined;
+            });
+        });
+
+        describe('Apply Filters', function () {
+            var fetchSpy,
+                restoreGQL,
+                filterGQL;
+
+            beforeEach(function () {
+                filterGQL = {};
+                fetchSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'fetchAndCombineFilters');
+                filterGQL.knexify = sandbox.stub();
+                filterGQL.json = {
+                    printStatements: sandbox.stub()
+                };
+
+                restoreGQL = filter.__set__('gql', filterGQL);
+            });
+
+            afterEach(function () {
+                restoreGQL();
+            });
+
+            it('should call fetchAndCombineFilters if _filters not set', function () {
+                var result = ghostBookshelf.Model.prototype.applyFilters();
+
+                fetchSpy.calledOnce.should.be.true;
+                should(result._filters).be.null;
+            });
+
+            it('should NOT call fetchAndCombineFilters if _filters IS set', function () {
+                ghostBookshelf.Model.prototype._filters = 'test';
+
+                var result = ghostBookshelf.Model.prototype.applyFilters();
+
+                fetchSpy.called.should.be.false;
+                result._filters.should.eql('test');
+            });
+
+            it('should call knexify with the filters that are set', function () {
+                ghostBookshelf.Model.prototype._filters = {statements: [
+                    {prop: 'title', op: '=', value: 'Hello Word'}
+                ]};
+                ghostBookshelf.Model.prototype.applyFilters();
+
+                fetchSpy.called.should.be.false;
+                filterGQL.knexify.called.should.be.true;
+                filterGQL.knexify.firstCall.args[1].should.eql({statements: [
+                    {prop: 'title', op: '=', value: 'Hello Word'}
+                ]});
+            });
+        });
+
+        describe('Post Process Filters', function () {
+            it('should not have tests yet, as this is about to be removed');
+        });
+    });
+
+    describe('Utils', function () {
+        describe('Combine Filters', function () {
+            var gql, combineFilters, parseSpy, mergeSpy, findSpy, rejectSpy;
+
+            beforeEach(function () {
+                combineFilters = filter.__get__('filterUtils').combineFilters;
+                gql = filter.__get__('gql');
+                parseSpy = sandbox.spy(gql, 'parse');
+                mergeSpy = sandbox.spy(gql.json, 'mergeStatements');
+                findSpy = sandbox.spy(gql.json, 'findStatement');
+                rejectSpy = sandbox.spy(gql.json, 'rejectStatements');
+            });
+
+            it('should return empty statement object when there are no filters', function () {
+                combineFilters().should.eql({statements: []});
+                parseSpy.called.should.be.false;
+                mergeSpy.calledOnce.should.be.true;
+                findSpy.called.should.be.false;
+                rejectSpy.called.should.be.false;
+            });
+
+            describe('Single filter rules', function () {
+                it('should return enforced filters if only those are set', function () {
+                    combineFilters('status:published').should.eql({
+                        statements: [
+                            {prop: 'status', op: '=', value: 'published'}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('should return default filters if only those are set (undefined)', function () {
+                    combineFilters(undefined, 'page:false').should.eql({
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('should return default filters if only those are set (null)', function () {
+                    combineFilters(null, 'page:false').should.eql({
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('should return custom filters if only those are set', function () {
+                    combineFilters(null, null, 'tags:[photo,video]').should.eql({
+                        statements: [
+                            {prop: 'tags', op: 'IN', value: ['photo', 'video']}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.true;
+                    mergeSpy.calledOnce.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('does NOT call parse on enforced filter if it is NOT a string', function () {
+                    var statement = {
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    };
+                    combineFilters(statement, null, null).should.eql({
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.false;
+                    mergeSpy.calledOnce.should.be.false;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('does NOT call parse on default filter if it is NOT a string', function () {
+                    var statement = {
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    };
+                    combineFilters(null, statement, null).should.eql({
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.false;
+                    mergeSpy.calledOnce.should.be.false;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('does NOT call parse on custom filter if it is NOT a string', function () {
+                    var statement = {
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    };
+                    combineFilters(null, null, statement).should.eql({
+                        statements: [
+                            {prop: 'page', op: '=', value: false}
+                        ]
+                    });
+                    parseSpy.calledOnce.should.be.false;
+                    mergeSpy.calledOnce.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+            });
+
+            describe('Combo filter rules', function () {
+                it('should merge enforced and default filters if both are provided', function () {
+                    combineFilters('status:published', 'page:false').should.eql({
+                        statements: [
+                            {prop: 'status', op: '=', value: 'published'},
+                            {prop: 'page', op: '=', value: false, func: 'and'}
+                        ]
+                    });
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('should merge custom filters if more than one is provided', function () {
+                    combineFilters(null, null, 'tag:photo', 'featured:true').should.eql({
+                        statements: [
+                            {prop: 'tag', op: '=', value: 'photo'},
+                            {prop: 'featured', op: '=', value: true, func: 'and'}
+                        ]
+                    });
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledOnce.should.be.true;
+                    findSpy.called.should.be.false;
+                    rejectSpy.called.should.be.false;
+                });
+
+                it('should try to reduce custom filters if custom and enforced are provided', function () {
+                    combineFilters('status:published', null, 'tag:photo').should.eql({
+                        statements: [
+                            {group: [
+                                {prop: 'status', op: '=', value: 'published'}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: '=', value: 'photo'}
+                            ], func: 'and'}
+                        ]
+                    });
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'}]);
+
+                    findSpy.calledOnce.should.be.true;
+                    findSpy.getCall(0).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        'prop'
+                    ]);
+                });
+
+                it('should actually reduce custom filters if one matches enforced', function () {
+                    combineFilters('status:published', null, 'tag:photo,status:draft').should.eql({
+                        statements: [
+                            {group: [
+                                {prop: 'status', op: '=', value: 'published'}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: '=', value: 'photo'}
+                            ], func: 'and'}
+                        ]
+                    });
+
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'},
+                        {op: '=', value: 'draft', prop: 'status', func: 'or'}]);
+
+                    findSpy.calledTwice.should.be.true;
+                    findSpy.getCall(0).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: '=', value: 'photo', prop: 'tag'},
+                        'prop'
+                    ]);
+                    findSpy.getCall(1).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: '=', value: 'draft', prop: 'status', func: 'or'},
+                        'prop'
+                    ]);
+                });
+
+                it('should return only enforced if custom filters are reduced to nothing', function () {
+                    combineFilters('status:published', null, 'status:draft').should.eql({
+                        statements: [
+                            {prop: 'status', op: '=', value: 'published'}
+                        ]
+                    });
+
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'draft', prop: 'status'}]);
+
+                    findSpy.calledOnce.should.be.true;
+                    findSpy.getCall(0).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: '=', value: 'draft', prop: 'status'},
+                        'prop'
+                    ]);
+                });
+
+                it('should try to reduce default filters if default and custom are provided', function () {
+                    combineFilters(null, 'page:false', 'tag:photo').should.eql({
+                        statements: [
+                            {group: [
+                                {prop: 'page', op: '=', value: false}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: '=', value: 'photo'}
+                            ], func: 'and'}
+                        ]
+                    });
+
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: false, prop: 'page'}]);
+
+                    findSpy.calledOnce.should.be.true;
+                    findSpy.firstCall.args.should.eql([
+                        [{op: '=', prop: 'tag', value: 'photo'}],
+                        {op: '=', prop: 'page', value: false},
+                        'prop'
+                    ]);
+                });
+
+                it('should actually reduce default filters if one matches custom', function () {
+                    combineFilters(null, 'page:false,author:cameron', 'tag:photo+page:true').should.eql({
+                        statements: [
+                            {group: [
+                                // currently has func: or needs fixing
+                                {prop: 'author', op: '=', value: 'cameron'}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: '=', value: 'photo'},
+                                {prop: 'page', op: '=', value: true, func: 'and'}
+                            ], func: 'and'}
+                        ]
+                    });
+
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+
+                    rejectSpy.firstCall.args[0].should.eql([
+                        {op: '=', value: false, prop: 'page'},
+                        {op: '=', value: 'cameron', prop: 'author'}
+                    ]);
+
+                    findSpy.calledTwice.should.be.true;
+                    findSpy.firstCall.args.should.eql([
+                        [
+                            {op: '=', prop: 'tag', value: 'photo'},
+                            {func: 'and', op: '=', prop: 'page', value: true}
+                        ],
+                        {op: '=', prop: 'page', value: false},
+                        'prop'
+                    ]);
+                    findSpy.secondCall.args.should.eql([
+                        [
+                            {op: '=', prop: 'tag', value: 'photo'},
+                            {func: 'and', op: '=', prop: 'page', value: true}
+                        ],
+                        {op: '=', prop: 'author', value: 'cameron'},
+                        'prop'
+                    ]);
+                });
+
+                it('should return only custom if default filters are reduced to nothing', function () {
+                    combineFilters(null, 'page:false', 'tag:photo,page:true').should.eql({
+                        statements: [
+                            {prop: 'tag', op: '=', value: 'photo'},
+                            {prop: 'page', op: '=', value: true, func: 'or'}
+                        ]
+                    });
+
+                    parseSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledOnce.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: false, prop: 'page'}]);
+
+                    findSpy.calledOnce.should.be.true;
+                    findSpy.firstCall.args.should.eql([
+                        [
+                            {op: '=', prop: 'tag', value: 'photo'},
+                            {func: 'or', op: '=', prop: 'page', value: true}
+                        ],
+                        {op: '=', prop: 'page', value: false},
+                        'prop'
+                    ]);
+                });
+
+                it('should return a merger of enforced and defaults plus custom filters if provided', function () {
+                    combineFilters('status:published', 'page:false', 'tag:photo').should.eql({
+                        statements: [
+                            {group: [
+                                {prop: 'status', op: '=', value: 'published'},
+                                {prop: 'page', op: '=', value: false, func: 'and'}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: '=', value: 'photo'}
+                            ], func: 'and'}
+                        ]
+                    });
+
+                    parseSpy.calledThrice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.calledTwice.should.be.true;
+                    rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'}]);
+                    rejectSpy.secondCall.args[0].should.eql([{op: '=', value: false, prop: 'page', func: 'and'}]);
+
+                    findSpy.calledTwice.should.be.true;
+                    findSpy.firstCall.args.should.eql([
+                        [{op: '=', prop: 'status', value: 'published'}],
+                        {op: '=', prop: 'tag', value: 'photo'},
+                        'prop'
+                    ]);
+                    findSpy.secondCall.args.should.eql([
+                        [{op: '=', prop: 'tag', value: 'photo'}],
+                        {func: 'and', op: '=', prop: 'page', value: false},
+                        'prop'
+                    ]);
+                });
+
+                it('should handle getting enforced, default and multiple custom filters', function () {
+                    combineFilters('status:published', 'page:false', 'tag:[photo,video],author:cameron', 'status:draft,page:false').should.eql({
+                        statements: [
+                            {group: [
+                                {prop: 'status', op: '=', value: 'published'}
+                            ]},
+                            {group: [
+                                {prop: 'tag', op: 'IN', value: ['photo', 'video']},
+                                {prop: 'author', op: '=', value: 'cameron', func: 'or'},
+                                {prop: 'page', op: '=', value: false, func: 'or'}
+                            ], func: 'and'}
+                        ]
+                    });
+
+                    parseSpy.callCount.should.eql(4);
+                    mergeSpy.calledTwice.should.be.true;
+                    rejectSpy.callCount.should.eql(2);
+                    rejectSpy.getCall(0).args[0].should.eql([{op: 'IN', value: ['photo', 'video'], prop: 'tag'},
+                        {op: '=', value: 'cameron', prop: 'author', func: 'or'},
+                        {op: '=', value: 'draft', prop: 'status', func: 'and'},
+                        {op: '=', value: false, prop: 'page', func: 'or'}]);
+                    rejectSpy.getCall(1).args[0].should.eql([{op: '=', value: false, prop: 'page'}]);
+
+                    findSpy.callCount.should.eql(5);
+                    findSpy.getCall(0).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: 'IN', prop: 'tag', value: ['photo', 'video']},
+                        'prop'
+                    ]);
+                    findSpy.getCall(1).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {prop: 'author', op: '=', value: 'cameron', func: 'or'},
+                        'prop'
+                    ]);
+                    findSpy.getCall(2).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {op: '=', value: 'draft', prop: 'status', func: 'and'},
+                        'prop'
+                    ]);
+                    findSpy.getCall(3).args.should.eql([
+                        [{op: '=', value: 'published', prop: 'status'}],
+                        {prop: 'page', op: '=', value: false, func: 'or'},
+                        'prop'
+                    ]);
+                    findSpy.getCall(4).args.should.eql([
+                        [
+                            {op: 'IN', value: ['photo', 'video'], prop: 'tag'},
+                            {op: '=', value: 'cameron', prop: 'author', func: 'or'},
+                            {op: '=', value: false, prop: 'page', func: 'or'}
+                        ],
+                        {op: '=', value: false, prop: 'page'},
+                        'prop'
+                    ]);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Note: I've left this unsquashed for now just to help it make sense, will squash later.

Following on from #6080, moving the filter behaviour into a plugin gives us a sensible location to keep all related code (rather than having a bunch of utils). Although there is still much room for improvement in terms of putting together a standard way of wiring i.e. access rules gets called on forge, this gets called explicitly inside of `findPage`.

In addition to moving the existing logic into a plugin, this PR adds a bunch of new logic around the concept of 'enforced', 'default' and 'custom' filters.

All of this is explained in detail [here](https://github.com/TryGhost/Ghost/issues/5614#issuecomment-155741608).

One key addition since that comment - I'm also reducing the custom filters against the enforced filters, in much the same way as default filters are reduced against custom filters... what this means is.
- A default filter is removed if a filter for the same property appears in the custom filters, because it has been overridden. E.g. if `page:false` is the default, but the custom filter specifies `page:true` the default is no longer needed.
- A custom filter is removed if a filter for the same property appears in the enforced filters, because custom filters cannot override the enforced filters. E.g. if `status:published` is enforced, and the custom filter specifies `status:draft`, the custom filter is removed as it is not permitted.

In time, it may be better to throw an error in this case.

---

Filter plugin with enforce/default logic

refs #5614, #5943
- adds a new 'filter' bookshelf plugin which extends the model
- the filter plugin provides handling for merging/combining various filters (enforced, defaults and custom/user-provided)
- the filter plugin also handles the calls to gql
- post processing is also moved to the plugin, to be further refactored/removed in future
- adds tests showing how filter could be abused prior to this commit

...

Remove old style defaults

refs #5614, #5943
- remove the old way of supplying defaults to the browse query

... 

Add some debugging tools to filters

I have added these lines back in so many times in the past month or so so that I could
figure out what was happening, I figured everyone else might find them useful.
