### PR TITLE
Inject ajax service in settings/labs

### DIFF
--- a/core/client/app/controllers/settings/labs.js
+++ b/core/client/app/controllers/settings/labs.js
@@ -16,6 +16,7 @@ export default Controller.extend({
     ghostPaths: service(),
     notifications: service(),
     session: service(),
+    ajax: service(),
 
     actions: {
         onUpload(file) {


### PR DESCRIPTION
closes #6530
- turns out one must inject a service in order to use it
