### PR TITLE
Split migrations/index.js & add tests

### DIFF
--- a/core/server/data/migration/backup.js
+++ b/core/server/data/migration/backup.js
@@ -1,0 +1,44 @@
+// # Backup Database
+// Provides for backing up the database before making potentially destructive changes
+var _        = require('lodash'),
+    fs       = require('fs'),
+    path     = require('path'),
+    Promise  = require('bluebird'),
+    config   = require('../../config'),
+    exporter = require('../export'),
+
+    writeExportFile,
+    backup;
+
+writeExportFile = function writeExportFile(exportResult) {
+    var filename = path.resolve(config.paths.contentPath + '/data/' + exportResult.filename);
+
+    return Promise.promisify(fs.writeFile)(filename, JSON.stringify(exportResult.data)).return(filename);
+};
+
+/**
+ * ## Backup
+ * does an export, and stores this in a local file
+ *
+ * @param {Function} [logInfo]
+ * @returns {Promise<*>}
+ */
+backup = function backup(logInfo) {
+    // If we get passed a function, use it to output noticies, else don't do anything
+    logInfo = _.isFunction(logInfo) ? logInfo : _.noop;
+
+    logInfo('Creating database backup');
+
+    var props = {
+        data: exporter.doExport(),
+        filename: exporter.fileName()
+    };
+
+    return Promise.props(props)
+        .then(writeExportFile)
+        .then(function successMessage(filename) {
+            logInfo('Database backup written to: ' + filename);
+        });
+};
+
+module.exports = backup;

--- a/core/server/data/migration/fixtures/index.js
+++ b/core/server/data/migration/fixtures/index.js
@@ -1,9 +1,11 @@
 var populate = require('./populate'),
     update   = require('./update'),
-    fixtures = require('./fixtures');
+    fixtures = require('./fixtures'),
+    settings = require('./settings');
 
 module.exports = {
     populate: populate,
     update: update,
-    fixtures: fixtures
+    fixtures: fixtures,
+    ensureDefaultSettings: settings
 };

--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -16,6 +16,7 @@ var Promise     = require('bluebird'),
     fetchRelationData,
     matchFunc,
     createOwner,
+    modelOptions = {context: {internal: true}},
 
     // public
     populate;
@@ -24,10 +25,9 @@ var Promise     = require('bluebird'),
  * ### Add All Models
  * Sequentially calls add on all the models specified in fixtures.json
  *
- * @param {Object} modelOptions
  * @returns {Promise<*>}
  */
-addAllModels = function addAllModels(modelOptions) {
+addAllModels = function addAllModels() {
     var ops = [];
 
     _.each(fixtures.models, function (items, modelName) {
@@ -47,10 +47,9 @@ addAllModels = function addAllModels(modelOptions) {
  * use filter and find to quickly locate the correct models.
  *
  * @param {Object} relation
- * @param {Object} modelOptions
  * @returns {Promise<*>}
  */
-fetchRelationData = function fetchRelationData(relation, modelOptions) {
+fetchRelationData = function fetchRelationData(relation) {
     var props = {
         from: models[relation.from.model].findAll(modelOptions),
         to: models[relation.to.model].findAll(modelOptions)
@@ -96,12 +95,11 @@ matchFunc = function matchFunc(match, key, value) {
  * ### Add All Relations
  * Sequentially calls add on all the relations specified in fixtures.json
  *
- * @param {Object} modelOptions
  * @returns {Promise|Array}
  */
-addAllRelations = function addAllRelations(modelOptions) {
+addAllRelations = function addAllRelations() {
     return Promise.map(fixtures.relations, function (relation) {
-        return fetchRelationData(relation, modelOptions).then(function (data) {
+        return fetchRelationData(relation).then(function (data) {
             var ops = [];
 
             _.each(relation.entries, function (entry, key) {
@@ -127,11 +125,10 @@ addAllRelations = function addAllRelations(modelOptions) {
  * Creates the user fixture and gives it the owner role.
  * By default, users are given the Author role, making it hard to do this using the fixture system
  *
- * @param {Object} modelOptions
  * @param {Function} logInfo
  * @returns {Promise<*>}
  */
-createOwner = function createOwner(modelOptions, logInfo) {
+createOwner = function createOwner(logInfo) {
     var user = {
         name:             'Ghost Owner',
         email:            'ghost@ghost.org',
@@ -154,19 +151,18 @@ createOwner = function createOwner(modelOptions, logInfo) {
  * Sequentially creates all models, in the order they are specified, and then
  * creates all the relationships, also maintaining order.
  *
- * @param {Object} modelOptions
  * @param {Function} logInfo
  * @returns {Promise<*>}
  */
-populate = function populate(modelOptions, logInfo) {
+populate = function populate(logInfo) {
     logInfo('Populating fixtures');
 
     // ### Ensure all models are added
-    return addAllModels(modelOptions).then(function () {
+    return addAllModels().then(function () {
         // ### Ensure all relations are added
-        return addAllRelations(modelOptions);
+        return addAllRelations();
     }).then(function () {
-        return createOwner(modelOptions, logInfo);
+        return createOwner(logInfo);
     });
 };
 

--- a/core/server/data/migration/fixtures/settings.js
+++ b/core/server/data/migration/fixtures/settings.js
@@ -1,0 +1,12 @@
+var models = require('../../../models'),
+    ensureDefaultSettings;
+
+ensureDefaultSettings = function ensureDefaultSettings(logInfo) {
+    // Initialise the default settings
+    logInfo('Populating default settings');
+    return models.Settings.populateDefaults().then(function () {
+        logInfo('Complete');
+    });
+};
+
+module.exports = ensureDefaultSettings;

--- a/core/server/data/migration/fixtures/update.js
+++ b/core/server/data/migration/fixtures/update.js
@@ -7,6 +7,7 @@ var sequence = require('../../../utils/sequence'),
 
     // Private
     getVersionTasks,
+    modelOptions = {context: {internal: true}},
 
     // Public
     update;
@@ -38,11 +39,10 @@ getVersionTasks = function getVersionTasks(version, logInfo) {
  * Handles doing subsequent updates for versions
  *
  * @param {Array} versions
- * @param {Object} modelOptions
  * @param {Function} logInfo
  * @returns {Promise<*>}
  */
-update = function update(versions, modelOptions, logInfo) {
+update = function update(versions, logInfo) {
     var ops = [];
 
     logInfo('Updating fixtures');

--- a/core/server/data/migration/index.js
+++ b/core/server/data/migration/index.js
@@ -1,61 +1,22 @@
-var _               = require('lodash'),
-    Promise         = require('bluebird'),
+var Promise         = require('bluebird'),
     crypto          = require('crypto'),
-    path            = require('path'),
-    fs              = require('fs'),
-    builder         = require('./builder'),
-    fixtures        = require('./fixtures'),
-    schema          = require('../schema').tables,
-    commands        = require('../schema').commands,
     versioning      = require('../schema').versioning,
-    exporter        = require('../export'),
-    config          = require('../../config'),
     errors          = require('../../errors'),
     models          = require('../../models'),
-    sequence        = require('../../utils/sequence'),
-
-    schemaTables    = _.keys(schema),
 
     // private
-    modelOptions,
     logInfo,
-    populateDefaultSettings,
     fixClientSecret,
+    populate = require('./populate'),
+    update   = require('./update'),
 
     // public
     init,
-    reset,
-    migrateUp,
-    migrateUpFreshDb,
-    backupDatabase;
-
-// modelOptions & logInfo are passed through to migration/fixture actions
-modelOptions = {context: {internal: true}};
+    reset    = require('./reset'),
+    backup   = require('./backup');
 
 logInfo = function logInfo(message) {
     errors.logInfo('Migrations', message);
-};
-
-populateDefaultSettings = function populateDefaultSettings() {
-    // Initialise the default settings
-    logInfo('Populating default settings');
-    return models.Settings.populateDefaults().then(function () {
-        logInfo('Complete');
-    });
-};
-
-backupDatabase = function backupDatabase() {
-    logInfo('Creating database backup');
-    return exporter.doExport().then(function (exportedData) {
-        // Save the exported data to the file system for download
-        return exporter.fileName().then(function (fileName) {
-            fileName = path.resolve(config.paths.contentPath + '/data/' + fileName);
-
-            return Promise.promisify(fs.writeFile)(fileName, JSON.stringify(exportedData)).then(function () {
-                logInfo('Database backup written to: ' + fileName);
-            });
-        });
-    });
 };
 
 // TODO: move to migration.to005() for next DB version
@@ -75,7 +36,6 @@ fixClientSecret = function () {
 init = function (tablesOnly) {
     tablesOnly = tablesOnly || false;
 
-    var self = this;
     // There are 4 possibilities:
     // 1. The database exists and is up-to-date
     // 2. The database exists but is out of date
@@ -88,10 +48,7 @@ init = function (tablesOnly) {
             // 2. The database exists but is out of date
             // Migrate to latest version
             logInfo('Database upgrade required from version ' + databaseVersion + ' to ' +  defaultVersion);
-            return self.migrateUp(databaseVersion, defaultVersion).then(function () {
-                // Finally update the databases current version
-                return versioning.setDatabaseVersion();
-            });
+            return update(databaseVersion, defaultVersion, logInfo);
         }
 
         if (databaseVersion === defaultVersion) {
@@ -114,7 +71,7 @@ init = function (tablesOnly) {
             // 4. The database has not yet been created
             // Bring everything up from initial version.
             logInfo('Database initialisation required for version ' + versioning.getDefaultDatabaseVersion());
-            return self.migrateUpFreshDb(tablesOnly);
+            return populate(logInfo, tablesOnly);
         }
         // 3. The database exists but the currentVersion setting does not or cannot be understood
         // In this case the setting was missing or there was some other problem
@@ -122,104 +79,8 @@ init = function (tablesOnly) {
     });
 };
 
-// ### Reset
-// Delete all tables from the database in reverse order
-reset = function () {
-    var tables = _.map(schemaTables, function (table) {
-        return function () {
-            return commands.deleteTable(table);
-        };
-    }).reverse();
-
-    return sequence(tables);
-};
-
-// Only do this if we have no database at all
-migrateUpFreshDb = function (tablesOnly) {
-    var tableSequence,
-        tables = _.map(schemaTables, function (table) {
-            return function () {
-                logInfo('Creating table: ' + table);
-                return commands.createTable(table);
-            };
-        });
-    logInfo('Creating tables...');
-    tableSequence = sequence(tables);
-
-    if (tablesOnly) {
-        return tableSequence;
-    }
-    return tableSequence.then(function () {
-        // Load the fixtures
-        return fixtures.populate(modelOptions, logInfo);
-    }).then(function () {
-        return populateDefaultSettings();
-    });
-};
-
-// Migrate from a specific version to the latest
-migrateUp = function (fromVersion, toVersion) {
-    var oldTables,
-        modifyUniCommands = [],
-        migrateOps = [];
-
-    // Is the current version lower than the version we can migrate from?
-    // E.g. is this blog's DB older than 003?
-    if (fromVersion < versioning.canMigrateFromVersion) {
-        return versioning.showCannotMigrateError();
-    }
-
-    return backupDatabase().then(function () {
-        return commands.getTables();
-    }).then(function (tables) {
-        oldTables = tables;
-        if (!_.isEmpty(oldTables)) {
-            return commands.checkTables();
-        }
-    }).then(function () {
-        migrateOps = migrateOps.concat(builder.getDeleteCommands(oldTables, schemaTables));
-        migrateOps = migrateOps.concat(builder.getAddCommands(oldTables, schemaTables));
-        return Promise.all(
-            _.map(oldTables, function (table) {
-                return commands.getIndexes(table).then(function (indexes) {
-                    modifyUniCommands = modifyUniCommands.concat(builder.modifyUniqueCommands(table, indexes));
-                });
-            })
-        );
-    }).then(function () {
-        return Promise.all(
-            _.map(oldTables, function (table) {
-                return commands.getColumns(table).then(function (columns) {
-                    migrateOps = migrateOps.concat(builder.dropColumnCommands(table, columns));
-                    migrateOps = migrateOps.concat(builder.addColumnCommands(table, columns));
-                });
-            })
-        );
-    }).then(function () {
-        migrateOps = migrateOps.concat(_.compact(modifyUniCommands));
-
-        // execute the commands in sequence
-        if (!_.isEmpty(migrateOps)) {
-            logInfo('Running migrations');
-
-            return sequence(migrateOps);
-        }
-    }).then(function () {
-        // Ensure all of the current default settings are created (these are fixtures, so should be inserted first)
-        return populateDefaultSettings();
-    }).then(function () {
-        fromVersion = process.env.FORCE_MIGRATION ? versioning.canMigrateFromVersion : fromVersion;
-        var versions = versioning.getMigrationVersions(fromVersion, toVersion);
-        // Finally, run any updates to the fixtures, including default settings, that are required
-        // for anything other than the from/current version (which we're already on)
-        return fixtures.update(versions.slice(1), modelOptions, logInfo);
-    });
-};
-
 module.exports = {
     init: init,
     reset: reset,
-    backupDatabase: backupDatabase,
-    migrateUp: migrateUp,
-    migrateUpFreshDb: migrateUpFreshDb
+    backupDatabase: backup
 };

--- a/core/server/data/migration/populate.js
+++ b/core/server/data/migration/populate.js
@@ -1,0 +1,40 @@
+// # Populate
+// Create a brand new database for a new install of ghost
+var Promise  = require('bluebird'),
+    commands = require('../schema').commands,
+    fixtures = require('./fixtures'),
+    schema   = require('../schema').tables,
+
+    schemaTables = Object.keys(schema),
+    populate;
+
+/**
+ * ## Populate
+ * Uses the schema to determine table structures, and automatically creates each table in order
+ * TODO: use this directly in tests, so migration.init() can forget about tablesOnly as an option
+ *
+ * @param {Function} logInfo
+ * @param {Boolean} [tablesOnly] - used by tests
+ * @returns {Promise<*>}
+ */
+populate = function populate(logInfo, tablesOnly) {
+    logInfo('Creating tables...');
+
+    var tableSequence = Promise.mapSeries(schemaTables, function createTable(table) {
+        logInfo('Creating table: ' + table);
+        return commands.createTable(table);
+    });
+
+    if (tablesOnly) {
+        return tableSequence;
+    }
+
+    return tableSequence.then(function () {
+        // Load the fixtures
+        return fixtures.populate(logInfo);
+    }).then(function () {
+        return fixtures.ensureDefaultSettings(logInfo);
+    });
+};
+
+module.exports = populate;

--- a/core/server/data/migration/reset.js
+++ b/core/server/data/migration/reset.js
@@ -1,0 +1,23 @@
+// ### Reset
+// Delete all tables from the database in reverse order
+var Promise      = require('bluebird'),
+    commands     = require('../schema').commands,
+    schema       = require('../schema').tables,
+
+    schemaTables = Object.keys(schema).reverse(),
+    reset;
+
+/**
+ * # Reset
+ * Deletes all the tables defined in the schema
+ * Uses reverse order, which ensures that foreign keys are removed before the parent table
+ *
+ * @returns {Promise<*>}
+ */
+reset = function reset() {
+    return Promise.mapSeries(schemaTables, function (table) {
+        return commands.deleteTable(table);
+    });
+};
+
+module.exports = reset;

--- a/core/server/data/migration/update.js
+++ b/core/server/data/migration/update.js
@@ -1,0 +1,100 @@
+// # Update Database
+// Handles migrating a database between two different database versions
+var _          = require('lodash'),
+    Promise    = require('bluebird'),
+    backup     = require('./backup'),
+    builder    = require('./builder'),
+    commands   = require('../schema').commands,
+    fixtures   = require('./fixtures'),
+    schema     = require('../schema').tables,
+    sequence   = require('../../utils/sequence'),
+    versioning = require('../schema').versioning,
+
+    schemaTables = Object.keys(schema),
+
+    updateDatabaseSchema,
+    update;
+
+/**
+ * ### Update Database Schema
+ * Automatically detect differences between the current DB and the schema, and fix them
+ * TODO refactor to use explicit instructions, as this has the potential to destroy data
+ *
+ * @param {Function} logInfo
+ * @returns {Promise<*>}
+ */
+updateDatabaseSchema = function updateDatabaseSchema(logInfo) {
+    var oldTables,
+        modifyUniCommands = [],
+        migrateOps = [];
+
+    return commands.getTables().then(function (tables) {
+        oldTables = tables;
+        if (!_.isEmpty(oldTables)) {
+            return commands.checkTables();
+        }
+    }).then(function () {
+        migrateOps = migrateOps.concat(builder.getDeleteCommands(oldTables, schemaTables));
+        migrateOps = migrateOps.concat(builder.getAddCommands(oldTables, schemaTables));
+        return Promise.all(
+            _.map(oldTables, function (table) {
+                return commands.getIndexes(table).then(function (indexes) {
+                    modifyUniCommands = modifyUniCommands.concat(builder.modifyUniqueCommands(table, indexes));
+                });
+            })
+        );
+    }).then(function () {
+        return Promise.all(
+            _.map(oldTables, function (table) {
+                return commands.getColumns(table).then(function (columns) {
+                    migrateOps = migrateOps.concat(builder.dropColumnCommands(table, columns));
+                    migrateOps = migrateOps.concat(builder.addColumnCommands(table, columns));
+                });
+            })
+        );
+    }).then(function () {
+        migrateOps = migrateOps.concat(_.compact(modifyUniCommands));
+
+        // execute the commands in sequence
+        if (!_.isEmpty(migrateOps)) {
+            logInfo('Running migrations');
+
+            return sequence(migrateOps);
+        }
+    });
+};
+
+/**
+ * ## Update
+ * Does a backup, then updates the database and fixtures
+ *
+ * @param {String} fromVersion
+ * @param {String} toVersion
+ * @param {Function} logInfo
+ * @returns {Promise<*>}
+ */
+update = function update(fromVersion, toVersion, logInfo) {
+    // Is the current version lower than the version we can migrate from?
+    // E.g. is this blog's DB older than 003?
+    if (fromVersion < versioning.canMigrateFromVersion) {
+        return versioning.showCannotMigrateError();
+    }
+
+    return backup(logInfo).then(function () {
+        return updateDatabaseSchema(logInfo);
+    }).then(function () {
+        // Ensure all of the current default settings are created (these are fixtures, so should be inserted first)
+        return fixtures.ensureDefaultSettings(logInfo);
+    }).then(function () {
+        fromVersion = process.env.FORCE_MIGRATION ? versioning.canMigrateFromVersion : fromVersion;
+        var versions = versioning.getMigrationVersions(fromVersion, toVersion);
+        // Finally, run any updates to the fixtures, including default settings, that are required
+        // for anything other than the from/current version (which we're already on)
+        return fixtures.update(versions.slice(1), logInfo);
+    }).then(function () {
+        // Finally update the databases current version
+        return versioning.setDatabaseVersion();
+    });
+};
+
+module.exports = update;

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -66,7 +66,7 @@ function dropUnique(table, column) {
 }
 
 function createTable(table) {
-    return db.knex.schema.createTable(table, function (t) {
+    return db.knex.schema.createTableIfNotExists(table, function (t) {
         var columnKeys = _.keys(schema[table]);
         _.each(columnKeys, function (column) {
             return addTableColumn(table, t, column);

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -5,15 +5,11 @@ var testUtils   = require('../utils/index'),
     Promise     = require('bluebird'),
     assert      = require('assert'),
     _           = require('lodash'),
-    rewire      = require('rewire'),
     validator   = require('validator'),
 
     // Stuff we are testing
     db              = require('../../server/data/db'),
-    config          = require('../../server/config'),
     versioning      = require('../../server/data/schema').versioning,
-    defaultConfig   = rewire('../../../config.example')[process.env.NODE_ENV],
-    migration       = rewire('../../server/data/migration'),
     exporter        = require('../../server/data/export'),
     importer        = require('../../server/data/import'),
     DataImporter    = require('../../server/data/import/data-importer'),
@@ -35,12 +31,6 @@ describe('Import', function () {
 
     describe('Resolves', function () {
         beforeEach(testUtils.setup());
-        beforeEach(function () {
-            var newConfig = _.extend({}, config, defaultConfig);
-
-            migration.__get__('config', newConfig);
-            config.set(newConfig);
-        });
 
         it('resolves DataImporter', function (done) {
             var importStub = sandbox.stub(DataImporter, 'importData', function () {

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -122,7 +122,7 @@ describe('Database Migration (special functions)', function () {
         it('should populate all fixtures correctly', function (done) {
             var logStub = sandbox.stub();
 
-            fixtures.populate({context: {internal: true}}, logStub).then(function () {
+            fixtures.populate(logStub).then(function () {
                 var props = {
                     posts: Models.Post.findAll({include: ['tags']}),
                     tags: Models.Tag.findAll(),

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -11,6 +11,7 @@ var should  = require('should'),
     update        = rewire('../../server/data/migration/fixtures/update'),
     populate      = rewire('../../server/data/migration/fixtures/populate'),
     fixtures004   = require('../../server/data/migration/fixtures/004'),
+    ensureDefaultSettings = require('../../server/data/migration/fixtures/settings'),
 
     sandbox       = sinon.sandbox.create();
 
@@ -32,7 +33,7 @@ describe('Fixtures', function () {
                 getVersionTasksStub = sandbox.stub().returns([]),
                 reset = update.__set__('getVersionTasks', getVersionTasksStub);
 
-            update(['004'], {}, logStub).then(function () {
+            update(['004'], logStub).then(function () {
                 logStub.calledOnce.should.be.true();
                 getVersionTasksStub.calledOnce.should.be.true();
                 reset();
@@ -45,7 +46,7 @@ describe('Fixtures', function () {
                 getVersionTasksStub = sandbox.stub().returns(Promise.resolve()),
                 reset = update.__set__('getVersionTasks', getVersionTasksStub);
 
-            update([], {}, logStub).then(function () {
+            update([], logStub).then(function () {
                 logStub.calledOnce.should.be.true();
                 getVersionTasksStub.calledOnce.should.be.false();
                 reset();
@@ -77,7 +78,7 @@ describe('Fixtures', function () {
                 clientOneStub.withArgs({slug: 'ghost-admin'}).returns(Promise.resolve());
                 clientOneStub.withArgs({slug: 'ghost-frontend'}).returns(Promise.resolve({}));
 
-                update(['004'], {}, logStub).then(function (result) {
+                update(['004'], logStub).then(function (result) {
                     should.exist(result);
 
                     logStub.called.should.be.true();
@@ -396,7 +397,7 @@ describe('Fixtures', function () {
                 roleOneStub = sandbox.stub(models.Role, 'findOne').returns(Promise.resolve({id: 1})),
                 userAddStub = sandbox.stub(models.User, 'add').returns(Promise.resolve({}));
 
-            populate({}, logStub).then(function () {
+            populate(logStub).then(function () {
                 logStub.called.should.be.true();
 
                 postAddStub.calledOnce.should.be.true();
@@ -475,7 +476,7 @@ describe('Fixtures', function () {
                     roleOneStub = sandbox.stub(models.Role, 'findOne').returns(Promise.resolve({id: 1})),
                     userAddStub = sandbox.stub(models.User, 'add').returns(Promise.resolve({}));
 
-                createOwner({}, logStub).then(function () {
+                createOwner(logStub).then(function () {
                     logStub.called.should.be.true();
                     roleOneStub.calledOnce.should.be.true();
                     userAddStub.called.should.be.true();
@@ -580,6 +581,20 @@ describe('Fixtures', function () {
                 getStub.callCount.should.eql(4);
                 getStub.getCall(2).calledWith('fun').should.be.true();
                 getStub.getCall(3).calledWith('foo').should.be.true();
+            });
+        });
+    });
+
+    describe('Ensure default settings', function () {
+        it('should call populate settings and provide messaging', function (done) {
+            var settingsStub = sandbox.stub(models.Settings, 'populateDefaults').returns(new Promise.resolve()),
+                logStub = sandbox.stub();
+
+            ensureDefaultSettings(logStub).then(function () {
+                settingsStub.calledOnce.should.be.true();
+                logStub.calledTwice.should.be.true();
+
+                done();
             });
         });
     });

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -2,17 +2,21 @@
 var should          = require('should'),
     sinon           = require('sinon'),
     _               = require('lodash'),
+    Promise         = require('bluebird'),
     crypto          = require('crypto'),
+    fs              = require('fs'),
 
     // Stuff we are testing
-    schema          = require('../../server/data/schema'),
+    exporter        = require('../../server/data/export'),
     fixtures        = require('../../server/data/migration/fixtures'),
+    migration       = require('../../server/data/migration'),
+    populate        = require('../../server/data/migration/populate'),
+    schema          = require('../../server/data/schema'),
+
     defaultSettings = schema.defaultSettings,
+    schemaTables    = Object.keys(schema.tables),
 
     sandbox = sinon.sandbox.create();
-
-// To stop jshint complaining
-should.equal(true, true);
 
 describe('Migrations', function () {
     afterEach(function () {
@@ -53,5 +57,144 @@ describe('Migrations', function () {
         });
     });
 
-    describe('Builder', function () {});
+    describe('Backup', function () {
+        it('should create a backup JSON file', function (done) {
+            var exportStub = sandbox.stub(exporter, 'doExport').returns(new Promise.resolve()),
+                filenameStub = sandbox.stub(exporter, 'fileName').returns(new Promise.resolve('test')),
+                logStub = sandbox.stub(),
+                fsStub = sandbox.stub(fs, 'writeFile').yields();
+
+            migration.backupDatabase(logStub).then(function () {
+                exportStub.calledOnce.should.be.true();
+                filenameStub.calledOnce.should.be.true();
+                fsStub.calledOnce.should.be.true();
+                logStub.calledTwice.should.be.true();
+
+                done();
+            }).catch(done);
+        });
+
+        it('should fall back to console.log if no logger provided', function (done) {
+            var exportStub = sandbox.stub(exporter, 'doExport').returns(new Promise.resolve()),
+                filenameStub = sandbox.stub(exporter, 'fileName').returns(new Promise.resolve('test')),
+                noopStub = sandbox.stub(_, 'noop'),
+                fsStub = sandbox.stub(fs, 'writeFile').yields();
+
+            migration.backupDatabase().then(function () {
+                exportStub.calledOnce.should.be.true();
+                filenameStub.calledOnce.should.be.true();
+                fsStub.calledOnce.should.be.true();
+                noopStub.calledTwice.should.be.true();
+                // restore early so we get the test output
+                noopStub.restore();
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('Reset', function () {
+        it('should delete all tables in reverse order', function (done) {
+            // Setup
+            var deleteStub = sandbox.stub(schema.commands, 'deleteTable').returns(new Promise.resolve());
+
+            // Execute
+            migration.reset().then(function (result) {
+                should.exist(result);
+                result.should.be.an.Array().with.lengthOf(schemaTables.length);
+
+                deleteStub.called.should.be.true();
+                deleteStub.callCount.should.be.eql(schemaTables.length);
+                // First call should be called with the last table
+                deleteStub.firstCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+                // Last call should be called with the first table
+                deleteStub.lastCall.calledWith(schemaTables[0]).should.be.true();
+
+                done();
+            }).catch(done);
+        });
+
+        it('should delete all tables in reverse order when called twice in a row', function (done) {
+            // Setup
+            var deleteStub = sandbox.stub(schema.commands, 'deleteTable').returns(new Promise.resolve());
+
+            // Execute
+            migration.reset().then(function (result) {
+                should.exist(result);
+                result.should.be.an.Array().with.lengthOf(schemaTables.length);
+
+                deleteStub.called.should.be.true();
+                deleteStub.callCount.should.be.eql(schemaTables.length);
+                // First call should be called with the last table
+                deleteStub.firstCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+                // Last call should be called with the first table
+                deleteStub.lastCall.calledWith(schemaTables[0]).should.be.true();
+
+                return migration.reset();
+            }).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Array().with.lengthOf(schemaTables.length);
+
+                deleteStub.called.should.be.true();
+                deleteStub.callCount.should.be.eql(schemaTables.length * 2);
+                // First call (second set) should be called with the last table
+                deleteStub.getCall(schemaTables.length).calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+                // Last call (second Set) should be called with the first table
+                deleteStub.getCall(schemaTables.length * 2 - 1).calledWith(schemaTables[0]).should.be.true();
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('Populate', function () {
+        it('should create all tables, and populate fixtures', function (done) {
+            // Setup
+            var createStub = sandbox.stub(schema.commands, 'createTable').returns(new Promise.resolve()),
+                fixturesStub = sandbox.stub(fixtures, 'populate').returns(new Promise.resolve()),
+                settingsStub = sandbox.stub(fixtures, 'ensureDefaultSettings').returns(new Promise.resolve()),
+                logStub = sandbox.stub();
+
+            populate(logStub).then(function (result) {
+                should.not.exist(result);
+
+                createStub.called.should.be.true();
+                createStub.callCount.should.be.eql(schemaTables.length);
+                createStub.firstCall.calledWith(schemaTables[0]).should.be.true();
+                createStub.lastCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+
+                fixturesStub.calledOnce.should.be.true();
+                settingsStub.calledOnce.should.be.true();
+
+                done();
+            });
+        });
+
+        it('should should only create tables, with tablesOnly setting', function (done) {
+            // Setup
+            var createStub = sandbox.stub(schema.commands, 'createTable').returns(new Promise.resolve()),
+                fixturesStub = sandbox.stub(fixtures, 'populate').returns(new Promise.resolve()),
+                settingsStub = sandbox.stub(fixtures, 'ensureDefaultSettings').returns(new Promise.resolve()),
+                logStub = sandbox.stub();
+
+            populate(logStub, true).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Array().with.lengthOf(schemaTables.length);
+
+                createStub.called.should.be.true();
+                createStub.callCount.should.be.eql(schemaTables.length);
+                createStub.firstCall.calledWith(schemaTables[0]).should.be.true();
+                createStub.lastCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+
+                fixturesStub.called.should.be.false();
+                settingsStub.called.should.be.false();
+
+                done();
+            });
+        });
+    });
+
+    describe('Update', function () {
+        it('should be tested!');
+    });
 });


### PR DESCRIPTION
Another step in the process of getting migrations straightened out - I've split all the key functions out into new homes, and added test coverage for everything except for `update`. That bit is about to get completely rewritten, and I'll add tests to the new version.

One minor functional change here - I changed the knex function used for creating tables to `createTableIfNotExists`. We use `deleteTableIfExists`,  so this is more consistent, and also makes it possible that the populate function might recover if it gets stopped part way through for some reason.

refs #6301
- changes createTable to use createTableIfNotExists, this is consistent with deletion
- splits out backup, reset, update and populate functions from migration/index into their own files
- moves the wrapped function for populatingDefaultSettings to fixtures.ensureDefaultSettings
- moves `modelOptions` down to the fixture files that actually use it
- adds test coverage for backup, reset and populate, but not for update as that needs refactoring
