### PR TITLE
Fix Select Component

### DIFF
--- a/core/client/app/components/gh-select-native.js
+++ b/core/client/app/components/gh-select-native.js
@@ -21,7 +21,9 @@ export default Component.extend({
 
     actions: {
         change() {
-            let [selectEl] = this.$('select');
+            // jscs:disable requireArrayDestructuring
+            let selectEl = this.$('select')[0];
+            // jscs:enable requireArrayDestructuring
             let {selectedIndex} = selectEl;
 
             // decrement index by 1 if we have a prompt


### PR DESCRIPTION
jQuery instance isn't iterable. So we can't really destructuring it. Quick fix will be just use simple syntax. :smile:

closed https://github.com/TryGhost/Ghost/issues/6171
