### PR TITLE
Replace unneeded lodash methods with native JS

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -53,7 +53,7 @@ configuration = {
      * @returns {Promise(Configurations)}
      */
     browse: function browse() {
-        return Promise.resolve({configuration: _.map(getValidKeys(), formatConfigurationObject)});
+        return Promise.resolve({configuration: getValidKeys().map(formatConfigurationObject)});
     },
 
     /**

--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -1,7 +1,6 @@
 // # DB API
 // API for DB operations
-var _                = require('lodash'),
-    Promise          = require('bluebird'),
+var Promise          = require('bluebird'),
     dataExport       = require('../data/export'),
     importer         = require('../data/importer'),
     models           = require('../models'),
@@ -74,7 +73,7 @@ db = {
             if (!utils.checkFileIsValid(options.importfile, importer.getTypes(), importer.getExtensions())) {
                 return Promise.reject(new errors.UnsupportedMediaTypeError(
                     i18n.t('errors.api.db.unsupportedFile') +
-                        _.reduce(importer.getExtensions(), function (memo, ext) {
+                        importer.getExtensions().reduce(function (memo, ext) {
                             return memo ? memo + ', ' + ext : ext;
                         })
                 ));

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -150,7 +150,7 @@ filterPaths = function (paths, active) {
                 item.package = false;
             }
 
-            if (_.indexOf(active, key) !== -1) {
+            if (active.indexOf(key) !== -1) {
                 item.active = true;
             }
             res.push(item);

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -75,8 +75,8 @@ updateSettingsCache = function (settings) {
     settings = settings || {};
 
     if (!_.isEmpty(settings)) {
-        _.map(settings, function (setting, key) {
-            settingsCache[key] = setting;
+        Object.keys(settings).map(function (key) {
+            settingsCache[key] = settings[key];
         });
 
         updateConfigCache();
@@ -269,7 +269,7 @@ canEditAllSettings = function (settingsInfo, options) {
                 return Promise.reject(new errors.NoPermissionError(i18n.t('errors.api.settings.noPermissionToEditSettings')));
             });
         },
-        checks = _.map(settingsInfo, function (settingInfo) {
+        checks = settingsInfo.map(function (settingInfo) {
             var setting = settingsCache[settingInfo.key];
 
             if (!setting) {

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -166,7 +166,7 @@ filterPaths = function (paths, active) {
  * @returns {Settings}
  */
 readSettingsResult = function (settingsModels) {
-    var settings = _.reduce(settingsModels, function (memo, member) {
+    var settings = settingsModels.reduce(function (memo, member) {
             if (!memo.hasOwnProperty(member.attributes.key)) {
                 memo[member.attributes.key] = member.attributes;
             }

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -148,7 +148,7 @@ themes = {
         var tasks, themeName;
 
         // Check whether the request is properly formatted.
-        if (!_.isArray(object.themes)) {
+        if (!Array.isArray(object.themes)) {
             return Promise.reject(new errors.BadRequestError(i18n.t('errors.api.themes.invalidRequest')));
         }
 

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -227,7 +227,7 @@ utils = {
             params = params.split(',');
         }
 
-        return _.map(params, function (item) {
+        return params.map(function (item) {
             return item.trim().toLowerCase();
         });
     },

--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -80,7 +80,7 @@ module.exports = {
 
             return Promise.all(loadPromises).then(function () {
                 // Save our installed apps to settings
-                return saveInstalledApps(_.keys(loadedApps));
+                return saveInstalledApps(Object.keys(loadedApps));
             }).then(function () {
                 // Extend the loadedApps onto the available apps
                 _.extend(availableApps, loadedApps);

--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -62,7 +62,7 @@ module.exports = {
 
                     return Promise.resolve(loadedApp);
                 },
-                loadPromises = _.map(appsToLoad, function (app) {
+                loadPromises = appsToLoad.map(function (app) {
                     // If already installed, just activate the app
                     if (_.contains(installedApps, app)) {
                         return loader.activateAppByName(app).then(function (loadedApp) {

--- a/core/server/apps/proxy.js
+++ b/core/server/apps/proxy.js
@@ -39,7 +39,7 @@ generateProxyFunctions = function (name, permissions) {
                     app: name
                 };
 
-            return _.reduce(apiMethods, function (memo, apiMethod, methodName) {
+            return Object.keys(apiMethods).reduce(function (memo, methodName) {
                 memo[methodName] = function () {
                     var args = _.toArray(arguments),
                         options = args[args.length - 1];
@@ -47,7 +47,7 @@ generateProxyFunctions = function (name, permissions) {
                     if (_.isObject(options)) {
                         options.context = _.clone(appContext);
                     }
-                    return apiMethod.apply({}, args);
+                    return apiMethods[methodName].apply({}, args);
                 };
 
                 return memo;

--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -171,7 +171,7 @@ function urlFor(context, data, absolute) {
 
     if (_.isObject(context) && context.relativeUrl) {
         urlPath = context.relativeUrl;
-    } else if (_.isString(context) && _.indexOf(knownObjects, context) !== -1) {
+    } else if (_.isString(context) && knownObjects.indexOf(context) !== -1) {
         // trying to create a url for an object
         if (context === 'post' && data.post) {
             urlPath = data.post.url;
@@ -215,7 +215,7 @@ function urlFor(context, data, absolute) {
             }
         }
         // other objects are recognised but not yet supported
-    } else if (_.isString(context) && _.indexOf(_.keys(knownPaths), context) !== -1) {
+    } else if (_.isString(context) && Object.keys(knownPaths).indexOf(context) !== -1) {
         // trying to create a url for a named path
         urlPath = knownPaths[context] || '/';
     }

--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -31,7 +31,7 @@ exporter = function () {
     return Promise.join(versioning.getDatabaseVersion(), utils.getTables()).then(function (results) {
         var version = results[0],
             tables = results[1],
-            selectOps = _.map(tables, function (name) {
+            selectOps = tables.map(function (name) {
                 if (excludedTables.indexOf(name) < 0) {
                     return config.database.knex(name).select();
                 }

--- a/core/server/data/fixtures/permissions/index.js
+++ b/core/server/data/fixtures/permissions/index.js
@@ -46,7 +46,7 @@ addRolesPermissionsForRole = function (roleName) {
 };
 
 addAllRolesPermissions = function () {
-    var roleNames = _.keys(fixtures.permissions_roles),
+    var roleNames = Object.keys(fixtures.permissions_roles),
         ops = [];
 
     _.each(roleNames, function (roleName) {

--- a/core/server/data/fixtures/permissions/index.js
+++ b/core/server/data/fixtures/permissions/index.js
@@ -29,7 +29,7 @@ addRolesPermissionsForRole = function (roleName) {
     return models.Role.forge({name: roleName}).fetch({withRelated: ['permissions']}).then(function (role) {
         return models.Permissions.forge().fetch().then(function (permissions) {
             if (_.isObject(fixturesForRole)) {
-                permissionsToAdd = _.map(permissions.toJSON(), function (permission) {
+                permissionsToAdd = permissions.toJSON().map(function (permission) {
                     var objectPermissions = fixturesForRole[permission.object_type];
                     if (objectPermissions === 'all') {
                         return permission.id;

--- a/core/server/data/fixtures/permissions/index.js
+++ b/core/server/data/fixtures/permissions/index.js
@@ -33,7 +33,7 @@ addRolesPermissionsForRole = function (roleName) {
                     var objectPermissions = fixturesForRole[permission.object_type];
                     if (objectPermissions === 'all') {
                         return permission.id;
-                    } else if (_.isArray(objectPermissions) && _.contains(objectPermissions, permission.action_type)) {
+                    } else if (Array.isArray(objectPermissions) && _.contains(objectPermissions, permission.action_type)) {
                         return permission.id;
                     }
                     return null;

--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -50,7 +50,7 @@ cleanError = function cleanError(error) {
 handleErrors = function handleErrors(errorList) {
     var processedErrors = [];
 
-    if (!_.isArray(errorList)) {
+    if (!Array.isArray(errorList)) {
         return Promise.reject(errorList);
     }
 
@@ -58,7 +58,7 @@ handleErrors = function handleErrors(errorList) {
         if (!error.raw) {
             // These are validation errors
             processedErrors.push(error);
-        } else if (_.isArray(error.raw)) {
+        } else if (Array.isArray(error.raw)) {
             processedErrors = processedErrors.concat(error.raw);
         } else {
             processedErrors.push(cleanError(error));

--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -79,8 +79,8 @@ checkDuplicateAttributes = function checkDuplicateAttributes(data, comparedValue
 
 sanitize = function sanitize(data) {
     var allProblems = {},
-        tablesInData = _.keys(data.data),
-        tableNames = _.sortBy(_.keys(tables), function (tableName) {
+        tablesInData = Object.keys(data.data),
+        tableNames = _.sortBy(Object.keys(tables), function (tableName) {
             // We want to guarantee posts and tags go first
             if (tableName === 'posts') {
                 return 1;
@@ -168,7 +168,7 @@ sanitize = function sanitize(data) {
 validate = function validate(data) {
     var validateOps = [];
 
-    _.each(_.keys(data.data), function (tableName) {
+    _.each(Object.keys(data.data), function (tableName) {
         _.each(data.data[tableName], function (importValues) {
             validateOps.push(validation.validateSchema(tableName, importValues));
         });

--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -121,7 +121,7 @@ utils = {
             });
             if (post) {
                 tags = _.filter(tableData.tags, function (tag) {
-                    return _.indexOf(tagIds, tag.id) !== -1;
+                    return tagIds.indexOf(tag.id) !== -1;
                 });
                 post.tags = [];
                 _.each(tags, function (tag) {

--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -63,7 +63,7 @@ utils = {
         });
 
         // We now have a list of users we need to figure out what their email addresses are
-        _.each(_.keys(userMap), function (userToMap) {
+        _.each(Object.keys(userMap), function (userToMap) {
             userToMap = parseInt(userToMap, 10);
             var foundUser = _.find(tableData.users, function (tableDataUser) {
                 return tableDataUser.id === userToMap;

--- a/core/server/data/importer/handlers/image.js
+++ b/core/server/data/importer/handlers/image.js
@@ -15,12 +15,12 @@ ImageHandler = {
     loadFile: function (files, baseDir) {
         var store = storage.getStorage(),
             baseDirRegex = baseDir ? new RegExp('^' + baseDir + '/') : new RegExp(''),
-            imageFolderRegexes = _.map(config.paths.imagesRelPath.split('/'), function (dir) {
+            imageFolderRegexes = config.paths.imagesRelPath.split('/').map(function (dir) {
                 return new RegExp('^' + dir + '/');
             });
 
         // normalize the directory structure
-        files = _.map(files, function (file) {
+        files = files.map(function (file) {
             var noBaseDir = file.name.replace(baseDirRegex, ''),
                 noGhostDirs = noBaseDir;
 

--- a/core/server/data/importer/handlers/json.js
+++ b/core/server/data/importer/handlers/json.js
@@ -22,7 +22,7 @@ JSONHandler = {
                 importData = JSON.parse(fileData);
 
                 // if importData follows JSON-API format `{ db: [exportedData] }`
-                if (_.keys(importData).length === 1) {
+                if (Object.keys(importData).length === 1) {
                     if (!importData.db || !Array.isArray(importData.db)) {
                         throw new Error(i18n.t('errors.data.importer.handlers.json.invalidJsonFormat'));
                     }

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -71,7 +71,7 @@ _.extend(ImportManager.prototype, {
      * @returns {String}
      */
     getGlobPattern: function (items) {
-        return '+(' + _.reduce(items, function (memo, ext) {
+        return '+(' + items.reduce(function (memo, ext) {
             return memo !== '' ? memo + '|'  + ext : ext;
         }, '') + ')';
     },

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -187,7 +187,7 @@ _.extend(ImportManager.prototype, {
      */
     getFilesFromZip: function (handler, directory) {
         var globPattern = this.getExtensionGlob(handler.extensions, ALL_DIRS);
-        return _.map(glob.sync(globPattern, {cwd: directory}), function (file) {
+        return glob.sync(globPattern, {cwd: directory}).map(function (file) {
             return {name: file, path: path.join(directory, file)};
         });
     },

--- a/core/server/data/migration/commands.js
+++ b/core/server/data/migration/commands.js
@@ -1,4 +1,4 @@
-var  _               = require('lodash'),
+var _               = require('lodash'),
     errors          = require('../../errors'),
     utils           = require('../utils'),
     schema          = require('../schema').tables,
@@ -19,7 +19,7 @@ logInfo = function logInfo(message) {
 
 getDeleteCommands = function getDeleteCommands(oldTables, newTables) {
     var deleteTables = _.difference(oldTables, newTables);
-    return _.map(deleteTables, function (table) {
+    return deleteTables.map(function (table) {
         return function () {
             logInfo(i18n.t('notices.data.migration.commands.deletingTable', {table: table}));
             return utils.deleteTable(table);
@@ -28,7 +28,7 @@ getDeleteCommands = function getDeleteCommands(oldTables, newTables) {
 };
 getAddCommands = function getAddCommands(oldTables, newTables) {
     var addTables = _.difference(newTables, oldTables);
-    return _.map(addTables, function (table) {
+    return addTables.map(function (table) {
         return function () {
             logInfo(i18n.t('notices.data.migration.commands.creatingTable', {table: table}));
             return utils.createTable(table);
@@ -39,7 +39,7 @@ addColumnCommands = function addColumnCommands(table, columns) {
     var columnKeys = _.keys(schema[table]),
         addColumns = _.difference(columnKeys, columns);
 
-    return _.map(addColumns, function (column) {
+    return addColumns.map(function (column) {
         return function () {
             logInfo(i18n.t('notices.data.migration.commands.addingColumn', {table: table, column: column}));
             return utils.addColumn(table, column);
@@ -48,7 +48,7 @@ addColumnCommands = function addColumnCommands(table, columns) {
 };
 modifyUniqueCommands = function modifyUniqueCommands(table, indexes) {
     var columnKeys = _.keys(schema[table]);
-    return _.map(columnKeys, function (column) {
+    return columnKeys.map(function (column) {
         if (schema[table][column].unique === true) {
             if (!_.contains(indexes, table + '_' + column + '_unique')) {
                 return function () {

--- a/core/server/data/migration/commands.js
+++ b/core/server/data/migration/commands.js
@@ -36,7 +36,7 @@ getAddCommands = function getAddCommands(oldTables, newTables) {
     });
 };
 addColumnCommands = function addColumnCommands(table, columns) {
-    var columnKeys = _.keys(schema[table]),
+    var columnKeys = Object.keys(schema[table]),
         addColumns = _.difference(columnKeys, columns);
 
     return addColumns.map(function (column) {
@@ -47,7 +47,7 @@ addColumnCommands = function addColumnCommands(table, columns) {
     });
 };
 modifyUniqueCommands = function modifyUniqueCommands(table, indexes) {
-    var columnKeys = _.keys(schema[table]);
+    var columnKeys = Object.keys(schema[table]);
     return columnKeys.map(function (column) {
         if (schema[table][column].unique === true) {
             if (!_.contains(indexes, table + '_' + column + '_unique')) {

--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -15,7 +15,7 @@ var _               = require('lodash'),
     config          = require('../../config'),
     i18n            = require('../../i18n'),
 
-    schemaTables    = _.keys(schema),
+    schemaTables    = Object.keys(schema),
 
     // private
     logInfo,

--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -123,7 +123,7 @@ init = function (tablesOnly) {
 // ### Reset
 // Delete all tables from the database in reverse order
 reset = function () {
-    var tables = _.map(schemaTables, function (table) {
+    var tables = schemaTables.map(function (table) {
         return function () {
             return utils.deleteTable(table);
         };
@@ -135,7 +135,7 @@ reset = function () {
 // Only do this if we have no database at all
 migrateUpFreshDb = function (tablesOnly) {
     var tableSequence,
-        tables = _.map(schemaTables, function (table) {
+        tables = schemaTables.map(function (table) {
             return function () {
                 logInfo(i18n.t('notices.data.migration.index.creatingTable', {table: table}));
                 return utils.createTable(table);
@@ -172,7 +172,7 @@ migrateUp = function (fromVersion, toVersion) {
         migrateOps = migrateOps.concat(commands.getDeleteCommands(oldTables, schemaTables));
         migrateOps = migrateOps.concat(commands.getAddCommands(oldTables, schemaTables));
         return Promise.all(
-            _.map(oldTables, function (table) {
+            oldTables.map(function (table) {
                 return utils.getIndexes(table).then(function (indexes) {
                     modifyUniCommands = modifyUniCommands.concat(commands.modifyUniqueCommands(table, indexes));
                 });
@@ -180,7 +180,7 @@ migrateUp = function (fromVersion, toVersion) {
         );
     }).then(function () {
         return Promise.all(
-            _.map(oldTables, function (table) {
+            oldTables.map(function (table) {
                 return utils.getColumns(table).then(function (columns) {
                     migrateOps = migrateOps.concat(commands.addColumnCommands(table, columns));
                 });

--- a/core/server/data/utils/clients/mysql.js
+++ b/core/server/data/utils/clients/mysql.js
@@ -18,7 +18,7 @@ doRawAndFlatten = function doRaw(query, flattenFn) {
 
 getTables = function getTables() {
     return doRawAndFlatten('show tables', function (response) {
-        return _.map(response[0], function (entry) { return _.values(entry); });
+        return response[0].map(function (entry) { return _.values(entry); });
     });
 };
 
@@ -40,7 +40,7 @@ getColumns = function getColumns(table) {
 // For details see: https://github.com/TryGhost/Ghost/issues/1947
 checkPostTable = function checkPostTable() {
     return config.database.knex.raw('SHOW FIELDS FROM posts where Field ="html" OR Field = "markdown"').then(function (response) {
-        return _.flatten(_.map(response[0], function (entry) {
+        return _.flatten(response[0].map(function (entry) {
             if (entry.Type.toLowerCase() !== 'mediumtext') {
                 return config.database.knex.raw('ALTER TABLE posts MODIFY ' + entry.Field + ' MEDIUMTEXT');
             }

--- a/core/server/data/utils/index.js
+++ b/core/server/data/utils/index.js
@@ -67,7 +67,7 @@ function dropUnique(table, column) {
 function createTable(table) {
     dbConfig = dbConfig || config.database;
     return dbConfig.knex.schema.createTable(table, function (t) {
-        var columnKeys = _.keys(schema[table]);
+        var columnKeys = Object.keys(schema[table]);
         _.each(columnKeys, function (column) {
             return addTableColumn(table, t, column);
         });
@@ -83,7 +83,7 @@ function getTables() {
     dbConfig = dbConfig || config.database;
     var client = dbConfig.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.contains(Object.keys(clients), client)) {
         return clients[client].getTables();
     }
 
@@ -94,7 +94,7 @@ function getIndexes(table) {
     dbConfig = dbConfig || config.database;
     var client = dbConfig.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.contains(Object.keys(clients), client)) {
         return clients[client].getIndexes(table);
     }
 
@@ -105,7 +105,7 @@ function getColumns(table) {
     dbConfig = dbConfig || config.database;
     var client = dbConfig.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.contains(Object.keys(clients), client)) {
         return clients[client].getColumns(table);
     }
 

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -149,7 +149,7 @@ validate = function validate(value, key, validations) {
         if (_.isBoolean(validationOptions)) {
             goodResult = validationOptions;
             validationOptions = [];
-        } else if (!_.isArray(validationOptions)) {
+        } else if (!Array.isArray(validationOptions)) {
             validationOptions = [validationOptions];
         }
 

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -35,7 +35,7 @@ validator.extend('isSlug', function isSlug(str) {
 // Validation against schema attributes
 // values are checked against the validation objects from schema.js
 validateSchema = function validateSchema(tableName, model) {
-    var columns = _.keys(schema[tableName]),
+    var columns = Object.keys(schema[tableName]),
         validationErrors = [];
 
     _.each(columns, function each(columnKey) {

--- a/core/server/data/versioning/index.js
+++ b/core/server/data/versioning/index.js
@@ -35,7 +35,7 @@ function getDatabaseVersion() {
                 .orWhere('key', 'currentVersion')
                 .select('value')
                 .then(function (versions) {
-                    var databaseVersion = _.reduce(versions, function (memo, version) {
+                    var databaseVersion = versions.reduce(function (memo, version) {
                         if (isNaN(version.value)) {
                             errors.throwError(i18n.t('errors.data.versioning.index.dbVersionNotRecognized'));
                         }

--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -55,7 +55,7 @@ _.extend(BaseSiteMapGenerator.prototype, {
         // Create all the url elements in JSON
         var self = this,
             nodes;
-        nodes = _.map(data, function (datum) {
+        nodes = data.map(function (datum) {
             var node = self.createUrlNodeFromDatum(datum);
             self.updateLastModified(datum);
             self.updateLookups(datum, node);
@@ -69,12 +69,12 @@ _.extend(BaseSiteMapGenerator.prototype, {
     generateXmlFromNodes: function () {
         var self = this,
             // Get a mapping of node to timestamp
-            timedNodes = _.map(this.nodeLookup, function (node, id) {
+            timedNodes = Object.keys(this.nodeLookup).map(function (id) {
                 return {
                     id: id,
                     // Using negative here to sort newest to oldest
                     ts: -(self.nodeTimeLookup[id] || 0),
-                    node: node
+                    node: self.nodeLookup[id]
                 };
             }, []),
             // Sort nodes by timestamp

--- a/core/server/data/xml/sitemap/index-generator.js
+++ b/core/server/data/xml/sitemap/index-generator.js
@@ -34,7 +34,7 @@ _.extend(SiteMapIndexGenerator.prototype, {
     generateSiteMapUrlElements: function () {
         var self = this;
 
-        return _.map(RESOURCES, function (resourceType) {
+        return RESOURCES.map(function (resourceType) {
             var url = config.urlFor({
                     relativeUrl: '/sitemap-' + resourceType + '.xml'
                 }, true),

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -96,7 +96,7 @@ errors = {
             stack,
             msgs;
 
-        if (_.isArray(err)) {
+        if (Array.isArray(err)) {
             _.each(err, function (e) {
                 var newArgs = [e].concat(origArgs);
                 errors.logError.apply(self, newArgs);
@@ -189,7 +189,7 @@ errors = {
         var statusCode = 500,
             errors = [];
 
-        if (!_.isArray(error)) {
+        if (!Array.isArray(error)) {
             error = [].concat(error);
         }
 
@@ -350,7 +350,7 @@ errors = {
             var statusCode = 500,
                 returnErrors = [];
 
-            if (!_.isArray(err)) {
+            if (!Array.isArray(err)) {
                 err = [].concat(err);
             }
 

--- a/core/server/filters.js
+++ b/core/server/filters.js
@@ -78,7 +78,7 @@ Filters.prototype.doFilter = function (name, args, context) {
                 return Promise.resolve(currentArgs);
             }
 
-            callables = _.map(callbacks[priority], function (callback) {
+            callables = callbacks[priority].map(function (callback) {
                 return function (args) {
                     return callback(args, context);
                 };

--- a/core/server/filters.js
+++ b/core/server/filters.js
@@ -74,7 +74,7 @@ Filters.prototype.doFilter = function (name, args, context) {
             var callables;
 
             // Bug out if no handlers on this priority
-            if (!_.isArray(callbacks[priority])) {
+            if (!Array.isArray(callbacks[priority])) {
                 return Promise.resolve(currentArgs);
             }
 

--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -64,7 +64,7 @@ body_class = function (options) {
         }
     }
 
-    classes = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+    classes = classes.reduce(function (memo, item) { return memo + ' ' + item; }, '');
     return new hbs.handlebars.SafeString(classes.trim());
 };
 

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -15,7 +15,7 @@ var hbs             = require('express-hbs'),
 content = function (options) {
     var truncateOptions = (options || {}).hash || {};
     truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
-    _.keys(truncateOptions).map(function (key) {
+    Object.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 

--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -13,7 +13,7 @@ function excerpt(options) {
     var truncateOptions = (options || {}).hash || {};
 
     truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
-    _.keys(truncateOptions).map(function (key) {
+    Object.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 

--- a/core/server/helpers/ghost_foot.js
+++ b/core/server/helpers/ghost_foot.js
@@ -7,7 +7,6 @@
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
 var hbs             = require('express-hbs'),
-    _               = require('lodash'),
     filters         = require('../filters'),
     api             = require('../api'),
     ghost_foot;
@@ -20,7 +19,7 @@ ghost_foot = function (options) {
         foot.push(response.settings[0].value);
         return filters.doFilter('ghost_foot', foot);
     }).then(function (foot) {
-        var footString = _.reduce(foot, function (memo, item) { return memo + ' ' + item; }, '');
+        var footString = foot.reduce(function (memo, item) { return memo + ' ' + item; }, '');
         return new hbs.handlebars.SafeString(footString.trim());
     });
 };

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -370,7 +370,7 @@ ghost_head = function (options) {
         head.push(response.settings[0].value);
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
-        var headString = _.reduce(head, function (memo, item) { return memo + '\n    ' + item; }, '');
+        var headString = head.reduce(function (memo, item) { return memo + '\n    ' + item; }, '');
         return new hbs.handlebars.SafeString(headString.trim());
     });
 };

--- a/core/server/helpers/post_class.js
+++ b/core/server/helpers/post_class.js
@@ -7,7 +7,6 @@
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 
 var hbs             = require('express-hbs'),
-    _               = require('lodash'),
     post_class;
 
 post_class = function (options) {
@@ -29,7 +28,7 @@ post_class = function (options) {
         classes.push('page');
     }
 
-    classes = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');
+    classes = classes.reduce(function (memo, item) { return memo + ' ' + item; }, '');
     return new hbs.handlebars.SafeString(classes.trim());
 };
 

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -27,7 +27,7 @@ tags = function (options) {
 
     function createTagList(tags) {
         if (autolink) {
-            return _.map(tags, function (tag) {
+            return tags.map(function (tag) {
                 return utils.linkTemplate({
                     url: config.urlFor('tag', {tag: tag}),
                     text: _.escape(tag.name)

--- a/core/server/i18n.js
+++ b/core/server/i18n.js
@@ -27,7 +27,7 @@ I18n = {
         // If the path returns an array (as in the case with anything that has multiple paragraphs such as emails), then
         // loop through them and return an array of translated/formatted strings. Otherwise, just return the normal
         // translated/formatted string.
-        if (_.isArray(string)) {
+        if (Array.isArray(string)) {
             msg = [];
             string.forEach(function (s) {
                 var m = new MessageFormat(s, currentLocale);

--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -52,7 +52,7 @@ function isValidOrigin(origin, client) {
     var configHostname = url.parse(config.url).hostname;
 
     if (origin && client && client.type === 'ua' && (
-        _.indexOf(getIPs(), origin) >= 0
+        getIPs().indexOf(origin) >= 0
         || _.some(client.trustedDomains, {trusted_domain: origin})
         || origin === configHostname
         || configHostname === 'my-ghost-blog.com'

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -54,7 +54,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
     // Ghost option handling - get permitted attributes from server/data/schema.js, where the DB schema is defined
     permittedAttributes: function permittedAttributes() {
-        return _.keys(schema.tables[this.tableName]);
+        return Object.keys(schema.tables[this.tableName]);
     },
 
     // Bookshelf `defaults` - default values setup on every model creation

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -50,12 +50,12 @@ exports.deleteAllContent = function deleteAllContent() {
     var self = this;
 
     return self.Post.findAll().then(function then(posts) {
-        return Promise.all(_.map(posts.toJSON(), function mapper(post) {
+        return Promise.all(posts.toJSON().map(function mapper(post) {
             return self.Post.destroy({id: post.id});
         }));
     }).then(function () {
         return self.Tag.findAll().then(function then(tags) {
-            return Promise.all(_.map(tags.toJSON(), function mapper(tag) {
+            return Promise.all(tags.toJSON().map(function mapper(tag) {
                 return self.Tag.destroy({id: tag.id});
             }));
         });

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -21,7 +21,7 @@ filterUtils = {
         try {
             enforced = enforced ? (_.isString(enforced) ? gql.parse(enforced) : enforced) : null;
             defaults = defaults ? (_.isString(defaults) ? gql.parse(defaults) : defaults) : null;
-            custom = _.map(custom, function (arg) {
+            custom = custom.map(function (arg) {
                 return _.isString(arg) ? gql.parse(arg) : arg;
             });
         } catch (error) {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -389,7 +389,7 @@ User = ghostBookshelf.Model.extend({
             userData = addedUser;
             // if we are given a "role" object, only pass in the role ID in place of the full object
             return Promise.resolve(roles).then(function then(roles) {
-                roles = _.map(roles, function mapper(role) {
+                roles = roles.map(function mapper(role) {
                     if (_.isString(role)) {
                         return parseInt(role, 10);
                     } else if (_.isNumber(role)) {

--- a/core/server/permissions/effective.js
+++ b/core/server/permissions/effective.js
@@ -8,7 +8,7 @@ effective = {
         return Models.User.findOne({id: id, status: 'all'}, {include: ['permissions', 'roles', 'roles.permissions']})
             .then(function (foundUser) {
                 var seenPerms = {},
-                    rolePerms = _.map(foundUser.related('roles').models, function (role) {
+                    rolePerms = foundUser.related('roles').models.map(function (role) {
                         return role.related('permissions').models;
                     }),
                     allPerms = [],

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -120,7 +120,7 @@ CanThisResult.prototype.buildObjectTypeHandlers = function (objTypes, actType, c
         setting:    Models.Settings
     };
     // Iterate through the object types, i.e. ['post', 'tag', 'user']
-    return _.reduce(objTypes, function (objTypeHandlers, objType) {
+    return objTypes.reduce(function (objTypeHandlers, objType) {
         // Grab the TargetModel through the objectTypeModelMap
         var TargetModel = objectTypeModelMap[objType];
 

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -67,7 +67,7 @@ function updateCheckData() {
                 return errors.rejectError(e);
             }
 
-            return _.reduce(apps, function (memo, item) { return memo === '' ? memo + item : memo + ', ' + item; }, '');
+            return apps.reduce(function (memo, item) { return memo === '' ? memo + item : memo + ', ' + item; }, '');
         }).catch(errors.rejectError));
     ops.push(api.posts.browse().catch(errors.rejectError));
     ops.push(api.users.browse(internal).catch(errors.rejectError));

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -183,7 +183,7 @@ function updateCheck() {
     // 2. we've already done a check this session
     // 3. we're not in production or development mode
     // TODO: need to remove config.updateCheck in favor of config.privacy.updateCheck in future version (it is now deprecated)
-    if (config.updateCheck === false || config.isPrivacyDisabled('useUpdateCheck') || _.indexOf(allowedCheckEnvironments, process.env.NODE_ENV) === -1) {
+    if (config.updateCheck === false || config.isPrivacyDisabled('useUpdateCheck') || allowedCheckEnvironments.indexOf(process.env.NODE_ENV) === -1) {
         // No update check
         return Promise.resolve();
     } else {

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -95,7 +95,7 @@ function updateCheckData() {
         data.post_count      = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
         data.user_count      = users && users.users && users.users.length ? users.users.length : 0;
         data.blog_created_at = users && users.users && users.users[0] && users.users[0].created_at ? moment(users.users[0].created_at).unix() : '';
-        data.npm_version     = _.isArray(npm) && npm[0] ? npm[0].toString().replace(/\n/, '') : '';
+        data.npm_version     = Array.isArray(npm) && npm[0] ? npm[0].toString().replace(/\n/, '') : '';
 
         return data;
     }).catch(updateCheckError);

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -149,7 +149,7 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array.with.lengthOf(6);
 
                     // Each post must either have the author 'leslie' or 'pat'
-                    authors = _.map(result.posts, function (post) {
+                    authors = result.posts.map(function (post) {
                         return post.author.slug;
                     });
                     authors.should.matchAny(/leslie|pat/);

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -333,7 +333,7 @@ describe('Post API', function () {
 
                 results.posts[0].title.should.exist;
                 should.not.exist(results.posts[0].foo);
-                objectKeys = _.keys(results.posts[0]);
+                objectKeys = Object.keys(results.posts[0]);
                 objectKeys.length.should.eql(1);
 
                 done();

--- a/core/test/unit/apps_spec.js
+++ b/core/test/unit/apps_spec.js
@@ -414,7 +414,7 @@ describe('Apps', function () {
             AppPermissions.DefaultPermissions.posts.should.containEql('read');
 
             // Make it hurt to add more so additional checks are added here
-            _.keys(AppPermissions.DefaultPermissions).length.should.equal(1);
+            Object.keys(AppPermissions.DefaultPermissions).length.should.equal(1);
         });
         it('uses default permissions if no package.json', function (done) {
             var perms = new AppPermissions('test');
@@ -486,7 +486,7 @@ describe('Apps', function () {
                 should.exist(readPerms.settings);
                 readPerms.settings.length.should.equal(5);
 
-                _.keys(readPerms).length.should.equal(3);
+                Object.keys(readPerms).length.should.equal(3);
 
                 done();
             }).catch(done);

--- a/core/test/unit/importer_spec.js
+++ b/core/test/unit/importer_spec.js
@@ -322,8 +322,8 @@ describe('Importer', function () {
                 name: 'export-003-api-wrapper.json'
             }];
             JSONHandler.loadFile(file).then(function (result) {
-                _.keys(result).should.containEql('meta');
-                _.keys(result).should.containEql('data');
+                Object.keys(result).should.containEql('meta');
+                Object.keys(result).should.containEql('data');
                 done();
             }).catch(done);
         });

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -25,7 +25,7 @@ describe('Permissions', function () {
         });
 
         beforeEach(function () {
-            var permissions = _.map(testUtils.DataGenerator.Content.permissions, function (testPerm) {
+            var permissions = testUtils.DataGenerator.Content.permissions.map(function (testPerm) {
                 return testUtils.DataGenerator.forKnex.createPermission(testPerm);
             });
 

--- a/core/test/unit/server_helpers/foreach_spec.js
+++ b/core/test/unit/server_helpers/foreach_spec.js
@@ -85,7 +85,7 @@ describe('{{#foreach}} helper', function () {
             options.fn.called.should.be.true;
             options.fn.getCalls().length.should.eql(_.size(context));
 
-            _.each(_.keys(context), function (value, index) {
+            _.each(Object.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
                 should(options.fn.getCall(index).args[1].data).be.undefined;
             });
@@ -153,7 +153,7 @@ describe('{{#foreach}} helper', function () {
             options.fn.called.should.be.true;
             options.fn.getCalls().length.should.eql(_.size(context));
 
-            _.each(_.keys(context), function (value, index) {
+            _.each(Object.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
                 should(options.fn.getCall(index).args[1].data).not.be.undefined;
 
@@ -230,7 +230,7 @@ describe('{{#foreach}} helper', function () {
             options.fn.called.should.be.true;
             options.fn.getCalls().length.should.eql(_.size(context));
 
-            _.each(_.keys(context), function (value, index) {
+            _.each(Object.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
                 should(options.fn.getCall(index).args[1].data).not.be.undefined;
 

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -440,13 +440,13 @@ DataGenerator.forModel = (function () {
         users,
         roles;
 
-    posts = _.map(DataGenerator.Content.posts, function (post) {
+    posts = DataGenerator.Content.posts.map(function (post) {
         return _.pick(post, 'title', 'markdown');
     });
 
     tags = DataGenerator.Content.tags;
 
-    users = _.map(DataGenerator.Content.users, function (user) {
+    users = DataGenerator.Content.users.map(function (user) {
         user = _.pick(user, 'name', 'email');
 
         return _.defaults({
@@ -454,8 +454,8 @@ DataGenerator.forModel = (function () {
         }, user);
     });
 
-    roles = _.map(DataGenerator.Content.roles, function (role, id) {
-        return _.extend({}, role, {id: id + 1});
+    roles = DataGenerator.Content.roles.map(function (id) {
+        return _.extend({}, DataGenerator.Content.roles[id], {id: id + 1});
     });
 
     return {

--- a/core/test/utils/fixtures/filter-param/index.js
+++ b/core/test/utils/fixtures/filter-param/index.js
@@ -266,7 +266,7 @@ function writeFetchFix(knex, resource) {
 
 function createUsers(knex, DataGenerator) {
     // First, loop through and prep the data
-    data.users = _.map(data.users, function (user) {
+    data.users = data.users.map(function (user) {
         return DataGenerator.forKnex.createUser(user);
     });
 
@@ -275,7 +275,7 @@ function createUsers(knex, DataGenerator) {
 }
 
 function createTags(knex, DataGenerator, created) {
-    data.tags = _.map(data.tags, function (tag) {
+    data.tags = data.tags.map(function (tag) {
         tag = DataGenerator.forKnex.createBasic(tag);
         tag.created_by = created.users[tag.created_by].id;
         return tag;
@@ -287,7 +287,7 @@ function createTags(knex, DataGenerator, created) {
 
 function createPosts(knex, DataGenerator, created) {
     var postsTags = [];
-    data.posts = _.map(data.posts, function (post, index) {
+    data.posts = data.posts.map(function (post, index) {
         post = DataGenerator.forKnex.createPost(post);
         post.created_by = created.users[post.author_id].id;
         post.author_id = created.users[post.author_id].id;
@@ -301,7 +301,7 @@ function createPosts(knex, DataGenerator, created) {
     // Next, insert it into the database & return the correctly indexed data
     return writeFetchFix(knex, 'posts').then(function (createdPosts) {
         // Handle post tags
-        postsTags = _.map(postsTags, function (postTag) {
+        postsTags = postsTags.map(function (postTag) {
             postTag.post_id = createdPosts[postTag.post_id].id;
             return postTag;
         });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -243,7 +243,7 @@ fixtures = {
             // grab 3 more users
             extraUsers = DataGenerator.Content.users.slice(2, 5);
 
-        extraUsers = _.map(extraUsers, function (user) {
+        extraUsers = extraUsers.map(function (user) {
             return DataGenerator.forKnex.createUser(_.extend({}, user, {
                 email: 'a' + user.email,
                 slug: 'a' + user.slug
@@ -274,7 +274,7 @@ fixtures = {
             // grab 3 more users
             extraUsers = DataGenerator.Content.users.slice(2, 5);
 
-        extraUsers = _.map(extraUsers, function (user) {
+        extraUsers = extraUsers.map(function (user) {
             return DataGenerator.forKnex.createUser(_.extend({}, user, {
                 email: 'inv' + user.email,
                 slug: 'inv' + user.slug,
@@ -343,7 +343,7 @@ fixtures = {
                 Owner: 4
             };
 
-        permsToInsert = _.map(permsToInsert, function (perms) {
+        permsToInsert = permsToInsert.map(function (perms) {
             perms.object_type = obj;
             actions.push(perms.action_type);
             return DataGenerator.forKnex.createBasic(perms);


### PR DESCRIPTION
There are a couple of lodash functions in use that are covered by native JavaScript. This PR replaces those uses.

Note: I left _.each untouched since we often use _.each on objects. Since this is some more work I'd like to hear feedback on this first. `.forEach` is only defined on arrays and our objects would have to be passed through `Object.keys` to be iterable.
