### PR TITLE
Change default setting for `to` inside foreach helper

### DIFF
--- a/core/server/helpers/foreach.js
+++ b/core/server/helpers/foreach.js
@@ -15,16 +15,23 @@ foreach = function (itemType, options) {
         errors.logWarn(i18n.t('warnings.helpers.foreach.iteratorNeeded'));
     }
 
+    // Initial values set based on parameters sent through. If nothing sent, set to defaults
     var fn = options.fn,
         inverse = options.inverse,
         columns = options.hash.columns,
         length = _.size(itemType),
         limit = parseInt(options.hash.limit, 10) || length,
         from = parseInt(options.hash.from, 10) || 1,
-        to = parseInt(options.hash.to, 10) || (from - 1) + limit,
+        to = parseInt(options.hash.to, 10) || length,
         output = '',
         data,
         contextPath;
+
+    // If a limit option was sent through (aka not equal to default (length))
+    // and from plus limit is less than the length, set to to the from + limit
+    if ((limit < length) && ((from + limit) <= length)) {
+        to = (from - 1) + limit;
+    }
 
     if (options.data && options.ids) {
         contextPath = hbsUtils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
@@ -43,13 +50,12 @@ foreach = function (itemType, options) {
             data.key = field;
             data.index = index;
             data.number = index + 1;
-            data.first = index === from - 1; // From uses 1-indexed, but array uses 0-indexed.
+            data.first = index === from - 1; // From uses 1-indexed, but array uses 0-indexed
             data.last = !!last;
             data.even = index % 2 === 1;
             data.odd = !data.even;
             data.rowStart = index % columns === 0;
             data.rowEnd = index % columns === (columns - 1);
-
             if (contextPath) {
                 data.contextPath = contextPath + field;
             }
@@ -62,9 +68,12 @@ foreach = function (itemType, options) {
     }
 
     function iterateCollection(context) {
+        // Context is all posts on the blog
         var count = 1,
             current = 1;
 
+        // For each post, if it is a post number that fits within the from and to
+        // send the key to execIteration to set to be added to the page
         _.each(context, function (item, key) {
             if (current < from) {
                 current += 1;

--- a/core/test/unit/server_helpers/foreach_spec.js
+++ b/core/test/unit/server_helpers/foreach_spec.js
@@ -412,7 +412,7 @@ describe('{{#foreach}} helper', function () {
 
         it('foreach with from 2, to 5 and limit 3', function () {
             var templateString = '<ul>{{#foreach posts from="2" to="5" limit="3"}}<li>{{title}}</li>{{else}}not this{{/foreach}}</ul>',
-                expected = '<ul><li>second</li><li>third</li><li>fourth</li><li>fifth</li></ul>';
+                expected = '<ul><li>second</li><li>third</li><li>fourth</li></ul>';
 
             shouldCompileToExpected(templateString, arrayHash, expected);
             shouldCompileToExpected(templateString, objectHash, expected);
@@ -425,10 +425,73 @@ describe('{{#foreach}} helper', function () {
             shouldCompileToExpected(templateString, arrayHash, expected);
             shouldCompileToExpected(templateString, objectHash, expected);
         });
-
         it('@last in foreach with from 2 and to 4', function () {
             var templateString = '<ul>{{#foreach posts from="2" to="4"}}{{#if @last}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
                 expected = '<ul><li>fourth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@last in foreach with from 4', function () {
+            var templateString = '<ul>{{#foreach posts from="4"}}{{#if @last}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>fifth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@first in foreach with from 4', function () {
+            var templateString = '<ul>{{#foreach posts from="4"}}{{#if @first}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>fourth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@last in foreach with to 4', function () {
+            var templateString = '<ul>{{#foreach posts to="4"}}{{#if @last}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>fourth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@first in foreach with to 4', function () {
+            var templateString = '<ul>{{#foreach posts to="4"}}{{#if @first}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>first</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@last in foreach with from 4 and limit 3', function () {
+            var templateString = '<ul>{{#foreach posts from="4" limit="3"}}{{#if @last}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>fifth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@first in foreach with from 4 and limit 3', function () {
+            var templateString = '<ul>{{#foreach posts from="4" limit="3"}}{{#if @first}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>fourth</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@last in foreach with to 4 and limit 3', function () {
+            var templateString = '<ul>{{#foreach posts to="4" limit="3"}}{{#if @last}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>third</li></ul>';
+
+            shouldCompileToExpected(templateString, arrayHash, expected);
+            shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        it('@first in foreach with to 4 and limit 3', function () {
+            var templateString = '<ul>{{#foreach posts to="4" limit="3"}}{{#if @first}}<li>{{title}}</li>{{/if}}{{/foreach}}</ul>',
+                expected = '<ul><li>first</li></ul>';
 
             shouldCompileToExpected(templateString, arrayHash, expected);
             shouldCompileToExpected(templateString, objectHash, expected);


### PR DESCRIPTION
closes #6604
- Default for `to` was always `(from-1) + limit`. This caused a problem
  where the `to` value could be higher than the length of the number of
  blog posts, causing `@last` to never be called/reached
- Now sets `to` to have a default of `length` and if a limit was sent
  through and not higher than `length`, to then set `to` to that value
- Added some extra tests for `@last` and `@first` use cases
- Added some inline commenting
