### PR TITLE
Fix 404 acceptance tests

### DIFF
--- a/core/client/tests/acceptance/settings/tags-test.js
+++ b/core/client/tests/acceptance/settings/tags-test.js
@@ -282,26 +282,19 @@ describe('Acceptance: Settings - Tags', function () {
             });
         });
 
-        describe('with 404', function () {
-            beforeEach(function () {
-                errorOverride();
+        it('redirects to 404 when tag does not exist', function () {
+            server.get('/tags/slug/unknown/', function () {
+                return new Mirage.Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'Tag not found.', errorType: 'NotFoundError'}]});
             });
 
-            afterEach(function () {
+            errorOverride();
+
+            visit('settings/tags/unknown');
+
+            andThen(() => {
                 errorReset();
-            });
-
-            it('redirects to 404 when tag does not exist', function () {
-                server.get('/tags/slug/unknown/', function () {
-                    return new Mirage.Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'Tag not found.', errorType: 'NotFoundError'}]});
-                });
-
-                visit('settings/tags/unknown');
-
-                andThen(() => {
-                    expect(currentPath()).to.equal('error404');
-                    expect(currentURL()).to.equal('/settings/tags/unknown');
-                });
+                expect(currentPath()).to.equal('error404');
+                expect(currentURL()).to.equal('/settings/tags/unknown');
             });
         });
     });

--- a/core/client/tests/acceptance/team-test.js
+++ b/core/client/tests/acceptance/team-test.js
@@ -321,26 +321,19 @@ describe('Acceptance: Team', function () {
             });
         });
 
-        describe('with 404', function () {
-            beforeEach(function () {
-                errorOverride();
+        it('redirects to 404 when tag does not exist', function () {
+            server.get('/users/slug/unknown/', function () {
+                return new Mirage.Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'User not found.', errorType: 'NotFoundError'}]});
             });
 
-            afterEach(function () {
+            errorOverride();
+
+            visit('/team/unknown');
+
+            andThen(() => {
                 errorReset();
-            });
-
-            it('redirects to 404 when tag does not exist', function () {
-                server.get('/users/slug/unknown/', function () {
-                    return new Mirage.Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'User not found.', errorType: 'NotFoundError'}]});
-                });
-
-                visit('/team/unknown');
-
-                andThen(() => {
-                    expect(currentPath()).to.equal('error404');
-                    expect(currentURL()).to.equal('/team/unknown');
-                });
+                expect(currentPath()).to.equal('error404');
+                expect(currentURL()).to.equal('/team/unknown');
             });
         });
     });


### PR DESCRIPTION
no issue

Fixes an issue in the 404 sections of settings/tags and team acceptance tests where error overriding made checks pass no matter what.

S/O to @kevinkucharczyk for the :fishing_pole_and_fish: 
