### PR TITLE
Add missing chars to slug generator

### DIFF
--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -60,8 +60,8 @@ utils = {
         // Remove non ascii characters
         string = unidecode(string);
 
-        // Replace URL reserved chars: `:/?#[]!$&()*+,;=` as well as `\%<>|^~£"`
-        string = string.replace(/(\s|\.|@|:|\/|\?|#|\[|\]|!|\$|&|\(|\)|\*|\+|,|;|=|\\|%|<|>|\||\^|~|"|–|—)/g, '-')
+        // Replace URL reserved chars: `@:/?#[]!$&()*+,;=` as well as `\%<>|^~£"{}` and \`
+        string = string.replace(/(\s|\.|@|:|\/|\?|#|\[|\]|!|\$|&|\(|\)|\*|\+|,|;|=|\\|%|<|>|\||\^|~|"|\{|\}|`|–|—)/g, '-')
             // Remove apostrophes
             .replace(/'/g, '')
             // Make the whole thing lowercase

--- a/core/test/unit/server_utils_spec.js
+++ b/core/test/unit/server_utils_spec.js
@@ -35,8 +35,20 @@ describe('Server Utilities', function () {
         });
 
         it('should replace most special characters with dashes', function () {
-            var result = safeString('a:b/c?d#e[f]g!h$i&j(k)l*m+n,o;p=q\\r%s<t>u|v^w~x£y"z@1.2', options);
-            result.should.equal('a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-1-2');
+            var result = safeString('a:b/c?d#e[f]g!h$i&j(k)l*m+n,o;{p}=q\\r%s<t>u|v^w~x£y"z@1.2`3', options);
+            result.should.equal('a-b-c-d-e-f-g-h-i-j-k-l-m-n-o-p-q-r-s-t-u-v-w-x-y-z-1-2-3');
+        });
+
+        it('should replace all of the html4 compat symbols in ascii except hyphen and underscore', function () {
+            // note: This is missing the soft-hyphen char that isn't much-liked by linters/browsers/etc,
+            // it passed the test before it was removed
+            var result = safeString('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿');
+            result.should.equal('_-c-y-ss-c-a-r-deg-23up-1o-1-41-23-4');
+        });
+
+        it('should replace all of the foreign chars in ascii', function () {
+            var result = safeString('ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ');
+            result.should.equal('aaaaaaaeceeeeiiiidnoooooxouuuuuthssaaaaaaaeceeeeiiiidnooooo-ouuuuythy');
         });
 
         it('should remove special characters at the beginning of a string', function () {


### PR DESCRIPTION
As a result of #6272, I went through the ASCII table to see if there were any other chars we were missing. Turns out there is - back tick: `

I couldn't find any other symbols or chars that weren't getting converted, however there are some chars which have slightly odd conversions E.g. © becomes `c`, but perhaps `copyright` would be better. Perhaps at some point it would be good to customise and/or improve those mappings.

For now this PR gets rid of chars that shouldn't be there at all.

closes #6272 
- curly braces and back-tick should also be replaced with a dash
- other symbols and chars in ascii table are either removed or replace
- not all the replacements are sensible, but better than having odd chars in the slug for now
