### PR TITLE
Make channel config dynamic

### DIFF
--- a/core/server/controllers/frontend/channel-config.js
+++ b/core/server/controllers/frontend/channel-config.js
@@ -1,42 +1,47 @@
-var config = require('../../config'),
-    defaults;
+var _ = require('lodash'),
+    config = require('../../config'),
+    getConfig;
 
-defaults = {
-    index: {
-        name: 'index',
-        route: '/',
-        frontPageTemplate: 'home'
-    },
-    tag: {
-        name: 'tag',
-        route: '/' + config.routeKeywords.tag + '/:slug/',
-        postOptions: {
-            filter: 'tags:%s'
+getConfig = function getConfig(name) {
+    var defaults = {
+        index: {
+            name: 'index',
+            route: '/',
+            frontPageTemplate: 'home'
         },
-        data: {
-            tag: {
-                type: 'read',
-                resource: 'tags',
-                options: {slug: '%s'}
-            }
+        tag: {
+            name: 'tag',
+            route: '/' + config.routeKeywords.tag + '/:slug/',
+            postOptions: {
+                filter: 'tags:%s'
+            },
+            data: {
+                tag: {
+                    type: 'read',
+                    resource: 'tags',
+                    options: {slug: '%s'}
+                }
+            },
+            slugTemplate: true
         },
-        slugTemplate: true
-    },
-    author: {
-        name: 'author',
-        route: '/' + config.routeKeywords.author + '/:slug/',
-        postOptions: {
-            filter: 'author:%s'
-        },
-        data: {
-            author: {
-                type: 'read',
-                resource: 'users',
-                options: {slug: '%s'}
-            }
-        },
-        slugTemplate: true
-    }
+        author: {
+            name: 'author',
+            route: '/' + config.routeKeywords.author + '/:slug/',
+            postOptions: {
+                filter: 'author:%s'
+            },
+            data: {
+                author: {
+                    type: 'read',
+                    resource: 'users',
+                    options: {slug: '%s'}
+                }
+            },
+            slugTemplate: true
+        }
+    };
+
+    return _.cloneDeep(defaults[name]);
 };
 
-module.exports = defaults;
+module.exports = getConfig;

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -41,10 +41,11 @@ function renderPost(req, res) {
     };
 }
 
-function renderChannel(channelOpts) {
+function renderChannel(name) {
     return function renderChannel(req, res, next) {
         // Parse the parameters we need from the URL
-        var pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
+        var channelOpts = channelConfig(name),
+            pageParam = req.params.page !== undefined ? parseInt(req.params.page, 10) : 1,
             slugParam = req.params.slug ? safeString(req.params.slug) : undefined;
 
         // Ensure we at least have an empty object for postOptions
@@ -102,20 +103,20 @@ function renderChannel(channelOpts) {
 }
 
 frontendControllers = {
-    index: renderChannel(_.cloneDeep(channelConfig.index)),
-    tag: renderChannel(_.cloneDeep(channelConfig.tag)),
-    author: renderChannel(_.cloneDeep(channelConfig.author)),
+    index: renderChannel('index'),
+    tag: renderChannel('tag'),
+    author: renderChannel('author'),
     rss: function (req, res, next) {
         // Temporary hack, channels will allow us to resolve this better eventually
         var tagPattern = new RegExp('^\\/' + config.routeKeywords.tag + '\\/.+'),
             authorPattern = new RegExp('^\\/' + config.routeKeywords.author + '\\/.+');
 
         if (tagPattern.test(res.locals.relativeUrl)) {
-            req.channelConfig = _.cloneDeep(channelConfig.tag);
+            req.channelConfig = channelConfig('tag');
         } else if (authorPattern.test(res.locals.relativeUrl)) {
-            req.channelConfig = _.cloneDeep(channelConfig.author);
+            req.channelConfig = channelConfig('author');
         } else {
-            req.channelConfig = _.cloneDeep(channelConfig.index);
+            req.channelConfig = channelConfig('index');
         }
 
         req.channelConfig.isRSS = true;

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -104,7 +104,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -146,7 +146,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -175,7 +175,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -209,7 +209,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -241,7 +241,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -297,7 +297,7 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
             rss(req, res, failTest(done));
         });
@@ -306,7 +306,7 @@ describe('RSS', function () {
             // setup
             req.originalUrl = '/tag/magic/rss/';
             req.params.slug = 'magic';
-            req.channelConfig = channelConfig.tag;
+            req.channelConfig = channelConfig('tag');
             req.channelConfig.isRSS = true;
 
             // test
@@ -325,7 +325,7 @@ describe('RSS', function () {
         it('should process the data correctly for an author feed', function (done) {
             req.originalUrl = '/author/joe/rss/';
             req.params.slug = 'joe';
-            req.channelConfig = channelConfig.author;
+            req.channelConfig = channelConfig('author');
             req.channelConfig.isRSS = true;
 
             // test
@@ -369,7 +369,7 @@ describe('RSS', function () {
                     results: {posts: [], meta: {pagination: {pages: 1}}}
                 });
             });
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             function secondCall() {
@@ -420,7 +420,7 @@ describe('RSS', function () {
         it('Redirects to /rss/ if page number is -1', function () {
             req = {params: {page: -1}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, null);
@@ -433,7 +433,7 @@ describe('RSS', function () {
         it('Redirects to /rss/ if page number is 0', function () {
             req = {params: {page: 0}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, null);
@@ -446,7 +446,7 @@ describe('RSS', function () {
         it('Redirects to /rss/ if page number is 1', function () {
             req = {params: {page: 1}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, null);
@@ -461,7 +461,7 @@ describe('RSS', function () {
 
             req = {params: {page: 0}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, null);
@@ -476,7 +476,7 @@ describe('RSS', function () {
 
             req = {params: {page: 1}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, null);
@@ -491,7 +491,7 @@ describe('RSS', function () {
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, failTest(done)).then(function () {
@@ -507,7 +507,7 @@ describe('RSS', function () {
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.index;
+            req.channelConfig = channelConfig('index');
             req.channelConfig.isRSS = true;
 
             rss(req, res, failTest(done)).then(function () {


### PR DESCRIPTION
This is instead of #6172 (lazy-loading middleware). It is both part of the progress towards making Ghost's internal concept of channels truly dynamic, and also needed to make it possible to change these values via labs (for hidden/internal tagging) and for any other settings.

refs #5091, #6166
- fetch channel config via an internal function
- prevents channel config from being statically cached at runtime
- means that labs & other settings can be used to change these values
