### PR TITLE
Fixed ghost admin error when missing theme folder.

### DIFF
--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -11,10 +11,14 @@ function isBlackListedFileType(file) {
 }
 
 function forwardToExpressStatic(req, res, next) {
-    express.static(
-        path.join(config.paths.themePath, req.app.get('activeTheme')),
-        {maxAge: utils.ONE_YEAR_MS}
-    )(req, res, next);
+    if (!req.app.get('activeTheme')) {
+        next();
+    } else {
+        express.static(
+            path.join(config.paths.themePath, req.app.get('activeTheme')),
+            {maxAge: utils.ONE_YEAR_MS}
+        )(req, res, next);
+    }
 }
 
 function staticTheme() {

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -65,4 +65,24 @@ describe('staticTheme', function () {
             done();
         });
     });
+
+    it('should not error if active theme is missing', function (done) {
+        var req = {
+                url: 'myvalidfile.css',
+                app: {
+                    get: function () { return undefined; }
+                }
+            },
+            activeThemeStub,
+            sandbox = sinon.sandbox.create();
+
+        activeThemeStub = sandbox.spy(req.app, 'get');
+
+        staticTheme(null)(req, null, function (reqArg, res, next2) {
+            /*jshint unused:false */
+            sandbox.restore();
+            next.called.should.be.false;
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Fixed ghost admin error when missing theme folder.

closes #6368
- Add test to recreate the error in the static theme middleware.
- Updated static theme middleware to not error if missing theme folder.

The issue actually was in a different file so it wasn't regression from #5155 but it was because of a change in the following commit: https://github.com/TryGhost/Ghost/commit/390d5fcea204f3a101e9e7cf6043e5dfb20e30a7
