### PR TITLE
Clean up the after the shouldjs upgrade tests closes #6505

### DIFF
--- a/core/test/functional/module/module_spec.js
+++ b/core/test/functional/module/module_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it */
-/*jshint expr:true*/
 // # Module tests
 // This tests using Ghost as an npm module
 var should     = require('should'),

--- a/core/test/functional/routes/api/authentication_spec.js
+++ b/core/test/functional/routes/api/authentication_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var supertest     = require('supertest'),
     should        = require('should'),
     testUtils     = require('../../../utils'),

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var supertest     = require('supertest'),
     should        = require('should'),
     testUtils     = require('../../../utils'),

--- a/core/test/functional/routes/api/error_spec.js
+++ b/core/test/functional/routes/api/error_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 // # Api Route tests
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     supertest     = require('supertest'),
     should        = require('should'),

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
@@ -192,7 +191,7 @@ describe('Post API', function () {
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
                     jsonResponse.posts[0].author.should.be.a.Number();
-                    testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true;
+                    testUtils.API.isISO8601(jsonResponse.posts[0].created_at).should.be.true();
                     jsonResponse.posts[0].created_by.should.be.a.Number();
                     // Tags aren't included by default
                     should.not.exist(jsonResponse.posts[0].tags);
@@ -815,7 +814,7 @@ describe('Post API', function () {
 
                     var jsonResponse = res.body,
                         changedValue = 'My new Title';
-                    jsonResponse.posts[0].title.exist;
+                    should.exist(jsonResponse.posts[0].title);
                     jsonResponse.posts[0].testvalue = changedValue;
                     jsonResponse.posts[0].id = 99;
                     request.put(testUtils.API.getApiQuery('posts/99/'))

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),

--- a/core/test/functional/routes/api/settings_spec.js
+++ b/core/test/functional/routes/api/settings_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),

--- a/core/test/functional/routes/api/slugs_spec.js
+++ b/core/test/functional/routes/api/slugs_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),

--- a/core/test/functional/routes/api/tags_spec.js
+++ b/core/test/functional/routes/api/tags_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -1,5 +1,4 @@
 /*global describe, it, before, after */
-/*jshint expr:true*/
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, after, it */
-/*jshint expr:true*/
 var testUtils = require('../../utils'),
     should    = require('should'),
     _         = require('lodash'),

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
     sinon       = require('sinon'),

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, afterEach, it */
-/*jshint expr:true*/
 var testUtils         = require('../../utils'),
     should            = require('should'),
 

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils = require('../../utils'),
     should    = require('should'),
     _         = require('lodash'),

--- a/core/test/integration/api/api_mail_spec.js
+++ b/core/test/integration/api/api_mail_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
     config          = require('../../../server/config'),

--- a/core/test/integration/api/api_notifications_spec.js
+++ b/core/test/integration/api/api_notifications_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils        = require('../../utils'),
     should           = require('should'),
     _                = require('lodash'),

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -1,5 +1,4 @@
  /*globals describe, before, beforeEach, afterEach, it */
- /*jshint expr:true*/
 var testUtils     = require('../../utils'),
     should        = require('should'),
     _             = require('lodash'),

--- a/core/test/integration/api/api_roles_spec.js
+++ b/core/test/integration/api/api_roles_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
     _           = require('lodash'),

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils           = require('../../utils'),
     should              = require('should'),
     _                   = require('lodash'),

--- a/core/test/integration/api/api_slugs_spec.js
+++ b/core/test/integration/api/api_slugs_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
 

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
     Promise     = require('bluebird'),

--- a/core/test/integration/api/api_themes_spec.js
+++ b/core/test/integration/api/api_themes_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var _             = require('lodash'),
     testUtils     = require('../../utils'),
     rewire        = require('rewire'),

--- a/core/test/integration/api/api_upload_spec.js
+++ b/core/test/integration/api/api_upload_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var fs          = require('fs-extra'),
     should      = require('should'),
     sinon       = require('sinon'),
@@ -9,9 +8,6 @@ var fs          = require('fs-extra'),
     // Stuff we are testing
     UploadAPI   = require('../../../server/api/upload'),
     store;
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Upload API', function () {
     // Doesn't test the DB

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
     sinon           = require('sinon'),

--- a/core/test/integration/export_spec.js
+++ b/core/test/integration/export_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils   = require('../utils/index'),
     should      = require('should'),
     sinon       = require('sinon'),

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, after, it */
-/*jshint expr:true*/
 var testUtils   = require('../utils/index'),
     should      = require('should'),
     sinon       = require('sinon'),

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../utils'),
     should      = require('should'),
 

--- a/core/test/integration/model/model_app-fields_spec.js
+++ b/core/test/integration/model/model_app-fields_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
 

--- a/core/test/integration/model/model_app-settings_spec.js
+++ b/core/test/integration/model/model_app-settings_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
 

--- a/core/test/integration/model/model_apps_spec.js
+++ b/core/test/integration/model/model_apps_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils    = require('../../utils'),
     should       = require('should'),
     sequence     = require('../../../server/utils/sequence'),

--- a/core/test/integration/model/model_permissions_spec.js
+++ b/core/test/integration/model/model_permissions_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, before, beforeEach, afterEach */
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
     sequence        = require('../../../server/utils/sequence'),
@@ -786,7 +785,7 @@ describe('Post Model', function () {
                         // Should not have a conflicted slug from the first
                         updatedSecondPost.get('slug').should.not.equal(firstPost.slug);
 
-                        eventSpy.calledThrice.should.be.true;
+                        eventSpy.calledThrice.should.be.true();
                         eventSpy.thirdCall.calledWith('post.edited').should.be.true();
 
                         return PostModel.findOne({

--- a/core/test/integration/model/model_roles_spec.js
+++ b/core/test/integration/model/model_roles_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, before, beforeEach, afterEach */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
 

--- a/core/test/integration/model/model_settings_spec.js
+++ b/core/test/integration/model/model_settings_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils       = require('../../utils'),
     should          = require('should'),
     sinon           = require('sinon'),

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
     sinon       = require('sinon'),

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils   = require('../../utils'),
     should      = require('should'),
     Promise     = require('bluebird'),

--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, after, it*/
-/*jshint expr:true*/
 var testUtils       = require('../utils'),
     should          = require('should'),
     rewire          = require('rewire'),

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, afterEach */
-/*jshint expr:true*/
 var should  = require('should'),
     sinon   = require('sinon'),
     _       = require('lodash'),

--- a/core/test/unit/apps_filters_spec.js
+++ b/core/test/unit/apps_filters_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should  = require('should'),
     sinon   = require('sinon'),
     Promise = require('bluebird'),

--- a/core/test/unit/apps_spec.js
+++ b/core/test/unit/apps_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var path         = require('path'),
     EventEmitter = require('events').EventEmitter,
     should       = require('should'),

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, before, beforeEach, afterEach */
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),
@@ -16,8 +15,6 @@ var should         = require('should'),
     // storing current environment
     currentEnv     = process.env.NODE_ENV;
 i18n.init();
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Config', function () {
     afterEach(function () {

--- a/core/test/unit/controllers/frontend/error_spec.js
+++ b/core/test/unit/controllers/frontend/error_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should   = require('should'),
     sinon    = require('sinon'),
     errors   = require('../../../../server/errors'),

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should   = require('should'),
     sinon    = require('sinon'),
     Promise  = require('bluebird'),

--- a/core/test/unit/controllers/frontend/index_spec.js
+++ b/core/test/unit/controllers/frontend/index_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var moment   = require('moment'),
     should   = require('should'),
     sinon    = require('sinon'),
@@ -13,9 +12,6 @@ var moment   = require('moment'),
 
     configUtils = require('../../../utils/configUtils'),
     sandbox = sinon.sandbox.create();
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Frontend Controller', function () {
     var adminEditPagePath = '/ghost/editor/';

--- a/core/test/unit/controllers/frontend/templates_spec.js
+++ b/core/test/unit/controllers/frontend/templates_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, afterEach, beforeEach*/
-/*jshint expr:true*/
 var should   = require('should'),
     rewire   = require('rewire'),
 
@@ -7,9 +6,6 @@ var should   = require('should'),
     templates = rewire('../../../../server/controllers/frontend/templates'),
 
     configUtils = require('../../../utils/configUtils');
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('templates', function () {
     afterEach(function () {

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, after, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should     = require('should'),
     Promise    = require('bluebird'),
     sinon      = require('sinon'),

--- a/core/test/unit/filters_spec.js
+++ b/core/test/unit/filters_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should  = require('should'),
     sinon   = require('sinon'),
     Promise = require('bluebird'),

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -1,5 +1,4 @@
 /* globals describe, beforeEach, afterEach, it */
-/*jshint expr:true*/
 var should     = require('should'),
     ghostUrl   = require('../../shared/ghost-url'),
 

--- a/core/test/unit/importer_spec.js
+++ b/core/test/unit/importer_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, afterEach, it*/
-/*jshint expr:true*/
 var should    = require('should'),
     sinon     = require('sinon'),
     Promise   = require('bluebird'),
@@ -21,9 +20,6 @@ var should    = require('should'),
 
     configUtils     = require('../utils/configUtils'),
     sandbox         = sinon.sandbox.create();
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Importer', function () {
     afterEach(function () {

--- a/core/test/unit/mail_spec.js
+++ b/core/test/unit/mail_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, afterEach, beforeEach, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     Promise         = require('bluebird'),
 

--- a/core/test/unit/middleware/auth-strategies_spec.js
+++ b/core/test/unit/middleware/auth-strategies_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should           = require('should'),
     sinon            = require('sinon'),
     Promise          = require('bluebird'),
@@ -28,9 +27,6 @@ var should           = require('should'),
         client_id: 1,
         expires: Date.now() - globalUtils.ONE_DAY_MS
     };
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Auth Strategies', function () {
     var next;

--- a/core/test/unit/middleware/authentication_spec.js
+++ b/core/test/unit/middleware/authentication_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var sinon                   = require('sinon'),
     should                  = require('should'),
     passport                = require('passport'),

--- a/core/test/unit/middleware/cache-control_spec.js
+++ b/core/test/unit/middleware/cache-control_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     sinon           = require('sinon'),
     middleware      = require('../../../server/middleware').middleware;

--- a/core/test/unit/middleware/check-ssl_spec.js
+++ b/core/test/unit/middleware/check-ssl_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var sinon    = require('sinon'),
     should   = require('should'),
     configUtils = require('../../utils/configUtils'),

--- a/core/test/unit/middleware/decide-is-admin_spec.js
+++ b/core/test/unit/middleware/decide-is-admin_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     sinon           = require('sinon'),
     decideIsAdmin   = require('../../../server/middleware/decide-is-admin');

--- a/core/test/unit/middleware/oauth_spec.js
+++ b/core/test/unit/middleware/oauth_spec.js
@@ -1,14 +1,10 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var sinon            = require('sinon'),
     should           = require('should'),
     Promise          = require('bluebird'),
 
     oAuth            = require('../../../server/middleware/oauth'),
     Models           = require('../../../server/models');
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('OAuth', function () {
     var next, req, res, sandbox;

--- a/core/test/unit/middleware/private-blogging_spec.js
+++ b/core/test/unit/middleware/private-blogging_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var crypto          = require('crypto'),
     should          = require('should'),
     sinon           = require('sinon'),
@@ -35,7 +34,8 @@ describe('Private Blogging', function () {
         var req, res, next;
 
         beforeEach(function () {
-            req = {}, res = {};
+            req = {};
+            res = {};
             apiSettingsStub = sandbox.stub(api.settings, 'read');
             next = sinon.spy();
         });

--- a/core/test/unit/middleware/redirect-to-setup_spec.js
+++ b/core/test/unit/middleware/redirect-to-setup_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var sinon           = require('sinon'),
     should          = require('should'),
     Promise         = require('bluebird'),

--- a/core/test/unit/middleware/serve-shared-file_spec.js
+++ b/core/test/unit/middleware/serve-shared-file_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var fs              = require('fs'),
     sinon           = require('sinon'),
     serveSharedFile = require('../../../server/middleware/serve-shared-file'),

--- a/core/test/unit/middleware/spam-prevention_spec.js
+++ b/core/test/unit/middleware/spam-prevention_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should      = require('should'),
     sinon       = require('sinon'),
     middleware  = require('../../../server/middleware').middleware;
@@ -92,7 +91,7 @@ describe('Middleware: spamPrevention', function () {
 
             middleware.spamPrevention.signin(req, null, spyNext);
             should(error).equal(undefined);
-            spyNext.should.be.calledOnce;
+            spyNext.should.be.called();
 
             process.hrtime.restore();
             done();

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -1,12 +1,9 @@
 /*globals describe, it, beforeEach */
-/*jshint expr:true*/
 var sinon        = require('sinon'),
     should       = require('should'),
 
     express      = require('express'),
     staticTheme  = require('../../../server/middleware/static-theme');
-
-should.equal(true, true);
 
 describe('staticTheme', function () {
     var next;

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var sinon        = require('sinon'),
     should       = require('should'),
     express      = require('express'),
@@ -14,8 +13,6 @@ var sinon        = require('sinon'),
 
     configUtils  = require('../../utils/configUtils'),
     sandbox      = sinon.sandbox.create();
-
-should.equal(true, true);
 
 describe('Theme Handler', function () {
     var req, res, next, blogApp;

--- a/core/test/unit/middleware/uncapitalise_spec.js
+++ b/core/test/unit/middleware/uncapitalise_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var sinon           = require('sinon'),
     should       = require('should'),
     uncapitalise    = require('../../../server/middleware/uncapitalise');

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     _               = require('lodash'),
     crypto          = require('crypto'),

--- a/core/test/unit/models_plugins/access-rules_spec.js
+++ b/core/test/unit/models_plugins/access-rules_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach */
-/*jshint expr:true*/
 var should = require('should'),
     sinon = require('sinon'),
 

--- a/core/test/unit/models_plugins/filter_spec.js
+++ b/core/test/unit/models_plugins/filter_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, before, beforeEach, afterEach */
-/*jshint expr:true*/
 var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
@@ -10,9 +9,6 @@ var should = require('should'),
     ghostBookshelf,
 
     sandbox = sinon.sandbox.create();
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Filter', function () {
     before(function () {

--- a/core/test/unit/models_plugins/pagination_spec.js
+++ b/core/test/unit/models_plugins/pagination_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, before, beforeEach, afterEach */
-/*jshint expr:true*/
 var should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var testUtils       = require('../utils'),
     should          = require('should'),
     sinon           = require('sinon'),

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     sinon           = require('sinon'),
     rewire          = require('rewire'),
@@ -14,9 +13,6 @@ var should          = require('should'),
     rss             = rewire('../../server/data/xml/rss'),
 
     configUtils     = require('../utils/configUtils');
-
-// To stop jshint complaining
-should.equal(true, true);
 
 // Helper function to prevent unit tests
 // from failing via timeout when they

--- a/core/test/unit/server_helpers/asset_spec.js
+++ b/core/test/unit/server_helpers/asset_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, after, it */
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/author_spec.js
+++ b/core/test/unit/server_helpers/author_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/content_spec.js
+++ b/core/test/unit/server_helpers/content_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/date_spec.js
+++ b/core/test/unit/server_helpers/date_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/encode_spec.js
+++ b/core/test/unit/server_helpers/encode_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/excerpt_spec.js
+++ b/core/test/unit/server_helpers/excerpt_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/foreach_spec.js
+++ b/core/test/unit/server_helpers/foreach_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     _              = require('lodash'),
@@ -62,7 +61,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(context, function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(value);
-                should(options.fn.getCall(index).args[1].data).be.undefined;
+                should(options.fn.getCall(index).args[1].data).be.undefined();
             });
         });
 
@@ -155,7 +154,7 @@ describe('{{#foreach}} helper', function () {
 
             _.each(_.keys(context), function (value, index) {
                 options.fn.getCall(index).args[0].should.eql(context[value]);
-                should(options.fn.getCall(index).args[1].data).not.be.undefined;
+                should(options.fn.getCall(index).args[1].data).not.be.undefined();
 
                 // Expected properties
                 resultData[index].data.should.containEql(expected[index]);

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     hbs            = require('express-hbs'),

--- a/core/test/unit/server_helpers/ghost_foot_spec.js
+++ b/core/test/unit/server_helpers/ghost_foot_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, afterEach, beforeEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     _              = require('lodash'),

--- a/core/test/unit/server_helpers/has_spec.js
+++ b/core/test/unit/server_helpers/has_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     hbs            = require('express-hbs'),

--- a/core/test/unit/server_helpers/image_spec.js
+++ b/core/test/unit/server_helpers/image_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, afterEach, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     hbs            = require('express-hbs'),

--- a/core/test/unit/server_helpers/input_password_spec.js
+++ b/core/test/unit/server_helpers/input_password_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/is_spec.js
+++ b/core/test/unit/server_helpers/is_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     hbs            = require('express-hbs'),

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/meta_title_spec.js
+++ b/core/test/unit/server_helpers/meta_title_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/navigation_spec.js
+++ b/core/test/unit/server_helpers/navigation_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/next_post_spec.js
+++ b/core/test/unit/server_helpers/next_post_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),
@@ -48,10 +47,10 @@ describe('{{next_post}} helper', function () {
                 slug: 'current',
                 created_at: new Date(0),
                 url: '/current/'}, optionsData).then(function () {
-                fn.calledOnce.should.be.true;
-                inverse.calledOnce.should.be.false;
+                fn.calledOnce.should.be.true();
+                inverse.calledOnce.should.be.false();
 
-                readPostStub.calledOnce.should.be.true;
+                readPostStub.calledOnce.should.be.true();
                 readPostStub.firstCall.args[0].include.should.eql('next,next.author,next.tags');
                 done();
             }).catch(function (err) {
@@ -82,8 +81,8 @@ describe('{{next_post}} helper', function () {
                 slug: 'current',
                 created_at: new Date(0),
                 url: '/current/'}, optionsData).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.true;
+                fn.called.should.be.false();
+                inverse.called.should.be.true();
                 done();
             }).catch(function (err) {
                 done(err);
@@ -107,9 +106,9 @@ describe('{{next_post}} helper', function () {
                 optionsData = {name: 'next_post', fn: fn, inverse: inverse};
 
             helpers.prev_post.call({}, optionsData).then(function () {
-                fn.called.should.be.false;
-                inverse.called.should.be.true;
-                readPostStub.called.should.be.false;
+                fn.called.should.be.false();
+                inverse.called.should.be.true();
+                readPostStub.called.should.be.false();
                 done();
             }).catch(function (err) {
                 done(err);
@@ -142,8 +141,8 @@ describe('{{next_post}} helper', function () {
                 created_at: new Date(0),
                 url: '/current/'}, optionsData)
             .then(function () {
-                fn.called.should.be.true;
-                inverse.called.should.be.false;
+                fn.called.should.be.true();
+                inverse.called.should.be.false();
                 done();
             }).catch(function (err) {
                 done(err);

--- a/core/test/unit/server_helpers/page_url_spec.js
+++ b/core/test/unit/server_helpers/page_url_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/pagination_spec.js
+++ b/core/test/unit/server_helpers/pagination_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/plural_spec.js
+++ b/core/test/unit/server_helpers/plural_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/post_class_spec.js
+++ b/core/test/unit/server_helpers/post_class_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/prev_post_spec.js
+++ b/core/test/unit/server_helpers/prev_post_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),

--- a/core/test/unit/server_helpers/tags_spec.js
+++ b/core/test/unit/server_helpers/tags_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/title_spec.js
+++ b/core/test/unit/server_helpers/title_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, before, beforeEach, afterEach, after, it*/
-/*jshint expr:true*/
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),

--- a/core/test/unit/server_helpers_index_spec.js
+++ b/core/test/unit/server_helpers_index_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, it*/
-/*jshint expr:true*/
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 var should         = require('should'),
     rewire         = require('rewire'),

--- a/core/test/unit/server_helpers_template_spec.js
+++ b/core/test/unit/server_helpers_template_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it*/
-/*jshint expr:true*/
 var should    = require('should'),
     hbs = require('express-hbs'),
 

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it*/
-/*jshint expr:true*/
 var should          = require('should'),
     http            = require('http'),
     config          = require('../../../config');

--- a/core/test/unit/server_utils_spec.js
+++ b/core/test/unit/server_utils_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, it, beforeEach, afterEach*/
-/*jshint expr:true*/
 var should          = require('should'),
     sinon           = require('sinon'),
     nock            = require('nock'),

--- a/core/test/unit/showdown_client_integrated_spec.js
+++ b/core/test/unit/showdown_client_integrated_spec.js
@@ -5,10 +5,9 @@
  */
 
 /*globals describe, it */
-/*jshint expr:true*/
 var should      = require('should'),
 
-// Stuff we are testing
+    // Stuff we are testing
     Showdown    = require('showdown-ghost'),
     converter   = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
 

--- a/core/test/unit/sitemap_spec.js
+++ b/core/test/unit/sitemap_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, afterEach, it */
-/*jshint expr:true*/
 var _           = require('lodash'),
     should      = require('should'),
     sinon       = require('sinon'),

--- a/core/test/unit/storage_local-file-store_spec.js
+++ b/core/test/unit/storage_local-file-store_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var fs              = require('fs-extra'),
     path            = require('path'),
     should          = require('should'),

--- a/core/test/unit/utils_pipeline_spec.js
+++ b/core/test/unit/utils_pipeline_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, afterEach, it*/
-/*jshint expr:true*/
 var should  = require('should'),
     sinon   = require('sinon'),
     Promise = require('bluebird'),

--- a/core/test/unit/xmlrpc_spec.js
+++ b/core/test/unit/xmlrpc_spec.js
@@ -1,5 +1,4 @@
 /*globals describe, beforeEach, afterEach, it*/
-/*jshint expr:true*/
 var nock            = require('nock'),
     should          = require('should'),
     sinon           = require('sinon'),

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
     "top-gh-contribs": "2.0.2"
   },
   "greenkeeper": {
-    "ignore": ["bower", "bluebird", "glob", "lodash", "mysql", "nodemailer", "pg", "showdown-ghost", "should", "validator"]
+    "ignore": ["bower", "bluebird", "glob", "lodash", "mysql", "nodemailer", "pg", "showdown-ghost", "validator"]
   }
 }


### PR DESCRIPTION
This PR does the following to address #6505 :
-Removed all of the /_jshint expr:true_/ comments from the tests
-Removed all of the should.equal(true, true) statements from the tests
-Removed should from the greenkeeper ignores
-Fixes some shouldjs calls where I missed some brackets in my original PR (Sorry!)

One thing to note with this PR is that in the test spam-prevention_spec.js an assertion was changed from calledOnce to called, as it was actually called 12 times.

If there are any issues at all let me know and ill make the changes as soon as I can.
