### PR TITLE
Remove use of Ember.on

### DIFF
--- a/core/client/app/components/gh-activating-list-item.js
+++ b/core/client/app/components/gh-activating-list-item.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {Component, on, run} = Ember;
+const {Component, run} = Ember;
 
 export default Component.extend({
     tagName: 'li',
@@ -8,9 +8,9 @@ export default Component.extend({
     active: false,
     linkClasses: null,
 
-    unfocusLink: on('click', function () {
+    click() {
         this.$('a').blur();
-    }),
+    },
 
     actions: {
         setActive(value) {

--- a/core/client/app/components/gh-selectize.js
+++ b/core/client/app/components/gh-selectize.js
@@ -2,7 +2,7 @@
 import Ember from 'ember';
 import EmberSelectizeComponent from 'ember-cli-selectize/components/ember-selectize';
 
-const {computed, isArray, isBlank, get, on, run} = Ember;
+const {computed, isArray, isBlank, get, run} = Ember;
 const emberA = Ember.A;
 
 export default EmberSelectizeComponent.extend({
@@ -13,28 +13,6 @@ export default EmberSelectizeComponent.extend({
         options.onChange = run.bind(this, '_onChange');
 
         return options;
-    }),
-
-    _dontOpenWhenBlank: on('didInsertElement', function () {
-        let openOnFocus = this.get('openOnFocus');
-
-        if (!openOnFocus) {
-            run.schedule('afterRender', this, function () {
-                let selectize = this._selectize;
-                if (selectize) {
-                    selectize.on('dropdown_open', function () {
-                        if (isBlank(selectize.$control_input.val())) {
-                            selectize.close();
-                        }
-                    });
-                    selectize.on('type', function (filter) {
-                        if (isBlank(filter)) {
-                            selectize.close();
-                        }
-                    });
-                }
-            });
-        }
     }),
 
     /**
@@ -105,9 +83,7 @@ export default EmberSelectizeComponent.extend({
         // we have a re-order, update the selection
         args.forEach((value) => {
             let obj = selection.find(function (item) {
-                // jscs:disable
-                return (get(item, valuePath) + '') === value;
-                // jscs:enable
+                return `${get(item, valuePath)}` === value;
             });
 
             if (obj) {
@@ -116,6 +92,33 @@ export default EmberSelectizeComponent.extend({
         });
 
         this.set('selection', reorderedSelection);
+    },
+
+    _preventOpeningWhenBlank() {
+        let openOnFocus = this.get('openOnFocus');
+
+        if (!openOnFocus) {
+            run.schedule('afterRender', this, function () {
+                let selectize = this._selectize;
+                if (selectize) {
+                    selectize.on('dropdown_open', function () {
+                        if (isBlank(selectize.$control_input.val())) {
+                            selectize.close();
+                        }
+                    });
+                    selectize.on('type', function (filter) {
+                        if (isBlank(filter)) {
+                            selectize.close();
+                        }
+                    });
+                }
+            });
+        }
+    },
+
+    didInsertElement() {
+        this._super(...arguments);
+        this._preventOpeningWhenBlank();
     }
 
 });

--- a/core/client/app/components/gh-skip-link.js
+++ b/core/client/app/components/gh-skip-link.js
@@ -1,7 +1,7 @@
 /*jshint scripturl:true*/
 import Ember from 'ember';
 
-const {$, Component, on} = Ember;
+const {$, Component} = Ember;
 
 export default Component.extend({
     tagName: 'a',
@@ -15,7 +15,7 @@ export default Component.extend({
     // anchor behaviors or ignored
     href: Ember.String.htmlSafe('javascript:;'),
 
-    scrollTo: on('click', function () {
+    click() {
         let anchor = this.get('anchor');
         let $el = Ember.$(anchor);
 
@@ -32,5 +32,5 @@ export default Component.extend({
                 $(this).removeAttr('tabindex');
             }).focus();
         }
-    })
+    }
 });

--- a/core/client/app/components/gh-trim-focus-input.js
+++ b/core/client/app/components/gh-trim-focus-input.js
@@ -1,7 +1,7 @@
 /*global device*/
 import Ember from 'ember';
 
-const {TextField, computed, on} = Ember;
+const {TextField, computed} = Ember;
 
 export default TextField.extend({
     focus: true,
@@ -16,16 +16,26 @@ export default TextField.extend({
         return false;
     }),
 
-    focusField: on('didInsertElement', function () {
+    _focusField() {
         // This fix is required until Mobile Safari has reliable
         // autofocus, select() or focus() support
         if (this.get('focus') && !device.ios()) {
             this.$().val(this.$().val()).focus();
         }
-    }),
+    },
 
-    trimValue: on('focusOut', function () {
+    _trimValue() {
         let text = this.$().val();
         this.$().val(text.trim());
-    })
+    },
+
+    didInsertElement() {
+        this._super(...arguments);
+        this._focusField();
+    },
+
+    focusOut() {
+        this._super(...arguments);
+        this._trimValue();
+    }
 });


### PR DESCRIPTION
no issue
- removes the few uses of `Ember.on` for lifecycle hooks or event hooks where order may be important

`Ember.on` use is discouraged so although we haven't used it often I felt like we should ensure we're consistent throughout the codebase. There's a great article with details of why it's discouraged here: http://notmessenger.com/proper-use-of-ember-on/
