### PR TITLE
Improve config.js handling in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,10 +58,7 @@ CHANGELOG.md
 /core/test/functional/*.png
 /core/test/coverage
 
-config.js
-/core/client/config.js
-!/core/client/app/mirage/config.js
-!/core/client/app/services/config.js
+/config.js
 
 # Built asset files
 /core/built


### PR DESCRIPTION
no issue
- all `config.js` files were ignored in git, this was causing issues in editors (well, Atom at least) where application files called `config.js` were being excluded from file lists and search/fuzzy finder. This change updates .gitignore to only ignore the root `config.js` file which is now the only file that is customised per-install
