### PR TITLE
Return cursor pointer to text inputs

### DIFF
--- a/core/client/app/styles/patterns/forms.css
+++ b/core/client/app/styles/patterns/forms.css
@@ -122,10 +122,14 @@ select {
     font-size: 1.4rem;
     font-weight: normal;
     user-select: text;
-    cursor: pointer;
     transition: border-color 0.15s linear;
 
     -webkit-appearance: none;
+}
+
+.gh-select,
+select {
+    cursor: pointer;
 }
 
 .gh-input.error,


### PR DESCRIPTION
refs #6412
- moves `cursor: pointer` style introduced in #6412 into more specific classes that only target `<select>` inputs rather than all inputs
