### PR TITLE
Migration related test improvements

### DIFF
--- a/core/test/integration/export_spec.js
+++ b/core/test/integration/export_spec.js
@@ -9,6 +9,8 @@ var testUtils   = require('../utils/index'),
     // Stuff we are testing
     versioning  = require('../../server/data/schema').versioning,
     exporter    = require('../../server/data/export/index'),
+
+    DEF_DB_VERSION  = versioning.getDefaultDatabaseVersion(),
     sandbox = sinon.sandbox.create();
 
 describe('Exporter', function () {
@@ -22,9 +24,9 @@ describe('Exporter', function () {
     should.exist(exporter);
 
     it('exports data', function (done) {
-        // Stub migrations to return 000 as the current database version
+        // Stub migrations to return DEF_DB_VERSION as the current database version
         var versioningStub = sandbox.stub(versioning, 'getDatabaseVersion', function () {
-            return Promise.resolve('004');
+            return Promise.resolve(DEF_DB_VERSION);
         });
 
         exporter().then(function (exportData) {
@@ -37,13 +39,13 @@ describe('Exporter', function () {
             should.exist(exportData.meta);
             should.exist(exportData.data);
 
-            exportData.meta.version.should.equal('004');
+            exportData.meta.version.should.equal(DEF_DB_VERSION);
 
             dbVersionSetting = _.findWhere(exportData.data.settings, {key: 'databaseVersion'});
 
             should.exist(dbVersionSetting);
 
-            dbVersionSetting.value.should.equal('004');
+            dbVersionSetting.value.should.equal(DEF_DB_VERSION);
 
             _.each(tables, function (name) {
                 should.exist(exportData.data[name]);

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -12,12 +12,14 @@ var testUtils   = require('../utils/index'),
     // Stuff we are testing
     db              = require('../../server/data/db'),
     config          = require('../../server/config'),
+    versioning      = require('../../server/data/schema').versioning,
     defaultConfig   = rewire('../../../config.example')[process.env.NODE_ENV],
     migration       = rewire('../../server/data/migration'),
     exporter        = require('../../server/data/export'),
     importer        = require('../../server/data/import'),
     DataImporter    = require('../../server/data/import/data-importer'),
 
+    DEF_DB_VERSION  = versioning.getDefaultDatabaseVersion(),
     knex = db.knex,
     sandbox = sinon.sandbox.create();
 
@@ -155,7 +157,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
@@ -211,7 +213,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // activeTheme should NOT have been overridden
                 _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
@@ -272,7 +274,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -317,7 +319,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -375,7 +377,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // activeTheme should NOT have been overridden
                 _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
@@ -435,7 +437,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -479,7 +481,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -529,7 +531,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -719,7 +721,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -944,7 +946,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -1181,7 +1183,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal('004', 'Wrong database version');
+                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -2,39 +2,35 @@ var _               = require('lodash'),
     url             = require('url'),
     moment          = require('moment'),
     config          = require('../../server/config'),
+    schema          = require('../../server/data/schema').tables,
     ApiRouteBase    = '/ghost/api/v0.1/',
     host            = config.server.host,
     port            = config.server.port,
-    schema          = 'http://',
+    protocol        = 'http://',
     expectedProperties = {
+        // API top level
         configuration: ['key', 'value', 'type'],
-        posts: ['posts', 'meta'],
-        tags: ['tags', 'meta'],
-        users: ['users', 'meta'],
-        roles: ['roles'],
-        pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
-        post: ['id', 'uuid', 'title', 'slug', 'markdown', 'html', 'meta_title', 'meta_description',
-            'featured', 'image', 'status', 'language', 'created_at', 'created_by', 'updated_at',
-            'updated_by', 'published_at', 'published_by', 'page', 'author', 'url'
-        ],
-        settings: ['settings', 'meta'],
-        setting: ['id', 'uuid', 'key', 'value', 'type', 'created_at', 'created_by', 'updated_at', 'updated_by'],
-        tag: ['id', 'uuid', 'name', 'slug', 'description', 'parent', 'image', 'hidden',
-            'meta_title', 'meta_description', 'created_at', 'created_by', 'updated_at', 'updated_by'
-        ],
-        theme: ['uuid', 'name', 'version', 'active'],
-        user: ['id', 'uuid', 'name', 'slug', 'email', 'image', 'cover', 'bio', 'website',
-            'location', 'accessibility', 'status', 'language', 'meta_title', 'meta_description', 'tour', 'last_login',
-            'created_at', 'created_by',  'updated_at', 'updated_by'
-        ],
+        posts:         ['posts', 'meta'],
+        tags:          ['tags', 'meta'],
+        users:         ['users', 'meta'],
+        settings:      ['settings', 'meta'],
+        roles:         ['roles'],
+        pagination:    ['page', 'limit', 'pages', 'total', 'next', 'prev'],
+        slugs:         ['slugs'],
+        slug:          ['slug'],
+        // object / model level
+        // Post API swaps author_id to author, and always returns a computed 'url' property
+        post:        _(schema.posts).keys().without('author_id').concat('author', 'url').value(),
+        // User API always removes the password field
+        user:        _(schema.users).keys().without('password').value(),
+        // Tag API swaps parent_id to parent
+        tag:         _(schema.tags).keys().without('parent_id').concat('parent').value(),
+        setting:     _.keys(schema.settings),
+        accesstoken: _.keys(schema.accesstokens),
+        role:        _.keys(schema.roles),
+        permission:  _.keys(schema.permissions),
         notification: ['type', 'message', 'status', 'id', 'dismissible', 'location'],
-        slugs: ['slugs'],
-        slug: ['slug'],
-        accesstoken: ['access_token', 'refresh_token', 'expires_in', 'token_type'],
-        role: ['id', 'uuid', 'name', 'description', 'created_at', 'created_by', 'updated_at', 'updated_by'],
-        permission: ['id', 'uuid', 'name', 'object_type', 'action_type', 'object_id', 'created_at', 'created_by',
-            'updated_at', 'updated_by'
-        ]
+        theme:        ['uuid', 'name', 'version', 'active']
     };
 
 function getApiQuery(route) {
@@ -42,26 +38,41 @@ function getApiQuery(route) {
 }
 
 function getApiURL(route) {
-    var baseURL = url.resolve(schema + host + ':' + port, ApiRouteBase);
+    var baseURL = url.resolve(protocol + host + ':' + port, ApiRouteBase);
     return url.resolve(baseURL, route);
 }
-function getSigninURL() {
-    return url.resolve(schema + host + ':' + port, 'ghost/signin/');
+
+function getURL() {
+    return protocol + host;
 }
+
+function getSigninURL() {
+    return url.resolve(protocol + host + ':' + port, 'ghost/signin/');
+}
+
 function getAdminURL() {
-    return url.resolve(schema + host + ':' + port, 'ghost/');
+    return url.resolve(protocol + host + ':' + port, 'ghost/');
+}
+
+function isISO8601(date) {
+    return moment(date).parsingFlags().iso;
 }
 
 // make sure the API only returns expected properties only
-function checkResponseValue(jsonResponse, properties) {
-    for (var i = 0; i < properties.length; i = i + 1) {
-        // For some reason, settings response objects do not have the 'hasOwnProperty' method
-        if (Object.prototype.hasOwnProperty.call(jsonResponse, properties[i])) {
-            continue;
-        }
-        jsonResponse.should.have.property(properties[i]);
-    }
-    Object.keys(jsonResponse).length.should.eql(properties.length);
+function checkResponseValue(jsonResponse, expectedProperties) {
+    var providedProperties = _.keys(jsonResponse),
+        missing = _.difference(expectedProperties, providedProperties),
+        unexpected = _.difference(providedProperties, expectedProperties);
+
+    _.each(missing, function (prop) {
+        jsonResponse.should.have.property(prop);
+    });
+
+    _.each(unexpected, function (prop) {
+        jsonResponse.should.not.have.property(prop);
+    });
+
+    providedProperties.length.should.eql(expectedProperties.length);
 }
 
 function checkResponse(jsonResponse, objectType, additionalProperties, missingProperties) {
@@ -70,14 +81,6 @@ function checkResponse(jsonResponse, objectType, additionalProperties, missingPr
     checkProperties = missingProperties ? _.xor(checkProperties, missingProperties) : checkProperties;
 
     checkResponseValue(jsonResponse, checkProperties);
-}
-
-function isISO8601(date) {
-    return moment(date).parsingFlags().iso;
-}
-
-function getURL() {
-    return schema + host;
 }
 
 module.exports = {


### PR DESCRIPTION
refs #6301
- Don't hardcode the model fields in utils/api -> use the schema + modify the lists
  = We can now easily see what the differences between the schema and the API result are
- Don't hardcode the default DB version in the import/export tools
  = We don't have to update this every time we update the database version
