### PR TITLE
Support Node v4 LTS semver-minor releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2"
+  - "4"
 sudo: false
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install Node.js.
 
 ```bash
 # Node v0.10.x - recommended
-# Node v0.12.x and v4.2.x - supported
+# Node v0.12.x and v4.2.x / v4.3.x - supported
 #
 # Choose wisely
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ~4.2.0",
+    "node": "~0.10.0 || ~0.12.0 || ^4.2.0",
     "iojs": "~1.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #6473
- Replace Node v4.2 with v4 in Travis config
- Replace ~4.2.0 with ^4.2.0 in engines to support semver-minor bumps in LTS line
