### PR TITLE
Add istanbul peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "grunt-mocha-istanbul": "2.4.0",
     "grunt-shell": "1.1.2",
     "grunt-update-submodules": "0.4.1",
+    "istanbul": "0.4.1",
     "jscs-jsdoc": "1.2.0",
     "matchdep": "0.3.0",
     "nock": "2.3.0",


### PR DESCRIPTION
no issue

this fixes a warning in npm v3 for grunt-mocha-istanbul that the peer dependency istanbul is not explicitly supplied
