### PR TITLE
Use AdaptiveStore for cookie fallback if local storage is unavailable

### DIFF
--- a/core/client/app/session-stores/application.js
+++ b/core/client/app/session-stores/application.js
@@ -1,5 +1,6 @@
-import LocalStorageStore from 'ember-simple-auth/session-stores/local-storage';
+import AdaptiveStore from 'ember-simple-auth/session-stores/adaptive';
 
-export default LocalStorageStore.extend({
-    key: 'ghost:session'
+export default AdaptiveStore.extend({
+    localStorageKey: 'ghost:session',
+    cookieName: 'ghost:session'
 });


### PR DESCRIPTION
closes #5829
- switch application session store to inherit from ESA's `AdaptiveStore` instead of `LocalStorageStore`
