### PR TITLE
deps: ember-data@2.4.2

### DIFF
--- a/core/client/app/serializers/post.js
+++ b/core/client/app/serializers/post.js
@@ -1,9 +1,7 @@
 /* jscs:disable requireCamelCaseOrUpperCaseIdentifiers */
 import Ember from 'ember';
-import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
-
-const {EmbeddedRecordsMixin} = DS;
+import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     // settings for the EmbeddedRecordsMixin.

--- a/core/client/app/serializers/user.js
+++ b/core/client/app/serializers/user.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
-import DS from 'ember-data';
 import ApplicationSerializer from 'ghost/serializers/application';
-
-const {EmbeddedRecordsMixin} = DS;
+import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
     attrs: {

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -37,7 +37,7 @@
     "ember-cli-selectize": "0.4.3",
     "ember-cli-sri": "2.1.0",
     "ember-cli-uglify": "1.2.0",
-    "ember-data": "2.4.0",
+    "ember-data": "2.4.2",
     "ember-data-filter": "1.13.0",
     "ember-disable-proxy-controllers": "1.0.1",
     "ember-export-application-global": "1.0.5",


### PR DESCRIPTION
no issue

Bugfix releases and use of previously missed module imports added in 2.4.0:
- https://github.com/emberjs/data/releases/tag/v2.4.1
- https://github.com/emberjs/data/releases/tag/v2.4.2
- uses the new public import path for `EmbeddedRecordsMixin` (http://emberjs.com/blog/2016/03/13/ember-data-2-4-released.html#toc_importing-modules)
