### PR TITLE
Fix missing error on signin when server has gone away

### DIFF
--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -26,7 +26,7 @@ export default Ember.Controller.extend(ValidationEngine, {
             this.get('session').authenticate(authStrategy, model.get('identification'), model.get('password')).catch(function (error) {
                 self.toggleProperty('loggingIn');
 
-                if (error.errors) {
+                if (error && error.errors) {
                     error.errors.forEach(function (err) {
                         err.message = err.message.htmlSafe();
                     });


### PR DESCRIPTION
no issue
- `session.authenticate` calls out to jQuery for the ajax request which then raises it's own error but returns nothing usable when the server is not reachable. This is a quick fix for our code always expecting some form of object back so we can pass through to the default error handler in the authentication step.

To be revisited once ember data has been updated in case the handling is different with the new `ember-ajax` library.
