### PR TITLE
Refactor mail service

### DIFF
--- a/core/server/mail/index.js
+++ b/core/server/mail/index.js
@@ -7,30 +7,16 @@ var _          = require('lodash'),
     config     = require('../config'),
     i18n       = require('../i18n');
 
-function GhostMailer(opts) {
-    opts = opts || {};
-    this.transport = opts.transport || null;
+function GhostMailer() {
+    var transport = config.mail && config.mail.transport || 'direct',
+        options = config.mail && _.clone(config.mail.options) || {};
+
+    this.state = {};
+
+    this.transport = nodemailer.createTransport(transport, options);
+
+    this.state.usingDirect = transport === 'direct';
 }
-
-// ## Email transport setup
-// *This promise should always resolve to avoid halting Ghost::init*.
-GhostMailer.prototype.init = function () {
-    var self = this;
-    self.state = {};
-    if (config.mail && config.mail.transport) {
-        this.createTransport();
-        return Promise.resolve();
-    }
-
-    self.transport = nodemailer.createTransport('direct');
-    self.state.usingDirect = true;
-
-    return Promise.resolve();
-};
-
-GhostMailer.prototype.createTransport = function () {
-    this.transport = nodemailer.createTransport(config.mail.transport, _.clone(config.mail.options) || {});
-};
 
 GhostMailer.prototype.from = function () {
     var from = config.mail && (config.mail.from || config.mail.fromaddress);
@@ -116,4 +102,4 @@ GhostMailer.prototype.send = function (message) {
     });
 };
 
-module.exports = new GhostMailer();
+module.exports = GhostMailer;

--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -21,6 +21,7 @@ checks = {
         this.nodeEnv();
         this.packages();
         this.contentPath();
+        this.mail();
         this.sqlite();
     },
 
@@ -208,6 +209,23 @@ checks = {
             console.error('Help and documentation can be found at http://support.ghost.org.\033[0m');
 
             process.exit(exitCodes.SQLITE_DB_NOT_WRITABLE);
+        }
+    },
+
+    mail: function checkMail() {
+        var configFile,
+            config;
+
+        try {
+            configFile = require(configFilePath);
+            config = configFile[mode];
+        } catch (e) {
+            configFilePath = path.join(appRoot, 'config.example.js');
+        }
+
+        if (!config.mail || !config.mail.transport) {
+            console.error('\x1B[31mWARNING: Ghost is attempting to use a direct method to send email. \nIt is recommended that you explicitly configure an email service.\033[0m');
+            console.error('\x1B[32mHelp and documentation can be found at http://support.ghost.org/mail.\033[0m\n');
         }
     }
 };

--- a/core/test/integration/api/api_mail_spec.js
+++ b/core/test/integration/api/api_mail_spec.js
@@ -3,11 +3,7 @@
 var testUtils       = require('../../utils'),
     should          = require('should'),
     config          = require('../../../server/config'),
-    mailer          = require('../../../server/mail'),
-	i18n            = require('../../../../core/server/i18n'),
-
-    // Stuff we are testing
-    MailAPI         = require('../../../server/api/mail'),
+    i18n            = require('../../../../core/server/i18n'),
 
     // test data
     mailData = {
@@ -27,15 +23,12 @@ describe('Mail API', function () {
     afterEach(testUtils.teardown);
     beforeEach(testUtils.setup('perms:mail', 'perms:init'));
 
-    should.exist(MailAPI);
-
     it('returns a success', function (done) {
         config.set({mail: {transport: 'stub'}});
 
-        mailer.init().then(function () {
-            mailer.transport.transportType.should.eql('STUB');
-            return MailAPI.send(mailData, testUtils.context.internal);
-        }).then(function (response) {
+        var MailAPI = require('../../../server/api/mail');
+
+        MailAPI.send(mailData, testUtils.context.internal).then(function (response) {
             should.exist(response.mail);
             should.exist(response.mail[0].message);
             should.exist(response.mail[0].status);
@@ -48,10 +41,9 @@ describe('Mail API', function () {
     it('returns a boo boo', function (done) {
         config.set({mail: {transport: 'stub', options: {error: 'Stub made a boo boo :('}}});
 
-        mailer.init().then(function () {
-            mailer.transport.transportType.should.eql('STUB');
-            return MailAPI.send(mailData, testUtils.context.internal);
-        }).then(function () {
+        var MailAPI = require('../../../server/api/mail');
+
+        MailAPI.send(mailData, testUtils.context.internal).then(function () {
             done(new Error('Stub did not error'));
         }).catch(function (error) {
             error.message.should.startWith('Error: Stub made a boo boo :(');


### PR DESCRIPTION
Closes #5350
- No longer necessary to initialize via async init().
- Adds a startup-check for mail configuration.
- Creates a notification in the admin client if
  mail transport is "direct" and sending a message fails.
