### PR TITLE
Rename post_count to count.posts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,8 +227,8 @@ var _              = require('lodash'),
                 // #### All Integration tests
                 integration: {
                     src: [
-                        'core/test/integration/**/model*_spec.js',
-                        'core/test/integration/**/api*_spec.js',
+                        'core/test/integration/**/*_spec.js',
+                        'core/test/integration/**/*_spec.js',
                         'core/test/integration/*_spec.js'
                     ]
                 },

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -8,7 +8,7 @@ var Promise      = require('bluebird'),
     pipeline     = require('../utils/pipeline'),
 
     docName      = 'tags',
-    allowedIncludes = ['post_count'],
+    allowedIncludes = ['count.posts'],
     tags;
 
 /**

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -14,7 +14,7 @@ var Promise         = require('bluebird'),
 
     docName         = 'users',
     // TODO: implement created_by, updated_by
-    allowedIncludes = ['post_count', 'permissions', 'roles', 'roles.permissions'],
+    allowedIncludes = ['count.posts', 'permissions', 'roles', 'roles.permissions'],
     users,
     sendInviteEmail;
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -19,7 +19,8 @@ var _          = require('lodash'),
     validation = require('../../data/validation'),
     plugins    = require('../plugins'),
 
-    ghostBookshelf;
+    ghostBookshelf,
+    proto;
 
 // ### ghostBookshelf
 // Initializes a new Bookshelf instance called ghostBookshelf, for reference elsewhere in Ghost.
@@ -39,6 +40,9 @@ ghostBookshelf.plugin(plugins.includeCount);
 
 // Load the Ghost pagination plugin, which gives us the `fetchPage` method on Models
 ghostBookshelf.plugin(plugins.pagination);
+
+// Cache an instance of the base model prototype
+proto = ghostBookshelf.Model.prototype;
 
 // ## ghostBookshelf.Model
 // The Base Model which other Ghost objects will inherit from,
@@ -173,7 +177,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             }
         });
 
-        return attrs;
+        // @TODO upgrade bookshelf & knex and use serialize & toJSON to do this in a neater way (see #6103)
+        return proto.finalize.call(this, attrs);
     },
 
     sanitize: function sanitize(attr) {

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -228,16 +228,16 @@ describe('Tags API', function () {
             }).catch(done);
         });
 
-        it('can browse with include post_count', function (done) {
-            TagAPI.browse({context: {user: 1}, include: 'post_count'}).then(function (results) {
+        it('can browse with include count.posts', function (done) {
+            TagAPI.browse({context: {user: 1}, include: 'count.posts'}).then(function (results) {
                 should.exist(results);
                 should.exist(results.tags);
                 results.tags.should.have.lengthOf(15);
-                testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
-                should.exist(results.tags[0].post_count);
+                testUtils.API.checkResponse(results.tags[0], 'tag', 'count');
+                should.exist(results.tags[0].count.posts);
 
-                results.tags[0].post_count.should.eql(2);
-                results.tags[1].post_count.should.eql(2);
+                results.tags[0].count.posts.should.eql(2);
+                results.tags[1].count.posts.should.eql(2);
                 results.meta.pagination.should.have.property('page', 1);
                 results.meta.pagination.should.have.property('limit', 15);
                 results.meta.pagination.should.have.property('pages', 4);
@@ -249,13 +249,13 @@ describe('Tags API', function () {
             }).catch(done);
         });
 
-        it('can browse page 4 with include post_count', function (done) {
-            TagAPI.browse({context: {user: 1}, include: 'post_count', page: 4}).then(function (results) {
+        it('can browse page 4 with include count.posts', function (done) {
+            TagAPI.browse({context: {user: 1}, include: 'count.posts', page: 4}).then(function (results) {
                 should.exist(results);
                 should.exist(results.tags);
                 results.tags.should.have.lengthOf(10);
-                testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
-                should.exist(results.tags[0].post_count);
+                testUtils.API.checkResponse(results.tags[0], 'tag', 'count');
+                should.exist(results.tags[0].count.posts);
 
                 results.meta.pagination.should.have.property('page', 4);
                 results.meta.pagination.should.have.property('limit', 15);
@@ -320,15 +320,15 @@ describe('Tags API', function () {
             return _.filter(tags, {id: 1})[0];
         }
 
-        it('returns post_count with include post_count', function (done) {
-            TagAPI.read({context: {user: 1}, include: 'post_count', slug: 'kitchen-sink'}).then(function (results) {
+        it('returns count.posts with include count.posts', function (done) {
+            TagAPI.read({context: {user: 1}, include: 'count.posts', slug: 'kitchen-sink'}).then(function (results) {
                 should.exist(results);
                 should.exist(results.tags);
                 results.tags.length.should.be.above(0);
 
-                testUtils.API.checkResponse(results.tags[0], 'tag', 'post_count');
-                should.exist(results.tags[0].post_count);
-                results.tags[0].post_count.should.equal(2);
+                testUtils.API.checkResponse(results.tags[0], 'tag', 'count');
+                should.exist(results.tags[0].count.posts);
+                results.tags[0].count.posts.should.equal(2);
 
                 done();
             }).catch(done);

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -187,29 +187,29 @@ describe('Users API', function () {
                 .catch(done);
         });
 
-        it('can browse with include post_count', function (done) {
-            UserAPI.browse(_.extend({}, testUtils.context.admin, {include: 'post_count'})).then(function (response) {
+        it('can browse with include count.posts', function (done) {
+            UserAPI.browse(_.extend({}, testUtils.context.admin, {include: 'count.posts'})).then(function (response) {
                 should.exist(response);
                 testUtils.API.checkResponse(response, 'users');
                 should.exist(response.users);
                 response.users.should.have.length(7);
                 response.users.should.have.length(7);
 
-                testUtils.API.checkResponse(response.users[0], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[1], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[2], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[3], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[4], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[5], 'user', 'post_count');
-                testUtils.API.checkResponse(response.users[6], 'user', 'post_count');
+                testUtils.API.checkResponse(response.users[0], 'user', 'count');
+                testUtils.API.checkResponse(response.users[1], 'user', 'count');
+                testUtils.API.checkResponse(response.users[2], 'user', 'count');
+                testUtils.API.checkResponse(response.users[3], 'user', 'count');
+                testUtils.API.checkResponse(response.users[4], 'user', 'count');
+                testUtils.API.checkResponse(response.users[5], 'user', 'count');
+                testUtils.API.checkResponse(response.users[6], 'user', 'count');
 
-                response.users[0].post_count.should.eql(0);
-                response.users[1].post_count.should.eql(0);
-                response.users[2].post_count.should.eql(0);
-                response.users[3].post_count.should.eql(7);
-                response.users[4].post_count.should.eql(0);
-                response.users[5].post_count.should.eql(0);
-                response.users[6].post_count.should.eql(0);
+                response.users[0].count.posts.should.eql(0);
+                response.users[1].count.posts.should.eql(0);
+                response.users[2].count.posts.should.eql(0);
+                response.users[3].count.posts.should.eql(7);
+                response.users[4].count.posts.should.eql(0);
+                response.users[5].count.posts.should.eql(0);
+                response.users[6].count.posts.should.eql(0);
 
                 response.meta.pagination.should.have.property('page', 1);
                 response.meta.pagination.should.have.property('limit', 15);

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -49,11 +49,11 @@ describe('Tag Model', function () {
         }).catch(done);
     });
 
-    it('returns post_count if include post_count', function (done) {
+    it('returns count.posts if include count.posts', function (done) {
         testUtils.fixtures.insertPosts().then(function () {
-            TagModel.findOne({slug: 'kitchen-sink'}, {include: 'post_count'}).then(function (tag) {
+            TagModel.findOne({slug: 'kitchen-sink'}, {include: 'count.posts'}).then(function (tag) {
                 should.exist(tag);
-                tag.get('post_count').should.equal(2);
+                tag.toJSON().count.posts.should.equal(2);
 
                 done();
             }).catch(done);
@@ -78,13 +78,13 @@ describe('Tag Model', function () {
             }).catch(done);
         });
 
-        it('with include post_count', function (done) {
-            TagModel.findPage({limit: 'all', include: 'post_count'}).then(function (results) {
+        it('with include count.posts', function (done) {
+            TagModel.findPage({limit: 'all', include: 'count.posts'}).then(function (results) {
                 results.meta.pagination.page.should.equal(1);
                 results.meta.pagination.limit.should.equal('all');
                 results.meta.pagination.pages.should.equal(1);
                 results.tags.length.should.equal(5);
-                should.exist(results.tags[0].post_count);
+                should.exist(results.tags[0].count.posts);
 
                 done();
             }).catch(done);


### PR DESCRIPTION
Prior to this PR the shiny new `advanced_browse_spec.js` was not getting run by Travis :cold_sweat: 

As a result, I discovered #6104, but this PR is not the place to fix it.

In this PR, I have 
1. renamed `post_count` to `count.posts` as described in #6009.
2. Got `advanced_browse_spec.js` to run in travis, and made it so that the failing tests are either skipped or done differently for now.

refs  #6009 
- This is a straight rename, no functionality is added
- The dot syntax requires pre/post processing to convert the name
- This PR also includes several updates to the tests, as they weren't being run as part of Travis!
