### PR TITLE
Fix mixed content security warnings due to gravatar images

### DIFF
--- a/core/client/app/components/gh-profile-image.js
+++ b/core/client/app/components/gh-profile-image.js
@@ -64,7 +64,7 @@ export default Component.extend({
 
         let style = '';
         if (email) {
-            let url = `http://www.gravatar.com/avatar/${window.md5(email)}?s=${size}&d=blank`;
+            let url = `//www.gravatar.com/avatar/${window.md5(email)}?s=${size}&d=blank`;
             style = `background-image: url(${url})`;
         }
         return Ember.String.htmlSafe(style);

--- a/core/client/tests/integration/components/gh-profile-image-test.js
+++ b/core/client/tests/integration/components/gh-profile-image-test.js
@@ -56,7 +56,7 @@ describeComponent(
 
         it('immediately renders the gravatar if valid email supplied', function () {
             let email = 'test@example.com';
-            let expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
+            let expectedUrl = `//www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
 
             this.set('email', email);
 
@@ -70,7 +70,7 @@ describeComponent(
 
         it('throttles gravatar loading as email is changed', function (done) {
             let email = 'test@example.com';
-            let expectedUrl = `http://www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
+            let expectedUrl = `//www.gravatar.com/avatar/${md5(email)}?s=100&d=blank`;
 
             this.set('email', 'test');
 


### PR DESCRIPTION
no issue
- switches gravatar URL generation to use protocol-relative URLs in `gh-profile-image` component
