### PR TITLE
Remove Nav Item Placeholder and Set as Base Url Value

### DIFF
--- a/core/client/app/components/gh-navitem-url-input.js
+++ b/core/client/app/components/gh-navitem-url-input.js
@@ -20,14 +20,9 @@ let isRelative = function (url) {
 
 export default TextField.extend({
     classNames: 'gh-input',
-    classNameBindings: ['fakePlaceholder'],
 
     isBaseUrl: computed('baseUrl', 'value', function () {
         return this.get('baseUrl') === this.get('value');
-    }),
-
-    fakePlaceholder: computed('isBaseUrl', 'hasFocus', 'isNew', function () {
-        return this.get('isBaseUrl') && this.get('isNew') && !this.get('hasFocus');
     }),
 
     didReceiveAttrs() {

--- a/core/client/app/controllers/settings/navigation.js
+++ b/core/client/app/controllers/settings/navigation.js
@@ -122,6 +122,11 @@ export default Controller.extend(SettingsSaveMixin, {
         addItem() {
             let newNavItem = this.get('newNavItem');
 
+            // If the url sent through is blank (user never edited the url)
+            if (newNavItem.get('url') === '') {
+                newNavItem.set('url', '/');
+            }
+
             return newNavItem.validate().then(() => {
                 this.addNewNavItem();
             });

--- a/core/client/app/styles/layouts/settings.css
+++ b/core/client/app/styles/layouts/settings.css
@@ -34,10 +34,6 @@
     cursor: move;
 }
 
-.gh-blognav-url .fake-placeholder {
-    color: #c1c1c1;
-}
-
 .gh-blognav-line {
     display: flex;
     width: 100%;

--- a/core/client/tests/acceptance/settings/navigation-test.js
+++ b/core/client/tests/acceptance/settings/navigation-test.js
@@ -150,11 +150,6 @@ describe('Acceptance: Settings - Navigation', function () {
                     find('.gh-blognav-label:last .response').is(':visible'),
                     'blank label has validation error'
                 ).to.be.true;
-
-                expect(
-                    find('.gh-blognav-url:last .response').is(':visible'),
-                    'blank url has validation error'
-                ).to.be.true;
             });
 
             fillIn('.gh-blognav-label:last input', 'New');
@@ -165,11 +160,6 @@ describe('Acceptance: Settings - Navigation', function () {
                     find('.gh-blognav-label:last .response').is(':visible'),
                     'label validation is visible after typing'
                 ).to.be.false;
-
-                expect(
-                    find('.gh-blognav-url:last .response').is(':visible'),
-                    'blank url still has validation error'
-                ).to.be.true;
             });
 
             fillIn('.gh-blognav-url:last input', '/new');

--- a/core/client/tests/integration/components/gh-navitem-url-input-test.js
+++ b/core/client/tests/integration/components/gh-navitem-url-input-test.js
@@ -189,21 +189,6 @@ describeComponent(
             expect($input.val()).to.equal(`${currentUrl} /test`);
         });
 
-        it('toggles .fake-placeholder on focus', function () {
-            this.set('isNew', true);
-            this.render(hbs `
-                {{gh-navitem-url-input baseUrl=baseUrl url=url isNew=isNew change="updateUrl" clearErrors=(action "clearErrors")}}
-            `);
-            let $input = this.$('input');
-
-            expect($input.hasClass('fake-placeholder')).to.be.true;
-
-            run(() => {
-                $input.trigger('focus');
-            });
-            expect($input.hasClass('fake-placeholder')).to.be.false;
-        });
-
         it('triggers "change" action on blur', function () {
             let changeActionCallCount = 0;
             this.on('updateUrl', () => {


### PR DESCRIPTION
Closes #6440
- Removed the `.fake-placeholder`class from the input, test, and css
- On adding a nav item, if the url value has not been set by the user,
  then set it to the base url as shown in the input
- If url has been set by the user, just do what it has always done

![nav items](https://cloud.githubusercontent.com/assets/4715098/13882729/f9845d08-ece3-11e5-83f7-808bf3a0e45e.gif)
