### PR TITLE
Lazy-load the middleware stack

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -15,7 +15,6 @@ var express     = require('express'),
     errors      = require('./errors'),
     helpers     = require('./helpers'),
     mailer      = require('./mail'),
-    middleware  = require('./middleware'),
     migrations  = require('./data/migration'),
     models      = require('./models'),
     permissions = require('./permissions'),
@@ -197,7 +196,7 @@ function init(options) {
         helpers.loadCoreHelpers(adminHbs);
 
         // ## Middleware and Routing
-        middleware(blogApp, adminApp);
+        require('./middleware')(blogApp, adminApp);
 
         // Log all theme errors and warnings
         validateThemes(config.paths.themePath)


### PR DESCRIPTION
Ghost's [boot up process](https://github.com/TryGhost/Ghost/issues/2182) and [middleware](https://github.com/TryGhost/Ghost/issues/4172) have needed refactoring for a while. Progress is being made slowly, and although I know we probably need to do something very different and a bit more drastic, today I want to propose this singular change for discussion to make things a little easier.

I've been playing around trying to change some things in our channel config file based on the new labs flag in #6166, and am struggling because so much stuff is required right at the very beginning of the init process, before the models / api etc layer is initialised and the settings are fetched from the DB. Essentially, the channel config module gets loaded and cached by require long before the labs data is available.

This change makes it so the entire middleware stack, which includes routing and all of our frontend controller behaviour, isn't required until after the big list of `init()` calls is finished. 
- move require('./middleware') after the app bootup
