### PR TITLE
Continuation of #6207 (convert feature controller to service)

### DIFF
--- a/core/client/app/components/gh-feature-flag.js
+++ b/core/client/app/components/gh-feature-flag.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+
+const {
+    computed,
+    inject: {service},
+    Component,
+    assert
+} = Ember;
+
+const FeatureFlagComponent = Component.extend({
+    tagName: 'label',
+    classNames: 'checkbox',
+    attributeBindings: ['for'],
+
+    feature: service(),
+
+    flagValue: computed('flag', 'feature.isFulfilled', {
+        get() {
+            assert('The "flag" parameter must be set', this.get('flag'));
+            return this.get(`feature.${this.get('flag')}`);
+        },
+        set(key, value) {
+            assert('The "flag" parameter must be set', this.get('flag'));
+            this.get('feature').set(this.get('flag'), value);
+            return value;
+        }
+    }),
+
+    for: computed('flag', function () {
+        return `labs-${this.get('flag')}`;
+    }),
+    name: computed('flag', function () {
+        return `labs[${this.get('flag')}]`;
+    })
+});
+
+FeatureFlagComponent.reopenClass({
+    positionalParams: ['flag']
+});
+
+export default FeatureFlagComponent;

--- a/core/client/app/components/gh-feature-flag.js
+++ b/core/client/app/components/gh-feature-flag.js
@@ -3,26 +3,33 @@ import Ember from 'ember';
 const {
     computed,
     inject: {service},
-    Component,
-    assert
+    Component
 } = Ember;
 
 const FeatureFlagComponent = Component.extend({
     tagName: 'label',
     classNames: 'checkbox',
     attributeBindings: ['for'],
+    _flagValue: null,
 
     feature: service(),
 
-    flagValue: computed('flag', 'feature.isFulfilled', {
+    isVisible: computed.notEmpty('_flagValue'),
+
+    init() {
+        this._super(...arguments);
+
+        this.get(`feature.${this.get('flag')}`).then((flagValue) => {
+            this.set('_flagValue', flagValue);
+        });
+    },
+
+    value: computed('_flagValue', {
         get() {
-            assert('The "flag" parameter must be set', this.get('flag'));
-            return this.get(`feature.${this.get('flag')}`);
+            return this.get('_flagValue');
         },
         set(key, value) {
-            assert('The "flag" parameter must be set', this.get('flag'));
-            this.get('feature').set(this.get('flag'), value);
-            return value;
+            return this.set(`feature.${this.get('flag')}`, value);
         }
     }),
 

--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -3,8 +3,7 @@ import Ember from 'ember';
 const {
     $,
     Controller,
-    computed,
-    inject: {service, controller},
+    inject: {service},
     isArray
 } = Ember;
 
@@ -17,36 +16,6 @@ export default Controller.extend({
     ghostPaths: service(),
     notifications: service(),
     session: service(),
-    feature: controller(),
-    ajax: service(),
-
-    labsJSON: computed('model.labs', function () {
-        return JSON.parse(this.get('model.labs') || {});
-    }),
-
-    saveLabs(optionName, optionValue) {
-        let labsJSON =  this.get('labsJSON');
-
-        // Set new value in the JSON object
-        labsJSON[optionName] = optionValue;
-
-        this.set('model.labs', JSON.stringify(labsJSON));
-
-        this.get('model').save().catch((errors) => {
-            this.showErrors(errors);
-            this.get('model').rollbackAttributes();
-        });
-    },
-
-    usePublicAPI: computed('feature.publicAPI', {
-        get() {
-            return this.get('feature.publicAPI');
-        },
-        set(key, value) {
-            this.saveLabs('publicAPI', value);
-            return value;
-        }
-    }),
 
     actions: {
         onUpload(file) {

--- a/core/client/app/services/feature.js
+++ b/core/client/app/services/feature.js
@@ -48,7 +48,7 @@ export default Service.extend({
         }
     },
 
-    labs: computed(function () {
+    labs: computed('_settings', function () {
         return new Promise((resolve, reject) => {
             if (this.get('_settings')) { // So we don't query the backend every single time
                 resolve(this._parseLabs(this.get('_settings')));
@@ -72,8 +72,9 @@ export default Service.extend({
                 set(labs, key, value);
 
                 settings.set('labs', JSON.stringify(labs));
-                settings.save().then(() => {
-                    resolve(labs[key]);
+                settings.save().then((savedSettings) => {
+                    this.set('_settings', savedSettings);
+                    resolve(this._parseLabs(savedSettings).get(key));
                 }).catch((errors) => {
                     this.get('notifications').showErrors(errors);
                     settings.rollbackAttributes();

--- a/core/client/app/services/feature.js
+++ b/core/client/app/services/feature.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+
+const {
+    Service,
+    computed,
+    inject: {service},
+    PromiseProxyMixin,
+    set
+} = Ember;
+
+export function feature(name) {
+    return computed(`config.${name}`, `labs.${name}`, {
+        get() {
+            return this.get(`config.${name}`) || this.get(`labs.${name}`);
+        },
+        set(key, value) {
+            this.update(name, value);
+            return value;
+        }
+    });
+}
+
+export default Service.extend(PromiseProxyMixin, {
+    store: service(),
+    config: service(),
+    notifications: service(),
+
+    publicAPI: feature('publicAPI'),
+
+    labs: computed('isSettled', 'content.labs', function () {
+        let value = {};
+
+        if (this.get('isFulfilled')) {
+            try {
+                value = JSON.parse(this.get('content.labs') || {});
+            } catch (err) {
+                value = {};
+            }
+        }
+
+        return value;
+    }),
+
+    update(key, value) {
+        let labs = this.get('labs');
+        let content = this.get('content');
+
+        set(labs, key, value);
+        content.set('labs', JSON.stringify(labs));
+        content.save().catch((errors) => {
+            this.get('notifications').showErrors(errors);
+            content.rollbackAttributes();
+        });
+    },
+
+    init() {
+        this._super(...arguments);
+
+        let promise = this.get('store').query('setting', {type: 'blog'}).then((settings) => {
+            return settings.get('firstObject');
+        });
+
+        this.set('promise', promise);
+    }
+});

--- a/core/client/app/templates/components/gh-feature-flag.hbs
+++ b/core/client/app/templates/components/gh-feature-flag.hbs
@@ -1,3 +1,3 @@
-{{input id=for name=name type="checkbox" checked=flagValue}}
+{{input id=for name=name type="checkbox" checked=value}}
 <span class="input-toggle-component"></span>
 <p>{{{yield}}}</p>

--- a/core/client/app/templates/components/gh-feature-flag.hbs
+++ b/core/client/app/templates/components/gh-feature-flag.hbs
@@ -1,0 +1,3 @@
+{{input id=for name=name type="checkbox" checked=flagValue}}
+<span class="input-toggle-component"></span>
+<p>{{{yield}}}</p>

--- a/core/client/app/templates/settings/labs.hbs
+++ b/core/client/app/templates/settings/labs.hbs
@@ -47,11 +47,9 @@
             <fieldset>
                 <div class="form-group for-checkbox">
                     <h3>Enable Beta Features</h3>
-                    <label class="checkbox" for="labs-publicAPI">
-                        {{input id="labs-publicAPI" name="labs[publicAPI]" type="checkbox" checked=usePublicAPI}}
-                        <span class="input-toggle-component"></span>
-                        <p>Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.</p>
-                    </label>
+                    {{#gh-feature-flag "publicAPI"}}
+                        Public API - For full instructions, read the <a href="http://support.ghost.org/public-api-beta/">developer guide</a>.
+                    {{/gh-feature-flag}}
                 </div>
             </fieldset>
         </form>

--- a/core/client/tests/integration/components/gh-feature-flag-test.js
+++ b/core/client/tests/integration/components/gh-feature-flag-test.js
@@ -10,12 +10,21 @@ import wait from 'ember-test-helpers/wait';
 
 function stubSettings(server, labs) {
     server.get('/ghost/api/v0.1/settings/', function () {
-        return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings: [{
-            id: '1',
-            type: 'blog',
-            key: 'labs',
-            value: JSON.stringify(labs)
-        }]})];
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings: [
+            {
+                id: '1',
+                type: 'blog',
+                key: 'labs',
+                value: JSON.stringify(labs)
+            },
+            // postsPerPage is needed to satisfy the validation
+            {
+                id: '2',
+                type: 'blog',
+                key: 'postsPerPage',
+                value: 1
+            }
+        ]})];
     });
 
     server.put('/ghost/api/v0.1/settings/', function (request) {

--- a/core/client/tests/integration/components/gh-feature-flag-test.js
+++ b/core/client/tests/integration/components/gh-feature-flag-test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import FeatureService, {feature} from 'ghost/services/feature';
+import Pretender from 'pretender';
+import wait from 'ember-test-helpers/wait';
+
+function stubSettings(server, labs) {
+    server.get('/ghost/api/v0.1/settings/', function () {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings: [{
+            id: '1',
+            type: 'blog',
+            key: 'labs',
+            value: JSON.stringify(labs)
+        }]})];
+    });
+
+    server.put('/ghost/api/v0.1/settings/', function (request) {
+        return [200, {'Content-Type': 'application/json'}, request.requestBody];
+    });
+}
+
+function addTestFlag() {
+    FeatureService.reopen({
+        testFlag: feature('testFlag')
+    });
+}
+
+describeComponent(
+    'gh-feature-flag',
+    'Integration: Component: gh-feature-flag',
+    {
+        integration: true
+    },
+    function() {
+        let server;
+
+        beforeEach(function () {
+            server = new Pretender();
+        });
+
+        afterEach(function () {
+            server.shutdown();
+        });
+
+        it('renders properties correctly', function () {
+            stubSettings(server, {testFlag: true});
+            addTestFlag();
+
+            this.render(hbs`{{gh-feature-flag "testFlag"}}`);
+            expect(this.$()).to.have.length(1);
+            expect(this.$('label').attr('for')).to.equal(this.$('input[type="checkbox"]').attr('id'));
+        });
+
+        it('renders correctly when flag is set to true', function () {
+            stubSettings(server, {testFlag: true});
+            addTestFlag();
+
+            this.render(hbs`{{gh-feature-flag "testFlag"}}`);
+            expect(this.$()).to.have.length(1);
+
+            return wait().then(() => {
+                expect(this.$('label input[type="checkbox"]').prop('checked')).to.be.true;
+            });
+        });
+
+        it('renders correctly when flag is set to false', function () {
+            stubSettings(server, {testFlag: false});
+            addTestFlag();
+
+            this.render(hbs`{{gh-feature-flag "testFlag"}}`);
+            expect(this.$()).to.have.length(1);
+
+            return wait().then(() => {
+                expect(this.$('label input[type="checkbox"]').prop('checked')).to.be.false;
+            });
+        });
+
+        it('updates to reflect changes in flag property', function () {
+            stubSettings(server, {testFlag: true});
+            addTestFlag();
+
+            this.render(hbs`{{gh-feature-flag "testFlag"}}`);
+            expect(this.$()).to.have.length(1);
+
+            return wait().then(() => {
+                expect(this.$('label input[type="checkbox"]').prop('checked')).to.be.true;
+
+                this.$('label').click();
+
+                return wait().then(() => {
+                    expect(this.$('label input[type="checkbox"]').prop('checked')).to.be.false;
+                });
+            });
+        });
+    }
+);

--- a/core/client/tests/integration/services/feature-test.js
+++ b/core/client/tests/integration/services/feature-test.js
@@ -1,0 +1,133 @@
+import {
+    describeModule,
+    it
+} from 'ember-mocha';
+import Pretender from 'pretender';
+import wait from 'ember-test-helpers/wait';
+import FeatureService, {feature} from 'ghost/services/feature';
+
+function stubSettings(server, labs) {
+    server.get('/ghost/api/v0.1/settings/', function () {
+        return [200, {'Content-Type': 'application/json'}, JSON.stringify({settings: [{
+            id: '1',
+            type: 'blog',
+            key: 'labs',
+            value: JSON.stringify(labs)
+        }]})];
+    });
+
+    server.put('/ghost/api/v0.1/settings/', function (request) {
+        return [200, {'Content-Type': 'application/json'}, request.requestBody];
+    });
+}
+
+function addTestFlag() {
+    FeatureService.reopen({
+        testFlag: feature('testFlag')
+    });
+}
+
+describeModule(
+    'service:feature',
+    'Integration: Service: feature',
+    {
+        integration: true
+    },
+    function () {
+        let server;
+
+        beforeEach(function () {
+            server = new Pretender();
+        });
+
+        afterEach(function () {
+            server.shutdown();
+        });
+
+        it('loads labs settings correctly', function (done) {
+            stubSettings(server, {testFlag: true});
+
+            let service = this.subject();
+
+            return wait().then(() => {
+                expect(service.get('labs').testFlag).to.be.true;
+                done();
+            });
+        });
+
+        it('returns false for set flag with config false and labs false', function (done) {
+            stubSettings(server, {testFlag: false});
+            addTestFlag();
+
+            let service = this.subject();
+            service.get('config').set('testFlag', false);
+
+            return wait().then(() => {
+                expect(service.get('labs').testFlag).to.be.false;
+                expect(service.get('testFlag')).to.be.false;
+                done();
+            });
+        });
+
+        it('returns true for set flag with config true and labs false', function (done) {
+            stubSettings(server, {testFlag: false});
+            addTestFlag();
+
+            let service = this.subject();
+            service.get('config').set('testFlag', true);
+
+            return wait().then(() => {
+                expect(service.get('labs').testFlag).to.be.false;
+                expect(service.get('testFlag')).to.be.true;
+                done();
+            });
+        });
+
+        it('returns true for set flag with config false and labs true', function (done) {
+            stubSettings(server, {testFlag: true});
+            addTestFlag();
+
+            let service = this.subject();
+            service.get('config').set('testFlag', false);
+
+            return wait().then(() => {
+                expect(service.get('labs').testFlag).to.be.true;
+                expect(service.get('testFlag')).to.be.true;
+                done();
+            });
+        });
+
+        it('returns true for set flag with config true and labs true', function (done) {
+            stubSettings(server, {testFlag: true});
+            addTestFlag();
+
+            let service = this.subject();
+            service.get('config').set('testFlag', true);
+
+            return wait().then(() => {
+                expect(service.get('labs').testFlag).to.be.true;
+                expect(service.get('testFlag')).to.be.true;
+                done();
+            });
+        });
+
+        it('saves correctly', function (done) {
+            stubSettings(server, {testFlag: false});
+            addTestFlag();
+
+            let service = this.subject();
+
+            return wait().then(() => {
+                expect(service.get('testFlag')).to.be.false;
+
+                service.set('testFlag', true);
+
+                return wait().then(() => {
+                    expect(server.handlers[1].numberOfCalls).to.equal(1);
+                    expect(service.get('testFlag')).to.be.true;
+                    done();
+                });
+            });
+        });
+    }
+);


### PR DESCRIPTION
refs #6207, #6207
- updates tests for new async behaviour
- fixes tests failing on validation errors
- fixes `feature.labs` not updating after successful save

NB: added as a PR for now, @acburdine can you cherry-pick this into your PR? Multi-user PRs seem to be a mess on github :disappointed: 
