### PR TITLE
[SPIKE] Sync when scrolling both editor and preview panes

### DIFF
--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -3,10 +3,12 @@ import EditorAPI from 'ghost/mixins/ed-editor-api';
 import EditorShortcuts from 'ghost/mixins/ed-editor-shortcuts';
 import EditorScroll from 'ghost/mixins/ed-editor-scroll';
 
-const {TextArea, run} = Ember;
+const {TextArea, inject, run} = Ember;
 
-export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
+export default TextArea.extend(EditorAPI, EditorShortcuts, {
     focus: false,
+
+    scrollSync: inject.service('scroll-sync'),
 
     /**
      * Tell the controller about focusIn events, will trigger an autosave on a new document
@@ -34,7 +36,14 @@ export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
 
         this.attrs.setEditor(this);
 
+        this.get('scrollSync').registerLeftPane(this.$()[0]);
+
         run.scheduleOnce('afterRender', this, this.afterRenderEvent);
+    },
+
+    willDestroyElement() {
+        this._super(...arguments);
+        this.get('scrollSync').teardownLeftPane();
     },
 
     afterRenderEvent() {

--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -5,14 +5,21 @@ const {$, Component, inject, run} = Ember;
 
 export default Component.extend({
     config: inject.service(),
+    scrollSync: inject.service('scroll-sync'),
 
     _scrollWrapper: null,
 
     didInsertElement() {
         this._super(...arguments);
         this._scrollWrapper = this.$().closest('.entry-preview-content');
+        this.get('scrollSync').registerRightPane(this._scrollWrapper[0]);
         this.adjustScrollPosition(this.get('scrollPosition'));
         run.scheduleOnce('afterRender', this, this.dropzoneHandler);
+    },
+
+    willDestroyElement() {
+        this._super(...arguments);
+        this.get('scrollSync').teardownRightPane();
     },
 
     didReceiveAttrs(attrs) {

--- a/core/client/app/services/scroll-sync.js
+++ b/core/client/app/services/scroll-sync.js
@@ -1,0 +1,81 @@
+import Ember from 'ember';
+
+const {$, run} = Ember;
+
+export default Ember.Service.extend({
+
+    _leftPaneElement: null,
+    _rightPaneElement: null,
+
+    _isScrollingOnLeft: false,
+    _isScrollingOnRight: false,
+
+    registerLeftPane(element) {
+        this._leftPaneElement = element;
+        $(this._leftPaneElement).on('scroll', run.bind(this, this._leftPaneScrollHandler));
+    },
+
+    teardownLeftPane() {
+        $(this._leftPaneElement).off('scroll');
+        this._leftPaneElement = null;
+    },
+
+    registerRightPane(element) {
+        this._rightPaneElement = element;
+        $(this._rightPaneElement).on('scroll', run.bind(this, this._rightPaneScrollHandler));
+    },
+
+    teardownRightPane() {
+        $(this._rightPaneElement).off('scroll');
+        this._rightPaneElement = null;
+    },
+
+    _syncPanes(scrolledPane, syncPane) {
+        if (!scrolledPane || !syncPane) {
+            return;
+        }
+
+        let height = scrolledPane.scrollHeight - scrolledPane.clientHeight;
+        let ratio = parseFloat(scrolledPane.scrollTop) / height;
+        let newScrollTop = (syncPane.scrollHeight - syncPane.clientHeight) * ratio;
+
+        syncPane.scrollTop = newScrollTop;
+    },
+
+    _leftPaneScrollHandler() {
+        run.throttle(this, () => {
+            this._leftPaneScrolled();
+        }, 10);
+    },
+
+    _rightPaneScrollHandler() {
+        run.throttle(this, () => {
+            this._rightPaneScrolled();
+        }, 10);
+    },
+
+    // syncs scroll left -> right
+    _leftPaneScrolled() {
+        if (this._isScrollingOnRight) {
+            this._isScrollingOnRight = false;
+            return;
+        }
+
+        this._isScrollingOnLeft = true;
+
+        this._syncPanes(this._leftPaneElement, this._rightPaneElement);
+    },
+
+    // syncs scroll left <- right
+    _rightPaneScrolled() {
+        if (this._isScrollingOnLeft) {
+            this._isScrollingOnLeft = false;
+            return;
+        }
+
+        this._isScrollingOnRight = true;
+
+        this._syncPanes(this._rightPaneElement, this._leftPaneElement);
+    }
+
+});

--- a/core/client/tests/unit/services/scroll-sync-test.js
+++ b/core/client/tests/unit/services/scroll-sync-test.js
@@ -1,0 +1,22 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeModule,
+  it
+} from 'ember-mocha';
+
+describeModule(
+  'service:scroll-sync',
+  'ScrollSyncService',
+  {
+    // Specify the other units that are required for this test.
+    // needs: ['service:foo']
+  },
+  function() {
+    // Replace this with your real tests.
+    it('exists', function() {
+      let service = this.subject();
+      expect(service).to.be.ok;
+    });
+  }
+);


### PR DESCRIPTION
no issue
- moves scroll syncing behaviour into a service
- sync scroll when either the editor or preview pane is scrolled

Q: Is this even wanted? There is a note in #5102 to the effect that having both panes sync the scroll would be a poor user experience - is this still the case or was that related to limitations of previous implementations?

TODO:
- [ ] remove old syncing code
- [ ] replicate scroll-on-new-content and other edge cases that existing syncing behaviour covers
- [ ] test usability in edge cases (e.g. lots of images, large difference in markdown vs preview height)

![two-way scroll sync](https://cloud.githubusercontent.com/assets/415/12371874/b2e4e05e-bc3a-11e5-9118-d80584062271.gif)
