### PR TITLE
Prevent 404-handler mixin from erroring on non-adapter errors

### DIFF
--- a/core/client/app/mixins/404-handler.js
+++ b/core/client/app/mixins/404-handler.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Mixin.create({
     actions: {
         error(error, transition) {
-            if (error.errors[0].errorType === 'NotFoundError') {
+            if (error.errors && error.errors[0].errorType === 'NotFoundError') {
                 transition.abort();
 
                 let routeInfo = transition.handlerInfos[transition.handlerInfos.length - 1];


### PR DESCRIPTION
no issue
- add a check for existence of `error.errors` as that won't be present on non-404 errors - fixes non-404 errors such as "no action handled x" being hidden by a completely different error
