### PR TITLE
Remove casperjs from travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,10 @@ matrix:
     - node_js: "0.10"
       env: TEST_SUITE=lint
 before_install:
-  - git clone git://github.com/n1k0/casperjs.git ~/casperjs
-  - cd ~/casperjs
-  - git checkout tags/1.1-beta3
-  - export PATH=$PATH:`pwd`/bin
-  - cd -
   - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_testing'; fi
   - if [ $DB == "pg" ]; then psql -c 'create database ghost_testing;' -U postgres; fi
 before_script:
   - phantomjs --version
-  - casperjs --version
 after_success:
   - |
       if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then


### PR DESCRIPTION
no issue

As the CasperJS suite is no longer being used, casperjs should be removed from travis' build setup
