### PR TITLE
Fix missing nav-current class bug when trailing slashes don't match

### DIFF
--- a/core/server/helpers/navigation.js
+++ b/core/server/helpers/navigation.js
@@ -40,6 +40,13 @@ navigation = function (options) {
         return label.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
     }
 
+    // strips trailing slashes and compares urls
+    function _isCurrentUrl(href, currentUrl) {
+        var strippedHref = href.replace(/\/+$/, ''),
+            strippedCurrentUrl = currentUrl.replace(/\/+$/, '');
+        return strippedHref === strippedCurrentUrl;
+    }
+
     // {{navigation}} should no-op if no data passed in
     if (navigationData.length === 0) {
         return new hbs.SafeString('');
@@ -47,7 +54,7 @@ navigation = function (options) {
 
     output = navigationData.map(function (e) {
         var out = {};
-        out.current = e.url === currentUrl;
+        out.current = _isCurrentUrl(e.url, currentUrl);
         out.label = e.label;
         out.slug = _slugify(e.label);
         out.url = hbs.handlebars.Utils.escapeExpression(e.url);

--- a/core/test/unit/server_helpers/navigation_spec.js
+++ b/core/test/unit/server_helpers/navigation_spec.js
@@ -117,6 +117,22 @@ describe('{{navigation}} helper', function () {
         rendered.string.should.containEql('nav-foo nav-current');
         rendered.string.should.containEql('nav-bar"');
     });
+
+    it('can annotate current url with trailing slash', function () {
+        var firstItem = {label: 'Foo', url: '/foo'},
+            secondItem = {label: 'Bar', url: '/qux'},
+            rendered;
+
+        optionsData.data.blog.navigation = [firstItem, secondItem];
+        optionsData.data.root.relativeUrl = '/foo/';
+        rendered = helpers.navigation(optionsData);
+
+        should.exist(rendered);
+        rendered.string.should.containEql('nav-foo');
+        rendered.string.should.containEql('nav-current');
+        rendered.string.should.containEql('nav-foo nav-current');
+        rendered.string.should.containEql('nav-bar"');
+    });
 });
 
 describe('{{navigation}} helper with custom template', function () {


### PR DESCRIPTION
closes #6422
- trim trailing slashes before comparing URLs in navigation helper
- add test case to make sure nav-current is appended regardless of trailing slash presence
