### PR TITLE
Add Issue Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+Short and descriptive example bug report title
+
+### Issue Summary
+
+A summary of the issue and the browser/OS environment in which it occurs. If
+suitable, include the steps required to reproduce the bug.
+
+### Steps to Reproduce
+
+1. This is the first step
+2. This is the second step
+3. Further steps, etc.
+
+Any other information you want to share that is relevant to the issue being
+reported. Especially, why do you consider this to be a bug? What do you expect to happen instead?
+
+### Technical details:
+
+* Ghost Version: 
+* Client OS:
+* Server OS:
+* Node Version:
+* Browser:
+* Database:


### PR DESCRIPTION
This PR adds the current template linked in README.md as a default Github Issue Template (https://github.com/blog/2111-issue-and-pull-request-templates).

Github's implementation sadly leads to more clutter in the root of the repository - they however allow for the file to exist in a `.github` directory (alongside CONTRIBUTING.md and PULL_REQUEST_TEMPLATE.md).

If we want to add an additional PULL_REQUEST_TEMPLATE.md I'd suggest moving at least the two template files inside the proposed `.github` directory (while keeping CONTRIBUTING.md) in the root.
