### PR TITLE
[Spike] Improve keymaster scope handling on tags management screen

### DIFF
--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -8,6 +8,8 @@ export default Component.extend({
 
     tag: null,
 
+    _previousKeymasterScope: null,
+
     scratchName: boundOneWay('tag.name'),
     scratchSlug: boundOneWay('tag.slug'),
     scratchDescription: boundOneWay('tag.description'),
@@ -91,12 +93,33 @@ export default Component.extend({
         }
     },
 
+    _setKeymasterScope() {
+        this._previousKeymasterScope = key.getScope();
+        key.setScope('gh-settings-form');
+    },
+
+    _resetKeymasterScope() {
+        key.setScope(this._previousKeymasterScope);
+    },
+
     focusIn() {
-        key.setScope('tag-settings-form');
+        this._setKeymasterScope();
     },
 
     focusOut() {
-        key.setScope('default');
+        this._resetKeymasterScope();
+    },
+
+    mouseEnter() {
+        this._setKeymasterScope();
+    },
+
+    mouseLeave() {
+        this._resetKeymasterScope();
+    },
+
+    touchStart() {
+        this._setKeymasterScope();
     },
 
     actions: {

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -1,3 +1,4 @@
+/* global key */
 import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
@@ -41,6 +42,7 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
     deactivate() {
         this._super(...arguments);
         this.send('resetPagination');
+        this.send('resetShortcutsScope');
     },
 
     stepThroughTags(step) {
@@ -95,6 +97,10 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
 
         newTag() {
             this.transitionTo('settings.tags.new');
+        },
+
+        resetShortcutsScope() {
+            key.setScope('default');
         }
     }
 });

--- a/core/client/app/templates/settings/tags.hbs
+++ b/core/client/app/templates/settings/tags.hbs
@@ -13,7 +13,7 @@
             isLoading=isLoading
             classNames="tag-list"
         }}
-            <section class="tag-list-content settings-tags {{if tagListFocused 'keyboard-focused'}}">
+            <section class="tag-list-content settings-tags {{if tagListFocused 'keyboard-focused'}}" {{action "resetShortcutsScope" on="touchStart" preventDefault=false}}>
                 {{#each tags as |tag|}}
                     <div class="settings-tag">
                         {{#link-to 'settings.tags.tag' tag class="tag-edit-button"}}


### PR DESCRIPTION
refs #6191, #6192
- supplement `focusIn` and `focusOut` event handlers in `gh-tag-settings-form` with `mouseEnter/Leave` and `touchStart` events so that the navigation shortcuts aren't lost after the first interaction with the settings form
- add a `resetShortcutsScope` action that is triggered on tags list `touchStart` so that touch screen devices can get the tags navigation shortcuts back
- as a final backup, reset the keymaster scope to `default` when leaving the tags route

How we're handling the various events:
- `focusIn/focusOut` handle keyboard navigation. Tabbing through screen elements will always trigger `focusIn` last which disables the default keymaster scope, once you tab out of the `gh-tag-settings-form` children only the `focusOut` event is triggered re-enabling the default scope.
- `mouseEnter/mouseLeave` handle mouse movement. Any time the mouse is over the `gh-tag-settings-form` element the default keymaster scope will be disabled.
- `touchStart` handles touch devices. Any touch on the tag settings form will disable the default scope, a touch on the tags list will re-enable the default scope.

Marked as a spike as it may be overkill. I'll pull the scope reset on `deactivate` into a separate PR as that will be useful immediately and I'll continue to ponder on any other edge cases here.
