### PR TITLE
Fix cache-control header for sitemaps

### DIFF
--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -1,5 +1,5 @@
 var _       = require('lodash'),
-    utils   = require('../../utils'),
+    utils   = require('../../../utils'),
     sitemap = require('./index');
 
 // Responsible for handling requests for sitemap files

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -1048,6 +1048,7 @@ describe('Frontend Routing', function () {
         it('should serve sitemap.xml', function (done) {
             request.get('/sitemap.xml')
                 .expect(200)
+                .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .end(doEnd(done));
         });
@@ -1055,6 +1056,7 @@ describe('Frontend Routing', function () {
         it('should serve sitemap-posts.xml', function (done) {
             request.get('/sitemap-posts.xml')
                 .expect(200)
+                .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .end(doEnd(done));
         });
@@ -1062,6 +1064,7 @@ describe('Frontend Routing', function () {
         it('should serve sitemap-pages.xml', function (done) {
             request.get('/sitemap-posts.xml')
                 .expect(200)
+                .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
                 .end(doEnd(done));
         });


### PR DESCRIPTION
no issue
- sitemaps were getting max-age=undefined as they were depending on the wrong utils folder
- test + fix included
