### PR TITLE
Remove i18n from migration output

### DIFF
--- a/core/server/data/migration/builder.js
+++ b/core/server/data/migration/builder.js
@@ -2,7 +2,6 @@ var  _              = require('lodash'),
     errors          = require('../../errors'),
     commands        = require('../schema').commands,
     schema          = require('../schema').tables,
-    i18n            = require('../../i18n'),
 
     // private
     logInfo,
@@ -15,14 +14,14 @@ var  _              = require('lodash'),
     modifyUniqueCommands;
 
 logInfo = function logInfo(message) {
-    errors.logInfo(i18n.t('notices.data.migration.commands.migrations'), message);
+    errors.logInfo('Migrations', message);
 };
 
 getDeleteCommands = function getDeleteCommands(oldTables, newTables) {
     var deleteTables = _.difference(oldTables, newTables);
     return _.map(deleteTables, function (table) {
         return function () {
-            logInfo(i18n.t('notices.data.migration.commands.deletingTable', {table: table}));
+            logInfo('Deleting table: ' + table);
             return commands.deleteTable(table);
         };
     });
@@ -32,7 +31,7 @@ getAddCommands = function getAddCommands(oldTables, newTables) {
     var addTables = _.difference(newTables, oldTables);
     return _.map(addTables, function (table) {
         return function () {
-            logInfo(i18n.t('notices.data.migration.commands.creatingTable', {table: table}));
+            logInfo('Creating table: ' + table);
             return commands.createTable(table);
         };
     });
@@ -44,7 +43,7 @@ addColumnCommands = function addColumnCommands(table, columns) {
 
     return _.map(addColumns, function (column) {
         return function () {
-            logInfo(i18n.t('notices.data.migration.commands.addingColumn', {table: table, column: column}));
+            logInfo('Adding column: ' + table + '.' + column);
             return commands.addColumn(table, column);
         };
     });
@@ -56,7 +55,7 @@ dropColumnCommands = function dropColumnCommands(table, columns) {
 
     return _.map(dropColumns, function (column) {
         return function () {
-            logInfo(i18n.t('notices.data.migration.commands.droppingColumn', {table: table, column: column}));
+            logInfo('Dropping column: ' + table + '.' + column);
             return commands.dropColumn(table, column);
         };
     });
@@ -68,14 +67,14 @@ modifyUniqueCommands = function modifyUniqueCommands(table, indexes) {
         if (schema[table][column].unique === true) {
             if (!_.contains(indexes, table + '_' + column + '_unique')) {
                 return function () {
-                    logInfo(i18n.t('notices.data.migration.commands.addingUnique', {table: table, column: column}));
+                    logInfo('Adding unique on: ' + table + '.' + column);
                     return commands.addUnique(table, column);
                 };
             }
         } else if (!schema[table][column].unique) {
             if (_.contains(indexes, table + '_' + column + '_unique')) {
                 return function () {
-                    logInfo(i18n.t('notices.data.migration.commands.droppingUnique', {table: table, column: column}));
+                    logInfo('Dropping unique on: ' + table + '.' + column);
                     return commands.dropUnique(table, column);
                 };
             }

--- a/core/server/data/migration/fixtures/index.js
+++ b/core/server/data/migration/fixtures/index.js
@@ -31,7 +31,7 @@ var Promise       = require('bluebird'),
     update;
 
 logInfo = function logInfo(message) {
-    errors.logInfo(i18n.t('notices.data.fixtures.migrations'), message);
+    errors.logInfo('Migrations', message);
 };
 
 /**
@@ -47,7 +47,7 @@ convertAdminToOwner = function convertAdminToOwner() {
         return models.Role.findOne({name: 'Owner'});
     }).then(function (ownerRole) {
         if (adminUser) {
-            logInfo(i18n.t('notices.data.fixtures.convertingAdmToOwner'));
+            logInfo('Converting admin to owner');
             return adminUser.roles().updatePivot({role_id: ownerRole.id});
         }
     });
@@ -65,7 +65,7 @@ createOwner = function createOwner() {
         user.roles = [ownerRole.id];
         user.password = utils.uid(50);
 
-        logInfo(i18n.t('notices.data.fixtures.creatingOwner'));
+        logInfo('Creating owner');
         return models.User.add(user, options);
     });
 };
@@ -78,7 +78,7 @@ populate = function populate() {
         Role = models.Role,
         Client = models.Client;
 
-    logInfo(i18n.t('notices.data.fixtures.populatingFixtures'));
+    logInfo('Populating fixtures');
 
     _.each(fixtures.posts, function (post) {
         ops.push(Post.add(post, options));
@@ -134,12 +134,12 @@ to003 = function to003() {
         Role = models.Role,
         Client = models.Client;
 
-    logInfo(i18n.t('notices.data.fixtures.upgradingFixturesTo', {version: '003'}));
+    logInfo('Upgrading fixtures to 003');
 
     // Add the client fixture if missing
     upgradeOp = Client.findOne({slug: fixtures.clients[0].slug}).then(function (client) {
         if (!client) {
-            logInfo(i18n.t('notices.data.fixtures.addingClientFixture'));
+            logInfo('Adding ghost-admin client fixture');
             return Client.add(fixtures.clients[0], options);
         }
     });
@@ -148,7 +148,7 @@ to003 = function to003() {
     // Add the owner role if missing
     upgradeOp = Role.findOne({name: fixtures.roles[3].name}).then(function (owner) {
         if (!owner) {
-            logInfo(i18n.t('notices.data.fixtures.addingOwnerRoleFixture'));
+            logInfo('Adding owner role fixture');
             _.each(fixtures.roles.slice(3), function (role) {
                 return Role.add(role, options);
             });
@@ -171,6 +171,7 @@ to004 = function to004() {
     var value,
         ops = [],
         upgradeOp,
+        // These messages are shown in the admin UI, not the console, and should therefore be translated
         jquery = [
             i18n.t('notices.data.fixtures.canSafelyDelete'),
             '<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>\n\n'
@@ -180,7 +181,7 @@ to004 = function to004() {
             i18n.t('notices.data.fixtures.canBeChanged')
         ];
 
-    logInfo(i18n.t('notices.data.fixtures.upgradingFixturesTo', {version: '004'}));
+    logInfo('Upgrading fixtures to 004');
 
     // add jquery setting and privacy info
     upgradeOp = function () {
@@ -189,7 +190,7 @@ to004 = function to004() {
                 value = setting.attributes.value;
                 // Only add jQuery if it's not already in there
                 if (value.indexOf(jquery.join('')) === -1) {
-                    logInfo(i18n.t('notices.data.fixtures.addingJquery'));
+                    logInfo('Adding jQuery link to ghost_foot');
                     value = jquery.join('') + value;
                     return models.Settings.edit({key: 'ghost_foot', value: value}, options).then(function () {
                         if (_.isEmpty(config.privacy)) {
@@ -211,7 +212,7 @@ to004 = function to004() {
     upgradeOp = function () {
         return models.Settings.findOne('isPrivate').then(function (setting) {
             if (setting) {
-                logInfo(i18n.t('notices.data.fixtures.updateIsPrivate'));
+                logInfo('Update isPrivate setting');
                 return models.Settings.edit({key: 'isPrivate', type: 'private'}, options);
             }
             return Promise.resolve();
@@ -223,7 +224,7 @@ to004 = function to004() {
     upgradeOp = function () {
         return models.Settings.findOne('password').then(function (setting) {
             if (setting) {
-                logInfo(i18n.t('notices.data.fixtures.updatePassword'));
+                logInfo('Update password setting');
                 return models.Settings.edit({key: 'password', type: 'private'}, options);
             }
             return Promise.resolve();
@@ -236,7 +237,7 @@ to004 = function to004() {
     upgradeOp = function () {
         return models.Client.findOne({slug: fixtures.clients[0].slug}).then(function (client) {
             if (client) {
-                logInfo(i18n.t('notices.data.fixtures.updateAdminClientFixture'));
+                logInfo('Update ghost-admin client fixture');
                 var adminClient = fixtures.clients[0];
                 adminClient.secret = crypto.randomBytes(6).toString('hex');
                 return models.Client.edit(adminClient, _.extend({}, options, {id: client.id}));
@@ -250,7 +251,7 @@ to004 = function to004() {
     upgradeOp = function () {
         return models.Client.findOne({slug: fixtures.clients[1].slug}).then(function (client) {
             if (!client) {
-                logInfo(i18n.t('notices.data.fixtures.addFrontendClientFixture'));
+                logInfo('Add ghost-frontend client fixture');
                 var frontendClient = fixtures.clients[1];
                 frontendClient.secret = crypto.randomBytes(6).toString('hex');
                 return models.Client.add(frontendClient, options);
@@ -277,7 +278,7 @@ to004 = function to004() {
                     }
                 });
                 if (tagOps.length > 0) {
-                    logInfo(i18n.t('notices.data.fixtures.cleaningTags', {length: tagOps.length}));
+                    logInfo('Cleaning ' + tagOps.length + ' malformed tags');
                     return Promise.all(tagOps);
                 }
             }
@@ -289,7 +290,7 @@ to004 = function to004() {
     // Add post_tag order
     upgradeOp = function () {
         var tagOps = [];
-        logInfo(i18n.t('notices.data.fixtures.collectingDataOnTagOrder'));
+        logInfo('Collecting data on tag order for posts...');
         return models.Post.findAll(_.extend({}, options)).then(function (posts) {
             if (posts) {
                 return posts.mapThen(function (post) {
@@ -314,9 +315,9 @@ to004 = function to004() {
             });
 
             if (tagOps.length > 0) {
-                logInfo(i18n.t('notices.data.fixtures.updatingOrder', {length: tagOps.length}));
+                logInfo('Updating order on ' + tagOps.length + ' tag relationships (could take a while)...');
                 return sequence(tagOps).then(function () {
-                    logInfo(i18n.t('notices.data.fixtures.updatedOrder'));
+                    logInfo('Tag order successfully updated');
                 });
             }
         });
@@ -327,7 +328,7 @@ to004 = function to004() {
     upgradeOp = function () {
         return models.Post.findOne({slug: fixtures.posts_0_7[0].slug, status: 'all'}, options).then(function (post) {
             if (!post) {
-                logInfo(i18n.t('notices.data.fixtures.addingUpgrade', {version: '0.7'}));
+                logInfo('Adding 0.7 upgrade post fixture');
                 // Set the published_at timestamp, but keep the post as a draft so doesn't appear on the frontend
                 // This is a hack to ensure that this post appears at the very top of the drafts list, because
                 // unpublished posts always appear first
@@ -344,7 +345,7 @@ to004 = function to004() {
 update = function update(fromVersion, toVersion) {
     var ops = [];
 
-    logInfo(i18n.t('notices.data.fixtures.updatingFixtures'));
+    logInfo('Updating fixtures');
     // Are we migrating to, or past 003?
     if ((fromVersion < '003' && toVersion >= '003') ||
         fromVersion === '003' && toVersion === '003' && process.env.FORCE_MIGRATION) {

--- a/core/server/data/migration/fixtures/permissions/index.js
+++ b/core/server/data/migration/fixtures/permissions/index.js
@@ -3,7 +3,6 @@
 var Promise     = require('bluebird'),
     _           = require('lodash'),
     errors      = require('../../../../errors'),
-    i18n        = require('../../../../i18n'),
     models      = require('../../../../models'),
     sequence    = require('../../../../utils/sequence'),
     fixtures    = require('./permissions'),
@@ -72,7 +71,7 @@ addAllPermissions = function (options) {
 
 // ## Populate
 populate = function (options) {
-    logInfo(i18n.t('errors.data.fixtures.populatingPermissions'));
+    logInfo('Populating permissions');
     // ### Ensure all permissions are added
     return addAllPermissions(options).then(function () {
         // ### Ensure all roles_permissions are added
@@ -86,12 +85,12 @@ populate = function (options) {
 to003 = function (options) {
     var ops = [];
 
-    logInfo(i18n.t('errors.data.fixtures.upgradingPermissions'));
+    logInfo('Upgrading permissions');
 
     // To safely upgrade, we need to clear up the existing permissions and permissions_roles before recreating the new
     // full set of permissions defined as of version 003
     return models.Permissions.forge().fetch().then(function (permissions) {
-        logInfo(i18n.t('errors.data.fixtures.removingOldPermissions'));
+        logInfo('Removing old permissions');
         permissions.each(function (permission) {
             ops.push(permission.related('roles').detach().then(function () {
                 return permission.destroy();

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -367,11 +367,6 @@
             "export": {
                 "errorExportingData": "Error exporting data"
             },
-            "fixtures": {
-                "populatingPermissions": "Populating permissions",
-                "upgradingPermissions": "Upgrading permissions",
-                "removingOldPermissions": "Removing old permissions"
-            },
             "import": {
                 "dataImporter": {
                     "unableToFindOwner": "Unable to find an owner"
@@ -519,56 +514,9 @@
         },
         "data": {
             "fixtures": {
-                "migrations": "Migrations",
-                "convertingAdmToOwner": "Converting admin to owner",
-                "creatingOwner": "Creating owner",
-                "populatingFixtures": "Populating fixtures",
-                "upgradingFixturesTo": "Upgrading fixtures to {version}",
-                "addingClientFixture": "Adding ghost-admin client fixture",
-                "addingOwnerRoleFixture": "Adding owner role fixture",
-                "updatingFixtures": "Updating fixtures",
                 "canSafelyDelete": "<!-- You can safely delete this line if your theme does not require jQuery -->\n",
                 "jQueryRemoved": "jQuery has been removed from Ghost core and is now being loaded from the jQuery Foundation's CDN.",
-                "canBeChanged": "This can be changed or removed in your <strong>Code Injection</strong> settings area.",
-                "addingJquery": "Adding jQuery link to ghost_foot",
-                "updateIsPrivate": "Update isPrivate setting",
-                "updatePassword": "Update password setting",
-                "updateAdminClientFixture": "Update ghost-admin client fixture",
-                "addFrontendClientFixture": "Add ghost-frontend client fixture",
-                "cleaningTags": "Cleaning {length} malformed tags",
-                "collectingDataOnTagOrder": "Collecting data on tag order for posts...",
-                "updatingOrder": "Updating order on {length} tag relationships (could take a while)...",
-                "updatedOrder": "Tag order successfully updated",
-                "addingUpgrade": "Adding {version} upgrade post fixture"
-            },
-            "migration": {
-                "commands": {
-                    "migrations": "Migrations",
-                    "deletingTable": "Deleting table: {table}",
-                    "creatingTable": "Creating table: {table}",
-                    "addingColumn": "Adding column: {table}.{column}",
-                    "droppingColumn": "Dropping column: {table}.{column}",
-                    "addingUnique": "Adding unique on: {table}.{column}",
-                    "droppingUnique": "Dropping unique on: {table}.{column}"
-                },
-                "index": {
-                    "migrations": "Migrations",
-                    "complete": "Complete",
-                    "populatingDefaultSettings": "Populating default settings",
-                    "creatingDatabaseBackup": "Creating database backup",
-                    "databaseBackupDestination": "Database backup written to: {filename}",
-                    "databaseUpgradeRequired": "Database upgrade required from version {dbVersion} to {defaultVersion}",
-                    "upToDateAtVersion": "Up to date at version {dbVersion}",
-                    "databaseNotCompatible": {
-                        "error": "Your database is not compatible with this version of Ghost",
-                        "help": "You will need to create a new database"
-                    },
-                    "dbInitialisationRequired": "Database initialisation required for version {version}",
-                    "problemWithDatabase": "There is a problem with the database",
-                    "creatingTable": "Creating table: {table}",
-                    "creatingTables": "Creating tables...",
-                    "runningMigrations": "Running migrations"
-                }
+                "canBeChanged": "This can be changed or removed in your <strong>Code Injection</strong> settings area."
             },
             "utils": {
                 "index": {


### PR DESCRIPTION
I'm PRing this ahead of some refactory changes.

refs #5345
- As discussed in #5345, this is effectively debug output.
- It currently only appears on the console, and console output should be in English
- If we add a UI later, this should be translated, but console/debug output should not
