### PR TITLE
Improve `getDatabaseVersion` & versioning tests

### DIFF
--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -110,7 +110,7 @@ init = function (tablesOnly) {
             );
         }
     }, function (err) {
-        if (err.message || err === 'Settings table does not exist') {
+        if (err && err.message === 'Settings table does not exist') {
             // 4. The database has not yet been created
             // Bring everything up from initial version.
             logInfo('Database initialisation required for version ' + versioning.getDefaultDatabaseVersion());

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -12,7 +12,7 @@ describe('DB API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup('users:roles', 'posts', 'perms:db', 'perms:init'));
+    beforeEach(testUtils.setup('users:roles', 'settings', 'posts', 'perms:db', 'perms:init'));
 
     should.exist(dbAPI);
 


### PR DESCRIPTION
Another small piece of the puzzle for improving migrations and getting test coverage.

The code to do with `currentVersion` was left over from before we ever did our first public release of Ghost, every subsequent migration has since set `databaseVersion`. We no longer support migrating from < 003,  so we can safely ignore `currentVersion` if it still exists in the settings table.

PR #6596 (exporter cleanup & tests) made a change so that it's possible to test knex, and introduced a precedent of doing so - something I hadn't figured out when I started adding tests to cover `versioning.js`. 

This PR brings coverage to 100% & also uses `should-sinon` to make the test assertions slightly neater.

refs #6301
- `currentVersion` was leftover from before the first public release of Ghost!
- simplified the code for `getDatabaseVersion`
- improved & made consistent how errors are handled in `getDatabaseVersion`
- migration error handling updated to reflect the changes in `getDatabaseVersion`
- added tests for both `getDatabaseVersion` and `setDatabaseVersion`
