### PR TITLE
Remove `$` from jshint's predef, always use Ember's `$`

### DIFF
--- a/core/client/.jshintrc
+++ b/core/client/.jshintrc
@@ -5,7 +5,6 @@
     "window",
     "-Promise",
     "-Notification",
-    "$",
     "validator",
     "moment"
   ],

--- a/core/client/app/assets/lib/uploader.js
+++ b/core/client/app/assets/lib/uploader.js
@@ -1,4 +1,7 @@
+import Ember from 'ember';
 import ghostPaths from 'ghost/utils/ghost-paths';
+
+const {$} = Ember;
 
 let Ghost = ghostPaths();
 

--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import uploader from 'ghost/assets/lib/uploader';
 
-const {Component, inject, run} = Ember;
+const {$, Component, inject, run} = Ember;
 
 export default Component.extend({
     config: inject.service(),

--- a/core/client/app/components/gh-posts-list-item.js
+++ b/core/client/app/components/gh-posts-list-item.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Component, computed, inject} = Ember;
+const {$, Component, computed, inject} = Ember;
 const {alias, equal} = computed;
 
 export default Component.extend({

--- a/core/client/app/components/gh-search-input.js
+++ b/core/client/app/components/gh-search-input.js
@@ -3,7 +3,7 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-const {Component, RSVP, computed, inject, observer} = Ember;
+const {$, Component, RSVP, computed, inject, observer} = Ember;
 const {filterBy} = computed;
 
 export default Component.extend({

--- a/core/client/app/components/gh-skip-link.js
+++ b/core/client/app/components/gh-skip-link.js
@@ -1,7 +1,7 @@
 /*jshint scripturl:true*/
 import Ember from 'ember';
 
-const {Component, on} = Ember;
+const {$, Component, on} = Ember;
 
 export default Component.extend({
     tagName: 'a',

--- a/core/client/app/controllers/modals/signin.js
+++ b/core/client/app/controllers/modals/signin.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
-const {Controller, computed, inject} = Ember;
+const {$, Controller, computed, inject} = Ember;
 
 export default Controller.extend(ValidationEngine, {
     validationType: 'signin',

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -5,7 +5,7 @@ import SlugGenerator from 'ghost/models/slug-generator';
 import boundOneWay from 'ghost/utils/bound-one-way';
 import isNumber from 'ghost/utils/isNumber';
 
-const {ArrayProxy, Controller, Handlebars, PromiseProxyMixin, RSVP, computed, guidFor, inject, isArray, observer, run} = Ember;
+const {$, ArrayProxy, Controller, Handlebars, PromiseProxyMixin, RSVP, computed, guidFor, inject, isArray, observer, run} = Ember;
 
 export default Controller.extend(SettingsMenuMixin, {
     debounceId: null,

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import {request as ajax} from 'ic-ajax';
 
-const {Controller, computed, inject} = Ember;
+const {$, Controller, computed, inject} = Ember;
 
 export default Controller.extend({
     uploadButtonText: 'Import',

--- a/core/client/app/controllers/signin.js
+++ b/core/client/app/controllers/signin.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 import {request as ajax} from 'ic-ajax';
 
-const {Controller, inject} = Ember;
+const {$, Controller, inject} = Ember;
 
 export default Controller.extend(ValidationEngine, {
     submitting: false,

--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -1,7 +1,7 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
 
-const {isBlank} = Ember;
+const {$, isBlank} = Ember;
 
 function paginatedResponse(modelName, allModels, request) {
     let page = +request.queryParams.page || 1;

--- a/core/client/app/mixins/body-event-listener.js
+++ b/core/client/app/mixins/body-event-listener.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Mixin, run} = Ember;
+const {$, Mixin, run} = Ember;
 
 function K() {
     return this;

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -1,6 +1,9 @@
+import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
+
+const {$} = Ember;
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - Navigation',


### PR DESCRIPTION
no issue
- fixes problems with "re-definition of $" errors

Pulled out from modals refactor PR so that it can be taken into account within other PRs until that one is merged.
