### PR TITLE
Never output null JSON-LD schema

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -103,9 +103,11 @@ function ghost_head(options) {
                 head.push.apply(head, finaliseStructuredData(metaData));
                 head.push('');
 
-                head.push('<script type="application/ld+json">\n' +
-                JSON.stringify(metaData.schema, null, '    ') +
-                '\n    </script>\n');
+                if (metaData.schema) {
+                    head.push('<script type="application/ld+json">\n' +
+                        JSON.stringify(metaData.schema, null, '    ') +
+                        '\n    </script>\n');
+                }
             }
 
             if (client && client.id && client.secret) {

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -595,6 +595,26 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
 
+        it('outputs structured data but not schema for custom channel', function (done) {
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', relativeUrl: '/featured/', context: ['featured']},
+                {data: {root: {context: ['featured']}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/featured\/" \/>/);
+                rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
+                rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
+                rendered.string.should.match(/<meta property="og:title" content="Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/testurl.com\/featured\/" \/>/);
+
+                rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
+
+                done();
+            }).catch(done);
+        });
+
         it('returns twitter and facebook descriptions if no meta description available', function (done) {
             var post = {
                 title: 'Welcome to Ghost',


### PR DESCRIPTION
This is a quick fix to prevent Ghost from outputting this on custom channels:

```
<script type="application/ld+json">
null
</script>
```

A much bigger refactor is needed to make sure that custom channels get useful metadata & JSON-LD schema but for the time being this stops nonsense from being output.

refs #5091, #6612
- fixes meta data so it won't output 'null' as a JSON-LD schema
- added test coverage for this if/else
- this case cannot happen within the existing system, it only happens with custom channels after #6612
