### PR TITLE
Change server-side labs utility to be synchronous

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -11,7 +11,7 @@ var _            = require('lodash'),
     docName      = 'settings',
     settings,
 
-    updateConfigTheme,
+    updateConfigCache,
     updateSettingsCache,
     settingsFilter,
     filterPaths,
@@ -34,7 +34,21 @@ var _            = require('lodash'),
 * Maintains the cache of theme specific variables that are reliant on settings.
 * @private
 */
-updateConfigTheme = function () {
+updateConfigCache = function () {
+    var errorMessages = [
+        'Error: Invalid JSON in settings.labs',
+        'The column with key "labs" could not be parsed as JSON',
+        'Please try updating a setting on the labs page, or manually editing your DB'
+    ], labsValue = {};
+
+    if (settingsCache.labs && settingsCache.labs.value) {
+        try {
+            labsValue = JSON.parse(settingsCache.labs.value);
+        } catch (e) {
+            errors.logError.apply(this, errorMessages);
+        }
+    }
+
     config.set({
         theme: {
             title: (settingsCache.title && settingsCache.title.value) || '',
@@ -42,7 +56,8 @@ updateConfigTheme = function () {
             logo: (settingsCache.logo && settingsCache.logo.value) || '',
             cover: (settingsCache.cover && settingsCache.cover.value) || '',
             navigation: (settingsCache.navigation && JSON.parse(settingsCache.navigation.value)) || []
-        }
+        },
+        labs: labsValue
     });
 };
 
@@ -61,7 +76,7 @@ updateSettingsCache = function (settings) {
             settingsCache[key] = setting;
         });
 
-        updateConfigTheme();
+        updateConfigCache();
 
         return Promise.resolve(settingsCache);
     }
@@ -70,7 +85,7 @@ updateSettingsCache = function (settings) {
         .then(function (result) {
             settingsCache = readSettingsResult(result.models);
 
-            updateConfigTheme();
+            updateConfigCache();
 
             return settingsCache;
         });

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -149,15 +149,13 @@ module.exports = function getWithLabs(context, options) {
             'See http://support.ghost.org/public-api-beta'
         ];
 
-    return labs.isSet('publicAPI').then(function (publicAPI) {
-        if (publicAPI === true) {
-            // get helper is  active
-            return get.call(self, context, options);
-        } else {
-            errors.logError.apply(this, errorMessages);
-            return Promise.resolve(function noGetHelper() {
-                return '<script>console.error("' + errorMessages.join(' ') + '");</script>';
-            });
-        }
-    });
+    if (labs.isSet('publicAPI') === true) {
+        // get helper is  active
+        return get.call(self, context, options);
+    } else {
+        errors.logError.apply(this, errorMessages);
+        return Promise.resolve(function noGetHelper() {
+            return '<script>console.error("' + errorMessages.join(' ') + '");</script>';
+        });
+    }
 };

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -23,30 +23,27 @@ var hbs             = require('express-hbs'),
     excerpt             = require('./excerpt'),
     tagsHelper          = require('./tags'),
     imageHelper         = require('./image'),
-
     labs                = require('../utils/labs'),
 
     blog,
     ghost_head;
 
 function getClient() {
-    return labs.isSet('publicAPI').then(function (publicAPI) {
-        if (publicAPI === true) {
-            return api.clients.read({slug: 'ghost-frontend'}).then(function (client) {
-                client = client.clients[0];
-                if (client.status === 'enabled') {
-                    return {
-                        id: client.slug,
-                        secret: client.secret
-                    };
-                }
+    if (labs.isSet('publicAPI') === true) {
+        return api.clients.read({slug: 'ghost-frontend'}).then(function (client) {
+            client = client.clients[0];
+            if (client.status === 'enabled') {
+                return {
+                    id: client.slug,
+                    secret: client.secret
+                };
+            }
 
-                return {};
-            });
-        }
+            return {};
+        });
+    }
 
-        return {};
-    });
+    return {};
 }
 
 function writeMetaTag(property, content, type) {

--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -158,17 +158,15 @@ auth = {
 
     // ### Require user depending on public API being activated.
     requiresAuthorizedUserPublicAPI: function requiresAuthorizedUserPublicAPI(req, res, next) {
-        return labs.isSet('publicAPI').then(function (publicAPI) {
-            if (publicAPI === true) {
+        if (labs.isSet('publicAPI') === true) {
+            return next();
+        } else {
+            if (req.user) {
                 return next();
             } else {
-                if (req.user) {
-                    return next();
-                } else {
-                    return errors.handleAPIError(new errors.NoPermissionError('Please Sign In'), req, res, next);
-                }
+                return errors.handleAPIError(new errors.NoPermissionError('Please Sign In'), req, res, next);
             }
-        });
+        }
     }
 };
 

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -1,28 +1,10 @@
-var _   = require('lodash'),
-    api = require('../api'),
+var config = require('../config'),
     flagIsSet;
 
 flagIsSet = function flagIsSet(flag) {
-    return api.settings.read({key: 'labs', context: {internal: true}}).then(function (response) {
-        var labs,
-            labsValue;
+    var labsConfig = config.labs;
 
-        labs = _.find(response.settings, function (setting) {
-            return setting.key === 'labs';
-        });
-
-        if (!labs || !labs.value) {
-            return false;
-        }
-
-        try {
-            labsValue = JSON.parse(labs.value);
-        } catch (e) {
-            return false;
-        }
-
-        return !!labsValue[flag] && labsValue[flag] === true;
-    });
+    return !!labsConfig[flag] && labsConfig[flag] === true;
 };
 
 module.exports.isSet = flagIsSet;

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -25,7 +25,7 @@ describe('{{#get}} helper', function () {
     beforeEach(function () {
         fn = sandbox.spy();
         inverse = sandbox.spy();
-        sandbox.stub(labs, 'isSet').returns(new Promise.resolve(true));
+        sandbox.stub(labs, 'isSet').returns(true);
     });
 
     afterEach(function () {

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -43,7 +43,7 @@ describe('{{ghost_head}} helper', function () {
             ]
         }));
 
-        sandbox.stub(labs, 'isSet').returns(new Promise.resolve(true));
+        sandbox.stub(labs, 'isSet').returns(true);
     });
 
     function expectGhostClientMeta(rendered) {


### PR DESCRIPTION
This achieves 'Rework the server-side labs utility to be synchronous (so that {{tags}} doesn't become async)' from the task list in #6165, but is totally separate to the tags work itself. Figured it made sense to get this merged separately.

refs #6165
- Use the settings cache to populate config.labs whenever settings change
- Use the labs util just to check if a flag isSet synchronously
