### PR TITLE
Fix image height auto not being honoured due to container with display flex

### DIFF
--- a/core/client/app/styles/layouts/flow.css
+++ b/core/client/app/styles/layouts/flow.css
@@ -148,8 +148,6 @@
 
 
 .gh-flow-content {
-    display: flex;
-    flex-direction: column;
     max-width: 700px;
     width: 100%;
     color: var(--midgrey);
@@ -415,6 +413,11 @@
 
 .gh-flow-content .gh-flow-faces {
     margin-bottom: 2vw;
+}
+.gh-flow-faces {
+    display: block;
+    width: 100%;
+    height: auto;
 }
 
 .gh-flow-content textarea {

--- a/core/client/app/templates/setup/three.hbs
+++ b/core/client/app/templates/setup/three.hbs
@@ -3,7 +3,7 @@
     <p>Ghost works best when shared with others. Collaborate, get feedback on your posts &amp; work together on ideas.</p>
 </header>
 
-<img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" />
+<img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" width="1716" height="236" />
 
 <form class="gh-flow-invite">
     {{#gh-form-group errors=errors hasValidated=hasValidated property="users"}}


### PR DESCRIPTION
closes #6380
- Set image dimensions on img tag for rendering performance
- Set image class to display block and height auto
- Remove display flex on container, not required.
