### PR TITLE
Disambiguate between error code & status code

### DIFF
--- a/core/server/errors/bad-request-error.js
+++ b/core/server/errors/bad-request-error.js
@@ -4,7 +4,7 @@
 function BadRequestError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 400;
+    this.statusCode = 400;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/data-import-error.js
+++ b/core/server/errors/data-import-error.js
@@ -4,7 +4,7 @@
 function DataImportError(message, offendingProperty, value) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 500;
+    this.statusCode = 500;
     this.errorType = this.name;
     this.property = offendingProperty || undefined;
     this.value = value || undefined;

--- a/core/server/errors/email-error.js
+++ b/core/server/errors/email-error.js
@@ -4,7 +4,7 @@
 function EmailError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 500;
+    this.statusCode = 500;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/internal-server-error.js
+++ b/core/server/errors/internal-server-error.js
@@ -4,7 +4,7 @@
 function InternalServerError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 500;
+    this.statusCode = 500;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/method-not-allowed-error.js
+++ b/core/server/errors/method-not-allowed-error.js
@@ -4,7 +4,7 @@
 function MethodNotAllowedError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 405;
+    this.statusCode = 405;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/no-permission-error.js
+++ b/core/server/errors/no-permission-error.js
@@ -4,7 +4,7 @@
 function NoPermissionError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 403;
+    this.statusCode = 403;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/not-found-error.js
+++ b/core/server/errors/not-found-error.js
@@ -4,7 +4,7 @@
 function NotFoundError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 404;
+    this.statusCode = 404;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/request-too-large-error.js
+++ b/core/server/errors/request-too-large-error.js
@@ -4,7 +4,7 @@
 function RequestEntityTooLargeError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 413;
+    this.statusCode = 413;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/too-many-requests-error.js
+++ b/core/server/errors/too-many-requests-error.js
@@ -4,7 +4,7 @@
 function TooManyRequestsError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 429;
+    this.statusCode = 429;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/unauthorized-error.js
+++ b/core/server/errors/unauthorized-error.js
@@ -4,7 +4,7 @@
 function UnauthorizedError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 401;
+    this.statusCode = 401;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/unsupported-media-type-error.js
+++ b/core/server/errors/unsupported-media-type-error.js
@@ -4,7 +4,7 @@
 function UnsupportedMediaTypeError(message) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 415;
+    this.statusCode = 415;
     this.errorType = this.name;
 }
 

--- a/core/server/errors/validation-error.js
+++ b/core/server/errors/validation-error.js
@@ -4,7 +4,7 @@
 function ValidationError(message, offendingProperty) {
     this.message = message;
     this.stack = new Error().stack;
-    this.code = 422;
+    this.statusCode = 422;
     if (offendingProperty) {
         this.property = offendingProperty;
     }

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -73,7 +73,7 @@ function getAjaxHelper(clientId, clientSecret) {
 
 function ghost_head(options) {
     // if error page do nothing
-    if (this.code >= 400) {
+    if (this.statusCode >= 400) {
         return;
     }
     var metaData = getMetaData(this, options.data.root),

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -97,7 +97,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });
@@ -110,7 +110,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });
@@ -123,7 +123,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });
@@ -156,7 +156,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });
@@ -169,7 +169,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('UnauthorizedError');
-                    err.code.should.equal(401);
+                    err.statusCode.should.equal(401);
                     err.message.should.equal('Invalid token structure');
                     done();
                 });
@@ -191,7 +191,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('UnauthorizedError');
-                    err.code.should.equal(401);
+                    err.statusCode.should.equal(401);
                     err.message.should.equal('Invalid token structure');
                     done();
                 });
@@ -226,7 +226,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });
@@ -259,7 +259,7 @@ describe('Authentication API', function () {
                     should.exist(err);
 
                     err.name.should.equal('NoPermissionError');
-                    err.code.should.equal(403);
+                    err.statusCode.should.equal(403);
 
                     done();
                 });

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -263,7 +263,7 @@ describe('Post API', function () {
             }).catch(function (err) {
                 should.exist(err);
                 err.message.should.eql('Validation (isSlug) failed for tag');
-                err.code.should.eql(422);
+                err.statusCode.should.eql(422);
                 done();
             });
         });
@@ -274,7 +274,7 @@ describe('Post API', function () {
             }).catch(function (err) {
                 should.exist(err);
                 err.message.should.eql('Validation (isSlug) failed for author');
-                err.code.should.eql(422);
+                err.statusCode.should.eql(422);
                 done();
             });
         });

--- a/core/test/integration/api/api_upload_spec.js
+++ b/core/test/integration/api/api_upload_spec.js
@@ -42,7 +42,7 @@ describe('Upload API', function () {
             UploadAPI.add({uploadimage: uploadimage}).then(function () {
                 done(new Error('Upload suceeded with invalid file.'));
             }, function (result) {
-                result.code.should.equal(415);
+                result.statusCode.should.equal(415);
                 result.errorType.should.equal('UnsupportedMediaTypeError');
                 done();
             });
@@ -59,7 +59,7 @@ describe('Upload API', function () {
             UploadAPI.add({uploadimage: uploadimage}).then(function () {
                 done(new Error('Upload suceeded with invalid file.'));
             }, function (result) {
-                result.code.should.equal(415);
+                result.statusCode.should.equal(415);
                 result.errorType.should.equal('UnsupportedMediaTypeError');
                 done();
             });
@@ -88,7 +88,7 @@ describe('Upload API', function () {
             UploadAPI.add({uploadimage: uploadimage}).then(function () {
                 done(new Error('Upload suceeded with invalid file.'));
             }, function (result) {
-                result.code.should.equal(415);
+                result.statusCode.should.equal(415);
                 result.errorType.should.equal('UnsupportedMediaTypeError');
                 done();
             });

--- a/core/test/unit/controllers/frontend/channels_spec.js
+++ b/core/test/unit/controllers/frontend/channels_spec.js
@@ -97,7 +97,7 @@ describe('Channels', function () {
     function testChannel404(props, done) {
         testChannelError(props, function (error) {
             error.errorType.should.eql('NotFoundError');
-            error.code.should.eql(404);
+            error.statusCode.should.eql(404);
         }, done);
     }
 

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -358,6 +358,7 @@ describe('Error handling', function () {
 
                 // Test that the message is correct
                 options.message.should.equal('Page not found');
+                // Template variable
                 options.code.should.equal(404);
                 this.statusCode.should.equal(404);
 
@@ -389,6 +390,7 @@ describe('Error handling', function () {
 
                 // Test that the message is correct
                 options.message.should.equal('Page not found');
+                // Template variable
                 options.code.should.equal(404);
                 this.statusCode.should.equal(404);
 
@@ -421,6 +423,7 @@ describe('Error handling', function () {
 
                 // Test that the message is correct
                 options.message.should.equal('I am a big bad error');
+                // Template variable
                 options.code.should.equal(500);
                 this.statusCode.should.equal(500);
 
@@ -452,6 +455,7 @@ describe('Error handling', function () {
 
                 // Test that the message is correct
                 options.message.should.equal('I am a big bad error');
+                // Template variable
                 options.code.should.equal(500);
                 this.statusCode.should.equal(500);
 
@@ -469,18 +473,18 @@ describe('Error handling', function () {
                 return res;
             });
 
-            err.code = 500;
+            err.statusCode = 500;
             errors.error500(err, req, res, null);
         });
 
         it('Renders custom error template if one exists', function (done) {
-            var code = 404,
+            var statusCode = 404,
                 error = {message: 'Custom view test'},
                 req = {
                     session: null
                 },
                 res = {
-                    status: function (code) {
+                    status: function (statusCode) {
                         /*jshint unused:false*/
                         return this;
                     },
@@ -493,7 +497,7 @@ describe('Error handling', function () {
                 },
                 next = null;
             errors.updateActiveTheme('theme-with-error');
-            errors.renderErrorPage(code, error, req, res, next);
+            errors.renderErrorPage(statusCode, error, req, res, next);
         });
     });
 });

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -417,7 +417,7 @@ describe('RSS', function () {
 
             rss(req, res, function (err) {
                 should.exist(err);
-                err.code.should.eql(404);
+                err.statusCode.should.eql(404);
                 res.redirect.called.should.be.false();
                 res.render.called.should.be.false();
                 done();
@@ -434,7 +434,7 @@ describe('RSS', function () {
 
             rss(req, res, function (err) {
                 should.exist(err);
-                err.code.should.eql(404);
+                err.statusCode.should.eql(404);
                 res.redirect.called.should.be.false();
                 res.render.called.should.be.false();
                 done();


### PR DESCRIPTION
This PR should fix several issues where Ghost either swallows a proper error code from somewhere and replaces it with a status code, or worse, where Ghost treats an error code like it's a status code and sends invalid responses from the API.

refs #6526 
- Change our errors to use `statusCode` for the status code (like res.statusCode)
- Use statusCode for anything that's supposed to be the statusCode, rather than an error idenfier/code
- Update all the tests that check the key
- Route tests don't need fixing as the status codes are still returned correctly
