### PR TITLE
Including timezones API in configuration endpoint

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -13,6 +13,11 @@ function labsFlag(key) {
     };
 }
 
+function fetchAvailableTimezones() {
+    var timezones = require('../data/timezones.json');
+    return timezones;
+}
+
 function getAboutConfig() {
     return {
         version: config.ghostVersion,
@@ -56,6 +61,11 @@ configuration = {
 
         if (options.key === 'about') {
             return Promise.resolve({configuration: [getAboutConfig()]});
+        }
+
+        // Timezone endpoint
+        if (options.key === 'timezones') {
+            return Promise.resolve({configuration: [fetchAvailableTimezones()]});
         }
 
         return Promise.resolve({configuration: []});

--- a/core/server/data/timezones.json
+++ b/core/server/data/timezones.json
@@ -1,0 +1,329 @@
+{
+	"timezones": [
+		{
+			"name": "Pacific/Samoa",
+			"label": "(GMT -11:00) Midway Island, Samoa",
+			"offset": -660
+		},
+		{
+			"name": "Pacific/Honolulu",
+			"label": "(GMT -10:00) Hawaii",
+			"offset": -600
+		},
+		{
+			"name": "US/Alaska",
+			"label": "(GMT -9:00) Alaska",
+			"offset": -540
+		},
+		{
+			"name": "Mexico/BajaNorte",
+			"label": "(GMT -8:00) Chihuahua, La Paz, Mazatlan",
+			"offset": -480
+		},
+		{
+			"name": "US/Pacific",
+			"label": "(GMT -8:00) Pacific Time (US & Canada); Tijuana",
+			"offset": -480
+		},
+		{
+			"name": "US/Arizona",
+			"label": "(GMT -7:00) Arizona",
+			"offset": -420
+		},
+		{
+			"name": "US/Mountain",
+			"label": "(GMT -7:00) Mountain Time (US & Canada)",
+			"offset": -420
+		},
+		{
+			"name": "America/Costa_Rica",
+			"label": "(GMT -6:00) Central America",
+			"offset": -360
+		},
+		{
+			"name": "US/Central",
+			"label": "(GMT -6:00) Central Time (US & Canada)",
+			"offset": -360
+		},
+		{
+			"name": "Mexico/General",
+			"label": "(GMT -6:00) Guadalajara, Mexico City, Monterrey",
+			"offset": -360
+		},
+		{
+			"name": "Canada/Saskatchewan",
+			"label": "(GMT -6:00) Saskatchewan",
+			"offset": -360
+		},
+		{
+			"name": "America/Bogota",
+			"label": "(GMT -5:00) Bogota, Lima, Quito",
+			"offset": -300
+		},
+		{
+			"name": "US/Eastern",
+			"label": "(GMT -5:00) Eastern Time (US & Canada)",
+			"offset": -300
+		},
+		{
+			"name": "US/East-Indiana",
+			"label": "(GMT -5:00) Indiana (East)",
+			"offset": -300
+		},
+		{
+			"name": "America/Caracas",
+			"label": "(GMT -4:30) Caracas, La Paz",
+			"offset": -270
+		},
+		{
+			"name": "Canada/Atlantic",
+			"label": "(GMT -4:00) Atlantic Time (Canada); Brasilia, Greenland",
+			"offset": -240
+		},
+		{
+			"name": "Canada/Newfoundland",
+			"label": "(GMT -3:30) Newfoundland",
+			"offset": -210
+		},
+		{
+			"name": "America/Buenos_Aires",
+			"label": "(GMT -3:00) Buenos Aires, Georgetown",
+			"offset": -180
+		},
+		{
+			"name": "America/Santiago",
+			"label": "(GMT -3:00) Santiago",
+			"offset": -180
+		},
+		{
+			"name": "America/Noronha",
+			"label": "(GMT -2:00) Fernando de Noronha",
+			"offset": -120
+		},
+		{
+			"name": "Atlantic/Azores",
+			"label": "(GMT -1:00) Azores",
+			"offset": -60
+		},
+		{
+			"name": "Atlantic/Cape_Verde",
+			"label": "(GMT -1:00) Cape Verde Is.",
+			"offset": -60
+		},
+		{
+			"name": "Africa/Casablanca",
+			"label": "(GMT) Casablanca, Monrovia",
+			"offset": 0
+		},
+		{
+			"name": "Europe/Dublin",
+			"label": "(GMT) Greenwich Mean Time : Dublin, Edinburgh, London",
+			"offset": 0
+		},
+		{
+			"name": "Europe/Amsterdam",
+			"label": "(GMT +1:00) Amsterdam, Berlin, Rome, Stockholm, Vienna",
+			"offset": 60
+		},
+		{
+			"name": "Europe/Prague",
+			"label": "(GMT +1:00) Belgrade, Bratislava, Budapest, Prague",
+			"offset": 60
+		},
+		{
+			"name": "Europe/Paris",
+			"label": "(GMT +1:00) Brussels, Copenhagen, Madrid, Paris",
+			"offset": 60
+		},
+		{
+			"name": "Europe/Warsaw",
+			"label": "(GMT +1:00) Sarajevo, Skopje, Warsaw, Zagreb",
+			"offset": 60
+		},
+		{
+			"name": "Africa/Bangui",
+			"label": "(GMT +1:00) West Central Africa",
+			"offset": 60
+		},
+		{
+			"name": "Europe/Istanbul",
+			"label": "(GMT +2:00) Athens, Beirut, Bucharest, Istanbul",
+			"offset": 120
+		},
+		{
+			"name": "Africa/Cairo",
+			"label": "(GMT +2:00) Cairo, Egypt",
+			"offset": 120
+		},
+		{
+			"name": "Africa/Harare",
+			"label": "(GMT +2:00) Harare",
+			"offset": 120
+		},
+		{
+			"name": "Europe/Kiev",
+			"label": "(GMT +2:00) Helsinki, Kiev, Riga, Sofia, Tallinn, Vilnius",
+			"offset": 120
+		},
+		{
+			"name": "Asia/Jerusalem",
+			"label": "(GMT +2:00) Jerusalem",
+			"offset": 120
+		},
+		{
+			"name": "Africa/Johannesburg",
+			"label": "(GMT +2:00) Pretoria",
+			"offset": 120
+		},
+		{
+			"name": "Asia/Baghdad",
+			"label": "(GMT +3:00) Baghdad",
+			"offset": 180
+		},
+		{
+			"name": "Asia/Riyadh",
+			"label": "(GMT +3:00) Kuwait, Nairobi, Riyadh",
+			"offset": 180
+		},
+		{
+			"name": "Asia/Tehran",
+			"label": "(GMT +3:30) Tehran",
+			"offset": 210
+		},
+		{
+			"name": "Asia/Muscat",
+			"label": "(GMT +4:00) Abu Dhabi, Muscat",
+			"offset": 240
+		},
+		{
+			"name": "Asia/Baku",
+			"label": "(GMT +4:00) Baku, Tbilisi, Yerevan",
+			"offset": 240
+		},
+		{
+			"name": "Europe/Moscow",
+			"label": "(GMT +4:00) Moscow, St. Petersburg, Volgograd",
+			"offset": 240
+		},
+		{
+			"name": "Asia/Kabul",
+			"label": "(GMT +4:30) Kabul",
+			"offset": 270
+		},
+		{
+			"name": "Asia/Karachi",
+			"label": "(GMT +5:00) Islamabad, Karachi, Tashkent",
+			"offset": 300
+		},
+		{
+			"name": "Asia/Calcutta",
+			"label": "(GMT +5:30) Chennai, Calcutta, Mumbai, New Delhi",
+			"offset": 330
+		},
+		{
+			"name": "Asia/Katmandu",
+			"label": "(GMT +5:45) Katmandu",
+			"offset": 345
+		},
+		{
+			"name": "Asia/Almaty",
+			"label": "(GMT +6:00) Almaty, Novosibirsk",
+			"offset": 360
+		},
+		{
+			"name": "Asia/Dhaka",
+			"label": "(GMT +6:00) Astana, Dhaka, Sri Jayawardenepura",
+			"offset": 360
+		},
+		{
+			"name": "Asia/Yekaterinburg",
+			"label": "(GMT +6:00) Yekaterinburg",
+			"offset": 360
+		},
+		{
+			"name": "Asia/Rangoon",
+			"label": "(GMT +6:30) Rangoon",
+			"offset": 390
+		},
+		{
+			"name": "Asia/Bangkok",
+			"label": "(GMT +7:00) Bangkok, Hanoi, Jakarta",
+			"offset": 420
+		},
+		{
+			"name": "Asia/Hong_Kong",
+			"label": "(GMT +8:00) Beijing, Chongqing, Hong Kong, Urumqi",
+			"offset": 480
+		},
+		{
+			"name": "Asia/Krasnoyarsk",
+			"label": "(GMT +8:00) Krasnoyarsk",
+			"offset": 480
+		},
+		{
+			"name": "Asia/Singapore",
+			"label": "(GMT +8:00) Kuala Lumpur, Perth, Singapore, Taipei",
+			"offset": 480
+		},
+		{
+			"name": "Asia/Irkutsk",
+			"label": "(GMT +9:00) Irkutsk, Ulaan Bataar",
+			"offset": 540
+		},
+		{
+			"name": "Asia/Tokyo",
+			"label": "(GMT +9:00) Osaka, Sapporo, Tokyo",
+			"offset": 540
+		},
+		{
+			"name": "Asia/Seoul",
+			"label": "(GMT +9:00) Seoul",
+			"offset": 540
+		},
+		{
+			"name": "Australia/Darwin",
+			"label": "(GMT +9:30) Darwin",
+			"offset": 570
+		},
+		{
+			"name": "Australia/Brisbane",
+			"label": "(GMT +10:00) Brisbane, Guam, Port Moresby",
+			"offset": 600
+		},
+		{
+			"name": "Asia/Yakutsk",
+			"label": "(GMT +10:00) Yakutsk",
+			"offset": 600
+		},
+		{
+			"name": "Australia/Adelaide",
+			"label": "(GMT +10:30) Adelaide",
+			"offset": 630
+		},
+		{
+			"name": "Australia/Canberra",
+			"label": "(GMT +11:00) Canberra, Hobart, Melbourne, Sydney, Vladivostok",
+			"offset": 660
+		},
+		{
+			"name": "Pacific/Fiji",
+			"label": "(GMT +12:00) Fiji, Kamchatka, Marshall Is.",
+			"offset": 720
+		},
+		{
+			"name": "Pacific/Kwajalein",
+			"label": "(GMT +12:00) International Date Line West",
+			"offset": 720
+		},
+		{
+			"name": "Asia/Magadan",
+			"label": "(GMT +12:00) Magadan, Soloman Is., New Caledonia",
+			"offset": 720
+		},
+		{
+			"name": "Pacific/Auckland",
+			"label": "(GMT +13:00) Auckland, Wellington",
+			"offset": 780
+		}
+	]
+}

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -24,6 +24,7 @@ apiRoutes = function apiRoutes(middleware) {
     // ## Configuration
     router.get('/configuration', authenticatePrivate, api.http(api.configuration.read));
     router.get('/configuration/:key', authenticatePrivate, api.http(api.configuration.read));
+    router.get('/configuration/timezones', authenticatePrivate, api.http(api.configuration.read));
 
     // ## Posts
     router.get('/posts', authenticatePublic, api.http(api.posts.browse));


### PR DESCRIPTION
Including timezones API in configuration endpoint

issue #6406
- endpoint configuration/timezones refers to timezones.json file in data
- added route for endpoint in api.js to use method read in configuration.js
