### PR TITLE
Unify usage of config in unit tests

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -399,7 +399,7 @@ ConfigManager.prototype.isPrivacyDisabled = function (privacyFlag) {
 ConfigManager.prototype.checkDeprecated = function () {
     var self = this;
     _.each(this.deprecatedItems, function (property) {
-        self.displayDeprecated(self, property.split('.'), []);
+        self.displayDeprecated(self._config, property.split('.'), []);
     });
 };
 

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -1,4 +1,4 @@
-/*globals describe, it, before, beforeEach, afterEach, after */
+/*globals describe, it, before, beforeEach, afterEach */
 /*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
@@ -6,32 +6,26 @@ var should         = require('should'),
     path           = require('path'),
     fs             = require('fs'),
     _              = require('lodash'),
-    rewire         = require('rewire'),
 
     testUtils      = require('../utils'),
 
     // Thing we are testing
-    defaultConfig  = require('../../../config.example')[process.env.NODE_ENV],
-    config         = require('../../server/config'),
-    origConfig     = _.cloneDeep(config),
+    configUtils    = require('../utils/configUtils'),
+    config         = configUtils.config,
     // storing current environment
     currentEnv     = process.env.NODE_ENV;
 
 // To stop jshint complaining
 should.equal(true, true);
 
-function resetConfig() {
-    config.set(_.merge({}, origConfig, defaultConfig));
-}
-
 describe('Config', function () {
-    after(function () {
-        resetConfig();
+    afterEach(function () {
+        configUtils.restore();
     });
 
     describe('Theme', function () {
         beforeEach(function () {
-            config.set({
+            configUtils.set({
                 url: 'http://my-ghost-blog.com',
                 theme: {
                     title: 'casper',
@@ -40,10 +34,6 @@ describe('Config', function () {
                     cover: 'casper'
                 }
             });
-        });
-
-        afterEach(function () {
-            resetConfig();
         });
 
         it('should have exactly the right keys', function () {
@@ -66,13 +56,6 @@ describe('Config', function () {
     });
 
     describe('Index', function () {
-        afterEach(function () {
-            // Make a copy of the default config file
-            // so we can restore it after every test.
-            // Using _.merge to recursively apply every property.
-            resetConfig();
-        });
-
         it('should have exactly the right keys', function () {
             var pathConfig = config.paths;
 
@@ -108,24 +91,24 @@ describe('Config', function () {
         });
 
         it('should not return a slash for subdir', function () {
-            config.set({url: 'http://my-ghost-blog.com'});
+            configUtils.set({url: 'http://my-ghost-blog.com'});
             config.paths.should.have.property('subdir', '');
 
-            config.set({url: 'http://my-ghost-blog.com/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/'});
             config.paths.should.have.property('subdir', '');
         });
 
         it('should handle subdirectories properly', function () {
-            config.set({url: 'http://my-ghost-blog.com/blog'});
+            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
             config.paths.should.have.property('subdir', '/blog');
 
-            config.set({url: 'http://my-ghost-blog.com/blog/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
             config.paths.should.have.property('subdir', '/blog');
 
-            config.set({url: 'http://my-ghost-blog.com/my/blog'});
+            configUtils.set({url: 'http://my-ghost-blog.com/my/blog'});
             config.paths.should.have.property('subdir', '/my/blog');
 
-            config.set({url: 'http://my-ghost-blog.com/my/blog/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/my/blog/'});
             config.paths.should.have.property('subdir', '/my/blog');
         });
 
@@ -133,7 +116,7 @@ describe('Config', function () {
             var contentPath = path.join(config.paths.appRoot, 'otherContent', '/'),
                 configFile = 'configFileDanceParty.js';
 
-            config.set({
+            configUtils.set({
                 config: configFile,
                 paths: {
                     contentPath: contentPath
@@ -149,10 +132,6 @@ describe('Config', function () {
     });
 
     describe('Storage', function () {
-        afterEach(function () {
-            resetConfig();
-        });
-
         it('should default to local-file-store', function () {
             var storagePath = path.join(config.paths.corePath, '/server/storage/', 'local-file-store');
 
@@ -163,7 +142,7 @@ describe('Config', function () {
         it('should allow setting a custom active storage', function () {
             var storagePath = path.join(config.paths.contentPath, 'storage', 's3');
 
-            config.set({
+            configUtils.set({
                 storage: {
                     active: 's3',
                     s3: {}
@@ -178,29 +157,21 @@ describe('Config', function () {
 
     describe('Url', function () {
         describe('urlJoin', function () {
-            before(function () {
-                resetConfig();
-            });
-
-            afterEach(function () {
-                resetConfig();
-            });
-
             it('should deduplicate slashes', function () {
-                config.set({url: 'http://my-ghost-blog.com/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/'});
                 config.urlJoin('/', '/my/', '/blog/').should.equal('/my/blog/');
                 config.urlJoin('/', '//my/', '/blog/').should.equal('/my/blog/');
                 config.urlJoin('/', '/', '/').should.equal('/');
             });
 
             it('should not deduplicate slashes in protocol', function () {
-                config.set({url: 'http://my-ghost-blog.com/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/'});
                 config.urlJoin('http://myurl.com', '/rss').should.equal('http://myurl.com/rss');
                 config.urlJoin('https://myurl.com/', '/rss').should.equal('https://myurl.com/rss');
             });
 
             it('should permit schemeless protocol', function () {
-                config.set({url: 'http://my-ghost-blog.com/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/'});
                 config.urlJoin('/', '/').should.equal('/');
                 config.urlJoin('//myurl.com', '/rss').should.equal('//myurl.com/rss');
                 config.urlJoin('//myurl.com/', '/rss').should.equal('//myurl.com/rss');
@@ -209,45 +180,37 @@ describe('Config', function () {
             });
 
             it('should deduplicate subdir', function () {
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlJoin('blog', 'blog/about').should.equal('blog/about');
                 config.urlJoin('blog/', 'blog/about').should.equal('blog/about');
             });
         });
 
         describe('urlFor', function () {
-            before(function () {
-                resetConfig();
-            });
-
-            afterEach(function () {
-                resetConfig();
-            });
-
             it('should return the home url with no options', function () {
                 config.urlFor().should.equal('/');
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor().should.equal('/blog/');
-                config.set({url: 'http://my-ghost-blog.com/blog/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
                 config.urlFor().should.equal('/blog/');
             });
 
             it('should return home url when asked for', function () {
                 var testContext = 'home';
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext).should.equal('/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
 
-                config.set({url: 'http://my-ghost-blog.com/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/'});
                 config.urlFor(testContext).should.equal('/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext).should.equal('/blog/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
                 config.urlFor(testContext).should.equal('/blog/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
             });
@@ -255,11 +218,11 @@ describe('Config', function () {
             it('should return rss url when asked for', function () {
                 var testContext = 'rss';
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext).should.equal('/rss/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/rss/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext).should.equal('/blog/rss/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/rss/');
             });
@@ -267,11 +230,11 @@ describe('Config', function () {
             it('should return url for a random path when asked for', function () {
                 var testContext = {relativeUrl: '/about/'};
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext).should.equal('/about/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/about/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext).should.equal('/blog/about/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
             });
@@ -279,15 +242,15 @@ describe('Config', function () {
             it('should deduplicate subdirectories in paths', function () {
                 var testContext = {relativeUrl: '/blog/about/'};
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext).should.equal('/blog/about/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext).should.equal('/blog/about/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
                 config.urlFor(testContext).should.equal('/blog/about/');
                 config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
             });
@@ -298,11 +261,11 @@ describe('Config', function () {
 
                 // url is now provided on the postmodel, permalinkSetting tests are in the model_post_spec.js test
                 testData.post.url = '/short-and-sweet/';
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext, testData).should.equal('/short-and-sweet/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
             });
@@ -311,11 +274,11 @@ describe('Config', function () {
                 var testContext = 'tag',
                     testData = {tag: testUtils.DataGenerator.Content.tags[0]};
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
             });
@@ -324,11 +287,11 @@ describe('Config', function () {
                 var testContext = 'author',
                     testData = {author: testUtils.DataGenerator.Content.users[0]};
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
             });
@@ -337,7 +300,7 @@ describe('Config', function () {
                 var testContext = 'image',
                     testData;
 
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
 
                 testData = {image: '/content/images/my-image.jpg'};
                 config.urlFor(testContext, testData).should.equal('/content/images/my-image.jpg');
@@ -352,7 +315,7 @@ describe('Config', function () {
                 // We don't make image urls absolute if they don't look like images relative to the image path
                 config.urlFor(testContext, testData, true).should.equal('/blog/content/images/my-image2.jpg');
 
-                config.set({url: 'http://my-ghost-blog.com/blog/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
 
                 testData = {image: '/content/images/my-image3.jpg'};
                 config.urlFor(testContext, testData).should.equal('/content/images/my-image3.jpg');
@@ -368,7 +331,7 @@ describe('Config', function () {
                 var testContext = 'nav',
                     testData;
 
-                config.set({url: 'http://my-ghost-blog.com', urlSSL: 'https://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com', urlSSL: 'https://my-ghost-blog.com'});
 
                 testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}};
                 config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
@@ -388,17 +351,17 @@ describe('Config', function () {
                 testData = {nav: {url: '#this-anchor'}};
                 config.urlFor(testContext, testData).should.equal('#this-anchor');
 
-                config.set({url: 'http://my-ghost-blog.com/blog'});
+                configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
                 config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
-                config.set({url: 'http://my-ghost-blog.com/'});
+                configUtils.set({url: 'http://my-ghost-blog.com/'});
                 testData = {nav: {url: 'mailto:marshmallow@my-ghost-blog.com'}};
                 config.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
             });
 
             it('should return other known paths when requested', function () {
-                config.set({url: 'http://my-ghost-blog.com'});
+                configUtils.set({url: 'http://my-ghost-blog.com'});
                 config.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
                 config.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
 
@@ -455,17 +418,17 @@ describe('Config', function () {
 
     describe('File', function () {
         var sandbox,
-            originalConfig,
             readFileStub,
-            overrideConfig = function (newConfig) {
-                readFileStub.returns(
-                    _.extend({}, defaultConfig, newConfig)
-                );
-            },
+            overrideReadFileConfig,
             expectedError = new Error('expected bootstrap() to throw error but none thrown');
 
         before(function () {
-            originalConfig = _.cloneDeep(rewire('../../server/config')._config);
+            // Create a function to override what reading the config file returns
+            overrideReadFileConfig = function (newConfig) {
+                readFileStub.returns(
+                    _.extend({}, configUtils.defaultConfig, newConfig)
+                );
+            };
         });
 
         beforeEach(function () {
@@ -474,8 +437,6 @@ describe('Config', function () {
         });
 
         afterEach(function () {
-            config = rewire('../../server/config');
-            resetConfig();
             sandbox.restore();
         });
 
@@ -486,18 +447,18 @@ describe('Config', function () {
             // the test infrastructure is setup so that there is always config present,
             // but we want to overwrite the test to actually load config.example.js, so that any local changes
             // don't break the tests
-            config.set({
+            configUtils.set({
                 paths: {
-                    appRoot: path.join(originalConfig.paths.appRoot, 'config.example.js')
+                    appRoot: path.join(configUtils.defaultConfig.paths.appRoot, 'config.example.js')
                 }
             });
 
             config.load().then(function (config) {
-                config.url.should.equal(defaultConfig.url);
-                config.database.client.should.equal(defaultConfig.database.client);
-                config.database.connection.should.eql(defaultConfig.database.connection);
-                config.server.host.should.equal(defaultConfig.server.host);
-                config.server.port.should.equal(defaultConfig.server.port);
+                config.url.should.equal(configUtils.defaultConfig.url);
+                config.database.client.should.equal(configUtils.defaultConfig.database.client);
+                config.database.connection.should.eql(configUtils.defaultConfig.database.connection);
+                config.server.host.should.equal(configUtils.defaultConfig.server.host);
+                config.server.port.should.equal(configUtils.defaultConfig.server.port);
 
                 done();
             }).catch(done);
@@ -507,12 +468,12 @@ describe('Config', function () {
             // We actually want the real method here.
             readFileStub.restore();
 
-            config.load(path.join(originalConfig.paths.appRoot, 'config.example.js')).then(function (config) {
-                config.url.should.equal(defaultConfig.url);
-                config.database.client.should.equal(defaultConfig.database.client);
-                config.database.connection.should.eql(defaultConfig.database.connection);
-                config.server.host.should.equal(defaultConfig.server.host);
-                config.server.port.should.equal(defaultConfig.server.port);
+            config.load(path.join(configUtils.defaultConfig.paths.appRoot, 'config.example.js')).then(function (config) {
+                config.url.should.equal(configUtils.defaultConfig.url);
+                config.database.client.should.equal(configUtils.defaultConfig.database.client);
+                config.database.connection.should.eql(configUtils.defaultConfig.database.connection);
+                config.server.host.should.equal(configUtils.defaultConfig.server.host);
+                config.server.port.should.equal(configUtils.defaultConfig.server.port);
 
                 done();
             }).catch(done);
@@ -535,25 +496,25 @@ describe('Config', function () {
 
         it('accepts urls with a valid scheme', function (done) {
             // replace the config file with invalid data
-            overrideConfig({url: 'http://testurl.com'});
+            overrideReadFileConfig({url: 'http://testurl.com'});
 
             config.load().then(function (localConfig) {
                 localConfig.url.should.equal('http://testurl.com');
 
                 // Next test
-                overrideConfig({url: 'https://testurl.com'});
+                overrideReadFileConfig({url: 'https://testurl.com'});
                 return config.load();
             }).then(function (localConfig) {
                 localConfig.url.should.equal('https://testurl.com');
 
                 // Next test
-                overrideConfig({url: 'http://testurl.com/blog/'});
+                overrideReadFileConfig({url: 'http://testurl.com/blog/'});
                 return config.load();
             }).then(function (localConfig) {
                 localConfig.url.should.equal('http://testurl.com/blog/');
 
                 // Next test
-                overrideConfig({url: 'http://testurl.com/ghostly/'});
+                overrideReadFileConfig({url: 'http://testurl.com/ghostly/'});
                 return config.load();
             }).then(function (localConfig) {
                 localConfig.url.should.equal('http://testurl.com/ghostly/');
@@ -563,7 +524,7 @@ describe('Config', function () {
         });
 
         it('rejects a fqdn without a scheme', function (done) {
-            overrideConfig({url: 'example.com'});
+            overrideReadFileConfig({url: 'example.com'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -576,7 +537,7 @@ describe('Config', function () {
         });
 
         it('rejects a hostname without a scheme', function (done) {
-            overrideConfig({url: 'example'});
+            overrideReadFileConfig({url: 'example'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -589,7 +550,7 @@ describe('Config', function () {
         });
 
         it('rejects a hostname with a scheme', function (done) {
-            overrideConfig({url: 'https://example'});
+            overrideReadFileConfig({url: 'https://example'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -602,7 +563,7 @@ describe('Config', function () {
         });
 
         it('rejects a url with an unsupported scheme', function (done) {
-            overrideConfig({url: 'ftp://example.com'});
+            overrideReadFileConfig({url: 'ftp://example.com'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -615,7 +576,7 @@ describe('Config', function () {
         });
 
         it('rejects a url with a protocol relative scheme', function (done) {
-            overrideConfig({url: '//example.com'});
+            overrideReadFileConfig({url: '//example.com'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -628,7 +589,7 @@ describe('Config', function () {
         });
 
         it('does not permit the word ghost as a url path', function (done) {
-            overrideConfig({url: 'http://example.com/ghost/'});
+            overrideReadFileConfig({url: 'http://example.com/ghost/'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -641,7 +602,7 @@ describe('Config', function () {
         });
 
         it('does not permit the word ghost to be a component in a url path', function (done) {
-            overrideConfig({url: 'http://example.com/blog/ghost/'});
+            overrideReadFileConfig({url: 'http://example.com/blog/ghost/'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -654,7 +615,7 @@ describe('Config', function () {
         });
 
         it('does not permit the word ghost to be a component in a url path', function (done) {
-            overrideConfig({url: 'http://example.com/ghost/blog/'});
+            overrideReadFileConfig({url: 'http://example.com/ghost/blog/'});
 
             config.load().then(function () {
                 done(expectedError);
@@ -668,7 +629,7 @@ describe('Config', function () {
 
         it('does not permit database config to be falsy', function (done) {
             // replace the config file with invalid data
-            overrideConfig({database: false});
+            overrideReadFileConfig({database: false});
 
             config.load().then(function () {
                 done(expectedError);
@@ -682,7 +643,7 @@ describe('Config', function () {
 
         it('does not permit database config to be empty', function (done) {
             // replace the config file with invalid data
-            overrideConfig({database: {}});
+            overrideReadFileConfig({database: {}});
 
             config.load().then(function () {
                 done(expectedError);
@@ -695,7 +656,7 @@ describe('Config', function () {
         });
 
         it('requires server to be present', function (done) {
-            overrideConfig({server: false});
+            overrideReadFileConfig({server: false});
 
             config.load().then(function (localConfig) {
                 /*jshint unused:false*/
@@ -709,7 +670,7 @@ describe('Config', function () {
         });
 
         it('allows server to use a socket', function (done) {
-            overrideConfig({server: {socket: 'test'}});
+            overrideReadFileConfig({server: {socket: 'test'}});
 
             config.load().then(function () {
                 var socketConfig = config.getSocket();
@@ -723,7 +684,7 @@ describe('Config', function () {
         });
 
         it('allows server to use a socket and user-defined permissions', function (done) {
-            overrideConfig({
+            overrideReadFileConfig({
                 server: {
                     socket: {
                         path: 'test',
@@ -744,7 +705,7 @@ describe('Config', function () {
         });
 
         it('allows server to have a host and a port', function (done) {
-            overrideConfig({server: {host: '127.0.0.1', port: '2368'}});
+            overrideReadFileConfig({server: {host: '127.0.0.1', port: '2368'}});
 
             config.load().then(function (localConfig) {
                 should.exist(localConfig);
@@ -756,7 +717,7 @@ describe('Config', function () {
         });
 
         it('rejects server if there is a host but no port', function (done) {
-            overrideConfig({server: {host: '127.0.0.1'}});
+            overrideReadFileConfig({server: {host: '127.0.0.1'}});
 
             config.load().then(function () {
                 done(expectedError);
@@ -769,7 +730,7 @@ describe('Config', function () {
         });
 
         it('rejects server if there is a port but no host', function (done) {
-            overrideConfig({server: {port: '2368'}});
+            overrideReadFileConfig({server: {port: '2368'}});
 
             config.load().then(function () {
                 done(expectedError);
@@ -782,7 +743,7 @@ describe('Config', function () {
         });
 
         it('rejects server if configuration is empty', function (done) {
-            overrideConfig({server: {}});
+            overrideReadFileConfig({server: {}});
 
             config.load().then(function () {
                 done(expectedError);
@@ -800,113 +761,93 @@ describe('Config', function () {
             // Can't use afterEach here, because mocha uses console.log to output the checkboxes
             // which we've just stubbed, so we need to restore it before the test ends to see ticks.
             resetEnvironment = function () {
-                logStub.restore();
                 process.env.NODE_ENV = currentEnv;
             };
 
         beforeEach(function () {
-            logStub = sinon.stub(console, 'log');
+            logStub = sinon.spy(console, 'log');
             process.env.NODE_ENV = 'development';
         });
 
         afterEach(function () {
             logStub.restore();
-            config = rewire('../../server/config');
+            resetEnvironment();
         });
 
         it('doesn\'t display warning when deprecated options not set', function () {
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
             logStub.calledOnce.should.be.false;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('displays warning when updateCheck exists and is truthy', function () {
-            config.set({
+            configUtils.set({
                 updateCheck: 'foo'
             });
             // Run the test code
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
 
             logStub.calledOnce.should.be.true;
 
             logStub.calledWithMatch('updateCheck').should.be.true;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('displays warning when updateCheck exists and is falsy', function () {
-            config.set({
+            configUtils.set({
                 updateCheck: false
             });
             // Run the test code
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
 
             logStub.calledOnce.should.be.true;
 
             logStub.calledWithMatch('updateCheck').should.be.true;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('displays warning when mail.fromaddress exists and is truthy', function () {
-            config.set({
+            configUtils.set({
                 mail: {
                     fromaddress: 'foo'
                 }
             });
             // Run the test code
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
 
             logStub.calledOnce.should.be.true;
 
             logStub.calledWithMatch('mail.fromaddress').should.be.true;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('displays warning when mail.fromaddress exists and is falsy', function () {
-            config.set({
+            configUtils.set({
                 mail: {
                     fromaddress: false
                 }
             });
             // Run the test code
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
 
             logStub.calledOnce.should.be.true;
 
             logStub.calledWithMatch('mail.fromaddress').should.be.true;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('doesn\'t display warning when only part of a deprecated option is set', function () {
-            config.set({
+            configUtils.set({
                 mail: {
                     notfromaddress: 'foo'
                 }
             });
 
-            config.checkDeprecated();
+            configUtils.config.checkDeprecated();
             logStub.calledOnce.should.be.false;
-
-            // Future tests: This is important here!
-            resetEnvironment();
         });
 
         it('can not modify the deprecatedItems on the config object', function () {
-            config.set({
+            configUtils.set({
                 deprecatedItems: ['foo']
             });
 
-            config.deprecatedItems.should.not.equal(['foo']);
-            resetEnvironment();
+            configUtils.config.deprecatedItems.should.not.equal(['foo']);
         });
     });
 });

--- a/core/test/unit/controllers/frontend/index_spec.js
+++ b/core/test/unit/controllers/frontend/index_spec.js
@@ -11,9 +11,7 @@ var moment   = require('moment'),
     api      = require('../../../../server/api'),
     frontend = require('../../../../server/controllers/frontend'),
 
-    config   = require('../../../../server/config'),
-    origConfig = _.cloneDeep(config),
-
+    configUtils = require('../../../utils/configUtils'),
     sandbox = sinon.sandbox.create();
 
 // To stop jshint complaining
@@ -23,8 +21,8 @@ describe('Frontend Controller', function () {
     var adminEditPagePath = '/ghost/editor/';
 
     afterEach(function () {
-        config.set(origConfig);
         sandbox.restore();
+        configUtils.restore();
     });
 
     // Helper function to prevent unit tests
@@ -52,7 +50,7 @@ describe('Frontend Controller', function () {
                 });
             });
 
-            config.set({
+            configUtils.set({
                 theme: {
                     permalinks: '/:slug/',
                     postsPerPage: 10
@@ -70,7 +68,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Renders home.hbs template when it exists in the active theme', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'index.hbs': '/content/themes/casper/index.hbs',
                 'home.hbs': '/content/themes/casper/home.hbs'
             }}}});
@@ -84,7 +82,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Renders index.hbs template on 2nd page when home.hbs exists', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'index.hbs': '/content/themes/casper/index.hbs',
                 'home.hbs': '/content/themes/casper/home.hbs'
             }}}});
@@ -102,7 +100,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Renders index.hbs template when home.hbs doesn\'t exist', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'index.hbs': '/content/themes/casper/index.hbs'
             }}}});
 
@@ -135,7 +133,7 @@ describe('Frontend Controller', function () {
 
             sandbox.stub(api.tags, 'read').returns(new Promise.resolve({tags: [mockTags[0]]}));
 
-            config.set({
+            configUtils.set({
                 theme: {
                     permalinks: '/tag/:slug/',
                     postsPerPage: '10'
@@ -153,7 +151,7 @@ describe('Frontend Controller', function () {
         });
 
         it('it will render custom tag-slug template if it exists', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'tag-video.hbs': '/content/themes/casper/tag-video.hbs',
                 'tag.hbs': '/content/themes/casper/tag.hbs',
                 'index.hbs': '/content/themes/casper/index.hbs'
@@ -172,7 +170,7 @@ describe('Frontend Controller', function () {
         });
 
         it('it will render tag template if it exists and there is no tag-slug template', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'tag.hbs': '/content/themes/casper/tag.hbs',
                 'index.hbs': '/content/themes/casper/index.hbs'
             }}}});
@@ -190,7 +188,7 @@ describe('Frontend Controller', function () {
         });
 
         it('it will fall back to index if there are no custom templates', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'index.hbs': '/content/themes/casper/index.hbs'
             }}}});
 
@@ -268,7 +266,7 @@ describe('Frontend Controller', function () {
                 return Promise.resolve(post || {posts: []});
             });
 
-            config.set({
+            configUtils.set({
                 theme: {
                     permalinks: '/:slug/'
                 }
@@ -298,7 +296,7 @@ describe('Frontend Controller', function () {
         describe('static pages', function () {
             describe('custom page templates', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:slug/'
                         }
@@ -306,7 +304,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('it will render a custom page-slug template if it exists', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
                     req.path = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
@@ -321,7 +319,7 @@ describe('Frontend Controller', function () {
 
                 it('it will use page.hbs if it exists and no page-slug template is present', function (done) {
                     delete casper['page-about.hbs'];
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
                     req.path = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
@@ -337,7 +335,7 @@ describe('Frontend Controller', function () {
                 it('defaults to post.hbs without a page.hbs or page-slug template', function (done) {
                     delete casper['page-about.hbs'];
                     delete casper['page.hbs'];
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
                     req.path = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
@@ -353,7 +351,7 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to slug', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:slug/'
                         }
@@ -361,7 +359,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('will render static page via /:slug/', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
 
                     req.path = '/' + mockPosts[0].posts[0].slug + '/';
                     req.route = {path: '*'};
@@ -426,7 +424,7 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to date', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:year/:month/:day/:slug/'
                         }
@@ -434,7 +432,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('will render static page via /:slug', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
 
                     req.path = '/' + mockPosts[0].posts[0].slug + '/';
                     req.route = {path: '*'};
@@ -486,7 +484,7 @@ describe('Frontend Controller', function () {
         describe('post', function () {
             describe('permalink set to slug', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:slug/'
                         }
@@ -496,7 +494,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('will render post via /:slug/', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
 
                     req.path = '/' + mockPosts[1].posts[0].slug + '/';
                     req.route = {path: '*'};
@@ -578,7 +576,7 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to date', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:year/:month/:day/:slug/'
                         }
@@ -589,7 +587,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('will render post via /YYYY/MM/DD/:slug/', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
                     req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
                     req.route = {path: '*'};
@@ -668,7 +666,7 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to author', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: 'author/:slug/'
                         }
@@ -679,7 +677,7 @@ describe('Frontend Controller', function () {
                 });
 
                 it('will render post via /:author/:slug/', function (done) {
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
 
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
                     req.route = {path: '*'};
@@ -758,13 +756,13 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to custom format', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:year/:slug/'
                         }
                     });
 
-                    config.set({paths: {availableThemes: {casper: casper}}});
+                    configUtils.set({paths: {availableThemes: {casper: casper}}});
 
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY');
                     mockPosts[1].posts[0].url = '/' + date + '/' + mockPosts[1].posts[0].slug + '/';
@@ -875,7 +873,7 @@ describe('Frontend Controller', function () {
 
             describe('permalink set to custom format no slash', function () {
                 beforeEach(function () {
-                    config.set({
+                    configUtils.set({
                         theme: {
                             permalinks: '/:year/:slug/'
                         }
@@ -923,9 +921,9 @@ describe('Frontend Controller', function () {
                 params: {}
             };
 
-            defaultPath = path.join(config.paths.appRoot, '/core/server/views/private.hbs');
+            defaultPath = path.join(configUtils.config.paths.appRoot, '/core/server/views/private.hbs');
 
-            config.set({
+            configUtils.set({
                 theme: {
                     permalinks: '/:slug/'
                 }
@@ -933,7 +931,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Should render default password page when theme has no password template', function (done) {
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             res.render = function (view) {
                 view.should.eql(defaultPath);
@@ -944,7 +942,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Should render theme password page when it exists', function (done) {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 'private.hbs': '/content/themes/casper/private.hbs'
             }}}});
 
@@ -957,7 +955,7 @@ describe('Frontend Controller', function () {
         });
 
         it('Should render with error when error is passed in', function (done) {
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
             res.error = 'Test Error';
 
             res.render = function (view, context) {
@@ -1032,7 +1030,7 @@ describe('Frontend Controller', function () {
                 return Promise.resolve(post || {posts: []});
             });
 
-            config.set({
+            configUtils.set({
                 theme: {
                     permalinks: '/:slug/'
                 }
@@ -1049,7 +1047,7 @@ describe('Frontend Controller', function () {
                 redirect: sinon.spy()
             };
 
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
         });
 
         it('should render draft post', function (done) {
@@ -1065,7 +1063,7 @@ describe('Frontend Controller', function () {
         });
 
         it('should render draft page', function (done) {
-            config.set({paths: {availableThemes: {casper: {'page.hbs': '/content/themes/casper/page.hbs'}}}});
+            configUtils.set({paths: {availableThemes: {casper: {'page.hbs': '/content/themes/casper/page.hbs'}}}});
             req.params = {uuid: 'abc-1234-01'};
             res.render = function (view, context) {
                 view.should.equal('page');

--- a/core/test/unit/controllers/frontend/templates_spec.js
+++ b/core/test/unit/controllers/frontend/templates_spec.js
@@ -2,20 +2,18 @@
 /*jshint expr:true*/
 var should   = require('should'),
     rewire   = require('rewire'),
-    _        = require('lodash'),
 
 // Stuff we are testing
     templates = rewire('../../../../server/controllers/frontend/templates'),
 
-    config   = require('../../../../server/config'),
-    origConfig = _.cloneDeep(config);
+    configUtils = require('../../../utils/configUtils');
 
 // To stop jshint complaining
 should.equal(true, true);
 
 describe('templates', function () {
     afterEach(function () {
-        config.set(origConfig);
+        configUtils.restore();
     });
 
     describe('utils', function () {
@@ -55,7 +53,7 @@ describe('templates', function () {
     describe('single', function () {
         describe('with many templates', function () {
             beforeEach(function () {
-                config.set({
+                configUtils.set({
                     paths: {
                         availableThemes: {
                             casper: {
@@ -110,7 +108,7 @@ describe('templates', function () {
         });
 
         it('will fall back to post even if no index.hbs', function () {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 assets: null,
                 'default.hbs': '/content/themes/casper/default.hbs'
             }}}});
@@ -124,7 +122,7 @@ describe('templates', function () {
     describe('channel', function () {
         describe('without tag templates', function () {
             beforeEach(function () {
-                config.set({paths: {availableThemes: {casper: {
+                configUtils.set({paths: {availableThemes: {casper: {
                     assets: null,
                     'default.hbs': '/content/themes/casper/default.hbs',
                     'index.hbs': '/content/themes/casper/index.hbs'
@@ -140,7 +138,7 @@ describe('templates', function () {
 
         describe('with tag templates', function () {
             beforeEach(function () {
-                config.set({paths: {availableThemes: {casper: {
+                configUtils.set({paths: {availableThemes: {casper: {
                     assets: null,
                     'default.hbs': '/content/themes/casper/default.hbs',
                     'index.hbs': '/content/themes/casper/index.hbs',
@@ -163,7 +161,7 @@ describe('templates', function () {
         });
 
         it('will fall back to index even if no index.hbs', function () {
-            config.set({paths: {availableThemes: {casper: {
+            configUtils.set({paths: {availableThemes: {casper: {
                 assets: null,
                 'default.hbs': '/content/themes/casper/default.hbs'
             }}}});

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -1,17 +1,16 @@
-/*globals describe, before, beforeEach, afterEach, it*/
+/*globals describe, after, before, beforeEach, afterEach, it*/
 /*jshint expr:true*/
 var should     = require('should'),
     Promise    = require('bluebird'),
     sinon      = require('sinon'),
     express    = require('express'),
     rewire     = require('rewire'),
-    _          = require('lodash'),
 
     // Stuff we are testing
-
     chalk      = require('chalk'),
-    config     = rewire('../../server/config'),
     errors     = rewire('../../server/errors'),
+    configUtils = require('../utils/configUtils'),
+
     // storing current environment
     currentEnv = process.env.NODE_ENV;
 
@@ -313,12 +312,10 @@ describe('Error handling', function () {
     });
 
     describe('Rendering', function () {
-        var sandbox,
-            originalConfig;
+        var sandbox;
 
         before(function () {
-            originalConfig = _.cloneDeep(config._config);
-            errors.__set__('getConfigModule', sinon.stub().returns(_.merge({}, originalConfig, {
+            configUtils.set({
                 paths: {
                     themePath: '/content/themes',
                     availableThemes: {
@@ -334,8 +331,13 @@ describe('Error handling', function () {
                         }
                     }
                 }
-            })));
+            });
+
             errors.updateActiveTheme('casper');
+        });
+
+        after(function () {
+            configUtils.restore();
         });
 
         beforeEach(function () {

--- a/core/test/unit/importer_spec.js
+++ b/core/test/unit/importer_spec.js
@@ -6,7 +6,6 @@ var should    = require('should'),
     _         = require('lodash'),
     testUtils = require('../utils'),
     moment    = require('moment'),
-    config    = require('../../server/config'),
     path      = require('path'),
     errors    = require('../../server/errors'),
 
@@ -18,8 +17,10 @@ var should    = require('should'),
     DataImporter    = require('../../server/data/importer/importers/data'),
     ImageImporter   = require('../../server/data/importer/importers/image'),
 
-    storage = require('../../server/storage'),
-    sandbox = sinon.sandbox.create();
+    storage         = require('../../server/storage'),
+
+    configUtils     = require('../utils/configUtils'),
+    sandbox         = sinon.sandbox.create();
 
 // To stop jshint complaining
 should.equal(true, true);
@@ -27,6 +28,7 @@ should.equal(true, true);
 describe('Importer', function () {
     afterEach(function () {
         sandbox.restore();
+        configUtils.restore();
     });
 
     describe('ImportManager', function () {
@@ -342,12 +344,7 @@ describe('Importer', function () {
     });
 
     describe('ImageHandler', function () {
-        var origConfig = _.cloneDeep(config),
-            store = storage.getStorage();
-
-        afterEach(function () {
-            config.set(_.merge({}, origConfig));
-        });
+        var store = storage.getStorage();
 
         it('has the correct interface', function () {
             ImageHandler.type.should.eql('images');
@@ -427,7 +424,7 @@ describe('Importer', function () {
         });
 
         it('can load a file (subdirectory)', function (done) {
-            config.set({url: 'http://testurl.com/subdir'});
+            configUtils.set({url: 'http://testurl.com/subdir'});
 
             var filename = 'test-image.jpeg',
                 file = [{

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -5,7 +5,7 @@ var should          = require('should'),
 
     // Stuff we are testing
     mailer          = require('../../server/mail'),
-    config          = require('../../server/config'),
+    configUtils     = require('../utils/configUtils'),
 
     SMTP;
 
@@ -23,7 +23,7 @@ SMTP = {
 
 describe('Mail', function () {
     afterEach(function () {
-        config.set({mail: null});
+        configUtils.restore();
     });
 
     it('should attach mail provider to ghost instance', function () {
@@ -34,7 +34,7 @@ describe('Mail', function () {
     });
 
     it('should setup SMTP transport on initialization', function (done) {
-        config.set({mail: SMTP});
+        configUtils.set({mail: SMTP});
         mailer.init().then(function () {
             mailer.should.have.property('transport');
             mailer.transport.transportType.should.eql('SMTP');
@@ -44,7 +44,7 @@ describe('Mail', function () {
     });
 
     it('should fallback to direct if config is empty', function (done) {
-        config.set({mail: {}});
+        configUtils.set({mail: {}});
         mailer.init().then(function () {
             mailer.should.have.property('transport');
             mailer.transport.transportType.should.eql('DIRECT');
@@ -69,7 +69,7 @@ describe('Mail', function () {
     });
 
     it('should use from address as configured in config.js', function () {
-        config.set({
+        configUtils.set({
             mail: {
                 from: '"Blog Title" <static@example.com>'
             }
@@ -79,49 +79,49 @@ describe('Mail', function () {
 
     it('should fall back to [blog.title] <ghost@[blog.url]> as from address', function () {
         // Standard domain
-        config.set({url: 'http://default.com', mail: {from: null}, theme: {title: 'Test'}});
+        configUtils.set({url: 'http://default.com', mail: {from: null}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <ghost@default.com>');
 
         // Trailing slash
-        config.set({url: 'http://default.com/', mail: {from: null}, theme: {title: 'Test'}});
+        configUtils.set({url: 'http://default.com/', mail: {from: null}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <ghost@default.com>');
 
         // Strip Port
-        config.set({url: 'http://default.com:2368/', mail: {from: null}, theme: {title: 'Test'}});
+        configUtils.set({url: 'http://default.com:2368/', mail: {from: null}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <ghost@default.com>');
     });
 
     it('should use mail.from if both from and fromaddress are present', function () {
         // Standard domain
-        config.set({mail: {from: '"bar" <from@default.com>', fromaddress: '"Qux" <fa@default.com>'}});
+        configUtils.set({mail: {from: '"bar" <from@default.com>', fromaddress: '"Qux" <fa@default.com>'}});
         mailer.from().should.equal('"bar" <from@default.com>');
     });
 
     it('should attach blog title if from or fromaddress are only email addresses', function () {
         // from and fromaddress are both set
-        config.set({mail: {from: 'from@default.com', fromaddress: 'fa@default.com'}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: 'from@default.com', fromaddress: 'fa@default.com'}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <from@default.com>');
 
         // only from set
-        config.set({mail: {from: 'from@default.com', fromaddress: null}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: 'from@default.com', fromaddress: null}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <from@default.com>');
 
         // only fromaddress set
-        config.set({mail: {from: null, fromaddress: 'fa@default.com'}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: null, fromaddress: 'fa@default.com'}, theme: {title: 'Test'}});
         mailer.from().should.equal('"Test" <fa@default.com>');
     });
 
     it('should ignore theme title if from address is Title <email@address.com> format', function () {
         // from and fromaddress are both set
-        config.set({mail: {from: '"R2D2" <from@default.com>', fromaddress: '"C3PO" <fa@default.com>'}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: '"R2D2" <from@default.com>', fromaddress: '"C3PO" <fa@default.com>'}, theme: {title: 'Test'}});
         mailer.from().should.equal('"R2D2" <from@default.com>');
 
         // only from set
-        config.set({mail: {from: '"R2D2" <from@default.com>', fromaddress: null}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: '"R2D2" <from@default.com>', fromaddress: null}, theme: {title: 'Test'}});
         mailer.from().should.equal('"R2D2" <from@default.com>');
 
         // only fromaddress set
-        config.set({mail: {from: null, fromaddress: '"C3PO" <fa@default.com>'}, theme: {title: 'Test'}});
+        configUtils.set({mail: {from: null, fromaddress: '"C3PO" <fa@default.com>'}, theme: {title: 'Test'}});
         mailer.from().should.equal('"C3PO" <fa@default.com>');
     });
 });

--- a/core/test/unit/middleware/authentication_spec.js
+++ b/core/test/unit/middleware/authentication_spec.js
@@ -1,13 +1,11 @@
 /*globals describe, it, beforeEach, afterEach */
 /*jshint expr:true*/
-var _                       = require('lodash'),
-    sinon                   = require('sinon'),
+var sinon                   = require('sinon'),
     should                  = require('should'),
     passport                = require('passport'),
     rewire                  = require('rewire'),
-    config                  = require('../../../server/config'),
+    configUtils             = require('../../utils/configUtils'),
     errors                  = require('../../../server/errors'),
-    defaultConfig           = rewire('../../../../config.example')[process.env.NODE_ENV],
     auth                    = rewire('../../../server/middleware/auth'),
     BearerStrategy          = require('passport-http-bearer').Strategy,
     ClientPasswordStrategy  = require('passport-oauth2-client-password').Strategy,
@@ -131,11 +129,11 @@ describe('Auth', function () {
 
     describe('User Authentication', function () {
         beforeEach(function () {
-            defaultConfig.url = 'http://my-domain.com';
-            var newConfig = _.extend({}, config, defaultConfig);
+            configUtils.set({url: 'http://my-domain.com'});
+        });
 
-            auth.__get__('config', newConfig);
-            config.set(newConfig);
+        afterEach(function () {
+            configUtils.restore();
         });
 
         it('should authenticate user', function (done) {
@@ -400,13 +398,13 @@ describe('Auth', function () {
             req.body.client_id = testClient;
             req.body.client_secret = testSecret;
             req.headers = {};
-            req.headers.origin = config.url;
+            req.headers.origin = configUtils.config.url;
 
             res.header = {};
 
             sandbox.stub(res, 'header', function (key, value) {
                 key.should.equal('Access-Control-Allow-Origin');
-                value.should.equal(config.url);
+                value.should.equal(configUtils.config.url);
             });
 
             registerSuccessfulClientPasswordStrategy();
@@ -426,7 +424,7 @@ describe('Auth', function () {
 
             sandbox.stub(res, 'header', function (key, value) {
                 key.should.equal('Access-Control-Allow-Origin');
-                value.should.equal(config.url);
+                value.should.equal(configUtils.config.url);
             });
 
             registerSuccessfulClientPasswordStrategy();
@@ -487,13 +485,13 @@ describe('Auth', function () {
             req.query.client_id = testClient;
             req.query.client_secret = testSecret;
             req.headers = {};
-            req.headers.origin = config.url;
+            req.headers.origin = configUtils.config.url;
 
             res.header = {};
 
             sandbox.stub(res, 'header', function (key, value) {
                 key.should.equal('Access-Control-Allow-Origin');
-                value.should.equal(config.url);
+                value.should.equal(configUtils.config.url);
             });
 
             registerSuccessfulClientPasswordStrategy();
@@ -510,13 +508,13 @@ describe('Auth', function () {
             req.query.client_id = testClient;
             req.query.client_secret = testSecret;
             req.headers = {};
-            req.headers.origin = config.url;
+            req.headers.origin = configUtils.config.url;
 
             res.header = {};
 
             sandbox.stub(res, 'header', function (key, value) {
                 key.should.equal('Access-Control-Allow-Origin');
-                value.should.equal(config.url);
+                value.should.equal(configUtils.config.url);
             });
 
             registerSuccessfulClientPasswordStrategy();

--- a/core/test/unit/middleware/check-ssl_spec.js
+++ b/core/test/unit/middleware/check-ssl_spec.js
@@ -2,7 +2,7 @@
 /*jshint expr:true*/
 var sinon    = require('sinon'),
     should   = require('should'),
-    config   = require('../../../server/config'),
+    configUtils = require('../../utils/configUtils'),
     checkSSL = require('../../../server/middleware/check-ssl');
 
 should.equal(true, true);
@@ -15,17 +15,19 @@ describe('checkSSL', function () {
         req = {};
         res = {};
         next = sandbox.spy();
+
+        configUtils.set({
+            url: 'http://default.com:2368/'
+        });
     });
 
     afterEach(function () {
         sandbox.restore();
+        configUtils.restore();
     });
 
     it('should not require SSL (frontend)', function (done) {
         req.url = '/';
-        config.set({
-            url: 'http://default.com:2368/'
-        });
         checkSSL(req, res, next);
         next.called.should.be.true;
         next.calledWith().should.be.true;
@@ -35,9 +37,6 @@ describe('checkSSL', function () {
     it('should require SSL (frontend)', function (done) {
         req.url = '/';
         req.secure = true;
-        config.set({
-            url: 'https://default.com:2368/'
-        });
         checkSSL(req, res, next);
         next.called.should.be.true;
         next.calledWith().should.be.true;
@@ -47,9 +46,6 @@ describe('checkSSL', function () {
     it('should not require SSL (admin)', function (done) {
         req.url = '/ghost';
         res.isAdmin = true;
-        config.set({
-            url: 'http://default.com:2368/'
-        });
         checkSSL(req, res, next);
         next.called.should.be.true;
         next.calledWith().should.be.true;
@@ -60,9 +56,7 @@ describe('checkSSL', function () {
         req.url = '/ghost';
         res.isAdmin = true;
         res.secure = true;
-        config.set({
-            url: 'http://default.com:2368/'
-        });
+
         checkSSL(req, res, next);
         next.called.should.be.true;
         next.calledWith().should.be.true;
@@ -73,7 +67,7 @@ describe('checkSSL', function () {
         req.url = '/ghost';
         res.isAdmin = true;
         req.secure = true;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/',
             forceAdminSSL: true
         });
@@ -88,7 +82,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
         res.redirect = {};
         req.secure = false;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/',
             urlSSL: '',
             forceAdminSSL: true
@@ -109,7 +103,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
         res.redirect = {};
         req.secure = false;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/blog/',
             urlSSL: '',
             forceAdminSSL: true
@@ -133,7 +127,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
         res.redirect = {};
         req.secure = false;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/',
             urlSSL: '',
             forceAdminSSL: true
@@ -153,7 +147,7 @@ describe('checkSSL', function () {
         req.url = '/';
         req.secure = false;
         res.redirect = {};
-        config.set({
+        configUtils.set({
             url: 'https://default.com:2368',
             urlSSL: '',
             forceAdminSSL: true
@@ -174,9 +168,10 @@ describe('checkSSL', function () {
         res.isAdmin = true;
         res.redirect = {};
         req.secure = false;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/',
-            urlSSL: 'https://ssl-domain.com:2368/'
+            urlSSL: 'https://ssl-domain.com:2368/',
+            forceAdminSSL: true
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
@@ -194,7 +189,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
         res.sendStatus = {};
         req.secure = false;
-        config.set({
+        configUtils.set({
             url: 'http://default.com:2368/',
             forceAdminSSL: {
                 redirect: false

--- a/core/test/unit/middleware/serve-shared-file_spec.js
+++ b/core/test/unit/middleware/serve-shared-file_spec.js
@@ -100,6 +100,6 @@ describe('serveSharedFile', function () {
         next.called.should.be.false;
         res.writeHead.called.should.be.true;
 
-        res.end.calledWith('User-agent: http://default.com:2368').should.be.true;
+        res.end.calledWith('User-agent: http://127.0.0.1:2369').should.be.true;
     });
 });

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -1,7 +1,6 @@
 /*globals describe, it, beforeEach, afterEach */
 /*jshint expr:true*/
-var _            = require('lodash'),
-    sinon        = require('sinon'),
+var sinon        = require('sinon'),
     should       = require('should'),
     express      = require('express'),
     Promise      = require('bluebird'),
@@ -11,12 +10,10 @@ var _            = require('lodash'),
     hbs          = require('express-hbs'),
     themeHandler = require('../../../server/middleware/theme-handler'),
     errors       = require('../../../server/errors'),
+    api          = require('../../../server/api'),
 
-    api      = require('../../../server/api'),
-    config   = require('../../../server/config'),
-    origConfig = _.cloneDeep(config),
-    defaultConfig  = require('../../../../config.example')[process.env.NODE_ENV],
-    sandbox = sinon.sandbox.create();
+    configUtils  = require('../../utils/configUtils'),
+    sandbox      = sinon.sandbox.create();
 
 should.equal(true, true);
 
@@ -33,9 +30,7 @@ describe('Theme Handler', function () {
 
     afterEach(function () {
         sandbox.restore();
-
-        // Reset config
-        config.set(_.merge({}, origConfig, defaultConfig));
+        configUtils.restore();
     });
 
     describe('ghostLocals', function () {
@@ -101,7 +96,7 @@ describe('Theme Handler', function () {
             var themeOptSpy = sandbox.stub(hbs, 'updateTemplateOptions');
             req.secure = true;
             res.locals = {};
-            config.set({urlSSL: 'https://secure.blog'});
+            configUtils.set({urlSSL: 'https://secure.blog'});
 
             themeHandler.configHbsForContext(req, res, next);
 
@@ -145,7 +140,7 @@ describe('Theme Handler', function () {
                 }]
             }));
             blogApp.set('activeTheme', 'not-casper');
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
                 activateThemeSpy.called.should.be.true;
@@ -162,7 +157,7 @@ describe('Theme Handler', function () {
                 }]
             }));
             blogApp.set('activeTheme', 'casper');
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
                 activateThemeSpy.called.should.be.false;
@@ -181,7 +176,7 @@ describe('Theme Handler', function () {
                 }]
             }));
             blogApp.set('activeTheme', 'not-casper');
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function (err) {
                 should.exist(err);
@@ -205,7 +200,7 @@ describe('Theme Handler', function () {
             }));
             res.isAdmin = true;
             blogApp.set('activeTheme', 'not-casper');
-            config.set({paths: {availableThemes: {casper: {}}}});
+            configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
                 errorSpy.called.should.be.false;

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -11,9 +11,9 @@ var should          = require('should'),
 
     // Things that get overridden
     api             = require('../../server/api'),
-    config          = require('../../server/config'),
-    origConfig      = _.cloneDeep(config),
-    rss             = rewire('../../server/data/xml/rss');
+    rss             = rewire('../../server/data/xml/rss'),
+
+    configUtils     = require('../utils/configUtils');
 
 // To stop jshint complaining
 should.equal(true, true);
@@ -48,7 +48,7 @@ describe('RSS', function () {
     afterEach(function () {
         sandbox.restore();
         rss = rewire('../../server/data/xml/rss');
-        config.set(_.merge({}, origConfig));
+        configUtils.restore();
     });
 
     describe('Check XML', function () {
@@ -65,7 +65,7 @@ describe('RSS', function () {
                 set: sinon.stub()
             };
 
-            config.set({url: 'http://my-ghost-blog.com'});
+            configUtils.set({url: 'http://my-ghost-blog.com'});
         });
 
         it('should get the RSS tags correct', function (done) {
@@ -215,7 +215,7 @@ describe('RSS', function () {
         });
 
         it('should process urls correctly with subdirectory', function (done) {
-            config.set({url: 'http://my-ghost-blog.com/blog/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
             rss.__set__('getData', function () {
                 return Promise.resolve({
                     title: 'Test Title',
@@ -274,7 +274,7 @@ describe('RSS', function () {
                 set: sinon.stub()
             };
 
-            config.set({url: 'http://my-ghost-blog.com', theme: {
+            configUtils.set({url: 'http://my-ghost-blog.com', theme: {
                 title: 'Test',
                 description: 'Some Text',
                 permalinks: '/:slug/'
@@ -346,7 +346,7 @@ describe('RSS', function () {
                 set: sinon.stub()
             };
 
-            config.set({url: 'http://my-ghost-blog.com'});
+            configUtils.set({url: 'http://my-ghost-blog.com'});
         });
 
         it('should not rebuild xml for same data and url', function (done) {
@@ -408,7 +408,7 @@ describe('RSS', function () {
         });
 
         it('Should 404 if page number too big', function (done) {
-            config.set({url: 'http://testurl.com/'});
+            configUtils.set({url: 'http://testurl.com/'});
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
@@ -425,7 +425,7 @@ describe('RSS', function () {
         });
 
         it('Redirects to last page if page number too big with subdirectory', function (done) {
-            config.set({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);

--- a/core/test/unit/server_helpers/asset_spec.js
+++ b/core/test/unit/server_helpers/asset_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -13,11 +14,11 @@ describe('{{asset}} helper', function () {
 
     before(function () {
         utils.loadHelpers();
-        utils.overrideConfig({assetHash: 'abc'});
+        configUtils.set({assetHash: 'abc'});
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded asset helper', function () {
@@ -66,7 +67,7 @@ describe('{{asset}} helper', function () {
 
     describe('with /blog subdirectory', function () {
         before(function () {
-            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
         });
 
         it('handles favicon correctly', function () {

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -12,7 +13,7 @@ describe('{{body_class}} helper', function () {
     var options = {};
     before(function () {
         utils.loadHelpers();
-        utils.overrideConfig({paths: {
+        configUtils.set({paths: {
             availableThemes: {
                 casper: {
                     assets: null,
@@ -38,7 +39,7 @@ describe('{{body_class}} helper', function () {
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded body_class helper', function () {

--- a/core/test/unit/server_helpers/ghost_foot_spec.js
+++ b/core/test/unit/server_helpers/ghost_foot_spec.js
@@ -44,6 +44,5 @@ describe('{{ghost_foot}} helper', function () {
 
     afterEach(function () {
         sandbox.restore();
-        utils.restoreConfig();
     });
 });

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -1,10 +1,11 @@
-/*globals describe, before, after, afterEach, beforeEach, it*/
+/*globals describe, before, afterEach, beforeEach, it*/
 /*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
     moment         = require('moment'),
 
 // Stuff we are testing
@@ -25,9 +26,7 @@ describe('{{ghost_head}} helper', function () {
 
     afterEach(function () {
         sandbox.restore();
-    });
-    after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     beforeEach(function () {
@@ -52,8 +51,8 @@ describe('{{ghost_head}} helper', function () {
     }
 
     describe('without Code Injection', function () {
-        before(function () {
-            utils.overrideConfig({
+        beforeEach(function () {
+            configUtils.set({
                 url: 'http://testurl.com/',
                 theme: {
                     title: 'Ghost',
@@ -665,8 +664,8 @@ describe('{{ghost_head}} helper', function () {
         });
 
         describe('with /blog subdirectory', function () {
-            before(function () {
-                utils.overrideConfig({
+            beforeEach(function () {
+                configUtils.set({
                     url: 'http://testurl.com/blog/',
                     theme: {
                         title: 'Ghost',
@@ -674,10 +673,6 @@ describe('{{ghost_head}} helper', function () {
                         cover: '/content/images/blog-cover.png'
                     }
                 });
-            });
-
-            after(function () {
-                utils.restoreConfig();
             });
 
             it('returns correct rss url with subdirectory', function (done) {
@@ -698,8 +693,8 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('with useStructuredData is set to false in config file', function () {
-        before(function () {
-            utils.overrideConfig({
+        beforeEach(function () {
+            configUtils.set({
                 url: 'http://testurl.com/',
                 theme: {
                     title: 'Ghost',
@@ -752,7 +747,7 @@ describe('{{ghost_head}} helper', function () {
                 settings: [{value: '<style>body {background: red;}</style>'}]
             }));
 
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://testurl.com/',
                 theme: {
                     title: 'Ghost',
@@ -781,7 +776,7 @@ describe('{{ghost_head}} helper', function () {
 
     describe('with Ajax Helper', function () {
         beforeEach(function () {
-            utils.overrideConfig({
+            configUtils.set({
                 url: '',
                 urlSSL: '',
                 forceAdminSSL: false
@@ -789,7 +784,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('renders script tags with basic configuration', function (done) {
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://example.com/'
             });
 
@@ -807,7 +802,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('renders basic url correctly', function (done) {
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://testurl.com/'
             });
 
@@ -825,7 +820,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('renders basic url correctly with subdirectory', function (done) {
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://testurl.com/blog/'
             });
 
@@ -843,7 +838,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('renders correct https url with forceAdminSSL set', function (done) {
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://testurl.com/',
                 forceAdminSSL: true
             });
@@ -862,7 +857,7 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('renders correct https url if urlSSL is set and forceAdminSSL is also set', function (done) {
-            utils.overrideConfig({
+            configUtils.set({
                 url: 'http://testurl.com/',
                 urlSSL: 'https://sslurl.com/',
                 forceAdminSSL: true

--- a/core/test/unit/server_helpers/image_spec.js
+++ b/core/test/unit/server_helpers/image_spec.js
@@ -4,6 +4,7 @@ var should         = require('should'),
     sinon          = require('sinon'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -14,7 +15,7 @@ describe('{{image}} helper', function () {
 
     before(function () {
         sandbox = sinon.sandbox.create();
-        utils.overrideConfig({url: 'http://testurl.com/'});
+        configUtils.set({url: 'http://testurl.com/'});
         utils.loadHelpers();
     });
 
@@ -23,7 +24,7 @@ describe('{{image}} helper', function () {
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded image helper', function () {
@@ -44,12 +45,12 @@ describe('{{image}} helper', function () {
 
     it('should output absolute url of image if the option is present ', function () {
         var rendered = helpers.image.call({
-            image: '/content/images/image-relative-url.png',
-            author: {image: '/content/images/author-image-relative-url.png'}
-        },
-        {
-            hash: {absolute: 'true'}
-        });
+                image: '/content/images/image-relative-url.png',
+                author: {image: '/content/images/author-image-relative-url.png'}
+            },
+            {
+                hash: {absolute: 'true'}
+            });
 
         should.exist(rendered);
         rendered.should.equal('http://testurl.com/content/images/image-relative-url.png');
@@ -66,57 +67,50 @@ describe('{{image}} helper', function () {
 
         should.not.exist(rendered);
     });
-});
 
-describe('{{image}} helper when Ghost is running on a sub-directory', function () {
-    var sandbox;
-
-    before(function () {
-        sandbox = sinon.sandbox.create();
-        utils.overrideConfig({url: 'http://testurl.com/blog'});
-        utils.loadHelpers();
-    });
-
-    afterEach(function () {
-        sandbox.restore();
-    });
-
-    after(function () {
-        utils.restoreConfig();
-    });
-
-    it('should output relative url of image', function () {
-        var rendered = helpers.image.call({
-            image: '/blog/content/images/image-relative-url.png',
-            author: {
-                image: '/blog/content/images/author-image-relative-url.png'
-            }
+    describe('with sub-directory', function () {
+        before(function () {
+            configUtils.set({url: 'http://testurl.com/blog'});
+        });
+        after(function () {
+            configUtils.restore();
         });
 
-        should.exist(rendered);
-        rendered.should.equal('/blog/content/images/image-relative-url.png');
-    });
+        it('should output relative url of image', function () {
+            var rendered = helpers.image.call({
+                image: '/blog/content/images/image-relative-url.png',
+                author: {
+                    image: '/blog/content/images/author-image-relative-url.png'
+                }
+            });
 
-    it('should output absolute url of image if the option is present ', function () {
-        var rendered = helpers.image.call({
-            image: '/blog/content/images/image-relative-url.png',
-            author: {image: '/blog/content/images/author-image-relatve-url.png'}},
-            {hash: {absolute: 'true'}
+            should.exist(rendered);
+            rendered.should.equal('/blog/content/images/image-relative-url.png');
         });
 
-        should.exist(rendered);
-        rendered.should.equal('http://testurl.com/blog/content/images/image-relative-url.png');
-    });
+        it('should output absolute url of image if the option is present ', function () {
+            var rendered = helpers.image.call({
+                    image: '/blog/content/images/image-relative-url.png',
+                    author: {image: '/blog/content/images/author-image-relatve-url.png'}
+                },
+                {
+                    hash: {absolute: 'true'}
+                });
 
-    it('should not change output for an external url', function () {
-        var rendered = helpers.image.call({
-            image: 'http://example.com/picture.jpg',
-            author: {
-                image: '/blog/content/images/author-image-relative-url.png'
-            }
+            should.exist(rendered);
+            rendered.should.equal('http://testurl.com/blog/content/images/image-relative-url.png');
         });
 
-        should.exist(rendered);
-        rendered.should.equal('http://example.com/picture.jpg');
+        it('should not change output for an external url', function () {
+            var rendered = helpers.image.call({
+                image: 'http://example.com/picture.jpg',
+                author: {
+                    image: '/blog/content/images/author-image-relative-url.png'
+                }
+            });
+
+            should.exist(rendered);
+            rendered.should.equal('http://example.com/picture.jpg');
+        });
     });
 });

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -11,7 +12,7 @@ var should         = require('should'),
 describe('{{meta_description}} helper', function () {
     before(function () {
         utils.loadHelpers();
-        utils.overrideConfig({
+        configUtils.set({
             theme: {
                 description: 'Just a blogging platform.'
             }
@@ -19,7 +20,7 @@ describe('{{meta_description}} helper', function () {
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded meta_description helper', function () {

--- a/core/test/unit/server_helpers/meta_title_spec.js
+++ b/core/test/unit/server_helpers/meta_title_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -11,7 +12,7 @@ var should         = require('should'),
 describe('{{meta_title}} helper', function () {
     before(function () {
         utils.loadHelpers();
-        utils.overrideConfig({
+        configUtils.set({
             theme: {
                 title: 'Ghost'
             }
@@ -19,7 +20,7 @@ describe('{{meta_title}} helper', function () {
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded meta_title helper', function () {

--- a/core/test/unit/server_helpers/navigation_spec.js
+++ b/core/test/unit/server_helpers/navigation_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
     path           = require('path'),
 
 // Stuff we are testing
@@ -20,7 +21,7 @@ describe('{{navigation}} helper', function () {
     before(function (done) {
         utils.loadHelpers();
         hbs.express3({
-            partialsDir: [utils.config.paths.helperTemplates]
+            partialsDir: [configUtils.config.paths.helperTemplates]
         });
 
         hbs.cachePartials(function () {
@@ -72,7 +73,7 @@ describe('{{navigation}} helper', function () {
 
     it('can render one item', function () {
         var singleItem = {label: 'Foo', url: '/foo'},
-            testUrl = 'href="' + utils.config.url + '/foo"',
+            testUrl = 'href="' + configUtils.config.url + '/foo"',
             rendered;
 
         optionsData.data.blog.navigation = [singleItem];
@@ -87,8 +88,8 @@ describe('{{navigation}} helper', function () {
     it('can render multiple items', function () {
         var firstItem = {label: 'Foo', url: '/foo'},
             secondItem = {label: 'Bar Baz Qux', url: '/qux'},
-            testUrl = 'href="' + utils.config.url + '/foo"',
-            testUrl2 = 'href="' + utils.config.url + '/qux"',
+            testUrl = 'href="' + configUtils.config.url + '/foo"',
+            testUrl2 = 'href="' + configUtils.config.url + '/qux"',
             rendered;
 
         optionsData.data.blog.navigation = [firstItem, secondItem];
@@ -124,7 +125,7 @@ describe('{{navigation}} helper with custom template', function () {
     before(function (done) {
         utils.loadHelpers();
         hbs.express3({
-            partialsDir: [path.resolve(utils.config.paths.corePath, 'test/unit/server_helpers/test_tpl')]
+            partialsDir: [path.resolve(configUtils.config.paths.corePath, 'test/unit/server_helpers/test_tpl')]
         });
 
         hbs.cachePartials(function () {
@@ -148,7 +149,7 @@ describe('{{navigation}} helper with custom template', function () {
 
     it('can render one item and @blog title', function () {
         var singleItem = {label: 'Foo', url: '/foo'},
-            testUrl = 'href="' + utils.config.url + '/foo"',
+            testUrl = 'href="' + configUtils.config.url + '/foo"',
             rendered;
 
         optionsData.data.blog.navigation = [singleItem];

--- a/core/test/unit/server_helpers/page_url_spec.js
+++ b/core/test/unit/server_helpers/page_url_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -43,11 +44,11 @@ describe('{{page_url}} helper', function () {
 
     describe('with /blog subdirectory', function () {
         before(function () {
-            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
         });
 
         after(function () {
-            utils.restoreConfig();
+            configUtils.restore();
         });
 
         it('can return a valid url with subdirectory', function () {
@@ -111,11 +112,11 @@ describe('{{pageUrl}} helper [DEPRECATED]', function () {
 
     describe('with /blog subdirectory', function () {
         before(function () {
-            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
         });
 
         after(function () {
-            utils.restoreConfig();
+            configUtils.restore();
         });
 
         it('can return a valid url with subdirectory', function () {

--- a/core/test/unit/server_helpers/pagination_spec.js
+++ b/core/test/unit/server_helpers/pagination_spec.js
@@ -3,6 +3,7 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
     path           = require('path'),
 
 // Stuff we are testing
@@ -12,7 +13,7 @@ var should         = require('should'),
 describe('{{pagination}} helper', function () {
     before(function (done) {
         utils.loadHelpers();
-        hbs.express3({partialsDir: [utils.config.paths.helperTemplates]});
+        hbs.express3({partialsDir: [configUtils.config.paths.helperTemplates]});
 
         hbs.cachePartials(function () {
             done();
@@ -127,7 +128,7 @@ describe('{{pagination}} helper', function () {
 describe('{{pagination}} helper with custom template', function () {
     before(function (done) {
         utils.loadHelpers();
-        hbs.express3({partialsDir: [path.resolve(utils.config.paths.corePath, 'test/unit/server_helpers/test_tpl')]});
+        hbs.express3({partialsDir: [path.resolve(configUtils.config.paths.corePath, 'test/unit/server_helpers/test_tpl')]});
 
         hbs.cachePartials(function () {
             done();

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -5,6 +5,7 @@ var should         = require('should'),
     Promise        = require('bluebird'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
+    configUtils    = require('../../utils/configUtils'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
@@ -16,7 +17,7 @@ describe('{{url}} helper', function () {
 
     before(function () {
         sandbox = sinon.sandbox.create();
-        utils.overrideConfig({url: 'http://testurl.com/'});
+        configUtils.set({url: 'http://testurl.com/'});
         utils.loadHelpers();
     });
 
@@ -32,7 +33,7 @@ describe('{{url}} helper', function () {
     });
 
     after(function () {
-        utils.restoreConfig();
+        configUtils.restore();
     });
 
     it('has loaded url helper', function () {
@@ -188,7 +189,7 @@ describe('{{url}} helper', function () {
 
     describe('with subdir', function () {
         it('external urls should be retained in a nav context with subdir', function () {
-            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
             rendered = helpers.url.call(
                 {url: 'http://casper.website/baz', label: 'Baz', slug: 'baz', current: true},
                 {hash: {absolute: 'true'}});
@@ -197,7 +198,7 @@ describe('{{url}} helper', function () {
         });
 
         it('should handle subdir being set in nav context', function () {
-            utils.overrideConfig({url: 'http://testurl.com/blog'});
+            configUtils.set({url: 'http://testurl.com/blog'});
 
             rendered = helpers.url.call(
                 {url: '/xyzzy', label: 'xyzzy', slug: 'xyzzy', current: true},

--- a/core/test/unit/server_helpers/utils.js
+++ b/core/test/unit/server_helpers/utils.js
@@ -7,12 +7,9 @@
 // We can likely have init functions which replace the need for this file
 
 var hbs     = require('express-hbs'),
-    _       = require('lodash'),
 
 // Stuff we are testing
     helpers = require('../../../server/helpers'),
-    config  = require('../../../server/config'),
-    origConfig = _.cloneDeep(config.get()),
     utils   = {};
 
 utils.loadHelpers = function () {
@@ -20,13 +17,4 @@ utils.loadHelpers = function () {
     helpers.loadCoreHelpers(adminHbs);
 };
 
-utils.overrideConfig = function (newConfig) {
-    config.set(newConfig);
-};
-
-utils.restoreConfig = function () {
-    config.set(origConfig);
-};
-
 module.exports = utils;
-module.exports.config = config;

--- a/core/test/utils/configUtils.js
+++ b/core/test/utils/configUtils.js
@@ -1,0 +1,26 @@
+var _           = require('lodash'),
+    config      = require('../../server/config'),
+    origConfig  = _.cloneDeep(config),
+
+    configUtils = {};
+
+configUtils.config = config;
+configUtils.defaultConfig = _.cloneDeep(config.get());
+
+configUtils.set = function (newConfig) {
+    config.set(newConfig);
+};
+
+configUtils.restore = function () {
+    var topLevelOptional = ['mail', 'updateCheck', 'storage', 'forceAdminSSL', 'urlSSL', 'compress', 'privacy'];
+
+    config.set(_.merge({}, origConfig, configUtils.defaultConfig));
+    // @TODO make this horror go away
+    _.each(topLevelOptional, function (option) {
+        if (origConfig[option] === undefined) {
+            delete config[option];
+        }
+    });
+};
+
+module.exports = configUtils;


### PR DESCRIPTION
As I was trying to work on the `ghost.url.api` utility that lives in `shared/ghost-url.js` I started running into weird unrelated errors.

This update ensures that every test that touches config, does it in the same way, and that `restore()` always gets called.

This fixes at least 2 issues with tests which were depending on config not getting unset properly between tests.

no issue
- provide a single point for accessing config in unit tests
- create a single way to set and restore config
- ensure that restore deletes top level optional keys that are now undefined
- solves issues with interdependent tests
