### PR TITLE
[WIP] Remove upgrade from <0.5.0

### DIFF
--- a/core/server/data/migration/fixtures/permissions/index.js
+++ b/core/server/data/migration/fixtures/permissions/index.js
@@ -15,8 +15,7 @@ var Promise     = require('bluebird'),
     addRolesPermissionsForRole,
 
     // public
-    populate,
-    to003;
+    populate;
 
 logInfo = function logInfo(message) {
     errors.logInfo('Migrations', message);
@@ -80,32 +79,6 @@ populate = function (options) {
     });
 };
 
-// ## Update
-// Update permissions to 003
-// Need to rename old permissions, and then add all of the missing ones
-to003 = function (options) {
-    var ops = [];
-
-    logInfo(i18n.t('errors.data.fixtures.upgradingPermissions'));
-
-    // To safely upgrade, we need to clear up the existing permissions and permissions_roles before recreating the new
-    // full set of permissions defined as of version 003
-    return models.Permissions.forge().fetch().then(function (permissions) {
-        logInfo(i18n.t('errors.data.fixtures.removingOldPermissions'));
-        permissions.each(function (permission) {
-            ops.push(permission.related('roles').detach().then(function () {
-                return permission.destroy();
-            }));
-        });
-
-        // Now we can perform the normal populate
-        return Promise.all(ops).then(function () {
-            return populate(options);
-        });
-    });
-};
-
 module.exports = {
-    populate: populate,
-    to003: to003
+    populate: populate
 };

--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -161,6 +161,15 @@ migrateUp = function (fromVersion, toVersion) {
         modifyUniCommands = [],
         migrateOps = [];
 
+    // Are we migrating from before 003?
+    if (fromVersion < '003') {
+        return errors.logAndRejectError(
+            'Unable to upgrade from version 0.4.2 or earlier',
+            'Please upgrade to 0.7.1 first',
+            'See http://support.ghost.org/how-to-upgrade/ for more information'
+        );
+    }
+
     return backupDatabase().then(function () {
         return commands.getTables();
     }).then(function (tables) {


### PR DESCRIPTION
This one's a WIP - just want to check if anyone can think of any reason why we shouldn't do this before I wrap it up.

Note, it will go out in a minor bump... so 0.8.0

refs #6301
- It's time, keeping around code for upgrading from <0.5.0 is unnecessary.
- Cleaning this up simplifies improving migrations for the future
