### PR TITLE
Remove unused modal outlet

### DIFF
--- a/core/client/app/templates/application.hbs
+++ b/core/client/app/templates/application.hbs
@@ -17,7 +17,6 @@
 
         {{gh-content-cover onClick="closeMenus" onMouseEnter="closeAutoNav"}}
 
-        {{outlet "modal"}}
         {{outlet "settings-menu"}}
     </div>{{!gh-viewport}}
 {{/gh-app}}


### PR DESCRIPTION
no issue
- leftover from the modals refactor, because of how modals work now this isn't really needed

/cc @kevinansfield 
