### PR TITLE
Fix role fixture ordering bug in pg tests

### DIFF
--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -18,6 +18,8 @@ describe('Database Migration (special functions)', function () {
     });
 
     describe('Fixtures', function () {
+        beforeEach(testUtils.setup());
+
         // Custom assertion for detection that a permissions is assigned to the correct roles
         should.Assertion.add('AssignedToRoles', function (roles) {
             var roleNames;
@@ -27,7 +29,9 @@ describe('Database Migration (special functions)', function () {
 
             this.obj.should.be.an.Object().with.property(['roles']);
             this.obj.roles.should.be.an.Array();
-            roleNames = _.pluck(this.obj.roles, 'name');
+
+            // Ensure the roles are in id order
+            roleNames = _(this.obj.roles).sortBy('id').pluck('name').value();
             roleNames.should.eql(roles);
         });
 
@@ -116,8 +120,6 @@ describe('Database Migration (special functions)', function () {
             permissions[29].name.should.eql('Browse roles');
             permissions[29].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author']);
         });
-
-        beforeEach(testUtils.setup());
 
         it('should populate all fixtures correctly', function (done) {
             var logStub = sandbox.stub();


### PR DESCRIPTION
I moved the hidden beforeEach whilst I was here, just to make this easier to read.

closes #6605
- ensure that roles are being output in order of their ID before asserting
- the asserting checks both the content and order of the array - this could be done differently as order doesn't really matter here, but will let us know if there are changes in DB behaviour
