### PR TITLE
Update knex and bookshelf

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bcryptjs": "2.3.0",
     "bluebird": "3.3.3",
     "body-parser": "1.14.2",
-    "bookshelf": "0.9.1",
+    "bookshelf": "0.9.2",
     "busboy": "0.2.12",
     "chalk": "1.1.1",
     "cheerio": "0.20.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "intl": "1.0.1",
     "intl-messageformat": "1.2.0",
     "jsonpath": "0.2.2",
-    "knex": "0.9.0",
+    "knex": "0.10.0",
     "lodash": "3.10.1",
     "moment": "2.11.2",
     "morgan": "1.6.1",


### PR DESCRIPTION
Closes #6573 
- bookshelf 0.9.2
- knex 0.10.0

I can't think of where the new "ignore undefined" behavior would be an issue. I don't think we should ever be sending `undefined` in an attempt to overwrite a column with an existing value if for no other reason than everything is serialized to JSON across the wire and it's not possible to use an explicit `undefined`. Anything that could be considered "unset" should either be an empty string or `null`.
