### PR TITLE
[SPIKE] Add "concat" handlebars helper

### DIFF
--- a/core/server/helpers/concat.js
+++ b/core/server/helpers/concat.js
@@ -1,0 +1,7 @@
+var concat;
+
+concat = function (options) {
+    return options.join('')
+};
+
+module.exports = has;


### PR DESCRIPTION
no issue
- adds `concat` as a handlebars helper that simply joins the passed in params

As a use-case example this is really helpful in combination with the `{{#get}}` helper so that you can use the existing context inside the `filter` param by using a sub-expression. E.g. to list all tags and the number of authors that have a post with that tag:

```
{{#get "tags" limit="all" as |tags|}}
    <ul class="tags">
        {{#each tags}}
            <li>
                {{name}} -
                {{#get "users" filter=(concat "posts.tags:" slug) as |users|}}
                    {{users.length}} Authors
                {{/get}}
            </li>
        {{/each}}
    </ul>
{{/get}}
```
