### PR TITLE
Fix "new post"->"tags" transition

### DIFF
--- a/core/client/app/controllers/post-settings-menu.js
+++ b/core/client/app/controllers/post-settings-menu.js
@@ -174,11 +174,6 @@ export default Controller.extend(SettingsMenuMixin, {
         this.set('debounceId', debounceId);
     },
 
-    // this exists because selectize throws errors on transition if it doesn't
-    existingTags: computed('model.tags.[]', function () {
-        return this.get('model.tags').toArray();
-    }),
-
     // live-query of all tags for tag input autocomplete
     availableTags: computed(function () {
         return this.get('store').filter('tag', {limit: 'all'}, () => {

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -30,8 +30,6 @@ export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, S
     },
 
     model() {
-        this.store.unloadAll('tag');
-
         return this.loadFirstPage().then(() => {
             return this.store.filter('tag', (tag) => {
                 return !tag.get('isNew');

--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -41,7 +41,7 @@
                 {{gh-selectize
                     id="tag-input"
                     multiple=true
-                    selection=existingTags
+                    selection=model.tags
                     content=availableTags
                     optionValuePath="content.uuid"
                     optionLabelPath="content.name"


### PR DESCRIPTION
refs #6483, closes #6541
- reverts #6533 as it causes selected tags to not save due to selectize modifying the CP's array rather than the model's tags attribute
- removes unloading of all tags when entering the tags screen. Tags list will now function similarly to the content list where already-loaded tags are visible immediately.

Fixes #6483 because it prevents selectize's data being changed out from underneath it before it's destroyed.

**Note:** This could cause data in the tags list to be incorrect in certain circumstances. Namely when a user has previously loaded a few pages of tags, they or another user edit tags or add/remove tags from some posts, they return to the tags screen (first page will be auto-refreshed) and don't scroll enough to trigger the infinite scroll requests that would refresh the data of subsequent pages.

It's worth noting that this is the same behaviour as the content list. Long-term fix is to have real-time push updates, the short term fix applied to the tags list was the forced reloading behaviour that this PR removes.
