### PR TITLE
Adding GitHub issue & PR templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,25 +86,20 @@ Short and descriptive example bug report title
 
 ### Issue Summary
 
-A summary of the issue and the browser/OS environment in which it occurs. If
-suitable, include the steps required to reproduce the bug.
+A summary of the issue and the browser/OS environment in which it occurs. 
 
 ### Steps to Reproduce
 
 1. This is the first step
-2. This is the second step
-3. Further steps, etc.
+2. This is the second step, etc.
 
-Any other information you want to share that is relevant to the issue being
-reported. Especially, why do you consider this to be a bug? What do you expect to happen instead?
+Any other info e.g. Why do you consider this to be a bug? What did you expect to happen instead?
 
 ### Technical details:
 
 * Ghost Version: master (latest commit: a761de2079dca4df49567b1bddac492f25033985)
-* Client OS: Mac OS X 10.10.1
-* Server OS: CentOS 6.4
 * Node Version: 0.10.16
-* Browser: Chrome 39.0.2171.71
+* Browser: Chrome 48.0.2564.109 on Mac OS X 10.10.4
 * Database: SQLite / MySQL / postgres
 ```
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,21 @@
+Welcome to Ghost's GitHub repo! 👋🎉
+
+Do you need help or have a question? Please come chat in Slack: https://ghost.org/slack 👫. Got an idea for a new feature? Please add it to our wishlist: http://ideas.ghost.org 🌟. Found a bug? Please fill out the sections below... thank you 👍
+
+### Issue Summary
+
+A summary of the issue and the browser/OS environment in which it occurs. 
+
+### Steps to Reproduce
+
+1. This is the first step
+2. This is the second step, etc.
+
+Any other info e.g. Why do you consider this to be a bug? What did you expect to happen instead?
+
+### Technical details:
+
+* Ghost Version:
+* Node Version:
+* Browser/OS: 
+* Database: 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+Got some code for us? Awesome 🎊!
+
+Please include a description of your change & check your PR against this list, thanks!
+- [ ] Commit message has a short title & issue references
+- [ ] Commits are squashed 
+- [ ] The build will pass (run `npm test`).
+
+More info can be found by clicking the "guidelines for contributing" link above.


### PR DESCRIPTION
An attempt at leveraging GitHub's new issue & PR templates, as well as moving our CONTRIBUTING.md into the .github folder = same number of things in the root directory.

My main wish has been that GitHub would let me add my own welcome copy to the `Please review the guidelines for contributing` block at the top of an issue/PR so that I can guide people towards getting help on Slack. 

The new templates let us put whatever we want in the issue body, so I've added a welcome block with lots of emoji. Beneath it is a streamlined(ish) version of the bug template. My main concern here is that this is a bit long.

![](http://puu.sh/nciPU.png)

The PR template just includes a quicklist:

![](http://puu.sh/ncipl.png)

I've pushed this to master on my fork & enabled issues, so that I could properly test this out. I think it's worth a try to see how it works?
