### PR TITLE
deps: supertest@1.1.0

### DIFF
--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -25,7 +25,7 @@ describe('Public API', function () {
             return testUtils.doAuth(request, 'posts', 'tags');
         }).then(function (token) {
             // enable public API
-            return request.put(testUtils.API.getApiQuery('settings/'))
+            request.put(testUtils.API.getApiQuery('settings/'))
                 .set('Authorization', 'Bearer ' + token)
                 .send(publicAPIaccessSetting)
                 .expect('Content-Type', /json/)

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -537,13 +537,9 @@ login = function login(request) {
                 password: user.password,
                 client_id: 'ghost-admin',
                 client_secret: 'not_available'
-            }).end(function (err, res) {
-                if (err) {
-                    return reject(err);
-                }
-
+            }).then(function then(res) {
                 resolve(res.body.access_token);
-            });
+            }, reject);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "rimraf-then": "^1.0.0",
     "should": "6.0.3",
     "sinon": "1.14.1",
-    "supertest": "1.0.1",
+    "supertest": "1.1.0",
     "testem": "0.8.3",
     "top-gh-contribs": "2.0.2"
   }


### PR DESCRIPTION
Closes #6449
- supertest now includes a `.then()` method and as a
  result, only one of either .then or .end may be called on
  a request object.
