### PR TITLE
Remove filters from theme helpers (no async)

### DIFF
--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -8,7 +8,6 @@
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
-    filters         = require('../filters'),
     // @TODO Fix this
     template        = require('../controllers/frontend/templates'),
     body_class;
@@ -65,10 +64,8 @@ body_class = function (options) {
         }
     }
 
-    return filters.doFilter('body_class', classes).then(function (classes) {
-        var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
-        return new hbs.handlebars.SafeString(classString.trim());
-    });
+    classes = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+    return new hbs.handlebars.SafeString(classes.trim());
 };
 
 module.exports = body_class;

--- a/core/server/helpers/meta_description.js
+++ b/core/server/helpers/meta_description.js
@@ -8,7 +8,6 @@
 
 var _           = require('lodash'),
     config      = require('../config'),
-    filters     = require('../filters'),
     meta_description;
 
 meta_description = function (options) {
@@ -31,10 +30,7 @@ meta_description = function (options) {
         description = this.post.meta_description;
     }
 
-    return filters.doFilter('meta_description', description).then(function (description) {
-        description = description || '';
-        return description.trim();
-    });
+    return (description || '').trim();
 };
 
 module.exports = meta_description;

--- a/core/server/helpers/meta_title.js
+++ b/core/server/helpers/meta_title.js
@@ -8,7 +8,6 @@
 
 var _           = require('lodash'),
     config      = require('../config'),
-    filters     = require('../filters'),
     meta_title;
 
 meta_title = function (options) {
@@ -37,10 +36,7 @@ meta_title = function (options) {
         title = blog.title + pageString;
     }
 
-    return filters.doFilter('meta_title', title).then(function (title) {
-        title = title || '';
-        return title.trim();
-    });
+    return (title || '').trim();
 };
 
 module.exports = meta_title;

--- a/core/server/helpers/post_class.js
+++ b/core/server/helpers/post_class.js
@@ -8,7 +8,6 @@
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
-    filters         = require('../filters'),
     post_class;
 
 post_class = function (options) {
@@ -30,10 +29,8 @@ post_class = function (options) {
         classes.push('page');
     }
 
-    return filters.doFilter('post_class', classes).then(function (classes) {
-        var classString = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
-        return new hbs.handlebars.SafeString(classString.trim());
-    });
+    classes = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+    return new hbs.handlebars.SafeString(classes.trim());
 };
 
 module.exports = post_class;

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -45,16 +45,13 @@ describe('{{body_class}} helper', function () {
         should.exist(handlebars.helpers.body_class);
     });
 
-    it('can render class string', function (done) {
+    it('can render class string', function () {
         options.data.root.context = ['home'];
 
-        helpers.body_class.call({}, options).then(function (rendered) {
-            should.exist(rendered);
+        var rendered = helpers.body_class.call({}, options);
+        should.exist(rendered);
 
-            rendered.string.should.equal('home-template');
-
-            done();
-        }).catch(done);
+        rendered.string.should.equal('home-template');
     });
 
     describe('can render class string for context', function () {
@@ -66,81 +63,103 @@ describe('{{body_class}} helper', function () {
             );
         }
 
-        it('Standard home page', function (done) {
-            callBodyClassWithContext(['home', 'index'], {relativeUrl: '/'}).then(function (rendered) {
-                rendered.string.should.equal('home-template');
-                done();
-            }).catch(done);
+        it('Standard home page', function () {
+            var rendered = callBodyClassWithContext(
+                ['home', 'index'],
+                {relativeUrl: '/'}
+            );
+
+            rendered.string.should.equal('home-template');
         });
 
-        it('a post', function (done) {
-            callBodyClassWithContext(['post'], {relativeUrl: '/a-post-title', post: {}}).then(function (rendered) {
-                rendered.string.should.equal('post-template');
-                done();
-            }).catch(done);
+        it('a post', function () {
+            var rendered = callBodyClassWithContext(
+                ['post'],
+                {relativeUrl: '/a-post-title', post: {}}
+            );
+
+            rendered.string.should.equal('post-template');
         });
 
-        it('paginated index', function (done) {
-            callBodyClassWithContext(['index', 'paged'], {relativeUrl: '/page/4'}).then(function (rendered) {
-                rendered.string.should.equal('paged archive-template');
-                done();
-            }).catch(done);
+        it('paginated index', function () {
+            var rendered = callBodyClassWithContext(
+                ['index', 'paged'],
+                {relativeUrl: '/page/4'}
+            );
+
+            rendered.string.should.equal('paged archive-template');
         });
 
-        it('tag page', function (done) {
-            callBodyClassWithContext(['tag'], {relativeUrl: '/tag/foo', tag: {slug: 'foo'}}).then(function (rendered) {
-                rendered.string.should.equal('tag-template tag-foo');
-                done();
-            }).catch(done);
+        it('tag page', function () {
+            var rendered = callBodyClassWithContext(
+                ['tag'],
+                {relativeUrl: '/tag/foo', tag: {slug: 'foo'}}
+            );
+
+            rendered.string.should.equal('tag-template tag-foo');
         });
 
-        it('paginated tag page', function (done) {
-            callBodyClassWithContext(['tag', 'paged'], {relativeUrl: '/tag/foo/page/2', tag: {slug: 'foo'}}).then(function (rendered) {
-                rendered.string.should.equal('tag-template tag-foo paged archive-template');
-                done();
-            }).catch(done);
+        it('paginated tag page', function () {
+            var rendered = callBodyClassWithContext(
+                ['tag', 'paged'],
+                {relativeUrl: '/tag/foo/page/2', tag: {slug: 'foo'}}
+            );
+
+            rendered.string.should.equal('tag-template tag-foo paged archive-template');
         });
 
-        it('author page', function (done) {
-            callBodyClassWithContext(['author'], {relativeUrl: '/author/bar', author: {slug: 'bar'}}).then(function (rendered) {
-                rendered.string.should.equal('author-template author-bar');
-                done();
-            }).catch(done);
+        it('author page', function () {
+            var rendered = callBodyClassWithContext(
+                ['author'],
+                {relativeUrl: '/author/bar', author: {slug: 'bar'}}
+            );
+
+            rendered.string.should.equal('author-template author-bar');
         });
 
-        it('paginated author page', function (done) {
-            callBodyClassWithContext(['author', 'paged'], {relativeUrl: '/author/bar/page/2', author: {slug: 'bar'}}).then(function (rendered) {
-                rendered.string.should.equal('author-template author-bar paged archive-template');
-                done();
-            }).catch(done);
+        it('paginated author page', function () {
+            var rendered = callBodyClassWithContext(
+                ['author', 'paged'],
+                {relativeUrl: '/author/bar/page/2', author: {slug: 'bar'}}
+            );
+
+            rendered.string.should.equal('author-template author-bar paged archive-template');
         });
 
-        it('private route for password protection', function (done) {
-            callBodyClassWithContext(['private'], {relativeUrl: '/private/'}).then(function (rendered) {
-                rendered.string.should.equal('private-template');
-                done();
-            }).catch(done);
+        it('private route for password protection', function () {
+            var rendered = callBodyClassWithContext(
+                ['private'],
+                {relativeUrl: '/private/'}
+            );
+
+            rendered.string.should.equal('private-template');
         });
 
-        it('post with tags', function (done) {
-            callBodyClassWithContext(['post'], {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}).then(function (rendered) {
-                rendered.string.should.equal('post-template tag-foo tag-bar');
-                done();
-            }).catch(done);
+        it('post with tags', function () {
+            var rendered = callBodyClassWithContext(
+                ['post'],
+                {relativeUrl: '/my-awesome-post/', post: {tags: [{slug: 'foo'}, {slug: 'bar'}]}}
+            );
+
+            rendered.string.should.equal('post-template tag-foo tag-bar');
         });
 
-        it('a static page', function (done) {
-            callBodyClassWithContext(['page'], {relativeUrl: '/about', post: {page: true}}).then(function (rendered) {
-                rendered.string.should.equal('post-template page-template page');
-                done();
-            }).catch(done);
+        it('a static page', function () {
+            var rendered = callBodyClassWithContext(
+                ['page'],
+                {relativeUrl: '/about', post: {page: true}}
+            );
+
+            rendered.string.should.equal('post-template page-template page');
         });
 
-        it('a static page with custom template', function (done) {
-            callBodyClassWithContext(['page'], {relativeUrl: '/about', post: {page: true, slug: 'about'}}).then(function (rendered) {
-                rendered.string.should.equal('post-template page-template page page-about page-template-about');
-                done();
-            }).catch(done);
+        it('a static page with custom template', function () {
+            var rendered = callBodyClassWithContext(
+                ['page'],
+                {relativeUrl: '/about', post: {page: true, slug: 'about'}}
+            );
+
+            rendered.string.should.equal('post-template page-template page page-about page-template-about');
         });
     });
 });

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -26,135 +26,113 @@ describe('{{meta_description}} helper', function () {
         should.exist(handlebars.helpers.meta_description);
     });
 
-    it('returns correct blog description', function (done) {
-        helpers.meta_description.call(
+    it('returns correct blog description', function () {
+        var rendered = helpers.meta_description.call(
             {},
             {data: {root: {context: ['home', 'index']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Just a blogging platform.');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Just a blogging platform.');
     });
 
-    it('returns empty description on paginated page', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description on paginated page', function () {
+        var rendered = helpers.meta_description.call(
             {},
             {data: {root: {context: ['index', 'paged']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns empty description for a tag page', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description for a tag page', function () {
+        var rendered = helpers.meta_description.call(
             {tag: {name: 'Rasper Red'}},
             {data: {root: {context: ['tag']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns empty description for a paginated tag page', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description for a paginated tag page', function () {
+        var rendered = helpers.meta_description.call(
             {tag: {name: 'Rasper Red'}},
             {data: {root: {context: ['tag', 'paged']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns tag meta_description if present for a tag page', function (done) {
-        helpers.meta_description.call(
+    it('returns tag meta_description if present for a tag page', function () {
+        var rendered = helpers.meta_description.call(
             {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
             {data: {root: {context: ['tag']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Rasper is the Cool Red Casper');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Rasper is the Cool Red Casper');
     });
 
-    it('returns empty description on paginated tag page that has meta data', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description on paginated tag page that has meta data', function () {
+        var rendered = helpers.meta_description.call(
             {tag: {name: 'Rasper Red', meta_description: 'Rasper is the Cool Red Casper'}},
             {data: {root: {context: ['tag', 'paged']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns correct description for an author page', function (done) {
-        helpers.meta_description.call(
+    it('returns correct description for an author page', function () {
+        var rendered = helpers.meta_description.call(
             {author: {bio: 'I am a Duck.'}},
             {data: {root: {context: ['author']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('I am a Duck.');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('I am a Duck.');
     });
 
-    it('returns empty description for a paginated author page', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description for a paginated author page', function () {
+        var rendered = helpers.meta_description.call(
             {author: {name: 'Donald Duck'}},
             {data: {root: {context: ['author', 'paged']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns empty description when meta_description is not set', function (done) {
-        helpers.meta_description.call(
+    it('returns empty description when meta_description is not set', function () {
+        var rendered = helpers.meta_description.call(
             {post: {title: 'Post Title', html: 'Very nice post indeed.'}},
             {data: {root: {context: ['post']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('');
     });
 
-    it('returns meta_description on post with meta_description set', function (done) {
-        helpers.meta_description.call(
+    it('returns meta_description on post with meta_description set', function () {
+        var rendered = helpers.meta_description.call(
             {post: {title: 'Post Title', meta_description: 'Nice post about stuff.'}},
             {data: {root: {context: ['post']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Nice post about stuff.');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Nice post about stuff.');
     });
 
-    it('returns meta_description on post when used within {{#foreach posts}}', function (done) {
-        helpers.meta_description.call(
+    it('returns meta_description on post when used within {{#foreach posts}}', function () {
+        var rendered = helpers.meta_description.call(
             {meta_description: 'Nice post about stuff.'},
             {data: {root: {context: ['home']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Nice post about stuff.');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Nice post about stuff.');
     });
 });

--- a/core/test/unit/server_helpers/meta_title_spec.js
+++ b/core/test/unit/server_helpers/meta_title_spec.js
@@ -26,160 +26,134 @@ describe('{{meta_title}} helper', function () {
         should.exist(handlebars.helpers.meta_title);
     });
 
-    it('returns correct title for homepage', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for homepage', function () {
+        var rendered = helpers.meta_title.call(
             {},
             {data: {root: {context: ['home']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Ghost');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Ghost');
     });
 
-    it('returns correct title for paginated page', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for paginated page', function () {
+        var rendered = helpers.meta_title.call(
             {},
             {data: {root: {context: [], pagination: {total: 2, page: 2}}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Ghost - Page 2');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Ghost - Page 2');
     });
 
-    it('returns correct title for a post', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for a post', function () {
+        var rendered = helpers.meta_title.call(
             {post: {title: 'Post Title'}},
             {data: {root: {context: ['post']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Post Title');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Post Title');
     });
 
-    it('returns correct title for a post with meta_title set', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for a post with meta_title set', function () {
+        var rendered = helpers.meta_title.call(
             {post: {title: 'Post Title', meta_title: 'Awesome Post'}},
             {data: {root: {context: ['post']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Awesome Post');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Awesome Post');
     });
 
-    it('returns correct title for a page with meta_title set', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for a page with meta_title set', function () {
+        var rendered = helpers.meta_title.call(
             {post: {title: 'About Page', meta_title: 'All about my awesomeness', page: true}},
             {data: {root: {context: ['page']}}}
-        ).then(function (rendered) {
-                should.exist(rendered);
-                String(rendered).should.equal('All about my awesomeness');
+        );
 
-                done();
-            }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('All about my awesomeness');
     });
 
-    it('returns correct title for a tag page', function (done) {
-        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red'}};
-        helpers.meta_title.call(
-            tag,
-            {data: {root: {context: ['tag']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Rasper Red - Ghost');
+    it('returns correct title for a tag page', function () {
+        var tag = {relativeUrl: '/tag/rasper-red', tag: {name: 'Rasper Red'}},
+            rendered = helpers.meta_title.call(
+                tag,
+                {data: {root: {context: ['tag']}}}
+            );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Rasper Red - Ghost');
     });
 
-    it('returns correct title for a paginated tag page', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for a paginated tag page', function () {
+        var rendered = helpers.meta_title.call(
             {tag: {name: 'Rasper Red'}},
             {data: {root: {context: ['tag', 'paged'], pagination: {total: 2, page: 2}}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Rasper Red - Page 2 - Ghost');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Rasper Red - Page 2 - Ghost');
     });
 
-    it('uses tag meta_title to override default response on tag page', function (done) {
-        helpers.meta_title.call(
+    it('uses tag meta_title to override default response on tag page', function () {
+        var rendered = helpers.meta_title.call(
             {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
             {data: {root: {context: ['tag']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Sasper Red');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Sasper Red');
     });
 
-    it('uses tag meta_title to override default response on paginated tag page', function (done) {
-        helpers.meta_title.call(
+    it('uses tag meta_title to override default response on paginated tag page', function () {
+        var rendered = helpers.meta_title.call(
             {tag: {name: 'Rasper Red', meta_title: 'Sasper Red'}},
             {data: {root: {context: ['tag']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Sasper Red');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Sasper Red');
     });
 
-    it('returns correct title for an author page', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for an author page', function () {
+        var rendered = helpers.meta_title.call(
             {author: {name: 'Donald Duck'}},
             {data: {root: {context: ['author']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Ghost');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Donald Duck - Ghost');
     });
 
-    it('returns correct title for a paginated author page', function (done) {
-        helpers.meta_title.call(
+    it('returns correct title for a paginated author page', function () {
+        var rendered = helpers.meta_title.call(
             {author: {name: 'Donald Duck'}},
             {data: {root: {context: ['author', 'paged'], pagination: {total: 2, page: 2}}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Donald Duck - Page 2 - Ghost');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Donald Duck - Page 2 - Ghost');
     });
 
-    it('returns correctly escaped title of a post', function (done) {
-        helpers.meta_title.call(
+    it('returns correctly escaped title of a post', function () {
+        var rendered = helpers.meta_title.call(
             {post: {title: 'Post Title "</>'}},
             {data: {root: {context: ['post']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Post Title "</>');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Post Title "</>');
     });
 
-    it('returns meta_title on post when used within {{#foreach posts}}', function (done) {
-        helpers.meta_title.call(
+    it('returns meta_title on post when used within {{#foreach posts}}', function () {
+        var rendered = helpers.meta_title.call(
             {meta_title: 'Awesome Post'},
             {data: {root: {context: ['home']}}}
-        ).then(function (rendered) {
-            should.exist(rendered);
-            String(rendered).should.equal('Awesome Post');
+        );
 
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        String(rendered).should.equal('Awesome Post');
     });
 });

--- a/core/test/unit/server_helpers/post_class_spec.js
+++ b/core/test/unit/server_helpers/post_class_spec.js
@@ -17,33 +17,26 @@ describe('{{post_class}} helper', function () {
         should.exist(handlebars.helpers.post_class);
     });
 
-    it('can render class string', function (done) {
-        helpers.post_class.call({}).then(function (rendered) {
-            should.exist(rendered);
-            rendered.string.should.equal('post');
-            done();
-        }).catch(done);
+    it('can render class string', function () {
+        var rendered = helpers.post_class.call({});
+
+        should.exist(rendered);
+        rendered.string.should.equal('post');
     });
 
-    it('can render featured class', function (done) {
-        var post = {featured: true};
+    it('can render featured class', function () {
+        var post = {featured: true},
+            rendered = helpers.post_class.call(post);
 
-        helpers.post_class.call(post).then(function (rendered) {
-            should.exist(rendered);
-            rendered.string.should.equal('post featured');
-
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        rendered.string.should.equal('post featured');
     });
 
-    it('can render page class', function (done) {
-        var post = {page: true};
+    it('can render page class', function () {
+        var post = {page: true},
+            rendered = helpers.post_class.call(post);
 
-        helpers.post_class.call(post).then(function (rendered) {
-            should.exist(rendered);
-            rendered.string.should.equal('post page');
-
-            done();
-        }).catch(done);
+        should.exist(rendered);
+        rendered.string.should.equal('post page');
     });
 });


### PR DESCRIPTION
The four helpers `{{meta_title}}`, `{{meta_description}}`, `{{body_class}}` & `{{post_class}}` all had filters wired into them. This functionality was there ready for apps to be able to modify the output, but has not been used as apps aren't a thing yet.

I'm removing these filters for now to resolve the issue reported in #5850. It will now be possible to use these 4 helpers inside `{{#next_post}}`, `{{#prev_post}}` and `{{#get}}` blocks. This does not resolve the issue whereby these 3 helpers cannot be nested inside each other. 

That will require a different strategy for asynchronous helpers, which can be achieved but is a much bigger project (will raise a new issue to cover this). Once we have figured that out, we'll be able to add these filters back.

closes #5850
- filters were added so that apps could change the output of the helpers, but as async helpers are a hack, this led to issues
- apps aren't currently a working part of Ghost, so for now, lets remove the filters
- we'll add these back when we have a better implementation of async helpers & this style of app is back on the cards
