### PR TITLE
deps: mocha@2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "istanbul": "0.4.2",
     "jscs-jsdoc": "1.3.1",
     "matchdep": "1.0.0",
+    "mocha": "2.4.5",
     "nock": "7.1.0",
     "rewire": "2.5.1",
     "rimraf-then": "1.0.0",


### PR DESCRIPTION
The changes to npm & peer dependencies mean we need to include mocha as a direct dependency
