### PR TITLE
Fix password reset

### DIFF
--- a/core/client/app/controllers/reset.js
+++ b/core/client/app/controllers/reset.js
@@ -37,7 +37,7 @@ export default Controller.extend(ValidationEngine, {
             let credentials = this.getProperties('newPassword', 'ne2Password', 'token');
 
             this.set('flowErrors', '');
-            this.get('hasValidated').addObjects((['newPassword', 'ne2Password']));
+            this.get('hasValidated').addObjects(['newPassword', 'ne2Password']);
             this.validate().then(() => {
                 this.toggleProperty('submitting');
                 ajax({
@@ -54,13 +54,17 @@ export default Controller.extend(ValidationEngine, {
                     this.get('notifications').showAPIError(response, {key: 'password.reset'});
                     this.toggleProperty('submitting');
                 });
-            }).catch(() => {
+            }).catch((error) => {
                 if (this.get('errors.newPassword')) {
                     this.set('flowErrors', this.get('errors.newPassword')[0].message);
                 }
 
                 if (this.get('errors.ne2Password')) {
                     this.set('flowErrors', this.get('errors.ne2Password')[0].message);
+                }
+
+                if (this.get('errors.length') === 0) {
+                    throw error;
                 }
             });
         }

--- a/core/client/app/routes/reset.js
+++ b/core/client/app/routes/reset.js
@@ -19,7 +19,6 @@ export default Route.extend(styleBody, {
     },
 
     setupController(controller, params) {
-        this._super(...arguments);
         controller.token = params.token;
     },
 


### PR DESCRIPTION
closes #6229
- removes `_super` call in the reset route's `setupController` hook to avoid a `model` property being set which was being picked up by the validation engine
- throw the error if we fail in the password reset process from something we aren't expecting
