### PR TITLE
Add Node.js engine v5.1.0 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.10"
   - "0.12"
   - "4.2"
+  - "5.1"
 sudo: false
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ~4.2.0",
+    "node": "~0.10.0 || ~0.12.0 || ~4.2.0 || ~5.1.0",
     "iojs": "~1.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
- adds support for node ~5.1.0 stable - `package.json`
- adds node ~5.1.0 stable to Travis CI - `.travis.yml`
