### PR TITLE
Fix slow running tests when using Sqlite3.

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -83,6 +83,14 @@ config = {
             client: 'sqlite3',
             connection: {
                 filename: path.join(__dirname, '/content/data/ghost-test.db')
+            },
+            pool: {
+                afterCreate: function (conn, done) {
+                    conn.run('PRAGMA synchronous=OFF;' +
+                    'PRAGMA journal_mode=MEMORY;' +
+                    'PRAGMA locking_mode=EXCLUSIVE;' +
+                    'BEGIN EXCLUSIVE; COMMIT;', done);
+                }
             }
         },
         server: {


### PR DESCRIPTION
closes #6355
Updated testing config to set a few settings on sqlite.

If you already have a config.js file you will have to add the pool config option to that file as well to test out the faster tests.
