### PR TITLE
Refactor sitemap generation to include images consistently

### DIFF
--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -1,10 +1,11 @@
-var _       = require('lodash'),
-    xml     = require('xml'),
-    moment  = require('moment'),
-    config  = require('../../../config'),
-    events  = require('../../../events'),
-    utils   = require('./utils'),
-    Promise = require('bluebird'),
+var _         = require('lodash'),
+    xml       = require('xml'),
+    moment    = require('moment'),
+    config    = require('../../../config'),
+    events    = require('../../../events'),
+    utils     = require('./utils'),
+    Promise   = require('bluebird'),
+    path      = require('path'),
     CHANGE_FREQ = 'weekly',
     XMLNS_DECLS;
 
@@ -139,9 +140,11 @@ _.extend(BaseSiteMapGenerator.prototype, {
 
     createUrlNodeFromDatum: function (datum) {
         var url = this.getUrlForDatum(datum),
-            priority = this.getPriorityForDatum(datum);
+            priority = this.getPriorityForDatum(datum),
+            node,
+            imgNode;
 
-        return {
+        node = {
             url: [
                 {loc: url},
                 {lastmod: moment(this.getLastModifiedForDatum(datum)).toISOString()},
@@ -149,6 +152,48 @@ _.extend(BaseSiteMapGenerator.prototype, {
                 {priority: priority}
             ]
         };
+
+        imgNode = this.createImageNodeFromDatum(datum);
+
+        if (imgNode) {
+            node.url.push(imgNode);
+        }
+
+        return node;
+    },
+
+    createImageNodeFromDatum: function (datum) {
+        // Check for cover first because user has cover but the rest only have image
+        var image = datum.cover || datum.image,
+            imageUrl,
+            imageEl;
+
+        if (!image) {
+            return;
+        }
+
+        // Grab the image url
+        imageUrl = this.getUrlForImage(image);
+
+        // Verify the url structure
+        if (!this.validateImageUrl(imageUrl)) {
+            return;
+        }
+
+        // Create the weird xml node syntax structure that is expected
+        imageEl = [
+            {'image:loc': imageUrl},
+            {'image:caption': path.basename(imageUrl)}
+        ];
+
+        // Return the node to be added to the url xml node
+        return {
+            'image:image': imageEl
+        };
+    },
+
+    validateImageUrl: function (imageUrl) {
+        return !!imageUrl;
     },
 
     setSiteMapContent: function (content) {

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -1,19 +1,14 @@
 var _      = require('lodash'),
-    path   = require('path'),
     api    = require('../../../api'),
     config = require('../../../config'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function PageMapGenerator(opts) {
-    _.extend(this, _.defaults(opts || {}, PageMapGenerator.Defaults));
+    _.extend(this, opts);
 
     BaseMapGenerator.apply(this, arguments);
 }
-
-PageMapGenerator.Defaults = {
-    // TODO?
-};
 
 // Inherit from the base generator class
 _.extend(PageMapGenerator.prototype, BaseMapGenerator.prototype);
@@ -54,29 +49,6 @@ _.extend(PageMapGenerator.prototype, {
     getPriorityForDatum: function (post) {
         // TODO: We could influence this with priority or meta information
         return post && post.name === 'home' ? 1.0 : 0.8;
-    },
-
-    createUrlNodeFromDatum: function (datum) {
-        var orig = BaseMapGenerator.prototype.createUrlNodeFromDatum.apply(this, arguments),
-            imageUrl,
-            imageEl;
-
-        // Check for image and add it
-        if (datum.image) {
-            // Grab the image url
-            imageUrl = this.getUrlForImage(datum.image);
-            // Create the weird xml node syntax structure that is expected
-            imageEl = [
-                {'image:loc': imageUrl},
-                {'image:caption': path.basename(imageUrl)}
-            ];
-            // Add the node to the url xml node
-            orig.url.push({
-                'image:image': imageEl
-            });
-        }
-
-        return orig;
     }
 });
 

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -1,19 +1,14 @@
 var _      = require('lodash'),
-    path   = require('path'),
     api    = require('../../../api'),
     config = require('../../../config'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function PostMapGenerator(opts) {
-    _.extend(this, _.defaults(opts || {}, PostMapGenerator.Defaults));
+    _.extend(this, opts);
 
     BaseMapGenerator.apply(this, arguments);
 }
-
-PostMapGenerator.Defaults = {
-    // TODO?
-};
 
 // Inherit from the base generator class
 _.extend(PostMapGenerator.prototype, BaseMapGenerator.prototype);
@@ -46,29 +41,6 @@ _.extend(PostMapGenerator.prototype, {
     getPriorityForDatum: function (post) {
         // give a slightly higher priority to featured posts
         return post.featured ? 0.9 : 0.8;
-    },
-
-    createUrlNodeFromDatum: function (datum) {
-        var orig = BaseMapGenerator.prototype.createUrlNodeFromDatum.apply(this, arguments),
-            imageUrl,
-            imageEl;
-
-        // Check for image and add it
-        if (datum.image) {
-            // Grab the image url
-            imageUrl = this.getUrlForImage(datum.image);
-            // Create the weird xml node syntax structure that is expected
-            imageEl = [
-                {'image:loc': imageUrl},
-                {'image:caption': path.basename(imageUrl)}
-            ];
-            // Add the node to the url xml node
-            orig.url.push({
-                'image:image': imageEl
-            });
-        }
-
-        return orig;
     }
 });
 

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -5,14 +5,10 @@ var _      = require('lodash'),
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function TagsMapGenerator(opts) {
-    _.extend(this, _.defaults(opts || {}, TagsMapGenerator.Defaults));
+    _.extend(this, opts);
 
     BaseMapGenerator.apply(this, arguments);
 }
-
-TagsMapGenerator.Defaults = {
-    // TODO?
-};
 
 // Inherit from the base generator class
 _.extend(TagsMapGenerator.prototype, BaseMapGenerator.prototype);

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,5 +1,4 @@
 var _      = require('lodash'),
-    path   = require('path'),
     api    = require('../../../api'),
     config = require('../../../config'),
     validator        = require('validator'),
@@ -7,14 +6,10 @@ var _      = require('lodash'),
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function UserMapGenerator(opts) {
-    _.extend(this, _.defaults(opts || {}, UserMapGenerator.Defaults));
+    _.extend(this, opts);
 
     BaseMapGenerator.apply(this, arguments);
 }
-
-UserMapGenerator.Defaults = {
-    // TODO?
-};
 
 // Inherit from the base generator class
 _.extend(UserMapGenerator.prototype, BaseMapGenerator.prototype);
@@ -47,30 +42,9 @@ _.extend(UserMapGenerator.prototype, {
         return 0.6;
     },
 
-    createUrlNodeFromDatum: function (datum) {
-        var orig = BaseMapGenerator.prototype.createUrlNodeFromDatum.apply(this, arguments),
-            imageUrl,
-            imageEl;
-
-        // Check for image and add it
-        if (datum.cover) {
-            // Grab the image url
-            imageUrl = this.getUrlForImage(datum.cover);
-            imageUrl = imageUrl.substring(0, 2) === '//' ? 'http:' + imageUrl : imageUrl;
-            if (validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true})) {
-                // Create the weird xml node syntax structure that is expected
-                imageEl = [
-                    {'image:loc': imageUrl},
-                    {'image:caption': path.basename(imageUrl)}
-                ];
-                // Add the node to the url xml node
-                orig.url.push({
-                    'image:image': imageEl
-                });
-            }
-        }
-
-        return orig;
+    validateImageUrl: function (imageUrl) {
+        return imageUrl &&
+            validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
     }
 });
 

--- a/core/test/unit/sitemap_spec.js
+++ b/core/test/unit/sitemap_spec.js
@@ -472,6 +472,19 @@ describe('Sitemap', function () {
 
                 generator.getPriorityForDatum({}).should.equal(0.8);
             });
+            it('adds an image:image element if page has an image', function () {
+                var generator = new PostGenerator(),
+                    urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                        image: 'page-100.jpg'
+                    })),
+                    hasImage;
+
+                hasImage = _.any(urlNode.url, function (node) {
+                    return !_.isUndefined(node['image:image']);
+                });
+
+                hasImage.should.equal(true);
+            });
         });
 
         describe('TagGenerator', function () {
@@ -480,6 +493,20 @@ describe('Sitemap', function () {
 
                 generator.getPriorityForDatum({}).should.equal(0.6);
             });
+
+            it('adds an image:image element if tag has an image', function () {
+                var generator = new PostGenerator(),
+                    urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                        image: 'tag-100.jpg'
+                    })),
+                    hasImage;
+
+                hasImage = _.any(urlNode.url, function (node) {
+                    return !_.isUndefined(node['image:image']);
+                });
+
+                hasImage.should.equal(true);
+            });
         });
 
         describe('UserGenerator', function () {
@@ -487,6 +514,20 @@ describe('Sitemap', function () {
                 var generator = new UserGenerator();
 
                 generator.getPriorityForDatum({}).should.equal(0.6);
+            });
+
+            it('adds an image:image element if user has a cover image', function () {
+                var generator = new PostGenerator(),
+                    urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                        cover: 'user-100.jpg'
+                    })),
+                    hasImage;
+
+                hasImage = _.any(urlNode.url, function (node) {
+                    return !_.isUndefined(node['image:image']);
+                });
+
+                hasImage.should.equal(true);
             });
         });
     });


### PR DESCRIPTION
fixes #6292
- Added createImageNodeFromDatum to BaseSiteMapGenerator
- Removed some unnecessary defaults code
- Add tests for posts, tags, users and posts with images

Test Plan:
- Created a new blog, user, post and tag
- Added images to user, post and tag
- Opened localhost:2368/sitemap.xml and navigated around
- Verified image tags in xml file source

<img width="871" alt="screen shot 2016-01-05 at 9 13 46 pm" src="https://cloud.githubusercontent.com/assets/164497/12135678/8a164b58-b3f3-11e5-9204-fedaa3948534.png">

Also ran `npm run test` and made sure it passed.
