### PR TITLE
Make it possible to override `useNullAsDefault`

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -23,7 +23,7 @@ function configure(dbConfig) {
     }
 
     if (client === 'sqlite3') {
-        dbConfig.useNullAsDefault = false;
+        dbConfig.useNullAsDefault = dbConfig.useNullAsDefault || false;
     }
 
     return dbConfig;


### PR DESCRIPTION
Just a fuckup on my part, realised this change was still sat on my stage and I'd forgotten to add it to the original commit. Without this, it's not possible to override the setting locally.

refs #6623, #6637
- this was supposed to be in the original
