### PR TITLE
Strutured data: Slack Unfurls & published_at fix

### DIFF
--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -14,7 +14,7 @@ var config = require('../../config'),
     getModifiedDate = require('./modified_date'),
     getOgType = require('./og_type'),
     getStructuredData = require('./structured_data'),
-    getPostSchema = require('./schema'),
+    getSchema = require('./schema'),
     getExcerpt = require('./excerpt');
 
 function getMetaData(data, root) {
@@ -38,12 +38,17 @@ function getMetaData(data, root) {
         blog: blog
     };
 
+    // TODO: cleanup these if statements
     if (data.post && data.post.html) {
         metaData.excerpt = getExcerpt(data.post.html, {words: 50});
     }
 
+    if (data.post && data.post.author && data.post.author.name) {
+        metaData.authorName = data.post.author.name;
+    }
+
     metaData.structuredData = getStructuredData(metaData);
-    metaData.schema = getPostSchema(metaData, data);
+    metaData.schema = getSchema(metaData, data);
 
     return metaData;
 }

--- a/core/server/data/meta/published_date.js
+++ b/core/server/data/meta/published_date.js
@@ -1,11 +1,7 @@
 function getPublishedDate(data) {
-    var context = data.context ? data.context[0] : null,
-        pubDate;
-    if (data[context]) {
-        pubDate = data[context].published_at || data[context].created_at || null;
-        if (pubDate) {
-            return new Date(pubDate).toISOString();
-        }
+    var context = data.context ? data.context[0] : null;
+    if (data[context] && data[context].published_at) {
+        return new Date(data[context].published_at).toISOString();
     }
     return null;
 }

--- a/core/server/data/meta/structured_data.js
+++ b/core/server/data/meta/structured_data.js
@@ -20,10 +20,14 @@ function getStructuredData(metaData) {
         'twitter:title': metaData.metaTitle,
         'twitter:description': metaData.metaDescription || metaData.excerpt,
         'twitter:url': metaData.canonicalUrl,
-        'twitter:image:src': metaData.coverImage
+        'twitter:image:src': metaData.coverImage,
+        'twitter:label1': metaData.authorName ? 'Written by' : undefined,
+        'twitter:data1': metaData.authorName,
+        'twitter:label2': metaData.keywords ? 'Filed under' : undefined,
+        'twitter:data2': metaData.keywords ? metaData.keywords.join(', ') : undefined
     };
 
-    // return structored data removing null or undefined keys
+    // return structured data removing null or undefined keys
     return Object.keys(structuredData).reduce(function (data, key) {
         var content = structuredData[key];
         if (content !== null && typeof content !== 'undefined') {

--- a/core/test/unit/metadata/published_date_spec.js
+++ b/core/test/unit/metadata/published_date_spec.js
@@ -13,16 +13,6 @@ describe('getPublishedDate', function () {
         should.equal(pubDate, '2016-01-01T12:56:45.232Z');
     });
 
-    it('should return created at date as ISO 8601 if no published at date', function () {
-        var pubDate = getPublishedDate({
-            context: ['author'],
-            author: {
-                created_at: new Date('2016-01-01 12:56:45.232Z')
-            }
-        });
-        should.equal(pubDate, '2016-01-01T12:56:45.232Z');
-    });
-
     it('should return published at over created at date as ISO 8601 if has both', function () {
         var pubDate = getPublishedDate({
             context: ['post'],

--- a/core/test/unit/metadata/structured_data_spec.js
+++ b/core/test/unit/metadata/structured_data_spec.js
@@ -3,11 +3,12 @@ var getStructuredData = require('../../../server/data/meta/structured_data'),
     should = require('should');
 
 describe('getStructuredData', function () {
-    it('should return structored data from metadata', function () {
+    it('should return structured data from metadata', function () {
         var metadata = {
             blog: {
                 title: 'Blog Title'
             },
+            authorName: 'Test User',
             ogType: 'article',
             metaTitle: 'Post Title',
             canonicalUrl: 'http://mysite.com/post/my-post-slug/',
@@ -29,22 +30,26 @@ describe('getStructuredData', function () {
             'og:type': 'article',
             'og:url': 'http://mysite.com/post/my-post-slug/',
             'twitter:card': 'summary_large_image',
+            'twitter:data1': 'Test User',
+            'twitter:data2': ['one', 'two', 'tag'].join(', '),
             'twitter:description': 'Post meta description',
             'twitter:image:src': 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            'twitter:label1': 'Written by',
+            'twitter:label2': 'Filed under',
             'twitter:title': 'Post Title',
             'twitter:url': 'http://mysite.com/post/my-post-slug/'
         });
     });
 
-    it('should return structored data from metadata with no nulls', function () {
+    it('should return structured data from metadata with no nulls', function () {
         var metadata = {
             blog: {
                 title: 'Blog Title'
             },
+            authorName: 'Test User',
             ogType: 'article',
             metaTitle: 'Post Title',
             canonicalUrl: 'http://mysite.com/post/my-post-slug/',
-            publishedDate: '2015-12-25T05:35:01.234Z',
             modifiedDate: '2016-01-21T22:13:05.412Z',
             coverImage: undefined,
             keywords: null,
@@ -53,12 +58,13 @@ describe('getStructuredData', function () {
 
         should.deepEqual(structuredData, {
             'article:modified_time': '2016-01-21T22:13:05.412Z',
-            'article:published_time': '2015-12-25T05:35:01.234Z',
             'og:site_name': 'Blog Title',
             'og:title': 'Post Title',
             'og:type': 'article',
             'og:url': 'http://mysite.com/post/my-post-slug/',
             'twitter:card': 'summary',
+            'twitter:data1': 'Test User',
+            'twitter:label1': 'Written by',
             'twitter:title': 'Post Title',
             'twitter:url': 'http://mysite.com/post/my-post-slug/'
         });


### PR DESCRIPTION
![](http://puu.sh/neWQt.png)

This adds twitter labels as defined in #6534, which improve the slack unfurls.

It also fixes a bug with `published_at` - it was falling back to the `created_at` date. This is incorrect for meta data, and also causes incorrect published_at dates to be output in the meta data for authors & tags.

refs #6534 
- fixes a bug where published_at was incorrectly falling back to the created_at date
- updated meta index to get author name
- add written by & published labels + data if the values are present (only on posts/pages)
- updated tests
