### PR TITLE
Fix underscore usage in post serializer

### DIFF
--- a/core/client/app/serializers/post.js
+++ b/core/client/app/serializers/post.js
@@ -11,13 +11,14 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
         tags: {embedded: 'always'}
     },
 
-    normalize(typeClass, hash, prop) {
+    normalizeHash: {
         // this is to enable us to still access the raw authorId
         // without requiring an extra get request (since it is an
         // async relationship).
-        hash.authorId = hash.author;
-
-        return this._super(typeClass, hash, prop);
+        posts(hash) {
+            hash.author_id = hash.author;
+            return hash;
+        }
     },
 
     normalizeSingleResponse(store, primaryModelClass, payload) {
@@ -47,7 +48,7 @@ export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
         delete data.uuid;
         delete data.html;
         // Inserted locally as a convenience.
-        delete data.authorId;
+        delete data.author_id;
         // Read-only virtual property.
         delete data.url;
 


### PR DESCRIPTION
closes #6512
- because of the keyForAttribute method in the application serializer, the hash property must be snake_case
- change the normalize method to the more concise normalizeHash method available on the rest serializer

TODO:
- [x] make sure this is actually fixed
