### PR TITLE
Fix ghost_head helper to not run if error page.

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -289,6 +289,11 @@ function getAjaxHelper(clientId, clientSecret) {
 }
 
 ghost_head = function (options) {
+    // if error page do nothing
+    if (this.code >= 400) {
+        return;
+    }
+
     // create a shortcut for theme config
     blog = config.theme;
 


### PR DESCRIPTION
issue #6289
- Made quick fix to return from ghost_head helper if error page
