### PR TITLE
Restore options

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -245,6 +245,7 @@ User = ghostBookshelf.Model.extend({
     findOne: function findOne(data, options) {
         var query,
             status,
+            optInc,
             lookupRole = data.role;
 
         delete data.role;
@@ -257,6 +258,7 @@ User = ghostBookshelf.Model.extend({
         delete data.status;
 
         options = options || {};
+        optInc = options.include;
         options.withRelated = _.union(options.withRelated, options.include);
         data = this.filterData(data);
 
@@ -285,6 +287,7 @@ User = ghostBookshelf.Model.extend({
 
         options = this.filterOptions(options, 'findOne');
         delete options.include;
+        options.include = optInc;
 
         return query.fetch(options);
     },


### PR DESCRIPTION
refs #6122
- restore original options after delete
- this is a fix for one use case, long term we should aim to leave
  options untouched and execute special queries with temporary data
