### PR TITLE
Migration messaging improvements

### DIFF
--- a/core/server/data/migration/004/01-add-tour-column-to-users.js
+++ b/core/server/data/migration/004/01-add-tour-column-to-users.js
@@ -2,17 +2,23 @@ var commands = require('../../schema').commands,
     db       = require('../../db'),
 
     table    = 'users',
-    column   = 'tour';
+    column   = 'tour',
+    message  = 'Adding column: ' + table + '.' + column;
 
-module.exports = function addTourColumnToUsers(logInfo) {
+module.exports = function addTourColumnToUsers(logger) {
     return db.knex.schema.hasTable(table).then(function (exists) {
         if (exists) {
             return db.knex.schema.hasColumn(table, column).then(function (exists) {
                 if (!exists) {
-                    logInfo('Adding column: ' + table + '.' + column);
+                    logger.info(message);
                     return commands.addColumn(table, column);
+                } else {
+                    logger.warn(message);
                 }
             });
+        } else {
+            // @TODO: this should probably be an error
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/004/02-add-sortorder-column-to-poststags.js
+++ b/core/server/data/migration/004/02-add-sortorder-column-to-poststags.js
@@ -2,17 +2,23 @@ var commands = require('../../schema').commands,
     db       = require('../../db'),
 
     table    = 'posts_tags',
-    column   = 'sort_order';
+    column   = 'sort_order',
+    message  = 'Adding column: ' + table + '.' + column;
 
-module.exports = function addSortOrderColumnToPostsTags(logInfo) {
+module.exports = function addSortOrderColumnToPostsTags(logger) {
     return db.knex.schema.hasTable(table).then(function (exists) {
         if (exists) {
             return db.knex.schema.hasColumn(table, column).then(function (exists) {
                 if (!exists) {
-                    logInfo('Adding column: ' + table + '.' + column);
+                    logger.info(message);
                     return commands.addColumn(table, column);
+                } else {
+                    logger.warn(message);
                 }
             });
+        } else {
+            // @TODO: this should probably be an error
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/004/03-add-many-columns-to-clients.js
+++ b/core/server/data/migration/004/03-add-many-columns-to-clients.js
@@ -5,17 +5,23 @@ var Promise  = require('bluebird'),
     table    = 'clients',
     columns  = ['redirection_uri', 'logo', 'status', 'type', 'description'];
 
-module.exports = function addManyColumnsToClients(logInfo) {
+module.exports = function addManyColumnsToClients(logger) {
     return db.knex.schema.hasTable(table).then(function (exists) {
         if (exists) {
             return Promise.mapSeries(columns, function (column) {
+                var message = 'Adding column: ' + table + '.' + column;
                 return db.knex.schema.hasColumn(table, column).then(function (exists) {
                     if (!exists) {
-                        logInfo('Adding column: ' + table + '.' + column);
+                        logger.info(message);
                         return commands.addColumn(table, column);
+                    } else {
+                        logger.warn(message);
                     }
                 });
             });
+        } else {
+            // @TODO: this should probably be an error
+            logger.warn('Adding columns to table: ' + table);
         }
     });
 };

--- a/core/server/data/migration/004/04-add-clienttrusteddomains-table.js
+++ b/core/server/data/migration/004/04-add-clienttrusteddomains-table.js
@@ -1,13 +1,16 @@
 var commands = require('../../schema').commands,
     db       = require('../../db'),
 
-    table    = 'client_trusted_domains';
+    table    = 'client_trusted_domains',
+    message  = 'Creating table: ' + table;
 
-module.exports = function addClientTrustedDomainsTable(logInfo) {
+module.exports = function addClientTrustedDomainsTable(logger) {
     return db.knex.schema.hasTable(table).then(function (exists) {
         if (!exists) {
-            logInfo('Creating table: ' + table);
+            logger.info(message);
             return commands.createTable(table);
+        } else {
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/004/05-drop-unique-on-clients-secret.js
+++ b/core/server/data/migration/004/05-drop-unique-on-clients-secret.js
@@ -2,17 +2,23 @@ var commands = require('../../schema').commands,
     db       = require('../../db'),
 
     table    = 'clients',
-    column   = 'secret';
+    column   = 'secret',
+    message  = 'Dropping unique on: ' + table + '.' + column;
 
-module.exports = function dropUniqueOnClientsSecret(logInfo) {
+module.exports = function dropUniqueOnClientsSecret(logger) {
     return db.knex.schema.hasTable(table).then(function (exists) {
         if (exists) {
             return commands.getIndexes(table).then(function (indexes) {
                 if (indexes.indexOf(table + '_' + column + '_unique') > -1) {
-                    logInfo('Dropping unique on: ' + table + '.' + column);
+                    logger.info(message);
                     return commands.dropUnique(table, column);
+                } else {
+                    logger.warn(message);
                 }
             });
+        } else {
+            // @TODO: this should probably be an error
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/backup.js
+++ b/core/server/data/migration/backup.js
@@ -20,14 +20,14 @@ writeExportFile = function writeExportFile(exportResult) {
  * ## Backup
  * does an export, and stores this in a local file
  *
- * @param {Function} [logInfo]
+ * @param {{info: logger.info, warn: logger.warn}} [logger]
  * @returns {Promise<*>}
  */
-backup = function backup(logInfo) {
-    // If we get passed a function, use it to output noticies, else don't do anything
-    logInfo = _.isFunction(logInfo) ? logInfo : _.noop;
+backup = function backup(logger) {
+    // If we get passed a function, use it to output notices, else don't do anything
+    logger = logger && _.isFunction(logger.info) ? logger : {info: _.noop};
 
-    logInfo('Creating database backup');
+    logger.info('Creating database backup');
 
     var props = {
         data: exporter.doExport(),
@@ -37,7 +37,7 @@ backup = function backup(logInfo) {
     return Promise.props(props)
         .then(writeExportFile)
         .then(function successMessage(filename) {
-            logInfo('Database backup written to: ' + filename);
+            logger.info('Database backup written to: ' + filename);
         });
 };
 

--- a/core/server/data/migration/fixtures/004/01-move-jquery-with-alert.js
+++ b/core/server/data/migration/fixtures/004/01-move-jquery-with-alert.js
@@ -15,9 +15,11 @@ var _             = require('lodash'),
     privacyMessage = [
         i18n.t('notices.data.fixtures.jQueryRemoved'),
         i18n.t('notices.data.fixtures.canBeChanged')
-    ];
+    ],
 
-module.exports = function moveJQuery(options, logInfo) {
+    message = 'Adding jQuery link to ghost_foot';
+
+module.exports = function moveJQuery(options, logger) {
     var value;
 
     return models.Settings.findOne('ghost_foot').then(function (setting) {
@@ -25,14 +27,14 @@ module.exports = function moveJQuery(options, logInfo) {
             value = setting.attributes.value;
             // Only add jQuery if it's not already in there
             if (value.indexOf(jquery.join('')) === -1) {
-                logInfo('Adding jQuery link to ghost_foot');
+                logger.info(message);
                 value = jquery.join('') + value;
 
                 return models.Settings.edit({key: 'ghost_foot', value: value}, options).then(function () {
                     if (_.isEmpty(config.privacy)) {
                         return Promise.resolve();
                     }
-                    logInfo(privacyMessage.join(' ').replace(/<\/?strong>/g, ''));
+                    logger.info(privacyMessage.join(' ').replace(/<\/?strong>/g, ''));
                     return notifications.add({
                         notifications: [{
                             type: 'info',
@@ -40,7 +42,11 @@ module.exports = function moveJQuery(options, logInfo) {
                         }]
                     }, options);
                 });
+            } else {
+                logger.warn(message);
             }
+        } else {
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/fixtures/004/02-update-private-setting-type.js
+++ b/core/server/data/migration/fixtures/004/02-update-private-setting-type.js
@@ -1,12 +1,16 @@
 // Update the `isPrivate` setting, so that it has a type of `private` rather than `blog`
 var models  = require('../../../../models'),
-    Promise = require('bluebird');
+    Promise = require('bluebird'),
 
-module.exports = function updatePrivateSetting(options, logInfo) {
+    message = 'Update isPrivate setting';
+
+module.exports = function updatePrivateSetting(options, logger) {
     return models.Settings.findOne('isPrivate').then(function (setting) {
         if (setting && setting.get('type') !== 'private') {
-            logInfo('Update isPrivate setting');
+            logger.info(message);
             return models.Settings.edit({key: 'isPrivate', type: 'private'}, options);
+        } else {
+            logger.warn(message);
         }
         return Promise.resolve();
     });

--- a/core/server/data/migration/fixtures/004/03-update-password-setting-type.js
+++ b/core/server/data/migration/fixtures/004/03-update-password-setting-type.js
@@ -1,12 +1,16 @@
 // Update the `password` setting, so that it has a type of `private` rather than `blog`
 var models  = require('../../../../models'),
-    Promise = require('bluebird');
+    Promise = require('bluebird'),
 
-module.exports = function updatePasswordSetting(options, logInfo) {
+    message = 'Update password setting';
+
+module.exports = function updatePasswordSetting(options, logger) {
     return models.Settings.findOne('password').then(function (setting) {
         if (setting && setting.get('type') !== 'private') {
-            logInfo('Update password setting');
+            logger.info(message);
             return models.Settings.edit({key: 'password', type: 'private'}, options);
+        } else {
+            logger.warn(message);
         }
         return Promise.resolve();
     });

--- a/core/server/data/migration/fixtures/004/04-update-ghost-admin-client.js
+++ b/core/server/data/migration/fixtures/004/04-update-ghost-admin-client.js
@@ -4,17 +4,20 @@ var models  = require('../../../../models'),
     Promise = require('bluebird'),
     crypto  = require('crypto'),
 
-    adminClient = require('../fixtures').models.Client[0];
+    adminClient = require('../fixtures').models.Client[0],
+    message = 'Update ghost-admin client fixture';
 
-module.exports = function updateGhostAdminClient(options, logInfo) {
+module.exports = function updateGhostAdminClient(options, logger) {
     // ghost-admin should already exist from 003 version
     return models.Client.findOne({slug: adminClient.slug}).then(function (client) {
         if (client && (client.get('secret') === 'not_available' || client.get('status') !== 'enabled')) {
-            logInfo('Update ghost-admin client fixture');
+            logger.info(message);
             return models.Client.edit(
                 _.extend({}, adminClient, {secret: crypto.randomBytes(6).toString('hex')}),
                 _.extend({}, options, {id: client.id})
             );
+        } else {
+            logger.warn(message);
         }
         return Promise.resolve();
     });

--- a/core/server/data/migration/fixtures/004/05-add-ghost-frontend-client.js
+++ b/core/server/data/migration/fixtures/004/05-add-ghost-frontend-client.js
@@ -2,13 +2,16 @@
 var models  = require('../../../../models'),
     Promise = require('bluebird'),
 
-    frontendClient  = require('../fixtures').models.Client[1];
+    frontendClient  = require('../fixtures').models.Client[1],
+    message = 'Add ghost-frontend client fixture';
 
-module.exports = function addGhostFrontendClient(options, logInfo) {
+module.exports = function addGhostFrontendClient(options, logger) {
     return models.Client.findOne({slug: frontendClient.slug}).then(function (client) {
         if (!client) {
-            logInfo('Add ghost-frontend client fixture');
+            logger.info(message);
             return models.Client.add(frontendClient, options);
+        } else {
+            logger.warn(message);
         }
         return Promise.resolve();
     });

--- a/core/server/data/migration/fixtures/004/06-clean-broken-tags.js
+++ b/core/server/data/migration/fixtures/004/06-clean-broken-tags.js
@@ -1,8 +1,9 @@
 // Clean tags which start with commas, the only illegal char in tags
 var models  = require('../../../../models'),
-    Promise = require('bluebird');
+    Promise = require('bluebird'),
+    message = 'Cleaning malformed tags';
 
-module.exports = function cleanBrokenTags(options, logInfo) {
+module.exports = function cleanBrokenTags(options, logger) {
     return models.Tag.findAll(options).then(function (tags) {
         var tagOps = [];
         if (tags) {
@@ -18,9 +19,13 @@ module.exports = function cleanBrokenTags(options, logInfo) {
                 }
             });
             if (tagOps.length > 0) {
-                logInfo('Cleaning ' + tagOps.length + ' malformed tags');
+                logger.info(message + '(' + tagOps.length + ')');
                 return Promise.all(tagOps);
+            } else {
+                logger.warn(message);
             }
+        } else {
+            logger.warn(message);
         }
         return Promise.resolve();
     });

--- a/core/server/data/migration/fixtures/004/07-add-post-tag-order.js
+++ b/core/server/data/migration/fixtures/004/07-add-post-tag-order.js
@@ -43,20 +43,22 @@ function processPostsArray(postsArray) {
     return postsArray.reduce(buildTagOpsArray, []);
 }
 
-module.exports = function addPostTagOrder(options, logInfo) {
+module.exports = function addPostTagOrder(options, logger) {
     modelOptions = options;
     migrationHasRunFlag = false;
 
-    logInfo('Collecting data on tag order for posts...');
+    logger.info('Collecting data on tag order for posts...');
     return models.Post.findAll(_.extend({}, modelOptions))
         .then(loadTagsForEachPost)
         .then(processPostsArray)
         .then(function (tagOps) {
             if (tagOps.length > 0 && !migrationHasRunFlag) {
-                logInfo('Updating order on ' + tagOps.length + ' tag relationships (could take a while)...');
+                logger.info('Updating order on ' + tagOps.length + ' tag relationships (could take a while)...');
                 return sequence(tagOps).then(function () {
-                    logInfo('Tag order successfully updated');
+                    logger.info('Tag order successfully updated');
                 });
+            } else {
+                logger.warn('Updating order on tag relationships');
             }
         });
 };

--- a/core/server/data/migration/fixtures/004/08-add-post-fixture.js
+++ b/core/server/data/migration/fixtures/004/08-add-post-fixture.js
@@ -1,5 +1,6 @@
 // Adds a new draft post with information about the new design
 var models  = require('../../../../models'),
+
     newPost = {
         title:            'You\'ve been upgraded to the latest version of Ghost',
         slug:             'ghost-0-7',
@@ -11,17 +12,20 @@ var models  = require('../../../../models'),
         language:         'en_US',
         meta_title:       null,
         meta_description: null
-    };
+    },
+    message = 'Adding 0.7 upgrade post fixture';
 
-module.exports = function addNewPostFixture(options, logInfo) {
+module.exports = function addNewPostFixture(options, logger) {
     return models.Post.findOne({slug: newPost.slug, status: 'all'}, options).then(function (post) {
         if (!post) {
-            logInfo('Adding 0.7 upgrade post fixture');
+            logger.info(message);
             // Set the published_at timestamp, but keep the post as a draft so doesn't appear on the frontend
             // This is a hack to ensure that this post appears at the very top of the drafts list, because
             // unpublished posts always appear first
             newPost.published_at = Date.now();
             return models.Post.add(newPost, options);
+        } else {
+            logger.warn(message);
         }
     });
 };

--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -125,10 +125,10 @@ addAllRelations = function addAllRelations() {
  * Creates the user fixture and gives it the owner role.
  * By default, users are given the Author role, making it hard to do this using the fixture system
  *
- * @param {Function} logInfo
+ * @param {{info: logger.info, warn: logger.warn}} logger
  * @returns {Promise<*>}
  */
-createOwner = function createOwner(logInfo) {
+createOwner = function createOwner(logger) {
     var user = {
         name:             'Ghost Owner',
         email:            'ghost@ghost.org',
@@ -140,7 +140,7 @@ createOwner = function createOwner(logInfo) {
         if (ownerRole) {
             user.roles = [ownerRole.id];
 
-            logInfo('Creating owner');
+            logger.info('Creating owner');
             return models.User.add(user, modelOptions);
         }
     });
@@ -151,18 +151,18 @@ createOwner = function createOwner(logInfo) {
  * Sequentially creates all models, in the order they are specified, and then
  * creates all the relationships, also maintaining order.
  *
- * @param {Function} logInfo
+ * @param {{info: logger.info, warn: logger.warn}} logger
  * @returns {Promise<*>}
  */
-populate = function populate(logInfo) {
-    logInfo('Populating fixtures');
+populate = function populate(logger) {
+    logger.info('Running fixture populations');
 
     // ### Ensure all models are added
     return addAllModels().then(function () {
         // ### Ensure all relations are added
         return addAllRelations();
     }).then(function () {
-        return createOwner(logInfo);
+        return createOwner(logger);
     });
 };
 

--- a/core/server/data/migration/fixtures/settings.js
+++ b/core/server/data/migration/fixtures/settings.js
@@ -1,12 +1,16 @@
 var models = require('../../../models'),
     ensureDefaultSettings;
 
-ensureDefaultSettings = function ensureDefaultSettings(logInfo) {
+/**
+ * ## Ensure Default Settings
+ * Wrapper around model.Settings.populateDefault, with logger
+ * @param {{info: logger.info, warn: logger.warn}} logger
+ * @returns {*}
+ */
+ensureDefaultSettings = function ensureDefaultSettings(logger) {
     // Initialise the default settings
-    logInfo('Populating default settings');
-    return models.Settings.populateDefaults().then(function () {
-        logInfo('Complete');
-    });
+    logger.info('Ensuring default settings');
+    return models.Settings.populateDefaults();
 };
 
 module.exports = ensureDefaultSettings;

--- a/core/server/data/migration/fixtures/update.js
+++ b/core/server/data/migration/fixtures/update.js
@@ -17,26 +17,26 @@ var sequence = require('../../../utils/sequence'),
  * Handles doing subsequent updates for versions
  *
  * @param {Array} versions
- * @param {Function} logInfo
+ * @param {{info: logger.info, warn: logger.warn}} logger
  * @returns {Promise<*>}
  */
-update = function update(versions, logInfo) {
-    logInfo('Updating fixtures');
+update = function update(versions, logger) {
+    logger.info('Running fixture updates');
 
     var ops = versions.reduce(function updateToVersion(ops, version) {
-        var tasks = versioning.getUpdateFixturesTasks(version, logInfo);
+        var tasks = versioning.getUpdateFixturesTasks(version, logger);
 
         if (tasks && tasks.length > 0) {
             ops.push(function runVersionTasks() {
-                logInfo('Updating fixtures to ', version);
-                return sequence(tasks, modelOptions, logInfo);
+                logger.info('Updating fixtures to ' + version);
+                return sequence(tasks, modelOptions, logger);
             });
         }
 
         return ops;
     }, []);
 
-    return sequence(ops, modelOptions, logInfo);
+    return sequence(ops, modelOptions, logger);
 };
 
 module.exports = update;

--- a/core/server/data/migration/populate.js
+++ b/core/server/data/migration/populate.js
@@ -13,15 +13,15 @@ var Promise  = require('bluebird'),
  * Uses the schema to determine table structures, and automatically creates each table in order
  * TODO: use this directly in tests, so migration.init() can forget about tablesOnly as an option
  *
- * @param {Function} logInfo
+ * @param {{info: logger.info, warn: logger.warn}} logger
  * @param {Boolean} [tablesOnly] - used by tests
  * @returns {Promise<*>}
  */
-populate = function populate(logInfo, tablesOnly) {
-    logInfo('Creating tables...');
+populate = function populate(logger, tablesOnly) {
+    logger.info('Creating tables...');
 
     var tableSequence = Promise.mapSeries(schemaTables, function createTable(table) {
-        logInfo('Creating table: ' + table);
+        logger.info('Creating table: ' + table);
         return commands.createTable(table);
     });
 
@@ -31,9 +31,9 @@ populate = function populate(logInfo, tablesOnly) {
 
     return tableSequence.then(function () {
         // Load the fixtures
-        return fixtures.populate(logInfo);
+        return fixtures.populate(logger);
     }).then(function () {
-        return fixtures.ensureDefaultSettings(logInfo);
+        return fixtures.ensureDefaultSettings(logger);
     });
 };
 

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -84,11 +84,19 @@ errors = {
         return Promise.reject(err);
     },
 
-    logInfo: function (component, info) {
+    logComponentInfo: function (component, info) {
         if ((process.env.NODE_ENV === 'development' ||
             process.env.NODE_ENV === 'staging' ||
             process.env.NODE_ENV === 'production')) {
             console.info(chalk.cyan(component + ':', info));
+        }
+    },
+
+    logComponentWarn: function (component, warning) {
+        if ((process.env.NODE_ENV === 'development' ||
+            process.env.NODE_ENV === 'staging' ||
+            process.env.NODE_ENV === 'production')) {
+            console.info(chalk.yellow(component + ':', warning));
         }
     },
 
@@ -401,7 +409,8 @@ errors = {
 // using Function#bind for expressjs
 _.each([
     'logWarn',
-    'logInfo',
+    'logComponentInfo',
+    'logComponentWarn',
     'rejectError',
     'throwError',
     'logError',

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -122,9 +122,12 @@ describe('Database Migration (special functions)', function () {
         });
 
         it('should populate all fixtures correctly', function (done) {
-            var logStub = sandbox.stub();
+            var loggerStub = {
+                info: sandbox.stub(),
+                warn: sandbox.stub()
+            };
 
-            fixtures.populate(logStub).then(function () {
+            fixtures.populate(loggerStub).then(function () {
                 var props = {
                     posts: Models.Post.findAll({include: ['tags']}),
                     tags: Models.Tag.findAll(),
@@ -134,7 +137,8 @@ describe('Database Migration (special functions)', function () {
                     permissions: Models.Permission.findAll({include: ['roles']})
                 };
 
-                logStub.called.should.be.true();
+                loggerStub.info.called.should.be.true();
+                loggerStub.warn.called.should.be.false();
 
                 return Promise.props(props).then(function (result) {
                     should.exist(result);


### PR DESCRIPTION
This builds on #6621 and ended up being a little more involved than I had originally intended. To start with I just added a flag to logInfo so that it would output the message differently - but the code was instantly harder to read and the tests became very hard to reason about.

Plus, I know, really, we need to move towards having proper 'loggers' as per #2001 and this uses the right sort of pattern.

So.. instead of passing a single `logInfo` method around the migration system, we now pass around a `logger` object which has an `info` and a `warn` method. They do similar things - prefixing a message with either 'Migrations:' or 'Skipping Migrations:' and adding a colour. The normal message is blue, the warning is yellow.

Everywhere in the data & fixture migrations where a migration is skipped over, a warning message is now being output. 

So, if I run a simple 003->004 migration, I get output like this, where you can see I didn't have any badly formed tags:

![](http://puu.sh/nP1zF.png)

And then if I use `FORCE_MIGRATION=true npm start` to get the migrations to run a second time, I get this:

![](http://puu.sh/nP1Bj.png)

And we can easily see that none of the migrations actually ran.

The aim here is just to make debugging easier & make things a little more explicit and clear. Hopefully we'll reap the benefits later :grin: 

refs #6301
- fix messages that joined with comma and therefore missed outputting version no
- change `logInfo` to `logger` that has both an info and a warn method
- add new warn method to errors
- add a warn message every time a migration (data or fixture) gets skipped over
- update logger everywhere, including tests
- update tests to check logger.warn gets called
