### PR TITLE
Restructure Configuration API endpoint

### DIFF
--- a/core/client/app/index.html
+++ b/core/client/app/index.html
@@ -31,13 +31,13 @@
     <meta name="msapplication-square150x150logo" content="{{asset "img/medium.png" ghost="true"}}" />
     <meta name="msapplication-square310x310logo" content="{{asset "img/large.png" ghost="true"}}" />
 
-    {{#each configuration}}
-        <meta name="env-{{this.key}}" content="{{this.value}}" data-type="{{this.type}}" />
+    {{#each configuration as |config key|}}
+        <meta name="env-{{key}}" content="{{config.value}}" data-type="{{config.type}}" />
     {{/each}}
 
-    {{#unless skip_google_fonts}}
+    {{#if configuration.useGoogleFonts.value}}
         <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,700" />
-    {{/unless}}
+    {{/if}}
 
     <link rel="stylesheet" href="{{asset "vendor.css" ghost="true" minifyInProduction="true"}}" />
     <link rel="stylesheet" href="{{asset "ghost.css" ghost="true" minifyInProduction="true"}}" />

--- a/core/client/app/routes/about.js
+++ b/core/client/app/routes/about.js
@@ -18,7 +18,7 @@ export default AuthenticatedRoute.extend(styleBody, {
 
     model() {
         let cachedConfig = this.get('cachedConfig');
-        let configUrl = this.get('ghostPaths.url').api('configuration');
+        let configUrl = this.get('ghostPaths.url').api('configuration', 'about');
 
         if (cachedConfig) {
             return cachedConfig;
@@ -26,12 +26,8 @@ export default AuthenticatedRoute.extend(styleBody, {
 
         return this.get('ajax').request(configUrl)
             .then((configurationResponse) => {
-                let configKeyValues = configurationResponse.configuration;
+                let [cachedConfig] = configurationResponse.configuration;
 
-                cachedConfig = {};
-                configKeyValues.forEach((configKeyValue) => {
-                    cachedConfig[configKeyValue.key] = configKeyValue.value;
-                });
                 this.set('cachedConfig', cachedConfig);
 
                 return cachedConfig;

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -22,7 +22,7 @@ apiRoutes = function apiRoutes(middleware) {
     router.del = router.delete;
 
     // ## Configuration
-    router.get('/configuration', authenticatePrivate, api.http(api.configuration.browse));
+    router.get('/configuration', authenticatePrivate, api.http(api.configuration.read));
     router.get('/configuration/:key', authenticatePrivate, api.http(api.configuration.read));
 
     // ## Posts

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -9,7 +9,6 @@ var _               = require('lodash'),
     protocol        = 'http://',
     expectedProperties = {
         // API top level
-        configuration: ['key', 'value', 'type'],
         posts:         ['posts', 'meta'],
         tags:          ['tags', 'meta'],
         users:         ['users', 'meta'],


### PR DESCRIPTION
OK SO! This is a super fun cross API/Ember PR :grin:
## API

I've restructured the configuration endpoint so that it's effectively two endpoints:
- `/configuration/` - basic config that any client might need
- `/configuration/about/`\- the more sensitive config used by the about page that would always need user auth

Both endpoints return something in the following structure:

```
{configuration: [
   {
      someKey: someValue,
      someOtherKey: someOtherValue
   }
]}
```

For the basic config, `someValue` is an object with a value and a type. For the about config, it's just a string representing the value. Here's what the about config looks like:

```
{configuration: [ 
  { 
    version: '0.7.8',
    environment: 'testing',
    database: 'sqlite3',
    mail: '' 
  } 
]}
```

So now, each individual key and value pair is not treated as an individual object any more. Instead, we treat this like a "read" request for a particular type of configuration... just like posts, if you do a read request for /post/:id/, you get one object and it's different based on which id you request.

Therefore, the configuration endpoint only has a 'read' method now, no browse method as we have no need to be able to see all the different configuration endpoints at one time.

This can be extended further for timezones and locales.

`/config/timezones/` would return something like: 

```
{configuration: [ 
  { 
    timezones: [huge array of timezones]
  } 
]}
```

That is, a top level configuration key, which contains an array with a single configuration item. That single item has one key 'timezones' and the value of that key happens to be a huge array this time.

And locales would follow the same pattern.

---
## Ember Client

I've restructured how the responses are handled to match up with the new data structure.

I also moved skip_google_fonts and changed it to be a config item instead.

Note that I've also added the gravatar privacy option which is currently being totally ignored by the client :disappointed: 

---

refs #6421, #6525
- The config API tests were swallowing all errors - fixed this first.
- The configuration API endpoint was a bit of an animal:
  - It's used currently in two ways, once for general config, another for the about page.
  - These two things are different, and would require different permissions in future.
  - There was also both a browse and a read version, even though only browse was used.
  - The response from the browse was being artificially turned into many objects, when its really just one with multiple keys
- The new version treats each type of config as a different single object with several keys
- The new version therefore only has a 'read' request
- A basic read request with no key will return basic config that any client would need
- A read request with the about key returns the about config
- A read request with a different key could therefore return some other config
