### PR TITLE
Debugging tools for filters

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -23,7 +23,7 @@ utils = {
     // ### Manual Default Options
     // These must be provided by the endpoint
     // browseDefaultOptions - valid for all browse api endpoints
-    browseDefaultOptions: ['page', 'limit', 'fields', 'filter', 'order'],
+    browseDefaultOptions: ['page', 'limit', 'fields', 'filter', 'order', 'debug'],
     // idDefaultOptions - valid whenever an id is valid
     idDefaultOptions: ['id'],
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -275,6 +275,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             itemCollection = this.forge(null, {context: options.context}),
             tableName      = _.result(this.prototype, 'tableName');
 
+        // Set this to true or pass ?debug=true as an API option to get output
+        itemCollection.debug = options.debug && process.env.NODE_ENV !== 'production';
+
         // Filter options so that only permitted ones remain
         options = this.filterOptions(options, 'findPage');
 

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -143,6 +143,10 @@ filter = function filter(Bookshelf) {
             }
 
             if (this._filters) {
+                if (this.debug) {
+                    gql.json.printStatements(this._filters.statements);
+                }
+
                 this.query(function (qb) {
                     gql.knexify(qb, self._filters);
                 });

--- a/core/server/models/plugins/include-count.js
+++ b/core/server/models/plugins/include-count.js
@@ -38,11 +38,19 @@ module.exports = function (Bookshelf) {
         fetch: function () {
             this.addCounts.apply(this, arguments);
 
+            if (this.debug) {
+                console.log('QUERY', this.query().toQuery());
+            }
+
             // Call parent fetch
             return modelProto.fetch.apply(this, arguments);
         },
         fetchAll: function () {
             this.addCounts.apply(this, arguments);
+
+            if (this.debug) {
+                console.log('QUERY', this.query().toQuery());
+            }
 
             // Call parent fetchAll
             return modelProto.fetchAll.apply(this, arguments);

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -172,6 +172,10 @@ pagination = function pagination(bookshelf) {
                 });
             }
 
+            if (this.debug) {
+                console.log('COUNT', countPromise.toQuery());
+            }
+
             // Setup the promise to do a fetch on our collection, running the specified query
             // @TODO: ensure option handling is done using an explicit pick elsewhere
             collectionPromise = self.fetchAll(_.omit(options, ['page', 'limit']));

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -18,7 +18,7 @@ describe('API Utils', function () {
     describe('Default Options', function () {
         it('should provide a set of default options', function () {
             apiUtils.globalDefaultOptions.should.eql(['context', 'include']);
-            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields', 'filter', 'order']);
+            apiUtils.browseDefaultOptions.should.eql(['page', 'limit', 'fields', 'filter', 'order', 'debug']);
             apiUtils.dataDefaultOptions.should.eql(['data']);
             apiUtils.idDefaultOptions.should.eql(['id']);
         });

--- a/core/test/unit/models_plugins/filter_spec.js
+++ b/core/test/unit/models_plugins/filter_spec.js
@@ -206,6 +206,19 @@ describe('Filter', function () {
                     {prop: 'title', op: '=', value: 'Hello Word'}
                 ]});
             });
+
+            it('should print statements in debug mode', function () {
+                ghostBookshelf.Model.prototype.debug = true;
+                ghostBookshelf.Model.prototype._filters = {statements: [
+                    {prop: 'tags', op: 'IN', value: ['photo', 'video']}
+                ]};
+
+                ghostBookshelf.Model.prototype.applyFilters();
+                filterGQL.json.printStatements.calledOnce.should.be.true;
+                filterGQL.json.printStatements.firstCall.args[0].should.eql([
+                    {prop: 'tags', op: 'IN', value: ['photo', 'video']}
+                ]);
+            });
         });
 
         describe('Post Process Filters', function () {

--- a/core/test/unit/models_plugins/pagination_spec.js
+++ b/core/test/unit/models_plugins/pagination_spec.js
@@ -190,7 +190,8 @@ describe('pagination', function () {
             // Mock out bookshelf model
             mockQuery = {
                 clone: sandbox.stub(),
-                select: sandbox.stub()
+                select: sandbox.stub(),
+                toQuery: sandbox.stub()
             };
             mockQuery.clone.returns(mockQuery);
             mockQuery.select.returns([{aggregate: 1}]);
@@ -213,7 +214,7 @@ describe('pagination', function () {
             bookshelf.Model.prototype.fetchPage.should.be.a.Function;
         });
 
-        it('fetchPage calls all paginationUtils and methods', function (done) {
+        it('calls all paginationUtils and methods', function (done) {
             paginationUtils.parseOptions.returns({});
 
             bookshelf.Model.prototype.fetchPage().then(function () {
@@ -249,7 +250,7 @@ describe('pagination', function () {
             }).catch(done);
         });
 
-        it('fetchPage calls all paginationUtils and methods when order set', function (done) {
+        it('calls all paginationUtils and methods when order set', function (done) {
             var orderOptions = {order: {id: 'DESC'}};
             paginationUtils.parseOptions.returns(orderOptions);
 
@@ -288,7 +289,7 @@ describe('pagination', function () {
             }).catch(done);
         });
 
-        it('fetchPage calls all paginationUtils and methods when group by set', function (done) {
+        it('calls all paginationUtils and methods when group by set', function (done) {
             var groupOptions = {groups: ['posts.id']};
             paginationUtils.parseOptions.returns(groupOptions);
 
@@ -327,7 +328,7 @@ describe('pagination', function () {
             }).catch(done);
         });
 
-        it('fetchPage returns expected response', function (done) {
+        it('returns expected response', function (done) {
             paginationUtils.parseOptions.returns({});
             bookshelf.Model.prototype.fetchPage().then(function (result) {
                 result.should.have.ownProperty('collection');
@@ -339,7 +340,7 @@ describe('pagination', function () {
             });
         });
 
-        it('fetchPage returns expected response even when aggregate is empty', function (done) {
+        it('returns expected response even when aggregate is empty', function (done) {
             // override aggregate response
             mockQuery.select.returns([]);
             paginationUtils.parseOptions.returns({});
@@ -350,6 +351,19 @@ describe('pagination', function () {
                 result.collection.should.be.an.Object;
                 result.pagination.should.be.an.Object;
 
+                done();
+            });
+        });
+
+        it('will output sql statements in debug mode', function (done) {
+            model.prototype.debug = true;
+            mockQuery.select.returns({toQuery: function () {}});
+            paginationUtils.parseOptions.returns({});
+
+            var consoleSpy = sandbox.spy(console, 'log');
+
+            bookshelf.Model.prototype.fetchPage().then(function () {
+                consoleSpy.calledOnce.should.be.true;
                 done();
             });
         });


### PR DESCRIPTION
Commit df2f1ad is a somewhat controversial commit because we do not have anything else like it. My reason for wanting to get it merged is that I have been constantly adding these lines whilst developing and then removing them before committing, it's gotten tedious and if I need them this much then the chances are others will too.

The version in this PR is slightly different to the one that was in #6082, as I had meant to wire it up through the API.

What this PR does, is allow you to either quickly hack a line in models/base/index.js or to provide `?debug=true` to the API. This is different to the `debug` that you can set in the database config, as it is very selective about what it outputs. It is therefore, significantly more useful IMO.

For example, if you're trying to debug a single test. You could add `.only` to the test on [line 70 of advanced_browse_spec.js](https://github.com/TryGhost/Ghost/blob/master/core/test/integration/api/advanced_browse_spec.js#L70), so that only that test is run. Then if you add `debug:true` to the config.example.js `testing` environment (note: it doesn't work if you change config.js because the tests use the example file, which is an added complication) so that you get the SQL debug output, the result in your console is this:

![](http://puu.sh/loCnH.png)

I deliberately made that tiny so you can see just how much stuff is output. Scrolling through that output is really time consuming and not at all what I wanted.

Meanwhile, what I really need to do in most cases is understand what's happening in the main queries that are being run. With this PR I can either edit line #279 in master or add `debug: true` to the query in my test file. 

The resulting output is:

![](http://puu.sh/loE9O.png)

3 things are output: 
1. The filter statements after having been parsed by GQL
2. The count query that is being run by the pagination plugin
3. The final query once all of the filters, order and group statements have been added.

It is much, much clearer and useful I think, not just for developing further advanced browse behaviour, but also for people getting started using the API via ajax or the get helper.

E.g.:

`{{#get "posts" limit="3" filter="featured:true+id:-{{post.id}}" debug="true"}}{{/get}}` will output this same debug output.
