### PR TITLE
Refactor gravatarLookup, remove request dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,11 +8,11 @@
 var _              = require('lodash'),
     chalk          = require('chalk'),
     fs             = require('fs-extra'),
+    https          = require('https'),
     moment         = require('moment'),
     getTopContribs = require('top-gh-contribs'),
     path           = require('path'),
     Promise        = require('bluebird'),
-    request        = require('request'),
 
     escapeChar     = process.platform.match(/^win/) ? '^' : '\\',
     cwd            = process.cwd().replace(/( |\(|\))/g, escapeChar + '$1'),
@@ -834,15 +834,17 @@ var _              = require('lodash'),
             ).then(function (results) {
                 var contributors = results[1],
                     contributorTemplate = '<article>\n    <a href="<%githubUrl%>" title="<%name%>">\n' +
-                    '        <img src="{{gh-path "admin" "/img/contributors"}}/<%name%>" alt="<%name%>" />\n' +
-                    '    </a>\n</article>',
+                        '        <img src="{{gh-path "admin" "/img/contributors"}}/<%name%>" alt="<%name%>" />\n' +
+                        '    </a>\n</article>',
 
                     downloadImagePromise = function (url, name) {
                         return new Promise(function (resolve, reject) {
-                            request(url)
-                            .pipe(fs.createWriteStream(imagePath + name))
-                            .on('close', resolve)
-                            .on('error', reject);
+                            https.get(url, function (res) {
+                                    fs.writeFile(imagePath + name, res, function () {
+                                        resolve();
+                                    });
+                                })
+                                .on('error', reject);
                         });
                     };
 

--- a/core/server/utils/gravatar.js
+++ b/core/server/utils/gravatar.js
@@ -1,0 +1,42 @@
+var Promise = require('bluebird'),
+    config = require('../config'),
+    crypto = require('crypto'),
+    https = require('https');
+
+module.exports.lookup = function lookup(userData, timeout) {
+    var gravatarUrl = '//www.gravatar.com/avatar/' +
+        crypto.createHash('md5').update(userData.email.toLowerCase().trim()).digest('hex') +
+        '?s=250';
+
+    return new Promise(function gravatarRequest(resolve) {
+        if (config.isPrivacyDisabled('useGravatar') || process.env.NODE_ENV.indexOf('testing') > -1) {
+            return resolve(userData);
+        }
+
+        var request, timer, timerEnded = false;
+
+        request = https.get('https:' + gravatarUrl + '&d=404&r=x', function (response) {
+            clearTimeout(timer);
+            if (response.statusCode !== 404 && !timerEnded) {
+                gravatarUrl += '&d=mm&r=x';
+                userData.image = gravatarUrl;
+            }
+
+            resolve(userData);
+        });
+
+        request.on('error', function () {
+            clearTimeout(timer);
+            // just resolve with no image url
+            if (!timerEnded) {
+                return resolve(userData);
+            }
+        });
+
+        timer = setTimeout(function () {
+            timerEnded = true;
+            request.abort();
+            return resolve(userData);
+        }, timeout || 2000);
+    });
+};

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -7,7 +7,7 @@ var testUtils       = require('../../utils'),
     _               = require('lodash'),
 
 // Stuff we are testing
-    ModelUser       = require('../../../server/models'),
+    models          = require('../../../server/models'),
     UserAPI         = require('../../../server/api/users'),
     mail            = require('../../../server/api/mail'),
 
@@ -39,7 +39,7 @@ describe('Users API', function () {
     it('dateTime fields are returned as Date objects', function (done) {
         var userData = testUtils.DataGenerator.forModel.users[0];
 
-        ModelUser.User.check({email: userData.email, password: userData.password}).then(function (user) {
+        models.User.check({email: userData.email, password: userData.password}).then(function (user) {
             return UserAPI.read({id: user.id});
         }).then(function (response) {
             response.users[0].created_at.should.be.an.instanceof(Date);
@@ -482,7 +482,7 @@ describe('Users API', function () {
             UserAPI.edit(
                 {users: [{name: 'newname', password: 'newpassword'}]}, _.extend({}, context.author, {id: userIdFor.author})
             ).then(function () {
-                return ModelUser.User.findOne({id: userIdFor.author}).then(function (response) {
+                return models.User.findOne({id: userIdFor.author}).then(function (response) {
                     response.get('name').should.eql('newname');
                     response.get('password').should.not.eql('newpassword');
                     done();
@@ -496,10 +496,6 @@ describe('Users API', function () {
 
         beforeEach(function () {
             newUser = _.clone(testUtils.DataGenerator.forKnex.createUser(testUtils.DataGenerator.Content.users[4]));
-
-            sandbox.stub(ModelUser.User, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
 
             sandbox.stub(mail, 'send', function () {
                 return Promise.resolve();

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -9,6 +9,7 @@ var testUtils   = require('../../utils'),
 
     // Stuff we are testing
     utils       = require('../../../server/utils'),
+    gravatar    = require('../../../server/utils/gravatar'),
     UserModel   = require('../../../server/models/user').User,
     RoleModel   = require('../../../server/models/role').Role,
     events      = require('../../../server/events'),
@@ -38,10 +39,6 @@ describe('User Model', function run() {
         it('can add first', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[0];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
-
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
@@ -55,10 +52,6 @@ describe('User Model', function run() {
         it('shortens slug if possible', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[2];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
-
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('slug').should.equal(true);
@@ -69,10 +62,6 @@ describe('User Model', function run() {
 
         it('does not short slug if not possible', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[2];
-
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
 
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
@@ -99,10 +88,6 @@ describe('User Model', function run() {
         it('does NOT lowercase email', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[2];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
-
             UserModel.add(userData, context).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
@@ -114,7 +99,7 @@ describe('User Model', function run() {
         it('can find gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
+            sandbox.stub(gravatar, 'lookup', function (userData) {
                 userData.image = 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404';
                 return Promise.resolve(userData);
             });
@@ -132,7 +117,7 @@ describe('User Model', function run() {
         it('can handle no gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[0];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
+            sandbox.stub(gravatar, 'lookup', function (userData) {
                 return Promise.resolve(userData);
             });
 
@@ -336,10 +321,6 @@ describe('User Model', function run() {
         it('can invite user', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4];
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
-
             UserModel.add(_.extend({}, userData, {status: 'invited'}), context).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
@@ -355,10 +336,6 @@ describe('User Model', function run() {
 
         it('can add active user', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4];
-
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
 
             RoleModel.findOne().then(function (role) {
                 userData.roles = [role.toJSON()];
@@ -406,10 +383,6 @@ describe('User Model', function run() {
             var userData = testUtils.DataGenerator.forModel.users[4],
                 userId;
 
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
-
             UserModel.add(_.extend({}, userData, {status: 'invited'}), context).then(function (createdUser) {
                 should.exist(createdUser);
                 createdUser.has('uuid').should.equal(true);
@@ -435,10 +408,6 @@ describe('User Model', function run() {
         it('can activate invited user', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4],
                 userId;
-
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
 
             UserModel.add(_.extend({}, userData, {status: 'invited'}), context).then(function (createdUser) {
                 should.exist(createdUser);
@@ -494,10 +463,6 @@ describe('User Model', function run() {
         it('can destroy invited user', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4],
                 userId;
-
-            sandbox.stub(UserModel, 'gravatarLookup', function (userData) {
-                return Promise.resolve(userData);
-            });
 
             UserModel.add(_.extend({}, userData, {status: 'invited'}), context).then(function (createdUser) {
                 should.exist(createdUser);

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -1,7 +1,7 @@
 /*globals describe, it*/
 /*jshint expr:true*/
 var should          = require('should'),
-    request         = require('request'),
+    http            = require('http'),
     config          = require('../../../config');
 
 describe('Server', function () {
@@ -10,11 +10,12 @@ describe('Server', function () {
         url = 'http://' + host + ':' + port;
 
     it('should not start a connect server when required', function (done) {
-        request(url, function (error, response, body) {
-            should(response).equal(undefined);
-            should(body).equal(undefined);
+        http.get(url, function () {
+            done('This request should not have worked');
+        }).on('error', function (error) {
             should(error).not.equal(undefined);
             should(error.code).equal('ECONNREFUSED');
+
             done();
         });
     });

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.3",
-    "request": "2.69.0",
     "rss": "1.2.1",
     "semver": "5.1.0",
     "showdown-ghost": "0.3.6",


### PR DESCRIPTION
I've been poking Ghost in various ways whilst looking at migrations, and how they work. Using `console.time` and `console.timeEnd` as well as [debug](https://github.com/visionmedia/debug) I was looking to see if migrations take much time to check that there's nothing to do (which is the majority of cases).

Whilst looking at this, I noticed our models take a particularly long time to be included at startup, and when I drilled down into the various models, as well as the base model (which I'd expect) the only other model which took more than a few ms to be required was the user model.

![](http://puu.sh/n5zq0.png)

0-2ms for most models, 13ms for Post, and a whopping 287ms for Users. This seemed odd!

I played around with the requires, and discovered that taking [request](https://github.com/request/request) out reduced the require time significantly. This made me wonder how much use of request we make, and the answer was hardly any! All 3 usages were easily written using node's built-in http/https modules. Here's the updated timings:

![](http://puu.sh/n5zkx.png)

Optimising boot time is definitely not the most important optimisation we could make (it would be better to optimise memory usage), but this to me seems like a super quick win getting rid of a dependency we don't really need.

If we ever do need a `request`-like dependency in future, I think it'd be worth giving [needle](https://github.com/tomas/needle) a try.

no issue
- request is quite a heavy dependency
- we were only using request in 3 places: a test, storing contrib images in the gruntfile & the gravatar lookup
- all 3 are relatively simple to do with the http/https module
- refactored all 3, removed request
