### PR TITLE
Support for random ordering of entites retrieved with #get helper

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -470,6 +470,11 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         if (include && include.indexOf('count.posts') > -1) {
             permittedAttributes.push('count.posts');
         }
+
+        if (order === 'random') {
+            return 'random';
+        }
+
         result = {};
         rules = order.split(',');
 

--- a/core/server/models/plugins/pagination.js
+++ b/core/server/models/plugins/pagination.js
@@ -161,13 +161,17 @@ pagination = function pagination(bookshelf) {
 
             // Apply ordering options if they are present
             if (options.order && !_.isEmpty(options.order)) {
-                _.forOwn(options.order, function (direction, property) {
-                    if (property === 'count.posts') {
-                        self.query('orderBy', 'count__posts', direction);
-                    } else {
-                        self.query('orderBy', tableName + '.' + property, direction);
-                    }
-                });
+                if (options.order === 'random') {
+                    self.query('orderByRaw', 'random()');
+                } else {
+                    _.forOwn(options.order, function (direction, property) {
+                        if (property === 'count.posts') {
+                            self.query('orderBy', 'count__posts', direction);
+                        } else {
+                            self.query('orderBy', tableName + '.' + property, direction);
+                        }
+                    });
+                }
             }
 
             if (options.groups && !_.isEmpty(options.groups)) {

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -520,6 +520,67 @@ describe('Filter Param Spec', function () {
         });
     });
 
+    describe('Ordering', function () {
+        describe('Order ascending by defualt', function () {
+            it('Fetches posts ordered by id defaulting to ascending', function (done) {
+                PostAPI.browse({limit: 3, order: 'id'}).then(function (result) {
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+                    var ids = _.pluck(result.posts, 'id');
+                    ids.should.eql([1, 2, 3]);
+                    done();
+                }).catch(done);
+            });
+        });
+        describe('Order ascending', function () {
+            it('Fetches posts ordered by id ascending', function (done) {
+                PostAPI.browse({limit: 3, order: 'id asc'}).then(function (result) {
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+                    var ids = _.pluck(result.posts, 'id');
+                    ids.should.eql([1, 2, 3]);
+                    done();
+                }).catch(done);
+            });
+        });
+        describe('Order descending', function () {
+            it('Fetches posts ordered by id descending', function (done) {
+                PostAPI.browse({limit: 3, order: 'id desc'}).then(function (result) {
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+                    var ids = _.pluck(result.posts, 'id');
+                    ids.should.eql([20, 18, 17]);
+                    done();
+                }).catch(done);
+            });
+        });
+        describe('Order by random', function () {
+            it('Fetches different sequence of posts each time', function (done) {
+                var search = function () {
+                    return PostAPI.browse({limit: 10, order: 'random'});
+                },
+                searchShouldBeValid = function (result) {
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+                };
+                search().then(function (firstResult) {
+                    searchShouldBeValid(firstResult);
+                    search().then(function (secondResult) {
+                        searchShouldBeValid(secondResult);
+                        var firstResultIds = _.pluck(firstResult.posts, 'id'),
+                        secondResultIds = _.pluck(secondResult.posts, 'id');
+                        firstResultIds.should.not.equal(secondResultIds);
+                        done();
+                    }).catch(done);
+                }).catch(done);
+            });
+        });
+    });
+
     describe('Old Use Cases', function () {
         // Please note: these tests are mostly here to help prove certain things whilst building out new behaviour
         describe('Old post "filters"', function () {


### PR DESCRIPTION
This change supports random ordering of results retrieved with `#get` helper, like `{{#get "posts" limit="10" order="random"}}`. Two more tests of existing ordering as a bonus.
