### PR TITLE
Fix stretched team image on setup/three

### DIFF
--- a/core/client/app/styles/layouts/flow.css
+++ b/core/client/app/styles/layouts/flow.css
@@ -415,6 +415,7 @@
 
 .gh-flow-content .gh-flow-faces {
     margin-bottom: 2vw;
+    width: 100%;
 }
 
 .gh-flow-content textarea {

--- a/core/client/app/templates/setup/three.hbs
+++ b/core/client/app/templates/setup/three.hbs
@@ -3,7 +3,7 @@
     <p>Ghost works best when shared with others. Collaborate, get feedback on your posts &amp; work together on ideas.</p>
 </header>
 
-<img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" />
+<div><img class="gh-flow-faces" src="{{gh-path 'admin' 'img/users.png'}}" alt="" /></div>
 
 <form class="gh-flow-invite">
     {{#gh-form-group errors=errors hasValidated=hasValidated property="users"}}


### PR DESCRIPTION
closes #6380
- wraps `<img>` element with a `<div>` to workaround buggy browser behaviour (https://github.com/philipwalton/flexbugs/issues/14)
- adds explicit `width: 100%` to the team `img` element to fix Firefox not scaling down to mobile sizes
