### PR TITLE
fix invalid preview url

### DIFF
--- a/core/client/app/templates/editor/edit.hbs
+++ b/core/client/app/templates/editor/edit.hbs
@@ -22,6 +22,7 @@
 
     {{gh-editor value=model.scratch
                 shouldFocusEditor=shouldFocusEditor
+                previewUrl=model.previewUrl
                 editorFocused=(action "autoSaveNew")
                 onTeardown=(action "cancelTimers")}}
 </section>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/302560/13952054/39de0ca8-f06f-11e5-86ad-bcb7f192db9d.png)

The preview button is not working and href always being empty.
This commit should fix it.
