### PR TITLE
Move client secret logic into the model

### DIFF
--- a/core/server/data/migration/fixtures/fixtures.json
+++ b/core/server/data/migration/fixtures/fixtures.json
@@ -70,16 +70,12 @@
         {
             "name":             "Ghost Admin",
             "slug":             "ghost-admin",
-            "status":           "enabled",
-            "type":             "ua",
-            "secret":           "not_available"
+            "status":           "enabled"
         },
         {
             "name":             "Ghost Frontend",
             "slug":             "ghost-frontend",
-            "status":           "enabled",
-            "type":             "ua",
-            "secret":           "not_available"
+            "status":           "enabled"
         }
     ]
 }

--- a/core/server/data/migration/fixtures/index.js
+++ b/core/server/data/migration/fixtures/index.js
@@ -93,10 +93,6 @@ populate = function populate() {
     });
 
     _.each(fixtures.clients, function (client) {
-        // no random secrets during testing
-        if (process.env.NODE_ENV.indexOf('testing') !== 0) {
-            client.secret = crypto.randomBytes(6).toString('hex');
-        }
         ops.push(Client.add(client, options));
     });
 
@@ -252,7 +248,6 @@ to004 = function to004() {
             if (!client) {
                 logInfo(i18n.t('notices.data.fixtures.addFrontendClientFixture'));
                 var frontendClient = fixtures.clients[1];
-                frontendClient.secret = crypto.randomBytes(6).toString('hex');
                 return models.Client.add(frontendClient, options);
             }
             return Promise.resolve();

--- a/core/server/models/client.js
+++ b/core/server/models/client.js
@@ -1,10 +1,26 @@
 var ghostBookshelf = require('./base'),
+    crypto         = require('crypto'),
+    uuid           = require('node-uuid'),
 
     Client,
     Clients;
 
 Client = ghostBookshelf.Model.extend({
+
     tableName: 'clients',
+
+    defaults: function defaults() {
+        var env = process.env.NODE_ENV,
+            secret = env.indexOf('testing') !== 0 ? crypto.randomBytes(6).toString('hex') : 'not_available';
+
+        return {
+            uuid: uuid.v4(),
+            secret: secret,
+            status: 'development',
+            type: 'ua'
+        };
+    },
+
     trustedDomains: function trustedDomains() {
         return this.hasMany('ClientTrustedDomain', 'client_id');
     }


### PR DESCRIPTION
This change doesn't need to be tied to a data version change as it doesn't impact on overall behaviour.

Upgrading from 003 works, as does fresh installs.

Upgrading from < 003 is no longer working since #6467 I have discovered (separately to making this change) due to a conflict in the way the rules are generated (deleting a table, then trying to delete a column from the already deleted table).

Seeing as <003 = 0.4.2, I'm ignoring this for now, but will remove all the code for handling pre 003 upgrades, and replace it with a simple error/warning that you need to upgrade to 0.7.1 first (note: I've already updated the [upgrade docs to reflect this](http://support.ghost.org/how-to-upgrade/)).

refs #6301
- Move secret generation logic to the model defaults, so there's no need to handle this in fixtures
- Tested upgrades from 003 & fresh installs -> all is well
