### PR TITLE
Update client for tag.post_count -> tag.count.posts rename

### DIFF
--- a/core/client/app/controllers/modals/delete-tag.js
+++ b/core/client/app/controllers/modals/delete-tag.js
@@ -1,16 +1,18 @@
 import Ember from 'ember';
 
-export default Ember.Controller.extend({
-    notifications: Ember.inject.service(),
-    application: Ember.inject.controller(),
+const {Controller, computed, inject} = Ember;
 
-    postInflection: Ember.computed('model.post_count', function () {
-        return this.get('model.post_count') > 1 ? 'posts' : 'post';
+export default Controller.extend({
+    application: inject.controller(),
+    notifications: inject.service(),
+
+    postInflection: computed('model.count.posts', function () {
+        return this.get('model.count.posts') > 1 ? 'posts' : 'post';
     }),
 
     actions: {
         confirmAccept: function () {
-            var tag = this.get('model');
+            let tag = this.get('model');
 
             this.send('closeMenus');
 

--- a/core/client/app/mirage/factories/tag.js
+++ b/core/client/app/mirage/factories/tag.js
@@ -11,9 +11,13 @@ export default Mirage.Factory.extend({
     meta_title(i) { return  `Meta Title for tag ${i}`; },
     name(i) { return  `Tag ${i}`; },
     parent() { return  null; },
-    post_count() { return 1; },
     slug(i) { return  `tag-${i}`; },
     updated_at() { return  '2015-10-19T16:25:07.756Z'; },
     updated_by() { return  1; },
-    uuid(i) { return  `tag-${i}`; }
+    uuid(i) { return  `tag-${i}`; },
+    count() {
+        return {
+            posts: 1
+        };
+    },
 });

--- a/core/client/app/models/tag.js
+++ b/core/client/app/models/tag.js
@@ -17,5 +17,5 @@ export default DS.Model.extend(ValidationEngine, {
     updated_at: DS.attr('moment-date'),
     created_by: DS.attr(),
     updated_by: DS.attr(),
-    post_count: DS.attr('number')
+    count: DS.attr('raw')
 });

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -9,7 +9,7 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
 
     paginationModel: 'tag',
     paginationSettings: {
-        include: 'post_count',
+        include: 'count.posts',
         limit: 15
     },
 

--- a/core/client/app/serializers/tag.js
+++ b/core/client/app/serializers/tag.js
@@ -12,7 +12,7 @@ export default ApplicationSerializer.extend({
         // Properties that exist on the model but we don't want sent in the payload
 
         delete data.uuid;
-        delete data.post_count;
+        delete data.count;
 
         hash[root] = [data];
     }

--- a/core/client/app/templates/modals/delete-tag.hbs
+++ b/core/client/app/templates/modals/delete-tag.hbs
@@ -1,8 +1,8 @@
 {{#gh-modal-dialog action="closeModal" showClose=true type="action" style="wide"
     title="Are you sure you want to delete this tag?" confirm=confirm}}
 
-    {{#if model.post_count}}
-        <strong>WARNING:</strong> <span class="red">This tag is attached to {{model.post_count}} {{postInflection}}.</span> You're about to delete "<strong>{{model.name}}</strong>". This is permanent! No backups, no restores, no magic undo button. We warned you, ok?
+    {{#if model.count.posts}}
+        <strong>WARNING:</strong> <span class="red">This tag is attached to {{model.count.posts}} {{postInflection}}.</span> You're about to delete "<strong>{{model.name}}</strong>". This is permanent! No backups, no restores, no magic undo button. We warned you, ok?
     {{else}}
         <strong>WARNING:</strong> You're about to delete "<strong>{{model.name}}</strong>". This is permanent! No backups, no restores, no magic undo button. We warned you, ok?
     {{/if}}

--- a/core/client/app/templates/settings/tags.hbs
+++ b/core/client/app/templates/settings/tags.hbs
@@ -20,7 +20,7 @@
                             <span class="tag-title">{{tag.name}}</span>
                             <span class="label label-default">/{{tag.slug}}</span>
                             <p class="tag-description">{{tag.description}}</p>
-                            <span class="tags-count">{{tag.post_count}}</span>
+                            <span class="tags-count">{{tag.count.posts}}</span>
                         {{/link-to}}
                     </div>
                 {{/each}}

--- a/core/client/app/transforms/raw.js
+++ b/core/client/app/transforms/raw.js
@@ -1,0 +1,13 @@
+import DS from 'ember-data';
+
+const {Transform} = DS;
+
+export default Transform.extend({
+    deserialize: function (serialized) {
+        return serialized;
+    },
+
+    serialize: function (deserialized) {
+        return deserialized;
+    }
+});


### PR DESCRIPTION
refs #6105
- adds `raw` ember-data transform to handle standard JSON `count` attribute
- update mirage factory to return correct `count.posts` format
- rename all uses of `post_count` to `count.posts`
