### PR TITLE
Always show current year in copyright text on "About" page

### DIFF
--- a/core/client/app/controllers/about.js
+++ b/core/client/app/controllers/about.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-const {Controller} = Ember;
+const {
+    Controller,
+    computed
+} = Ember;
 
 export default Controller.extend({
     updateNotificationCount: 0,
@@ -9,5 +12,10 @@ export default Controller.extend({
         updateNotificationChange(count) {
             this.set('updateNotificationCount', count);
         }
-    }
+    },
+
+    copyrightYear: computed(function () {
+        let date = new Date();
+        return date.getFullYear();
+    })
 });

--- a/core/client/app/templates/about.hbs
+++ b/core/client/app/templates/about.hbs
@@ -36,7 +36,7 @@
         </section>
 
         <footer class="gh-copyright-info">
-            Copyright 2013 - 2016 Ghost Foundation, released under the <a href="https://github.com/TryGhost/Ghost/blob/master/LICENSE">MIT license</a>.
+            Copyright 2013 - {{copyrightYear}} Ghost Foundation, released under the <a href="https://github.com/TryGhost/Ghost/blob/master/LICENSE">MIT license</a>.
             <br>
             <a href="https://ghost.org/">Ghost</a> is a trademark of the <a href="https://ghost.org/about/">Ghost Foundation</a>.
         </footer>


### PR DESCRIPTION
no issue 
- add `copyrightYear` CP to about page controller
- displays the current year in the copyright notice
