### PR TITLE
Move db connection out of config

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -7,7 +7,7 @@ var path          = require('path'),
     fs            = require('fs'),
     url           = require('url'),
     _             = require('lodash'),
-    knex          = require('knex'),
+
     validator     = require('validator'),
     readDirectory = require('../utils/read-directory'),
     readThemes    = require('../utils/read-themes'),
@@ -18,8 +18,7 @@ var path          = require('path'),
     appRoot       = path.resolve(__dirname, '../../../'),
     corePath      = path.resolve(appRoot, 'core/'),
     testingEnvs   = ['testing', 'testing-mysql', 'testing-pg'],
-    defaultConfig = {},
-    knexInstance;
+    defaultConfig = {};
 
 function ConfigManager(config) {
     /**
@@ -86,25 +85,6 @@ ConfigManager.prototype.init = function (rawConfig) {
     });
 };
 
-function configureDriver(client) {
-    var pg;
-
-    if (client === 'pg' || client === 'postgres' || client === 'postgresql') {
-        try {
-            pg = require('pg');
-        } catch (e) {
-            pg = require('pg.js');
-        }
-
-        // By default PostgreSQL returns data as strings along with an OID that identifies
-        // its type.  We're setting the parser to convert OID 20 (int8) into a javascript
-        // integer.
-        pg.types.setTypeParser(20, function (val) {
-            return val === null ? null : parseInt(val, 10);
-        });
-    }
-}
-
 /**
  * Allows you to set the config object.
  * @param {Object} config Only accepts an object at the moment.
@@ -156,12 +136,7 @@ ConfigManager.prototype.set = function (config) {
     assetHash = this._config.assetHash ||
         (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10);
 
-    if (!knexInstance && this._config.database && this._config.database.client) {
-        configureDriver(this._config.database.client);
-        knexInstance = knex(this._config.database);
-    }
-
-    // Protect against accessing a non-existant object.
+    // Protect against accessing a non-existent object.
     // This ensures there's always at least a storage object
     // because it's referenced in multiple places.
     this._config.storage = this._config.storage || {};
@@ -174,9 +149,6 @@ ConfigManager.prototype.set = function (config) {
     }
 
     _.merge(this._config, {
-        database: {
-            knex: knexInstance
-        },
         ghostVersion: packageInfo.version,
         paths: {
             appRoot:          appRoot,

--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,0 +1,30 @@
+var knex     = require('knex'),
+    config   = require('../../config'),
+    dbConfig = config.database,
+    knexInstance;
+
+function configureDriver(client) {
+    var pg;
+
+    if (client === 'pg' || client === 'postgres' || client === 'postgresql') {
+        try {
+            pg = require('pg');
+        } catch (e) {
+            pg = require('pg.js');
+        }
+
+        // By default PostgreSQL returns data as strings along with an OID that identifies
+        // its type.  We're setting the parser to convert OID 20 (int8) into a javascript
+        // integer.
+        pg.types.setTypeParser(20, function (val) {
+            return val === null ? null : parseInt(val, 10);
+        });
+    }
+}
+
+if (!knexInstance && dbConfig && dbConfig.client) {
+    configureDriver(dbConfig.client);
+    knexInstance = knex(dbConfig);
+}
+
+module.exports = knexInstance;

--- a/core/server/data/db/index.js
+++ b/core/server/data/db/index.js
@@ -1,0 +1,10 @@
+var connection;
+
+Object.defineProperty(exports, 'knex', {
+    enumerable: true,
+    configurable: false,
+    get: function get() {
+        connection = connection || require('./connection');
+        return connection;
+    }
+});

--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -1,6 +1,6 @@
 var _           = require('lodash'),
     Promise     = require('bluebird'),
-    config      = require('../../config'),
+    db          = require('../../data/db'),
     commands    = require('../schema').commands,
     versioning  = require('../schema').versioning,
     serverUtils = require('../../utils'),
@@ -33,7 +33,7 @@ exporter = function () {
             tables = results[1],
             selectOps = _.map(tables, function (name) {
                 if (excludedTables.indexOf(name) < 0) {
-                    return config.database.knex(name).select();
+                    return db.knex(name).select();
                 }
             });
 

--- a/core/server/data/schema/clients/mysql.js
+++ b/core/server/data/schema/clients/mysql.js
@@ -1,5 +1,5 @@
-var _       = require('lodash'),
-    config  = require('../../../config/index'),
+var _  = require('lodash'),
+    db = require('../../../data/db'),
 
     // private
     doRawAndFlatten,
@@ -11,7 +11,7 @@ var _       = require('lodash'),
     checkPostTable;
 
 doRawAndFlatten = function doRaw(query, flattenFn) {
-    return config.database.knex.raw(query).then(function (response) {
+    return db.knex.raw(query).then(function (response) {
         return _.flatten(flattenFn(response));
     });
 };
@@ -39,10 +39,10 @@ getColumns = function getColumns(table) {
 // data type text instead of mediumtext.
 // For details see: https://github.com/TryGhost/Ghost/issues/1947
 checkPostTable = function checkPostTable() {
-    return config.database.knex.raw('SHOW FIELDS FROM posts where Field ="html" OR Field = "markdown"').then(function (response) {
+    return db.knex.raw('SHOW FIELDS FROM posts where Field ="html" OR Field = "markdown"').then(function (response) {
         return _.flatten(_.map(response[0], function (entry) {
             if (entry.Type.toLowerCase() !== 'mediumtext') {
-                return config.database.knex.raw('ALTER TABLE posts MODIFY ' + entry.Field + ' MEDIUMTEXT');
+                return db.knex.raw('ALTER TABLE posts MODIFY ' + entry.Field + ' MEDIUMTEXT');
             }
         }));
     });

--- a/core/server/data/schema/clients/pg.js
+++ b/core/server/data/schema/clients/pg.js
@@ -1,5 +1,5 @@
-var _       = require('lodash'),
-    config  = require('../../../config/index'),
+var _  = require('lodash'),
+    db = require('../../../data/db'),
 
     // private
     doRawFlattenAndPluck,
@@ -10,7 +10,7 @@ var _       = require('lodash'),
     getColumns;
 
 doRawFlattenAndPluck = function doRaw(query, name) {
-    return config.database.knex.raw(query).then(function (response) {
+    return db.knex.raw(query).then(function (response) {
         return _.flatten(_.pluck(response.rows, name));
     });
 };

--- a/core/server/data/schema/clients/sqlite3.js
+++ b/core/server/data/schema/clients/sqlite3.js
@@ -1,5 +1,5 @@
-var _       = require('lodash'),
-    config  = require('../../../config/index'),
+var _  = require('lodash'),
+    db = require('../../../data/db'),
 
     // private
     doRaw,
@@ -10,7 +10,7 @@ var _       = require('lodash'),
     getColumns;
 
 doRaw = function doRaw(query, fn) {
-    return config.database.knex.raw(query).then(function (response) {
+    return db.knex.raw(query).then(function (response) {
         return fn(response);
     });
 };

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -1,11 +1,9 @@
 var _       = require('lodash'),
     Promise = require('bluebird'),
-    config  = require('../../config'),
     i18n    = require('../../i18n'),
+    db      = require('../db'),
     schema  = require('./schema'),
-    clients = require('./clients'),
-
-    dbConfig;
+    clients = require('./clients');
 
 function addTableColumn(tablename, table, columnname) {
     var column,
@@ -44,37 +42,31 @@ function addTableColumn(tablename, table, columnname) {
 }
 
 function addColumn(table, column) {
-    dbConfig = dbConfig || config.database;
-    return dbConfig.knex.schema.table(table, function (t) {
+    return db.knex.schema.table(table, function (t) {
         addTableColumn(table, t, column);
     });
 }
 
 function dropColumn(table, column) {
-    dbConfig = dbConfig || config.database;
-
-    return dbConfig.knex.schema.table(table, function (table) {
+    return db.knex.schema.table(table, function (table) {
         table.dropColumn(column);
     });
 }
 
 function addUnique(table, column) {
-    dbConfig = dbConfig || config.database;
-    return dbConfig.knex.schema.table(table, function (table) {
+    return db.knex.schema.table(table, function (table) {
         table.unique(column);
     });
 }
 
 function dropUnique(table, column) {
-    dbConfig = dbConfig || config.database;
-    return dbConfig.knex.schema.table(table, function (table) {
+    return db.knex.schema.table(table, function (table) {
         table.dropUnique(column);
     });
 }
 
 function createTable(table) {
-    dbConfig = dbConfig || config.database;
-    return dbConfig.knex.schema.createTable(table, function (t) {
+    return db.knex.schema.createTable(table, function (t) {
         var columnKeys = _.keys(schema[table]);
         _.each(columnKeys, function (column) {
             return addTableColumn(table, t, column);
@@ -83,13 +75,11 @@ function createTable(table) {
 }
 
 function deleteTable(table) {
-    dbConfig = dbConfig || config.database;
-    return dbConfig.knex.schema.dropTableIfExists(table);
+    return db.knex.schema.dropTableIfExists(table);
 }
 
 function getTables() {
-    dbConfig = dbConfig || config.database;
-    var client = dbConfig.client;
+    var client = db.knex.client.config.client;
 
     if (_.contains(_.keys(clients), client)) {
         return clients[client].getTables();
@@ -99,8 +89,7 @@ function getTables() {
 }
 
 function getIndexes(table) {
-    dbConfig = dbConfig || config.database;
-    var client = dbConfig.client;
+    var client = db.knex.client.config.client;
 
     if (_.contains(_.keys(clients), client)) {
         return clients[client].getIndexes(table);
@@ -110,8 +99,7 @@ function getIndexes(table) {
 }
 
 function getColumns(table) {
-    dbConfig = dbConfig || config.database;
-    var client = dbConfig.client;
+    var client = db.knex.client.config.client;
 
     if (_.contains(_.keys(clients), client)) {
         return clients[client].getColumns(table);
@@ -121,8 +109,7 @@ function getColumns(table) {
 }
 
 function checkTables() {
-    dbConfig = dbConfig || config.database;
-    var client = dbConfig.client;
+    var client = db.knex.client.config.client;
 
     if (client === 'mysql') {
         return clients[client].checkPostTable();

--- a/core/server/data/schema/versioning.js
+++ b/core/server/data/schema/versioning.js
@@ -1,6 +1,6 @@
 var _               = require('lodash'),
+    db              = require('../db'),
     errors          = require('../../errors'),
-    config          = require('../../config'),
     i18n            = require('../../i18n'),
     defaultSettings = require('./default-settings'),
 
@@ -23,13 +23,11 @@ function getDefaultDatabaseVersion() {
 // The migration version number according to the database
 // This is what the database is currently at and may need to be updated
 function getDatabaseVersion() {
-    var knex = config.database.knex;
-
-    return knex.schema.hasTable('settings').then(function (exists) {
+    return db.knex.schema.hasTable('settings').then(function (exists) {
         // Check for the current version from the settings table
         if (exists) {
             // Temporary code to deal with old databases with currentVersion settings
-            return knex('settings')
+            return db.knex('settings')
                 .where('key', 'databaseVersion')
                 .orWhere('key', 'currentVersion')
                 .select('value')
@@ -54,7 +52,7 @@ function getDatabaseVersion() {
 }
 
 function setDatabaseVersion() {
-    return config.database.knex('settings')
+    return db.knex('settings')
         .where('key', 'databaseVersion')
         .update({value: defaultDatabaseVersion});
 }

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -9,7 +9,6 @@ var express     = require('express'),
     uuid        = require('node-uuid'),
     Promise     = require('bluebird'),
     i18n        = require('./i18n'),
-
     api         = require('./api'),
     config      = require('./config'),
     errors      = require('./errors'),

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -8,6 +8,7 @@
 var _          = require('lodash'),
     bookshelf  = require('bookshelf'),
     config     = require('../../config'),
+    db         = require('../../data/db'),
     errors     = require('../../errors'),
     filters    = require('../../filters'),
     moment     = require('moment'),
@@ -25,7 +26,7 @@ var _          = require('lodash'),
 
 // ### ghostBookshelf
 // Initializes a new Bookshelf instance called ghostBookshelf, for reference elsewhere in Ghost.
-ghostBookshelf = bookshelf(config.database.knex);
+ghostBookshelf = bookshelf(db.knex);
 
 // Load the Bookshelf registry plugin, which helps us avoid circular dependencies
 ghostBookshelf.plugin('registry');

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -10,6 +10,7 @@ var testUtils   = require('../utils/index'),
     validator   = require('validator'),
 
     // Stuff we are testing
+    db              = require('../../server/data/db'),
     config          = require('../../server/config'),
     defaultConfig   = rewire('../../../config.example')[process.env.NODE_ENV],
     migration       = rewire('../../server/data/migration'),
@@ -17,7 +18,7 @@ var testUtils   = require('../utils/index'),
     importer        = require('../../server/data/import'),
     DataImporter    = require('../../server/data/import/data-importer'),
 
-    knex = config.database.knex,
+    knex = db.knex,
     sandbox = sinon.sandbox.create();
 
 // Tests in here do an import for each test

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -6,7 +6,7 @@ var testUtils       = require('../../utils'),
 
     // Stuff we are testing
     SettingsModel   = require('../../../server/models/settings').Settings,
-    config          = require('../../../server/config'),
+    db              = require('../../../server/data/db'),
     events          = require('../../../server/events'),
     sandbox         = sinon.sandbox.create(),
     context         = testUtils.context.admin;
@@ -176,7 +176,7 @@ describe('Settings Model', function () {
 
     describe('populating defaults from settings.json', function () {
         beforeEach(function (done) {
-            config.database.knex('settings').truncate().then(function () {
+            db.knex('settings').truncate().then(function () {
                 done();
             });
         });

--- a/core/test/utils/fixtures/filter-param/index.js
+++ b/core/test/utils/fixtures/filter-param/index.js
@@ -1,8 +1,8 @@
 /**
  * These fixtures are just for testing the filter spec
  */
-var _ = require('lodash'),
-    config = require('../../../../server/config'),
+var _    = require('lodash'),
+    db   = require('../../../../server/data/db'),
     data = {};
 
 data.tags = [
@@ -313,17 +313,16 @@ function createPosts(knex, DataGenerator, created) {
 }
 
 module.exports = function (DataGenerator) {
-    var knex = config.database.knex,
-       created = {};
+    var created = {};
     // Create users first
-    return createUsers(knex, DataGenerator).then(function (createdUsers) {
+    return createUsers(db.knex, DataGenerator).then(function (createdUsers) {
         created.users = createdUsers;
         // Next create tags
-        return createTags(knex, DataGenerator, created);
+        return createTags(db.knex, DataGenerator, created);
     }).then(function (createdTags) {
         created.tags = createdTags;
         // Finally, setup posts with the right authors and tags
-        return createPosts(knex, DataGenerator, created);
+        return createPosts(db.knex, DataGenerator, created);
     }).then(function (createdPosts) {
         created.posts = createdPosts;
         return created;

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -3,6 +3,7 @@ var Promise       = require('bluebird'),
     fs            = require('fs-extra'),
     path          = require('path'),
     uuid          = require('node-uuid'),
+    db            = require('../../server/data/db'),
     migration     = require('../../server/data/migration/'),
     Models        = require('../../server/models'),
     SettingsAPI   = require('../../server/api/settings'),
@@ -33,18 +34,16 @@ var Promise       = require('bluebird'),
 /** TEST FIXTURES **/
 fixtures = {
     insertPosts: function insertPosts() {
-        var knex = config.database.knex;
-        return Promise.resolve(knex('posts').insert(DataGenerator.forKnex.posts)).then(function () {
-            return knex('tags').insert(DataGenerator.forKnex.tags);
+        return Promise.resolve(db.knex('posts').insert(DataGenerator.forKnex.posts)).then(function () {
+            return db.knex('tags').insert(DataGenerator.forKnex.tags);
         }).then(function () {
-            return knex('posts_tags').insert(DataGenerator.forKnex.posts_tags);
+            return db.knex('posts_tags').insert(DataGenerator.forKnex.posts_tags);
         });
     },
 
     insertMultiAuthorPosts: function insertMultiAuthorPosts(max) {
         /*jshint unused:false*/
-        var knex = config.database.knex,
-            author,
+        var author,
             authors,
             i, j, k = postsInserted,
             posts = [];
@@ -53,9 +52,9 @@ fixtures = {
         // insert users of different roles
         return Promise.resolve(fixtures.createUsersWithRoles()).then(function () {
             // create the tags
-            return knex('tags').insert(DataGenerator.forKnex.tags);
+            return db.knex('tags').insert(DataGenerator.forKnex.tags);
         }).then(function () {
-            return knex('users').select('id');
+            return db.knex('users').select('id');
         }).then(function (results) {
             authors = _.pluck(results, 'id');
 
@@ -71,14 +70,14 @@ fixtures = {
 
             return sequence(_.times(posts.length, function (index) {
                 return function () {
-                    return knex('posts').insert(posts[index]);
+                    return db.knex('posts').insert(posts[index]);
                 };
             }));
         }).then(function () {
             return Promise.all([
                 // PostgreSQL can return results in any order
-                knex('posts').orderBy('id', 'asc').select('id'),
-                knex('tags').select('id')
+                db.knex('posts').orderBy('id', 'asc').select('id'),
+                db.knex('tags').select('id')
             ]);
         }).then(function (results) {
             var posts = _.pluck(results[0], 'id'),
@@ -96,7 +95,7 @@ fixtures = {
 
             return sequence(_.times(promises.length, function (index) {
                 return function () {
-                    return knex('posts_tags').insert(promises[index]);
+                    return db.knex('posts_tags').insert(promises[index]);
                 };
             }));
         });
@@ -106,8 +105,7 @@ fixtures = {
         var lang,
             status,
             posts = [],
-            i, j, k = postsInserted,
-            knex = config.database.knex;
+            i, j, k = postsInserted;
 
         max = max || 50;
 
@@ -128,7 +126,7 @@ fixtures = {
 
         return sequence(_.times(posts.length, function (index) {
             return function () {
-                return knex('posts').insert(posts[index]);
+                return db.knex('posts').insert(posts[index]);
             };
         }));
     },
@@ -137,8 +135,7 @@ fixtures = {
         max = max || 50;
         var tags = [],
             tagName,
-            i,
-            knex = config.database.knex;
+            i;
 
         for (i = 0; i < max; i += 1) {
             tagName = uuid.v4().split('-')[0];
@@ -147,7 +144,7 @@ fixtures = {
 
         return sequence(_.times(tags.length, function (index) {
             return function () {
-                return knex('tags').insert(tags[index]);
+                return db.knex('tags').insert(tags[index]);
             };
         }));
     },
@@ -155,12 +152,10 @@ fixtures = {
     insertMorePostsTags: function insertMorePostsTags(max) {
         max = max || 50;
 
-        var knex = config.database.knex;
-
         return Promise.all([
             // PostgreSQL can return results in any order
-            knex('posts').orderBy('id', 'asc').select('id'),
-            knex('tags').select('id', 'name')
+            db.knex('posts').orderBy('id', 'asc').select('id'),
+            db.knex('tags').select('id', 'name')
         ]).then(function (results) {
             var posts = _.pluck(results[0], 'id'),
                 injectionTagId = _.chain(results[1])
@@ -180,68 +175,62 @@ fixtures = {
 
             return sequence(_.times(promises.length, function (index) {
                 return function () {
-                    return knex('posts_tags').insert(promises[index]);
+                    return db.knex('posts_tags').insert(promises[index]);
                 };
             }));
         });
     },
     insertRoles: function insertRoles() {
-        var knex = config.database.knex;
-        return knex('roles').insert(DataGenerator.forKnex.roles);
+        return db.knex('roles').insert(DataGenerator.forKnex.roles);
     },
 
     initOwnerUser: function initOwnerUser() {
-        var user = DataGenerator.Content.users[0],
-            knex = config.database.knex;
+        var user = DataGenerator.Content.users[0];
 
         user = DataGenerator.forKnex.createBasic(user);
         user = _.extend({}, user, {status: 'inactive'});
 
-        return knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
-            return knex('users').insert(user);
+        return db.knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
+            return db.knex('users').insert(user);
         }).then(function () {
-            return knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
+            return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
         });
     },
 
     insertOwnerUser: function insertOwnerUser() {
-        var user,
-            knex = config.database.knex;
+        var user;
 
         user = DataGenerator.forKnex.createUser(DataGenerator.Content.users[0]);
 
-        return knex('users').insert(user).then(function () {
-            return knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
+        return db.knex('users').insert(user).then(function () {
+            return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
         });
     },
 
     overrideOwnerUser: function overrideOwnerUser(slug) {
-        var user,
-            knex = config.database.knex;
+        var user;
 
         user = DataGenerator.forKnex.createUser(DataGenerator.Content.users[0]);
         if (slug) {
             user.slug = slug;
         }
 
-        return knex('users')
+        return db.knex('users')
             .where('id', '=', '1')
             .update(user);
     },
 
     createUsersWithRoles: function createUsersWithRoles() {
-        var knex = config.database.knex;
-        return knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
-            return knex('users').insert(DataGenerator.forKnex.users);
+        return db.knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
+            return db.knex('users').insert(DataGenerator.forKnex.users);
         }).then(function () {
-            return knex('roles_users').insert(DataGenerator.forKnex.roles_users);
+            return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users);
         });
     },
 
     createExtraUsers: function createExtraUsers() {
-        var knex = config.database.knex,
-            // grab 3 more users
-            extraUsers = DataGenerator.Content.users.slice(2, 5);
+        // grab 3 more users
+        var extraUsers = DataGenerator.Content.users.slice(2, 5);
 
         extraUsers = _.map(extraUsers, function (user) {
             return DataGenerator.forKnex.createUser(_.extend({}, user, {
@@ -250,8 +239,8 @@ fixtures = {
             }));
         });
 
-        return knex('users').insert(extraUsers).then(function () {
-            return knex('roles_users').insert([
+        return db.knex('users').insert(extraUsers).then(function () {
+            return db.knex('roles_users').insert([
                 {user_id: 5, role_id: 1},
                 {user_id: 6, role_id: 2},
                 {user_id: 7, role_id: 3}
@@ -261,18 +250,16 @@ fixtures = {
 
     // Creates a client, and access and refresh tokens for user 3 (author)
     createTokensForUser: function createTokensForUser() {
-        var knex = config.database.knex;
-        return knex('clients').insert(DataGenerator.forKnex.clients).then(function () {
-            return knex('accesstokens').insert(DataGenerator.forKnex.createToken({user_id: 3}));
+        return db.knex('clients').insert(DataGenerator.forKnex.clients).then(function () {
+            return db.knex('accesstokens').insert(DataGenerator.forKnex.createToken({user_id: 3}));
         }).then(function () {
-            return knex('refreshtokens').insert(DataGenerator.forKnex.createToken({user_id: 3}));
+            return db.knex('refreshtokens').insert(DataGenerator.forKnex.createToken({user_id: 3}));
         });
     },
 
     createInvitedUsers: function createInvitedUser() {
-        var knex = config.database.knex,
-            // grab 3 more users
-            extraUsers = DataGenerator.Content.users.slice(2, 5);
+        // grab 3 more users
+        var extraUsers = DataGenerator.Content.users.slice(2, 5);
 
         extraUsers = _.map(extraUsers, function (user) {
             return DataGenerator.forKnex.createUser(_.extend({}, user, {
@@ -282,8 +269,8 @@ fixtures = {
             }));
         });
 
-        return knex('users').insert(extraUsers).then(function () {
-            return knex('roles_users').insert([
+        return db.knex('users').insert(extraUsers).then(function () {
+            return db.knex('roles_users').insert([
                 {user_id: 8, role_id: 1},
                 {user_id: 9, role_id: 2},
                 {user_id: 10, role_id: 3}
@@ -292,15 +279,13 @@ fixtures = {
     },
 
     insertOne: function insertOne(obj, fn) {
-        var knex = config.database.knex;
-        return knex(obj)
+        return db.knex(obj)
            .insert(DataGenerator.forKnex[fn](DataGenerator.Content[obj][0]));
     },
 
     insertApps: function insertApps() {
-        var knex = config.database.knex;
-        return knex('apps').insert(DataGenerator.forKnex.apps).then(function () {
-            return knex('app_fields').insert(DataGenerator.forKnex.app_fields);
+        return db.knex('apps').insert(DataGenerator.forKnex.apps).then(function () {
+            return db.knex('app_fields').insert(DataGenerator.forKnex.app_fields);
         });
     },
 
@@ -331,8 +316,7 @@ fixtures = {
     },
 
     permissionsFor: function permissionsFor(obj) {
-        var knex = config.database.knex,
-            permsToInsert = permsFixtures.permissions[obj],
+        var permsToInsert = permsFixtures.permissions[obj],
             permsRolesToInsert = permsFixtures.permissions_roles,
             actions = [],
             permissionsRoles = [],
@@ -363,17 +347,15 @@ fixtures = {
             }
         });
 
-        return knex('permissions').insert(permsToInsert).then(function () {
-            return knex('permissions_roles').insert(permissionsRoles);
+        return db.knex('permissions').insert(permsToInsert).then(function () {
+            return db.knex('permissions_roles').insert(permissionsRoles);
         });
     },
     insertClients: function insertClients() {
-        var knex = config.database.knex;
-        return knex('clients').insert(DataGenerator.forKnex.clients);
+        return db.knex('clients').insert(DataGenerator.forKnex.clients);
     },
     insertAccessToken: function insertAccessToken(override) {
-        var knex = config.database.knex;
-        return knex('accesstokens').insert(DataGenerator.forKnex.createToken(override));
+        return db.knex('accesstokens').insert(DataGenerator.forKnex.createToken(override));
     }
 };
 


### PR DESCRIPTION
This is one small step towards a new world order inside of Ghost core, where things are what they say they are, and aren't all interdependent. 

A special shout out to @esatterwhite for this one - I'd have cherry-picked the commits but I couldn't get a valid reference.

refs #5047
- database connections are not configuration
