### PR TITLE
Acceptance tests for password reset flow on signin screen

### DIFF
--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -1,5 +1,6 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
+import Mirage from 'ember-cli-mirage';
 
 const {$, isBlank} = Ember;
 
@@ -60,6 +61,30 @@ export default function () {
             refresh_token: 'XP13eDjwV5mxOcrq1jkIY9idhdvN3R1Br5vxYpYIub2P5Hdc8pdWMOGmwFyoUshiEB62JWHTl8H1kACJR18Z8aMXbnk5orG28br2kmVgtVZKqOSoiiWrQoeKTqrRV0t7ua8uY5HdDUaKpnYKyOdpagsSPn3WEj8op4vHctGL3svOWOjZhq6F2XeVPMR7YsbiwBE8fjT3VhTB3KRlBtWZd1rE0Qo2EtSplWyjGKv1liAEiL0ndQoLeeSOCH4rTP7',
             token_type: 'Bearer'
         };
+    });
+
+    this.post('/authentication/passwordreset', function (db, request) {
+        // jscs:disable requireObjectDestructuring
+        let {passwordreset} = $.deparam(request.requestBody);
+        let email = passwordreset[0].email;
+        // jscs:enable requireObjectDestructuring
+
+        if (email === 'unknown@example.com') {
+            return new Mirage.Response(404, {}, {
+                errors: [
+                    {
+                        message: 'There is no user with that email address.',
+                        errorType: 'NotFoundError'
+                    }
+                ]
+            });
+        } else {
+            return {
+                passwordreset: [
+                    {message: 'Check your email for further instructions.'}
+                ]
+            };
+        }
     });
 
     /* Download Count ------------------------------------------------------- */

--- a/core/client/tests/acceptance/password-reset-test.js
+++ b/core/client/tests/acceptance/password-reset-test.js
@@ -1,0 +1,107 @@
+/* jshint expr:true */
+import {
+    describe,
+    it,
+    beforeEach,
+    afterEach
+} from 'mocha';
+import { expect } from 'chai';
+import startApp from '../helpers/start-app';
+import destroyApp from '../helpers/destroy-app';
+
+describe('Acceptance: Password Reset', function() {
+    let application;
+
+    beforeEach(function() {
+        application = startApp();
+    });
+
+    afterEach(function() {
+        destroyApp(application);
+    });
+
+    describe('request reset', function () {
+        it('is successful with valid data', function () {
+            visit('/signin');
+            fillIn('input[name="identification"]', 'test@example.com');
+            click('.forgotten-link');
+
+            andThen(function () {
+                // an alert with instructions is displayed
+                expect(find('.gh-alert-blue').length, 'alert count')
+                    .to.equal(1);
+            });
+        });
+
+        it('shows error messages with invalid data', function () {
+            visit('/signin');
+
+            // no email provided
+            click('.forgotten-link');
+
+            andThen(function () {
+                // email field is invalid
+                expect(
+                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                    'email field has error class (no email)'
+                ).to.be.true;
+
+                // password field is valid
+                expect(
+                    find('input[name="password"]').closest('.form-group').hasClass('error'),
+                    'password field has error class (no email)'
+                ).to.be.false;
+
+                // error message shown
+                expect(find('p.main-error').text().trim(), 'error message')
+                    .to.equal('We need your email address to reset your password!');
+            });
+
+            // invalid email provided
+            fillIn('input[name="identification"]', 'test');
+            click('.forgotten-link');
+
+            andThen(function () {
+                // email field is invalid
+                expect(
+                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                    'email field has error class (invalid email)'
+                ).to.be.true;
+
+                // password field is valid
+                expect(
+                    find('input[name="password"]').closest('.form-group').hasClass('error'),
+                    'password field has error class (invalid email)'
+                ).to.be.false;
+
+                // error message
+                expect(find('p.main-error').text().trim(), 'error message')
+                    .to.equal('We need your email address to reset your password!');
+            });
+
+            // unknown email provided
+            fillIn('input[name="identification"]', 'unknown@example.com');
+            click('.forgotten-link');
+
+            andThen(function () {
+                // email field is invalid
+                expect(
+                    find('input[name="identification"]').closest('.form-group').hasClass('error'),
+                    'email field has error class (unknown email)'
+                ).to.be.true;
+
+                // password field is valid
+                expect(
+                    find('input[name="password"]').closest('.form-group').hasClass('error'),
+                    'password field has error class (unknown email)'
+                ).to.be.false;
+
+                // error message
+                expect(find('p.main-error').text().trim(), 'error message')
+                    .to.equal('There is no user with that email address.');
+            });
+        });
+    });
+
+    // TODO: add tests for the change password screen
+});


### PR DESCRIPTION
refs #6039
- adds `/authentication/passwordreset` endpoint to mirage config
- tests the "Forgot?" link behaviour on the signin form

NB: This will fail until #6425 is merged as this tests the correct behaviour rather than the currently broken behaviour ;-)
