### PR TITLE
Remove jquery-hammerjs bower dependency

### DIFF
--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -15,7 +15,6 @@
     "jquery": "2.1.4",
     "jquery-deparam": "~0.5.0",
     "jquery-file-upload": "9.5.6",
-    "jquery-hammerjs": "1.0.1",
     "jquery-ui": "1.11.4",
     "jqueryui-touch-punch": "furf/jquery-ui-touch-punch#4bc009145202d9c7483ba85f3a236a8f3470354d",
     "jquery.simulate.drag-sortable": "0.1.0",


### PR DESCRIPTION
no issue
- removes `jquery-hammerjs` from `bower.json` as it doesn't appear to be used anywhere and isn't included in the build by ember-cli
