### PR TITLE
Fix jsDoc on i18n.t()

### DIFF
--- a/core/server/i18n.js
+++ b/core/server/i18n.js
@@ -17,10 +17,10 @@ I18n = {
      * Helper method to find and compile the given data context with a proper string resource.
      *
      * @param {string} path Path with in the JSON language file to desired string (ie: "errors.init.jsNotBuilt")
-     * @param {json} context
+     * @param {object} [bindings]
      * @returns {string}
      */
-    t: function t(path, context) {
+    t: function t(path, bindings) {
         var string = I18n.findString(path),
             msg;
 
@@ -32,11 +32,11 @@ I18n = {
             string.forEach(function (s) {
                 var m = new MessageFormat(s, currentLocale);
 
-                msg.push(m.format(context));
+                msg.push(m.format(bindings));
             });
         } else {
             msg = new MessageFormat(string, currentLocale);
-            msg = msg.format(context);
+            msg = msg.format(bindings);
         }
 
         return msg;


### PR DESCRIPTION
- my IDE has been moaning at me for every usage of i18n.t that didn't have 2 args
- this uses the optional notation and expects an object instead of JSON (JSON requires keys to be quoted)
