### PR TITLE
Properly use htmlSafe styles

### DIFF
--- a/core/client/app/components/gh-posts-list-item.js
+++ b/core/client/app/components/gh-posts-list-item.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
     }),
 
     authorAvatarBackground: Ember.computed('authorAvatar', function () {
-        return `background-image: url(${this.get('authorAvatar')})`.htmlSafe();
+        return Ember.String.htmlSafe(`background-image: url(${this.get('authorAvatar')})`);
     }),
 
     viewOrEdit: Ember.computed('previewIsHidden', function () {

--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -48,10 +48,12 @@ export default Ember.Component.extend({
         const email = this.get('validEmail'),
               size = this.get('size');
 
+        let style = '';
         if (email) {
             let url = `http://www.gravatar.com/avatar/${md5(email)}?s=${size}&d=blank`;
-            return Ember.String.htmlSafe(`background-image: url(${url})`);
+            style = `background-image: url(${url})`;
         }
+        return Ember.String.htmlSafe(style);
     }),
 
     didInsertElement: function () {

--- a/core/client/app/components/gh-user-active.js
+++ b/core/client/app/components/gh-user-active.js
@@ -14,7 +14,7 @@ export default Ember.Component.extend({
     userImageBackground: Ember.computed('user.image', 'userDefault', function () {
         var url = this.get('user.image') || this.get('userDefault');
 
-        return `background-image: url(${url})`.htmlSafe();
+        return Ember.String.htmlSafe(`background-image: url(${url})`);
     }),
 
     lastLogin: Ember.computed('user.last_login', function () {

--- a/core/client/app/controllers/team/user.js
+++ b/core/client/app/controllers/team/user.js
@@ -56,7 +56,7 @@ export default Ember.Controller.extend(ValidationEngine, {
     userImageBackground: Ember.computed('user.image', 'userDefault', function () {
         var url = this.get('user.image') || this.get('userDefault');
 
-        return `background-image: url(${url})`.htmlSafe();
+        return Ember.String.htmlSafe(`background-image: url(${url})`);
     }),
 
     // end duplicated
@@ -68,7 +68,7 @@ export default Ember.Controller.extend(ValidationEngine, {
     coverImageBackground: Ember.computed('user.cover', 'coverDefault', function () {
         var url = this.get('user.cover') || this.get('coverDefault');
 
-        return `background-image: url(${url})`.htmlSafe();
+        return Ember.String.htmlSafe(`background-image: url(${url})`);
     }),
 
     coverTitle: Ember.computed('user.name', function () {

--- a/core/client/app/templates/team/user.hbs
+++ b/core/client/app/templates/team/user.hbs
@@ -36,7 +36,7 @@
 
     <div class="view-container settings-user">
 
-        <figure class="user-cover" style="{{coverImageBackground}}">
+        <figure class="user-cover" style={{coverImageBackground}}>
             <button class="btn btn-default user-cover-edit js-modal-cover" {{action "openModal" "upload" user "cover"}}>Change Cover</button>
         </figure>
 
@@ -49,7 +49,7 @@
             <fieldset class="user-details-top">
 
                 <figure class="user-image">
-                    <div id="user-image" class="img" style="{{userImageBackground}}"><span class="hidden">{{user.name}}"s Picture</span></div>
+                    <div id="user-image" class="img" style={{userImageBackground}}><span class="hidden">{{user.name}}"s Picture</span></div>
                     <button type="button" {{action "openModal" "upload" user "image"}} class="edit-user-image js-modal-image">Edit Picture</button>
                 </figure>
 


### PR DESCRIPTION
Some cleanup to address warnings during tests and dev usage:
- Use `Ember.String.htmlSafe` instead of prototype extensions
- Always return a safe string for a property returning one (never undefined)
- Do not quote style attribute bindings
