### PR TITLE
Correctly clear settings cache after import

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -85,7 +85,9 @@ db = {
 
         function importContent(options) {
             return importer.importFromFile(options.importfile)
-                .then(api.settings.updateSettingsCache)
+                .then(function () {
+                    api.settings.updateSettingsCache();
+                })
                 .return({db: []});
         }
 


### PR DESCRIPTION
fixes #6435

---

Explanation: Simply passing the function to `.then` would have it pass in the result of the `importFromFile` (which is non-empty). `updateSettingsCache` only resets the cache when called with an empty argument.
