### PR TITLE
[Spike] Internal/Hidden Tag admin support

### DIFF
--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -13,6 +13,7 @@ export default Component.extend({
     scratchDescription: boundOneWay('tag.description'),
     scratchMetaTitle: boundOneWay('tag.meta_title'),
     scratchMetaDescription: boundOneWay('tag.meta_description'),
+    scratchHidden: boundOneWay('tag.hidden'),
 
     isViewingSubview: false,
 
@@ -110,6 +111,10 @@ export default Component.extend({
 
         clearCoverImage() {
             this.attrs.setProperty('image', '');
+        },
+
+        setHidden(event) {
+            this.attrs.setProperty('hidden', event.target.checked);
         },
 
         setUploaderReference() {

--- a/core/client/app/controllers/feature.js
+++ b/core/client/app/controllers/feature.js
@@ -25,6 +25,10 @@ export default Controller.extend(PromiseProxyMixin, {
         return this.get('config.publicAPI') || this.get('labs.publicAPI');
     }),
 
+    hiddenTags: computed('config.hiddenTags', 'labs.hiddenTags', function () {
+        return this.get('config.hiddenTags') || this.get('labs.hiddenTags');
+    }),
+
     init() {
         this._super(...arguments);
 

--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -15,6 +15,7 @@ export default Controller.extend(SettingsMenuMixin, {
 
     application: inject.controller(),
     config: inject.service(),
+    feature: inject.controller(),
     ghostPaths: inject.service('ghost-paths'),
     notifications: inject.service(),
     session: inject.service(),
@@ -457,34 +458,40 @@ export default Controller.extend(SettingsMenuMixin, {
             });
         },
 
-        addTag(tagName, index) {
+        addTag(name, index) {
             let currentTags = this.get('model.tags');
             let currentTagNames = currentTags.map((tag) => {
                 return tag.get('name').toLowerCase();
             });
-            let availableTagNames,
-                tagToAdd;
+            let hashtagRegex = /^#.?/;
+            let hashtag = false;
 
-            tagName = tagName.trim();
+            name = name.trim();
+
+            if (this.get('feature.hashtags')) {
+                hashtag = hashtagRegex.test(name);
+            }
 
             // abort if tag is already selected
-            if (currentTagNames.contains(tagName.toLowerCase())) {
+            if (currentTagNames.contains(name.toLowerCase())) {
                 return;
             }
 
             this.get('availableTags').then((availableTags) => {
-                availableTagNames = availableTags.map((tag) => {
+                let availableTagNames = availableTags.map((tag) => {
                     return tag.get('name').toLowerCase();
                 });
+                let tagToAdd;
 
                 // find existing tag or create new
-                if (availableTagNames.contains(tagName.toLowerCase())) {
+                if (availableTagNames.contains(name.toLowerCase())) {
                     tagToAdd = availableTags.find((tag) => {
-                        return tag.get('name').toLowerCase() === tagName.toLowerCase();
+                        return tag.get('name').toLowerCase() === name.toLowerCase();
                     });
                 } else {
                     tagToAdd = this.get('store').createRecord('tag', {
-                        name: tagName
+                        name,
+                        hashtag
                     });
 
                     // we need to set a UUID so that selectize has a unique value

--- a/core/client/app/controllers/posts.js
+++ b/core/client/app/controllers/posts.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Controller, compare, computed} = Ember;
+const {Controller, compare, computed, inject} = Ember;
 const {equal} = computed;
 
 // a custom sort function is needed in order to sort the posts list the same way the server would:
@@ -67,6 +67,8 @@ function publishedAtCompare(item1, item2) {
 }
 
 export default Controller.extend({
+
+    feature: inject.controller(),
 
     // See PostsRoute's shortcuts
     postListFocused: equal('keyboardFocus', 'postList'),

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -41,6 +41,16 @@ export default Controller.extend({
         }
     }),
 
+    useHiddenTags: computed('feature.hiddenTags', {
+        get() {
+            return this.get('feature.hiddenTags');
+        },
+        set(key, value) {
+            this.saveLabs('hiddenTags', value);
+            return value;
+        }
+    }),
+
     actions: {
         onUpload(file) {
             let formData = new FormData();

--- a/core/client/app/controllers/settings/tags/tag.js
+++ b/core/client/app/controllers/settings/tags/tag.js
@@ -8,6 +8,7 @@ export default Controller.extend({
     tag: alias('model'),
     isMobile: alias('tagsController.isMobile'),
 
+    feature: inject.controller(),
     tagsController: inject.controller('settings.tags'),
     notifications: inject.service(),
 
@@ -15,7 +16,9 @@ export default Controller.extend({
         let tag = this.get('tag');
         let currentValue = tag.get(propKey);
 
-        newValue = newValue.trim();
+        if (newValue && newValue.trim) {
+            newValue = newValue.trim();
+        }
 
         // Quit if there was no change
         if (newValue === currentValue) {

--- a/core/client/app/mirage/factories/tag.js
+++ b/core/client/app/mirage/factories/tag.js
@@ -5,7 +5,7 @@ export default Mirage.Factory.extend({
     created_at() { return  '2015-09-11T09:44:29.871Z'; },
     created_by() { return  1; },
     description(i) { return  `Description for tag ${i}.`; },
-    hidden() { return  false; },
+    hashtag() { return  false; },
     image(i) { return  `/content/images/2015/10/tag-${i}.jpg`; },
     meta_description(i) { return  `Meta description for tag ${i}.`; },
     meta_title(i) { return  `Meta Title for tag ${i}`; },

--- a/core/client/app/models/post.js
+++ b/core/client/app/models/post.js
@@ -4,7 +4,7 @@ import DS from 'ember-data';
 import ValidationEngine from 'ghost/mixins/validation-engine';
 
 const {computed, inject} = Ember;
-const {equal} = computed;
+const {equal, filterBy} = computed;
 const {Model, attr, belongsTo, hasMany} = DS;
 
 export default Model.extend(ValidationEngine, {
@@ -63,6 +63,7 @@ export default Model.extend(ValidationEngine, {
 
     isPublished: equal('status', 'published'),
     isDraft: equal('status', 'draft'),
+    hashtags: filterBy('tags', 'hashtag', true),
 
     // remove client-generated tags, which have `id: null`.
     // Ember Data won't recognize/update them automatically

--- a/core/client/app/models/tag.js
+++ b/core/client/app/models/tag.js
@@ -15,7 +15,7 @@ export default Model.extend(ValidationEngine, {
     meta_title: attr('string'),
     meta_description: attr('string'),
     image: attr('string'),
-    hidden: attr('boolean'),
+    hashtag: attr('boolean'),
     created_at: attr('moment-date'),
     updated_at: attr('moment-date'),
     created_by: attr(),

--- a/core/client/app/styles/layouts/content.css
+++ b/core/client/app/styles/layouts/content.css
@@ -106,6 +106,10 @@
     opacity: 0;
 }
 
+.content-list .status {
+    margin-right: 7px;
+}
+
 .content-list .status .draft {
     color: var(--red);
 }

--- a/core/client/app/templates/components/gh-tag-settings-form.hbs
+++ b/core/client/app/templates/components/gh-tag-settings-form.hbs
@@ -31,6 +31,19 @@
                 <p>Maximum: <b>200</b> characters. You’ve used {{gh-count-down-characters scratchDescription 200}}</p>
             {{/gh-form-group}}
 
+            {{#if hiddenTags}}
+                {{#gh-form-group}}
+                    <label>Hidden Tag</label>
+                    <div class="for-checkbox">
+                        <label class="checkbox" for="tag-hidden">
+                            {{input id="tag-hidden" name="hidden" type="checkbox" checked=scratchHidden change=(action 'setHidden')}}
+                            <span class="input-toggle-component"></span>
+                            <p>Tag is hidden for internal use</p>
+                        </label>
+                    </div>
+                {{/gh-form-group}}
+            {{/if}}
+
             <ul class="nav-list nav-list-block">
                 <li class="nav-list-item" {{action 'openMeta'}}>
                     <button type="button" class="meta-data-button">

--- a/core/client/app/templates/posts.hbs
+++ b/core/client/app/templates/posts.hbs
@@ -32,6 +32,11 @@
                                         <span class="draft">Draft</span>
                                     {{/if}}
                                 </span>
+                                {{#if feature.hashtags}}
+                                    {{#each post.hashtags as |hashtag|}}
+                                        <span class="label label-default">{{hashtag.name}}</span>
+                                    {{/each}}
+                                {{/if}}
                             </section>
                         {{/link-to}}
                     {{/gh-posts-list-item}}

--- a/core/client/app/templates/settings/labs.hbs
+++ b/core/client/app/templates/settings/labs.hbs
@@ -52,6 +52,11 @@
                         <span class="input-toggle-component"></span>
                         <p>Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.</p>
                     </label>
+                    <label class="checkbox" for="labs-hiddenTags">
+                        {{input id="labs-hiddenTags" name="labs[hiddenTags]" type="checkbox" checked=useHiddenTags}}
+                        <span class="input-toggle-component"></span>
+                        <p>Hidden Tags - tags which don't show up in your theme.</p>
+                    </label>
                 </div>
             </fieldset>
         </form>

--- a/core/client/app/templates/settings/tags/tag.hbs
+++ b/core/client/app/templates/settings/tags/tag.hbs
@@ -1,1 +1,4 @@
-{{gh-tag-settings-form tag=tag setProperty=(action "setProperty") openModal="openModal"}}
+{{gh-tag-settings-form tag=tag
+                       setProperty=(action "setProperty")
+                       openModal="openModal"
+                       hiddenTags=feature.hiddenTags}}

--- a/core/client/tests/acceptance/settings/tags-test.js
+++ b/core/client/tests/acceptance/settings/tags-test.js
@@ -183,6 +183,12 @@ describe('Acceptance: Settings - Tags', function () {
                     .to.equal('New Name');
             });
 
+            // trigger save of boolean value, will error if not handled correctly
+            // TODO: it may be possible to use Pretender's request tracking to
+            // verify that the correct value was sent to the API
+            // TODO: re-enable once out of labs or test with hiddenTags enabled
+            // click('input[name="hidden"]');
+
             // start new tag
             click('.view-actions .btn-green');
 

--- a/core/client/tests/integration/components/gh-tag-settings-form-test.js
+++ b/core/client/tests/integration/components/gh-tag-settings-form-test.js
@@ -167,6 +167,30 @@ describeComponent(
             });
         });
 
+        it('triggers setProperty action on hidden tag checkbox change', function () {
+            let expectedProperty = 'hidden';
+            let expectedValue;
+
+            this.set('actions.setProperty', function (property, value) {
+                expect(property, 'property').to.equal(expectedProperty);
+                expect(value, 'value').to.equal(expectedValue);
+            });
+
+            this.render(hbs`
+                {{gh-tag-settings-form tag=tag setProperty=(action 'setProperty') openModal='openModal' hiddenTags=true}}
+            `);
+
+            expectedValue = true;
+            run(() => {
+                this.$('input[name="hidden"]').click();
+            });
+
+            expectedValue = false;
+            run(() => {
+                this.$('input[name="hidden"]').click();
+            });
+        });
+
         it('displays error messages for validated fields', function () {
             let errors = this.get('tag.errors');
             let hasValidated = this.get('tag.hasValidated');

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -11,6 +11,7 @@ function getValidKeys() {
     var validKeys = {
             fileStorage: config.fileStorage === false ? false : true,
             publicAPI: config.publicAPI === true ? true : false,
+            hiddenTags: config.hiddenTags === true ? true : false,
             apps: config.apps === true ? true : false,
             version: config.ghostVersion,
             environment: process.env.NODE_ENV,

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -53,7 +53,7 @@ tags = {
      * @return {Promise<Tag>} Tag
      */
     read: function read(options) {
-        var attrs = ['id', 'slug'],
+        var attrs = ['id', 'slug', 'hidden'],
             tasks;
 
         /**

--- a/core/server/controllers/frontend/channel-config.js
+++ b/core/server/controllers/frontend/channel-config.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
     config = require('../../config'),
+    labs = require('../../utils/labs'),
     getConfig;
 
 getConfig = function getConfig(name) {
@@ -13,13 +14,13 @@ getConfig = function getConfig(name) {
             name: 'tag',
             route: '/' + config.routeKeywords.tag + '/:slug/',
             postOptions: {
-                filter: 'tags:%s'
+                filter: labs.isSet('hiddenTags') ? 'tags:%s+tags.hidden:false' : 'tags:%s'
             },
             data: {
                 tag: {
                     type: 'read',
                     resource: 'tags',
-                    options: {slug: '%s'}
+                    options: labs.isSet('hiddenTags') ? {slug: '%s', hidden: false} : {slug: '%s'}
                 }
             },
             slugTemplate: true

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -33,8 +33,9 @@ tagUpdate = {
     },
 
     createTagThenAttachTagToPost: function createTagThenAttachTagToPost(TagModel, post, tag, index, options) {
+        var fields = ['name', 'slug', 'description', 'image', 'hidden', 'parent_id', 'meta_title', 'meta_description'];
         return function () {
-            return TagModel.add({name: tag.name}, options).then(function then(createdTag) {
+            return TagModel.add(_.pick(tag, fields), options).then(function then(createdTag) {
                 return tagUpdate.attachTagToPost(post, createdTag, index, options)();
             });
         };

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -75,7 +75,8 @@ Tag = ghostBookshelf.Model.extend({
             // whitelists for the `options` hash argument on methods, by method name.
             // these are the only options that can be passed to Bookshelf / Knex.
             validOptions = {
-                findPage: ['page', 'limit', 'columns', 'filter', 'order']
+                findPage: ['page', 'limit', 'columns', 'filter', 'order'],
+                findOne: ['hidden']
             };
 
         if (validOptions[methodName]) {

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -4,7 +4,7 @@ var config = require('../config'),
 flagIsSet = function flagIsSet(flag) {
     var labsConfig = config.labs;
 
-    return !!labsConfig[flag] && labsConfig[flag] === true;
+    return labsConfig && labsConfig[flag] && labsConfig[flag] === true;
 };
 
 module.exports.isSet = flagIsSet;

--- a/core/test/unit/controllers/frontend/channel-config_spec.js
+++ b/core/test/unit/controllers/frontend/channel-config_spec.js
@@ -1,0 +1,54 @@
+/*globals describe, afterEach, it*/
+/*jshint expr:true*/
+var should   = require('should'),
+    sinon    = require('sinon'),
+
+// Stuff we are testing
+    labs      = require('../../../../server/utils/labs'),
+    channelConfig = require('../../../../server/controllers/frontend/channel-config'),
+
+    sandbox = sinon.sandbox.create();
+
+describe('Channel Config', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('should get the index config', function () {
+        var result = channelConfig('index');
+        should.exist(result);
+        result.name.should.eql('index');
+    });
+
+    it('should get the author config', function () {
+        var result = channelConfig('author');
+        should.exist(result);
+        result.name.should.eql('author');
+    });
+
+    it('should get the tag config', function () {
+        var result = channelConfig('tag');
+        should.exist(result);
+        result.name.should.eql('tag');
+    });
+
+    describe('hidden tags labs flag', function () {
+        it('should return old tag config if labs flag is not set', function () {
+            sandbox.stub(labs, 'isSet').returns(false);
+            var result = channelConfig('tag');
+            should.exist(result);
+            result.name.should.eql('tag');
+            result.postOptions.filter.should.eql('tags:%s');
+            result.data.tag.options.should.eql({slug: '%s'});
+        });
+
+        it('should return new tag config if labs flag is not set', function () {
+            sandbox.stub(labs, 'isSet').returns(true);
+            var result = channelConfig('tag');
+            should.exist(result);
+            result.name.should.eql('tag');
+            result.postOptions.filter.should.eql('tags:%s+tags.hidden:false');
+            result.data.tag.options.should.eql({slug: '%s', hidden: false});
+        });
+    });
+});


### PR DESCRIPTION
refs #6165
- use `#` to denote hidden tags in editor tags input
- display hidden/internal tags in content list (see screenshot)

WIP spike of client functionality outlined in #6165.

![screen shot 2015-12-08 at 14 56 47](https://cloud.githubusercontent.com/assets/415/11658761/543606c4-9dbc-11e5-81b0-5f236e4bd517.png)
