### PR TITLE
Docs link & unique error codes for startup checks

### DIFF
--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -5,7 +5,15 @@ var packages = require('../../../package.json'),
     mode = process.env.NODE_ENV === undefined ? 'development' : process.env.NODE_ENV,
     appRoot = path.resolve(__dirname, '../../../'),
     configFilePath = process.env.GHOST_CONFIG || path.join(appRoot, 'config.js'),
-    checks;
+    checks,
+    exitCodes = {
+        NODE_VERSION_UNSUPPORTED: 231,
+        NODE_ENV_CONFIG_MISSING: 232,
+        DEPENDENCIES_MISSING: 233,
+        CONTENT_PATH_NOT_ACCESSIBLE: 234,
+        CONTENT_PATH_NOT_WRITABLE: 235,
+        SQLITE_DB_NOT_WRITABLE: 236
+    };
 
 checks = {
     check: function check() {
@@ -27,9 +35,9 @@ checks = {
             console.error('\x1B[31mERROR: Unsupported version of Node');
             console.error('\x1B[31mGhost needs Node version ' + packages.engines.node +
                           ' you are using version ' + process.versions.node + '\033[0m\n');
-            console.error('\x1B[32mPlease go to http://nodejs.org to get a supported version or set GHOST_NODE_VERSION_CHECK=false\033[0m');
+            console.error('\x1B[32mPlease see http://support.ghost.org/supported-node-versions/ for more information\033[0m');
 
-            process.exit(1);
+            process.exit(exitCodes.NODE_VERSION_UNSUPPORTED);
         }
     },
 
@@ -55,7 +63,7 @@ checks = {
             console.error('\x1B[32mEnsure your config.js has a section for the current NODE_ENV value' +
                             ' and is formatted properly.\033[0m');
 
-            process.exit(1);
+            process.exit(exitCodes.NODE_ENV_CONFIG_MISSING);
         }
     },
 
@@ -85,7 +93,7 @@ checks = {
         console.error('\x1B[32m\nPlease run `npm install --production` and try starting Ghost again.');
         console.error('\x1B[32mHelp and documentation can be found at http://support.ghost.org.\033[0m\n');
 
-        process.exit(1);
+        process.exit(exitCodes.DEPENDENCIES_MISSING);
     },
 
     // Check content path permissions
@@ -129,7 +137,7 @@ checks = {
             console.error('  ' + e.message);
             console.error('\n' + errorHelp);
 
-            process.exit(1);
+            process.exit(exitCodes.CONTENT_PATH_NOT_ACCESSIBLE);
         }
 
         // Check each of the content path subdirectories
@@ -151,7 +159,7 @@ checks = {
             console.error('  ' + e.message);
             console.error('\n' + errorHelp);
 
-            process.exit(1);
+            process.exit(exitCodes.CONTENT_PATH_NOT_WRITABLE);
         }
     },
 
@@ -199,7 +207,7 @@ checks = {
             console.error('\n\x1B[32mCheck that the sqlite3 database file permissions allow read and write access.');
             console.error('Help and documentation can be found at http://support.ghost.org.\033[0m');
 
-            process.exit(1);
+            process.exit(exitCodes.SQLITE_DB_NOT_WRITABLE);
         }
     }
 };


### PR DESCRIPTION
In #6063 the help text for the startup check was updated to include info about the new env var. This replaces that with a link to the docs with more comprehensive information about what the error means and how to fix it.

In #6063, the exit codes were also changed from 0 to 1. At the time I merged it as 0 = no error, which is incorrect, however afterwards I remembered we set the exit code to 0 to prevent the big block of output from npm which obscures the error message.

However, in newer versions of npm things all work differently, so I think it makes sense to output a unique error code for each error and document what the codes mean. Googling an error code should then get the user to the right part of the docs.

As we improve the docs, the error messages can also be improved with more direct links, hopefully over time we'll be able to provide a much better experience.

Exit codes start with '23' (like 2368) to try to make them a little bit unique.

refs #5821, #6063 
- switch out help test to go to a comprehensive doc
- change error codes from 1 to unique codes
