### PR TITLE
Moving 'permalinks' and 'postsPerPage' to config.theme cache

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -55,7 +55,9 @@ updateConfigCache = function () {
             description: (settingsCache.description && settingsCache.description.value) || '',
             logo: (settingsCache.logo && settingsCache.logo.value) || '',
             cover: (settingsCache.cover && settingsCache.cover.value) || '',
-            navigation: (settingsCache.navigation && JSON.parse(settingsCache.navigation.value)) || []
+            navigation: (settingsCache.navigation && JSON.parse(settingsCache.navigation.value)) || [],
+            postsPerPage: (settingsCache.postsPerPage && settingsCache.postsPerPage.value) || 5,
+            permalinks: (settingsCache.permalinks && settingsCache.permalinks.value) || '/:slug/'
         },
         labs: labsValue
     });

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -90,9 +90,9 @@ function createUrl(urlPath, absolute, secure) {
 // Creates the url path for a post, given a post and a permalink
 // Parameters:
 // - post - a json object representing a post
-// - permalinks - a string containing the permalinks setting
-function urlPathForPost(post, permalinks) {
+function urlPathForPost(post) {
     var output = '',
+        permalinks = ghostConfig.theme.permalinks,
         tags = {
             year:   function () { return moment(post.published_at).format('YYYY'); },
             month:  function () { return moment(post.published_at).format('MM'); },

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -4,6 +4,7 @@
  */
 var api = require('../../api'),
     _   = require('lodash'),
+    config = require('../../config'),
     Promise = require('bluebird'),
     queryDefaults,
     defaultPostQuery = {};
@@ -24,7 +25,7 @@ _.extend(defaultPostQuery, queryDefaults, {
 
 /**
  * ## Fetch Posts Per page
- * Grab the postsPerPage setting from the database
+ * Grab the postsPerPage setting
  *
  * @param {Object} options
  * @returns {Object} postOptions
@@ -32,17 +33,15 @@ _.extend(defaultPostQuery, queryDefaults, {
 function fetchPostsPerPage(options) {
     options = options || {};
 
-    return api.settings.read('postsPerPage').then(function then(response) {
-        var postsPerPage = parseInt(response.settings[0].value);
+    var postsPerPage = parseInt(config.theme.postsPerPage);
 
-        // No negative posts per page, must be number
-        if (!isNaN(postsPerPage) && postsPerPage > 0) {
-            options.limit = postsPerPage;
-        }
+    // No negative posts per page, must be number
+    if (!isNaN(postsPerPage) && postsPerPage > 0) {
+        options.limit = postsPerPage;
+    }
 
-        // Ensure the options key is present, so this can be merged with other options
-        return {options: options};
-    });
+    // Ensure the options key is present, so this can be merged with other options
+    return {options: options};
 }
 
 /**
@@ -85,47 +84,38 @@ function processQuery(query, slugParam) {
  * @returns {Promise} response
  */
 function fetchData(channelOptions) {
-    // Temporary workaround to make RSS work, moving towards dynamic channels will provide opportunities to
-    // improve this, I hope :)
-    function handlePostsPerPage(channelOptions) {
-        if (channelOptions.isRSS) {
-            return Promise.resolve({options: channelOptions.postOptions});
-        } else {
-            return fetchPostsPerPage(channelOptions.postOptions);
+    // @TODO improve this further
+    var pageOptions = channelOptions.isRSS ?
+        {options: channelOptions.postOptions} : fetchPostsPerPage(channelOptions.postOptions),
+        postQuery,
+        props = {};
+
+    // All channels must have a posts query, use the default if not provided
+    postQuery = _.defaultsDeep({}, pageOptions, defaultPostQuery);
+    props.posts = processQuery(postQuery, channelOptions.slugParam);
+
+    _.each(channelOptions.data, function (query, name) {
+        props[name] = processQuery(query, channelOptions.slugParam);
+    });
+
+    return Promise.props(props).then(function formatResponse(results) {
+        var response = _.cloneDeep(results.posts);
+        delete results.posts;
+
+        // process any remaining data
+        if (!_.isEmpty(results)) {
+            response.data = {};
+
+            _.each(results, function (result, name) {
+                if (channelOptions.data[name].type === 'browse') {
+                    response.data[name] = result;
+                } else {
+                    response.data[name] = result[channelOptions.data[name].resource];
+                }
+            });
         }
-    }
 
-    return handlePostsPerPage(channelOptions).then(function fetchData(pageOptions) {
-        var postQuery,
-            props = {};
-
-        // All channels must have a posts query, use the default if not provided
-        postQuery = _.defaultsDeep({}, pageOptions, defaultPostQuery);
-        props.posts = processQuery(postQuery, channelOptions.slugParam);
-
-        _.each(channelOptions.data, function (query, name) {
-            props[name] = processQuery(query, channelOptions.slugParam);
-        });
-
-        return Promise.props(props).then(function formatResponse(results) {
-            var response = _.cloneDeep(results.posts);
-            delete results.posts;
-
-            // process any remaining data
-            if (!_.isEmpty(results)) {
-                response.data = {};
-
-                _.each(results, function (result, name) {
-                    if (channelOptions.data[name].type === 'browse') {
-                        response.data[name] = result;
-                    } else {
-                        response.data[name] = result[channelOptions.data[name].resource];
-                    }
-                });
-            }
-
-            return response;
-        });
+        return response;
     });
 }
 

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -32,22 +32,16 @@ function handleError(next) {
 
 function getData(channelOpts, slugParam) {
     channelOpts.data = channelOpts.data || {};
-    channelOpts.data.permalinks = {
-        type: 'read',
-        resource: 'settings',
-        options: 'permalinks'
-    };
 
     return fetchData(channelOpts, slugParam).then(function (result) {
         var response = {},
             titleStart = '';
 
-        if (result.data.tag) { titleStart = result.data.tag[0].name + ' - ' || ''; }
-        if (result.data.author) { titleStart = result.data.author[0].name + ' - ' || ''; }
+        if (result.data && result.data.tag) { titleStart = result.data.tag[0].name + ' - ' || ''; }
+        if (result.data && result.data.author) { titleStart = result.data.author[0].name + ' - ' || ''; }
 
         response.title = titleStart + config.theme.title;
         response.description = config.theme.description;
-        response.permalinks = result.data.permalinks[0];
         response.results = {
             posts: result.posts,
             meta: result.meta
@@ -141,7 +135,7 @@ generateFeed = function generateFeed(data) {
     });
 
     data.results.posts.forEach(function forEach(post) {
-        var itemUrl = config.urlFor('post', {post: post, permalinks: data.permalinks, secure: data.secure}, true),
+        var itemUrl = config.urlFor('post', {post: post, secure: data.secure}, true),
             htmlContent = processUrls(post.html, data.siteUrl, itemUrl),
             item = {
                 title: post.title,

--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -1,7 +1,6 @@
 var _       = require('lodash'),
     xml     = require('xml'),
     moment  = require('moment'),
-    api     = require('../../../api'),
     config  = require('../../../config'),
     events  = require('../../../events'),
     utils   = require('./utils'),
@@ -52,40 +51,18 @@ _.extend(BaseSiteMapGenerator.prototype, {
     },
 
     generateXmlFromData: function (data) {
-        // This has to be async because of the permalinks retrieval
-        var self = this;
+        // Create all the url elements in JSON
+        var self = this,
+            nodes;
+        nodes = _.map(data, function (datum) {
+            var node = self.createUrlNodeFromDatum(datum);
+            self.updateLastModified(datum);
+            self.updateLookups(datum, node);
 
-        // Fetch the permalinks value only once for all the urlFor calls
-        return this.getPermalinksValue().then(function (permalinks) {
-            // Create all the url elements in JSON
-            return _.map(data, function (datum) {
-                var node = self.createUrlNodeFromDatum(datum, permalinks);
-                self.updateLastModified(datum);
-                self.updateLookups(datum, node);
-
-                return node;
-            });
-        }).then(this.generateXmlFromNodes.bind(this));
-    },
-
-    getPermalinksValue: function () {
-        var self = this;
-
-        if (this.permalinks) {
-            return Promise.resolve(this.permalinks);
-        }
-
-        return api.settings.read('permalinks').then(function (response) {
-            self.permalinks = response.settings[0];
-            return self.permalinks;
+            return node;
         });
-    },
 
-    updatePermalinksValue: function (permalinks) {
-        this.permalinks = permalinks;
-
-        // Re-generate xml with new permalinks values
-        this.updateXmlFromNodes();
+        return this.generateXmlFromNodes(nodes);
     },
 
     generateXmlFromNodes: function () {
@@ -121,17 +98,14 @@ _.extend(BaseSiteMapGenerator.prototype, {
     },
 
     addOrUpdateUrl: function (model) {
-        var self = this,
-            datum = model.toJSON();
+        var datum = model.toJSON(),
+            node = this.createUrlNodeFromDatum(datum);
 
-        return this.getPermalinksValue().then(function (permalinks) {
-            var node = self.createUrlNodeFromDatum(datum, permalinks);
-            self.updateLastModified(datum);
-            // TODO: Check if the node values changed, and if not don't regenerate
-            self.updateLookups(datum, node);
+        this.updateLastModified(datum);
+        // TODO: Check if the node values changed, and if not don't regenerate
+        this.updateLookups(datum, node);
 
-            return self.updateXmlFromNodes();
-        });
+        return this.updateXmlFromNodes();
     },
 
     removeUrl: function (model) {
@@ -163,8 +137,8 @@ _.extend(BaseSiteMapGenerator.prototype, {
         return datum.updated_at || datum.published_at || datum.created_at;
     },
 
-    createUrlNodeFromDatum: function (datum, permalinks) {
-        var url = this.getUrlForDatum(datum, permalinks),
+    createUrlNodeFromDatum: function (datum) {
+        var url = this.getUrlForDatum(datum),
             priority = this.getPriorityForDatum(datum);
 
         return {

--- a/core/server/data/xml/sitemap/manager.js
+++ b/core/server/data/xml/sitemap/manager.js
@@ -71,15 +71,6 @@ _.extend(SiteMapManager.prototype, {
         return this[type].siteMapContent;
     },
 
-    // TODO: Call this from settings model when it's changed
-    permalinksUpdated: function (permalinks) {
-        if (!this.initialized) {
-            return;
-        }
-
-        this.posts.updatePermalinksValue(permalinks.toJSON ? permalinks.toJSON() : permalinks);
-    },
-
     _refreshAllPosts: _.throttle(function () {
         this.posts.refreshAllPosts();
     }, 3000, {

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -43,12 +43,12 @@ _.extend(PageMapGenerator.prototype, {
         });
     },
 
-    getUrlForDatum: function (post, permalinks) {
+    getUrlForDatum: function (post) {
         if (post.id === 0 && !_.isEmpty(post.name)) {
             return config.urlFor(post.name, true);
         }
 
-        return config.urlFor('post', {post: post, permalinks: permalinks}, true);
+        return config.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -39,8 +39,8 @@ _.extend(PostMapGenerator.prototype, {
         });
     },
 
-    getUrlForDatum: function (post, permalinks) {
-        return config.urlFor('post', {post: post, permalinks: permalinks}, true);
+    getUrlForDatum: function (post) {
+        return config.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -36,8 +36,8 @@ _.extend(TagsMapGenerator.prototype, {
         });
     },
 
-    getUrlForDatum: function (tag, permalinks) {
-        return config.urlFor('tag', {tag: tag, permalinks: permalinks}, true);
+    getUrlForDatum: function (tag) {
+        return config.urlFor('tag', {tag: tag}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -38,8 +38,8 @@ _.extend(UserMapGenerator.prototype, {
         });
     },
 
-    getUrlForDatum: function (user, permalinks) {
-        return config.urlFor('author', {author: user, permalinks: permalinks}, true);
+    getUrlForDatum: function (user) {
+        return config.urlFor('author', {author: user}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -5,10 +5,6 @@ var hbs             = require('express-hbs'),
     coreHelpers     = {},
     registerHelpers;
 
-// Pre-load settings data:
-// - activeTheme
-// - permalinks
-
 if (!utils.isProduction) {
     hbs.handlebars.logger.level = 0;
 }

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -25,14 +25,17 @@ themeHandler = {
     // ### configHbsForContext Middleware
     // Setup handlebars for the current context (admin or theme)
     configHbsForContext: function configHbsForContext(req, res, next) {
-        var themeData = config.theme,
+        var themeData = _.cloneDeep(config.theme),
             blogApp = req.app;
 
         if (req.secure && config.urlSSL) {
             // For secure requests override .url property with the SSL version
-            themeData = _.clone(themeData);
             themeData.url = config.urlSSL.replace(/\/$/, '');
         }
+
+        // Change camelCase to snake_case
+        themeData.posts_per_page = themeData.postsPerPage;
+        delete themeData.postsPerPage;
 
         hbs.updateTemplateOptions({data: {blog: themeData}});
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -4,9 +4,7 @@ var testUtils       = require('../../utils'),
     should          = require('should'),
     sequence        = require('../../../server/utils/sequence'),
     _               = require('lodash'),
-    Promise         = require('bluebird'),
     sinon           = require('sinon'),
-    SettingsModel   = require('../../../server/models/settings').Settings,
 
     // Stuff we are testing
     ghostBookshelf  = require('../../../server/models/base'),
@@ -14,7 +12,10 @@ var testUtils       = require('../../utils'),
     events          = require('../../../server/events'),
     DataGenerator   = testUtils.DataGenerator,
     context         = testUtils.context.owner,
-    sandbox         = sinon.sandbox.create();
+    sandbox         = sinon.sandbox.create(),
+
+    config   = require('../../../server/config'),
+    origConfig = _.cloneDeep(config);
 
 describe('Post Model', function () {
     // Keep the DB clean
@@ -26,6 +27,7 @@ describe('Post Model', function () {
         afterEach(testUtils.teardown);
         afterEach(function () {
             sandbox.restore();
+            config.set(origConfig);
         });
         beforeEach(testUtils.setup('owner', 'posts', 'apps'));
 
@@ -58,11 +60,9 @@ describe('Post Model', function () {
 
         describe('findAll', function () {
             beforeEach(function () {
-                sandbox.stub(SettingsModel, 'findOne', function () {
-                    return Promise.resolve({toJSON: function () {
-                        return {value: '/:slug/'};
-                    }});
-                });
+                config.set({theme: {
+                    permalinks: '/:slug/'
+                }});
             });
 
             it('can findAll', function (done) {
@@ -95,11 +95,9 @@ describe('Post Model', function () {
 
         describe('findPage', function () {
             beforeEach(function () {
-                sandbox.stub(SettingsModel, 'findOne', function () {
-                    return Promise.resolve({toJSON: function () {
-                        return {value: '/:slug/'};
-                    }});
-                });
+                config.set({theme: {
+                    permalinks: '/:slug/'
+                }});
             });
 
             it('can findPage (default)', function (done) {
@@ -256,6 +254,12 @@ describe('Post Model', function () {
         });
 
         describe('findOne', function () {
+            beforeEach(function () {
+                config.set({theme: {
+                    permalinks: '/:slug/'
+                }});
+            });
+
             it('can findOne', function (done) {
                 var firstPost;
 
@@ -277,12 +281,6 @@ describe('Post Model', function () {
             it('can findOne, returning all related data', function (done) {
                 var firstPost;
 
-                sandbox.stub(SettingsModel, 'findOne', function () {
-                    return Promise.resolve({toJSON: function () {
-                        return {value: '/:slug/'};
-                    }});
-                });
-
                 PostModel.findOne({}, {include: ['author', 'fields', 'tags', 'created_by', 'updated_by', 'published_by']})
                     .then(function (result) {
                         should.exist(result);
@@ -296,11 +294,6 @@ describe('Post Model', function () {
 
             it('can findOne, returning a slug only permalink', function (done) {
                 var firstPost = 1;
-                sandbox.stub(SettingsModel, 'findOne', function () {
-                    return Promise.resolve({toJSON: function () {
-                        return {value: '/:slug/'};
-                    }});
-                });
 
                 PostModel.findOne({id: firstPost})
                     .then(function (result) {
@@ -320,11 +313,9 @@ describe('Post Model', function () {
                     yyyy = today.getFullYear(),
                     postLink = '/' + yyyy + '/' + mm + '/' + dd + '/html-ipsum/';
 
-                sandbox.stub(SettingsModel, 'findOne', function () {
-                    return Promise.resolve({toJSON: function () {
-                        return {value: '/:year/:month/:day/:slug/'};
-                    }});
-                });
+                config.set({theme: {
+                    permalinks: '/:year/:month/:day/:slug/'
+                }});
 
                 PostModel.findOne({id: firstPost})
                     .then(function (result) {

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -409,48 +409,46 @@ describe('Config', function () {
 
         describe('urlPathForPost', function () {
             it('should output correct url for post', function () {
-                var permalinkSetting = '/:slug/',
-                /*jshint unused:false*/
-                    testData = testUtils.DataGenerator.Content.posts[2],
+                config.set({theme: {permalinks: '/:slug/'}});
+
+                var testData = testUtils.DataGenerator.Content.posts[2],
                     postLink = '/short-and-sweet/';
 
-                // next test
-                config.urlPathForPost(testData, permalinkSetting).should.equal(postLink);
+                config.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('should output correct url for post with date permalink', function () {
-                var permalinkSetting = '/:year/:month/:day/:slug/',
-                /*jshint unused:false*/
-                    testData = testUtils.DataGenerator.Content.posts[2],
+                config.set({theme: {permalinks: '/:year/:month/:day/:slug/'}});
+                var testData = testUtils.DataGenerator.Content.posts[2],
                     today = testData.published_at,
                     dd = ('0' + today.getDate()).slice(-2),
                     mm = ('0' + (today.getMonth() + 1)).slice(-2),
                     yyyy = today.getFullYear(),
                     postLink = '/' + yyyy + '/' + mm + '/' + dd + '/short-and-sweet/';
-                // next test
-                config.urlPathForPost(testData, permalinkSetting).should.equal(postLink);
+
+                config.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('should output correct url for page with date permalink', function () {
-                var permalinkSetting = '/:year/:month/:day/:slug/',
-                /*jshint unused:false*/
-                    testData = testUtils.DataGenerator.Content.posts[5],
+                config.set({theme: {permalinks: '/:year/:month/:day/:slug/'}});
+
+                var testData = testUtils.DataGenerator.Content.posts[5],
                     postLink = '/static-page-test/';
-                // next test
-                config.urlPathForPost(testData, permalinkSetting).should.equal(postLink);
+
+                config.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('should output correct url for post with complex permalink', function () {
-                var permalinkSetting = '/:year/:id/:author/',
-                /*jshint unused:false*/
-                    testData = _.extend(
+                config.set({theme: {permalinks: '/:year/:id/:author/'}});
+
+                var testData = _.extend(
                         {}, testUtils.DataGenerator.Content.posts[2], {id: 3}, {author: {slug: 'joe-bloggs'}}
                     ),
                     today = testData.published_at,
                     yyyy = today.getFullYear(),
                     postLink = '/' + yyyy + '/3/joe-bloggs/';
-                // next test
-                config.urlPathForPost(testData, permalinkSetting).should.equal(postLink);
+
+                config.urlPathForPost(testData).should.equal(postLink);
             });
         });
     });

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -3,16 +3,19 @@
 var should   = require('should'),
     sinon    = require('sinon'),
     Promise  = require('bluebird'),
+    _        = require('lodash'),
 
     // Stuff we are testing
     api      = require('../../../../server/api'),
     fetchData = require('../../../../server/controllers/frontend/fetch-data'),
 
+    config   = require('../../../../server/config'),
+    origConfig = _.cloneDeep(config),
+
     sandbox = sinon.sandbox.create();
 
 describe('fetchData', function () {
-    var apiSettingsStub,
-        apiPostsStub,
+    var apiPostsStub,
         apiTagStub,
         apiUserStub;
 
@@ -21,21 +24,16 @@ describe('fetchData', function () {
             .returns(new Promise.resolve({posts: [], meta: {pagination: {}}}));
         apiTagStub = sandbox.stub(api.tags, 'read').returns(new Promise.resolve({tags: []}));
         apiUserStub = sandbox.stub(api.users, 'read').returns(new Promise.resolve({users: []}));
-        apiSettingsStub = sandbox.stub(api.settings, 'read');
     });
 
     afterEach(function () {
+        config.set(origConfig);
         sandbox.restore();
     });
 
     describe('channel config', function () {
         beforeEach(function () {
-            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
-                settings: [{
-                    key: 'postsPerPage',
-                    value: '10'
-                }]
-            }));
+            config.set({theme: {postsPerPage: 10}});
         });
 
         it('should handle no post options', function (done) {
@@ -44,7 +42,6 @@ describe('fetchData', function () {
                 result.should.be.an.Object.with.properties('posts', 'meta');
                 result.should.not.have.property('data');
 
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledOnce.should.be.true;
                 apiPostsStub.firstCall.args[0].should.be.an.Object;
                 apiPostsStub.firstCall.args[0].should.have.property('include');
@@ -60,7 +57,6 @@ describe('fetchData', function () {
                 result.should.be.an.Object.with.properties('posts', 'meta');
                 result.should.not.have.property('data');
 
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledOnce.should.be.true;
                 apiPostsStub.firstCall.args[0].should.be.an.Object;
                 apiPostsStub.firstCall.args[0].should.have.property('include');
@@ -88,7 +84,6 @@ describe('fetchData', function () {
                 result.data.featured.should.be.an.Object.with.properties('posts', 'meta');
                 result.data.featured.should.not.have.properties('data');
 
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledTwice.should.be.true;
                 apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
@@ -117,7 +112,6 @@ describe('fetchData', function () {
                 result.data.featured.should.be.an.Object.with.properties('posts', 'meta');
                 result.data.featured.should.not.have.properties('data');
 
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledTwice.should.be.true;
                 apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
@@ -148,7 +142,6 @@ describe('fetchData', function () {
                 result.should.be.an.Object.with.properties('posts', 'meta', 'data');
                 result.data.should.be.an.Object.with.properties('tag');
 
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledOnce.should.be.true;
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
@@ -160,17 +153,11 @@ describe('fetchData', function () {
 
     describe('valid postsPerPage', function () {
         beforeEach(function () {
-            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
-                settings: [{
-                    key: 'postsPerPage',
-                    value: '10'
-                }]
-            }));
+            config.set({theme: {postsPerPage: 10}});
         });
 
         it('Adds limit & includes to options by default', function (done) {
             fetchData({}).then(function () {
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledOnce.should.be.true;
                 apiPostsStub.firstCall.args[0].should.be.an.Object;
                 apiPostsStub.firstCall.args[0].should.have.property('include');
@@ -182,17 +169,11 @@ describe('fetchData', function () {
 
     describe('invalid postsPerPage', function () {
         beforeEach(function () {
-            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
-                settings: [{
-                    key: 'postsPerPage',
-                    value: '-1'
-                }]
-            }));
+            config.set({theme: {postsPerPage: '-1'}});
         });
 
         it('Will not add limit if postsPerPage is not valid', function (done) {
             fetchData({}).then(function () {
-                apiSettingsStub.calledOnce.should.be.true;
                 apiPostsStub.calledOnce.should.be.true;
                 apiPostsStub.firstCall.args[0].should.be.an.Object;
                 apiPostsStub.firstCall.args[0].should.have.property('include');

--- a/core/test/unit/controllers/frontend/index_spec.js
+++ b/core/test/unit/controllers/frontend/index_spec.js
@@ -20,8 +20,7 @@ var moment   = require('moment'),
 should.equal(true, true);
 
 describe('Frontend Controller', function () {
-    var apiSettingsStub,
-        adminEditPagePath = '/ghost/editor/';
+    var adminEditPagePath = '/ghost/editor/';
 
     afterEach(function () {
         config.set(origConfig);
@@ -53,13 +52,12 @@ describe('Frontend Controller', function () {
                 });
             });
 
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
-            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
-                settings: [{
-                    key: 'postsPerPage',
-                    value: '10'
-                }]
-            }));
+            config.set({
+                theme: {
+                    permalinks: '/:slug/',
+                    postsPerPage: 10
+                }
+            });
 
             req = {
                 app: {get: function () { return 'casper';}},
@@ -137,20 +135,12 @@ describe('Frontend Controller', function () {
 
             sandbox.stub(api.tags, 'read').returns(new Promise.resolve({tags: [mockTags[0]]}));
 
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
-
-            apiSettingsStub.withArgs('postsPerPage').returns(Promise.resolve({
-                settings: [{
-                    key: 'postsPerPage',
-                    value: '10'
-                }]
-            }));
-            apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                settings: [{
-                    key: 'permalinks',
-                    value: '/tag/:slug/'
-                }]
-            }));
+            config.set({
+                theme: {
+                    permalinks: '/tag/:slug/',
+                    postsPerPage: '10'
+                }
+            });
 
             req = {
                 app: {get: function () { return 'casper';}},
@@ -278,7 +268,11 @@ describe('Frontend Controller', function () {
                 return Promise.resolve(post || {posts: []});
             });
 
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            config.set({
+                theme: {
+                    permalinks: '/:slug/'
+                }
+            });
 
             casper = {
                 assets: null,
@@ -304,11 +298,11 @@ describe('Frontend Controller', function () {
         describe('static pages', function () {
             describe('custom page templates', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:slug/'
+                        }
+                    });
                 });
 
                 it('it will render a custom page-slug template if it exists', function (done) {
@@ -359,11 +353,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to slug', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:slug/'
+                        }
+                    });
                 });
 
                 it('will render static page via /:slug/', function (done) {
@@ -432,11 +426,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to date', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:year/:month/:day/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:year/:month/:day/:slug/'
+                        }
+                    });
                 });
 
                 it('will render static page via /:slug', function (done) {
@@ -492,11 +486,11 @@ describe('Frontend Controller', function () {
         describe('post', function () {
             describe('permalink set to slug', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:slug/'
+                        }
+                    });
 
                     mockPosts[1].posts[0].url = '/' + mockPosts[1].posts[0].slug + '/';
                 });
@@ -584,11 +578,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to date', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:year/:month/:day/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:year/:month/:day/:slug/'
+                        }
+                    });
 
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
                     mockPosts[1].posts[0].url = '/' + date + '/' + mockPosts[1].posts[0].slug + '/';
@@ -674,11 +668,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to author', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:author/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: 'author/:slug/'
+                        }
+                    });
 
                     // set post url to permalink-defined url
                     mockPosts[1].posts[0].url = '/test/' + mockPosts[1].posts[0].slug + '/';
@@ -764,11 +758,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to custom format', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:year/:slug/'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:year/:slug/'
+                        }
+                    });
 
                     config.set({paths: {availableThemes: {casper: casper}}});
 
@@ -881,11 +875,11 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to custom format no slash', function () {
                 beforeEach(function () {
-                    apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                        settings: [{
-                            value: '/:year/:slug'
-                        }]
-                    }));
+                    config.set({
+                        theme: {
+                            permalinks: '/:year/:slug/'
+                        }
+                    });
 
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY');
                     mockPosts[1].posts[0].url = '/' + date + '/' + mockPosts[1].posts[0].slug + '/';
@@ -931,7 +925,11 @@ describe('Frontend Controller', function () {
 
             defaultPath = path.join(config.paths.appRoot, '/core/server/views/private.hbs');
 
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            config.set({
+                theme: {
+                    permalinks: '/:slug/'
+                }
+            });
         });
 
         it('Should render default password page when theme has no password template', function (done) {
@@ -1034,7 +1032,11 @@ describe('Frontend Controller', function () {
                 return Promise.resolve(post || {posts: []});
             });
 
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
+            config.set({
+                theme: {
+                    permalinks: '/:slug/'
+                }
+            });
 
             req = {
                 app: {get: function () {return 'casper'; }},

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -248,16 +248,8 @@ describe('RSS', function () {
     });
 
     describe('dataBuilder', function () {
-        var apiSettingsStub, apiBrowseStub, apiTagStub, apiUserStub;
+        var apiBrowseStub, apiTagStub, apiUserStub;
         beforeEach(function () {
-            apiSettingsStub = sandbox.stub(api.settings, 'read');
-            apiSettingsStub.withArgs('permalinks').returns(Promise.resolve({
-                settings: [{
-                    key: 'permalinks',
-                    value: '/:slug/'
-                }]
-            }));
-
             apiBrowseStub = sandbox.stub(api.posts, 'browse', function () {
                 return Promise.resolve({posts: [], meta: {pagination: {pages: 3}}});
             });
@@ -284,13 +276,13 @@ describe('RSS', function () {
 
             config.set({url: 'http://my-ghost-blog.com', theme: {
                 title: 'Test',
-                description: 'Some Text'
+                description: 'Some Text',
+                permalinks: '/:slug/'
             }});
         });
 
         it('should process the data correctly for the index feed', function (done) {
             res.send = function send(xmlData) {
-                apiSettingsStub.calledOnce.should.be.true;
                 apiBrowseStub.calledOnce.should.be.true;
                 apiBrowseStub.calledWith({page: 1, include: 'author,tags,fields'}).should.be.true;
                 xmlData.should.match(/<channel><title><!\[CDATA\[Test\]\]><\/title>/);
@@ -311,7 +303,6 @@ describe('RSS', function () {
 
             // test
             res.send = function send(xmlData) {
-                apiSettingsStub.calledOnce.should.be.true;
                 apiBrowseStub.calledOnce.should.be.true;
                 apiBrowseStub.calledWith({page: 1, filter: 'tags:magic', include: 'author,tags,fields'}).should.be.true;
                 apiTagStub.calledOnce.should.be.true;
@@ -330,7 +321,6 @@ describe('RSS', function () {
 
             // test
             res.send = function send(xmlData) {
-                apiSettingsStub.calledOnce.should.be.true;
                 apiBrowseStub.calledOnce.should.be.true;
                 apiBrowseStub.calledWith({page: 1, filter: 'author:joe', include: 'author,tags,fields'}).should.be.true;
                 apiUserStub.calledOnce.should.be.true;

--- a/core/test/unit/sitemap_spec.js
+++ b/core/test/unit/sitemap_spec.js
@@ -295,20 +295,7 @@ describe('Sitemap', function () {
     });
 
     describe('Generators', function () {
-        var stubPermalinks = function (generator) {
-                sandbox.stub(generator, 'getPermalinksValue', function () {
-                    return Promise.resolve({
-                        id: 13,
-                        uuid: 'ac6d6bb2-0b64-4941-b5ef-e69000bb738a',
-                        key: 'permalinks',
-                        value: '/:slug/',
-                        type: 'blog'
-                    });
-                });
-
-                return generator;
-            },
-            stubUrl = function (generator) {
+        var stubUrl = function (generator) {
                 sandbox.stub(generator, 'getUrlForDatum', function (datum) {
                     return 'http://my-ghost-blog.com/url/' + datum.id;
                 });
@@ -329,8 +316,6 @@ describe('Sitemap', function () {
             it('can initialize with empty siteMapContent', function (done) {
                 var generator = new BaseGenerator();
 
-                stubPermalinks(generator);
-
                 generator.init().then(function () {
                     should.exist(generator.siteMapContent);
 
@@ -343,7 +328,6 @@ describe('Sitemap', function () {
             it('can initialize with non-empty siteMapContent', function (done) {
                 var generator = new BaseGenerator();
 
-                stubPermalinks(generator);
                 stubUrl(generator);
 
                 sandbox.stub(generator, 'getData', function () {
@@ -419,7 +403,6 @@ describe('Sitemap', function () {
             it('can initialize with non-empty siteMapContent', function (done) {
                 var generator = new PostGenerator();
 
-                stubPermalinks(generator);
                 stubUrl(generator);
 
                 sandbox.stub(generator, 'getData', function () {


### PR DESCRIPTION
This PR is a WIP demonstrating how much simpler our code can become if we use static caches for key blog settings, instead of async/promise-based lookups.

By adding the `permalinks` and `postsPerPage` blog settings to the already existing `config.theme` cache (updated whenever the settings change) that we have for passing these things down to the theme, there are several pieces of complex logic that can be moved from the codebase, including:
- the crazy permalinks dance we're doing with events and promises inside the post model in order to send `url` with a post
- permalinks value fetching inside of sitemaps
- complex code when fetching data for channels & rss
