### PR TITLE
Upgrade should.js to version 8.2.1 (Issue #6448)

### DIFF
--- a/core/test/functional/module/module_spec.js
+++ b/core/test/functional/module/module_spec.js
@@ -43,9 +43,9 @@ describe('Module', function () {
         it('should have start/stop/restart functions', function (done) {
             ghost().then(function (ghostServer) {
                 should.exist(ghostServer);
-                ghostServer.start.should.be.a.Function;
-                ghostServer.restart.should.be.a.Function;
-                ghostServer.stop.should.be.a.Function;
+                ghostServer.start.should.be.a.Function();
+                ghostServer.restart.should.be.a.Function();
+                ghostServer.stop.should.be.a.Function();
 
                 done();
             }).catch(done);

--- a/core/test/functional/routes/api/error_spec.js
+++ b/core/test/functional/routes/api/error_spec.js
@@ -12,6 +12,8 @@ var supertest     = require('supertest'),
     ghost         = require('../../../../../core'),
     request;
 
+require('should-http');
+
 describe('Unauthorized', function () {
     before(function (done) {
         ghost().then(function (ghostServer) {
@@ -38,9 +40,9 @@ describe('Unauthorized', function () {
                     }
 
                     should.not.exist(res.headers['x-cache-invalidate']);
-                    res.should.be.json;
+                    res.should.be.json();
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
+                    should.exist(jsonResponse);
                     // TODO: testUtils.API.checkResponseValue(jsonResponse, ['error']);
                     done();
                 });

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -2,7 +2,7 @@
 /*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     supertest     = require('supertest'),
-
+    should        = require('should'),
     ghost         = require('../../../../../core'),
 
     request;
@@ -49,7 +49,7 @@ describe('Notifications API', function () {
 
                     var jsonResponse = res.body;
 
-                    jsonResponse.notifications.should.exist;
+                    should.exist(jsonResponse.notifications);
 
                     testUtils.API.checkResponse(jsonResponse.notifications[0], 'notification');
 
@@ -85,7 +85,7 @@ describe('Notifications API', function () {
                     var location = res.headers.location,
                         jsonResponse = res.body;
 
-                    jsonResponse.notifications.should.exist;
+                    should.exist(jsonResponse.notifications);
                     testUtils.API.checkResponse(jsonResponse.notifications[0], 'notification');
 
                     jsonResponse.notifications[0].type.should.equal(newNotification.type);
@@ -105,7 +105,7 @@ describe('Notifications API', function () {
                             // a delete returns a JSON object containing the notification
                             // we just deleted.
                             var deleteResponse = res.body;
-                            deleteResponse.notifications.should.exist;
+                            should.exist(deleteResponse.notifications);
                             deleteResponse.notifications[0].type.should.equal(newNotification.type);
                             deleteResponse.notifications[0].message.should.equal(newNotification.message);
                             deleteResponse.notifications[0].status.should.equal(newNotification.status);

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -45,7 +45,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(5);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -69,7 +69,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(6);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -93,7 +93,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(8);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -115,7 +115,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -137,7 +137,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(4);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -159,7 +159,7 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse, 'posts');
                     jsonResponse.posts.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -184,16 +184,16 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     jsonResponse.posts[0].id.should.equal(1);
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    jsonResponse.posts[0].page.should.not.be.ok();
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
-                    jsonResponse.posts[0].author.should.be.a.Number;
+                    jsonResponse.posts[0].author.should.be.a.Number();
                     testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true;
-                    jsonResponse.posts[0].created_by.should.be.a.Number;
+                    jsonResponse.posts[0].created_by.should.be.a.Number();
                     // Tags aren't included by default
                     should.not.exist(jsonResponse.posts[0].tags);
                     done();
@@ -213,15 +213,15 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     jsonResponse.posts[0].slug.should.equal('welcome-to-ghost');
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    jsonResponse.posts[0].page.should.not.be.ok();
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
-                    jsonResponse.posts[0].author.should.be.a.Number;
-                    jsonResponse.posts[0].created_by.should.be.a.Number;
+                    jsonResponse.posts[0].author.should.be.a.Number();
+                    jsonResponse.posts[0].created_by.should.be.a.Number();
                     // Tags aren't included by default
                     should.not.exist(jsonResponse.posts[0].tags);
                     done();
@@ -241,14 +241,14 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post', 'tags');
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    jsonResponse.posts[0].page.should.not.be.ok();
 
-                    jsonResponse.posts[0].author.should.be.an.Object;
+                    jsonResponse.posts[0].author.should.be.an.Object();
                     testUtils.API.checkResponse(jsonResponse.posts[0].author, 'user');
-                    jsonResponse.posts[0].tags[0].should.be.an.Object;
+                    jsonResponse.posts[0].tags[0].should.be.an.Object();
                     testUtils.API.checkResponse(jsonResponse.posts[0].tags[0], 'tag');
                     done();
                 });
@@ -267,14 +267,14 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['next', 'previous']);
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    jsonResponse.posts[0].page.should.not.be.ok();
 
-                    jsonResponse.posts[0].next.should.be.an.Object;
+                    jsonResponse.posts[0].next.should.be.an.Object();
                     testUtils.API.checkResponse(jsonResponse.posts[0].next, 'post');
-                    jsonResponse.posts[0].previous.should.be.an.Object;
+                    jsonResponse.posts[0].previous.should.be.an.Object();
                     testUtils.API.checkResponse(jsonResponse.posts[0].previous, 'post');
                     done();
                 });
@@ -293,10 +293,10 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
-                    jsonResponse.posts[0].page.should.be.ok;
+                    jsonResponse.posts[0].page.should.be.ok();
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
                     done();
                 });
@@ -315,8 +315,8 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -335,8 +335,8 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -355,8 +355,8 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -385,13 +385,13 @@ describe('Post API', function () {
 
                     var draftPost = res.body;
                     res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=draft');
-                    draftPost.posts.should.exist;
+                    should.exist(draftPost.posts);
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
                     draftPost.posts[0].status = publishedState;
                     testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
 
-                    draftPost.posts[0].tags.should.exist;
+                    should.exist(draftPost.posts[0].tags);
                     draftPost.posts[0].tags.length.should.be.above(0);
                     draftPost.posts[0].tags[0].name.should.eql(newTagName);
                     testUtils.API.checkResponse(draftPost.posts[0].tags[0], 'tag');
@@ -411,14 +411,14 @@ describe('Post API', function () {
                             _.has(res.headers, 'x-cache-invalidate').should.equal(true);
                             res.headers['x-cache-invalidate'].should.eql('/*');
 
-                            publishedPost.should.exist;
-                            publishedPost.posts.should.exist;
+                            should.exist(publishedPost);
+                            should.exist(publishedPost.posts);
                             publishedPost.posts.length.should.be.above(0);
                             publishedPost.posts[0].title.should.eql(newTitle);
                             publishedPost.posts[0].status.should.eql(publishedState);
                             testUtils.API.checkResponse(publishedPost.posts[0], 'post', 'tags');
 
-                            publishedPost.posts[0].tags.should.exist;
+                            should.exist(publishedPost.posts[0].tags);
                             publishedPost.posts[0].tags.length.should.be.above(0);
                             publishedPost.posts[0].tags[0].name.should.eql(newTagName);
                             testUtils.API.checkResponse(publishedPost.posts[0].tags[0], 'tag');
@@ -438,15 +438,15 @@ describe('Post API', function () {
                                     // Require cache invalidation when post was updated and published
                                     res.headers['x-cache-invalidate'].should.eql('/*');
 
-                                    updatedPost.should.exist;
-                                    updatedPost.posts.should.exist;
+                                    should.exist(updatedPost);
+                                    should.exist(updatedPost.posts);
                                     updatedPost.posts.length.should.be.above(0);
                                     updatedPost.posts[0].title.should.eql(newTitle);
-                                    testUtils.API.isISO8601(updatedPost.posts[0].created_at).should.be.true;
-                                    testUtils.API.isISO8601(updatedPost.posts[0].updated_at).should.be.true;
+                                    testUtils.API.isISO8601(updatedPost.posts[0].created_at).should.be.true();
+                                    testUtils.API.isISO8601(updatedPost.posts[0].updated_at).should.be.true();
                                     testUtils.API.checkResponse(updatedPost.posts[0], 'post', 'tags');
 
-                                    updatedPost.posts[0].tags.should.exist;
+                                    should.exist(updatedPost.posts[0].tags);
                                     updatedPost.posts[0].tags.length.should.be.above(0);
                                     updatedPost.posts[0].tags[0].name.should.eql(newTagName);
                                     testUtils.API.checkResponse(updatedPost.posts[0].tags[0], 'tag');
@@ -473,7 +473,7 @@ describe('Post API', function () {
                     var jsonResponse = res.body,
                         changedTitle = 'My new Title',
                         changedAuthor = 2;
-                    jsonResponse.posts[0].should.exist;
+                    should.exist(jsonResponse.posts[0]);
                     jsonResponse.posts[0].title = changedTitle;
                     jsonResponse.posts[0].author = changedAuthor;
 
@@ -490,7 +490,7 @@ describe('Post API', function () {
 
                             var putBody = res.body;
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.should.exist;
+                            should.exist(putBody);
                             putBody.posts[0].title.should.eql(changedTitle);
                             putBody.posts[0].author.should.eql(changedAuthor);
 
@@ -519,7 +519,7 @@ describe('Post API', function () {
 
                     var draftPost = res.body;
                     res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=draft');
-                    draftPost.posts.should.exist;
+                    should.exist(draftPost.posts);
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
                     testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
@@ -564,7 +564,7 @@ describe('Post API', function () {
 
                     var draftPost = res.body;
                     res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=published');
-                    draftPost.posts.should.exist;
+                    should.exist(draftPost.posts);
                     draftPost.posts.length.should.be.above(0);
                     draftPost.posts[0].title.should.eql(newTitle);
                     testUtils.API.checkResponse(draftPost.posts[0], 'post', 'tags');
@@ -602,8 +602,8 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body;
 
-                    jsonResponse.should.exist;
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    should.exist(jsonResponse);
+                    jsonResponse.posts[0].page.should.not.be.ok();
                     jsonResponse.posts[0].page = true;
 
                     request.put(testUtils.API.getApiQuery('posts/1/'))
@@ -619,8 +619,8 @@ describe('Post API', function () {
 
                             var putBody = res.body;
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.should.exist;
-                            putBody.posts[0].page.should.be.ok;
+                            should.exist(putBody);
+                            putBody.posts[0].page.should.be.ok();
 
                             testUtils.API.checkResponse(putBody.posts[0], 'post');
                             done();
@@ -640,8 +640,8 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body;
 
-                    jsonResponse.should.exist;
-                    jsonResponse.posts[0].page.should.be.ok;
+                    should.exist(jsonResponse);
+                    jsonResponse.posts[0].page.should.be.ok();
                     jsonResponse.posts[0].page = false;
 
                     request.put(testUtils.API.getApiQuery('posts/7/'))
@@ -658,8 +658,8 @@ describe('Post API', function () {
                             var putBody = res.body;
 
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.should.exist;
-                            putBody.posts[0].page.should.not.be.ok;
+                            should.exist(putBody);
+                            putBody.posts[0].page.should.not.be.ok();
                             testUtils.API.checkResponse(putBody.posts[0], 'post');
                             done();
                         });
@@ -678,7 +678,7 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body,
                         changedValue = 'invalid';
-                    jsonResponse.should.exist;
+                    should.exist(jsonResponse);
                     jsonResponse.posts[0].page.should.eql(false);
                     jsonResponse.posts[0].page = changedValue;
 
@@ -695,7 +695,7 @@ describe('Post API', function () {
 
                             should.not.exist(res.headers['x-cache-invalidate']);
                             jsonResponse = res.body;
-                            jsonResponse.errors.should.exist;
+                            should.exist(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                             done();
                         });
@@ -742,7 +742,7 @@ describe('Post API', function () {
                     }
 
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
+                    should.exist(jsonResponse);
 
                     request.put(testUtils.API.getApiQuery('posts/2/'))
                         .set('Authorization', 'Bearer ' + accesstoken)
@@ -773,7 +773,7 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body,
                         changedValue = 'My new Title';
-                    jsonResponse.should.exist;
+                    should.exist(jsonResponse);
                     jsonResponse.title = changedValue;
                     jsonResponse.published_at = null;
 
@@ -790,8 +790,8 @@ describe('Post API', function () {
 
                             var putBody = res.body;
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.should.exist;
-                            putBody.posts.should.exist;
+                            should.exist(putBody);
+                            should.exist(putBody.posts);
                             putBody.posts[0].title.should.eql(changedValue);
                             if (_.isEmpty(putBody.posts[0].published_at)) {
                                 should.fail('null', 'valid date', 'publish_at should not be empty');
@@ -831,7 +831,7 @@ describe('Post API', function () {
 
                             should.not.exist(res.headers['x-cache-invalidate']);
                             jsonResponse = res.body;
-                            jsonResponse.errors.should.exist;
+                            should.exist(jsonResponse.errors);
                             testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                             done();
                         });
@@ -854,8 +854,8 @@ describe('Post API', function () {
                     }
 
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     res.headers['x-cache-invalidate'].should.eql('/*');
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     jsonResponse.posts[0].id.should.eql(deletePostId);
@@ -876,8 +876,8 @@ describe('Post API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -901,7 +901,7 @@ describe('Post API', function () {
 
                     var draftPost = res.body;
 
-                    draftPost.should.exist;
+                    should.exist(draftPost);
                     draftPost.posts[0].title.should.eql(newTitle);
                     draftPost.posts[0].status = publishedState;
                     testUtils.API.checkResponse(draftPost.posts[0], 'post');
@@ -917,8 +917,8 @@ describe('Post API', function () {
                             }
 
                             var jsonResponse = res.body;
-                            jsonResponse.should.exist;
-                            jsonResponse.posts.should.exist;
+                            should.exist(jsonResponse);
+                            should.exist(jsonResponse.posts);
                             testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                             done();
                         });
@@ -999,11 +999,11 @@ describe('Post API', function () {
                     should.not.exist(res.headers['x-cache-invalidate']);
 
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
                     jsonResponse.posts[0].slug.should.not.match(/^\/[0-9]{4}\/[0-9]{2}\/[0-9]{2}/);
-                    jsonResponse.posts[0].page.should.not.be.ok;
+                    jsonResponse.posts[0].page.should.not.be.ok();
                     done();
                 });
         });
@@ -1020,8 +1020,8 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body,
                         changedValue = 'My new Title';
-                    jsonResponse.should.exist;
-                    jsonResponse.posts.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.posts);
                     jsonResponse.posts[0].title = changedValue;
 
                     request.put(testUtils.API.getApiQuery('posts/2/'))
@@ -1037,7 +1037,7 @@ describe('Post API', function () {
                             var putBody = res.body;
 
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.should.exist;
+                            should.exist(putBody);
                             putBody.posts[0].title.should.eql(changedValue);
 
                             testUtils.API.checkResponse(putBody.posts[0], 'post');

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -59,7 +59,7 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.posts.should.exist;
+                should.exist(jsonResponse.posts);
                 testUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(5);
                 testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -83,7 +83,7 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.posts.should.exist;
+                should.exist(jsonResponse.posts);
                 testUtils.API.checkResponse(jsonResponse, 'posts');
                 jsonResponse.posts.should.have.length(5);
                 testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
@@ -107,7 +107,7 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.tags.should.exist;
+                should.exist(jsonResponse.tags);
                 testUtils.API.checkResponse(jsonResponse, 'tags');
                 jsonResponse.tags.should.have.length(15);
                 testUtils.API.checkResponse(jsonResponse.tags[0], 'tag');
@@ -128,7 +128,7 @@ describe('Public API', function () {
                 }
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.tags.should.exist;
+                should.exist(jsonResponse.tags);
                 testUtils.API.checkResponse(jsonResponse, 'tags');
                 jsonResponse.tags.should.have.length(56);
                 testUtils.API.checkResponse(jsonResponse.tags[0], 'tag');
@@ -150,7 +150,7 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.tags.should.exist;
+                should.exist(jsonResponse.tags);
                 testUtils.API.checkResponse(jsonResponse, 'tags');
                 jsonResponse.tags.should.have.length(4);
                 testUtils.API.checkResponse(jsonResponse.tags[0], 'tag');
@@ -172,8 +172,8 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.errors.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
                 testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                 done();
             });
@@ -192,8 +192,8 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.errors.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
                 testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                 done();
             });
@@ -212,8 +212,8 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.errors.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
                 testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                 done();
             });
@@ -232,8 +232,8 @@ describe('Public API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.errors.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
                 testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                 done();
             });

--- a/core/test/functional/routes/api/settings_spec.js
+++ b/core/test/functional/routes/api/settings_spec.js
@@ -44,7 +44,7 @@ describe('Settings API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
+                should.exist(jsonResponse);
 
                 testUtils.API.checkResponse(jsonResponse, 'settings');
                 done();
@@ -65,12 +65,12 @@ describe('Settings API', function () {
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
 
-                jsonResponse.should.exist;
-                jsonResponse.settings.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
 
                 testUtils.API.checkResponseValue(jsonResponse.settings[0], ['id', 'uuid', 'key', 'value', 'type', 'created_at', 'created_by', 'updated_at', 'updated_by']);
                 jsonResponse.settings[0].key.should.eql('title');
-                testUtils.API.isISO8601(jsonResponse.settings[0].created_at).should.be.true;
+                testUtils.API.isISO8601(jsonResponse.settings[0].created_at).should.be.true();
                 done();
             });
     });
@@ -88,8 +88,8 @@ describe('Settings API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.errors.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.errors);
                 testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                 done();
             });
@@ -113,8 +113,8 @@ describe('Settings API', function () {
                         ]
                     };
 
-                jsonResponse.should.exist;
-                jsonResponse.settings.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.settings);
 
                 request.put(testUtils.API.getApiQuery('settings/'))
                     .set('Authorization', 'Bearer ' + accesstoken)
@@ -129,7 +129,7 @@ describe('Settings API', function () {
 
                         var putBody = res.body;
                         res.headers['x-cache-invalidate'].should.eql('/*');
-                        putBody.should.exist;
+                        should.exist(putBody);
                         putBody.settings[0].value.should.eql(changedValue);
                         testUtils.API.checkResponse(putBody, 'settings');
                         done();
@@ -149,7 +149,7 @@ describe('Settings API', function () {
 
                 var jsonResponse = res.body,
                     changedValue = 'Ghost changed';
-                jsonResponse.should.exist;
+                should.exist(jsonResponse);
                 jsonResponse.title = changedValue;
 
                 request.put(testUtils.API.getApiQuery('settings/'))
@@ -179,7 +179,7 @@ describe('Settings API', function () {
 
                 var jsonResponse = res.body,
                     newValue = 'new value';
-                jsonResponse.should.exist;
+                should.exist(jsonResponse);
                 should.exist(jsonResponse.settings);
                 jsonResponse.settings = [{key: 'testvalue', value: newValue}];
 
@@ -196,7 +196,7 @@ describe('Settings API', function () {
 
                         jsonResponse = res.body;
                         should.not.exist(res.headers['x-cache-invalidate']);
-                        jsonResponse.errors.should.exist;
+                        should.exist(jsonResponse.errors);
                         testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                         done();
                     });

--- a/core/test/functional/routes/api/slugs_spec.js
+++ b/core/test/functional/routes/api/slugs_spec.js
@@ -43,8 +43,8 @@ describe('Slug API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.slugs.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.slugs);
                 jsonResponse.slugs.should.have.length(1);
                 testUtils.API.checkResponse(jsonResponse.slugs[0], 'slug');
                 jsonResponse.slugs[0].slug.should.equal('a-post-title');
@@ -66,8 +66,8 @@ describe('Slug API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.slugs.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.slugs);
                 jsonResponse.slugs.should.have.length(1);
                 testUtils.API.checkResponse(jsonResponse.slugs[0], 'slug');
                 jsonResponse.slugs[0].slug.should.equal('atag');
@@ -89,8 +89,8 @@ describe('Slug API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.slugs.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.slugs);
                 jsonResponse.slugs.should.have.length(1);
                 testUtils.API.checkResponse(jsonResponse.slugs[0], 'slug');
                 jsonResponse.slugs[0].slug.should.equal('user-name');
@@ -112,8 +112,8 @@ describe('Slug API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.slugs.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.slugs);
                 jsonResponse.slugs.should.have.length(1);
                 testUtils.API.checkResponse(jsonResponse.slugs[0], 'slug');
                 jsonResponse.slugs[0].slug.should.equal('cool-app');
@@ -134,7 +134,7 @@ describe('Slug API', function () {
                 }
 
                 var jsonResponse = res.body;
-                jsonResponse.should.not.exist;
+                should.exist(jsonResponse.errors);
 
                 done();
             });

--- a/core/test/functional/routes/api/tags_spec.js
+++ b/core/test/functional/routes/api/tags_spec.js
@@ -43,11 +43,11 @@ describe('Tag API', function () {
 
                 should.not.exist(res.headers['x-cache-invalidate']);
                 var jsonResponse = res.body;
-                jsonResponse.should.exist;
-                jsonResponse.tags.should.exist;
+                should.exist(jsonResponse);
+                should.exist(jsonResponse.tags);
                 jsonResponse.tags.should.have.length(6);
                 testUtils.API.checkResponse(jsonResponse.tags[0], 'tag');
-                testUtils.API.isISO8601(jsonResponse.tags[0].created_at).should.be.true;
+                testUtils.API.isISO8601(jsonResponse.tags[0].created_at).should.be.true();
 
                 done();
             });

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -43,15 +43,15 @@ describe('User API', function () {
                     }
 
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
-                    testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true;
-                    testUtils.API.isISO8601(jsonResponse.users[0].created_at).should.be.true;
-                    testUtils.API.isISO8601(jsonResponse.users[0].updated_at).should.be.true;
+                    testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true();
+                    testUtils.API.isISO8601(jsonResponse.users[0].created_at).should.be.true();
+                    testUtils.API.isISO8601(jsonResponse.users[0].updated_at).should.be.true();
 
                     done();
                 });
@@ -70,7 +70,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
@@ -92,7 +92,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     testUtils.API.checkResponse(jsonResponse, 'users');
 
                     jsonResponse.users.should.have.length(1);
@@ -116,7 +116,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -138,7 +138,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -160,7 +160,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -182,7 +182,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -204,7 +204,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -227,7 +227,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -252,7 +252,7 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.users.should.exist;
+                    should.exist(jsonResponse.users);
                     should.not.exist(jsonResponse.meta);
 
                     jsonResponse.users.should.have.length(1);
@@ -277,8 +277,8 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -297,8 +297,8 @@ describe('User API', function () {
 
                     should.not.exist(res.headers['x-cache-invalidate']);
                     var jsonResponse = res.body;
-                    jsonResponse.should.exist;
-                    jsonResponse.errors.should.exist;
+                    should.exist(jsonResponse);
+                    should.exist(jsonResponse.errors);
                     testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
                     done();
                 });
@@ -318,7 +318,7 @@ describe('User API', function () {
                     var jsonResponse = res.body,
                         changedValue = 'http://joe-bloggs.ghost.org',
                         dataToSend;
-                    jsonResponse.users[0].should.exist;
+                    should.exist(jsonResponse.users[0]);
                     testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
                     dataToSend = {users: [
@@ -338,7 +338,7 @@ describe('User API', function () {
 
                             var putBody = res.body;
                             res.headers['x-cache-invalidate'].should.eql('/*');
-                            putBody.users[0].should.exist;
+                            should.exist(putBody.users[0]);
                             putBody.users[0].website.should.eql(changedValue);
                             putBody.users[0].email.should.eql(jsonResponse.users[0].email);
                             testUtils.API.checkResponse(putBody.users[0], 'user');

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -31,7 +31,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 3 items according to the limit property
-                    result.posts.should.be.an.Array.with.lengthOf(3);
+                    result.posts.should.be.an.Array().with.lengthOf(3);
 
                     // None of the items returned should be the post with id 4, as that was excluded
                     ids = _.pluck(result.posts, 'id');
@@ -56,7 +56,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(3);
                     result.meta.pagination.pages.should.eql(3);
@@ -81,13 +81,13 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(9);
+                    result.posts.should.be.an.Array().with.lengthOf(9);
 
                     ids = _.pluck(result.posts, 'id');
                     ids.should.eql([14, 11, 9, 8, 7, 6, 5, 3, 2]);
 
                     _.each(result.posts, function (post) {
-                        post.page.should.be.false;
+                        post.page.should.be.false();
                         post.status.should.eql('published');
                     });
 
@@ -95,7 +95,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -119,14 +119,14 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 3 matching items
-                    result.tags.should.be.an.Array.with.lengthOf(3);
+                    result.tags.should.be.an.Array().with.lengthOf(3);
 
                     // TODO: add the ordering
                     // TODO: manage the count
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     // TODO complete meta data assertions
 
                     done();
@@ -146,7 +146,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 2 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(6);
+                    result.posts.should.be.an.Array().with.lengthOf(6);
 
                     // Each post must either have the author 'leslie' or 'pat'
                     authors = _.map(result.posts, function (post) {
@@ -159,7 +159,7 @@ describe('Filter Param Spec', function () {
                         var tags = _.pluck(post.tags, 'slug');
                         // This construct ensures we get an assertion or a failure
                         if (!_.isEmpty(post.image)) {
-                            post.image.should.not.be.empty;
+                            post.image.should.not.be.empty();
                         } else {
                             tags = _.pluck(post.tags, 'slug');
                             tags.should.containEql('audio');
@@ -171,7 +171,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -196,7 +196,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 2 matching items
-                    result.users.should.be.an.Array.with.lengthOf(2);
+                    result.users.should.be.an.Array().with.lengthOf(2);
 
                     ids = _.pluck(result.users, 'id');
                     ids.should.eql([1, 2]);
@@ -206,7 +206,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(3);
                     result.meta.pagination.pages.should.eql(1);
@@ -232,7 +232,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     // TODO complete meta data assertions
 
                     done();
@@ -251,7 +251,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 2 matching items
-                    result.users.should.be.an.Array.with.lengthOf(2);
+                    result.users.should.be.an.Array().with.lengthOf(2);
 
                     ids = _.pluck(result.users, 'id');
                     ids.should.eql([2, 1]);
@@ -261,7 +261,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -285,7 +285,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 3 matching items
-                    result.tags.should.be.an.Array.with.lengthOf(3);
+                    result.tags.should.be.an.Array().with.lengthOf(3);
 
                     ids = _.pluck(result.tags, 'id');
                     ids.should.containEql(4);
@@ -304,7 +304,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -328,7 +328,7 @@ describe('Filter Param Spec', function () {
 
                 // 2. The data part of the response should be correct
                 // We should have 5 matching items
-                result.tags.should.be.an.Array.with.lengthOf(6);
+                result.tags.should.be.an.Array().with.lengthOf(6);
 
                 // Each tag should have the correct count
                 _.find(result.tags, function (tag) {
@@ -357,7 +357,7 @@ describe('Filter Param Spec', function () {
 
                 // 3. The meta object should contain the right details
                 result.meta.should.have.property('pagination');
-                result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                 result.meta.pagination.page.should.eql(1);
                 result.meta.pagination.limit.should.eql(15);
                 result.meta.pagination.pages.should.eql(1);
@@ -380,7 +380,7 @@ describe('Filter Param Spec', function () {
 
                 // 2. The data part of the response should be correct
                 // We should have 5 matching items
-                result.tags.should.be.an.Array.with.lengthOf(6);
+                result.tags.should.be.an.Array().with.lengthOf(6);
 
                 // Each tag should have the correct count
                 _.find(result.tags, function (tag) {
@@ -412,7 +412,7 @@ describe('Filter Param Spec', function () {
 
                 // 3. The meta object should contain the right details
                 result.meta.should.have.property('pagination');
-                result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                 result.meta.pagination.page.should.eql(1);
                 result.meta.pagination.limit.should.eql(15);
                 result.meta.pagination.pages.should.eql(1);
@@ -439,7 +439,7 @@ describe('Filter Param Spec', function () {
 
                 // 2. The data part of the response should be correct
                 // We should have 5 matching items
-                result.users.should.be.an.Array.with.lengthOf(3);
+                result.users.should.be.an.Array().with.lengthOf(3);
 
                 // Each user should have the correct count
                 _.find(result.users, function (user) {
@@ -456,7 +456,7 @@ describe('Filter Param Spec', function () {
 
                 // 3. The meta object should contain the right details
                 result.meta.should.have.property('pagination');
-                result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                 result.meta.pagination.page.should.eql(1);
                 result.meta.pagination.limit.should.eql(15);
                 result.meta.pagination.pages.should.eql(1);
@@ -479,7 +479,7 @@ describe('Filter Param Spec', function () {
 
                 // 2. The data part of the response should be correct
                 // We should have 5 matching items
-                result.users.should.be.an.Array.with.lengthOf(3);
+                result.users.should.be.an.Array().with.lengthOf(3);
 
                 // Each user should have the correct count
                 _.find(result.users, function (user) {
@@ -499,7 +499,7 @@ describe('Filter Param Spec', function () {
 
                 // 3. The meta object should contain the right details
                 result.meta.should.have.property('pagination');
-                result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                 result.meta.pagination.page.should.eql(1);
                 result.meta.pagination.limit.should.eql(15);
                 result.meta.pagination.pages.should.eql(1);
@@ -533,14 +533,14 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 4 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(4);
+                    result.posts.should.be.an.Array().with.lengthOf(4);
 
                     ids = _.pluck(result.posts, 'id');
                     ids.should.eql([11, 9, 3, 2]);
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -565,14 +565,14 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(5);
+                    result.posts.should.be.an.Array().with.lengthOf(5);
 
                     ids = _.pluck(result.posts, 'id');
                     ids.should.eql([13, 12, 11, 10, 9]);
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(2);
                     result.meta.pagination.limit.should.eql(5);
                     result.meta.pagination.pages.should.eql(3);
@@ -599,14 +599,14 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(15);
+                    result.posts.should.be.an.Array().with.lengthOf(15);
 
                     ids = _.pluck(result.posts, 'id');
                     ids.should.eql([20, 18, 17, 16, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4]);
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(2);
@@ -631,7 +631,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(3);
+                    result.posts.should.be.an.Array().with.lengthOf(3);
 
                     // All posts should be marked as featured 'true'
                     featured = _.pluck(result.posts, 'featured');
@@ -643,7 +643,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -668,7 +668,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(15);
+                    result.posts.should.be.an.Array().with.lengthOf(15);
 
                     // All posts should be marked as featured 'false'
                     featured = _.pluck(result.posts, 'featured');
@@ -680,7 +680,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -707,7 +707,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(18);
+                    result.posts.should.be.an.Array().with.lengthOf(18);
 
                     // All posts should be marked as page 'false'
                     page = _.pluck(result.posts, 'page');
@@ -719,7 +719,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql('all');
                     result.meta.pagination.pages.should.eql(1);
@@ -745,7 +745,7 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 5 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(2);
+                    result.posts.should.be.an.Array().with.lengthOf(2);
 
                     // All posts should be marked as page 'true'
                     page = _.pluck(result.posts, 'page');
@@ -757,7 +757,7 @@ describe('Filter Param Spec', function () {
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -787,11 +787,11 @@ describe('Filter Param Spec', function () {
 
                     // 2. The data part of the response should be correct
                     // We should have 4 matching items
-                    result.posts.should.be.an.Array.with.lengthOf(0);
+                    result.posts.should.be.an.Array().with.lengthOf(0);
 
                     // 3. The meta object should contain the right details
                     result.meta.should.have.property('pagination');
-                    result.meta.pagination.should.be.an.Object.with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
                     result.meta.pagination.page.should.eql(1);
                     result.meta.pagination.limit.should.eql(15);
                     result.meta.pagination.pages.should.eql(1);
@@ -817,7 +817,7 @@ describe('Filter Param Spec', function () {
                 result.should.have.property('meta');
 
                 _.each(result.posts, function (post) {
-                    post.page.should.be.false;
+                    post.page.should.be.false();
                     post.status.should.eql('published');
                 });
 
@@ -833,7 +833,7 @@ describe('Filter Param Spec', function () {
                 result.should.have.property('meta');
 
                 _.each(result.posts, function (post) {
-                    post.page.should.be.false;
+                    post.page.should.be.false();
                     post.status.should.eql('published');
                 });
 
@@ -849,7 +849,7 @@ describe('Filter Param Spec', function () {
                 result.should.have.property('meta');
 
                 _.each(result.posts, function (post) {
-                    post.page.should.be.false;
+                    post.page.should.be.false();
                     post.status.should.eql('published');
                 });
 
@@ -865,7 +865,7 @@ describe('Filter Param Spec', function () {
                 result.should.have.property('meta');
 
                 _.each(result.posts, function (post) {
-                    post.page.should.be.false;
+                    post.page.should.be.false();
                     post.status.should.eql('published');
                 });
 

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -59,7 +59,7 @@ describe('Authentication API', function () {
             it('should report that setup has not been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
                     should.exist(result);
-                    result.setup[0].status.should.be.false;
+                    result.setup[0].status.should.be.false();
 
                     done();
                 }).catch(done);
@@ -136,7 +136,7 @@ describe('Authentication API', function () {
             it('should report that setup has been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
                     should.exist(result);
-                    result.setup[0].status.should.be.true;
+                    result.setup[0].status.should.be.true();
 
                     done();
                 }).catch(done);
@@ -177,8 +177,8 @@ describe('Authentication API', function () {
 
             it('should generate a password reset token', function (done) {
                 AuthAPI.generateResetToken(testGenerateReset).then(function (result) {
-                    result.should.exist;
-                    result.passwordreset.should.be.an.Array.with.lengthOf(1);
+                    should.exist(result);
+                    result.passwordreset.should.be.an.Array().with.lengthOf(1);
                     result.passwordreset[0].should.have.property('message', 'Check your email for further instructions.');
                     done();
                 }).catch(done);
@@ -206,7 +206,7 @@ describe('Authentication API', function () {
             it('should report that setup has not been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
                     should.exist(result);
-                    result.setup[0].status.should.be.false;
+                    result.setup[0].status.should.be.false();
 
                     done();
                 }).catch(done);
@@ -239,7 +239,7 @@ describe('Authentication API', function () {
             it('should report that setup has been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
                     should.exist(result);
-                    result.setup[0].status.should.be.true;
+                    result.setup[0].status.should.be.true();
 
                     done();
                 }).catch(done);
@@ -272,7 +272,7 @@ describe('Authentication API', function () {
             it('should report that setup has been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
                     should.exist(result);
-                    result.setup[0].status.should.be.true;
+                    result.setup[0].status.should.be.true();
 
                     done();
                 }).catch(done);

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -21,7 +21,7 @@ describe('DB API', function () {
         return dbAPI.deleteAllContent(testUtils.context.owner).then(function (result) {
             should.exist(result.db);
             result.db.should.be.instanceof(Array);
-            result.db.should.be.empty;
+            result.db.should.be.empty();
         }).then(function () {
             return ModelTag.Tag.findAll(testUtils.context.owner).then(function (results) {
                 should.exist(results);
@@ -40,7 +40,7 @@ describe('DB API', function () {
         return dbAPI.deleteAllContent(testUtils.context.admin).then(function (result) {
             should.exist(result.db);
             result.db.should.be.instanceof(Array);
-            result.db.should.be.empty;
+            result.db.should.be.empty();
         }).then(function () {
             return ModelTag.Tag.findAll(testUtils.context.admin).then(function (results) {
                 should.exist(results);

--- a/core/test/integration/api/api_notifications_spec.js
+++ b/core/test/integration/api/api_notifications_spec.js
@@ -28,7 +28,7 @@ describe('Notifications API', function () {
             should.exist(result.notifications);
 
             notification = result.notifications[0];
-            notification.dismissible.should.be.true;
+            notification.dismissible.should.be.true();
             should.exist(notification.location);
             notification.location.should.equal('bottom');
 
@@ -49,7 +49,7 @@ describe('Notifications API', function () {
             should.exist(result.notifications);
 
             notification = result.notifications[0];
-            notification.dismissible.should.be.true;
+            notification.dismissible.should.be.true();
             should.exist(notification.location);
             notification.location.should.equal('bottom');
 
@@ -71,7 +71,7 @@ describe('Notifications API', function () {
             should.exist(result.notifications);
 
             notification = result.notifications[0];
-            notification.id.should.be.a.Number;
+            notification.id.should.be.a.Number();
             notification.id.should.not.equal(99);
             should.exist(notification.status);
             notification.status.should.equal('alert');

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -283,7 +283,7 @@ describe('Post API', function () {
             PostAPI.browse({context: {user: 1}, status: 'all', limit: 5, fields: 'title'}).then(function (results) {
                 should.exist(results.posts);
 
-                results.posts[0].title.should.exist;
+                should.exist(results.posts[0].title);
                 should.not.exist(results.posts[0].slug);
 
                 done();
@@ -294,8 +294,8 @@ describe('Post API', function () {
             PostAPI.browse({context: {user: 1}, status: 'all', limit: 5, fields: 'slug,published_at'}).then(function (results) {
                 should.exist(results.posts);
 
-                results.posts[0].published_at.should.exist;
-                results.posts[0].slug.should.exist;
+                should.exist(results.posts[0].published_at);
+                should.exist(results.posts[0].slug);
                 should.not.exist(results.posts[0].title);
 
                 done();
@@ -306,8 +306,8 @@ describe('Post API', function () {
             PostAPI.browse({context: {user: 1}, status: 'all', limit: 5, fields: 'Slug,Published_At'}).then(function (results) {
                 should.exist(results.posts);
 
-                results.posts[0].published_at.should.exist;
-                results.posts[0].slug.should.exist;
+                should.exist(results.posts[0].published_at);
+                should.exist(results.posts[0].slug);
                 should.not.exist(results.posts[0].title);
 
                 done();
@@ -318,8 +318,8 @@ describe('Post API', function () {
             PostAPI.browse({context: {user: 1}, status: 'all', limit: 5, fields: ' slug , published_at  '}).then(function (results) {
                 should.exist(results.posts);
 
-                results.posts[0].published_at.should.exist;
-                results.posts[0].slug.should.exist;
+                should.exist(results.posts[0].published_at);
+                should.exist(results.posts[0].slug);
                 should.not.exist(results.posts[0].title);
 
                 done();
@@ -331,7 +331,7 @@ describe('Post API', function () {
                 var objectKeys;
                 should.exist(results.posts);
 
-                results.posts[0].title.should.exist;
+                should.exist(results.posts[0].title);
                 should.not.exist(results.posts[0].foo);
                 objectKeys = _.keys(results.posts[0]);
                 objectKeys.length.should.eql(1);
@@ -492,8 +492,8 @@ describe('Post API', function () {
             PostAPI.read({context: {user: 1}, id: 3, include: 'next,next.tags,next.author'}).then(function (results) {
                 should.exist(results.posts[0].next.slug);
                 results.posts[0].next.slug.should.eql('not-so-short-bit-complex');
-                results.posts[0].next.author.should.be.an.Object;
-                results.posts[0].next.tags.should.be.an.Array;
+                results.posts[0].next.author.should.be.an.Object();
+                results.posts[0].next.tags.should.be.an.Array();
                 done();
             }).catch(done);
         });
@@ -503,7 +503,7 @@ describe('Post API', function () {
                 should.exist(results.posts[0].next.slug);
                 results.posts[0].next.slug.should.eql('short-and-sweet');
                 results.posts[0].next.author.should.eql(1);
-                results.posts[0].next.tags.should.be.an.Array;
+                results.posts[0].next.tags.should.be.an.Array();
                 results.posts[0].next.tags[0].name.should.eql('chorizo');
                 done();
             }).catch(done);
@@ -521,9 +521,9 @@ describe('Post API', function () {
             PostAPI.read({context: {user: 1}, id: 3, include: 'previous,previous.author,previous.tags'}).then(function (results) {
                 should.exist(results.posts[0].previous.slug);
                 results.posts[0].previous.slug.should.eql('ghostly-kitchen-sink');
-                results.posts[0].previous.author.should.be.an.Object;
+                results.posts[0].previous.author.should.be.an.Object();
                 results.posts[0].previous.author.name.should.eql('Joe Bloggs');
-                results.posts[0].previous.tags.should.be.an.Array;
+                results.posts[0].previous.tags.should.be.an.Array();
                 results.posts[0].previous.tags.should.have.lengthOf(2);
                 results.posts[0].previous.tags[0].slug.should.eql('kitchen-sink');
                 done();
@@ -535,7 +535,7 @@ describe('Post API', function () {
                 should.exist(results.posts[0].previous.slug);
                 should.not.exist(results.posts[0].previous.tags);
                 results.posts[0].previous.slug.should.eql('ghostly-kitchen-sink');
-                results.posts[0].previous.author.should.be.an.Object;
+                results.posts[0].previous.author.should.be.an.Object();
                 results.posts[0].previous.author.name.should.eql('Joe Bloggs');
                 done();
             }).catch(done);

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -237,7 +237,7 @@ describe('Users API', function () {
             } else {
                 testUtils.API.checkResponse(response.users[0], 'user');
             }
-            response.users[0].created_at.should.be.a.Date;
+            response.users[0].created_at.should.be.an.instanceof(Date);
         }
 
         it('Owner can read', function (done) {
@@ -300,7 +300,7 @@ describe('Users API', function () {
             response.users.should.have.length(1);
             testUtils.API.checkResponse(response.users[0], 'user');
             response.users[0].name.should.equal(newName);
-            response.users[0].updated_at.should.be.a.Date;
+            response.users[0].updated_at.should.be.an.instanceof(Date);
         }
 
         it('throws an error if there is an id mismatch', function (done) {
@@ -515,7 +515,7 @@ describe('Users API', function () {
             should.not.exist(response.meta);
             response.users.should.have.length(1);
             testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
-            response.users[0].created_at.should.be.a.Date;
+            response.users[0].created_at.should.be.an.instanceof(Date);
         }
 
         describe('Owner', function () {
@@ -704,7 +704,7 @@ describe('Users API', function () {
             should.not.exist(response.meta);
             response.users.should.have.length(1);
             testUtils.API.checkResponse(response.users[0], 'user');
-            response.users[0].created_at.should.be.a.Date;
+            response.users[0].created_at.should.be.an.instanceof(Date);
         }
 
         describe('Owner', function () {
@@ -851,7 +851,7 @@ describe('Users API', function () {
             response.users.should.have.length(1);
             testUtils.API.checkResponse(response.users[0], 'user', ['roles']);
             response.users[0].name.should.equal(newName);
-            response.users[0].updated_at.should.be.a.Date;
+            response.users[0].updated_at.should.be.an.instanceof(Date);
         }
 
         it('throws an error if there is an id mismatch', function (done) {

--- a/core/test/integration/model/model_apps_spec.js
+++ b/core/test/integration/model/model_apps_spec.js
@@ -76,7 +76,7 @@ describe('App Model', function () {
 
             return AppModel.destroy(firstApp);
         }).then(function (response) {
-            response.toJSON().should.be.empty;
+            response.toJSON().should.be.empty();
 
             return AppModel.findOne(firstApp);
         }).then(function (newResults) {

--- a/core/test/integration/model/model_permissions_spec.js
+++ b/core/test/integration/model/model_permissions_spec.js
@@ -77,7 +77,7 @@ describe('Permission Model', function () {
 
             return PermissionModel.destroy(firstPermission);
         }).then(function (response) {
-            response.toJSON().should.be.empty;
+            response.toJSON().should.be.empty();
             return PermissionModel.findOne(firstPermission);
         }).then(function (newResults) {
             should.equal(newResults, null);

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -42,16 +42,16 @@ describe('Post Model', function () {
 
         function checkFirstPostData(firstPost) {
             should.not.exist(firstPost.author_id);
-            firstPost.author.should.be.an.Object;
+            firstPost.author.should.be.an.Object();
             firstPost.url.should.equal('/html-ipsum/');
-            firstPost.fields.should.be.an.Array;
-            firstPost.tags.should.be.an.Array;
+            firstPost.fields.should.be.an.Array();
+            firstPost.tags.should.be.an.Array();
             firstPost.author.name.should.equal(DataGenerator.Content.users[0].name);
             firstPost.fields[0].key.should.equal(DataGenerator.Content.app_fields[0].key);
             firstPost.created_at.should.be.an.instanceof(Date);
-            firstPost.created_by.should.be.an.Object;
-            firstPost.updated_by.should.be.an.Object;
-            firstPost.published_by.should.be.an.Object;
+            firstPost.created_by.should.be.an.Object();
+            firstPost.updated_by.should.be.an.Object();
+            firstPost.published_by.should.be.an.Object();
             firstPost.created_by.name.should.equal(DataGenerator.Content.users[0].name);
             firstPost.updated_by.name.should.equal(DataGenerator.Content.users[0].name);
             firstPost.published_by.name.should.equal(DataGenerator.Content.users[0].name);
@@ -246,7 +246,7 @@ describe('Post Model', function () {
                     .then(function (paginationResult) {
                         should.exist(paginationResult.meta);
 
-                        paginationResult.meta.pagination.page.should.be.a.Number;
+                        paginationResult.meta.pagination.page.should.be.a.Number();
 
                         done();
                     }).catch(done);
@@ -343,9 +343,9 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     should.exist(edited);
                     edited.attributes.title.should.equal('new title');
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.published.edited').should.be.true;
-                    eventSpy.secondCall.calledWith('post.edited').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.published.edited').should.be.true();
+                    eventSpy.secondCall.calledWith('post.edited').should.be.true();
 
                     done();
                 }).catch(done);
@@ -365,9 +365,9 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     should.exist(edited);
                     edited.attributes.status.should.equal('published');
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.published').should.be.true;
-                    eventSpy.secondCall.calledWith('post.edited').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.published').should.be.true();
+                    eventSpy.secondCall.calledWith('post.edited').should.be.true();
 
                     done();
                 }).catch(done);
@@ -387,9 +387,9 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     should.exist(edited);
                     edited.attributes.status.should.equal('draft');
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true;
-                    eventSpy.secondCall.calledWith('post.edited').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true();
+                    eventSpy.secondCall.calledWith('post.edited').should.be.true();
 
                     done();
                 }).catch(done);
@@ -410,9 +410,9 @@ describe('Post Model', function () {
                     should.exist(edited);
                     edited.attributes.status.should.equal('draft');
                     edited.attributes.page.should.equal(true);
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.deleted').should.be.true;
-                    eventSpy.secondCall.calledWith('page.added').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.deleted').should.be.true();
+                    eventSpy.secondCall.calledWith('page.added').should.be.true();
 
                     return PostModel.edit({page: 0}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
@@ -420,8 +420,8 @@ describe('Post Model', function () {
                     edited.attributes.status.should.equal('draft');
                     edited.attributes.page.should.equal(false);
                     eventSpy.callCount.should.equal(4);
-                    eventSpy.thirdCall.calledWith('page.deleted').should.be.true;
-                    eventSpy.lastCall.calledWith('post.added').should.be.true;
+                    eventSpy.thirdCall.calledWith('page.deleted').should.be.true();
+                    eventSpy.lastCall.calledWith('post.added').should.be.true();
                     done();
                 }).catch(done);
             });
@@ -443,10 +443,10 @@ describe('Post Model', function () {
                     edited.attributes.page.should.equal(true);
 
                     eventSpy.callCount.should.equal(4);
-                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true;
-                    eventSpy.secondCall.calledWith('post.deleted').should.be.true;
-                    eventSpy.thirdCall.calledWith('page.added').should.be.true;
-                    eventSpy.lastCall.calledWith('page.published').should.be.true;
+                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true();
+                    eventSpy.secondCall.calledWith('post.deleted').should.be.true();
+                    eventSpy.thirdCall.calledWith('page.added').should.be.true();
+                    eventSpy.lastCall.calledWith('page.published').should.be.true();
 
                     return PostModel.edit({page: 0}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
@@ -455,10 +455,10 @@ describe('Post Model', function () {
                     edited.attributes.page.should.equal(false);
 
                     eventSpy.callCount.should.equal(8);
-                    eventSpy.getCall(4).calledWith('page.unpublished').should.be.true;
-                    eventSpy.getCall(5).calledWith('page.deleted').should.be.true;
-                    eventSpy.getCall(6).calledWith('post.added').should.be.true;
-                    eventSpy.getCall(7).calledWith('post.published').should.be.true;
+                    eventSpy.getCall(4).calledWith('page.unpublished').should.be.true();
+                    eventSpy.getCall(5).calledWith('page.deleted').should.be.true();
+                    eventSpy.getCall(6).calledWith('post.added').should.be.true();
+                    eventSpy.getCall(7).calledWith('post.published').should.be.true();
                     done();
                 }).catch(done);
             });
@@ -478,10 +478,10 @@ describe('Post Model', function () {
                     should.exist(edited);
                     edited.attributes.status.should.equal('published');
                     edited.attributes.page.should.equal(true);
-                    eventSpy.calledThrice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.deleted').should.be.true;
-                    eventSpy.secondCall.calledWith('page.added').should.be.true;
-                    eventSpy.thirdCall.calledWith('page.published').should.be.true;
+                    eventSpy.calledThrice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.deleted').should.be.true();
+                    eventSpy.secondCall.calledWith('page.added').should.be.true();
+                    eventSpy.thirdCall.calledWith('page.published').should.be.true();
 
                     return PostModel.edit({page: 0, status: 'draft'}, _.extend({}, context, {id: postId}));
                 }).then(function (edited) {
@@ -489,9 +489,9 @@ describe('Post Model', function () {
                     edited.attributes.status.should.equal('draft');
                     edited.attributes.page.should.equal(false);
                     eventSpy.callCount.should.equal(6);
-                    eventSpy.getCall(3).calledWith('page.unpublished').should.be.true;
-                    eventSpy.getCall(4).calledWith('page.deleted').should.be.true;
-                    eventSpy.getCall(5).calledWith('post.added').should.be.true;
+                    eventSpy.getCall(3).calledWith('page.unpublished').should.be.true();
+                    eventSpy.getCall(4).calledWith('page.deleted').should.be.true();
+                    eventSpy.getCall(5).calledWith('post.added').should.be.true();
                     done();
                 }).catch(done);
             });
@@ -596,8 +596,8 @@ describe('Post Model', function () {
 
                     createdPostUpdatedDate = createdPost.get('updated_at');
 
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('post.added').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('post.added').should.be.true();
 
                     // Set the status to published to check that `published_at` is set.
                     return createdPost.save({status: 'published'}, context);
@@ -608,9 +608,9 @@ describe('Post Model', function () {
                     publishedPost.get('updated_by').should.equal(1);
                     publishedPost.get('updated_at').should.not.equal(createdPostUpdatedDate);
 
-                    eventSpy.calledThrice.should.be.true;
-                    eventSpy.secondCall.calledWith('post.published').should.be.true;
-                    eventSpy.thirdCall.calledWith('post.edited').should.be.true;
+                    eventSpy.calledThrice.should.be.true();
+                    eventSpy.secondCall.calledWith('post.published').should.be.true();
+                    eventSpy.thirdCall.calledWith('post.edited').should.be.true();
 
                     done();
                 }).catch(done);
@@ -628,9 +628,9 @@ describe('Post Model', function () {
                     should.exist(newPost);
                     new Date(newPost.get('published_at')).getTime().should.equal(previousPublishedAtDate.getTime());
 
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.added').should.be.true;
-                    eventSpy.secondCall.calledWith('post.published').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.added').should.be.true();
+                    eventSpy.secondCall.calledWith('post.published').should.be.true();
 
                     done();
                 }).catch(done);
@@ -661,15 +661,15 @@ describe('Post Model', function () {
                     should.exist(createdPost);
                     createdPost.get('title').should.equal(untrimmedCreateTitle.trim());
 
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('post.added').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('post.added').should.be.true();
 
                     return createdPost.save({title: untrimmedUpdateTitle}, context);
                 }).then(function (updatedPost) {
                     updatedPost.get('title').should.equal(untrimmedUpdateTitle.trim());
 
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.secondCall.calledWith('post.edited').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.secondCall.calledWith('post.edited').should.be.true();
 
                     done();
                 }).catch(done);
@@ -701,7 +701,7 @@ describe('Post Model', function () {
 
                         post.get('slug').should.equal('test-title-' + num);
                         post.get('markdown').should.equal('Test Content ' + num);
-                        eventSpy.getCall(i).calledWith('post.added').should.be.true;
+                        eventSpy.getCall(i).calledWith('post.added').should.be.true();
                     });
 
                     done();
@@ -716,8 +716,8 @@ describe('Post Model', function () {
 
                 PostModel.add(newPost, context).then(function (createdPost) {
                     createdPost.get('slug').should.equal('apprehensive-titles-have-too-many-spaces-and-m-dashes-and-also-n-dashes');
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('post.added').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('post.added').should.be.true();
 
                     done();
                 }).catch(done);
@@ -731,8 +731,8 @@ describe('Post Model', function () {
 
                 PostModel.add(newPost, context).then(function (createdPost) {
                     createdPost.get('slug').should.not.equal('rss');
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('post.added').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('post.added').should.be.true();
 
                     done();
                 });
@@ -765,16 +765,16 @@ describe('Post Model', function () {
                     .then(function (createdFirstPost) {
                         // Store the slug for later
                         firstPost.slug = createdFirstPost.get('slug');
-                        eventSpy.calledOnce.should.be.true;
-                        eventSpy.firstCall.calledWith('post.added').should.be.true;
+                        eventSpy.calledOnce.should.be.true();
+                        eventSpy.firstCall.calledWith('post.added').should.be.true();
 
                         // Create the second post
                         return PostModel.add(secondPost, context);
                     }).then(function (createdSecondPost) {
                         // Store the slug for comparison later
                         secondPost.slug = createdSecondPost.get('slug');
-                        eventSpy.calledTwice.should.be.true;
-                        eventSpy.secondCall.calledWith('post.added').should.be.true;
+                        eventSpy.calledTwice.should.be.true();
+                        eventSpy.secondCall.calledWith('post.added').should.be.true();
 
                         // Update with a conflicting slug from the first post
                         return createdSecondPost.save({
@@ -787,7 +787,7 @@ describe('Post Model', function () {
                         updatedSecondPost.get('slug').should.not.equal(firstPost.slug);
 
                         eventSpy.calledThrice.should.be.true;
-                        eventSpy.thirdCall.calledWith('post.edited').should.be.true;
+                        eventSpy.thirdCall.calledWith('post.edited').should.be.true();
 
                         return PostModel.findOne({
                             id: updatedSecondPost.id,
@@ -826,9 +826,9 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true;
-                    eventSpy.secondCall.calledWith('post.deleted').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('post.unpublished').should.be.true();
+                    eventSpy.secondCall.calledWith('post.deleted').should.be.true();
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -838,7 +838,7 @@ describe('Post Model', function () {
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
                 }).then(function (postsTags) {
-                    postsTags.should.be.empty;
+                    postsTags.should.be.empty();
 
                     done();
                 }).catch(done);
@@ -864,8 +864,8 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('post.deleted').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('post.deleted').should.be.true();
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -875,7 +875,7 @@ describe('Post Model', function () {
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
                 }).then(function (postsTags) {
-                    postsTags.should.be.empty;
+                    postsTags.should.be.empty();
 
                     done();
                 }).catch(done);
@@ -892,7 +892,7 @@ describe('Post Model', function () {
                     page = results.toJSON();
                     page.id.should.equal(firstItemData.id);
                     page.status.should.equal('published');
-                    page.page.should.be.true;
+                    page.page.should.be.true();
 
                     // Destroy the page
                     return PostModel.destroy(firstItemData);
@@ -901,9 +901,9 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    eventSpy.calledTwice.should.be.true;
-                    eventSpy.firstCall.calledWith('page.unpublished').should.be.true;
-                    eventSpy.secondCall.calledWith('page.deleted').should.be.true;
+                    eventSpy.calledTwice.should.be.true();
+                    eventSpy.firstCall.calledWith('page.unpublished').should.be.true();
+                    eventSpy.secondCall.calledWith('page.deleted').should.be.true();
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -913,7 +913,7 @@ describe('Post Model', function () {
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
                 }).then(function (postsTags) {
-                    postsTags.should.be.empty;
+                    postsTags.should.be.empty();
 
                     done();
                 }).catch(done);
@@ -937,8 +937,8 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    eventSpy.calledOnce.should.be.true;
-                    eventSpy.firstCall.calledWith('page.deleted').should.be.true;
+                    eventSpy.calledOnce.should.be.true();
+                    eventSpy.firstCall.calledWith('page.deleted').should.be.true();
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -948,7 +948,7 @@ describe('Post Model', function () {
                     // Double check we can't find any related tags
                     return ghostBookshelf.knex.select().table('posts_tags').where('post_id', firstItemData.id);
                 }).then(function (postsTags) {
-                    postsTags.should.be.empty;
+                    postsTags.should.be.empty();
 
                     done();
                 }).catch(done);

--- a/core/test/integration/model/model_roles_spec.js
+++ b/core/test/integration/model/model_roles_spec.js
@@ -78,7 +78,7 @@ describe('Role Model', function () {
 
             return RoleModel.destroy(firstRole);
         }).then(function (response) {
-            response.toJSON().should.be.empty;
+            response.toJSON().should.be.empty();
             return RoleModel.findOne(firstRole);
         }).then(function (newResults) {
             should.equal(newResults, null);

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -80,9 +80,9 @@ describe('Settings Model', function () {
                 edited.attributes.key.should.equal('description');
                 edited.attributes.value.should.equal('new value');
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.firstCall.calledWith('settings.edited').should.be.true;
-                eventSpy.secondCall.calledWith('settings.description.edited').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.firstCall.calledWith('settings.edited').should.be.true();
+                eventSpy.secondCall.calledWith('settings.description.edited').should.be.true();
 
                 done();
             }).catch(done);
@@ -122,11 +122,11 @@ describe('Settings Model', function () {
                 // We can't rely on the order of updates.
                 // We can however expect the first and third call to
                 // to be `settings.edited`.
-                eventSpy.firstCall.calledWith('settings.edited').should.be.true;
-                eventSpy.thirdCall.calledWith('settings.edited').should.be.true;
+                eventSpy.firstCall.calledWith('settings.edited').should.be.true();
+                eventSpy.thirdCall.calledWith('settings.edited').should.be.true();
 
-                eventSpy.calledWith('settings.description.edited').should.be.true;
-                eventSpy.calledWith('settings.title.edited').should.be.true;
+                eventSpy.calledWith('settings.description.edited').should.be.true();
+                eventSpy.calledWith('settings.title.edited').should.be.true();
 
                 done();
             }).catch(done);
@@ -145,9 +145,9 @@ describe('Settings Model', function () {
                 createdSetting.attributes.value.should.equal(newSetting.value, 'value is correct');
                 createdSetting.attributes.type.should.equal('core');
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.firstCall.calledWith('settings.added').should.be.true;
-                eventSpy.secondCall.calledWith('settings.TestSetting1.added').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.firstCall.calledWith('settings.added').should.be.true();
+                eventSpy.secondCall.calledWith('settings.TestSetting1.added').should.be.true();
 
                 done();
             }).catch(done);
@@ -163,7 +163,7 @@ describe('Settings Model', function () {
 
                 return SettingsModel.destroy(settingToDestroy);
             }).then(function (response) {
-                response.toJSON().should.be.empty;
+                response.toJSON().should.be.empty();
 
                 return SettingsModel.findOne(settingToDestroy);
             }).then(function (newResults) {

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -149,7 +149,7 @@ describe('Tag Model', function () {
         it('should create the test data correctly', function () {
             // creates two test tags
             should.exist(tagJSON);
-            tagJSON.should.be.an.Array.with.lengthOf(3);
+            tagJSON.should.be.an.Array().with.lengthOf(3);
             tagJSON.should.have.enumerable(0).with.property('name', 'existing tag a');
             tagJSON.should.have.enumerable(1).with.property('name', 'existing-tag-b');
             tagJSON.should.have.enumerable(2).with.property('name', 'existing_tag_c');
@@ -358,7 +358,7 @@ describe('Tag Model', function () {
         it('should create the test data correctly', function () {
             // creates a test tag
             should.exist(tagJSON);
-            tagJSON.should.be.an.Array.with.lengthOf(3);
+            tagJSON.should.be.an.Array().with.lengthOf(3);
             tagJSON.should.have.enumerable(0).with.property('name', 'existing tag a');
             tagJSON.should.have.enumerable(1).with.property('name', 'existing-tag-b');
             tagJSON.should.have.enumerable(2).with.property('name', 'existing_tag_c');
@@ -367,7 +367,7 @@ describe('Tag Model', function () {
             should.exist(postJSON);
             postJSON.title.should.eql('HTML Ipsum');
             should.exist(postJSON.tags);
-            postJSON.tags.should.be.an.Array.and.have.lengthOf(3);
+            postJSON.tags.should.be.an.Array().and.have.lengthOf(3);
             postJSON.tags.should.have.enumerable(0).with.property('name', 'tag1');
             postJSON.tags.should.have.enumerable(1).with.property('name', 'tag2');
             postJSON.tags.should.have.enumerable(2).with.property('name', 'tag3');

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -287,7 +287,7 @@ describe('User Model', function run() {
                 .then(function (paginationResult) {
                     should.exist(paginationResult.meta);
 
-                    paginationResult.meta.pagination.page.should.be.a.Number;
+                    paginationResult.meta.pagination.page.should.be.a.Number();
 
                     done();
                 }).catch(done);
@@ -346,8 +346,8 @@ describe('User Model', function run() {
                 createdUser.attributes.password.should.not.equal(userData.password, 'password was hashed');
                 createdUser.attributes.email.should.eql(userData.email, 'email address correct');
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.firstCall.calledWith('user.added').should.be.true;
+                eventSpy.calledOnce.should.be.true();
+                eventSpy.firstCall.calledWith('user.added').should.be.true();
 
                 done();
             }).catch(done);
@@ -371,9 +371,9 @@ describe('User Model', function run() {
                 createdUser.get('email').should.eql(userData.email, 'email address correct');
                 createdUser.related('roles').toJSON()[0].name.should.eql('Administrator', 'role set correctly');
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.firstCall.calledWith('user.added').should.be.true;
-                eventSpy.secondCall.calledWith('user.activated').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.firstCall.calledWith('user.added').should.be.true();
+                eventSpy.secondCall.calledWith('user.activated').should.be.true();
 
                 done();
             }).catch(done);
@@ -394,9 +394,9 @@ describe('User Model', function run() {
                 should.exist(edited);
                 edited.attributes.website.should.equal('http://some.newurl.com');
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.firstCall.calledWith('user.activated.edited').should.be.true;
-                eventSpy.secondCall.calledWith('user.edited').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.firstCall.calledWith('user.activated.edited').should.be.true();
+                eventSpy.secondCall.calledWith('user.edited').should.be.true();
 
                 done();
             }).catch(done);
@@ -419,15 +419,15 @@ describe('User Model', function run() {
 
                 userId = createdUser.attributes.id;
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.firstCall.calledWith('user.added').should.be.true;
+                eventSpy.calledOnce.should.be.true();
+                eventSpy.firstCall.calledWith('user.added').should.be.true();
 
                 return UserModel.edit({website: 'http://some.newurl.com'}, {id: userId});
             }).then(function (createdUser) {
                 createdUser.attributes.status.should.equal('invited');
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.secondCall.calledWith('user.edited').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.secondCall.calledWith('user.edited').should.be.true();
                 done();
             }).catch(done);
         });
@@ -449,16 +449,16 @@ describe('User Model', function run() {
 
                 userId = createdUser.attributes.id;
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.firstCall.calledWith('user.added').should.be.true;
+                eventSpy.calledOnce.should.be.true();
+                eventSpy.firstCall.calledWith('user.added').should.be.true();
 
                 return UserModel.edit({status: 'active'}, {id: userId});
             }).then(function (createdUser) {
                 createdUser.attributes.status.should.equal('active');
 
-                eventSpy.calledThrice.should.be.true;
-                eventSpy.secondCall.calledWith('user.activated').should.be.true;
-                eventSpy.thirdCall.calledWith('user.edited').should.be.true;
+                eventSpy.calledThrice.should.be.true();
+                eventSpy.secondCall.calledWith('user.activated').should.be.true();
+                eventSpy.thirdCall.calledWith('user.edited').should.be.true();
                 done();
             }).catch(done);
         });
@@ -476,11 +476,11 @@ describe('User Model', function run() {
                 // Destroy the user
                 return UserModel.destroy(firstUser);
             }).then(function (response) {
-                response.toJSON().should.be.empty;
+                response.toJSON().should.be.empty();
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.firstCall.calledWith('user.deactivated').should.be.true;
-                eventSpy.secondCall.calledWith('user.deleted').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.firstCall.calledWith('user.deactivated').should.be.true();
+                eventSpy.secondCall.calledWith('user.deleted').should.be.true();
 
                 // Double check we can't find the user again
                 return UserModel.findOne(firstUser);
@@ -508,16 +508,16 @@ describe('User Model', function run() {
 
                 userId = {id: createdUser.attributes.id};
 
-                eventSpy.calledOnce.should.be.true;
-                eventSpy.firstCall.calledWith('user.added').should.be.true;
+                eventSpy.calledOnce.should.be.true();
+                eventSpy.firstCall.calledWith('user.added').should.be.true();
 
                 // Destroy the user
                 return UserModel.destroy(userId);
             }).then(function (response) {
-                response.toJSON().should.be.empty;
+                response.toJSON().should.be.empty();
 
-                eventSpy.calledTwice.should.be.true;
-                eventSpy.secondCall.calledWith('user.deleted').should.be.true;
+                eventSpy.calledTwice.should.be.true();
+                eventSpy.secondCall.calledWith('user.deleted').should.be.true();
 
                 // Double check we can't find the user again
                 return UserModel.findOne(userId);

--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -33,15 +33,15 @@ describe('Update Check', function () {
             data.node_version.should.equal(process.versions.node);
             data.env.should.equal(process.env.NODE_ENV);
             data.database_type.should.match(/sqlite3|pg|mysql/);
-            data.blog_id.should.be.a.string;
-            data.blog_id.should.not.be.empty;
+            data.blog_id.should.be.a.String();
+            data.blog_id.should.not.be.empty();
             data.theme.should.be.equal('casper');
-            data.apps.should.be.a.string;
-            data.blog_created_at.should.be.a.number;
+            data.apps.should.be.a.String();
+            data.blog_created_at.should.be.a.Number();
             data.user_count.should.be.above(0);
             data.post_count.should.be.above(0);
-            data.npm_version.should.be.a.string;
-            data.npm_version.should.not.be.empty;
+            data.npm_version.should.be.a.String();
+            data.npm_version.should.not.be.empty();
 
             done();
         }).catch(done);

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -73,8 +73,8 @@ describe('API Utils', function () {
                 checkObjectStub = sandbox.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
 
             apiUtils.validate('test')(object, {}).then(function (options) {
-                checkObjectStub.calledOnce.should.be.true;
-                checkObjectStub.calledWith(object, 'test').should.be.true;
+                checkObjectStub.calledOnce.should.be.true();
+                checkObjectStub.calledWith(object, 'test').should.be.true();
                 options.should.have.ownProperty('data');
                 options.data.should.have.ownProperty('test');
                 done();
@@ -93,8 +93,8 @@ describe('API Utils', function () {
                 checkObjectStub = sandbox.stub(apiUtils, 'checkObject').returns(Promise.resolve(object));
 
             apiUtils.validate('test')(object, undefined).then(function (options) {
-                checkObjectStub.calledOnce.should.be.true;
-                checkObjectStub.calledWith(object, 'test').should.be.true;
+                checkObjectStub.calledOnce.should.be.true();
+                checkObjectStub.calledWith(object, 'test').should.be.true();
                 options.should.have.ownProperty('data');
                 options.data.should.have.ownProperty('test');
                 done();
@@ -184,7 +184,7 @@ describe('API Utils', function () {
                 options[key] = value;
 
                 errors = apiUtils.validateOptions(options);
-                errors.should.be.an.Array.and.have.lengthOf(1);
+                errors.should.be.an.Array().and.have.lengthOf(1);
                 errors.should.have.enumerable('0').with.property('errorType', 'ValidationError');
             });
         }
@@ -256,7 +256,7 @@ describe('API Utils', function () {
         it('should not call prepareInclude if there is no include option', function () {
             var prepareIncludeStub = sandbox.stub(apiUtils, 'prepareInclude');
             apiUtils.convertOptions(['a', 'b', 'c'])({}).should.eql({});
-            prepareIncludeStub.called.should.be.false;
+            prepareIncludeStub.called.should.be.false();
         });
 
         it('should pass options.include to prepareInclude if provided', function () {
@@ -267,11 +267,11 @@ describe('API Utils', function () {
                 actualResult;
             actualResult = apiUtils.convertOptions(allowed)(_.clone(options));
 
-            prepareIncludeStub.calledOnce.should.be.true;
-            prepareIncludeStub.calledWith(options.include, allowed).should.be.true;
+            prepareIncludeStub.calledOnce.should.be.true();
+            prepareIncludeStub.calledWith(options.include, allowed).should.be.true();
 
             actualResult.should.have.hasOwnProperty('include');
-            actualResult.include.should.be.an.Array;
+            actualResult.include.should.be.an.Array();
             actualResult.include.should.eql(expectedResult);
         });
     });
@@ -323,7 +323,7 @@ describe('API Utils', function () {
                 should.exist(data);
                 data.should.have.ownProperty('posts');
                 data.should.not.eql(object);
-                data.posts.should.be.an.Array;
+                data.posts.should.be.an.Array();
                 data.posts[0].should.have.ownProperty('author_id');
                 data.posts[0].should.not.have.ownProperty('author');
                 done();
@@ -336,7 +336,7 @@ describe('API Utils', function () {
                 should.exist(data);
                 data.should.have.ownProperty('posts');
                 data.should.eql(object);
-                data.posts.should.be.an.Array;
+                data.posts.should.be.an.Array();
                 data.posts[0].should.have.ownProperty('author_id');
                 data.posts[0].should.not.have.ownProperty('author');
                 done();
@@ -375,40 +375,40 @@ describe('API Utils', function () {
 
     describe('checkFileExists', function () {
         it('should return true if file exists in input', function () {
-            apiUtils.checkFileExists({test: {type: 'file', path: 'path'}}, 'test').should.be.true;
+            apiUtils.checkFileExists({test: {type: 'file', path: 'path'}}, 'test').should.be.true();
         });
 
         it('should return false if file does not exist in input', function () {
-            apiUtils.checkFileExists({test: {type: 'file', path: 'path'}}, 'notthere').should.be.false;
+            apiUtils.checkFileExists({test: {type: 'file', path: 'path'}}, 'notthere').should.be.false();
         });
 
         it('should return false if file is incorrectly structured', function () {
-            apiUtils.checkFileExists({test: 'notafile'}, 'test').should.be.false;
+            apiUtils.checkFileExists({test: 'notafile'}, 'test').should.be.false();
         });
     });
 
     describe('checkFileIsValid', function () {
         it('returns true if file has valid extension and type', function () {
-            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['text'], ['.txt']).should.be.true;
-            apiUtils.checkFileIsValid({name: 'test.jpg', type: 'jpeg'}, ['text', 'jpeg'], ['.txt', '.jpg']).should.be.true;
+            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['text'], ['.txt']).should.be.true();
+            apiUtils.checkFileIsValid({name: 'test.jpg', type: 'jpeg'}, ['text', 'jpeg'], ['.txt', '.jpg']).should.be.true();
         });
 
         it('returns false if file has invalid extension', function () {
-            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['text'], ['.tar']).should.be.false;
-            apiUtils.checkFileIsValid({name: 'test', type: 'text'}, ['text'], ['.txt']).should.be.false;
+            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['text'], ['.tar']).should.be.false();
+            apiUtils.checkFileIsValid({name: 'test', type: 'text'}, ['text'], ['.txt']).should.be.false();
         });
 
         it('returns false if file has invalid type', function () {
-            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['archive'], ['.txt']).should.be.false;
+            apiUtils.checkFileIsValid({name: 'test.txt', type: 'text'}, ['archive'], ['.txt']).should.be.false();
         });
     });
 
     describe('isPublicContext', function () {
         it('should call out to permissions', function () {
             var permsStub = sandbox.stub(permissions, 'parseContext').returns({public: true});
-            apiUtils.detectPublicContext({context: 'test'}).should.be.true;
-            permsStub.called.should.be.true;
-            permsStub.calledWith('test').should.be.true;
+            apiUtils.detectPublicContext({context: 'test'}).should.be.true();
+            permsStub.called.should.be.true();
+            permsStub.calledWith('test').should.be.true();
         });
     });
 
@@ -416,8 +416,8 @@ describe('API Utils', function () {
         it('should call out to permissions', function () {
             var permsStub = sandbox.stub(permissions, 'applyPublicRules');
             apiUtils.applyPublicPermissions('test', {});
-            permsStub.called.should.be.true;
-            permsStub.calledWith('test', {}).should.be.true;
+            permsStub.called.should.be.true();
+            permsStub.calledWith('test', {}).should.be.true();
         });
     });
 

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -565,9 +565,9 @@ describe('Config', function () {
                 validateStub = sandbox.stub(config, 'validate').returns(Promise.resolve());
 
             config.load().then(function () {
-                existsStub.calledOnce.should.be.true;
-                writeFileStub.calledOnce.should.be.true;
-                validateStub.calledOnce.should.be.true;
+                existsStub.calledOnce.should.be.true();
+                writeFileStub.calledOnce.should.be.true();
+                validateStub.calledOnce.should.be.true();
                 done();
             }).catch(done);
         });
@@ -608,7 +608,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -621,7 +621,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -634,7 +634,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -647,7 +647,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -660,7 +660,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -673,7 +673,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -686,7 +686,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -699,7 +699,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -713,7 +713,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -727,7 +727,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -741,7 +741,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -753,7 +753,7 @@ describe('Config', function () {
             config.load().then(function () {
                 var socketConfig = config.getSocket();
 
-                socketConfig.should.be.an.Object;
+                socketConfig.should.be.an.Object();
                 socketConfig.path.should.equal('test');
                 socketConfig.permissions.should.equal('660');
 
@@ -774,7 +774,7 @@ describe('Config', function () {
             config.load().then(function () {
                 var socketConfig = config.getSocket();
 
-                socketConfig.should.be.an.Object;
+                socketConfig.should.be.an.Object();
                 socketConfig.path.should.equal('test');
                 socketConfig.permissions.should.equal('666');
 
@@ -801,7 +801,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -814,7 +814,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -827,7 +827,7 @@ describe('Config', function () {
                 done(expectedError);
             }).catch(function (err) {
                 should.exist(err);
-                err.should.be.an.Error;
+                err.should.be.an.Error();
 
                 done();
             }).catch(done);
@@ -854,7 +854,7 @@ describe('Config', function () {
 
         it('doesn\'t display warning when deprecated options not set', function () {
             configUtils.config.checkDeprecated();
-            logStub.calledOnce.should.be.false;
+            logStub.calledOnce.should.be.false();
         });
 
         it('displays warning when updateCheck exists and is truthy', function () {
@@ -864,9 +864,9 @@ describe('Config', function () {
             // Run the test code
             configUtils.config.checkDeprecated();
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
 
-            logStub.calledWithMatch('updateCheck').should.be.true;
+            logStub.calledWithMatch('updateCheck').should.be.true();
         });
 
         it('displays warning when updateCheck exists and is falsy', function () {
@@ -876,9 +876,9 @@ describe('Config', function () {
             // Run the test code
             configUtils.config.checkDeprecated();
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
 
-            logStub.calledWithMatch('updateCheck').should.be.true;
+            logStub.calledWithMatch('updateCheck').should.be.true();
         });
 
         it('displays warning when mail.fromaddress exists and is truthy', function () {
@@ -890,9 +890,9 @@ describe('Config', function () {
             // Run the test code
             configUtils.config.checkDeprecated();
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
 
-            logStub.calledWithMatch('mail.fromaddress').should.be.true;
+            logStub.calledWithMatch('mail.fromaddress').should.be.true();
         });
 
         it('displays warning when mail.fromaddress exists and is falsy', function () {
@@ -904,9 +904,9 @@ describe('Config', function () {
             // Run the test code
             configUtils.config.checkDeprecated();
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
 
-            logStub.calledWithMatch('mail.fromaddress').should.be.true;
+            logStub.calledWithMatch('mail.fromaddress').should.be.true();
         });
 
         it('doesn\'t display warning when only part of a deprecated option is set', function () {
@@ -917,7 +917,7 @@ describe('Config', function () {
             });
 
             configUtils.config.checkDeprecated();
-            logStub.calledOnce.should.be.false;
+            logStub.calledOnce.should.be.false();
         });
 
         it('can not modify the deprecatedItems on the config object', function () {

--- a/core/test/unit/controllers/frontend/context_spec.js
+++ b/core/test/unit/controllers/frontend/context_spec.js
@@ -26,7 +26,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(0);
+            res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
 
         it('should return empty array with no error with basic parameters', function () {
@@ -34,7 +34,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(0);
+            res.locals.context.should.be.an.Array().with.lengthOf(0);
         });
     });
 
@@ -46,7 +46,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('home');
             res.locals.context[1].should.eql('index');
         });
@@ -58,7 +58,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('home');
             res.locals.context[1].should.eql('index');
         });
@@ -70,7 +70,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('index');
         });
 
@@ -82,7 +82,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('paged');
             res.locals.context[1].should.eql('index');
         });
@@ -96,7 +96,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('rss');
         });
 
@@ -107,7 +107,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('rss');
         });
 
@@ -119,7 +119,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('paged');
             res.locals.context[1].should.eql('rss');
         });
@@ -133,7 +133,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('tag');
         });
 
@@ -144,7 +144,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('post');
         });
 
@@ -155,7 +155,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('tag');
         });
 
@@ -167,7 +167,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('paged');
             res.locals.context[1].should.eql('tag');
         });
@@ -181,7 +181,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('author');
         });
 
@@ -192,7 +192,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('post');
         });
 
@@ -203,7 +203,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('author');
         });
 
@@ -215,7 +215,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(2);
+            res.locals.context.should.be.an.Array().with.lengthOf(2);
             res.locals.context[0].should.eql('paged');
             res.locals.context[1].should.eql('author');
         });
@@ -229,7 +229,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('post');
         });
 
@@ -241,7 +241,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('page');
         });
     });
@@ -254,7 +254,7 @@ describe('Contexts', function () {
             setResponseContext(req, res, data);
 
             should.exist(res.locals.context);
-            res.locals.context.should.be.an.Array.with.lengthOf(1);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('private');
         });
     });

--- a/core/test/unit/controllers/frontend/error_spec.js
+++ b/core/test/unit/controllers/frontend/error_spec.js
@@ -26,8 +26,8 @@ describe('handleError', function () {
         var notFoundError = new errors.NotFoundError('Something wasn\'t found');
         handleError(next)(notFoundError);
 
-        next.calledOnce.should.be.true;
-        next.firstCall.args.should.be.empty;
+        next.calledOnce.should.be.true();
+        next.firstCall.args.should.be.empty();
     });
 
     it('should call next with error for other errors', function () {
@@ -35,9 +35,9 @@ describe('handleError', function () {
 
         handleError(next)(otherError);
 
-        next.calledOnce.should.be.true;
+        next.calledOnce.should.be.true();
         next.firstCall.args.should.have.lengthOf(1);
-        next.firstCall.args[0].should.be.an.Object;
+        next.firstCall.args[0].should.be.an.Object();
         next.firstCall.args[0].should.be.instanceof(Error);
     });
 });

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -39,11 +39,11 @@ describe('fetchData', function () {
         it('should handle no post options', function (done) {
             fetchData({}).then(function (result) {
                 should.exist(result);
-                result.should.be.an.Object.with.properties('posts', 'meta');
+                result.should.be.an.Object().with.properties('posts', 'meta');
                 result.should.not.have.property('data');
 
-                apiPostsStub.calledOnce.should.be.true;
-                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.calledOnce.should.be.true();
+                apiPostsStub.firstCall.args[0].should.be.an.Object();
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
 
@@ -54,11 +54,11 @@ describe('fetchData', function () {
         it('should handle post options with only page', function (done) {
             fetchData({postOptions: {page: 2}}).then(function (result) {
                 should.exist(result);
-                result.should.be.an.Object.with.properties('posts', 'meta');
+                result.should.be.an.Object().with.properties('posts', 'meta');
                 result.should.not.have.property('data');
 
-                apiPostsStub.calledOnce.should.be.true;
-                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.calledOnce.should.be.true();
+                apiPostsStub.firstCall.args[0].should.be.an.Object();
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.firstCall.args[0].should.have.property('page', 2);
@@ -79,12 +79,12 @@ describe('fetchData', function () {
             };
             fetchData(channelOpts).then(function (result) {
                 should.exist(result);
-                result.should.be.an.Object.with.properties('posts', 'meta', 'data');
-                result.data.should.be.an.Object.with.properties('featured');
-                result.data.featured.should.be.an.Object.with.properties('posts', 'meta');
+                result.should.be.an.Object().with.properties('posts', 'meta', 'data');
+                result.data.should.be.an.Object().with.properties('featured');
+                result.data.featured.should.be.an.Object().with.properties('posts', 'meta');
                 result.data.featured.should.not.have.properties('data');
 
-                apiPostsStub.calledTwice.should.be.true;
+                apiPostsStub.calledTwice.should.be.true();
                 apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');
@@ -107,12 +107,12 @@ describe('fetchData', function () {
             fetchData(channelOpts).then(function (result) {
                 should.exist(result);
 
-                result.should.be.an.Object.with.properties('posts', 'meta', 'data');
-                result.data.should.be.an.Object.with.properties('featured');
-                result.data.featured.should.be.an.Object.with.properties('posts', 'meta');
+                result.should.be.an.Object().with.properties('posts', 'meta', 'data');
+                result.data.should.be.an.Object().with.properties('featured');
+                result.data.featured.should.be.an.Object().with.properties('posts', 'meta');
                 result.data.featured.should.not.have.properties('data');
 
-                apiPostsStub.calledTwice.should.be.true;
+                apiPostsStub.calledTwice.should.be.true();
                 apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.firstCall.args[0].should.have.property('page', 2);
@@ -139,10 +139,10 @@ describe('fetchData', function () {
 
             fetchData(channelOpts).then(function (result) {
                 should.exist(result);
-                result.should.be.an.Object.with.properties('posts', 'meta', 'data');
-                result.data.should.be.an.Object.with.properties('tag');
+                result.should.be.an.Object().with.properties('posts', 'meta', 'data');
+                result.data.should.be.an.Object().with.properties('tag');
 
-                apiPostsStub.calledOnce.should.be.true;
+                apiPostsStub.calledOnce.should.be.true();
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiTagStub.firstCall.args[0].should.have.property('slug', 'testing');
@@ -158,8 +158,8 @@ describe('fetchData', function () {
 
         it('Adds limit & includes to options by default', function (done) {
             fetchData({}).then(function () {
-                apiPostsStub.calledOnce.should.be.true;
-                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.calledOnce.should.be.true();
+                apiPostsStub.firstCall.args[0].should.be.an.Object();
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 done();
@@ -174,8 +174,8 @@ describe('fetchData', function () {
 
         it('Will not add limit if postsPerPage is not valid', function (done) {
             fetchData({}).then(function () {
-                apiPostsStub.calledOnce.should.be.true;
-                apiPostsStub.firstCall.args[0].should.be.an.Object;
+                apiPostsStub.calledOnce.should.be.true();
+                apiPostsStub.firstCall.args[0].should.be.an.Object();
                 apiPostsStub.firstCall.args[0].should.have.property('include');
                 apiPostsStub.firstCall.args[0].should.not.have.property('limit');
 

--- a/core/test/unit/controllers/frontend/format-response_spec.js
+++ b/core/test/unit/controllers/frontend/format-response_spec.js
@@ -15,7 +15,7 @@ describe('formatResponse', function () {
 
             formatted = formatResponse.single(postObject);
 
-            formatted.should.be.an.Object.with.property('post');
+            formatted.should.be.an.Object().with.property('post');
             formatted.post.should.eql(postObject);
         });
     });
@@ -30,7 +30,7 @@ describe('formatResponse', function () {
 
             formatted = formatResponse.channel(data);
 
-            formatted.should.be.an.Object.with.properties('posts', 'pagination');
+            formatted.should.be.an.Object().with.properties('posts', 'pagination');
             formatted.posts.should.eql(data.posts);
             formatted.pagination.should.eql(data.meta.pagination);
         });
@@ -45,7 +45,7 @@ describe('formatResponse', function () {
 
             formatted = formatResponse.channel(data);
 
-            formatted.should.be.an.Object.with.properties('posts', 'pagination', 'tag');
+            formatted.should.be.an.Object().with.properties('posts', 'pagination', 'tag');
             formatted.tag.should.eql(data.data.tag[0]);
         });
 
@@ -64,8 +64,8 @@ describe('formatResponse', function () {
 
             formatted = formatResponse.channel(data);
 
-            formatted.should.be.an.Object.with.properties('posts', 'pagination', 'featured');
-            formatted.featured.should.be.an.Object.with.properties('posts', 'pagination');
+            formatted.should.be.an.Object().with.properties('posts', 'pagination', 'featured');
+            formatted.featured.should.be.an.Object().with.properties('posts', 'pagination');
         });
     });
 });

--- a/core/test/unit/controllers/frontend/index_spec.js
+++ b/core/test/unit/controllers/frontend/index_spec.js
@@ -376,7 +376,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -385,7 +385,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[0].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -393,7 +393,7 @@ describe('Frontend Controller', function () {
                 it('will redirect static page to admin edit page via /:slug/edit', function (done) {
                     req.path = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[0].posts[0].id + '/');
                         done();
                     };
@@ -405,8 +405,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -415,8 +415,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -450,7 +450,7 @@ describe('Frontend Controller', function () {
                     res.render = sinon.spy();
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -459,7 +459,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
                     res.render = sinon.spy();
                     res.redirect = function (arg) {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[0].posts[0].id + '/');
                         done();
                     };
@@ -473,8 +473,8 @@ describe('Frontend Controller', function () {
                     res.redirect = sinon.spy();
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -500,7 +500,7 @@ describe('Frontend Controller', function () {
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('post');
-                        context.post.should.exist;
+                        should.exist(context.post);
                         context.post.should.equal(mockPosts[1].posts[0]);
                         done();
                     };
@@ -512,7 +512,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['2012/12/30', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -521,7 +521,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -530,7 +530,7 @@ describe('Frontend Controller', function () {
                 it('will redirect post to admin edit page via /:slug/edit', function (done) {
                     req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
                         done();
                     };
@@ -542,8 +542,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['2012/12/30', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -552,8 +552,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -567,8 +567,8 @@ describe('Frontend Controller', function () {
                         }
 
                         should.not.exist(err);
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -594,7 +594,7 @@ describe('Frontend Controller', function () {
 
                     res.render = function (view, context) {
                         view.should.equal('post');
-                        context.post.should.exist;
+                        should.exist(context.post);
                         context.post.should.equal(mockPosts[1].posts[0]);
                         done();
                     };
@@ -607,7 +607,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -616,7 +616,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + mockPosts[1].posts[0].slug + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -625,7 +625,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -635,7 +635,7 @@ describe('Frontend Controller', function () {
                     var dateFormat = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
                     req.path = '/' + [dateFormat, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
                         done();
                     };
@@ -647,8 +647,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -657,8 +657,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -696,7 +696,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -705,7 +705,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test-2', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -714,7 +714,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + mockPosts[1].posts[0].slug + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -724,7 +724,7 @@ describe('Frontend Controller', function () {
                     req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     res.redirect = function (arg) {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
                         done();
                     };
@@ -737,8 +737,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [date, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -747,8 +747,8 @@ describe('Frontend Controller', function () {
                     req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -798,7 +798,7 @@ describe('Frontend Controller', function () {
                         };
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -814,7 +814,7 @@ describe('Frontend Controller', function () {
                         };
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -829,7 +829,7 @@ describe('Frontend Controller', function () {
                         };
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
+                        res.render.called.should.be.false();
                         done();
                     });
                 });
@@ -844,7 +844,7 @@ describe('Frontend Controller', function () {
                             locals: {},
                             render: sinon.spy(),
                             redirect: function (arg) {
-                                res.render.called.should.be.false;
+                                res.render.called.should.be.false();
                                 arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
                                 done();
                             }
@@ -864,8 +864,8 @@ describe('Frontend Controller', function () {
                         };
 
                     frontend.single(req, res, function () {
-                        res.render.called.should.be.false;
-                        res.redirect.called.should.be.false;
+                        res.render.called.should.be.false();
+                        res.redirect.called.should.be.false();
                         done();
                     });
                 });
@@ -893,7 +893,7 @@ describe('Frontend Controller', function () {
                             locals: {},
                             render: sinon.spy(),
                             redirect: function (arg) {
-                                res.render.called.should.be.false;
+                                res.render.called.should.be.false();
                                 arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
                                 done();
                             }
@@ -1080,8 +1080,8 @@ describe('Frontend Controller', function () {
 
             frontend.preview(req, res, function (err) {
                 should.not.exist(err);
-                res.render.called.should.be.false;
-                res.redirect.called.should.be.false;
+                res.render.called.should.be.false();
+                res.redirect.called.should.be.false();
                 done();
             });
         });
@@ -1089,7 +1089,7 @@ describe('Frontend Controller', function () {
         it('should call redirect if post is published', function (done) {
             req.params = {uuid: 'abc-1234-03'};
             res.redirect = function (status, url) {
-                res.render.called.should.be.false;
+                res.render.called.should.be.false();
                 status.should.eql(301);
                 url.should.eql('/getting-started/');
                 done();

--- a/core/test/unit/controllers/frontend/templates_spec.js
+++ b/core/test/unit/controllers/frontend/templates_spec.js
@@ -75,7 +75,7 @@ describe('templates', function () {
                     page: 0,
                     slug: 'test-post'
                 });
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('post');
             });
 
@@ -84,7 +84,7 @@ describe('templates', function () {
                     page: 0,
                     slug: 'welcome-to-ghost'
                 });
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('post-welcome-to-ghost', 'post');
             });
 
@@ -93,7 +93,7 @@ describe('templates', function () {
                     page: 1,
                     slug: 'contact'
                 });
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('page');
             });
 
@@ -102,7 +102,7 @@ describe('templates', function () {
                     page: 1,
                     slug: 'about'
                 });
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('page-about');
             });
         });
@@ -114,7 +114,7 @@ describe('templates', function () {
             }}}});
 
             var view = templates.single('casper', {page: 1});
-            view.should.exist;
+            should.exist(view);
             view.should.eql('post');
         });
     });
@@ -131,7 +131,7 @@ describe('templates', function () {
 
             it('will return correct view for a tag', function () {
                 var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('index');
             });
         });
@@ -149,13 +149,13 @@ describe('templates', function () {
 
             it('will return correct view for a tag', function () {
                 var view = templates.channel('casper', {name: 'tag', slugParam: 'design', slugTemplate: true});
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('tag-design');
             });
 
             it('will return correct view for a tag', function () {
                 var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
-                view.should.exist;
+                should.exist(view);
                 view.should.eql('tag');
             });
         });
@@ -167,7 +167,7 @@ describe('templates', function () {
             }}}});
 
             var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
-            view.should.exist;
+            should.exist(view);
             view.should.eql('index');
         });
     });

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -67,7 +67,7 @@ describe('Error handling', function () {
         it('logs default warn with no message supplied', function () {
             errors.logWarn();
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.yellow('\nWarning: no message supplied'), '\n');
 
@@ -80,7 +80,7 @@ describe('Error handling', function () {
 
             errors.logWarn(errorText);
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(chalk.yellow('\nWarning: ' + errorText), '\n');
 
             // Future tests: This is important here!
@@ -93,7 +93,7 @@ describe('Error handling', function () {
 
             errors.logWarn(errorText, contextText);
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.yellow('\nWarning: ' + errorText), '\n', chalk.white(contextText), '\n'
             );
@@ -109,7 +109,7 @@ describe('Error handling', function () {
 
             errors.logWarn(errorText, contextText, helpText);
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.yellow('\nWarning: ' + errorText), '\n', chalk.white(contextText), '\n', chalk.green(helpText), '\n'
             );
@@ -140,8 +140,8 @@ describe('Error handling', function () {
             errors.logError(err);
 
             // Calls log with message on Error objects
-            logStub.calledOnce.should.be.true;
-            logStub.calledWith(chalk.red('\nERROR:',  err.message), '\n', '\n', err.stack, '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.calledWith(chalk.red('\nERROR:',  err.message), '\n', '\n', err.stack, '\n').should.be.true();
         });
 
         it('logs errors from strings', function () {
@@ -150,8 +150,8 @@ describe('Error handling', function () {
             errors.logError(err);
 
             // Calls log with string on strings
-            logStub.calledOnce.should.be.true;
-            logStub.calledWith(chalk.red('\nERROR:', err), '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.calledWith(chalk.red('\nERROR:', err), '\n').should.be.true();
         });
 
         it('logs errors from an error object and two string arguments', function () {
@@ -161,7 +161,7 @@ describe('Error handling', function () {
             errors.logError(err, message, message);
 
             // Calls log with message on Error objects
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.red('\nERROR:', err.message), '\n', chalk.white(message), '\n', chalk.green(message), '\n', err.stack, '\n'
             );
@@ -173,10 +173,10 @@ describe('Error handling', function () {
             errors.logError(message, message, message);
 
             // Calls log with message on Error objects
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.red('\nERROR:', message), '\n', chalk.white(message), '\n', chalk.green(message), '\n'
-            ).should.be.true;
+            ).should.be.true();
         });
 
         it('logs errors from an undefined error argument', function () {
@@ -186,10 +186,10 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.red('\nERROR:', 'An unknown error occurred.'), '\n', chalk.white(message), '\n', chalk.green(message), '\n'
-            ).should.be.true;
+            ).should.be.true();
         });
 
         it('logs errors from an undefined context argument', function () {
@@ -199,8 +199,8 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
-            logStub.calledWith(chalk.red('\nERROR:', message), '\n', chalk.green(message), '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.calledWith(chalk.red('\nERROR:', message), '\n', chalk.green(message), '\n').should.be.true();
         });
 
         it('logs errors from an undefined help argument', function () {
@@ -210,8 +210,8 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
-            logStub.calledWith(chalk.red('\nERROR:', message), '\n', chalk.white(message), '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.calledWith(chalk.red('\nERROR:', message), '\n', chalk.white(message), '\n').should.be.true();
         });
 
         it('logs errors from a null error argument', function () {
@@ -221,10 +221,10 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
+            logStub.calledOnce.should.be.true();
             logStub.calledWith(
                 chalk.red('\nERROR:', 'An unknown error occurred.'), '\n', chalk.white(message), '\n', chalk.green(message), '\n'
-            ).should.be.true;
+            ).should.be.true();
         });
 
         it('logs errors from a null context argument', function () {
@@ -234,8 +234,8 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
-            logStub.firstCall.calledWith(chalk.red('\nERROR:', message), '\n', chalk.green(message), '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.firstCall.calledWith(chalk.red('\nERROR:', message), '\n', chalk.green(message), '\n').should.be.true();
         });
 
         it('logs errors from a null help argument', function () {
@@ -245,8 +245,8 @@ describe('Error handling', function () {
 
             // Calls log with message on Error objects
 
-            logStub.calledOnce.should.be.true;
-            logStub.firstCall.calledWith(chalk.red('\nERROR:', message), '\n', chalk.white(message), '\n').should.be.true;
+            logStub.calledOnce.should.be.true();
+            logStub.firstCall.calledWith(chalk.red('\nERROR:', message), '\n', chalk.white(message), '\n').should.be.true();
         });
 
         it('logs promise errors and redirects', function (done) {
@@ -300,12 +300,12 @@ describe('Error handling', function () {
 
             errors.handleAPIError(err, req, res, next);
 
-            next.called.should.be.false;
-            errors.logError.calledOnce.should.be.true;
-            errors.formatHttpErrors.calledOnce.should.be.true;
+            next.called.should.be.false();
+            errors.logError.calledOnce.should.be.true();
+            errors.formatHttpErrors.calledOnce.should.be.true();
 
-            res.status.calledWith(404).should.be.true;
-            res.json.calledOnce.should.be.true;
+            res.status.calledWith(404).should.be.true();
+            res.json.calledOnce.should.be.true();
             res.json.firstCall.args[0].errors[0].message.should.eql(msg);
             res.json.firstCall.args[0].errors[0].errorType.should.eql('NotFoundError');
         });

--- a/core/test/unit/importer_spec.js
+++ b/core/test/unit/importer_spec.js
@@ -99,8 +99,8 @@ describe('Importer', function () {
                     fileSpy = sandbox.stub(ImportManager, 'processFile').returns(Promise.resolve());
 
                 ImportManager.loadFile(testFile).then(function () {
-                    zipSpy.calledOnce.should.be.false;
-                    fileSpy.calledOnce.should.be.true;
+                    zipSpy.calledOnce.should.be.false();
+                    fileSpy.calledOnce.should.be.true();
                     done();
                 }).catch(done);
             });
@@ -112,8 +112,8 @@ describe('Importer', function () {
                     fileSpy = sandbox.stub(ImportManager, 'processFile').returns(Promise.resolve());
 
                 ImportManager.loadFile(testZip).then(function () {
-                    zipSpy.calledOnce.should.be.true;
-                    fileSpy.calledOnce.should.be.false;
+                    zipSpy.calledOnce.should.be.true();
+                    fileSpy.calledOnce.should.be.false();
                     done();
                 }).catch(done);
             });
@@ -135,16 +135,16 @@ describe('Importer', function () {
                 getFileSpy.withArgs(MarkdownHandler).returns([]);
 
                 ImportManager.processZip(testZip).then(function (zipResult) {
-                    extractSpy.calledOnce.should.be.true;
-                    validSpy.calledOnce.should.be.true;
-                    baseDirSpy.calledOnce.should.be.true;
-                    getFileSpy.calledThrice.should.be.true;
-                    jsonSpy.calledOnce.should.be.true;
-                    imageSpy.called.should.be.false;
-                    mdSpy.called.should.be.false;
+                    extractSpy.calledOnce.should.be.true();
+                    validSpy.calledOnce.should.be.true();
+                    baseDirSpy.calledOnce.should.be.true();
+                    getFileSpy.calledThrice.should.be.true();
+                    jsonSpy.calledOnce.should.be.true();
+                    imageSpy.called.should.be.false();
+                    mdSpy.called.should.be.false();
 
                     ImportManager.processFile(testFile, '.json').then(function (fileResult) {
-                        jsonSpy.calledTwice.should.be.true;
+                        jsonSpy.calledTwice.should.be.true();
 
                         // They should both have data keys, and they should be equivalent
                         zipResult.should.have.property('data');
@@ -159,19 +159,19 @@ describe('Importer', function () {
                 it('accepts a zip with a base directory', function () {
                     var testDir = path.resolve('core/test/utils/fixtures/import/zips/zip-with-base-dir');
 
-                    ImportManager.isValidZip(testDir).should.be.ok;
+                    ImportManager.isValidZip(testDir).should.be.ok();
                 });
 
                 it('accepts a zip without a base directory', function () {
                     var testDir = path.resolve('core/test/utils/fixtures/import/zips/zip-without-base-dir');
 
-                    ImportManager.isValidZip(testDir).should.be.ok;
+                    ImportManager.isValidZip(testDir).should.be.ok();
                 });
 
                 it('accepts a zip with an image directory', function () {
                     var testDir = path.resolve('core/test/utils/fixtures/import/zips/zip-image-dir');
 
-                    ImportManager.isValidZip(testDir).should.be.ok;
+                    ImportManager.isValidZip(testDir).should.be.ok();
                 });
 
                 it('fails a zip with two base directories', function () {
@@ -222,10 +222,10 @@ describe('Importer', function () {
                     imageSpy = sandbox.spy(ImageImporter, 'preProcess');
 
                 ImportManager.preProcess(inputCopy).then(function (output) {
-                    dataSpy.calledOnce.should.be.true;
-                    dataSpy.calledWith(inputCopy).should.be.true;
-                    imageSpy.calledOnce.should.be.true;
-                    imageSpy.calledWith(inputCopy).should.be.true;
+                    dataSpy.calledOnce.should.be.true();
+                    dataSpy.calledWith(inputCopy).should.be.true();
+                    imageSpy.calledOnce.should.be.true();
+                    imageSpy.calledWith(inputCopy).should.be.true();
                     // eql checks for equality
                     // equal checks the references are for the same object
                     output.should.not.equal(input);
@@ -258,8 +258,8 @@ describe('Importer', function () {
                 ImportManager.doImport(inputCopy).then(function (output) {
                     // eql checks for equality
                     // equal checks the references are for the same object
-                    dataSpy.calledOnce.should.be.true;
-                    imageSpy.calledOnce.should.be.true;
+                    dataSpy.calledOnce.should.be.true();
+                    imageSpy.calledOnce.should.be.true();
                     dataSpy.getCall(0).args[0].should.eql(expectedData);
                     imageSpy.getCall(0).args[0].should.eql(expectedImages);
 
@@ -292,11 +292,11 @@ describe('Importer', function () {
                     cleanupSpy = sandbox.stub(ImportManager, 'cleanUp').returns({});
 
                 ImportManager.importFromFile({}).then(function () {
-                    loadFileSpy.calledOnce.should.be.true;
-                    preProcessSpy.calledOnce.should.be.true;
-                    doImportSpy.calledOnce.should.be.true;
-                    generateReportSpy.calledOnce.should.be.true;
-                    cleanupSpy.calledOnce.should.be.true;
+                    loadFileSpy.calledOnce.should.be.true();
+                    preProcessSpy.calledOnce.should.be.true();
+                    doImportSpy.calledOnce.should.be.true();
+                    generateReportSpy.calledOnce.should.be.true();
+                    cleanupSpy.calledOnce.should.be.true();
                     sinon.assert.callOrder(loadFileSpy, preProcessSpy, doImportSpy, generateReportSpy, cleanupSpy);
 
                     done();
@@ -373,8 +373,8 @@ describe('Importer', function () {
                 storageSpy = sandbox.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true;
-                storeSpy.calledOnce.should.be.true;
+                storageSpy.calledOnce.should.be.true();
+                storeSpy.calledOnce.should.be.true();
                 storeSpy.firstCall.args[1].originalPath.should.equal('test-image.jpeg');
                 storeSpy.firstCall.args[1].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
                 storeSpy.firstCall.args[1].newPath.should.eql('/content/images/test-image.jpeg');
@@ -393,8 +393,8 @@ describe('Importer', function () {
                 storageSpy = sandbox.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true;
-                storeSpy.calledOnce.should.be.true;
+                storageSpy.calledOnce.should.be.true();
+                storeSpy.calledOnce.should.be.true();
                 storeSpy.firstCall.args[1].originalPath.should.equal('photos/my-cat.jpeg');
                 storeSpy.firstCall.args[1].targetDir.should.match(/(\/|\\)content(\/|\\)images(\/|\\)photos$/);
                 storeSpy.firstCall.args[1].newPath.should.eql('/content/images/photos/my-cat.jpeg');
@@ -413,8 +413,8 @@ describe('Importer', function () {
                 storageSpy = sandbox.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true;
-                storeSpy.calledOnce.should.be.true;
+                storageSpy.calledOnce.should.be.true();
+                storeSpy.calledOnce.should.be.true();
                 storeSpy.firstCall.args[1].originalPath.should.equal('content/images/my-cat.jpeg');
                 storeSpy.firstCall.args[1].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
                 storeSpy.firstCall.args[1].newPath.should.eql('/content/images/my-cat.jpeg');
@@ -435,8 +435,8 @@ describe('Importer', function () {
                 storageSpy = sandbox.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(file)).then(function () {
-                storageSpy.calledOnce.should.be.true;
-                storeSpy.calledOnce.should.be.true;
+                storageSpy.calledOnce.should.be.true();
+                storeSpy.calledOnce.should.be.true();
                 storeSpy.firstCall.args[1].originalPath.should.equal('test-image.jpeg');
                 storeSpy.firstCall.args[1].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
                 storeSpy.firstCall.args[1].newPath.should.eql('/subdir/content/images/test-image.jpeg');
@@ -466,7 +466,7 @@ describe('Importer', function () {
                 storageSpy = sandbox.spy(storage, 'getStorage');
 
             ImageHandler.loadFile(_.clone(files)).then(function () {
-                storageSpy.calledOnce.should.be.true;
+                storageSpy.calledOnce.should.be.true();
                 storeSpy.callCount.should.eql(4);
                 storeSpy.firstCall.args[1].originalPath.should.equal('testing.png');
                 storeSpy.firstCall.args[1].targetDir.should.match(/(\/|\\)content(\/|\\)images$/);
@@ -584,7 +584,7 @@ describe('Importer', function () {
                 }];
 
             MarkdownHandler.loadFile(file).then(function (result) {
-                result.data.posts.should.be.empty;
+                result.data.posts.should.be.empty();
 
                 done();
             }).catch(done);
@@ -656,8 +656,8 @@ describe('Importer', function () {
                importerSpy = sandbox.stub(importer, 'doImport').returns(Promise.resolve());
 
             DataImporter.doImport(inputData.data).then(function () {
-                importerSpy.calledOnce.should.be.true;
-                importerSpy.calledWith(inputData.data).should.be.true;
+                importerSpy.calledOnce.should.be.true();
+                importerSpy.calledWith(inputData.data).should.be.true();
             });
         });
     });
@@ -708,8 +708,8 @@ describe('Importer', function () {
                 });
 
             ImageImporter.doImport(inputData.images).then(function () {
-                storageSpy.calledOnce.should.be.true;
-                storageApi.save.calledTwice.should.be.true;
+                storageSpy.calledOnce.should.be.true();
+                storageApi.save.calledTwice.should.be.true();
             });
         });
     });

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -47,7 +47,7 @@ describe('Mail', function () {
         should.exist(mailer);
         mailer.should.have.property('init');
         mailer.should.have.property('transport');
-        mailer.should.have.property('send').and.be.a.function;
+        mailer.should.have.property('send').and.be.a.Function();
     });
 
     it('should setup SMTP transport on initialization', function (done) {
@@ -55,7 +55,7 @@ describe('Mail', function () {
         mailer.init().then(function () {
             mailer.should.have.property('transport');
             mailer.transport.transportType.should.eql('SMTP');
-            mailer.transport.sendMail.should.be.a.function;
+            mailer.transport.sendMail.should.be.a.Function();
             done();
         }).catch(done);
     });
@@ -105,7 +105,7 @@ describe('Mail', function () {
             mailer.send({subject: '', html: '123'})
         ]).then(function (descriptors) {
             descriptors.forEach(function (d) {
-                d.isRejected().should.be.true;
+                d.isRejected().should.be.true();
                 d.reason().should.be.an.instanceOf(Error);
                 d.reason().message.should.eql('Error: Incomplete message data.');
             });

--- a/core/test/unit/middleware/auth-strategies_spec.js
+++ b/core/test/unit/middleware/auth-strategies_spec.js
@@ -64,9 +64,9 @@ describe('Auth Strategies', function () {
                 clientSecret = 'not_available';
 
             authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
-                clientStub.calledOnce.should.be.true;
-                clientStub.calledWith({slug: clientId}).should.be.true;
-                next.called.should.be.true;
+                clientStub.calledOnce.should.be.true();
+                clientStub.calledWith({slug: clientId}).should.be.true();
+                next.called.should.be.true();
                 next.firstCall.args.length.should.eql(2);
                 should.equal(next.firstCall.args[0], null);
                 next.firstCall.args[1].slug.should.eql(clientId);
@@ -78,10 +78,10 @@ describe('Auth Strategies', function () {
             var clientId = 'invalid_id',
                 clientSecret = 'not_available';
             authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
-                clientStub.calledOnce.should.be.true;
-                clientStub.calledWith({slug: clientId}).should.be.true;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                clientStub.calledOnce.should.be.true();
+                clientStub.calledWith({slug: clientId}).should.be.true();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });
@@ -90,10 +90,10 @@ describe('Auth Strategies', function () {
             var clientId = 'ghost-admin',
                 clientSecret = 'invalid_secret';
             authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
-                clientStub.calledOnce.should.be.true;
-                clientStub.calledWith({slug: clientId}).should.be.true;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                clientStub.calledOnce.should.be.true();
+                clientStub.calledWith({slug: clientId}).should.be.true();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });
@@ -105,10 +105,10 @@ describe('Auth Strategies', function () {
             fakeClient.status = 'disabled';
 
             authStrategies.clientPasswordStrategy(clientId, clientSecret, next).then(function () {
-                clientStub.calledOnce.should.be.true;
-                clientStub.calledWith({slug: clientId}).should.be.true;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                clientStub.calledOnce.should.be.true();
+                clientStub.calledWith({slug: clientId}).should.be.true();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });
@@ -139,13 +139,13 @@ describe('Auth Strategies', function () {
                 userId = 3;
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
-                tokenStub.calledOnce.should.be.true;
-                tokenStub.calledWith({token: accessToken}).should.be.true;
-                userStub.calledOnce.should.be.true;
-                userStub.calledWith({id: userId}).should.be.true;
-                next.calledOnce.should.be.true;
+                tokenStub.calledOnce.should.be.true();
+                tokenStub.calledWith({token: accessToken}).should.be.true();
+                userStub.calledOnce.should.be.true();
+                userStub.calledWith({id: userId}).should.be.true();
+                next.calledOnce.should.be.true();
                 next.firstCall.args.length.should.eql(3);
-                next.calledWith(null, {id: userId}, {scope: '*'}).should.be.true;
+                next.calledWith(null, {id: userId}, {scope: '*'}).should.be.true();
                 done();
             }).catch(done);
         });
@@ -154,11 +154,11 @@ describe('Auth Strategies', function () {
             var accessToken = 'invalid_token';
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
-                tokenStub.calledOnce.should.be.true;
-                tokenStub.calledWith({token: accessToken}).should.be.true;
-                userStub.called.should.be.false;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                tokenStub.calledOnce.should.be.true();
+                tokenStub.calledWith({token: accessToken}).should.be.true();
+                userStub.called.should.be.false();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });
@@ -171,12 +171,12 @@ describe('Auth Strategies', function () {
             fakeValidToken.user_id = userId;
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
-                tokenStub.calledOnce.should.be.true;
-                tokenStub.calledWith({token: accessToken}).should.be.true;
-                userStub.calledOnce.should.be.true;
-                userStub.calledWith({id: userId}).should.be.true;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                tokenStub.calledOnce.should.be.true();
+                tokenStub.calledWith({token: accessToken}).should.be.true();
+                userStub.calledOnce.should.be.true();
+                userStub.calledWith({id: userId}).should.be.true();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });
@@ -185,11 +185,11 @@ describe('Auth Strategies', function () {
             var accessToken = 'expired-token';
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
-                tokenStub.calledOnce.should.be.true;
-                tokenStub.calledWith({token: accessToken}).should.be.true;
-                userStub.calledOnce.should.be.false;
-                next.called.should.be.true;
-                next.calledWith(null, false).should.be.true;
+                tokenStub.calledOnce.should.be.true();
+                tokenStub.calledWith({token: accessToken}).should.be.true();
+                userStub.calledOnce.should.be.false();
+                next.called.should.be.true();
+                next.calledWith(null, false).should.be.true();
                 done();
             }).catch(done);
         });

--- a/core/test/unit/middleware/authentication_spec.js
+++ b/core/test/unit/middleware/authentication_spec.js
@@ -104,8 +104,8 @@ describe('Auth', function () {
         req.user = {id: 1};
 
         auth.requiresAuthorizedUser(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -123,7 +123,7 @@ describe('Auth', function () {
         });
 
         auth.requiresAuthorizedUser(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -143,8 +143,8 @@ describe('Auth', function () {
             registerSuccessfulBearerStrategy();
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, user, info).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, user, info).should.be.true();
             done();
         });
 
@@ -155,8 +155,8 @@ describe('Auth', function () {
 
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith().should.be.true;
+            next.called.should.be.true();
+            next.calledWith().should.be.true();
             done();
         });
 
@@ -177,7 +177,7 @@ describe('Auth', function () {
             registerUnsuccessfulBearerStrategy();
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -197,7 +197,7 @@ describe('Auth', function () {
             registerUnsuccessfulBearerStrategy();
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -219,7 +219,7 @@ describe('Auth', function () {
             registerUnsuccessfulBearerStrategy();
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -230,8 +230,8 @@ describe('Auth', function () {
             registerFaultyBearerStrategy();
             auth.authenticateUser(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith('error').should.be.true;
+            next.called.should.be.true();
+            next.calledWith('error').should.be.true();
             done();
         });
     });
@@ -242,8 +242,8 @@ describe('Auth', function () {
             req.headers.authorization = 'Bearer ' + token;
 
             auth.authenticateClient(req, res, next);
-            next.called.should.be.true;
-            next.calledWith().should.be.true;
+            next.called.should.be.true();
+            next.calledWith().should.be.true();
             done();
         });
 
@@ -263,7 +263,7 @@ describe('Auth', function () {
             });
 
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -281,7 +281,7 @@ describe('Auth', function () {
             });
 
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -300,7 +300,7 @@ describe('Auth', function () {
             });
 
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -319,7 +319,7 @@ describe('Auth', function () {
             });
 
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -339,8 +339,8 @@ describe('Auth', function () {
 
             registerUnsuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
-            errorStub.calledTwice.should.be.true;
+            next.called.should.be.false();
+            errorStub.calledTwice.should.be.true();
             errorStub.getCall(0).args[1].should.eql('Client credentials were not provided');
 
             done();
@@ -363,8 +363,8 @@ describe('Auth', function () {
 
             registerUnsuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
-            errorStub.calledTwice.should.be.true;
+            next.called.should.be.false();
+            errorStub.calledTwice.should.be.true();
             errorStub.getCall(0).args[1].should.eql('Client credentials were not valid');
 
             done();
@@ -389,7 +389,7 @@ describe('Auth', function () {
 
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
 
@@ -410,8 +410,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -430,8 +430,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -452,8 +452,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -474,8 +474,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -497,8 +497,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -520,8 +520,8 @@ describe('Auth', function () {
             registerSuccessfulClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith(null, client).should.be.true;
+            next.called.should.be.true();
+            next.calledWith(null, client).should.be.true();
             done();
         });
 
@@ -534,8 +534,8 @@ describe('Auth', function () {
             registerFaultyClientPasswordStrategy();
             auth.authenticateClient(req, res, next);
 
-            next.called.should.be.true;
-            next.calledWith('error').should.be.true;
+            next.called.should.be.true();
+            next.calledWith('error').should.be.true();
             done();
         });
     });

--- a/core/test/unit/middleware/cache-control_spec.js
+++ b/core/test/unit/middleware/cache-control_spec.js
@@ -23,7 +23,7 @@ describe('Middleware: cacheControl', function () {
     it('correctly sets the public profile headers', function (done) {
         middleware.cacheControl('public')(null, res, function (a) {
             should.not.exist(a);
-            res.set.calledOnce.should.be.true;
+            res.set.calledOnce.should.be.true();
             res.set.calledWith({'Cache-Control': 'public, max-age=0'});
             done();
         });
@@ -32,7 +32,7 @@ describe('Middleware: cacheControl', function () {
     it('correctly sets the private profile headers', function (done) {
         middleware.cacheControl('private')(null, res, function (a) {
             should.not.exist(a);
-            res.set.calledOnce.should.be.true;
+            res.set.calledOnce.should.be.true();
             res.set.calledWith({
                 'Cache-Control':
                     'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
@@ -44,7 +44,7 @@ describe('Middleware: cacheControl', function () {
     it('will not set headers without a profile', function (done) {
         middleware.cacheControl()(null, res, function (a) {
             should.not.exist(a);
-            res.set.called.should.be.false;
+            res.set.called.should.be.false();
             done();
         });
     });
@@ -54,18 +54,18 @@ describe('Middleware: cacheControl', function () {
             privateCC = middleware.cacheControl('private');
 
         publicCC(null, res, function () {
-            res.set.calledOnce.should.be.true;
+            res.set.calledOnce.should.be.true();
             res.set.calledWith({'Cache-Control': 'public, max-age=0'});
 
             privateCC(null, res, function () {
-                res.set.calledTwice.should.be.true;
+                res.set.calledTwice.should.be.true();
                 res.set.calledWith({
                     'Cache-Control':
                         'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
                 });
 
                 publicCC(null, res, function () {
-                    res.set.calledThrice.should.be.true;
+                    res.set.calledThrice.should.be.true();
                     res.set.calledWith({'Cache-Control': 'public, max-age=0'});
 
                     privateCC(null, res, function () {
@@ -83,7 +83,7 @@ describe('Middleware: cacheControl', function () {
         res.isPrivateBlog = true;
         middleware.cacheControl('public')(null, res, function (a) {
             should.not.exist(a);
-            res.set.calledOnce.should.be.true;
+            res.set.calledOnce.should.be.true();
             res.set.calledWith({
                 'Cache-Control':
                     'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'

--- a/core/test/unit/middleware/check-ssl_spec.js
+++ b/core/test/unit/middleware/check-ssl_spec.js
@@ -29,8 +29,8 @@ describe('checkSSL', function () {
     it('should not require SSL (frontend)', function (done) {
         req.url = '/';
         checkSSL(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -38,8 +38,8 @@ describe('checkSSL', function () {
         req.url = '/';
         req.secure = true;
         checkSSL(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -47,8 +47,8 @@ describe('checkSSL', function () {
         req.url = '/ghost';
         res.isAdmin = true;
         checkSSL(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -58,8 +58,8 @@ describe('checkSSL', function () {
         res.secure = true;
 
         checkSSL(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -72,8 +72,8 @@ describe('checkSSL', function () {
             forceAdminSSL: true
         });
         checkSSL(req, res, next);
-        next.called.should.be.true;
-        next.calledWith().should.be.true;
+        next.called.should.be.true();
+        next.calledWith().should.be.true();
         done();
     });
 
@@ -89,12 +89,12 @@ describe('checkSSL', function () {
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
-            url.should.not.be.empty;
+            url.should.not.be.empty();
             url.should.eql('https://default.com:2368/ghost/');
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -110,12 +110,12 @@ describe('checkSSL', function () {
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
-            url.should.not.be.empty;
+            url.should.not.be.empty();
             url.should.eql('https://default.com:2368/blog/ghost/');
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -134,12 +134,12 @@ describe('checkSSL', function () {
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
-            url.should.not.be.empty;
+            url.should.not.be.empty();
             url.should.eql('https://default.com:2368/ghost/?test=true');
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -154,12 +154,12 @@ describe('checkSSL', function () {
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
-            url.should.not.be.empty;
+            url.should.not.be.empty();
             url.should.eql('https://default.com:2368/');
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -175,12 +175,12 @@ describe('checkSSL', function () {
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
-            url.should.not.be.empty;
+            url.should.not.be.empty();
             url.should.eql('https://ssl-domain.com:2368/ghost/');
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 
@@ -200,7 +200,7 @@ describe('checkSSL', function () {
             return;
         });
         checkSSL(req, res, next);
-        next.called.should.be.false;
+        next.called.should.be.false();
         done();
     });
 });

--- a/core/test/unit/middleware/oauth_spec.js
+++ b/core/test/unit/middleware/oauth_spec.js
@@ -67,7 +67,7 @@ describe('OAuth', function () {
 
             sandbox.stub(res, 'end', function (json) {
                 try {
-                    json.should.exist;
+                    should.exist(json);
                     json = JSON.parse(json);
                     json.should.have.property('access_token');
                     json.should.have.property('refresh_token');
@@ -176,7 +176,7 @@ describe('OAuth', function () {
 
             sandbox.stub(res, 'end', function (json) {
                 try {
-                    json.should.exist;
+                    should.exist(json);
                     json = JSON.parse(json);
                     json.should.have.property('access_token');
                     json.should.have.property('expires_in');

--- a/core/test/unit/middleware/private-blogging_spec.js
+++ b/core/test/unit/middleware/private-blogging_spec.js
@@ -49,8 +49,8 @@ describe('Private Blogging', function () {
             }));
 
             privateBlogging.checkIsPrivate(req, res, next).then(function () {
-                next.called.should.be.true;
-                res.isPrivateBlog.should.be.false;
+                next.called.should.be.true();
+                res.isPrivateBlog.should.be.false();
 
                 done();
             }).catch(done);
@@ -65,7 +65,7 @@ describe('Private Blogging', function () {
             }));
 
             privateBlogging.checkIsPrivate(req, res, next).then(function () {
-                res.isPrivateBlog.should.be.true;
+                res.isPrivateBlog.should.be.true();
 
                 done();
             }).catch(done);
@@ -78,7 +78,7 @@ describe('Private Blogging', function () {
 
             it('filterPrivateRoutes should call next if not private', function () {
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                next.called.should.be.true;
+                next.called.should.be.true();
             });
 
             it('isPrivateSessionAuth should redirect if blog is not private', function () {
@@ -87,7 +87,7 @@ describe('Private Blogging', function () {
                     isPrivateBlog: false
                 };
                 privateBlogging.isPrivateSessionAuth(req, res, next);
-                res.redirect.called.should.be.true;
+                res.redirect.called.should.be.true();
             });
         });
 
@@ -110,50 +110,50 @@ describe('Private Blogging', function () {
             it('filterPrivateRoutes should call next if admin', function () {
                 res.isAdmin = true;
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                next.called.should.be.true;
+                next.called.should.be.true();
             });
 
             it('filterPrivateRoutes should call next if is the "private" route', function () {
                 req.path = req.url = '/private/';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                next.called.should.be.true;
+                next.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is sitemap', function () {
                 req.path = req.url = '/sitemap.xml';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is sitemap with param', function () {
                 req.url = '/sitemap.xml?weird=param';
                 req.path = '/sitemap.xml';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is rss', function () {
                 req.path = req.url = '/rss/';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is author rss', function () {
                 req.path = req.url = '/author/halfdan/rss/';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is tag rss', function () {
                 req.path = req.url = '/tag/slimer/rss/';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should throw 404 if url is rss plus something', function () {
                 req.path = req.url = '/rss/sometag';
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                errorSpy.called.should.be.true;
+                errorSpy.called.should.be.true();
             });
 
             it('filterPrivateRoutes should render custom robots.txt', function () {
@@ -164,14 +164,14 @@ describe('Private Blogging', function () {
                     cb(null, 'User-agent: * Disallow: /');
                 });
                 privateBlogging.filterPrivateRoutes(req, res, next);
-                res.writeHead.called.should.be.true;
-                res.end.called.should.be.true;
+                res.writeHead.called.should.be.true();
+                res.end.called.should.be.true();
             });
 
             it('authenticateProtection should call next if error', function () {
                 res.error = 'Test Error';
                 privateBlogging.authenticateProtection(req, res, next);
-                next.called.should.be.true;
+                next.called.should.be.true();
             });
 
             describe('with hash verification', function () {
@@ -193,7 +193,7 @@ describe('Private Blogging', function () {
                     };
 
                     privateBlogging.authenticatePrivateSession(req, res, next).then(function () {
-                        next.called.should.be.true;
+                        next.called.should.be.true();
 
                         done();
                     }).catch(done);
@@ -208,7 +208,7 @@ describe('Private Blogging', function () {
                     res.redirect = sinon.spy();
 
                     privateBlogging.authenticatePrivateSession(req, res, next).then(function () {
-                        res.redirect.called.should.be.true;
+                        res.redirect.called.should.be.true();
 
                         done();
                     }).catch(done);
@@ -224,7 +224,7 @@ describe('Private Blogging', function () {
                     res.redirect = sandbox.spy();
 
                     privateBlogging.isPrivateSessionAuth(req, res, next).then(function () {
-                        res.redirect.called.should.be.true;
+                        res.redirect.called.should.be.true();
 
                         done();
                     }).catch(done);
@@ -237,7 +237,7 @@ describe('Private Blogging', function () {
                     };
 
                     privateBlogging.isPrivateSessionAuth(req, res, next).then(function () {
-                        next.called.should.be.true;
+                        next.called.should.be.true();
 
                         done();
                     }).catch(done);
@@ -247,8 +247,8 @@ describe('Private Blogging', function () {
                     req.body = {password: 'wrongpassword'};
 
                     privateBlogging.authenticateProtection(req, res, next).then(function () {
-                        res.error.should.not.be.empty;
-                        next.called.should.be.true;
+                        res.error.should.not.be.empty();
+                        next.called.should.be.true();
 
                         done();
                     }).catch(done);
@@ -260,7 +260,7 @@ describe('Private Blogging', function () {
                     res.redirect = sandbox.spy();
 
                     privateBlogging.authenticateProtection(req, res, next).then(function () {
-                        res.redirect.called.should.be.true;
+                        res.redirect.called.should.be.true();
 
                         done();
                     }).catch(done);

--- a/core/test/unit/middleware/redirect-to-setup_spec.js
+++ b/core/test/unit/middleware/redirect-to-setup_spec.js
@@ -30,8 +30,8 @@ describe('redirectToSetup', function () {
 
         req.path = '/';
         res.redirect = sinon.spy(function () {
-            next.called.should.be.false;
-            res.redirect.called.should.be.true;
+            next.called.should.be.false();
+            res.redirect.called.should.be.true();
             done();
         });
 
@@ -47,8 +47,8 @@ describe('redirectToSetup', function () {
         req.path = '/';
 
         next = sinon.spy(function () {
-            next.called.should.be.true;
-            res.redirect.called.should.be.false;
+            next.called.should.be.true();
+            res.redirect.called.should.be.false();
             done();
         });
 
@@ -64,8 +64,8 @@ describe('redirectToSetup', function () {
         req.path = '/ghost/setup/';
 
         next = sinon.spy(function () {
-            next.called.should.be.true;
-            res.redirect.called.should.be.false;
+            next.called.should.be.true();
+            res.redirect.called.should.be.false();
             done();
         });
 

--- a/core/test/unit/middleware/serve-shared-file_spec.js
+++ b/core/test/unit/middleware/serve-shared-file_spec.js
@@ -22,14 +22,14 @@ describe('serveSharedFile', function () {
     it('should return a middleware', function () {
         var result = serveSharedFile('robots.txt', 'text/plain', 3600);
 
-        result.should.be.a.Function;
+        result.should.be.a.Function();
     });
 
     it('should skip if the request does NOT match the file', function () {
         var middleware = serveSharedFile('robots.txt', 'text/plain', 3600);
         req.path = '/favicon.ico';
         middleware(req, res, next);
-        next.called.should.be.true;
+        next.called.should.be.true();
     });
 
     it('should load the file and send it', function () {
@@ -47,15 +47,15 @@ describe('serveSharedFile', function () {
         };
 
         middleware(req, res, next);
-        next.called.should.be.false;
-        res.writeHead.called.should.be.true;
+        next.called.should.be.false();
+        res.writeHead.called.should.be.true();
         res.writeHead.args[0][0].should.equal(200);
-        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true;
+        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true();
 
-        res.end.calledWith(body).should.be.true;
+        res.end.calledWith(body).should.be.true();
     });
 
     it('should send the correct headers', function () {
@@ -73,13 +73,13 @@ describe('serveSharedFile', function () {
         };
 
         middleware(req, res, next);
-        next.called.should.be.false;
-        res.writeHead.called.should.be.true;
+        next.called.should.be.false();
+        res.writeHead.called.should.be.true();
         res.writeHead.args[0][0].should.equal(200);
-        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true;
-        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true;
+        res.writeHead.calledWith(200, sinon.match.has('Content-Type')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('Content-Length')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('ETag')).should.be.true();
+        res.writeHead.calledWith(200, sinon.match.has('Cache-Control', 'public, max-age=3600')).should.be.true();
     });
 
     it('should replace {{blog-url}} in text/plain', function () {
@@ -97,9 +97,9 @@ describe('serveSharedFile', function () {
         };
 
         middleware(req, res, next);
-        next.called.should.be.false;
-        res.writeHead.called.should.be.true;
+        next.called.should.be.false();
+        res.writeHead.called.should.be.true();
 
-        res.end.calledWith('User-agent: http://127.0.0.1:2369').should.be.true;
+        res.end.calledWith('User-agent: http://127.0.0.1:2369').should.be.true();
     });
 });

--- a/core/test/unit/middleware/spam-prevention_spec.js
+++ b/core/test/unit/middleware/spam-prevention_spec.js
@@ -3,6 +3,7 @@
 var should      = require('should'),
     sinon       = require('sinon'),
     middleware  = require('../../../server/middleware').middleware;
+require('should-sinon');
 
 describe('Middleware: spamPrevention', function () {
     var sandbox,
@@ -43,7 +44,7 @@ describe('Middleware: spamPrevention', function () {
             req.body.grant_type = 'refresh_token';
             middleware.spamPrevention.signin(req, null, next);
 
-            next.calledOnce.should.be.true;
+            next.calledOnce.should.be.true();
             done();
         });
 
@@ -53,7 +54,7 @@ describe('Middleware: spamPrevention', function () {
             middleware.spamPrevention.signin(req, null, spyNext);
 
             should.exist(error);
-            error.should.be.a.BadRequestError;
+            error.errorType.should.eql('BadRequestError');
             done();
         });
 
@@ -64,7 +65,7 @@ describe('Middleware: spamPrevention', function () {
 
             middleware.spamPrevention.signin(req, null, spyNext);
             should.exist(error);
-            error.should.be.a.UnauthorizedError;
+            error.errorType.should.eql('TooManyRequestsError');
 
             done();
         });
@@ -80,7 +81,7 @@ describe('Middleware: spamPrevention', function () {
             }
 
             middleware.spamPrevention.signin(req, null, spyNext);
-            error.should.be.a.UnauthorizedError;
+            error.errorType.should.eql('TooManyRequestsError');
             error = null;
 
             // fast forward 1 hour
@@ -118,7 +119,7 @@ describe('Middleware: spamPrevention', function () {
             };
 
             middleware.spamPrevention.forgotten(req, null, spyNext);
-            error.should.be.a.BadRequestError;
+            error.errorType.should.eql('BadRequestError');
 
             done();
         });
@@ -129,7 +130,7 @@ describe('Middleware: spamPrevention', function () {
             }
 
             middleware.spamPrevention.forgotten(req, null, spyNext);
-            error.should.be.a.UnauthorizedError;
+            error.errorType.should.eql('TooManyRequestsError');
 
             done();
         });
@@ -147,7 +148,7 @@ describe('Middleware: spamPrevention', function () {
             }
 
             middleware.spamPrevention.forgotten(req, null, spyNext);
-            error.should.be.a.UnauthorizedError;
+            error.errorType.should.eql('TooManyRequestsError');
 
             done();
         });
@@ -173,7 +174,7 @@ describe('Middleware: spamPrevention', function () {
 
             middleware.spamPrevention.protected(req, res, spyNext);
             res.error.message.should.equal('No password entered');
-            spyNext.should.be.calledOnce;
+            spyNext.should.be.calledOnce();
 
             done();
         });

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -21,7 +21,7 @@ describe('staticTheme', function () {
         };
 
         staticTheme(null)(req, null, next);
-        next.called.should.be.true;
+        next.called.should.be.true();
     });
 
     it('should call next if md file type', function () {
@@ -30,7 +30,7 @@ describe('staticTheme', function () {
         };
 
         staticTheme(null)(req, null, next);
-        next.called.should.be.true;
+        next.called.should.be.true();
     });
 
     it('should call next if json file type', function () {
@@ -39,7 +39,7 @@ describe('staticTheme', function () {
         };
 
         staticTheme(null)(req, null, next);
-        next.called.should.be.true;
+        next.called.should.be.true();
     });
 
     it('should call express.static if valid file type', function (done) {
@@ -58,10 +58,10 @@ describe('staticTheme', function () {
         staticTheme(null)(req, null, function (reqArg, res, next2) {
             /*jshint unused:false */
             sandbox.restore();
-            next.called.should.be.false;
-            activeThemeStub.called.should.be.true;
-            expressStatic.called.should.be.true;
-            expressStatic.args[0][1].maxAge.should.exist;
+            next.called.should.be.false();
+            activeThemeStub.called.should.be.true();
+            expressStatic.called.should.be.true();
+            should.exist(expressStatic.args[0][1].maxAge);
             done();
         });
     });
@@ -81,7 +81,7 @@ describe('staticTheme', function () {
         staticTheme(null)(req, null, function (reqArg, res, next2) {
             /*jshint unused:false */
             sandbox.restore();
-            next.called.should.be.false;
+            next.called.should.be.false();
             done();
         });
     });

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -39,11 +39,11 @@ describe('Theme Handler', function () {
 
             themeHandler.ghostLocals(req, res, next);
 
-            res.locals.should.be.an.Object;
-            res.locals.version.should.exist;
-            res.locals.safeVersion.should.exist;
+            res.locals.should.be.an.Object();
+            should.exist(res.locals.version);
+            should.exist(res.locals.safeVersion);
             res.locals.relativeUrl.should.equal(req.path);
-            next.called.should.be.true;
+            next.called.should.be.true();
         });
     });
 
@@ -57,10 +57,10 @@ describe('Theme Handler', function () {
 
             themeHandler.activateTheme(blogApp, 'casper');
 
-            errorStub.calledWith('casper').should.be.true;
-            fsStub.calledOnce.should.be.true;
-            hbsStub.calledOnce.should.be.true;
-            hbsStub.firstCall.args[0].should.be.an.Object.and.have.property('partialsDir');
+            errorStub.calledWith('casper').should.be.true();
+            fsStub.calledOnce.should.be.true();
+            hbsStub.calledOnce.should.be.true();
+            hbsStub.firstCall.args[0].should.be.an.Object().and.have.property('partialsDir');
             hbsStub.firstCall.args[0].partialsDir.should.have.lengthOf(2);
             blogApp.get('activeTheme').should.equal('casper');
         });
@@ -74,10 +74,10 @@ describe('Theme Handler', function () {
 
             themeHandler.activateTheme(blogApp, 'casper');
 
-            errorStub.calledWith('casper').should.be.true;
-            fsStub.calledOnce.should.be.true;
-            hbsStub.calledOnce.should.be.true;
-            hbsStub.firstCall.args[0].should.be.an.Object.and.have.property('partialsDir');
+            errorStub.calledWith('casper').should.be.true();
+            fsStub.calledOnce.should.be.true();
+            hbsStub.calledOnce.should.be.true();
+            hbsStub.firstCall.args[0].should.be.an.Object().and.have.property('partialsDir');
             hbsStub.firstCall.args[0].partialsDir.should.have.lengthOf(1);
             blogApp.get('activeTheme').should.equal('casper');
         });
@@ -89,7 +89,7 @@ describe('Theme Handler', function () {
             themeHandler.configHbsForContext(req, res, next);
 
             should.not.exist(res.locals.secure);
-            next.called.should.be.true;
+            next.called.should.be.true();
         });
 
         it('handles secure context', function () {
@@ -100,13 +100,13 @@ describe('Theme Handler', function () {
 
             themeHandler.configHbsForContext(req, res, next);
 
-            themeOptSpy.calledOnce.should.be.true;
-            themeOptSpy.firstCall.args[0].should.be.an.Object.and.have.property('data');
-            themeOptSpy.firstCall.args[0].data.should.be.an.Object.and.have.property('blog');
-            themeOptSpy.firstCall.args[0].data.blog.should.be.an.Object.and.have.property('url');
+            themeOptSpy.calledOnce.should.be.true();
+            themeOptSpy.firstCall.args[0].should.be.an.Object().and.have.property('data');
+            themeOptSpy.firstCall.args[0].data.should.be.an.Object().and.have.property('blog');
+            themeOptSpy.firstCall.args[0].data.blog.should.be.an.Object().and.have.property('url');
             themeOptSpy.firstCall.args[0].data.blog.url.should.eql('https://secure.blog');
             res.locals.secure.should.equal(true);
-            next.called.should.be.true;
+            next.called.should.be.true();
         });
 
         it('sets view path', function () {
@@ -116,7 +116,7 @@ describe('Theme Handler', function () {
 
             themeHandler.configHbsForContext(req, res, next);
 
-            blogApp.get('views').should.not.be.undefined;
+            blogApp.get('views').should.not.be.undefined();
         });
 
         it('sets view path', function () {
@@ -126,7 +126,7 @@ describe('Theme Handler', function () {
 
             themeHandler.configHbsForContext(req, res, next);
 
-            blogApp.get('views').should.not.be.undefined;
+            blogApp.get('views').should.not.be.undefined();
         });
     });
 
@@ -143,7 +143,7 @@ describe('Theme Handler', function () {
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
-                activateThemeSpy.called.should.be.true;
+                activateThemeSpy.called.should.be.true();
                 done();
             });
         });
@@ -160,7 +160,7 @@ describe('Theme Handler', function () {
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
-                activateThemeSpy.called.should.be.false;
+                activateThemeSpy.called.should.be.false();
                 done();
             });
         });
@@ -180,8 +180,8 @@ describe('Theme Handler', function () {
 
             themeHandler.updateActiveTheme(req, res, function (err) {
                 should.exist(err);
-                errorSpy.called.should.be.true;
-                activateThemeSpy.called.should.be.false;
+                errorSpy.called.should.be.true();
+                activateThemeSpy.called.should.be.false();
                 err.message.should.eql('The currently active theme "rasper" is missing.');
                 done();
             });
@@ -203,10 +203,10 @@ describe('Theme Handler', function () {
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
             themeHandler.updateActiveTheme(req, res, function () {
-                errorSpy.called.should.be.false;
-                activateThemeSpy.called.should.be.false;
-                warnSpy.called.should.be.true;
-                warnSpy.calledWith('The currently active theme "rasper" is missing.').should.be.true;
+                errorSpy.called.should.be.false();
+                activateThemeSpy.called.should.be.false();
+                warnSpy.called.should.be.true();
+                warnSpy.calledWith('The currently active theme "rasper" is missing.').should.be.true();
                 done();
             });
         });

--- a/core/test/unit/middleware/uncapitalise_spec.js
+++ b/core/test/unit/middleware/uncapitalise_spec.js
@@ -3,6 +3,7 @@
 var sinon           = require('sinon'),
     should       = require('should'),
     uncapitalise    = require('../../../server/middleware/uncapitalise');
+require('should-sinon');
 
 should.equal(true, true);
 
@@ -29,7 +30,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/signup';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce;
+            next.should.be.calledOnce();
             done();
         });
 
@@ -43,9 +44,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called;
-            res.redirect.should.be.calledOnce;
-            res.redirect.calledWith(301, 'http://localhost/ghost/signup').should.be.true;
+            next.should.not.be.called();
+            res.redirect.should.be.calledOnce();
+            res.redirect.calledWith(301, 'http://localhost/ghost/signup').should.be.true();
             done();
         });
     });
@@ -55,7 +56,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/api/v0.1';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce;
+            next.should.be.calledOnce();
             done();
         });
 
@@ -69,9 +70,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called;
-            res.redirect.should.be.calledOnce;
-            res.redirect.calledWith(301, 'http://localhost/ghost/api/v0.1/asdfj').should.be.true;
+            next.should.not.be.called();
+            res.redirect.should.be.calledOnce();
+            res.redirect.calledWith(301, 'http://localhost/ghost/api/v0.1/asdfj').should.be.true();
             done();
         });
     });
@@ -81,7 +82,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/this-is-my-blog-post';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce;
+            next.should.be.calledOnce();
             done();
         });
 
@@ -95,9 +96,9 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called;
-            res.redirect.should.be.calledOnce;
-            res.redirect.calledWith(301, 'http://localhost/this-is-my-blog-post').should.be.true;
+            next.should.not.be.called();
+            res.redirect.should.be.calledOnce();
+            res.redirect.calledWith(301, 'http://localhost/this-is-my-blog-post').should.be.true();
             done();
         });
     });

--- a/core/test/unit/models_plugins/access-rules_spec.js
+++ b/core/test/unit/models_plugins/access-rules_spec.js
@@ -26,7 +26,7 @@ describe('Access Rules', function () {
 
     describe('Base Model', function () {
         it('should assign isPublicContext to prototype', function () {
-            ghostBookshelf.Model.prototype.isPublicContext.should.be.a.Function;
+            ghostBookshelf.Model.prototype.isPublicContext.should.be.a.Function();
         });
 
         it('should get called when a model is forged', function () {
@@ -35,19 +35,19 @@ describe('Access Rules', function () {
 
         describe('isPublicContext', function () {
             it('should isPublicContext false if no context is set', function () {
-                ghostBookshelf.Model.forge().isPublicContext().should.be.false;
+                ghostBookshelf.Model.forge().isPublicContext().should.be.false();
             });
 
             it('should return false if context has no `public` property', function () {
-                ghostBookshelf.Model.forge(null, {context: 'test'}).isPublicContext().should.be.false;
+                ghostBookshelf.Model.forge(null, {context: 'test'}).isPublicContext().should.be.false();
             });
 
             it('should return false if context.public is false', function () {
-                ghostBookshelf.Model.forge(null, {context: {public: false}}).isPublicContext().should.be.false;
+                ghostBookshelf.Model.forge(null, {context: {public: false}}).isPublicContext().should.be.false();
             });
 
             it('should return true if context.public is true', function () {
-                ghostBookshelf.Model.forge(null, {context: {public: true}}).isPublicContext().should.be.true;
+                ghostBookshelf.Model.forge(null, {context: {public: true}}).isPublicContext().should.be.true();
             });
         });
     });

--- a/core/test/unit/models_plugins/filter_spec.js
+++ b/core/test/unit/models_plugins/filter_spec.js
@@ -34,13 +34,13 @@ describe('Filter', function () {
     describe('Base Model', function () {
         describe('Enforced & Default Filters', function () {
             it('should add filter functions to prototype', function () {
-                ghostBookshelf.Model.prototype.enforcedFilters.should.be.a.Function;
-                ghostBookshelf.Model.prototype.defaultFilters.should.be.a.Function;
+                ghostBookshelf.Model.prototype.enforcedFilters.should.be.a.Function();
+                ghostBookshelf.Model.prototype.defaultFilters.should.be.a.Function();
             });
 
             it('filter functions should return undefined', function () {
-                should(ghostBookshelf.Model.prototype.enforcedFilters()).be.undefined;
-                should(ghostBookshelf.Model.prototype.defaultFilters()).be.undefined;
+                should(ghostBookshelf.Model.prototype.enforcedFilters()).be.undefined();
+                should(ghostBookshelf.Model.prototype.defaultFilters()).be.undefined();
             });
         });
 
@@ -53,7 +53,7 @@ describe('Filter', function () {
             });
 
             it('should add function to prototype', function () {
-                ghostBookshelf.Model.prototype.fetchAndCombineFilters.should.be.a.Function;
+                ghostBookshelf.Model.prototype.fetchAndCombineFilters.should.be.a.Function();
             });
 
             it('should set _filters to be the result of combineFilters', function () {
@@ -70,9 +70,9 @@ describe('Filter', function () {
             it('should call combineFilters with undefined x4 if passed no options', function () {
                 var result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
 
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, undefined, undefined]);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with enforced filters if set', function () {
@@ -82,10 +82,10 @@ describe('Filter', function () {
 
                 result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
 
-                filterSpy.calledOnce.should.be.true;
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterSpy.calledOnce.should.be.true();
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql(['status:published', undefined, undefined, undefined]);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with default filters if set', function () {
@@ -95,10 +95,10 @@ describe('Filter', function () {
 
                 result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
 
-                filterSpy.calledOnce.should.be.true;
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterSpy.calledOnce.should.be.true();
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql([undefined, 'page:false', undefined, undefined]);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with custom filters if set', function () {
@@ -106,9 +106,9 @@ describe('Filter', function () {
                     filter: 'tag:photo'
                 });
 
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, 'tag:photo', undefined]);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with old-style custom filters if set', function () {
@@ -116,9 +116,9 @@ describe('Filter', function () {
                     where: 'author:cameron'
                 });
 
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql([undefined, undefined, undefined, 'author:cameron']);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with enforced and defaults if set', function () {
@@ -130,11 +130,11 @@ describe('Filter', function () {
 
                 result = ghostBookshelf.Model.prototype.fetchAndCombineFilters();
 
-                filterSpy.calledOnce.should.be.true;
-                filterSpy2.calledOnce.should.be.true;
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterSpy.calledOnce.should.be.true();
+                filterSpy2.calledOnce.should.be.true();
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args.should.eql(['status:published', 'page:false', undefined, undefined]);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
 
             it('should call combineFilters with all values if set', function () {
@@ -149,12 +149,12 @@ describe('Filter', function () {
                     where: 'author:cameron'
                 });
 
-                filterSpy.calledOnce.should.be.true;
-                filterSpy2.calledOnce.should.be.true;
-                filterUtils.combineFilters.calledOnce.should.be.true;
+                filterSpy.calledOnce.should.be.true();
+                filterSpy2.calledOnce.should.be.true();
+                filterUtils.combineFilters.calledOnce.should.be.true();
                 filterUtils.combineFilters.firstCall.args
                     .should.eql(['status:published', 'page:false', 'tag:photo', 'author:cameron']);
-                should(result._filters).be.undefined;
+                should(result._filters).be.undefined();
             });
         });
 
@@ -181,8 +181,8 @@ describe('Filter', function () {
             it('should call fetchAndCombineFilters if _filters not set', function () {
                 var result = ghostBookshelf.Model.prototype.applyFilters();
 
-                fetchSpy.calledOnce.should.be.true;
-                should(result._filters).be.null;
+                fetchSpy.calledOnce.should.be.true();
+                should(result._filters).be.null();
             });
 
             it('should NOT call fetchAndCombineFilters if _filters IS set', function () {
@@ -190,7 +190,7 @@ describe('Filter', function () {
 
                 var result = ghostBookshelf.Model.prototype.applyFilters();
 
-                fetchSpy.called.should.be.false;
+                fetchSpy.called.should.be.false();
                 result._filters.should.eql('test');
             });
 
@@ -200,8 +200,8 @@ describe('Filter', function () {
                 ]};
                 ghostBookshelf.Model.prototype.applyFilters();
 
-                fetchSpy.called.should.be.false;
-                filterGQL.knexify.called.should.be.true;
+                fetchSpy.called.should.be.false();
+                filterGQL.knexify.called.should.be.true();
                 filterGQL.knexify.firstCall.args[1].should.eql({statements: [
                     {prop: 'title', op: '=', value: 'Hello Word'}
                 ]});
@@ -214,7 +214,7 @@ describe('Filter', function () {
                 ]};
 
                 ghostBookshelf.Model.prototype.applyFilters();
-                filterGQL.json.printStatements.calledOnce.should.be.true;
+                filterGQL.json.printStatements.calledOnce.should.be.true();
                 filterGQL.json.printStatements.firstCall.args[0].should.eql([
                     {prop: 'tags', op: 'IN', value: ['photo', 'video']}
                 ]);
@@ -241,10 +241,10 @@ describe('Filter', function () {
 
             it('should return empty statement object when there are no filters', function () {
                 combineFilters().should.eql({statements: []});
-                parseSpy.called.should.be.false;
-                mergeSpy.calledOnce.should.be.true;
-                findSpy.called.should.be.false;
-                rejectSpy.called.should.be.false;
+                parseSpy.called.should.be.false();
+                mergeSpy.calledOnce.should.be.true();
+                findSpy.called.should.be.false();
+                rejectSpy.called.should.be.false();
             });
 
             describe('Single filter rules', function () {
@@ -254,10 +254,10 @@ describe('Filter', function () {
                             {prop: 'status', op: '=', value: 'published'}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('should return default filters if only those are set (undefined)', function () {
@@ -266,10 +266,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('should return default filters if only those are set (null)', function () {
@@ -278,10 +278,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('should return custom filters if only those are set', function () {
@@ -290,10 +290,10 @@ describe('Filter', function () {
                             {prop: 'tags', op: 'IN', value: ['photo', 'video']}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.true;
-                    mergeSpy.calledOnce.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.true();
+                    mergeSpy.calledOnce.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('does NOT call parse on enforced filter if it is NOT a string', function () {
@@ -307,10 +307,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.false;
-                    mergeSpy.calledOnce.should.be.false;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.false();
+                    mergeSpy.calledOnce.should.be.false();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('does NOT call parse on default filter if it is NOT a string', function () {
@@ -324,10 +324,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.false;
-                    mergeSpy.calledOnce.should.be.false;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.false();
+                    mergeSpy.calledOnce.should.be.false();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('does NOT call parse on custom filter if it is NOT a string', function () {
@@ -341,10 +341,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false}
                         ]
                     });
-                    parseSpy.calledOnce.should.be.false;
-                    mergeSpy.calledOnce.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledOnce.should.be.false();
+                    mergeSpy.calledOnce.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
             });
 
@@ -356,10 +356,10 @@ describe('Filter', function () {
                             {prop: 'page', op: '=', value: false, func: 'and'}
                         ]
                     });
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('should merge custom filters if more than one is provided', function () {
@@ -369,10 +369,10 @@ describe('Filter', function () {
                             {prop: 'featured', op: '=', value: true, func: 'and'}
                         ]
                     });
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledOnce.should.be.true;
-                    findSpy.called.should.be.false;
-                    rejectSpy.called.should.be.false;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledOnce.should.be.true();
+                    findSpy.called.should.be.false();
+                    rejectSpy.called.should.be.false();
                 });
 
                 it('should try to reduce custom filters if custom and enforced are provided', function () {
@@ -386,12 +386,12 @@ describe('Filter', function () {
                             ], func: 'and'}
                         ]
                     });
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'}]);
 
-                    findSpy.calledOnce.should.be.true;
+                    findSpy.calledOnce.should.be.true();
                     findSpy.getCall(0).args.should.eql([
                         [{op: '=', value: 'published', prop: 'status'}],
                         {op: '=', value: 'photo', prop: 'tag'},
@@ -411,13 +411,13 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'},
                         {op: '=', value: 'draft', prop: 'status', func: 'or'}]);
 
-                    findSpy.calledTwice.should.be.true;
+                    findSpy.calledTwice.should.be.true();
                     findSpy.getCall(0).args.should.eql([
                         [{op: '=', value: 'published', prop: 'status'}],
                         {op: '=', value: 'photo', prop: 'tag'},
@@ -437,12 +437,12 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'draft', prop: 'status'}]);
 
-                    findSpy.calledOnce.should.be.true;
+                    findSpy.calledOnce.should.be.true();
                     findSpy.getCall(0).args.should.eql([
                         [{op: '=', value: 'published', prop: 'status'}],
                         {op: '=', value: 'draft', prop: 'status'},
@@ -462,12 +462,12 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: false, prop: 'page'}]);
 
-                    findSpy.calledOnce.should.be.true;
+                    findSpy.calledOnce.should.be.true();
                     findSpy.firstCall.args.should.eql([
                         [{op: '=', prop: 'tag', value: 'photo'}],
                         {op: '=', prop: 'page', value: false},
@@ -489,16 +489,16 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
 
                     rejectSpy.firstCall.args[0].should.eql([
                         {op: '=', value: false, prop: 'page'},
                         {op: '=', value: 'cameron', prop: 'author'}
                     ]);
 
-                    findSpy.calledTwice.should.be.true;
+                    findSpy.calledTwice.should.be.true();
                     findSpy.firstCall.args.should.eql([
                         [
                             {op: '=', prop: 'tag', value: 'photo'},
@@ -525,12 +525,12 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledTwice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledOnce.should.be.true;
+                    parseSpy.calledTwice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledOnce.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: false, prop: 'page'}]);
 
-                    findSpy.calledOnce.should.be.true;
+                    findSpy.calledOnce.should.be.true();
                     findSpy.firstCall.args.should.eql([
                         [
                             {op: '=', prop: 'tag', value: 'photo'},
@@ -554,13 +554,13 @@ describe('Filter', function () {
                         ]
                     });
 
-                    parseSpy.calledThrice.should.be.true;
-                    mergeSpy.calledTwice.should.be.true;
-                    rejectSpy.calledTwice.should.be.true;
+                    parseSpy.calledThrice.should.be.true();
+                    mergeSpy.calledTwice.should.be.true();
+                    rejectSpy.calledTwice.should.be.true();
                     rejectSpy.firstCall.args[0].should.eql([{op: '=', value: 'photo', prop: 'tag'}]);
                     rejectSpy.secondCall.args[0].should.eql([{op: '=', value: false, prop: 'page', func: 'and'}]);
 
-                    findSpy.calledTwice.should.be.true;
+                    findSpy.calledTwice.should.be.true();
                     findSpy.firstCall.args.should.eql([
                         [{op: '=', prop: 'status', value: 'published'}],
                         {op: '=', prop: 'tag', value: 'photo'},
@@ -588,7 +588,7 @@ describe('Filter', function () {
                     });
 
                     parseSpy.callCount.should.eql(4);
-                    mergeSpy.calledTwice.should.be.true;
+                    mergeSpy.calledTwice.should.be.true();
                     rejectSpy.callCount.should.eql(2);
                     rejectSpy.getCall(0).args[0].should.eql([{op: 'IN', value: ['photo', 'video'], prop: 'tag'},
                         {op: '=', value: 'cameron', prop: 'author', func: 'or'},

--- a/core/test/unit/models_plugins/pagination_spec.js
+++ b/core/test/unit/models_plugins/pagination_spec.js
@@ -161,15 +161,15 @@ describe('pagination', function () {
             it('should add query options if limit is set', function () {
                 addLimitAndOffset(collection, {limit: 5, page: 1});
 
-                collection.query.calledTwice.should.be.true;
-                collection.query.firstCall.calledWith('limit', 5).should.be.true;
-                collection.query.secondCall.calledWith('offset', 0).should.be.true;
+                collection.query.calledTwice.should.be.true();
+                collection.query.firstCall.calledWith('limit', 5).should.be.true();
+                collection.query.secondCall.calledWith('offset', 0).should.be.true();
             });
 
             it('should not add query options if limit is not set', function () {
                 addLimitAndOffset(collection, {page: 1});
 
-                collection.query.called.should.be.false;
+                collection.query.called.should.be.false();
             });
         });
     });
@@ -211,7 +211,7 @@ describe('pagination', function () {
 
         it('extends Model with fetchPage', function () {
             bookshelf.Model.prototype.should.have.ownProperty('fetchPage');
-            bookshelf.Model.prototype.fetchPage.should.be.a.Function;
+            bookshelf.Model.prototype.fetchPage.should.be.a.Function();
         });
 
         it('calls all paginationUtils and methods', function (done) {
@@ -228,23 +228,23 @@ describe('pagination', function () {
                     paginationUtils.formatResponse
                 );
 
-                paginationUtils.parseOptions.calledOnce.should.be.true;
-                paginationUtils.parseOptions.calledWith(undefined).should.be.true;
+                paginationUtils.parseOptions.calledOnce.should.be.true();
+                paginationUtils.parseOptions.calledWith(undefined).should.be.true();
 
-                paginationUtils.addLimitAndOffset.calledOnce.should.be.true;
-                paginationUtils.formatResponse.calledOnce.should.be.true;
+                paginationUtils.addLimitAndOffset.calledOnce.should.be.true();
+                paginationUtils.formatResponse.calledOnce.should.be.true();
 
-                model.prototype.query.calledOnce.should.be.true;
-                model.prototype.query.firstCall.calledWith().should.be.true;
+                model.prototype.query.calledOnce.should.be.true();
+                model.prototype.query.firstCall.calledWith().should.be.true();
 
-                mockQuery.clone.calledOnce.should.be.true;
-                mockQuery.clone.firstCall.calledWith().should.be.true;
+                mockQuery.clone.calledOnce.should.be.true();
+                mockQuery.clone.firstCall.calledWith().should.be.true();
 
-                mockQuery.select.calledOnce.should.be.true;
-                mockQuery.select.calledWith().should.be.true;
+                mockQuery.select.calledOnce.should.be.true();
+                mockQuery.select.calledWith().should.be.true();
 
-                model.prototype.fetchAll.calledOnce.should.be.true;
-                model.prototype.fetchAll.calledWith({}).should.be.true;
+                model.prototype.fetchAll.calledOnce.should.be.true();
+                model.prototype.fetchAll.calledWith({}).should.be.true();
 
                 done();
             }).catch(done);
@@ -266,24 +266,24 @@ describe('pagination', function () {
                     paginationUtils.formatResponse
                 );
 
-                paginationUtils.parseOptions.calledOnce.should.be.true;
-                paginationUtils.parseOptions.calledWith(orderOptions).should.be.true;
+                paginationUtils.parseOptions.calledOnce.should.be.true();
+                paginationUtils.parseOptions.calledWith(orderOptions).should.be.true();
 
-                paginationUtils.addLimitAndOffset.calledOnce.should.be.true;
-                paginationUtils.formatResponse.calledOnce.should.be.true;
+                paginationUtils.addLimitAndOffset.calledOnce.should.be.true();
+                paginationUtils.formatResponse.calledOnce.should.be.true();
 
-                model.prototype.query.calledTwice.should.be.true;
-                model.prototype.query.firstCall.calledWith().should.be.true;
-                model.prototype.query.secondCall.calledWith('orderBy', 'undefined.id', 'DESC').should.be.true;
+                model.prototype.query.calledTwice.should.be.true();
+                model.prototype.query.firstCall.calledWith().should.be.true();
+                model.prototype.query.secondCall.calledWith('orderBy', 'undefined.id', 'DESC').should.be.true();
 
-                mockQuery.clone.calledOnce.should.be.true;
-                mockQuery.clone.firstCall.calledWith().should.be.true;
+                mockQuery.clone.calledOnce.should.be.true();
+                mockQuery.clone.firstCall.calledWith().should.be.true();
 
-                mockQuery.select.calledOnce.should.be.true;
-                mockQuery.select.calledWith().should.be.true;
+                mockQuery.select.calledOnce.should.be.true();
+                mockQuery.select.calledWith().should.be.true();
 
-                model.prototype.fetchAll.calledOnce.should.be.true;
-                model.prototype.fetchAll.calledWith(orderOptions).should.be.true;
+                model.prototype.fetchAll.calledOnce.should.be.true();
+                model.prototype.fetchAll.calledWith(orderOptions).should.be.true();
 
                 done();
             }).catch(done);
@@ -305,24 +305,24 @@ describe('pagination', function () {
                     paginationUtils.formatResponse
                 );
 
-                paginationUtils.parseOptions.calledOnce.should.be.true;
-                paginationUtils.parseOptions.calledWith(groupOptions).should.be.true;
+                paginationUtils.parseOptions.calledOnce.should.be.true();
+                paginationUtils.parseOptions.calledWith(groupOptions).should.be.true();
 
-                paginationUtils.addLimitAndOffset.calledOnce.should.be.true;
-                paginationUtils.formatResponse.calledOnce.should.be.true;
+                paginationUtils.addLimitAndOffset.calledOnce.should.be.true();
+                paginationUtils.formatResponse.calledOnce.should.be.true();
 
-                model.prototype.query.calledTwice.should.be.true;
-                model.prototype.query.firstCall.calledWith().should.be.true;
-                model.prototype.query.secondCall.calledWith('groupBy', 'posts.id').should.be.true;
+                model.prototype.query.calledTwice.should.be.true();
+                model.prototype.query.firstCall.calledWith().should.be.true();
+                model.prototype.query.secondCall.calledWith('groupBy', 'posts.id').should.be.true();
 
-                mockQuery.clone.calledOnce.should.be.true;
-                mockQuery.clone.firstCall.calledWith().should.be.true;
+                mockQuery.clone.calledOnce.should.be.true();
+                mockQuery.clone.firstCall.calledWith().should.be.true();
 
-                mockQuery.select.calledOnce.should.be.true;
-                mockQuery.select.calledWith().should.be.true;
+                mockQuery.select.calledOnce.should.be.true();
+                mockQuery.select.calledWith().should.be.true();
 
-                model.prototype.fetchAll.calledOnce.should.be.true;
-                model.prototype.fetchAll.calledWith(groupOptions).should.be.true;
+                model.prototype.fetchAll.calledOnce.should.be.true();
+                model.prototype.fetchAll.calledWith(groupOptions).should.be.true();
 
                 done();
             }).catch(done);
@@ -333,8 +333,8 @@ describe('pagination', function () {
             bookshelf.Model.prototype.fetchPage().then(function (result) {
                 result.should.have.ownProperty('collection');
                 result.should.have.ownProperty('pagination');
-                result.collection.should.be.an.Object;
-                result.pagination.should.be.an.Object;
+                result.collection.should.be.an.Object();
+                result.pagination.should.be.an.Object();
 
                 done();
             });
@@ -348,8 +348,8 @@ describe('pagination', function () {
             bookshelf.Model.prototype.fetchPage().then(function (result) {
                 result.should.have.ownProperty('collection');
                 result.should.have.ownProperty('pagination');
-                result.collection.should.be.an.Object;
-                result.pagination.should.be.an.Object;
+                result.collection.should.be.an.Object();
+                result.pagination.should.be.an.Object();
 
                 done();
             });
@@ -363,7 +363,7 @@ describe('pagination', function () {
             var consoleSpy = sandbox.spy(console, 'log');
 
             bookshelf.Model.prototype.fetchPage().then(function () {
-                consoleSpy.calledOnce.should.be.true;
+                consoleSpy.calledOnce.should.be.true();
                 done();
             });
         });

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -168,7 +168,7 @@ describe('Permissions', function () {
             permissions.applyPublicRules('posts', 'read', _.cloneDeep(draft)).then(function () {
                 done('Did not throw an error for draft');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 done();
             });
         });
@@ -179,7 +179,7 @@ describe('Permissions', function () {
             permissions.applyPublicRules('posts', 'browse', _.cloneDeep(draft)).then(function () {
                 done('Did not throw an error for draft');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 done();
             });
         });
@@ -208,7 +208,7 @@ describe('Permissions', function () {
             permissions.applyPublicRules('posts', 'browse', _.cloneDeep(draft)).then(function () {
                 done('Did not throw an error for draft');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 done();
             });
         });
@@ -219,7 +219,7 @@ describe('Permissions', function () {
             permissions.applyPublicRules('posts', 'browse', _.cloneDeep(draft)).then(function () {
                 done('Did not throw an error for draft');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 done();
             });
         });
@@ -230,13 +230,13 @@ describe('Permissions', function () {
             permissions.applyPublicRules('posts', 'read', _.cloneDeep(draft)).then(function () {
                 done('Did not throw an error for draft');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 draft = {context: {},  data: {status: 'draft', uuid: '1234-abcd', slug: 'abcd'}};
 
                 return permissions.applyPublicRules('posts', 'read', _.cloneDeep(draft)).then(function () {
                     done('Did not throw an error for draft');
                 }).catch(function (err) {
-                    err.should.be.a.String;
+                    err.should.be.a.String();
                     done();
                 });
             });
@@ -269,7 +269,7 @@ describe('Permissions', function () {
             permissions.applyPublicRules('users', 'browse', _.cloneDeep(inactive)).then(function () {
                 done('Did not throw an error for inactive');
             }).catch(function (err) {
-                err.should.be.a.String;
+                err.should.be.a.String();
                 done();
             });
         });

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -80,7 +80,7 @@ describe('RSS', function () {
 
             res.send = function send(xmlData) {
                 should.exist(xmlData);
-                res.set.calledWith('Content-Type', 'text/xml; charset=UTF-8').should.be.true;
+                res.set.calledWith('Content-Type', 'text/xml; charset=UTF-8').should.be.true();
 
                 // xml & rss tags
                 xmlData.should.match(/^<\?xml version="1.0" encoding="UTF-8"\?>/);
@@ -283,8 +283,8 @@ describe('RSS', function () {
 
         it('should process the data correctly for the index feed', function (done) {
             res.send = function send(xmlData) {
-                apiBrowseStub.calledOnce.should.be.true;
-                apiBrowseStub.calledWith({page: 1, include: 'author,tags,fields'}).should.be.true;
+                apiBrowseStub.calledOnce.should.be.true();
+                apiBrowseStub.calledWith({page: 1, include: 'author,tags,fields'}).should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Test\]\]><\/title>/);
                 done();
             };
@@ -303,9 +303,9 @@ describe('RSS', function () {
 
             // test
             res.send = function send(xmlData) {
-                apiBrowseStub.calledOnce.should.be.true;
-                apiBrowseStub.calledWith({page: 1, filter: 'tags:\'magic\'', include: 'author,tags,fields'}).should.be.true;
-                apiTagStub.calledOnce.should.be.true;
+                apiBrowseStub.calledOnce.should.be.true();
+                apiBrowseStub.calledWith({page: 1, filter: 'tags:\'magic\'', include: 'author,tags,fields'}).should.be.true();
+                apiTagStub.calledOnce.should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Magic - Test\]\]><\/title>/);
                 done();
             };
@@ -321,9 +321,9 @@ describe('RSS', function () {
 
             // test
             res.send = function send(xmlData) {
-                apiBrowseStub.calledOnce.should.be.true;
-                apiBrowseStub.calledWith({page: 1, filter: 'author:\'joe\'', include: 'author,tags,fields'}).should.be.true;
-                apiUserStub.calledOnce.should.be.true;
+                apiBrowseStub.calledOnce.should.be.true();
+                apiBrowseStub.calledWith({page: 1, filter: 'author:\'joe\'', include: 'author,tags,fields'}).should.be.true();
+                apiUserStub.calledOnce.should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Joe Blogs - Test\]\]><\/title>/);
                 done();
             };
@@ -418,8 +418,8 @@ describe('RSS', function () {
             rss(req, res, function (err) {
                 should.exist(err);
                 err.code.should.eql(404);
-                res.redirect.called.should.be.false;
-                res.render.called.should.be.false;
+                res.redirect.called.should.be.false();
+                res.render.called.should.be.false();
                 done();
             }).catch(done);
         });
@@ -435,8 +435,8 @@ describe('RSS', function () {
             rss(req, res, function (err) {
                 should.exist(err);
                 err.code.should.eql(404);
-                res.redirect.called.should.be.false;
-                res.render.called.should.be.false;
+                res.redirect.called.should.be.false();
+                res.render.called.should.be.false();
                 done();
             }).catch(done);
         });

--- a/core/test/unit/server_helpers/foreach_spec.js
+++ b/core/test/unit/server_helpers/foreach_spec.js
@@ -57,7 +57,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
@@ -82,12 +82,12 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).be.undefined;
+                should(options.fn.getCall(index).args[1].data).be.undefined();
             });
         });
 
@@ -108,12 +108,12 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined;
+                should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
                 resultData[index].data.should.containEql(expected[index]);
@@ -150,7 +150,7 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
@@ -185,12 +185,12 @@ describe('{{#foreach}} helper', function () {
             context = 'hello world this is ghost'.split(' ');
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined;
+                should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
                 resultData[index].data.should.containEql(expected[index]);
@@ -227,12 +227,12 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.true;
+            options.fn.called.should.be.true();
             options.fn.getCalls().length.should.eql(_.size(context));
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined;
+                should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
                 resultData[index].data.should.containEql(expected[index]);
@@ -254,9 +254,9 @@ describe('{{#foreach}} helper', function () {
 
             runTest(_this, context, options);
 
-            options.fn.called.should.be.false;
-            options.inverse.called.should.be.true;
-            options.inverse.calledOnce.should.be.true;
+            options.fn.called.should.be.false();
+            options.inverse.called.should.be.true();
+            options.inverse.calledOnce.should.be.true();
         });
     });
 

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -66,11 +66,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.true;
-                fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                fn.called.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                 fn.firstCall.args[0].posts.should.eql(testPostsArr);
                 fn.firstCall.args[0].posts.should.have.lengthOf(4);
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);
@@ -82,10 +82,10 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.firstCall.args[0].pagination.should.be.an.Object;
-                fn.firstCall.args[0].meta.should.be.an.Object;
-                fn.firstCall.args[0].meta.pagination.should.be.an.Object;
-                inverse.called.should.be.false;
+                fn.firstCall.args[0].pagination.should.be.an.Object();
+                fn.firstCall.args[0].meta.should.be.an.Object();
+                fn.firstCall.args[0].meta.pagination.should.be.an.Object();
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);
@@ -99,7 +99,7 @@ describe('{{#get}} helper', function () {
             ).then(function () {
                 should.not.exist(fn.firstCall.args[0].pagination);
                 should.not.exist(fn.firstCall.args[0].meta);
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);
@@ -111,11 +111,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: '3'}, fn: fn, inverse: inverse}
             ).then(function () {
-                    fn.calledOnce.should.be.true;
-                    fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                    fn.calledOnce.should.be.true();
+                    fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                     fn.firstCall.args[0].posts.should.have.lengthOf(3);
                     fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(0, 3));
-                    inverse.called.should.be.false;
+                    inverse.called.should.be.false();
 
                     done();
                 }).catch(done);
@@ -127,11 +127,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: '1'}, fn: fn, inverse: inverse}
             ).then(function () {
-                    fn.calledOnce.should.be.true;
-                    fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                    fn.calledOnce.should.be.true();
+                    fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                     fn.firstCall.args[0].posts.should.have.lengthOf(1);
                     fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(0, 1));
-                    inverse.called.should.be.false;
+                    inverse.called.should.be.false();
 
                     done();
                 }).catch(done);
@@ -143,11 +143,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {limit: '1'}, fn: fn, inverse: inverse}
             ).then(function () {
-                    fn.calledOnce.should.be.true;
-                    fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                    fn.calledOnce.should.be.true();
+                    fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                     fn.firstCall.args[0].posts.should.have.lengthOf(1);
                     fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(0, 1));
-                    inverse.called.should.be.false;
+                    inverse.called.should.be.false();
 
                     done();
                 }).catch(done);
@@ -159,11 +159,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:test'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.calledOnce.should.be.true;
-                fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                fn.calledOnce.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                 fn.firstCall.args[0].posts.should.have.lengthOf(1);
                 fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(2, 3));
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
                 done();
             }).catch(done);
         });
@@ -174,11 +174,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'author:cameron'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.calledOnce.should.be.true;
-                fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                fn.calledOnce.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                 fn.firstCall.args[0].posts.should.have.lengthOf(2);
                 fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(0, 2));
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
                 done();
             }).catch(done);
         });
@@ -189,11 +189,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'featured:true'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.calledOnce.should.be.true;
-                fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                fn.calledOnce.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                 fn.firstCall.args[0].posts.should.have.lengthOf(1);
                 fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(2, 3));
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
                 done();
             }).catch(done);
         });
@@ -204,11 +204,11 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {id: '2'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.calledOnce.should.be.true;
-                fn.firstCall.args[0].should.be.an.Object.with.property('posts');
+                fn.calledOnce.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
                 fn.firstCall.args[0].posts.should.have.lengthOf(1);
                 fn.firstCall.args[0].posts.should.eql(testPostsArr.slice(1, 2));
-                inverse.called.should.be.false;
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);
@@ -220,10 +220,10 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:none'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false;
-                inverse.calledOnce.should.be.true;
-                inverse.firstCall.args[1].should.be.an.Object.and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object.and.not.have.property('error');
+                fn.called.should.be.false();
+                inverse.calledOnce.should.be.true();
+                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
+                inverse.firstCall.args[1].data.should.be.an.Object().and.not.have.property('error');
 
                 done();
             }).catch(done);
@@ -237,10 +237,10 @@ describe('{{#get}} helper', function () {
                 'magic',
                 {hash: {}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false;
-                inverse.calledOnce.should.be.true;
-                inverse.firstCall.args[1].should.be.an.Object.and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object.and.have.property('error');
+                fn.called.should.be.false();
+                inverse.calledOnce.should.be.true();
+                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
+                inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
                 inverse.firstCall.args[1].data.error.should.eql('Invalid resource given to get helper');
 
                 done();
@@ -253,10 +253,10 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {status: 'thing!'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false;
-                inverse.calledOnce.should.be.true;
-                inverse.firstCall.args[1].should.be.an.Object.and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object.and.have.property('error');
+                fn.called.should.be.false();
+                inverse.calledOnce.should.be.true();
+                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
+                inverse.firstCall.args[1].data.should.be.an.Object().and.have.property('error');
                 inverse.firstCall.args[1].data.error.should.match(/^Validation/);
 
                 done();
@@ -268,8 +268,8 @@ describe('{{#get}} helper', function () {
                 {},
                 'posts'
             ).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.false;
+                fn.called.should.be.false();
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);
@@ -292,8 +292,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:[{{post.tags}}]'}, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array.with.lengthOf(1);
-                browseStub.firstCall.args[0].should.be.an.Object.with.property('filter');
+                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 browseStub.firstCall.args[0].filter.should.eql('tags:[test,magic]');
 
                 done();
@@ -306,8 +306,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'author:{{post.author}}'}, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array.with.lengthOf(1);
-                browseStub.firstCall.args[0].should.be.an.Object.with.property('filter');
+                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 browseStub.firstCall.args[0].filter.should.eql('author:cameron');
 
                 done();
@@ -320,8 +320,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'id:-{{post.id}}'}, fn: fn, inverse: inverse}
             ).then(function () {
-                    browseStub.firstCall.args.should.be.an.Array.with.lengthOf(1);
-                    browseStub.firstCall.args[0].should.be.an.Object.with.property('filter');
+                    browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                    browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                     browseStub.firstCall.args[0].filter.should.eql('id:-3');
 
                     done();
@@ -337,8 +337,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:{{post.tags.[0].slug}}'}, fn: fn, inverse: inverse}
             ).then(function () {
-                browseStub.firstCall.args.should.be.an.Array.with.lengthOf(1);
-                browseStub.firstCall.args[0].should.be.an.Object.with.property('filter');
+                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 browseStub.firstCall.args[0].filter.should.eql('tags:' + output);
 
                 done();
@@ -351,8 +351,8 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'id:{{post.thing}}'}, fn: fn, inverse: inverse}
             ).then(function () {
-                    browseStub.firstCall.args.should.be.an.Array.with.lengthOf(1);
-                    browseStub.firstCall.args[0].should.be.an.Object.with.property('filter');
+                    browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                    browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                     browseStub.firstCall.args[0].filter.should.eql('id:');
 
                     done();

--- a/core/test/unit/server_helpers/has_spec.js
+++ b/core/test/unit/server_helpers/has_spec.js
@@ -27,8 +27,8 @@ describe('{{#has}} helper', function () {
             {hash: {tag: 'invalid, bar, wat'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should handle tags with case-insensitivity', function () {
@@ -40,8 +40,8 @@ describe('{{#has}} helper', function () {
             {hash: {tag: 'GhoSt'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should match exact tags, not superstrings', function () {
@@ -53,8 +53,8 @@ describe('{{#has}} helper', function () {
             {hash: {tag: 'magic'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 
     it('should match exact tags, not substrings', function () {
@@ -66,8 +66,8 @@ describe('{{#has}} helper', function () {
             {hash: {tag: 'magical'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 
     it('should handle tag list that validates false', function () {
@@ -79,8 +79,8 @@ describe('{{#has}} helper', function () {
             {hash: {tag: 'much, such, wow'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 
     it('should not do anything if there are no attributes', function () {
@@ -92,8 +92,8 @@ describe('{{#has}} helper', function () {
             {fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.false;
+        fn.called.should.be.false();
+        inverse.called.should.be.false();
     });
 
     it('should not do anything when an invalid attribute is given', function () {
@@ -105,8 +105,8 @@ describe('{{#has}} helper', function () {
             {hash: {invalid: 'nonsense'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.false;
+        fn.called.should.be.false();
+        inverse.called.should.be.false();
     });
 
     it('should handle author list that evaluates to true', function () {
@@ -118,8 +118,8 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sam, pat'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should handle author list that evaluates to false', function () {
@@ -131,8 +131,8 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sam, pat'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 
     it('should handle authors with case-insensitivity', function () {
@@ -144,8 +144,8 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sAm, pat'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should handle tags and authors like an OR query (pass)', function () {
@@ -157,8 +157,8 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sam, pat', tag: 'much, such, wow'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should handle tags and authors like an OR query (pass)', function () {
@@ -170,8 +170,8 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sam, pat', tag: 'much, such, wow'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should handle tags and authors like an OR query (fail)', function () {
@@ -183,7 +183,7 @@ describe('{{#has}} helper', function () {
             {hash: {author: 'joe, sam, pat', tag: 'much, such, wow'}, fn: fn, inverse: inverse}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 });

--- a/core/test/unit/server_helpers/is_spec.js
+++ b/core/test/unit/server_helpers/is_spec.js
@@ -30,8 +30,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['home', 'index']}}}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should match OR context "index, paged"', function () {
@@ -44,8 +44,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['tag', 'paged']}}}
         );
 
-        fn.called.should.be.true;
-        inverse.called.should.be.false;
+        fn.called.should.be.true();
+        inverse.called.should.be.false();
     });
 
     it('should not match "paged"', function () {
@@ -58,8 +58,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['index', 'home']}}}
         );
 
-        fn.called.should.be.false;
-        inverse.called.should.be.true;
+        fn.called.should.be.false();
+        inverse.called.should.be.true();
     });
 
     it('should log warning with no args', function () {
@@ -73,8 +73,8 @@ describe('{{#is}} helper', function () {
             {fn: fn, inverse: inverse, data: {root: {context: ['index', 'home']}}}
         );
 
-        logWarn.called.should.be.true;
-        fn.called.should.be.false;
-        inverse.called.should.be.false;
+        logWarn.called.should.be.true();
+        fn.called.should.be.false();
+        inverse.called.should.be.false();
     });
 });

--- a/core/test/unit/server_helpers/prev_post_spec.js
+++ b/core/test/unit/server_helpers/prev_post_spec.js
@@ -48,10 +48,10 @@ describe('{{prev_post}} helper', function () {
                 slug: 'current',
                 created_at: new Date(0),
                 url: '/current/'}, optionsData).then(function () {
-                fn.calledOnce.should.be.true;
-                inverse.calledOnce.should.be.false;
+                fn.calledOnce.should.be.true();
+                inverse.calledOnce.should.be.false();
 
-                readPostStub.calledOnce.should.be.true;
+                readPostStub.calledOnce.should.be.true();
                 readPostStub.firstCall.args[0].include.should.eql('previous,previous.author,previous.tags');
 
                 done();
@@ -84,8 +84,8 @@ describe('{{prev_post}} helper', function () {
                 slug: 'current',
                 created_at: new Date(0),
                 url: '/current/'}, optionsData).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.true;
+                fn.called.should.be.false();
+                inverse.called.should.be.true();
                 done();
             }).catch(function (err) {
                 done(err);
@@ -109,9 +109,9 @@ describe('{{prev_post}} helper', function () {
                 optionsData = {name: 'prev_post', fn: fn, inverse: inverse};
 
             helpers.prev_post.call({}, optionsData).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.true;
-                readPostStub.called.should.be.false;
+                fn.called.should.be.false();
+                inverse.called.should.be.true();
+                readPostStub.called.should.be.false();
                 done();
             }).catch(function (err) {
                 done(err);
@@ -141,8 +141,8 @@ describe('{{prev_post}} helper', function () {
                 slug: 'current',
                 created_at: new Date(0),
                 url: '/current/'}, optionsData).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.true;
+                fn.called.should.be.false();
+                inverse.called.should.be.true();
                 done();
             }).catch(function (err) {
                 done(err);

--- a/core/test/unit/storage_local-file-store_spec.js
+++ b/core/test/unit/storage_local-file-store_spec.js
@@ -72,7 +72,7 @@ describe('Local File System Storage', function () {
     it('should create month and year directory', function (done) {
         localFileStore.save(image).then(function (url) {
             /*jshint unused:false*/
-            fs.mkdirs.calledOnce.should.be.true;
+            fs.mkdirs.calledOnce.should.be.true();
             fs.mkdirs.args[0][0].should.equal(path.resolve('./content/images/2013/09'));
             done();
         }).catch(done);
@@ -81,7 +81,7 @@ describe('Local File System Storage', function () {
     it('should copy temp file to new location', function (done) {
         localFileStore.save(image).then(function (url) {
             /*jshint unused:false*/
-            fs.copy.calledOnce.should.be.true;
+            fs.copy.calledOnce.should.be.true();
             fs.copy.args[0][0].should.equal('tmp/123456.jpg');
             fs.copy.args[0][1].should.equal(path.resolve('./content/images/2013/09/IMAGE.jpg'));
             done();

--- a/core/test/unit/utils_pipeline_spec.js
+++ b/core/test/unit/utils_pipeline_spec.js
@@ -57,7 +57,7 @@ describe('Pipeline', function () {
 
         return pipeline(tasks, 1, 2, 3).then(
             function () {
-                tasks[0].calledOnce.should.be.true;
+                tasks[0].calledOnce.should.be.true();
                 tasks[0].firstCall.args.should.eql(expected);
 
                 done();
@@ -72,7 +72,7 @@ describe('Pipeline', function () {
 
         return pipeline(tasks, new Resolver(1), new Resolver(2), new Resolver(3)).then(
             function () {
-                tasks[0].calledOnce.should.be.true;
+                tasks[0].calledOnce.should.be.true();
                 tasks[0].firstCall.args.should.eql(expected);
 
                 done();
@@ -91,12 +91,12 @@ describe('Pipeline', function () {
         return pipeline(tasks, 1, 2, 3).then(
             function (result) {
                 result.should.eql(6);
-                tasks[0].calledOnce.should.be.true;
+                tasks[0].calledOnce.should.be.true();
                 tasks[0].firstCall.args.should.eql(expected);
-                tasks[1].calledOnce.should.be.true;
-                tasks[1].firstCall.calledWith(4).should.be.true;
-                tasks[2].calledOnce.should.be.true;
-                tasks[2].firstCall.calledWith(5).should.be.true;
+                tasks[1].calledOnce.should.be.true();
+                tasks[1].firstCall.calledWith(4).should.be.true();
+                tasks[2].calledOnce.should.be.true();
+                tasks[2].firstCall.calledWith(5).should.be.true();
 
                 done();
             }
@@ -115,12 +115,12 @@ describe('Pipeline', function () {
         return pipeline(tasks, new Resolver(1), new Resolver(2), new Resolver(3)).then(
             function (result) {
                 result.should.eql(6);
-                tasks[0].calledOnce.should.be.true;
+                tasks[0].calledOnce.should.be.true();
                 tasks[0].firstCall.args.should.eql(expected);
-                tasks[1].calledOnce.should.be.true;
-                tasks[1].firstCall.calledWith(4).should.be.true;
-                tasks[2].calledOnce.should.be.true;
-                tasks[2].firstCall.calledWith(5).should.be.true;
+                tasks[1].calledOnce.should.be.true();
+                tasks[1].firstCall.calledWith(4).should.be.true();
+                tasks[2].calledOnce.should.be.true();
+                tasks[2].firstCall.calledWith(5).should.be.true();
 
                 done();
             }

--- a/core/test/unit/xmlrpc_spec.js
+++ b/core/test/unit/xmlrpc_spec.js
@@ -38,7 +38,7 @@ describe('XMLRPC', function () {
 
         xmlrpc.init();
         events.emit('post.published', testPost);
-        ping1.isDone().should.be.true;
-        ping2.isDone().should.be.true;
+        ping1.isDone().should.be.true();
+        ping2.isDone().should.be.true();
     });
 });

--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
     "nock": "7.1.0",
     "rewire": "2.5.1",
     "rimraf-then": "1.0.0",
-    "should": "6.0.3",
+    "should": "8.2.1",
+    "should-http": "0.0.4",
+    "should-sinon": "0.0.5",
     "sinon": "1.17.3",
     "supertest": "1.1.0",
     "top-gh-contribs": "2.0.2"


### PR DESCRIPTION
This PR upgrades should.js to the latest version (issue #6448), it also introduces the packages should-http and should-sinon. I have gone through all of the tests and updated them to comply with the new version of should.js, I believe I have covered everything but if I have missed something or there are any changes you would like made let me know and ill have a look as soon as I can.

Couple of things to point out here that I am not sure is 100% correct due to my unfamiliarity with the code base:

The test case 'should not be able to get a slug for an unknown type' in core/test/functional/routes/api/slugs_spec.js (line 137) was changed from checking the response does not exist to checking for a errors property on the response. 

In the test core/test/unit/middleware/spam-prevention_spec.js some of the assertions were changed from `error.should.be.a.UnauthorizedError;` to checking for a specific errorType such as `error.errorType.should.eql('TooManyRequestsError');`

closes #6448
-upgraded should.js to the latest version (8.2.1)
-Changed the tests so that they comply with the breaking changes introduced in the new version of should.js
-Installs the package should-http so should.be.json() can be used
-Installs the package should-sinon so that should.be.calledOnce() can be used
