### PR TITLE
Allow umlauts in slugs

### DIFF
--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -57,6 +57,14 @@ utils = {
         // Handle the £ symbol separately, since it needs to be removed before the unicode conversion.
         string = string.replace(/£/g, '-');
 
+        // Replace all known non ascii characters
+        string = string
+            .replace(/ä/gi, 'ae')
+            .replace(/ö/gi, 'oe')
+            .replace(/ü/gi, 'ue')
+            .replace(/ß/gi, 'ss')
+        ;
+
         // Remove non ascii characters
         string = unidecode(string);
 

--- a/core/test/unit/server_utils_spec.js
+++ b/core/test/unit/server_utils_spec.js
@@ -19,6 +19,13 @@ describe('Server Utilities', function () {
         var safeString = utils.safeString,
             options = {};
 
+        it('should replace known non ascii characters', function () {
+            safeString('äÄ', options).should.equal('aeae');
+            safeString('öÖ', options).should.equal('oeoe');
+            safeString('üÜ', options).should.equal('ueue');
+            safeString('ß', options).should.equal('ss');
+        });
+
         it('should remove beginning and ending whitespace', function () {
             var result = safeString(' stringwithspace ', options);
             result.should.equal('stringwithspace');
@@ -47,8 +54,8 @@ describe('Server Utilities', function () {
         });
 
         it('should replace all of the foreign chars in ascii', function () {
-            var result = safeString('ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ');
-            result.should.equal('aaaaaaaeceeeeiiiidnoooooxouuuuuthssaaaaaaaeceeeeiiiidnooooo-ouuuuythy');
+            var result = safeString('ÀÁÂÃÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕ×ØÙÚÛÝÞßàáâãåæçèéêëìíîïðñòóôõ÷øùúûýþÿ');
+            result.should.equal('aaaaaaeceeeeiiiidnooooxouuuuthssaaaaaaeceeeeiiiidnoooo-ouuuythy');
         });
 
         it('should remove special characters at the beginning of a string', function () {


### PR DESCRIPTION
According to: https://ideas.ghost.org/forums/285309-wishlist/suggestions/7935447-convert-german-umlauts-or-special-characters-in-th

The server utility `safeString` replaces...
- `ä` with `ae`
- `ö` with `oe`
- `ü` with `ue`
- `ß` with `ss`.

This is the default behaviour for the german language. All other characters e.g. `Ã`, `Å`, `Æ` or `ø` are not affected by this change. 
