### PR TITLE
Always override database config + exit tests on error

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -104,6 +104,12 @@ ConfigManager.prototype.set = function (config) {
     // local copy with properties that have been explicitly set.
     _.merge(this._config, config);
 
+    // Special case for the database config, which should be overridden not merged
+
+    if (config && config.database) {
+        this._config.database = config.database;
+    }
+
     // Special case for the them.navigation JSON object, which should be overridden not merged
     if (config && config.theme && config.theme.navigation) {
         this._config.theme.navigation = config.theme.navigation;

--- a/core/test/functional/routes/admin_spec.js
+++ b/core/test/functional/routes/admin_spec.js
@@ -49,6 +49,7 @@ describe('Admin Routing', function () {
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
             console.log(e.stack);
+            done(e);
         });
     });
 

--- a/core/test/functional/routes/channel_spec.js
+++ b/core/test/functional/routes/channel_spec.js
@@ -36,6 +36,7 @@ describe('Channel Routes', function () {
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
             console.log(e.stack);
+            done(e);
         });
     });
 

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -46,6 +46,7 @@ describe('Frontend Routing', function () {
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
             console.log(e.stack);
+            done(e);
         });
     });
 


### PR DESCRIPTION
A combination of the changes that have been made recently to the way database config is loaded (#6495), to the test sqlite config (#6354), and some changes to error handling that I have in an upcoming PR (#6599) has surfaced a pretty horrible bug with the database config:

When testing, Ghost initially loads the example config & then sometime later it loads, and merges in the correct config. The use of `_.merge()` results in database configuration which is half of two different configs squashed together. 

For example, the mysql config would still have the `filename` and special pool settings from [the sqlite example testing config](https://github.com/TryGhost/Ghost/blob/master/config.example.js#L82). Eeek.

This PR completely overwrites the database settings after merge, if they are present. This is the same fix that is used to protect the navigation config from getting merged in much the same way. At some point soon we really need to rework config/index.js, but this fixes the issue for the time being.

Whilst debugging this issue, I also noticed that `done` is not called for some of the `before` hooks if an error happens in the route tests. This made it harder to debug the issue, so I've fixed it at the same time.

refs #6354, #6495 & #6599
- don't allow config.database to be merged, instead, override it always
- make sure that route tests call done even when they error
