### PR TITLE
Update author query to use filter

### DIFF
--- a/core/client/app/routes/posts.js
+++ b/core/client/app/routes/posts.js
@@ -9,7 +9,8 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
     paginationModel: 'post',
     paginationSettings: {
         status: 'all',
-        staticPages: 'all'
+        staticPages: 'all',
+        filter: ''
     },
 
     model: function () {
@@ -18,7 +19,7 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
 
         return this.get('session.user').then(function (user) {
             if (user.get('isAuthor')) {
-                paginationSettings.author = user.get('slug');
+                paginationSettings.filter += `+author:${user.get('slug')}`;
             }
 
             return self.loadFirstPage().then(function () {


### PR DESCRIPTION
I found a spot where old style tag/author filters were being used.

It is also possible to start updating other places, for example a few lines up from this change we could update `paginationSettings` to be:

```
paginationSettings: {
  filter: 'status:[draft,published]+page:[true,false]'
},
```

The new style filtering doesn't yet have a concept of 'all' but listing out possible values in array syntax does a 'where in' query, and works just the same.

Long term, I hope to add the 'all' concept back where it's useful, so for status but possibly not for page.

The only reason I haven't made this change yet, is I felt it could be confusing, as `filter` currently only works for browse queries, not read queries. In lots of places we use ?status=all to override the incorrect default behaviour of not returning results for read requests, as discusses [here](https://github.com/TryGhost/Ghost/issues/5947#issuecomment-148364744).

Fixing that default behaviour would be required so that we can update those requests too, so perhaps it should all be done together?

refs #5943 
