### PR TITLE
Dev dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "istanbul": "0.4.2",
     "jscs-jsdoc": "1.3.1",
     "matchdep": "1.0.0",
-    "nock": "2.3.0",
+    "nock": "7.1.0",
     "rewire": "2.3.3",
     "rimraf-then": "^1.0.0",
     "should": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "matchdep": "1.0.0",
     "nock": "7.1.0",
     "rewire": "2.5.1",
-    "rimraf-then": "^1.0.0",
+    "rimraf-then": "1.0.0",
     "should": "6.0.3",
     "sinon": "1.14.1",
     "supertest": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "grunt-update-submodules": "0.4.1",
     "istanbul": "0.4.2",
     "jscs-jsdoc": "1.3.1",
-    "matchdep": "0.3.0",
+    "matchdep": "1.0.0",
     "nock": "2.3.0",
     "rewire": "2.3.3",
     "rimraf-then": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "grunt-contrib-compress": "0.14.0",
     "grunt-contrib-copy": "0.8.2",
     "grunt-contrib-jshint": "0.12.0",
-    "grunt-contrib-uglify": "0.11.0",
+    "grunt-contrib-uglify": "0.11.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-docker": "0.0.10",
     "grunt-express-server": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.7.0",
     "grunt-contrib-compress": "0.14.0",
-    "grunt-contrib-copy": "0.8.0",
+    "grunt-contrib-copy": "0.8.2",
     "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-uglify": "0.11.0",
     "grunt-contrib-watch": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "jscs-jsdoc": "1.3.1",
     "matchdep": "1.0.0",
     "nock": "7.1.0",
-    "rewire": "2.3.3",
+    "rewire": "2.5.1",
     "rimraf-then": "^1.0.0",
     "should": "6.0.3",
     "sinon": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "grunt-bg-shell": "2.3.1",
     "grunt-cli": "0.1.13",
     "grunt-contrib-clean": "0.7.0",
-    "grunt-contrib-compress": "0.13.0",
+    "grunt-contrib-compress": "0.14.0",
     "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-uglify": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "grunt-express-server": "0.5.1",
     "grunt-jscs": "2.7.0",
     "grunt-mocha-cli": "2.0.0",
-    "grunt-mocha-istanbul": "2.4.0",
+    "grunt-mocha-istanbul": "3.0.1",
     "grunt-shell": "1.1.2",
     "grunt-update-submodules": "0.4.1",
     "istanbul": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "rewire": "2.5.1",
     "rimraf-then": "1.0.0",
     "should": "6.0.3",
-    "sinon": "1.14.1",
+    "sinon": "1.17.3",
     "supertest": "1.1.0",
     "testem": "0.8.3",
     "top-gh-contribs": "2.0.2"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "grunt-mocha-istanbul": "3.0.1",
     "grunt-shell": "1.1.2",
     "grunt-update-submodules": "0.4.1",
-    "istanbul": "0.4.1",
+    "istanbul": "0.4.2",
     "jscs-jsdoc": "1.2.0",
     "matchdep": "0.3.0",
     "nock": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "grunt-docker": "0.0.10",
     "grunt-express-server": "0.5.1",
     "grunt-jscs": "2.7.0",
-    "grunt-mocha-cli": "1.13.0",
+    "grunt-mocha-cli": "2.0.0",
     "grunt-mocha-istanbul": "2.4.0",
     "grunt-shell": "1.1.2",
     "grunt-update-submodules": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "grunt-shell": "1.1.2",
     "grunt-update-submodules": "0.4.1",
     "istanbul": "0.4.2",
-    "jscs-jsdoc": "1.2.0",
+    "jscs-jsdoc": "1.3.1",
     "matchdep": "0.3.0",
     "nock": "2.3.0",
     "rewire": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "grunt-contrib-watch": "0.6.1",
     "grunt-docker": "0.0.10",
     "grunt-express-server": "0.5.1",
-    "grunt-jscs": "2.4.0",
+    "grunt-jscs": "2.7.0",
     "grunt-mocha-cli": "1.13.0",
     "grunt-mocha-istanbul": "2.4.0",
     "grunt-shell": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "grunt-contrib-clean": "0.7.0",
     "grunt-contrib-compress": "0.14.0",
     "grunt-contrib-copy": "0.8.2",
-    "grunt-contrib-jshint": "0.11.2",
+    "grunt-contrib-jshint": "0.12.0",
     "grunt-contrib-uglify": "0.11.0",
     "grunt-contrib-watch": "0.6.1",
     "grunt-docker": "0.0.10",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "grunt": "0.4.5",
     "grunt-bg-shell": "2.3.1",
     "grunt-cli": "0.1.13",
-    "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-clean": "0.7.0",
     "grunt-contrib-compress": "0.13.0",
     "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-jshint": "0.11.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "should": "6.0.3",
     "sinon": "1.17.3",
     "supertest": "1.1.0",
-    "testem": "0.8.3",
     "top-gh-contribs": "2.0.2"
   },
   "greenkeeper": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "bower": "1.4.1",
-    "csscomb": "3.0.4",
+    "csscomb": "3.1.8",
     "grunt": "0.4.5",
     "grunt-bg-shell": "2.3.1",
     "grunt-cli": "0.1.13",


### PR DESCRIPTION
This upgrades all of our dev dependencies with, currently, 2 exceptions:
- should.js: has a breaking API change & needs a decent amount of work (see #6448)
- supertest: causes an error in `test/functional/routes/api/public_api_spec.js` (see #6449)

All other upgrades have been super straightforward :dash: 
