### PR TITLE
Remove unused `ember-resize` dependency

### DIFF
--- a/core/client/ember-cli-build.js
+++ b/core/client/ember-cli-build.js
@@ -70,8 +70,8 @@ module.exports = function (defaults) {
     app.import('bower_components/blueimp-md5/js/md5.js');
 
     if (app.env === 'test') {
-        app.import('bower_components/jquery.simulate.drag-sortable/jquery.simulate.drag-sortable.js');
-        app.import('bower_components/jquery-deparam/jquery-deparam.js');
+        app.import(app.bowerDirectory + '/jquery.simulate.drag-sortable/jquery.simulate.drag-sortable.js', {type: 'test'});
+        app.import(app.bowerDirectory + '/jquery-deparam/jquery-deparam.js', {type: 'test'});
     }
 
     // 'dem Styles

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -42,7 +42,6 @@
     "ember-disable-proxy-controllers": "1.0.1",
     "ember-export-application-global": "1.0.5",
     "ember-myth": "0.1.1",
-    "ember-resize": "0.0.10",
     "ember-resolver": "2.0.3",
     "ember-simple-auth": "1.0.0",
     "ember-sinon": "0.3.0",


### PR DESCRIPTION
no issue
- removes `ember-resize` dep that crept back in under the radar in the Ember 2.2 update
- updates `ember-cli-build`'s test dependencies to match the format specified in http://ember-cli.com/managing-dependencies/#test-assets
