### PR TITLE
Release should run all prod tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -960,7 +960,7 @@ var _              = require('lodash'),
                     dest: '<%= paths.releaseBuild %>/'
                 });
 
-                grunt.task.run(['init', 'shell:ember:prod', 'clean:release',  'shell:dedupe', 'shell:shrinkwrap', 'copy:release', 'compress:release']);
+                grunt.task.run(['init', 'prod', 'clean:release',  'shell:dedupe', 'shell:shrinkwrap', 'copy:release', 'compress:release']);
             }
         );
     };


### PR DESCRIPTION
refs #6150

For some reason, release was only set to do the ember prod task, not all prod tasks
This ensures ghost-url gets minified and included as well as future proofing any other prod tasks
