### PR TITLE
Rename confusing 'context' variables

### DIFF
--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,11 +1,11 @@
 var config = require('../../config');
 
-function getAssetUrl(context, isAdmin, minify) {
+function getAssetUrl(path, isAdmin, minify) {
     var output = '';
 
     output += config.paths.subdir + '/';
 
-    if (!context.match(/^favicon\.ico$/) && !context.match(/^shared/) && !context.match(/^asset/)) {
+    if (!path.match(/^favicon\.ico$/) && !path.match(/^shared/) && !path.match(/^asset/)) {
         if (isAdmin) {
             output += 'ghost/';
         } else {
@@ -13,17 +13,17 @@ function getAssetUrl(context, isAdmin, minify) {
         }
     }
 
-    // Get rid of any leading slash on the context
-    context = context.replace(/^\//, '');
+    // Get rid of any leading slash on the path
+    path = path.replace(/^\//, '');
 
     // replace ".foo" with ".min.foo" in production
     if (minify) {
-        context = context.replace(/\.([^\.]*)$/, '.min.$1');
+        path = path.replace(/\.([^\.]*)$/, '.min.$1');
     }
 
-    output += context;
+    output += path;
 
-    if (!context.match(/^favicon\.ico$/)) {
+    if (!path.match(/^favicon\.ico$/)) {
         output = output + '?v=' + config.assetHash;
     }
 

--- a/core/server/helpers/asset.js
+++ b/core/server/helpers/asset.js
@@ -6,7 +6,7 @@
 var getAssetUrl = require('../data/meta/asset_url'),
     hbs = require('express-hbs');
 
-function asset(context, options) {
+function asset(path, options) {
     var isAdmin,
         minify;
 
@@ -18,7 +18,7 @@ function asset(context, options) {
         minify = false;
     }
     return new hbs.handlebars.SafeString(
-        getAssetUrl(context, isAdmin, minify)
+        getAssetUrl(path, isAdmin, minify)
     );
 }
 

--- a/core/server/helpers/author.js
+++ b/core/server/helpers/author.js
@@ -16,11 +16,7 @@ var hbs             = require('express-hbs'),
     utils           = require('./utils'),
     author;
 
-author = function (context, options) {
-    if (_.isUndefined(options)) {
-        options = context;
-    }
-
+author = function (options) {
     if (options.fn) {
         return hbs.handlebars.helpers.with.call(this, this.author, options);
     }

--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -6,29 +6,28 @@
 var moment          = require('moment'),
     date;
 
-date = function (context, options) {
-    if (!options && context.hasOwnProperty('hash')) {
-        options = context;
-        context = undefined;
+date = function (date, options) {
+    if (!options && date.hasOwnProperty('hash')) {
+        options = date;
+        date = undefined;
 
         // set to published_at by default, if it's available
         // otherwise, this will print the current date
         if (this.published_at) {
-            context = this.published_at;
+            date = this.published_at;
         }
     }
 
     // ensure that context is undefined, not null, as that can cause errors
-    context = context === null ? undefined : context;
+    date = date === null ? undefined : date;
 
     var f = options.hash.format || 'MMM Do, YYYY',
-        timeago = options.hash.timeago,
-        date;
+        timeago = options.hash.timeago;
 
     if (timeago) {
-        date = moment(context).fromNow();
+        date = moment(date).fromNow();
     } else {
-        date = moment(context).format(f);
+        date = moment(date).format(f);
     }
     return date;
 };

--- a/core/server/helpers/encode.js
+++ b/core/server/helpers/encode.js
@@ -4,11 +4,11 @@
 //
 // Returns URI encoded string
 
-var hbs             = require('express-hbs'),
+var hbs = require('express-hbs'),
     encode;
 
-encode = function (context, str) {
-    var uri = context || str;
+encode = function (string, options) {
+    var uri = string || options;
     return new hbs.handlebars.SafeString(encodeURIComponent(uri));
 };
 

--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -6,7 +6,7 @@
 // Defaults to words="50"
 
 var hbs = require('express-hbs'),
-    _ = require('lodash'),
+    _   = require('lodash'),
     getMetaDataExcerpt = require('../data/meta/excerpt');
 
 function excerpt(options) {

--- a/core/server/helpers/foreach.js
+++ b/core/server/helpers/foreach.js
@@ -10,7 +10,7 @@ var hbs             = require('express-hbs'),
     hbsUtils        = hbs.handlebars.Utils,
     foreach;
 
-foreach = function (context, options) {
+foreach = function (itemType, options) {
     if (!options) {
         errors.logWarn(i18n.t('warnings.helpers.foreach.iteratorNeeded'));
     }
@@ -18,7 +18,7 @@ foreach = function (context, options) {
     var fn = options.fn,
         inverse = options.inverse,
         columns = options.hash.columns,
-        length = _.size(context),
+        length = _.size(itemType),
         limit = parseInt(options.hash.limit, 10) || length,
         from = parseInt(options.hash.from, 10) || 1,
         to = parseInt(options.hash.to, 10) || (from - 1) + limit,
@@ -30,8 +30,8 @@ foreach = function (context, options) {
         contextPath = hbsUtils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
     }
 
-    if (hbsUtils.isFunction(context)) {
-        context = context.call(this);
+    if (hbsUtils.isFunction(itemType)) {
+        itemType = itemType.call(this);
     }
 
     if (options.data) {
@@ -55,9 +55,9 @@ foreach = function (context, options) {
             }
         }
 
-        output = output + fn(context[field], {
+        output = output + fn(itemType[field], {
             data: data,
-            blockParams: hbsUtils.blockParams([context[field], field], [contextPath + field, null])
+            blockParams: hbsUtils.blockParams([itemType[field], field], [contextPath + field, null])
         });
     }
 
@@ -79,8 +79,8 @@ foreach = function (context, options) {
         });
     }
 
-    if (context && typeof context === 'object') {
-        iterateCollection(context);
+    if (itemType && typeof itemType === 'object') {
+        iterateCollection(itemType);
     }
 
     if (length === 0) {

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -25,11 +25,11 @@ pathAliases     = {
 /**
  * ## Is Browse
  * Is this a Browse request or a Read request?
- * @param {Object} context
+ * @param {Object} resource
  * @param {Object} options
  * @returns {boolean}
  */
-function isBrowse(context, options) {
+function isBrowse(resource, options) {
     var browse = true;
 
     if (options.id || options.slug) {
@@ -85,18 +85,18 @@ function parseOptions(data, options) {
 
 /**
  * ## Get
- * @param {Object} context
+ * @param {Object} resource
  * @param {Object} options
  * @returns {Promise}
  */
-get = function get(context, options) {
+get = function get(resource, options) {
     options = options || {};
     options.hash = options.hash || {};
     options.data = options.data || {};
 
     var self = this,
         data = hbs.handlebars.createFrame(options.data),
-        apiOptions = _.omit(options.hash, 'context'),
+        apiOptions = options.hash,
         apiMethod;
 
     if (!options.fn) {
@@ -105,14 +105,14 @@ get = function get(context, options) {
         return Promise.resolve();
     }
 
-    if (!_.contains(resources, context)) {
+    if (!_.contains(resources, resource)) {
         data.error = i18n.t('warnings.helpers.get.invalidResource');
         errors.logWarn(data.error);
         return Promise.resolve(options.inverse(self, {data: data}));
     }
 
     // Determine if this is a read or browse
-    apiMethod = isBrowse(context, apiOptions) ? api[context].browse : api[context].read;
+    apiMethod = isBrowse(resource, apiOptions) ? api[resource].browse : api[resource].read;
     // Parse the options we're going to pass to the API
     apiOptions = parseOptions(this, apiOptions);
 
@@ -120,13 +120,13 @@ get = function get(context, options) {
         var blockParams;
 
         // If no result is found, call the inverse or `{{else}}` function
-        if (_.isEmpty(result[context])) {
+        if (_.isEmpty(result[resource])) {
             return options.inverse(self, {data: data});
         }
 
         // block params allows the theme developer to name the data using something like
         // `{{#get "posts" as |result pageInfo|}}`
-        blockParams = [result[context]];
+        blockParams = [result[resource]];
         if (result.meta && result.meta.pagination) {
             result.pagination = result.meta.pagination;
             blockParams.push(result.meta.pagination);
@@ -143,7 +143,7 @@ get = function get(context, options) {
     });
 };
 
-module.exports = function getWithLabs(context, options) {
+module.exports = function getWithLabs(resource, options) {
     var self = this,
         errorMessages = [
             i18n.t('warnings.helpers.get.helperNotAvailable'),
@@ -153,7 +153,7 @@ module.exports = function getWithLabs(context, options) {
 
     if (labs.isSet('publicAPI') === true) {
         // get helper is  active
-        return get.call(self, context, options);
+        return get.call(self, resource, options);
     } else {
         errors.logError.apply(this, errorMessages);
         return Promise.resolve(function noGetHelper() {

--- a/core/server/helpers/navigation.js
+++ b/core/server/helpers/navigation.js
@@ -16,7 +16,7 @@ navigation = function (options) {
         currentUrl = options.data.root.relativeUrl,
         self = this,
         output,
-        context;
+        data;
 
     if (!_.isObject(navigationData) || _.isFunction(navigationData)) {
         return errors.logAndThrowError(i18n.t('warnings.helpers.navigation.invalidData'));
@@ -62,9 +62,9 @@ navigation = function (options) {
         return out;
     });
 
-    context = _.merge({}, {navigation: output});
+    data = _.merge({}, {navigation: output});
 
-    return template.execute('navigation', context, options);
+    return template.execute('navigation', data, options);
 };
 
 module.exports = navigation;

--- a/core/server/helpers/page_url.js
+++ b/core/server/helpers/page_url.js
@@ -15,7 +15,7 @@ var config          = require('../config'),
     page_url,
     pageUrl;
 
-page_url = function (context, block) {
+page_url = function (pageNum, options) {
     /*jshint unused:false*/
     var url = config.paths.subdir;
 
@@ -27,8 +27,8 @@ page_url = function (context, block) {
         url += '/' + config.routeKeywords.author + '/' + this.authorSlug;
     }
 
-    if (context > 1) {
-        url += '/' + config.routeKeywords.page + '/' + context;
+    if (pageNum > 1) {
+        url += '/' + config.routeKeywords.page + '/' + pageNum;
     }
 
     url += '/';
@@ -44,13 +44,13 @@ page_url = function (context, block) {
 // Returns the URL for the page specified in the current object
 // context. This helper is deprecated and will be removed in future versions.
 //
-pageUrl = function (context, block) {
+pageUrl = function (pageNum, options) {
     errors.logWarn(i18n.t('warnings.helpers.page_url.isDeprecated'));
 
     /*jshint unused:false*/
     var self = this;
 
-    return page_url.call(self, context, block);
+    return page_url.call(self, pageNum, options);
 };
 
 module.exports = page_url;

--- a/core/server/helpers/pagination.js
+++ b/core/server/helpers/pagination.js
@@ -29,17 +29,17 @@ pagination = function (options) {
         return errors.logAndThrowError(i18n.t('warnings.helpers.pagination.valuesMustBeNumeric'));
     }
 
-    var context = _.merge({}, this.pagination);
+    var data = _.merge({}, this.pagination);
 
     if (this.tag !== undefined) {
-        context.tagSlug = this.tag.slug;
+        data.tagSlug = this.tag.slug;
     }
 
     if (this.author !== undefined) {
-        context.authorSlug = this.author.slug;
+        data.authorSlug = this.author.slug;
     }
 
-    return template.execute('pagination', context, options);
+    return template.execute('pagination', data, options);
 };
 
 module.exports = pagination;

--- a/core/server/helpers/plural.js
+++ b/core/server/helpers/plural.js
@@ -14,18 +14,18 @@ var hbs             = require('express-hbs'),
     i18n            = require('../i18n'),
     plural;
 
-plural = function (context, options) {
+plural = function (number, options) {
     if (_.isUndefined(options.hash) || _.isUndefined(options.hash.empty) ||
         _.isUndefined(options.hash.singular) || _.isUndefined(options.hash.plural)) {
         return errors.logAndThrowError(i18n.t('warnings.helpers.plural.valuesMustBeDefined'));
     }
 
-    if (context === 0) {
-        return new hbs.handlebars.SafeString(options.hash.empty.replace('%', context));
-    } else if (context === 1) {
-        return new hbs.handlebars.SafeString(options.hash.singular.replace('%', context));
-    } else if (context >= 2) {
-        return new hbs.handlebars.SafeString(options.hash.plural.replace('%', context));
+    if (number === 0) {
+        return new hbs.handlebars.SafeString(options.hash.empty.replace('%', number));
+    } else if (number === 1) {
+        return new hbs.handlebars.SafeString(options.hash.singular.replace('%', number));
+    } else if (number >= 2) {
+        return new hbs.handlebars.SafeString(options.hash.plural.replace('%', number));
     }
 };
 

--- a/core/server/helpers/prev_next.js
+++ b/core/server/helpers/prev_next.js
@@ -25,7 +25,7 @@ fetch = function (apiOptions, options) {
 // If prevNext method is called without valid post data then we must return a promise, if there is valid post data
 // then the promise is handled in the api call.
 
-prevNext =  function (options) {
+prevNext = function (options) {
     options = options || {};
 
     var apiOptions = {


### PR DESCRIPTION
This PR cleans up some really badly named variables + a couple of other bits of extraneous code from the theme helpers + meta data.

The aim is to make the code easier to understand, so that it's clear what `context` means when we're in theme land.

no issue
- In Ghost, 'context' means the page or section of a blog we're currently within
  when rendering a theme, e.g. 'post' or 'tag' or 'home'.
- In handlebars 'context' refers to the blob of JSON that is tied to a template.
- These two uses of the word 'context' have gotten very confusing, so I've removed all usage of 'context' within the Ghost handlebars helpers, EXCEPT where they actually refer to the current context (e.g. the is helper)
