### PR TITLE
Reset shortcuts scope when leaving tags route

### DIFF
--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -1,3 +1,4 @@
+/* global key */
 import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
@@ -40,6 +41,7 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
 
     deactivate() {
         this._super(...arguments);
+        this.send('resetShortcutsScope');
         this.send('resetPagination');
     },
 
@@ -95,6 +97,10 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
 
         newTag() {
             this.transitionTo('settings.tags.new');
+        },
+
+        resetShortcutsScope() {
+            key.setScope('default');
         }
     }
 });


### PR DESCRIPTION
refs #6191, #6192
- adds additional safeguard to tags route to ensure keymaster scope doesn't get stuck in a non-default scope that may break shortcuts elsewhere
