### PR TITLE
Improve 404 error handling in post route

### DIFF
--- a/core/client/app/routes/posts/post.js
+++ b/core/client/app/routes/posts/post.js
@@ -1,9 +1,10 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
+import NotFoundHandler from 'ghost/mixins/404-handler';
 import isNumber from 'ghost/utils/isNumber';
 import isFinite from 'ghost/utils/isFinite';
 
-export default AuthenticatedRoute.extend(ShortcutsRoute, {
+export default AuthenticatedRoute.extend(ShortcutsRoute, NotFoundHandler, {
     model(params) {
         let post,
             postId,
@@ -28,14 +29,14 @@ export default AuthenticatedRoute.extend(ShortcutsRoute, {
             staticPages: 'all'
         };
 
-        return this.store.queryRecord('post', query).then((records) => {
+        return this.store.query('post', query).then((records) => {
             let post = records.get('firstObject');
 
             if (post) {
                 return post;
             }
 
-            this.transitionTo('error404', postId);
+            return this.replaceWith('posts.index');
         });
     },
 

--- a/core/client/tests/acceptance/posts/post-test.js
+++ b/core/client/tests/acceptance/posts/post-test.js
@@ -11,6 +11,7 @@ import startApp from '../../helpers/start-app';
 import destroyApp from '../../helpers/destroy-app';
 import { invalidateSession, authenticateSession } from 'ghost/tests/helpers/ember-simple-auth';
 import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
+import Mirage from 'ember-cli-mirage';
 
 describe('Acceptance: Posts - Post', function() {
     let application;
@@ -51,17 +52,19 @@ describe('Acceptance: Posts - Post', function() {
             });
         });
 
-        describe('with 404', function () {
-            it('redirects to 404 when post does not exist', function () {
-                let posts = server.createList('post', 3);
+        it('redirects to 404 when post does not exist', function () {
+            server.get('/posts/200/', function () {
+                return new Mirage.Response(404, {'Content-Type': 'application/json'}, {errors: [{message: 'Post not found.', errorType: 'NotFoundError'}]});
+            });
 
-                visit('/4');
+            errorOverride();
 
-                andThen(() => {
-                    // it redirects to 404 error page
-                    expect(currentPath()).to.equal('error404');
-                    expect(currentURL()).to.equal('/4');
-                });
+            visit('/200');
+
+            andThen(() => {
+                errorReset();
+                expect(currentPath()).to.equal('error404');
+                expect(currentURL()).to.equal('/200');
             });
         });
     });


### PR DESCRIPTION
closes #6503
- change post route 404 handling to match that of the editor and tag routes
- fix 404 tests
