### PR TITLE
[Hold] Use Timezones in Blog Settings

### DIFF
--- a/core/client/app/components/gh-datetime-input.js
+++ b/core/client/app/components/gh-datetime-input.js
@@ -4,7 +4,10 @@ import boundOneWay from 'ghost/utils/bound-one-way';
 import {formatDate} from 'ghost/utils/date-formatting';
 import {invokeAction} from 'ember-invoke-action';
 
-const {Component} = Ember;
+const {
+    Component,
+    RSVP
+} = Ember;
 
 export default Component.extend(TextInputMixin, {
     tagName: 'span',
@@ -16,17 +19,19 @@ export default Component.extend(TextInputMixin, {
     inputName: null,
 
     didReceiveAttrs() {
-        let datetime = this.get('datetime') || moment();
+        let datetime = RSVP.resolve(this.get('datetime') || moment.utc());
 
         if (!this.get('update')) {
             throw new Error(`You must provide an \`update\` action to \`{{${this.templateName}}}\`.`);
         }
 
-        this.set('datetime', formatDate(datetime));
+        datetime.then((date) => {
+            this.set('datetime', formatDate(date));
+        });
     },
 
     focusOut() {
-        let datetime = this.get('datetime');
+        let datetime = this.get('datetime') || moment.utc();
 
         invokeAction(this, 'update', datetime);
     }

--- a/core/client/app/components/gh-select-native.js
+++ b/core/client/app/components/gh-select-native.js
@@ -25,11 +25,9 @@ export default Component.extend({
             let selectEl = this.$('select')[0];
             // jscs:enable requireArrayDestructuring
             let {selectedIndex} = selectEl;
-
             // decrement index by 1 if we have a prompt
             let hasPrompt = !!this.get('prompt');
             let contentIndex = hasPrompt ? selectedIndex - 1 : selectedIndex;
-
             let selection = this.get('content').objectAt(contentIndex);
 
             // set the local, shadowed selection to avoid leaking

--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -15,10 +15,14 @@ export default Controller.extend(SettingsSaveMixin, {
     showUploadLogoModal: false,
     showUploadCoverModal: false,
 
+    availableTimezones: null,
+
     notifications: service(),
     config: service(),
     _scratchFacebook: null,
     _scratchTwitter: null,
+    timeZone: service(),
+    clock: service(),
 
     selectedTheme: computed('model.activeTheme', 'themes', function () {
         let activeTheme = this.get('model.activeTheme');
@@ -34,12 +38,27 @@ export default Controller.extend(SettingsSaveMixin, {
         return selectedTheme;
     }),
 
+    selectedTimezone: computed('model.activeTimezone', 'availableTimezones', function () {
+        let activeTimezone = this.get('model.activeTimezone');
+        let availableTimezones = this.get('availableTimezones');
+
+        return availableTimezones
+            .filterBy('name', activeTimezone)
+            .get('firstObject');
+    }),
+
     logoImageSource: computed('model.logo', function () {
         return this.get('model.logo') || '';
     }),
 
     coverImageSource: computed('model.cover', function () {
         return this.get('model.cover') || '';
+    }),
+
+    localTime: computed('selectedTimezone', 'clock.second', function () {
+        let timezone = this.get('selectedTimezone.name');
+        this.get('clock.second');
+        return timezone ? moment.tz(timezone).format('HH:mm:ss') : moment.utc().format('HH:mm:ss');
     }),
 
     isDatedPermalinks: computed('model.permalinks', {
@@ -82,7 +101,6 @@ export default Controller.extend(SettingsSaveMixin, {
     save() {
         let notifications = this.get('notifications');
         let config = this.get('config');
-
         return this.get('model').save().then((model) => {
             config.set('blogTitle', model.get('title'));
 
@@ -111,7 +129,9 @@ export default Controller.extend(SettingsSaveMixin, {
         setTheme(theme) {
             this.set('model.activeTheme', theme.name);
         },
-
+        setTimezone(timezone) {
+            this.set('model.activeTimezone', timezone.name);
+        },
         toggleUploadCoverModal() {
             this.toggleProperty('showUploadCoverModal');
         },

--- a/core/client/app/helpers/gh-format-timeago.js
+++ b/core/client/app/helpers/gh-format-timeago.js
@@ -6,10 +6,10 @@ export default Helper.helper(function (params) {
     if (!params || !params.length) {
         return;
     }
-
     let [timeago] = params;
+    let utc = moment.utc();
 
-    return moment(timeago).fromNow();
+    return moment(timeago).fromNow(utc);
     // stefanpenner says cool for small number of timeagos.
     // For large numbers moment sucks => single Ember.Object based clock better
     // https://github.com/manuelmitasch/ghost-admin-ember-demo/commit/fba3ab0a59238290c85d4fa0d7c6ed1be2a8a82e#commitcomment-5396524

--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -264,6 +264,16 @@ export function testConfig() {
         return {};
     });
 
+    /* Configuration -------------------------------------------------------- */
+
+    this.get('/configuration/timezones/', function (db) {
+        return {
+            configuration: [{
+                timezones: db.timezones
+            }]
+        };
+    });
+
     /* Slugs ---------------------------------------------------------------- */
 
     this.get('/slugs/post/:slug/', function (db, request) {

--- a/core/client/app/mirage/fixtures/settings.js
+++ b/core/client/app/mirage/fixtures/settings.js
@@ -202,6 +202,17 @@ export default [
         value: ''
     },
     {
+        created_at: '2015-09-11T09:44:30.810Z',
+        created_by: 1,
+        id: 16,
+        key: 'activeTimezone',
+        type: 'blog',
+        updated_at: '2015-09-23T13:32:49.868Z',
+        updated_by: 1,
+        uuid: '310c9169-9613-48b0-8bc4-d1e1c9be85b8',
+        value: 'Europe/Dublin'
+    },
+    {
         key: 'availableThemes',
         value: [
             {

--- a/core/client/app/mirage/fixtures/timezones.js
+++ b/core/client/app/mirage/fixtures/timezones.js
@@ -1,0 +1,327 @@
+export default [
+    {
+        name: 'Pacific/Pago_Pago',
+        label: '(GMT -11:00) Midway Island, Samoa',
+        offset: -660
+    },
+    {
+        name: 'Pacific/Honolulu',
+        label: '(GMT -10:00) Hawaii',
+        offset: -600
+    },
+    {
+        name: 'America/Anchorage',
+        label: '(GMT -9:00) Alaska',
+        offset: -540
+    },
+    {
+        name: 'America/Tijuana',
+        label: '(GMT -8:00) Chihuahua, La Paz, Mazatlan',
+        offset: -480
+    },
+    {
+        name: 'America/Los_Angeles',
+        label: '(GMT -8:00) Pacific Time (US & Canada); Tijuana',
+        offset: -480
+    },
+    {
+        name: 'America/Phoenix',
+        label: '(GMT -7:00) Arizona',
+        offset: -420
+    },
+    {
+        name: 'America/Denver',
+        label: '(GMT -7:00) Mountain Time (US & Canada)',
+        offset: -420
+    },
+    {
+        name: 'America/Costa_Rica',
+        label: '(GMT -6:00) Central America',
+        offset: -360
+    },
+    {
+        name: 'America/Chicago',
+        label: '(GMT -6:00) Central Time (US & Canada)',
+        offset: -360
+    },
+    {
+        name: 'America/Mexico_City',
+        label: '(GMT -6:00) Guadalajara, Mexico City, Monterrey',
+        offset: -360
+    },
+    {
+        name: 'America/Regina',
+        label: '(GMT -6:00) Saskatchewan',
+        offset: -360
+    },
+    {
+        name: 'America/Bogota',
+        label: '(GMT -5:00) Bogota, Lima, Quito',
+        offset: -300
+    },
+    {
+        name: 'America/New_York',
+        label: '(GMT -5:00) Eastern Time (US & Canada)',
+        offset: -300
+    },
+    {
+        name: 'America/Fort_Wayne',
+        label: '(GMT -5:00) Indiana (East)',
+        offset: -300
+    },
+    {
+        name: 'America/Caracas',
+        label: '(GMT -4:30) Caracas, La Paz',
+        offset: -270
+    },
+    {
+        name: 'America/Halifax',
+        label: '(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland',
+        offset: -240
+    },
+    {
+        name: 'America/St_Johns',
+        label: '(GMT -3:30) Newfoundland',
+        offset: -210
+    },
+    {
+        name: 'America/Argentina/Buenos_Aires',
+        label: '(GMT -3:00) Buenos Aires, Georgetown',
+        offset: -180
+    },
+    {
+        name: 'America/Santiago',
+        label: '(GMT -3:00) Santiago',
+        offset: -180
+    },
+    {
+        name: 'America/Noronha',
+        label: '(GMT -2:00) Fernando de Noronha',
+        offset: -120
+    },
+    {
+        name: 'Atlantic/Azores',
+        label: '(GMT -1:00) Azores',
+        offset: -60
+    },
+    {
+        name: 'Atlantic/Cape_Verde',
+        label: '(GMT -1:00) Cape Verde Is.',
+        offset: -60
+    },
+    {
+        name: 'Africa/Casablanca',
+        label: '(GMT) Casablanca, Monrovia',
+        offset: 0
+    },
+    {
+        name: 'Europe/Dublin',
+        label: '(GMT) Greenwich Mean Time : Dublin, Edinburgh, London',
+        offset: 0
+    },
+    {
+        name: 'Europe/Amsterdam',
+        label: '(GMT +1:00) Amsterdam, Berlin, Rome, Stockholm, Vienna',
+        offset: 60
+    },
+    {
+        name: 'Europe/Prague',
+        label: '(GMT +1:00) Belgrade, Bratislava, Budapest, Prague',
+        offset: 60
+    },
+    {
+        name: 'Europe/Paris',
+        label: '(GMT +1:00) Brussels, Copenhagen, Madrid, Paris',
+        offset: 60
+    },
+    {
+        name: 'Europe/Warsaw',
+        label: '(GMT +1:00) Sarajevo, Skopje, Warsaw, Zagreb',
+        offset: 60
+    },
+    {
+        name: 'Africa/Lagos',
+        label: '(GMT +1:00) West Central Africa',
+        offset: 60
+    },
+    {
+        name: 'Europe/Istanbul',
+        label: '(GMT +2:00) Athens, Beirut, Bucharest, Istanbul',
+        offset: 120
+    },
+    {
+        name: 'Africa/Cairo',
+        label: '(GMT +2:00) Cairo, Egypt',
+        offset: 120
+    },
+    {
+        name: 'Africa/Maputo',
+        label: '(GMT +2:00) Harare',
+        offset: 120
+    },
+    {
+        name: 'Europe/Kiev',
+        label: '(GMT +2:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius',
+        offset: 120
+    },
+    {
+        name: 'Asia/Jerusalem',
+        label: '(GMT +2:00) Jerusalem',
+        offset: 120
+    },
+    {
+        name: 'Africa/Johannesburg',
+        label: '(GMT +2:00) Pretoria',
+        offset: 120
+    },
+    {
+        name: 'Asia/Baghdad',
+        label: '(GMT +3:00) Baghdad',
+        offset: 180
+    },
+    {
+        name: 'Asia/Riyadh',
+        label: '(GMT +3:00) Kuwait, Nairobi, Riyadh',
+        offset: 180
+    },
+    {
+        name: 'Asia/Tehran',
+        label: '(GMT +3:30) Tehran',
+        offset: 210
+    },
+    {
+        name: 'Asia/Dubai',
+        label: '(GMT +4:00) Abu Dhabi, Muscat',
+        offset: 240
+    },
+    {
+        name: 'Asia/Baku',
+        label: '(GMT +4:00) Baku, Tbilisi, Yerevan',
+        offset: 240
+    },
+    {
+        name: 'Europe/Moscow',
+        label: '(GMT +4:00) Moscow, St. Petersburg, Volgograd',
+        offset: 240
+    },
+    {
+        name: 'Asia/Kabul',
+        label: '(GMT +4:30) Kabul',
+        offset: 270
+    },
+    {
+        name: 'Asia/Karachi',
+        label: '(GMT +5:00) Islamabad, Karachi, Tashkent',
+        offset: 300
+    },
+    {
+        name: 'Asia/Kolkata',
+        label: '(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi',
+        offset: 330
+    },
+    {
+        name: 'Asia/Kathmandu',
+        label: '(GMT +5:45) Katmandu',
+        offset: 345
+    },
+    {
+        name: 'Asia/Almaty',
+        label: '(GMT +6:00) Almaty, Novosibirsk',
+        offset: 360
+    },
+    {
+        name: 'Asia/Dhaka',
+        label: '(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura',
+        offset: 360
+    },
+    {
+        name: 'Asia/Yekaterinburg',
+        label: '(GMT +6:00) Yekaterinburg',
+        offset: 360
+    },
+    {
+        name: 'Asia/Rangoon',
+        label: '(GMT +6:30) Rangoon',
+        offset: 390
+    },
+    {
+        name: 'Asia/Bangkok',
+        label: '(GMT +7:00) Bangkok, Hanoi, Jakarta',
+        offset: 420
+    },
+    {
+        name: 'Asia/Hong_Kong',
+        label: '(GMT +8:00) Beijing, Chongqing, Hong Kong, Urumqi',
+        offset: 480
+    },
+    {
+        name: 'Asia/Krasnoyarsk',
+        label: '(GMT +8:00) Krasnoyarsk',
+        offset: 480
+    },
+    {
+        name: 'Asia/Singapore',
+        label: '(GMT +8:00) Kuala Lumpur, Perth, Singapore, Taipei',
+        offset: 480
+    },
+    {
+        name: 'Asia/Irkutsk',
+        label: '(GMT +9:00) Irkutsk, Ulaan Bataar',
+        offset: 540
+    },
+    {
+        name: 'Asia/Tokyo',
+        label: '(GMT +9:00) Osaka, Sapporo, Tokyo',
+        offset: 540
+    },
+    {
+        name: 'Asia/Seoul',
+        label: '(GMT +9:00) Seoul',
+        offset: 540
+    },
+    {
+        name: 'Australia/Darwin',
+        label: '(GMT +9:30) Darwin',
+        offset: 570
+    },
+    {
+        name: 'Australia/Brisbane',
+        label: '(GMT +10:00) Brisbane, Guam, Port Moresby',
+        offset: 600
+    },
+    {
+        name: 'Asia/Yakutsk',
+        label: '(GMT +10:00) Yakutsk',
+        offset: 600
+    },
+    {
+        name: 'Australia/Adelaide',
+        label: '(GMT +10:30) Adelaide',
+        offset: 630
+    },
+    {
+        name: 'Australia/Sydney',
+        label: '(GMT +11:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok',
+        offset: 660
+    },
+    {
+        name: 'Pacific/Fiji',
+        label: '(GMT +12:00) Fiji, Kamchatka, Marshall Is.',
+        offset: 720
+    },
+    {
+        name: 'Pacific/Kwajalein',
+        label: '(GMT +12:00) International Date Line West',
+        offset: 720
+    },
+    {
+        name: 'Asia/Magadan',
+        label: '(GMT +12:00) Magadan, Soloman Is., New Caledonia',
+        offset: 720
+    },
+    {
+        name: 'Pacific/Auckland',
+        label: '(GMT +13:00) Auckland, Wellington',
+        offset: 780
+    }
+];

--- a/core/client/app/models/post.js
+++ b/core/client/app/models/post.js
@@ -28,11 +28,11 @@ export default Model.extend(ValidationEngine, {
     metaDescription: attr('string'),
     author: belongsTo('user', {async: true}),
     authorId: attr('number'),
-    updatedAt: attr('moment-date'),
+    updatedAt: attr('moment-utc'),
     updatedBy: attr(),
-    publishedAt: attr('moment-date'),
+    publishedAt: attr('moment-utc'),
     publishedBy: belongsTo('user', {async: true}),
-    createdAt: attr('moment-date'),
+    createdAt: attr('moment-utc'),
     createdBy: attr(),
     tags: hasMany('tag', {
         embedded: 'always',
@@ -42,6 +42,7 @@ export default Model.extend(ValidationEngine, {
 
     config: service(),
     ghostPaths: service(),
+    timeZone: service(),
 
     absoluteUrl: computed('url', 'ghostPaths.url', 'config.blogUrl', function () {
         let blogUrl = this.get('config.blogUrl');
@@ -62,6 +63,19 @@ export default Model.extend(ValidationEngine, {
 
     scratch: null,
     titleScratch: null,
+
+    // Computed Date properties
+    // timeZone.offset service returns the moment-timezone from the
+    // activeTimezone, set in the blogs settings
+
+    publishedAtOffset: computed('timeZone.offset', 'publishedAt', function() {
+        let publishedAt = this.get('publishedAt');
+        let momentPublishedAt = publishedAt ? moment(publishedAt) : moment.utc();
+
+        return this.get('timeZone.offset').then((offset) => {
+            return momentPublishedAt.tz(offset);
+        });
+    }),
 
     // Computed post properties
 

--- a/core/client/app/models/role.js
+++ b/core/client/app/models/role.js
@@ -9,8 +9,8 @@ export default Model.extend({
     uuid: attr('string'),
     name: attr('string'),
     description: attr('string'),
-    createdAt: attr('moment-date'),
-    updatedAt: attr('moment-date'),
+    createdAt: attr('moment-utc'),
+    updatedAt: attr('moment-utc'),
     createdBy: attr(),
     updatedBy: attr(),
 

--- a/core/client/app/models/setting.js
+++ b/core/client/app/models/setting.js
@@ -16,6 +16,7 @@ export default Model.extend(ValidationEngine, {
     permalinks: attr('string'),
     activeTheme: attr('string'),
     availableThemes: attr(),
+    activeTimezone: attr('string', {defaultValue: 'Europe/Dublin'}),
     ghost_head: attr('string'),
     ghost_foot: attr('string'),
     facebook: attr('string'),

--- a/core/client/app/models/tag.js
+++ b/core/client/app/models/tag.js
@@ -15,8 +15,8 @@ export default Model.extend(ValidationEngine, {
     metaDescription: attr('string'),
     image: attr('string'),
     hidden: attr('boolean'),
-    createdAt: attr('moment-date'),
-    updatedAt: attr('moment-date'),
+    createdAt: attr('moment-utc'),
+    updatedAt: attr('moment-utc'),
     createdBy: attr(),
     updatedBy: attr(),
     count: attr('raw')

--- a/core/client/app/models/user.js
+++ b/core/client/app/models/user.js
@@ -28,10 +28,10 @@ export default Model.extend(ValidationEngine, {
     language: attr('string', {defaultValue: 'en_US'}),
     metaTitle: attr('string'),
     metaDescription: attr('string'),
-    lastLogin: attr('moment-date'),
-    createdAt: attr('moment-date'),
+    lastLogin: attr('moment-utc'),
+    createdAt: attr('moment-utc'),
     createdBy: attr('number'),
-    updatedAt: attr('moment-date'),
+    updatedAt: attr('moment-utc'),
     updatedBy: attr('number'),
     roles: hasMany('role', {
         embedded: 'always',

--- a/core/client/app/routes/settings/general.js
+++ b/core/client/app/routes/settings/general.js
@@ -1,11 +1,19 @@
+import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import styleBody from 'ghost/mixins/style-body';
+
+const {
+    RSVP,
+    inject: {service}
+} = Ember;
 
 export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     titleToken: 'Settings - General',
 
     classNames: ['settings-view-general'],
+
+    config: service(),
 
     beforeModel() {
         this._super(...arguments);
@@ -15,7 +23,15 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     model() {
-        return this.store.queryRecord('setting', {type: 'blog,theme,private'});
+        return RSVP.hash({
+            settings: this.store.queryRecord('setting', {type: 'blog,theme,private'}),
+            availableTimezones: this.get('config.availableTimezones')
+        });
+    },
+
+    setupController(controller, models) {
+        controller.set('model', models.settings);
+        controller.set('availableTimezones', models.availableTimezones);
     },
 
     actions: {

--- a/core/client/app/services/clock.js
+++ b/core/client/app/services/clock.js
@@ -1,0 +1,37 @@
+import Ember from 'ember';
+
+const {
+    Service,
+    run
+} = Ember;
+
+const ONE_SECOND = 1000;
+
+// Creates a clock service to run intervals.
+
+export default Service.extend({
+    second: null,
+    minute: null,
+    hour:   null,
+
+    init() {
+        this.tick();
+    },
+
+    tick() {
+        let now = moment.utc();
+        this.setProperties({
+            second: now.seconds(),
+            minute: now.minutes(),
+            hour:   now.hours()
+        });
+
+        if (!Ember.testing) {
+            run.later(() => {
+                this.tick();
+            }, ONE_SECOND);
+        }
+
+    }
+
+});

--- a/core/client/app/services/config.js
+++ b/core/client/app/services/config.js
@@ -1,6 +1,11 @@
 import Ember from 'ember';
 
-const {Service, _ProxyMixin, computed} = Ember;
+const {
+    Service,
+    _ProxyMixin,
+    computed,
+    inject: {service}
+} = Ember;
 
 function isNumeric(num) {
     return Ember.$.isNumeric(num);
@@ -25,6 +30,9 @@ function _mapType(val, type) {
 }
 
 export default Service.extend(_ProxyMixin, {
+    ajax: service(),
+    ghostPaths: service(),
+
     content: computed(function () {
         let metaConfigTags = Ember.$('meta[name^="env-"]');
         let config = {};
@@ -40,5 +48,15 @@ export default Service.extend(_ProxyMixin, {
         });
 
         return config;
+    }),
+
+    availableTimezones: computed(function() {
+        let timezonesUrl = this.get('ghostPaths.url').api('configuration', 'timezones');
+
+        return this.get('ajax').request(timezonesUrl).then((configTimezones) => {
+            let [ timezonesObj ] = configTimezones.configuration;
+            timezonesObj = timezonesObj.timezones;
+            return timezonesObj;
+        });
     })
 });

--- a/core/client/app/services/time-zone.js
+++ b/core/client/app/services/time-zone.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+const {
+    Service,
+    computed,
+    inject: {service}
+} = Ember;
+
+export default Service.extend({
+    store: service(),
+
+    _parseTimezones(settings) {
+        let activeTimezone = settings.get('activeTimezone');
+        let offset = activeTimezone;
+
+        return offset;
+    },
+
+    _settings: computed(function () {
+        let store = this.get('store');
+        return store.queryRecord('setting', {type: 'blog'});
+    }),
+
+    offset: computed('_settings.activeTimezone', function () {
+        return this.get('_settings').then((settings) => {
+            return this._parseTimezones(settings);
+        });
+    })
+
+});

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -32,7 +32,7 @@
 
             {{#gh-form-group errors=model.errors property="post-setting-date"}}
                 <label for="post-setting-date">Publish Date</label>
-                {{gh-datetime-input value=model.publishedAt
+                {{gh-datetime-input value=model.publishedAtOffset
                                     update=(action "setPublishedAt")
                                     inputClass="post-setting-date"
                                     inputId="post-setting-date"

--- a/core/client/app/templates/posts.hbs
+++ b/core/client/app/templates/posts.hbs
@@ -24,7 +24,7 @@
                                         {{#if post.page}}
                                             <span class="page">Page</span>
                                         {{else}}
-                                            <time datetime="{{post.publishedAt}}" class="date published">
+                                            <time datetime="{{post.publishedAtOffset}}" class="date published">
                                                 Published {{gh-format-timeago post.publishedAt}}
                                             </time>
                                         {{/if}}

--- a/core/client/app/templates/settings/general.hbs
+++ b/core/client/app/templates/settings/general.hbs
@@ -113,6 +113,22 @@
                     {{/gh-form-group}}
                 </div>
 
+                <div class="form-group for-select">
+                    <label for="activeTimezone">Timezone</label>
+                    <span class="gh-select" data-select-text="{{selectedTimezone.label}}" tabindex="0">
+                        {{gh-select-native
+                            id="activeTimezone"
+                            name="general[activeTimezone]"
+                            content=availableTimezones
+                            optionValuePath="name"
+                            optionLabelPath="label"
+                            selection=selectedTimezone
+                            action="setTimezone"
+                        }}
+                    </span>
+                    <p>The local time here is currently {{localTime}}</p>
+                </div>
+
                 <div class="form-group for-checkbox">
                     <label for="isPrivate">Make this blog private</label>
                     <label class="checkbox" for="isPrivate">

--- a/core/client/app/transforms/moment-utc.js
+++ b/core/client/app/transforms/moment-utc.js
@@ -1,0 +1,18 @@
+/* global moment */
+import Transform from 'ember-data/transform';
+
+export default Transform.extend({
+    deserialize(serialized) {
+        if (serialized) {
+            return moment.utc(serialized);
+        }
+        return serialized;
+    },
+
+    serialize(deserialized) {
+        if (deserialized) {
+            return deserialized.toJSON();
+        }
+        return deserialized;
+    }
+});

--- a/core/client/app/utils/date-formatting.js
+++ b/core/client/app/utils/date-formatting.js
@@ -24,7 +24,11 @@ function verifyTimeStamp(dateString) {
 }
 
 // Parses a string to a Moment
-function parseDateString(value) {
+function parseDateString(value, offset) {
+    // We need the offset here, otherwise the date will be parsed
+    // in UTC timezone
+    moment.tz.setDefault(offset);
+
     return value ? moment(verifyTimeStamp(value), parseDateFormats, true) : undefined;
 }
 

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -19,6 +19,7 @@
     "keymaster": "1.6.3",
     "lodash": "3.7.0",
     "moment": "2.12.0",
+    "moment-timezone": "0.5.1",
     "normalize.css": "3.0.3",
     "password-generator": "2.0.2",
     "pretender": "1.0.0",

--- a/core/client/ember-cli-build.js
+++ b/core/client/ember-cli-build.js
@@ -55,6 +55,7 @@ module.exports = function (defaults) {
     app.import('bower_components/showdown-ghost/src/extensions/footnotes.js');
     app.import('bower_components/showdown-ghost/src/extensions/highlight.js');
     app.import('bower_components/moment/moment.js');
+    app.import('bower_components/moment-timezone/builds/moment-timezone-with-data.js');
     app.import('bower_components/keymaster/keymaster.js');
     app.import('bower_components/devicejs/lib/device.js');
     app.import('bower_components/jquery-ui/jquery-ui.js');

--- a/core/client/tests/acceptance/settings/general-test.js
+++ b/core/client/tests/acceptance/settings/general-test.js
@@ -132,6 +132,21 @@ describe('Acceptance: Settings - General', function () {
                 expect(find('#activeTheme select option').length, 'available themes').to.equal(1);
                 expect(find('#activeTheme select option').text().trim()).to.equal('Blog - 1.0');
             });
+        });
+
+        it('renders timezone selector correctly', function () {
+            visit('/settings/general');
+
+            andThen(() => {
+                expect(currentURL(), 'currentURL').to.equal('/settings/general');
+
+                expect(find('#activeTimezone select option').length, 'available timezones').to.equal(65);
+                expect(find('#activeTimezone option:selected').text().trim()).to.equal('(GMT) Greenwich Mean Time : Dublin, Edinburgh, London');
+            });
+        });
+
+        it('handles private blog settings correctly', function () {
+            visit('/settings/general');
 
             // handles private blog settings correctly
             andThen(() => {

--- a/core/client/tests/unit/components/gh-image-uploader-test.js
+++ b/core/client/tests/unit/components/gh-image-uploader-test.js
@@ -51,6 +51,7 @@ describeComponent(
             'service:session',
             'service:ajax',
             'service:feature',
+            'service:ghostPaths',
             'component:x-file-input',
             'component:one-way-input'
         ],

--- a/core/client/tests/unit/controllers/settings/navigation-test.js
+++ b/core/client/tests/unit/controllers/settings/navigation-test.js
@@ -22,7 +22,7 @@ describeModule(
     'Unit: Controller: settings/navigation',
     {
         // Specify the other units that are required for this test.
-        needs: ['service:config', 'service:notifications', 'model:navigation-item']
+        needs: ['service:config', 'service:notifications', 'model:navigation-item', 'service:ajax', 'service:ghostPaths']
     },
     function () {
         it('blogUrl: captures config and ensures trailing slash', function () {

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -60,7 +60,8 @@ updateConfigCache = function () {
             postsPerPage: (settingsCache.postsPerPage && settingsCache.postsPerPage.value) || 5,
             permalinks: (settingsCache.permalinks && settingsCache.permalinks.value) || '/:slug/',
             twitter: (settingsCache.twitter && settingsCache.twitter.value) || '',
-            facebook: (settingsCache.facebook && settingsCache.facebook.value) || ''
+            facebook: (settingsCache.facebook && settingsCache.facebook.value) || '',
+            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || 'Europe/Dublin'
         },
         labs: labsValue
     });

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -40,6 +40,12 @@
                 "isLength": [1, 1000]
             }
         },
+        "activeTimezone": {
+            "defaultValue": "Europe/Dublin",
+            "validations": {
+                "isNull": false
+            }
+        },
         "forceI18n": {
             "defaultValue": "true",
             "validations": {

--- a/core/server/data/timezones.json
+++ b/core/server/data/timezones.json
@@ -1,7 +1,7 @@
 {
 	"timezones": [
 		{
-			"name": "Pacific/Samoa",
+			"name": "Pacific/Pago_Pago",
 			"label": "(GMT -11:00) Midway Island, Samoa",
 			"offset": -660
 		},
@@ -11,27 +11,27 @@
 			"offset": -600
 		},
 		{
-			"name": "US/Alaska",
+			"name": "America/Anchorage",
 			"label": "(GMT -9:00) Alaska",
 			"offset": -540
 		},
 		{
-			"name": "Mexico/BajaNorte",
+			"name": "America/Tijuana",
 			"label": "(GMT -8:00) Chihuahua, La Paz, Mazatlan",
 			"offset": -480
 		},
 		{
-			"name": "US/Pacific",
+			"name": "America/Los_Angeles",
 			"label": "(GMT -8:00) Pacific Time (US & Canada); Tijuana",
 			"offset": -480
 		},
 		{
-			"name": "US/Arizona",
+			"name": "America/Phoenix",
 			"label": "(GMT -7:00) Arizona",
 			"offset": -420
 		},
 		{
-			"name": "US/Mountain",
+			"name": "America/Denver",
 			"label": "(GMT -7:00) Mountain Time (US & Canada)",
 			"offset": -420
 		},
@@ -41,17 +41,17 @@
 			"offset": -360
 		},
 		{
-			"name": "US/Central",
+			"name": "America/Chicago",
 			"label": "(GMT -6:00) Central Time (US & Canada)",
 			"offset": -360
 		},
 		{
-			"name": "Mexico/General",
+			"name": "America/Mexico_City",
 			"label": "(GMT -6:00) Guadalajara, Mexico City, Monterrey",
 			"offset": -360
 		},
 		{
-			"name": "Canada/Saskatchewan",
+			"name": "America/Regina",
 			"label": "(GMT -6:00) Saskatchewan",
 			"offset": -360
 		},
@@ -61,12 +61,12 @@
 			"offset": -300
 		},
 		{
-			"name": "US/Eastern",
+			"name": "America/New_York",
 			"label": "(GMT -5:00) Eastern Time (US & Canada)",
 			"offset": -300
 		},
 		{
-			"name": "US/East-Indiana",
+			"name": "America/Fort_Wayne",
 			"label": "(GMT -5:00) Indiana (East)",
 			"offset": -300
 		},
@@ -76,17 +76,17 @@
 			"offset": -270
 		},
 		{
-			"name": "Canada/Atlantic",
+			"name": "America/Halifax",
 			"label": "(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland",
 			"offset": -240
 		},
 		{
-			"name": "Canada/Newfoundland",
+			"name": "America/St_Johns",
 			"label": "(GMT -3:30) Newfoundland",
 			"offset": -210
 		},
 		{
-			"name": "America/Buenos_Aires",
+			"name": "America/Argentina/Buenos_Aires",
 			"label": "(GMT -3:00) Buenos Aires, Georgetown",
 			"offset": -180
 		},
@@ -141,7 +141,7 @@
 			"offset": 60
 		},
 		{
-			"name": "Africa/Bangui",
+			"name": "Africa/Lagos",
 			"label": "(GMT +1:00) West Central Africa",
 			"offset": 60
 		},
@@ -156,7 +156,7 @@
 			"offset": 120
 		},
 		{
-			"name": "Africa/Harare",
+			"name": "Africa/Maputo",
 			"label": "(GMT +2:00) Harare",
 			"offset": 120
 		},
@@ -191,7 +191,7 @@
 			"offset": 210
 		},
 		{
-			"name": "Asia/Muscat",
+			"name": "Asia/Dubai",
 			"label": "(GMT +4:00) Abu Dhabi, Muscat",
 			"offset": 240
 		},
@@ -216,12 +216,12 @@
 			"offset": 300
 		},
 		{
-			"name": "Asia/Calcutta",
+			"name": "Asia/Kolkata",
 			"label": "(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi",
 			"offset": 330
 		},
 		{
-			"name": "Asia/Katmandu",
+			"name": "Asia/Kathmandu",
 			"label": "(GMT +5:45) Katmandu",
 			"offset": 345
 		},
@@ -301,7 +301,7 @@
 			"offset": 630
 		},
 		{
-			"name": "Australia/Canberra",
+			"name": "Australia/Sydney",
 			"label": "(GMT +11:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok",
 			"offset": 660
 		},

--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -1,34 +1,38 @@
 // # Date Helper
 // Usage: `{{date format="DD MM, YYYY"}}`, `{{date updated_at format="DD MM, YYYY"}}`
 //
-// Formats a date using moment.js. Formats published_at by default but will also take a date as a parameter
+// Formats a date using moment-timezone.js. Formats published_at by default but will also take a date as a parameter
 
-var moment          = require('moment'),
-    date;
+var moment          = require('moment-timezone'),
+    date,
+    timezone;
 
 date = function (date, options) {
     if (!options && date.hasOwnProperty('hash')) {
         options = date;
         date = undefined;
+        timezone = options.data.blog.timezone;
 
         // set to published_at by default, if it's available
         // otherwise, this will print the current date
         if (this.published_at) {
-            date = this.published_at;
+            date = moment(this.published_at).tz(timezone).format();
         }
     }
 
     // ensure that context is undefined, not null, as that can cause errors
     date = date === null ? undefined : date;
 
-    var f = options.hash.format || 'MMM Do, YYYY',
-        timeago = options.hash.timeago;
+    var f = options.hash.format || 'MMM DD, YYYY',
+        timeago = options.hash.timeago,
+        timeNow = moment().tz(timezone);
 
     if (timeago) {
-        date = moment(date).fromNow();
+        date = timezone ?  moment(date).tz(timezone).from(timeNow) : moment(date).fromNow();
     } else {
-        date = moment(date).format(f);
+        date = timezone ? moment(date).tz(timezone).format(f) : moment(date).format(f);
     }
+
     return date;
 };
 

--- a/core/test/unit/server_helpers/date_spec.js
+++ b/core/test/unit/server_helpers/date_spec.js
@@ -6,7 +6,7 @@ var should         = require('should'),
 // Stuff we are testing
     handlebars     = hbs.handlebars,
     helpers        = require('../../../server/helpers'),
-    moment         = require('moment');
+    moment         = require('moment-timezone');
 
 describe('{{date}} helper', function () {
     before(function () {
@@ -17,22 +17,23 @@ describe('{{date}} helper', function () {
         should.exist(handlebars.helpers.date);
     });
 
-    // TODO: When timezone support is added these tests should be updated
-    //       to test the output of the helper against static strings instead
-    //       of calling moment().  Without timezone support the output of this
-    //       helper may differ depending on what timezone the tests are run in.
-
     it('creates properly formatted date strings', function () {
         var testDates = [
-                '2013-12-31T11:28:58.593Z',
-                '2014-01-01T01:28:58.593Z',
-                '2014-02-20T01:28:58.593Z',
-                '2014-03-01T01:28:58.593Z'
+                '2013-12-31T11:28:58.593+02:00',
+                '2014-01-01T01:28:58.593+11:00',
+                '2014-02-20T01:28:58.593-04:00',
+                '2014-03-01T01:28:58.593+00:00'
             ],
+            timezones = 'Europe/Dublin',
             format = 'MMM Do, YYYY',
             context = {
                 hash: {
                     format: format
+                },
+                data: {
+                    blog: {
+                        timezone: 'Europe/Dublin'
+                    }
                 }
             };
 
@@ -40,20 +41,27 @@ describe('{{date}} helper', function () {
             var rendered = helpers.date.call({published_at: d}, context);
 
             should.exist(rendered);
-            rendered.should.equal(moment(d).format(format));
+            rendered.should.equal(moment(d).tz(timezones).format(format));
         });
     });
 
     it('creates properly formatted time ago date strings', function () {
         var testDates = [
-                '2013-12-31T23:58:58.593Z',
-                '2014-01-01T00:28:58.593Z',
-                '2014-11-20T01:28:58.593Z',
-                '2014-03-01T01:28:58.593Z'
+                '2013-12-31T23:58:58.593+02:00',
+                '2014-01-01T00:28:58.593+11:00',
+                '2014-11-20T01:28:58.593-04:00',
+                '2014-03-01T01:28:58.593+00:00'
             ],
+            timezones = 'Europe/Dublin',
+            timeNow = moment().tz('Europe/Dublin'),
             context = {
                 hash: {
                     timeago: true
+                },
+                data: {
+                    blog: {
+                        timezone: 'Europe/Dublin'
+                    }
                 }
             };
 
@@ -61,7 +69,7 @@ describe('{{date}} helper', function () {
             var rendered = helpers.date.call({published_at: d}, context);
 
             should.exist(rendered);
-            rendered.should.equal(moment(d).fromNow());
+            rendered.should.equal(moment(d).tz(timezones).from(timeNow));
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "morgan": "1.7.0",
     "multer": "1.1.0",
     "netjet": "1.1.0",
+    "moment-timezone": "0.5.1",
     "node-uuid": "1.4.7",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.2.2",


### PR DESCRIPTION
Use Timezones from Blog settings (general/settings)

closes #6406
- [x] adding timeZone Service to get the offset (=timezone reg. moment-timezone) overall available
- [x] new publishedAtOffset date as CP using timeZone service and moment-timezone to calculate offset incl. DST
- [x] ~~using timezone-obj transform to work with an array in ember and string in backend~~ -> obsolete since using moment-timezone, removed it again
- [x] ~~hardcoded timezones in controller to choose from and save in settings~~
- [x] adding a moment-utc transform to only work with utc times in backend
- [x] when switching the timezone in the select box, the user will be shown the local time of the selected timezone
- [x] added clock service to show actual time ticking below select box as it didn't change with the time before
- [x] default timezone is '(GMT) Greenwich Mean Time : Dublin, Edinburgh, London' (if no timezone is saved in the settings yet, the default value will be used)
- [x] instead of using hardcoded timezones in controller, get it from configuration/timezones API
- [x] /core/client/app/helpers/gh-format-timeago.js -> no change needed
- [x] updated helper in /core/server/helpers/date.js, new helper {{@blog.timezone}} is now available
- [x] little issue atm: select box doesn't select the correct value after pageload or reload -> fixed by @kevinansfield 
- [x] Removed the format 'DD MMM YY @ HH:mm (UTC Z)' which resolves to '01 Jan 16 @ 14:00 (UTC +02:00)' and changed it back to 'DD MMM YY @ HH:mm'
- [x] added fixtures to mirage, set except for clock service in test env, added 'service.ajax' & 'service:ghostPaths' to navigation-test.js
- [x] updated 'date_spec.js' in 'server-helper' to include the timezone for the tests
