### PR TITLE
Fix 404 error handling in editor, tags, and team routes

### DIFF
--- a/core/client/app/mixins/404-handler.js
+++ b/core/client/app/mixins/404-handler.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+    actions: {
+        error(error, transition) {
+            if (error.errors[0].errorType === 'NotFoundError') {
+                transition.abort();
+
+                let routeInfo = transition.handlerInfos[transition.handlerInfos.length - 1];
+                let router = this.get('router');
+                let params = [];
+
+                for (const key of Object.keys(routeInfo.params)) {
+                    params.push(routeInfo.params[key]);
+                }
+
+                return this.transitionTo('error404', router.generate(routeInfo.name, ...params).replace('/ghost/', '').replace(/^\//g, ''));
+            }
+
+            return this._super(...arguments);
+        }
+    }
+});

--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -1,10 +1,11 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import base from 'ghost/mixins/editor-base-route';
+import NotFoundHandler from 'ghost/mixins/404-handler';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
-export default AuthenticatedRoute.extend(base, {
+export default AuthenticatedRoute.extend(base, NotFoundHandler, {
     titleToken: 'Editor',
 
     beforeModel(transition) {

--- a/core/client/app/routes/settings/tags/tag.js
+++ b/core/client/app/routes/settings/tags/tag.js
@@ -1,7 +1,8 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import AuthenticatedRoute from 'ghost/routes/authenticated';
+import NotFoundHandler from 'ghost/mixins/404-handler';
 
-export default AuthenticatedRoute.extend({
+export default AuthenticatedRoute.extend(NotFoundHandler, {
 
     model(params) {
         return this.store.queryRecord('tag', {slug: params.tag_slug});
@@ -16,5 +17,4 @@ export default AuthenticatedRoute.extend({
         this._super(...arguments);
         this.set('controller.model', null);
     }
-
 });

--- a/core/client/app/routes/team/user.js
+++ b/core/client/app/routes/team/user.js
@@ -2,8 +2,9 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
+import NotFoundHandler from 'ghost/mixins/404-handler';
 
-export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
+export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, NotFoundHandler, {
     titleToken: 'Team - User',
 
     classNames: ['team-view-user'],

--- a/core/client/tests/helpers/adapter-error.js
+++ b/core/client/tests/helpers/adapter-error.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+
+// This is needed for testing error responses in acceptance tests
+// See http://williamsbdev.com/posts/testing-rsvp-errors-handled-globally/
+
+let originalException;
+let originalLoggerError;
+
+export function errorOverride() {
+    originalException = Ember.Test.adapter.exception;
+    originalLoggerError = Ember.Logger.error;
+    Ember.Test.adapter.exception = function () {};
+    Ember.Logger.error = function () {};
+}
+
+export function errorReset() {
+    Ember.Test.adapter.exception = originalException;
+    Ember.Logger.error = originalLoggerError;
+}


### PR DESCRIPTION
closes #6094
- adds 404-handler mixin
- applies mixin to settings/tags/tag and editor/edit routes

TODO: 
- [x] Add tests
- [x] :8ball:
