### PR TITLE
Added .git folder to ignored folders

### DIFF
--- a/core/server/utils/read-directory.js
+++ b/core/server/utils/read-directory.js
@@ -22,7 +22,7 @@ function readDirectory(dir, options) {
     }
 
     ignore = options.ignore || [];
-    ignore.push('node_modules', 'bower_components', '.DS_Store');
+    ignore.push('node_modules', 'bower_components', '.DS_Store', '.git');
 
     return readDir(dir)
         .filter(function (filename) {


### PR DESCRIPTION
Any .git folder should not be searched by Ghost and in this case it was checking the .git folder as a possible theme folder. This PR simply adds .git folders to the ignore list when reading a directory.

https://github.com/TryGhost/Ghost/issues/6140
