### PR TITLE
Disable knex useNullAsDefault warning

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -3,8 +3,9 @@ var knex     = require('knex'),
     dbConfig = config.database,
     knexInstance;
 
-function configureDriver(client) {
-    var pg;
+function configure(dbConfig) {
+    var client = dbConfig.client,
+        pg;
 
     if (client === 'pg' || client === 'postgres' || client === 'postgresql') {
         try {
@@ -20,11 +21,16 @@ function configureDriver(client) {
             return val === null ? null : parseInt(val, 10);
         });
     }
+
+    if (client === 'sqlite3') {
+        dbConfig.useNullAsDefault = false;
+    }
+
+    return dbConfig;
 }
 
 if (!knexInstance && dbConfig && dbConfig.client) {
-    configureDriver(dbConfig.client);
-    knexInstance = knex(dbConfig);
+    knexInstance = knex(configure(dbConfig));
 }
 
 module.exports = knexInstance;


### PR DESCRIPTION
@jaswilli I think this is the correct fix for the warning? We should not be depending on the old behaviour of knex interpreting undefined as null, and if we are, we want to know about it?

With this fix, if people get errors, they can override them by setting `useNullAsDefault` to true temporarily, but hopefully they'll report them so we can fix the bugs. 

I think this makes sense?

refs #6623
- automatically set useNullAsDefault to false for sqlite3 so that we don't get a warning
- we should _not_ be relying on the behaviour of interpretting undefined anywhere, so it is correct that an error should be output if this happens so that we can fix the bad behaviour
