### PR TITLE
Fix teardown of gh-profile-image when fileStorage=false

### DIFF
--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -88,10 +88,12 @@ export default Component.extend({
     },
 
     willDestroyElement() {
+        let $input = this.$('.js-file-input');
+
         this._super(...arguments);
 
-        if (this.$('.js-file-input').data()['blueimp-fileupload']) {
-            this.$('.js-file-input').fileupload('destroy');
+        if ($input.length && $input.data()['blueimp-fileupload']) {
+            $input.fileupload('destroy');
         }
     },
 

--- a/core/client/tests/integration/components/gh-profile-image-test.js
+++ b/core/client/tests/integration/components/gh-profile-image-test.js
@@ -43,6 +43,17 @@ describeComponent(
             expect(this.$()).to.have.length(1);
         });
 
+        it('renders and tears down ok with fileStorage:false', function () {
+            this.set('fileStorage', false);
+
+            this.render(hbs`
+                {{gh-profile-image fileStorage=fileStorage}}
+            `);
+
+            expect(this.$()).to.have.length(1);
+            expect(this.$('input')).to.have.length(0);
+        }),
+
         it('immediately renders the gravatar if valid email supplied', function () {
             let email = 'test@example.com';
             let expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;


### PR DESCRIPTION
closes #6253
- don't expect the file input to be present in `willDestroyElement`
