### PR TITLE
Checkbox labels are cut off on mobile.

### DIFF
--- a/core/client/app/styles/patterns/forms.css
+++ b/core/client/app/styles/patterns/forms.css
@@ -198,8 +198,8 @@ textarea {
 
 .for-radio p,
 .for-checkbox p {
+    overflow: auto;
     color: #b3b2a8;
-    white-space: nowrap;
     font-weight: normal;
 }
 


### PR DESCRIPTION
Closes #6089 .

Based on @kevinkucharczyk's suggestion (Thanks!).

I just want to keep the traction going for these low hanging fruits :smile: 
