### PR TITLE
Change URL for download count service

### DIFF
--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -90,7 +90,7 @@ export default function () {
     /* Download Count ------------------------------------------------------- */
 
     let downloadCount = 0;
-    this.get('http://ghost.org/count/', function () {
+    this.get('https://count.ghost.org/', function () {
         downloadCount++;
         return {
             count: downloadCount

--- a/core/client/app/utils/ghost-paths.js
+++ b/core/client/app/utils/ghost-paths.js
@@ -28,7 +28,7 @@ export default function () {
         apiRoot,
         subdir,
         blogRoot: `${subdir}/`,
-        count: 'https://ghost.org/count/',
+        count: 'https://count.ghost.org/',
 
         url: {
             admin() {


### PR DESCRIPTION
no issue
- we're moving the internal endpoint for fetching counts to count.ghost.org

Note: I get local test failures but they don't seem to be with related code:

```
not ok 43 Chrome 48.0 - Integration: Component: gh-cm-editor handles editor events
    ---
        message: >
            has focused class after focus: expected false to be true
        stack: >
            AssertionError: has focused class after focus: expected false to be true
        Log: |
    ...
not ok 62 Chrome 48.0 - Integration: Component: gh-navitem-url-input toggles .fake-placeholder on focus
    ---
        message: >
            expected true to be false
        stack: >
            AssertionError: expected true to be false
        Log: |
    ...
not ok 302 Firefox 43.0 - Integration: Component: gh-cm-editor handles editor events
    ---
        message: >
            has focused class after focus: expected false to be true
        Log: |
    ...
not ok 321 Firefox 43.0 - Integration: Component: gh-navitem-url-input toggles .fake-placeholder on focus
    ---
        message: >
            expected true to be false
        Log: |
    ...
```
