### PR TITLE
Fix 401 error when uploading images

### DIFF
--- a/core/client/app/instance-initializers/jquery-ajax-oauth-prefilter.js
+++ b/core/client/app/instance-initializers/jquery-ajax-oauth-prefilter.js
@@ -1,0 +1,21 @@
+import Ember from 'ember';
+
+const {merge} = Ember;
+
+export default {
+    name: 'jquery-ajax-oauth-prefilter',
+    after: 'ember-simple-auth',
+
+    initialize(application) {
+        let session = application.lookup('service:session');
+
+        Ember.$.ajaxPrefilter(function (options) {
+            session.authorize('authorizer:oauth2', function (headerName, headerValue) {
+                let headerObject = {};
+
+                headerObject[headerName] = headerValue;
+                options.headers = merge(options.headers || {}, headerObject);
+            });
+        });
+    }
+};


### PR DESCRIPTION
closes #6377
- restores ajax prefilter initializer that was removed in #6243
- adds regression test for standard `$.ajax` requests sending Authorization header

This can be removed once we no longer have jquery plugins that make internal ajax calls that don't go through ember-ajax.
