### PR TITLE
Clear images in gh-uploader when navigating between items

### DIFF
--- a/core/client/app/components/gh-uploader.js
+++ b/core/client/app/components/gh-uploader.js
@@ -36,13 +36,14 @@ export default Component.extend({
             this.$()[0].uploaderUi.reset();
         }
 
-        // re-init if we receive a new image but the uploader is blank
+        // re-init if we receive a new image
         // - handles back button navigating from blank image to populated image
+        // - handles navigating between populated images
+
         if (!isEmpty(newValue) && this.$()) {
-            if (this.$('.js-upload-target').attr('src') === '') {
-                this.$()[0].uploaderUi.reset();
-                this.$()[0].uploaderUi.initWithImage();
-            }
+            this.$('.js-upload-target').attr('src', '');
+            this.$()[0].uploaderUi.reset();
+            this.$()[0].uploaderUi.initWithImage();
         }
     },
 


### PR DESCRIPTION
closes #6198 

I've also tried experimenting with adding a loading indicator while waiting for a new image to load. Unfortunately I haven't found a solution that felt satisfying to me. For example, it would be possible to create a new `Image` object an listen to its `load` event:

```
var img = new Image();
img.onload = function() {
  // handle showing image
}
img.src = '/image.jpg';
```

This did work, but it feels kinda hacky and I'm not sure how reliable this is. So right now we simply clear the image.
