### PR TITLE
Switch channel filters to use strings not literals

### DIFF
--- a/core/server/controllers/frontend/channel-config.js
+++ b/core/server/controllers/frontend/channel-config.js
@@ -13,7 +13,7 @@ getConfig = function getConfig(name) {
             name: 'tag',
             route: '/' + config.routeKeywords.tag + '/:slug/',
             postOptions: {
-                filter: 'tags:%s'
+                filter: 'tags:\'%s\''
             },
             data: {
                 tag: {
@@ -28,7 +28,7 @@ getConfig = function getConfig(name) {
             name: 'author',
             route: '/' + config.routeKeywords.author + '/:slug/',
             postOptions: {
-                filter: 'author:%s'
+                filter: 'author:\'%s\''
             },
             data: {
                 author: {

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -304,7 +304,7 @@ describe('RSS', function () {
             // test
             res.send = function send(xmlData) {
                 apiBrowseStub.calledOnce.should.be.true;
-                apiBrowseStub.calledWith({page: 1, filter: 'tags:magic', include: 'author,tags,fields'}).should.be.true;
+                apiBrowseStub.calledWith({page: 1, filter: 'tags:\'magic\'', include: 'author,tags,fields'}).should.be.true;
                 apiTagStub.calledOnce.should.be.true;
                 xmlData.should.match(/<channel><title><!\[CDATA\[Magic - Test\]\]><\/title>/);
                 done();
@@ -322,7 +322,7 @@ describe('RSS', function () {
             // test
             res.send = function send(xmlData) {
                 apiBrowseStub.calledOnce.should.be.true;
-                apiBrowseStub.calledWith({page: 1, filter: 'author:joe', include: 'author,tags,fields'}).should.be.true;
+                apiBrowseStub.calledWith({page: 1, filter: 'author:\'joe\'', include: 'author,tags,fields'}).should.be.true;
                 apiUserStub.calledOnce.should.be.true;
                 xmlData.should.match(/<channel><title><!\[CDATA\[Joe Blogs - Test\]\]><\/title>/);
                 done();


### PR DESCRIPTION
fixes #6247
- GQL has a bug where literals starting with numbers are incorrectly parsed
- Using strings instead of literals is a workaround, but is probably safer anyway
