### PR TITLE
Ensure null query options don't break ghost-url

### DIFF
--- a/core/shared/ghost-url.js
+++ b/core/shared/ghost-url.js
@@ -33,11 +33,14 @@
                 queryOptions,
                 requestUrl = apiUrl;
 
-            if (args.length && typeof args[args.length - 1] === 'object') {
-                queryOptions = args.pop();
-            } else {
+            queryOptions = args.pop();
+
+            if (queryOptions && typeof queryOptions !== 'object') {
+                args.push(queryOptions);
                 queryOptions = {};
             }
+
+            queryOptions = queryOptions || {};
 
             queryOptions.client_id = clientId;
             queryOptions.client_secret = clientSecret;

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -73,6 +73,27 @@ describe('Ghost Ajax Helper', function () {
         rendered.should.match(/c=en\%20coded/);
     });
 
+    it('handles null/undefined queryOptions correctly', function () {
+        ghostUrl.init({
+            clientId: 'ghost-frontend',
+            clientSecret: 'notasecret',
+            url: 'test'
+        });
+
+        var test = {
+                a: null
+            },
+            rendered = ghostUrl.url.api(test.a), // null value
+            rendered2 = ghostUrl.url.api(test.b); // undefined value
+
+        rendered.should.match(/test/);
+        rendered.should.match(/client_id=ghost-frontend/);
+        rendered.should.match(/client_secret=notasecret/);
+        rendered2.should.match(/test/);
+        rendered2.should.match(/client_id=ghost-frontend/);
+        rendered2.should.match(/client_secret=notasecret/);
+    });
+
     it('generates complex query correctly', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',


### PR DESCRIPTION
closes #6565
- adds test that fails previously but works with change
