### PR TITLE
Minimize rerender warnings

### DIFF
--- a/core/client/app/components/gh-cm-editor.js
+++ b/core/client/app/components/gh-cm-editor.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
     isFocused: false,
 
     value: '', // make sure a value exists
-    editor: null, // reference to CodeMirror editor
+    _editor: null, // reference to CodeMirror editor
 
     // options for the editor
     lineNumbers: true,
@@ -31,13 +31,13 @@ export default Ember.Component.extend({
             });
         });
 
-        this.set('editor', editor);
+        this._editor = editor;
     },
 
     willDestroyElement: function () {
-        var editor = this.get('editor').getWrapperElement();
+        var editor = this._editor.getWrapperElement();
         editor.parentNode.removeChild(editor);
-        this.set('editor', null);
+        this._editor = null;
     }
 
 });

--- a/core/client/app/components/gh-content-preview-content.js
+++ b/core/client/app/components/gh-content-preview-content.js
@@ -6,7 +6,7 @@ export default Ember.Component.extend({
 
     content: null,
 
-    didRender: function () {
+    didInsertElement: function () {
         var el = this.$();
 
         el.on('scroll', Ember.run.bind(el, setScrollClassName, {

--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -4,8 +4,10 @@ import uploader from 'ghost/assets/lib/uploader';
 export default Ember.Component.extend({
     config: Ember.inject.service(),
 
+    _scrollWrapper: null,
+
     didInsertElement: function () {
-        this.set('scrollWrapper', this.$().closest('.entry-preview-content'));
+        this._scrollWrapper = this.$().closest('.entry-preview-content');
         this.adjustScrollPosition(this.get('scrollPosition'));
         Ember.run.scheduleOnce('afterRender', this, this.dropzoneHandler);
     },
@@ -23,7 +25,7 @@ export default Ember.Component.extend({
     },
 
     adjustScrollPosition: function (scrollPosition) {
-        var scrollWrapper = this.get('scrollWrapper');
+        var scrollWrapper = this._scrollWrapper;
 
         if (scrollWrapper) {
             scrollWrapper.scrollTop(scrollPosition);

--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -1,4 +1,3 @@
-/* global md5 */
 import Ember from 'ember';
 
 /**
@@ -27,6 +26,12 @@ export default Ember.Component.extend({
     ghostPaths: Ember.inject.service('ghost-paths'),
     displayGravatar: Ember.computed.notEmpty('validEmail'),
 
+    init: function () {
+        this._super(...arguments);
+        // Fire this immediately in case we're initialized with a valid email
+        this.trySetValidEmail();
+    },
+
     defaultImage: Ember.computed('ghostPaths', function () {
         const url = this.get('ghostPaths.url').asset('/shared/img/user-image.png');
         return Ember.String.htmlSafe(`background-image: url(${url})`);
@@ -50,7 +55,7 @@ export default Ember.Component.extend({
 
         let style = '';
         if (email) {
-            let url = `http://www.gravatar.com/avatar/${md5(email)}?s=${size}&d=blank`;
+            let url = `http://www.gravatar.com/avatar/${window.md5(email)}?s=${size}&d=blank`;
             style = `background-image: url(${url})`;
         }
         return Ember.String.htmlSafe(style);
@@ -59,9 +64,6 @@ export default Ember.Component.extend({
     didInsertElement: function () {
         var size = this.get('size'),
             uploadElement = this.$('.js-file-input');
-
-        // Fire this immediately in case we're initialized with a valid email
-        this.trySetValidEmail();
 
         // while theoretically the 'add' and 'processalways' functions could be
         // added as properties of the hash passed to fileupload(), for some reason

--- a/core/client/app/components/gh-selectize.js
+++ b/core/client/app/components/gh-selectize.js
@@ -15,7 +15,7 @@ export default EmberSelectizeComponent.extend({
         var openOnFocus = this.get('openOnFocus');
 
         if (!openOnFocus) {
-            Ember.run.next(this, function () {
+            Ember.run.schedule('afterRender', this, function () {
                 var selectize = this._selectize;
                 if (selectize) {
                     selectize.on('dropdown_open', function () {

--- a/core/client/app/mixins/editor-base-controller.js
+++ b/core/client/app/mixins/editor-base-controller.js
@@ -14,20 +14,17 @@ PostModel.eachAttribute(function (name) {
 export default Ember.Mixin.create({
     postSettingsMenuController: Ember.inject.controller('post-settings-menu'),
 
-    autoSaveId: null,
-    timedSaveId: null,
+    _autoSaveId: null,
+    _timedSaveId: null,
     editor: null,
     submitting: false,
 
     notifications: Ember.inject.service(),
 
     init: function () {
-        var self = this;
-
-        this._super();
-
-        window.onbeforeunload = function () {
-            return self.get('hasDirtyAttributes') ? self.unloadDirtyMessage() : null;
+        this._super(...arguments);
+        window.onbeforeunload = () => {
+            return this.get('hasDirtyAttributes') ? this.unloadDirtyMessage() : null;
         };
     },
 
@@ -47,10 +44,10 @@ export default Ember.Mixin.create({
             };
 
             timedSaveId = Ember.run.throttle(this, 'send', 'save', saveOptions, 60000, false);
-            this.set('timedSaveId', timedSaveId);
+            this._timedSaveId = timedSaveId;
 
             autoSaveId = Ember.run.debounce(this, 'send', 'save', saveOptions, 3000);
-            this.set('autoSaveId', autoSaveId);
+            this._autoSaveId = autoSaveId;
         }
     }),
 
@@ -254,8 +251,8 @@ export default Ember.Mixin.create({
             var status,
                 prevStatus = this.get('model.status'),
                 isNew = this.get('model.isNew'),
-                autoSaveId = this.get('autoSaveId'),
-                timedSaveId = this.get('timedSaveId'),
+                autoSaveId = this._autoSaveId,
+                timedSaveId = this._timedSaveId,
                 self = this,
                 psmController = this.get('postSettingsMenuController'),
                 promise;
@@ -280,12 +277,12 @@ export default Ember.Mixin.create({
 
             if (autoSaveId) {
                 Ember.run.cancel(autoSaveId);
-                this.set('autoSaveId', null);
+                this._autoSaveId = null;
             }
 
             if (timedSaveId) {
                 Ember.run.cancel(timedSaveId);
-                this.set('timedSaveId', null);
+                this._timedSaveId = null;
             }
 
             // Set the properties that are indirected


### PR DESCRIPTION
Ember 1.13 introduced a warning when inefficient rerenders are caused. The most basic way to understand this is changing a property in `didInsertElement`:

``` js
// app/components/show-name.js
import Ember from 'ember';

export default Ember.Component.extend({
  name: 'bob',
  didInsertElement() {
    this.set('name', 'mike');
  }
});
```

``` hbs
{{! app/templates/components/show-name.hbs }}
{{name}}
```

Ember renders the template, showing "bob". Then it calls the `didInsertElement` hook, where the author has asked the name to be changed to "mike". Thus we need to rerender the template (and potentially child templates) which is slow. Better would be to know we need "mike" in the first place.

Of course real-world occurrences of this can be a bit more contrived.

Here I've refactored some code that was causing warnings, or even code that was simply using Ember's `set`/`get` system (which is observable/bindable) for what is basically just internal state for the component.
