### PR TITLE
Don't include app fields

### DIFF
--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -19,7 +19,7 @@ queryDefaults = {
 // Default post query needs to always include author & tags
 _.extend(defaultPostQuery, queryDefaults, {
     options: {
-        include: 'author,tags,fields'
+        include: 'author,tags'
     }
 });
 

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -108,7 +108,7 @@ frontendControllers = {
         var params = {
                 uuid: req.params.uuid,
                 status: 'all',
-                include: 'author,tags,fields'
+                include: 'author,tags'
             };
 
         api.posts.read(params).then(function then(result) {
@@ -160,8 +160,8 @@ frontendControllers = {
 
         // Sanitize params we're going to use to lookup the post.
         postLookup = _.pick(params, 'slug', 'id');
-        // Add author, tag and fields
-        postLookup.include = 'author,tags,fields';
+        // Add author & tag
+        postLookup.include = 'author,tags';
 
         // Query database to find post
         return api.posts.read(postLookup).then(function then(result) {

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -85,7 +85,7 @@ describe('fetchData', function () {
                 result.data.featured.should.not.have.properties('data');
 
                 apiPostsStub.calledTwice.should.be.true();
-                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
+                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');
                 apiPostsStub.secondCall.args[0].should.have.property('limit', 3);
@@ -113,7 +113,7 @@ describe('fetchData', function () {
                 result.data.featured.should.not.have.properties('data');
 
                 apiPostsStub.calledTwice.should.be.true();
-                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags,fields');
+                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.firstCall.args[0].should.have.property('page', 2);
                 apiPostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -284,7 +284,7 @@ describe('RSS', function () {
         it('should process the data correctly for the index feed', function (done) {
             res.send = function send(xmlData) {
                 apiBrowseStub.calledOnce.should.be.true();
-                apiBrowseStub.calledWith({page: 1, include: 'author,tags,fields'}).should.be.true();
+                apiBrowseStub.calledWith({page: 1, include: 'author,tags'}).should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Test\]\]><\/title>/);
                 done();
             };
@@ -304,7 +304,7 @@ describe('RSS', function () {
             // test
             res.send = function send(xmlData) {
                 apiBrowseStub.calledOnce.should.be.true();
-                apiBrowseStub.calledWith({page: 1, filter: 'tags:\'magic\'', include: 'author,tags,fields'}).should.be.true();
+                apiBrowseStub.calledWith({page: 1, filter: 'tags:\'magic\'', include: 'author,tags'}).should.be.true();
                 apiTagStub.calledOnce.should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Magic - Test\]\]><\/title>/);
                 done();
@@ -322,7 +322,7 @@ describe('RSS', function () {
             // test
             res.send = function send(xmlData) {
                 apiBrowseStub.calledOnce.should.be.true();
-                apiBrowseStub.calledWith({page: 1, filter: 'author:\'joe\'', include: 'author,tags,fields'}).should.be.true();
+                apiBrowseStub.calledWith({page: 1, filter: 'author:\'joe\'', include: 'author,tags'}).should.be.true();
                 apiUserStub.calledOnce.should.be.true();
                 xmlData.should.match(/<channel><title><!\[CDATA\[Joe Blogs - Test\]\]><\/title>/);
                 done();


### PR DESCRIPTION
no issue

Including app fields along with tags & authors was a preoptimisation.
We don't use them yet, and having them results in database calls that are unnecessary.
