### PR TITLE
deps:sqlite3@3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rss": "1.2.0",
     "semver": "5.0.3",
     "showdown-ghost": "0.3.6",
-    "sqlite3": "3.1.0",
+    "sqlite3": "3.1.1",
     "unidecode": "0.1.7",
     "validator": "4.1.0",
     "xml": "1.0.0"


### PR DESCRIPTION
The update from sqlite3 3.1.0 to 3.1.1 just adds support for node 5.0.0. 

Ghost is not going to be officially supporting node v5, but with this change + #6063 it will be possible for users to opt out of the version check at their own risk.

Additionally, with these two changes, we'll be adding a bit of a layer of protection such that people trying to install Ghost on newer node versions don't run into the problem at the node-sqlite3 install step and think the problem is there. At the moment, a lot of Ghost users end up raising issues on the node-sqlite3 repo, just to find out it's because we don't support the version.
