### PR TITLE
fixing 'undefined is not a function' error when loading apps

### DIFF
--- a/core/server/apps/permissions.js
+++ b/core/server/apps/permissions.js
@@ -2,7 +2,7 @@
 var fs = require('fs'),
     Promise = require('bluebird'),
     path = require('path'),
-    parsePackageJson = require('../utils/parse-package-json').parsePackageJson;
+    parsePackageJson = require('../utils/parse-package-json');
 
 function AppPermissions(appPath) {
     this.appPath = appPath;


### PR DESCRIPTION
The 'parsePackageJson' method is itself the export defined by parse-package-json; it is not a method on the export. Looks like this bug was a result of a refactoring away from 'require-tree', but not removing the method reference.

I was able to successfully load apps after this change.
