### PR TITLE
Add aria-hidden to the pagination arrows

### DIFF
--- a/core/server/helpers/tpl/pagination.hbs
+++ b/core/server/helpers/tpl/pagination.hbs
@@ -1,9 +1,9 @@
 <nav class="pagination" role="navigation">
     {{#if prev}}
-        <a class="newer-posts" href="{{page_url prev}}">&larr; Newer Posts</a>
+        <a class="newer-posts" href="{{page_url prev}}"><span aria-hidden="true">&larr;</span> Newer Posts</a>
     {{/if}}
     <span class="page-number">Page {{page}} of {{pages}}</span>
     {{#if next}}
-        <a class="older-posts" href="{{page_url next}}">Older Posts &rarr;</a>
+        <a class="older-posts" href="{{page_url next}}">Older Posts <span aria-hidden="true">&rarr;</span></a>
     {{/if}}
 </nav>


### PR DESCRIPTION
Pagination arrows seem to be an appropriate place to use aria-hidden. That is the use-case for bootstrap (http://getbootstrap.com/components/#aligned-links) and based upon my understanding of aria seems to be correct.
