### PR TITLE
Make regex for subfolder deduplication more restrictive

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -143,6 +143,10 @@ ConfigManager.prototype.set = function (config) {
 
     subdir = localPath === '/' ? '' : localPath;
 
+    if (!_.isEmpty(subdir)) {
+        this._config.slugs.protected.push(subdir.split('/').pop());
+    }
+
     // Allow contentPath to be over-written by passed in config object
     // Otherwise default to default content path location
     contentPath = this._config.paths.contentPath || path.resolve(appRoot, 'content');

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -51,8 +51,8 @@ function urlJoin() {
 
     // Deduplicate subdirectory
     if (subdir) {
-        subdirRegex = new RegExp(subdir + '\/' + subdir);
-        url = url.replace(subdirRegex, subdir);
+        subdirRegex = new RegExp(subdir + '\/' + subdir + '\/');
+        url = url.replace(subdirRegex, subdir + '/');
     }
 
     return url;

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -112,6 +112,14 @@ describe('Config', function () {
             config.paths.should.have.property('subdir', '/my/blog');
         });
 
+        it('should add subdir to list of protected slugs', function () {
+            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
+            config.slugs.protected.should.containEql('blog');
+
+            configUtils.set({url: 'http://my-ghost-blog.com/my/blog'});
+            config.slugs.protected.should.containEql('blog');
+        });
+
         it('should allow specific properties to be user defined', function () {
             var contentPath = path.join(config.paths.appRoot, 'otherContent', '/'),
                 configFile = 'configFileDanceParty.js';
@@ -268,6 +276,10 @@ describe('Config', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 config.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
+
+                testData.post.url = '/blog-one/';
+                config.urlFor(testContext, testData).should.equal('/blog/blog-one/');
+                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
             });
 
             it('should return url for a tag when asked for', function () {


### PR DESCRIPTION
- Add subdir to protected slugs
- Fix regex for subfolder deduplication

fixes #5605 

(This is essentially what was in #5606, but with the fix proposed by @ErisDS)
