### PR TITLE
Add Preload link headers for browsers and CDNs

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -212,7 +212,8 @@ ConfigManager.prototype.set = function (config) {
         },
         deprecatedItems: ['updateCheck', 'mail.fromaddress'],
         // create a hash for cache busting assets
-        assetHash: assetHash
+        assetHash: assetHash,
+        preloadHeaders: this._config.preloadHeaders || false
     });
 
     // Also pass config object to

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -25,6 +25,7 @@ var bodyParser      = require('body-parser'),
     themeHandler     = require('./theme-handler'),
     uncapitalise     = require('./uncapitalise'),
     cors             = require('./cors'),
+    netjet           = require('netjet'),
 
     ClientPasswordStrategy  = require('passport-oauth2-client-password').Strategy,
     BearerStrategy          = require('passport-http-bearer').Strategy,
@@ -70,6 +71,14 @@ setupMiddleware = function setupMiddleware(blogApp, adminApp) {
         }
     }
 
+    // Preload link headers
+    if (config.preloadHeaders) {
+        blogApp.use(netjet({
+            cache: {
+                max: config.preloadHeaders
+            }
+        }));
+    }
     // Favicon
     blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "moment": "2.13.0",
     "morgan": "1.7.0",
     "multer": "1.1.0",
+    "netjet": "1.1.0",
     "node-uuid": "1.4.7",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.2.2",


### PR DESCRIPTION
The W3C [Preload](https://www.w3.org/TR/preload/) specification defines link headers that allows a browser to separate resource fetching from resource inclusion or execution. These headers also allow CDNs and other proxies to prime caches and make other optimizations before the browser even starts requesting the resources.

A Preload link header is an HTTP header in the following form (brackets being part of the form, rather than as a placeholder):

```
Link: </path/to/image.png>; rel=preload; as=image
```

In supported browsers and CDNs, this header would start an image fetch for image.png if not in local cache.

---

This PR adds support for adding these headers automatically to HTML request by using the [`netjet`](https://github.com/cloudflare/netjet) middleware. This looks for images, scripts, and stylesheets from the response HTML and adds them as preload headers.
