### PR TITLE
Add .git folder to ignore folders list

### DIFF
--- a/core/server/utils/read-directory.js
+++ b/core/server/utils/read-directory.js
@@ -22,7 +22,7 @@ function readDirectory(dir, options) {
     }
 
     ignore = options.ignore || [];
-    ignore.push('node_modules', 'bower_components', '.DS_Store');
+    ignore.push('node_modules', 'bower_components', '.DS_Store', '.git');
 
     return readDir(dir)
         .filter(function (filename) {


### PR DESCRIPTION
closes #6140
- simply added '.git' to the list of folder names to ignore when checking for valid themes.
