### PR TITLE
Add greenkeeper ignore spec to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
     "supertest": "1.0.1",
     "testem": "0.8.3",
     "top-gh-contribs": "2.0.2"
+  },
+  "greenkeeper": {
+    "ignore": ["bookshelf", "knex", "bluebird", "glob", "lodash", "nodemailer", "showdown-ghost", "should", "supertest"]
   }
 }


### PR DESCRIPTION
refs #6452
- add a list of our deliberately pinned dependencies and dev dependencies, so that greenkeeper will ignore these
