### PR TITLE
Include babel polyfill when compiling client

### DIFF
--- a/core/client/ember-cli-build.js
+++ b/core/client/ember-cli-build.js
@@ -17,6 +17,10 @@ assetLocation = function (fileName) {
 
 module.exports = function (defaults) {
     var app = new EmberApp(defaults, {
+        babel: {
+            optional: ['es6.spec.symbols'],
+            includePolyfill: true
+        },
         outputPaths: {
             app: {
                 js: assetLocation('ghost.js')


### PR DESCRIPTION
no issue
- fixes issues when using `phantomjs` or other browsers that are not fully es6 compatible
