### PR TITLE
Fix logging out from editor page

### DIFF
--- a/core/client/app/routes/signout.js
+++ b/core/client/app/routes/signout.js
@@ -18,7 +18,6 @@ export default AuthenticatedRoute.extend(styleBody, {
         this.get('notifications').clearAll();
         if (canInvoke(transition, 'send')) {
             transition.send('invalidateSession');
-            transition.abort();
         } else {
             this.send('invalidateSession');
         }


### PR DESCRIPTION
closes #6514
- removes transition.abort from the signout method because it can override the ember-simple-auth's page refresh
