### PR TITLE
Pass post tags as array to ember-cli-selectize

### DIFF
--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -174,6 +174,11 @@ export default Controller.extend(SettingsMenuMixin, {
         this.set('debounceId', debounceId);
     },
 
+    // this exists because selectize throws errors on transition if it doesn't
+    existingTags: computed('model.tags.[]', function () {
+        return this.get('model.tags').toArray();
+    }),
+
     // live-query of all tags for tag input autocomplete
     availableTags: computed(function () {
         return this.get('store').filter('tag', {limit: 'all'}, () => {

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -41,7 +41,7 @@
                 {{gh-selectize
                     id="tag-input"
                     multiple=true
-                    selection=model.tags
+                    selection=existingTags
                     content=availableTags
                     optionValuePath="content.uuid"
                     optionLabelPath="content.name"


### PR DESCRIPTION
closes #6483
- fix new post => settings/tags transition error

I'm not exactly sure why this works, my guess is it has something to do with ember-cli-selectize not handling record arrays correctly (you have to have the toArray() call). If it's a new record, on transition the post model gets destroyed, which must result in an observer firing with a null value.
