### PR TITLE
Fix preview icon position in editor

### DIFF
--- a/core/client/app/styles/layouts/editor.css
+++ b/core/client/app/styles/layouts/editor.css
@@ -337,6 +337,7 @@
 }
 
 .post-view-link i {
+    display: inline;
     font-size: 10px;
 }
 


### PR DESCRIPTION
Fix preview icon position in editor.
That icon's property currently `display: block` inherited from `global.css`, so this happened:

![g2](https://cloud.githubusercontent.com/assets/5537552/13168529/2a413874-d710-11e5-9338-ef5f86e70766.png)

this is more reasonable:

![g1](https://cloud.githubusercontent.com/assets/5537552/13168537/4d374d3c-d710-11e5-83ee-552d88214278.png)
