### PR TITLE
Remove should-sinon dependency

### DIFF
--- a/core/test/unit/exporter_spec.js
+++ b/core/test/unit/exporter_spec.js
@@ -14,8 +14,6 @@ var should    = require('should'),
 
     sandbox = sinon.sandbox.create();
 
-require('should-sinon');
-
 describe('Exporter', function () {
     var versionStub, tablesStub, queryMock, knexMock, knexStub;
 
@@ -50,34 +48,34 @@ describe('Exporter', function () {
 
                 should.exist(exportData);
 
-                versionStub.should.be.calledOnce();
-                tablesStub.should.be.calledOnce();
-                knexStub.get.should.be.called();
-                knexMock.should.be.called();
-                queryMock.select.should.be.called();
+                versionStub.calledOnce.should.be.true();
+                tablesStub.calledOnce.should.be.true();
+                knexStub.get.called.should.be.true();
+                knexMock.called.should.be.true();
+                queryMock.select.called.should.be.true();
 
-                knexMock.should.have.callCount(expectedCallCount);
-                queryMock.select.should.have.callCount(expectedCallCount);
+                knexMock.callCount.should.eql(expectedCallCount);
+                queryMock.select.callCount.should.have.eql(expectedCallCount);
 
-                knexMock.getCall(0).should.be.calledWith('posts');
-                knexMock.getCall(1).should.be.calledWith('users');
-                knexMock.getCall(2).should.be.calledWith('roles');
-                knexMock.getCall(3).should.be.calledWith('roles_users');
-                knexMock.getCall(4).should.be.calledWith('permissions');
-                knexMock.getCall(5).should.be.calledWith('permissions_users');
-                knexMock.getCall(6).should.be.calledWith('permissions_roles');
-                knexMock.getCall(7).should.be.calledWith('permissions_apps');
-                knexMock.getCall(8).should.be.calledWith('settings');
-                knexMock.getCall(9).should.be.calledWith('tags');
-                knexMock.getCall(10).should.be.calledWith('posts_tags');
-                knexMock.getCall(11).should.be.calledWith('apps');
-                knexMock.getCall(12).should.be.calledWith('app_settings');
-                knexMock.getCall(13).should.be.calledWith('app_fields');
+                knexMock.getCall(0).args[0].should.eql('posts');
+                knexMock.getCall(1).args[0].should.eql('users');
+                knexMock.getCall(2).args[0].should.eql('roles');
+                knexMock.getCall(3).args[0].should.eql('roles_users');
+                knexMock.getCall(4).args[0].should.eql('permissions');
+                knexMock.getCall(5).args[0].should.eql('permissions_users');
+                knexMock.getCall(6).args[0].should.eql('permissions_roles');
+                knexMock.getCall(7).args[0].should.eql('permissions_apps');
+                knexMock.getCall(8).args[0].should.eql('settings');
+                knexMock.getCall(9).args[0].should.eql('tags');
+                knexMock.getCall(10).args[0].should.eql('posts_tags');
+                knexMock.getCall(11).args[0].should.eql('apps');
+                knexMock.getCall(12).args[0].should.eql('app_settings');
+                knexMock.getCall(13).args[0].should.eql('app_fields');
 
-                knexMock.should.not.be.calledWith('clients');
-                knexMock.should.not.be.calledWith('client_trusted_domains');
-                knexMock.should.not.be.calledWith('refreshtokens');
-                knexMock.should.not.be.calledWith('accesstokens');
+                knexMock.calledWith('clients').should.be.false();
+                knexMock.calledWith('client_trusted_domains').should.be.false();
+                knexMock.calledWith('refreshtokens').should.be.false();
+                knexMock.calledWith('accesstokens').should.be.false();
 
                 done();
             }).catch(done);
@@ -91,7 +89,7 @@ describe('Exporter', function () {
             // Execute
             exporter.doExport().then(function (exportData) {
                 should.not.exist(exportData);
-                errorStub.should.be.calledOnce();
+                errorStub.calledOnce.should.be.true();
                 done();
             }).catch(done);
         });
@@ -105,7 +103,7 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.should.be.calledOnce();
+                settingsStub.calledOnce.should.be.true();
                 result.should.match(/^testblog\.ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
@@ -119,7 +117,7 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.should.be.calledOnce();
+                settingsStub.calledOnce.should.be.true();
                 result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();
@@ -133,7 +131,7 @@ describe('Exporter', function () {
 
             exporter.fileName().then(function (result) {
                 should.exist(result);
-                settingsStub.should.be.calledOnce();
+                settingsStub.calledOnce.should.be.true();
                 result.should.match(/^ghost\.[0-9]{4}-[0-9]{2}-[0-9]{2}\.json$/);
 
                 done();

--- a/core/test/unit/middleware/spam-prevention_spec.js
+++ b/core/test/unit/middleware/spam-prevention_spec.js
@@ -2,7 +2,6 @@
 var should      = require('should'),
     sinon       = require('sinon'),
     middleware  = require('../../../server/middleware').middleware;
-require('should-sinon');
 
 describe('Middleware: spamPrevention', function () {
     var sandbox,
@@ -91,7 +90,7 @@ describe('Middleware: spamPrevention', function () {
 
             middleware.spamPrevention.signin(req, null, spyNext);
             should(error).equal(undefined);
-            spyNext.should.be.called();
+            spyNext.called.should.be.true();
 
             process.hrtime.restore();
             done();
@@ -173,7 +172,7 @@ describe('Middleware: spamPrevention', function () {
 
             middleware.spamPrevention.protected(req, res, spyNext);
             res.error.message.should.equal('No password entered');
-            spyNext.should.be.calledOnce();
+            spyNext.calledOnce.should.be.true();
 
             done();
         });

--- a/core/test/unit/middleware/uncapitalise_spec.js
+++ b/core/test/unit/middleware/uncapitalise_spec.js
@@ -1,8 +1,7 @@
 /*globals describe, beforeEach, afterEach, it*/
-var sinon           = require('sinon'),
+var sinon        = require('sinon'),
     should       = require('should'),
-    uncapitalise    = require('../../../server/middleware/uncapitalise');
-require('should-sinon');
+    uncapitalise = require('../../../server/middleware/uncapitalise');
 
 should.equal(true, true);
 
@@ -29,7 +28,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/signup';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce();
+            next.calledOnce.should.be.true();
             done();
         });
 
@@ -43,8 +42,8 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called();
-            res.redirect.should.be.calledOnce();
+            next.called.should.be.false();
+            res.redirect.calledOnce.should.be.true();
             res.redirect.calledWith(301, 'http://localhost/ghost/signup').should.be.true();
             done();
         });
@@ -55,7 +54,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/ghost/api/v0.1';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce();
+            next.calledOnce.should.be.true();
             done();
         });
 
@@ -69,8 +68,8 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called();
-            res.redirect.should.be.calledOnce();
+            next.called.should.be.false();
+            res.redirect.calledOnce.should.be.true();
             res.redirect.calledWith(301, 'http://localhost/ghost/api/v0.1/asdfj').should.be.true();
             done();
         });
@@ -81,7 +80,7 @@ describe('Middleware: uncapitalise', function () {
             req.path = '/this-is-my-blog-post';
             uncapitalise(req, res, next);
 
-            next.should.be.calledOnce();
+            next.calledOnce.should.be.true();
             done();
         });
 
@@ -95,8 +94,8 @@ describe('Middleware: uncapitalise', function () {
 
             uncapitalise(req, res, next);
 
-            next.should.not.be.called();
-            res.redirect.should.be.calledOnce();
+            next.called.should.be.false();
+            res.redirect.calledOnce.should.be.true();
             res.redirect.calledWith(301, 'http://localhost/this-is-my-blog-post').should.be.true();
             done();
         });

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "rimraf-then": "1.0.0",
     "should": "8.2.1",
     "should-http": "0.0.4",
-    "should-sinon": "0.0.5",
     "sinon": "1.17.3",
     "supertest": "1.1.0",
     "top-gh-contribs": "2.0.2"


### PR DESCRIPTION
Unfortunately, `should-sinon` has very minimal documentation  and therefore it is hard to discern what is considered a correctly-written assertion:
- in some cases, refactoring to use `should-sinon` causes false positives
- in other cases, assertions that work written in the normal way fail when written using `should-sinon` (e.g. getters, combos with rewire)
  The additional overhead created by these issues outweigh any benefit from the easier-to-read assertions

See comments in [slack](https://ghost.slack.com/archives/dev/p1457972737000044) as well.

no issue
- removes should-sinon dependency from package.json
- rewrites all usages of should-sinon to use normal should assertions
