### PR TITLE
Fixing bug with ghost-url overwriting url

### DIFF
--- a/core/shared/ghost-url.js
+++ b/core/shared/ghost-url.js
@@ -54,7 +54,7 @@
     init = function (options) {
         clientId = options.clientId ? options.clientId : '';
         clientSecret = options.clientSecret ? options.clientSecret : '';
-        apiUrl = options.url ? options.url : '';
+        apiUrl = options.url ? options.url : (apiUrl.match(/{\{api-url}}/) ? '' : apiUrl);
     };
 
     if (typeof window !== 'undefined') {

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -18,6 +18,15 @@ describe('Ghost Ajax Helper', function () {
         configUtils.restore();
     });
 
+    it('sets url empty if it is not set on init', function () {
+        ghostUrl.init({
+            clientId: '',
+            clientSecret: ''
+        });
+
+        ghostUrl.url.api().should.equal('');
+    });
+
     it('renders basic url correctly when no arguments are presented', function () {
         ghostUrl.init({
             clientId: '',


### PR DESCRIPTION
refs #6223
- I made a stupid error, whereby apiUrl was always set to '' in themes
