### PR TITLE
editor: count CJK characters

### DIFF
--- a/core/client/app/helpers/gh-count-cjk-characters.js
+++ b/core/client/app/helpers/gh-count-cjk-characters.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import counter from 'ghost/utils/cjk-character-count';
+
+const {Helper} = Ember;
+
+export default Helper.helper(function (params) {
+    if (!params || !params.length) {
+        return;
+    }
+
+    let markdown = params[0] || '';
+
+    if (/^\s*$/.test(markdown)) {
+        return '';
+    }
+
+    let count = counter(markdown);
+
+    if (count === 0) {
+        return '';
+    } else {
+        return count + (count === 1 ? ' CJK character' : ' CJK characters');
+    }
+});

--- a/core/client/app/templates/components/gh-editor.hbs
+++ b/core/client/app/templates/components/gh-editor.hbs
@@ -29,6 +29,7 @@
             <a href="#" {{action 'selectTab' 'markdown'}} class="{{if markdownActive 'active'}}">Markdown</a>
             <a href="#" {{action 'selectTab' 'preview'}} class="{{if previewActive 'active'}}">Preview</a>
         </span>
+        <span class="entry-cjk-character-count">{{gh-count-cjk-characters value}}</span>
         <span class="entry-word-count">{{gh-count-words value}}</span>
     </header>
     <section class="entry-preview-content js-entry-preview-content">

--- a/core/client/app/utils/cjk-character-count.js
+++ b/core/client/app/utils/cjk-character-count.js
@@ -1,0 +1,8 @@
+// jscs: disable
+/* global XRegExp */
+
+export default function (s) {
+    let charCJK = new XRegExp("[\\p{Katakana}\\p{Hiragana}\\p{Han}\\p{Hangul}]", 'g');
+    let cjk = s.match(charCJK);
+    return cjk === null ? 0 : cjk.length;
+}

--- a/core/client/tests/unit/components/gh-editor-test.js
+++ b/core/client/tests/unit/components/gh-editor-test.js
@@ -15,6 +15,7 @@ describeComponent(
             'component:gh-ed-editor',
             'component:gh-ed-preview',
             'helper:gh-count-words',
+            'helper:gh-count-cjk-characters',
             'helper:route-action',
             'service:notifications'
         ]


### PR DESCRIPTION
As there are no natural divisions between words in Chinese and Japanese, the `word-count` module used by Ghost cannot correctly count the CJK characters. This commits adds a new module `cjk-character-count` to extract all CJK characters from the editor using XRegExp and display the number of them beside the `words` label. If no CJK character is found, nothing will be added to the editor.

Before: (should be 7)
![2016-01-26 16-13-54](https://cloud.githubusercontent.com/assets/4532423/12575729/c78d3530-c449-11e5-9ed8-0c00050fcdc9.png)

After:
![2016-01-26 16-11-35](https://cloud.githubusercontent.com/assets/4532423/12575739/e456cc58-c449-11e5-988b-13c538fdfe35.png)

After(no CJK characters):
![2016-01-26 16-13-06](https://cloud.githubusercontent.com/assets/4532423/12575749/ff5d58e6-c449-11e5-8fdf-2da8108ffa59.png)
