### PR TITLE
Fix posts.post route not redirecting to 404

### DIFF
--- a/core/client/app/mirage/factories/post.js
+++ b/core/client/app/mirage/factories/post.js
@@ -2,5 +2,22 @@
 import Mirage from 'ember-cli-mirage';
 
 export default Mirage.Factory.extend({
-    // TODO: fill in with actual factory data
+    uuid(i) { return  `post-${i}`; },
+    description(i) { return  `Title for post ${i}.`; },
+    slug(i) { return  `post-${i}`; },
+    markdown(i) { return  `Markdown for post ${i}.`; },
+    html(i) { return  `HTML for post ${i}.`; },
+    image(i) { return  `/content/images/2015/10/post-${i}.jpg`; },
+    featured() { return  false; },
+    page() { return  false; },
+    status(i) { return  `/content/images/2015/10/post-${i}.jpg`; },
+    meta_description(i) { return  `Meta description for post ${i}.`; },
+    meta_title(i) { return  `Meta Title for post ${i}`; },
+    author_id() { return  1; },
+    updated_at() { return  '2015-10-19T16:25:07.756Z'; },
+    updated_by() { return  1; },
+    published_at() { return  '2015-10-19T16:25:07.756Z'; },
+    published_by() { return  1; },
+    created_at() { return  '2015-09-11T09:44:29.871Z'; },
+    created_by() { return  1; }
 });

--- a/core/client/app/routes/editor/edit.js
+++ b/core/client/app/routes/editor/edit.js
@@ -37,7 +37,7 @@ export default AuthenticatedRoute.extend(base, NotFoundHandler, {
                 return post;
             }
 
-            return this.replaceRoute('posts.index');
+            return this.replaceWith('posts.index');
         });
     },
 
@@ -46,7 +46,7 @@ export default AuthenticatedRoute.extend(base, NotFoundHandler, {
 
         return this.get('session.user').then((user) => {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
-                return this.replaceRoute('posts.index');
+                return this.replaceWith('posts.index');
             }
         });
     },

--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -28,19 +28,21 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             staticPages: 'all'
         };
 
-        return this.store.queryRecord('post', query).then((post) => {
+        return this.store.queryRecord('post', query).then((records) => {
+            let post = records.get('firstObject');
+
             if (post) {
                 return post;
             }
 
-            return this.replaceRoute('posts.index');
+            this.transitionTo('error404', postId);
         });
     },
 
     afterModel(post) {
         return this.get('session.user').then((user) => {
             if (user.get('isAuthor') && !post.isAuthoredByUser(user)) {
-                return this.replaceRoute('posts.index');
+                return this.replaceWith('posts.index');
             }
         });
     },

--- a/core/client/tests/acceptance/posts/post-test.js
+++ b/core/client/tests/acceptance/posts/post-test.js
@@ -1,0 +1,67 @@
+/* jshint expr:true */
+/* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
+import {
+    describe,
+    it,
+    beforeEach,
+    afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../../helpers/start-app';
+import destroyApp from '../../helpers/destroy-app';
+import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
+import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+
+describe('Acceptance: Posts - Post', function() {
+    let application;
+
+    beforeEach(function() {
+        application = startApp();
+    });
+
+    afterEach(function() {
+        destroyApp(application);
+    });
+
+    describe('when logged in', function () {
+        beforeEach(function () {
+            let role = server.create('role', {name: 'Administrator'});
+            let user = server.create('user', {roles: [role]});
+
+            // load the settings fixtures
+            // TODO: this should always be run for acceptance tests
+            server.loadFixtures();
+
+            return authenticateSession(application);
+        });
+
+        it('can visit post route', function () {
+            let posts = server.createList('post', 3);
+
+            visit('/');
+
+            andThen(() => {
+                // it redirects to first post
+                expect(currentURL(), 'currentURL').to.equal(`/${posts[0].id}`);
+
+                expect(find('.posts-list li').first().hasClass('active'), 'highlights latest post').to.be.true;
+
+                expect(find('.posts-list li').length, 'post list count').to.equal(3);
+            });
+        });
+
+        describe('with 404', function () {
+            it('redirects to 404 when post does not exist', function () {
+                let posts = server.createList('post', 3);
+
+                visit('/4');
+
+                andThen(() => {
+                    // it redirects to 404 error page
+                    expect(currentPath()).to.equal('error404');
+                    expect(currentURL()).to.equal('/4');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes #6385
- redirect to 404 when post is not found
- replace replaceRoute calls with replaceWith calls in routes (replaceRoute is only available on controllers)
