### PR TITLE
Fix missing tags list link on mobile

### DIFF
--- a/core/client/app/templates/settings/tags/tag.hbs
+++ b/core/client/app/templates/settings/tags/tag.hbs
@@ -1,7 +1,6 @@
 {{gh-tag-settings-form tag=tag
                        setProperty=(action "setProperty")
-                       showDeleteTagModal=(action "toggleDeleteTagModal")
-                       isMobile=isMobile}}
+                       showDeleteTagModal=(action "toggleDeleteTagModal")}}
 
 {{#if showDeleteTagModal}}
     {{gh-fullscreen-modal "delete-tag"

--- a/core/client/tests/integration/components/gh-tag-settings-form-test.js
+++ b/core/client/tests/integration/components/gh-tag-settings-form-test.js
@@ -15,6 +15,10 @@ let configStub = Ember.Service.extend({
     blogUrl: 'http://localhost:2368'
 });
 
+let mediaQueriesStub = Ember.Service.extend({
+    maxWidth600: false
+});
+
 describeComponent(
     'gh-tag-settings-form',
     'Integration: Component: gh-tag-settings-form',
@@ -44,6 +48,9 @@ describeComponent(
 
             this.register('service:config', configStub);
             this.inject.service('config', {as: 'config'});
+
+            this.register('service:media-queries', mediaQueriesStub);
+            this.inject.service('media-queries', {as: 'mediaQueries'});
         });
 
         it('renders', function () {
@@ -300,6 +307,16 @@ describeComponent(
             run(() => {
                 this.$('.tag-delete-button').click();
             });
+        });
+
+        it('shows settings.tags arrow link on mobile', function () {
+            this.set('mediaQueries.maxWidth600', true);
+
+            this.render(hbs`
+                {{gh-tag-settings-form tag=tag setProperty=(action 'setProperty')}}
+            `);
+
+            expect(this.$('.tag-settings-pane .settings-menu-header .settings-menu-header-action').length, 'settings.tags link is shown').to.equal(1);
         });
     }
 );


### PR DESCRIPTION
closes #6397
- don't pass isMobile to gh-tag-settings-form
- add gh-tag-settings-form test for mobile settings.tags link
