### PR TITLE
Dependency updates (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",
     "downsize": "0.0.8",
-    "express": "4.13.3",
+    "express": "4.13.4",
     "express-hbs": "0.8.4",
     "extract-zip": "1.4.1",
     "fs-extra": "0.26.4",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sqlite3": "3.1.1",
     "unidecode": "0.1.8",
     "validator": "4.5.0",
-    "xml": "1.0.0"
+    "xml": "1.0.1"
   },
   "optionalDependencies": {
     "mysql": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "morgan": "1.6.1",
     "node-uuid": "1.4.7",
     "nodemailer": "0.7.1",
-    "oauth2orize": "1.2.0",
+    "oauth2orize": "1.2.2",
     "passport": "0.3.2",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "bookshelf": "0.9.1",
     "busboy": "0.2.12",
     "chalk": "1.1.1",
-    "cheerio": "0.19.0",
+    "cheerio": "0.20.0",
     "compression": "1.6.0",
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jsonpath": "0.2.2",
     "knex": "0.9.0",
     "lodash": "3.10.1",
-    "moment": "2.11.1",
+    "moment": "2.11.2",
     "morgan": "1.6.1",
     "node-uuid": "1.4.7",
     "nodemailer": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "0.26.5",
     "ghost-gql": "0.0.3",
     "glob": "5.0.15",
-    "html-to-text": "1.5.1",
+    "html-to-text": "1.6.0",
     "intl": "1.0.1",
     "intl-messageformat": "1.2.0",
     "jsonpath": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "busboy": "0.2.12",
     "chalk": "1.1.1",
     "cheerio": "0.20.0",
-    "compression": "1.6.0",
+    "compression": "1.6.1",
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",
     "downsize": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "express": "4.13.4",
     "express-hbs": "0.8.4",
     "extract-zip": "1.4.1",
-    "fs-extra": "0.26.4",
+    "fs-extra": "0.26.5",
     "ghost-gql": "0.0.3",
     "glob": "5.0.15",
     "html-to-text": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "top-gh-contribs": "2.0.2"
   },
   "greenkeeper": {
-    "ignore": ["bower", "bluebird", "glob", "lodash", "nodemailer", "showdown-ghost", "should", "supertest"]
+    "ignore": ["bower", "bluebird", "glob", "lodash", "mysql", "nodemailer", "pg", "showdown-ghost", "should", "validator"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.3",
-    "request": "2.67.0",
+    "request": "2.69.0",
     "rss": "1.2.1",
     "semver": "5.1.0",
     "showdown-ghost": "0.3.6",


### PR DESCRIPTION
Updates all of the dependencies which haven't already been pinned for some reason, with the exception of...
- validator, see why here: #6462.

Most of these changes are super minor, and I wouldn't have done it again so soon without greenkeeper if it wasn't for the fact that the moment update is to fix a security issue.
