### PR TITLE
Data & fixture migration cleanup

### DIFF
--- a/core/server/data/migration/fixtures/004/01-move-jquery-with-alert.js
+++ b/core/server/data/migration/fixtures/004/01-move-jquery-with-alert.js
@@ -24,7 +24,7 @@ module.exports = function moveJQuery(options, logger) {
 
     return models.Settings.findOne('ghost_foot').then(function (setting) {
         if (setting) {
-            value = setting.attributes.value;
+            value = setting.get('value');
             // Only add jQuery if it's not already in there
             if (value.indexOf(jquery.join('')) === -1) {
                 logger.info(message);

--- a/core/server/data/migration/fixtures/004/02-update-private-setting-type.js
+++ b/core/server/data/migration/fixtures/004/02-update-private-setting-type.js
@@ -1,6 +1,5 @@
 // Update the `isPrivate` setting, so that it has a type of `private` rather than `blog`
 var models  = require('../../../../models'),
-    Promise = require('bluebird'),
 
     message = 'Update isPrivate setting';
 
@@ -12,6 +11,5 @@ module.exports = function updatePrivateSetting(options, logger) {
         } else {
             logger.warn(message);
         }
-        return Promise.resolve();
     });
 };

--- a/core/server/data/migration/fixtures/004/03-update-password-setting-type.js
+++ b/core/server/data/migration/fixtures/004/03-update-password-setting-type.js
@@ -1,6 +1,5 @@
 // Update the `password` setting, so that it has a type of `private` rather than `blog`
 var models  = require('../../../../models'),
-    Promise = require('bluebird'),
 
     message = 'Update password setting';
 
@@ -12,6 +11,5 @@ module.exports = function updatePasswordSetting(options, logger) {
         } else {
             logger.warn(message);
         }
-        return Promise.resolve();
     });
 };

--- a/core/server/data/migration/fixtures/004/04-update-ghost-admin-client.js
+++ b/core/server/data/migration/fixtures/004/04-update-ghost-admin-client.js
@@ -1,7 +1,6 @@
 // Update the `ghost-admin` client so that it has a proper secret
 var models  = require('../../../../models'),
     _       = require('lodash'),
-    Promise = require('bluebird'),
     crypto  = require('crypto'),
 
     adminClient = require('../fixtures').models.Client[0],
@@ -19,6 +18,5 @@ module.exports = function updateGhostAdminClient(options, logger) {
         } else {
             logger.warn(message);
         }
-        return Promise.resolve();
     });
 };

--- a/core/server/data/migration/fixtures/004/05-add-ghost-frontend-client.js
+++ b/core/server/data/migration/fixtures/004/05-add-ghost-frontend-client.js
@@ -1,6 +1,5 @@
 // Create a new `ghost-frontend` client for use in themes
 var models  = require('../../../../models'),
-    Promise = require('bluebird'),
 
     frontendClient  = require('../fixtures').models.Client[1],
     message = 'Add ghost-frontend client fixture';
@@ -13,6 +12,5 @@ module.exports = function addGhostFrontendClient(options, logger) {
         } else {
             logger.warn(message);
         }
-        return Promise.resolve();
     });
 };

--- a/core/server/data/migration/fixtures/004/06-clean-broken-tags.js
+++ b/core/server/data/migration/fixtures/004/06-clean-broken-tags.js
@@ -27,6 +27,5 @@ module.exports = function cleanBrokenTags(options, logger) {
         } else {
             logger.warn(message);
         }
-        return Promise.resolve();
     });
 };

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -72,57 +72,62 @@ describe('Fixtures', function () {
         });
 
         describe('Update to 004', function () {
-            it('should call all the 004 fixture upgrades', function (done) {
-                // Stub all the model methods so that nothing happens
-                var settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(Promise.resolve()),
-                    settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve()),
-                    clientOneStub = sandbox.stub(models.Client, 'findOne'),
-                    clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve()),
-                    clientAddStub = sandbox.stub(models.Client, 'add').returns(Promise.resolve()),
-                    tagAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve()),
-                    postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve()),
-                    postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve({})),
-                    postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve());
+            it('should call all the 004 fixture upgrade tasks', function (done) {
+                // Setup
+                // Create a new stub, this will replace sequence, so that db calls don't actually get run
+                var sequenceStub = sandbox.stub(),
+                    sequenceReset = update.__set__('sequence', sequenceStub);
 
-                clientOneStub.withArgs({slug: 'ghost-admin'}).returns(Promise.resolve());
-                clientOneStub.withArgs({slug: 'ghost-frontend'}).returns(Promise.resolve({}));
+                // The first time we call sequence, it should be to execute a top level version, e.g 004
+                // yieldsTo('0') means this stub will execute the function at index 0 of the array passed as the
+                // first argument. In short the `runVersionTasks` function gets executed, and sequence gets called
+                // again with the array of tasks to execute for 004, which is what we want to check
+                sequenceStub.onFirstCall().yieldsTo('0').returns(Promise.resolve([]));
 
                 update(['004'], loggerStub).then(function (result) {
                     should.exist(result);
 
-                    // Gets called 3 times to output peripheral info
-                    loggerStub.info.called.should.be.true();
-                    loggerStub.info.callCount.should.eql(3);
-                    // Should be called 8 times, once for each skipped migration
-                    loggerStub.warn.called.should.be.true();
-                    loggerStub.warn.callCount.should.eql(8);
+                    loggerStub.info.calledTwice.should.be.true();
+                    loggerStub.warn.called.should.be.false();
 
-                    settingsOneStub.calledThrice.should.be.true();
-                    settingsEditStub.called.should.be.false();
-                    clientOneStub.calledTwice.should.be.true();
-                    clientEditStub.called.should.be.false();
-                    clientAddStub.called.should.be.false();
-                    tagAllStub.calledOnce.should.be.true();
-                    postAllStub.calledOnce.should.be.true();
-                    postOneStub.calledOnce.should.be.true();
-                    postAddStub.called.should.be.false();
+                    sequenceStub.calledTwice.should.be.true();
+                    sequenceStub.firstCall.calledWith(sinon.match.array, sinon.match.object, loggerStub).should.be.true();
+                    sequenceStub.secondCall.calledWith(sinon.match.array, sinon.match.object, loggerStub).should.be.true();
 
-                    sinon.assert.callOrder(
-                        settingsOneStub, settingsOneStub, settingsOneStub, clientOneStub, clientOneStub, tagAllStub,
-                        postAllStub, postOneStub
-                    );
+                    sequenceStub.firstCall.args[0].should.be.an.Array().with.lengthOf(1);
+                    sequenceStub.secondCall.args[0].should.be.an.Array().with.lengthOf(8);
 
+                    sequenceStub.firstCall.args[0][0].should.be.a.Function().with.property('name', 'runVersionTasks');
+
+                    sequenceStub.secondCall.args[0][0].should.be.a.Function().with.property('name', 'moveJQuery');
+                    sequenceStub.secondCall.args[0][1].should.be.a.Function().with.property('name', 'updatePrivateSetting');
+                    sequenceStub.secondCall.args[0][2].should.be.a.Function().with.property('name', 'updatePasswordSetting');
+                    sequenceStub.secondCall.args[0][3].should.be.a.Function().with.property('name', 'updateGhostAdminClient');
+                    sequenceStub.secondCall.args[0][4].should.be.a.Function().with.property('name', 'addGhostFrontendClient');
+                    sequenceStub.secondCall.args[0][5].should.be.a.Function().with.property('name', 'cleanBrokenTags');
+                    sequenceStub.secondCall.args[0][6].should.be.a.Function().with.property('name', 'addPostTagOrder');
+                    sequenceStub.secondCall.args[0][7].should.be.a.Function().with.property('name', 'addNewPostFixture');
+
+                    // Reset
+                    sequenceReset();
                     done();
                 }).catch(done);
             });
 
             describe('Tasks:', function () {
+                var getObjStub, settingsOneStub, settingsEditStub, clientOneStub, clientEditStub;
+
+                beforeEach(function () {
+                    getObjStub = {get: sandbox.stub()};
+                    settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(Promise.resolve(getObjStub));
+                    settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
+                    clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(getObjStub));
+                    clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve());
+                });
+
                 describe('01-move-jquery-with-alert', function () {
                     it('tries to move jQuery to ghost_foot', function (done) {
-                        var settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(Promise.resolve({
-                                attributes: {value: ''}
-                            })),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
+                        getObjStub.get.returns('');
 
                         fixtures004[0]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
@@ -136,13 +141,10 @@ describe('Fixtures', function () {
                     });
 
                     it('does not move jQuery to ghost_foot if it is already there', function (done) {
-                        var settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(Promise.resolve({
-                                attributes: {
-                                    value: '<!-- You can safely delete this line if your theme does not require jQuery -->\n'
-                                        + '<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>\n\n'
-                                }
-                            })),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
+                        getObjStub.get.returns(
+                            '<!-- You can safely delete this line if your theme does not require jQuery -->\n'
+                            + '<script type="text/javascript" src="https://code.jquery.com/jquery-1.11.3.min.js"></script>\n\n'
+                        );
 
                         fixtures004[0]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
@@ -155,13 +157,24 @@ describe('Fixtures', function () {
                         }).catch(done);
                     });
 
+                    it('does not move jQuery to ghost_foot if the setting is missing', function (done) {
+                        settingsOneStub.returns(Promise.resolve());
+
+                        fixtures004[0]({}, loggerStub).then(function () {
+                            settingsOneStub.calledOnce.should.be.true();
+                            settingsOneStub.calledWith('ghost_foot').should.be.true();
+                            settingsEditStub.called.should.be.false();
+                            loggerStub.info.called.should.be.false();
+                            loggerStub.warn.calledOnce.should.be.true();
+
+                            done();
+                        }).catch(done);
+                    });
+
                     it('tried to move jQuery AND add a privacy message if any privacy settings are on', function (done) {
+                        var notificationsAddStub = sandbox.stub(notifications, 'add').returns(Promise.resolve());
                         configUtils.set({privacy: {useGoogleFonts: false}});
-                        var settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(Promise.resolve({
-                                attributes: {value: ''}
-                            })),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve()),
-                            notificationsAddStub = sandbox.stub(notifications, 'add').returns(Promise.resolve());
+                        getObjStub.get.returns('');
 
                         fixtures004[0]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
@@ -178,45 +191,35 @@ describe('Fixtures', function () {
 
                 describe('02-update-private-setting-type', function () {
                     it('tries to update setting type correctly', function (done) {
-                        var settingObjStub = {get: sandbox.stub()},
-                            settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(
-                                Promise.resolve(settingObjStub)
-                            ),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
-
                         fixtures004[1]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
                             settingsOneStub.calledWith('isPrivate').should.be.true();
-                            settingObjStub.get.calledOnce.should.be.true();
-                            settingObjStub.get.calledWith('type').should.be.true();
+                            getObjStub.get.calledOnce.should.be.true();
+                            getObjStub.get.calledWith('type').should.be.true();
                             settingsEditStub.calledOnce.should.be.true();
                             settingsEditStub.calledWith({key: 'isPrivate', type: 'private'}).should.be.true();
                             loggerStub.info.calledOnce.should.be.true();
                             loggerStub.warn.called.should.be.false();
-                            sinon.assert.callOrder(settingsOneStub, settingObjStub.get, loggerStub.info, settingsEditStub);
+                            sinon.assert.callOrder(settingsOneStub, getObjStub.get, loggerStub.info, settingsEditStub);
 
                             done();
                         }).catch(done);
                     });
 
                     it('does not try to update setting type if it is already set', function (done) {
-                        var settingObjStub = {get: sandbox.stub().returns('private')},
-                            settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(
-                                Promise.resolve(settingObjStub)
-                            ),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
+                        getObjStub.get.returns('private');
 
                         fixtures004[1]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
                             settingsOneStub.calledWith('isPrivate').should.be.true();
-                            settingObjStub.get.calledOnce.should.be.true();
-                            settingObjStub.get.calledWith('type').should.be.true();
+                            getObjStub.get.calledOnce.should.be.true();
+                            getObjStub.get.calledWith('type').should.be.true();
 
                             settingsEditStub.called.should.be.false();
                             loggerStub.info.called.should.be.false();
                             loggerStub.warn.calledOnce.should.be.true();
 
-                            sinon.assert.callOrder(settingsOneStub, settingObjStub.get, loggerStub.warn);
+                            sinon.assert.callOrder(settingsOneStub, getObjStub.get, loggerStub.warn);
 
                             done();
                         }).catch(done);
@@ -225,12 +228,6 @@ describe('Fixtures', function () {
 
                 describe('03-update-password-setting-type', function () {
                     it('tries to update setting type correctly', function (done) {
-                        var settingObjStub = {get: sandbox.stub()},
-                            settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(
-                                Promise.resolve(settingObjStub)
-                            ),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
-
                         fixtures004[2]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
                             settingsOneStub.calledWith('password').should.be.true();
@@ -245,23 +242,19 @@ describe('Fixtures', function () {
                     });
 
                     it('does not try to update setting type if it is already set', function (done) {
-                        var settingObjStub = {get: sandbox.stub().returns('private')},
-                            settingsOneStub = sandbox.stub(models.Settings, 'findOne').returns(
-                                Promise.resolve(settingObjStub)
-                            ),
-                            settingsEditStub = sandbox.stub(models.Settings, 'edit').returns(Promise.resolve());
+                        getObjStub.get.returns('private');
 
                         fixtures004[2]({}, loggerStub).then(function () {
                             settingsOneStub.calledOnce.should.be.true();
                             settingsOneStub.calledWith('password').should.be.true();
-                            settingObjStub.get.calledOnce.should.be.true();
-                            settingObjStub.get.calledWith('type').should.be.true();
+                            getObjStub.get.calledOnce.should.be.true();
+                            getObjStub.get.calledWith('type').should.be.true();
 
                             settingsEditStub.called.should.be.false();
                             loggerStub.info.called.should.be.false();
                             loggerStub.warn.calledOnce.should.be.true();
 
-                            sinon.assert.callOrder(settingsOneStub, settingObjStub.get);
+                            sinon.assert.callOrder(settingsOneStub, getObjStub.get);
 
                             done();
                         }).catch(done);
@@ -270,21 +263,17 @@ describe('Fixtures', function () {
 
                 describe('04-update-ghost-admin-client', function () {
                     it('tries to update client correctly', function (done) {
-                        var clientObjStub = {get: sandbox.stub()},
-                            clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(clientObjStub)),
-                            clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve());
-
                         fixtures004[3]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
                             clientOneStub.calledWith({slug: 'ghost-admin'}).should.be.true();
-                            clientObjStub.get.calledTwice.should.be.true();
-                            clientObjStub.get.calledWith('secret').should.be.true();
-                            clientObjStub.get.calledWith('status').should.be.true();
+                            getObjStub.get.calledTwice.should.be.true();
+                            getObjStub.get.calledWith('secret').should.be.true();
+                            getObjStub.get.calledWith('status').should.be.true();
                             clientEditStub.calledOnce.should.be.true();
                             loggerStub.info.calledOnce.should.be.true();
                             loggerStub.warn.called.should.be.false();
                             sinon.assert.callOrder(
-                                clientOneStub, clientObjStub.get, clientObjStub.get, loggerStub.info, clientEditStub
+                                clientOneStub, getObjStub.get, getObjStub.get, loggerStub.info, clientEditStub
                             );
 
                             done();
@@ -292,48 +281,40 @@ describe('Fixtures', function () {
                     });
 
                     it('does not try to update client if the secret and status are already correct', function (done) {
-                        var clientObjStub = {get: sandbox.stub()},
-                            clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(clientObjStub)),
-                            clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve());
-
-                        clientObjStub.get.withArgs('secret').returns('abc');
-                        clientObjStub.get.withArgs('status').returns('enabled');
+                        getObjStub.get.withArgs('secret').returns('abc');
+                        getObjStub.get.withArgs('status').returns('enabled');
 
                         fixtures004[3]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
                             clientOneStub.calledWith({slug: 'ghost-admin'}).should.be.true();
-                            clientObjStub.get.calledTwice.should.be.true();
-                            clientObjStub.get.calledWith('secret').should.be.true();
-                            clientObjStub.get.calledWith('status').should.be.true();
+                            getObjStub.get.calledTwice.should.be.true();
+                            getObjStub.get.calledWith('secret').should.be.true();
+                            getObjStub.get.calledWith('status').should.be.true();
                             clientEditStub.called.should.be.false();
                             loggerStub.info.called.should.be.false();
                             loggerStub.warn.calledOnce.should.be.true();
-                            sinon.assert.callOrder(clientOneStub, clientObjStub.get, clientObjStub.get, loggerStub.warn);
+                            sinon.assert.callOrder(clientOneStub, getObjStub.get, getObjStub.get, loggerStub.warn);
 
                             done();
                         }).catch(done);
                     });
 
                     it('tries to update client if secret is correct but status is wrong', function (done) {
-                        var clientObjStub = {get: sandbox.stub()},
-                            clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(clientObjStub)),
-                            clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve());
-
-                        clientObjStub.get.withArgs('secret').returns('abc');
-                        clientObjStub.get.withArgs('status').returns('development');
+                        getObjStub.get.withArgs('secret').returns('abc');
+                        getObjStub.get.withArgs('status').returns('development');
 
                         fixtures004[3]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
                             clientOneStub.calledWith({slug: 'ghost-admin'}).should.be.true();
-                            clientObjStub.get.calledTwice.should.be.true();
-                            clientObjStub.get.calledWith('secret').should.be.true();
-                            clientObjStub.get.calledWith('status').should.be.true();
+                            getObjStub.get.calledTwice.should.be.true();
+                            getObjStub.get.calledWith('secret').should.be.true();
+                            getObjStub.get.calledWith('status').should.be.true();
 
                             clientEditStub.calledOnce.should.be.true();
                             loggerStub.info.calledOnce.should.be.true();
                             loggerStub.warn.called.should.be.false();
                             sinon.assert.callOrder(
-                                clientOneStub, clientObjStub.get, clientObjStub.get, loggerStub.info, clientEditStub
+                                clientOneStub, getObjStub.get, getObjStub.get, loggerStub.info, clientEditStub
                             );
 
                             done();
@@ -341,24 +322,20 @@ describe('Fixtures', function () {
                     });
 
                     it('tries to update client if status is correct but secret is wrong', function (done) {
-                        var clientObjStub = {get: sandbox.stub()},
-                            clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(clientObjStub)),
-                            clientEditStub = sandbox.stub(models.Client, 'edit').returns(Promise.resolve());
-
-                        clientObjStub.get.withArgs('secret').returns('not_available');
-                        clientObjStub.get.withArgs('status').returns('enabled');
+                        getObjStub.get.withArgs('secret').returns('not_available');
+                        getObjStub.get.withArgs('status').returns('enabled');
 
                         fixtures004[3]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
                             clientOneStub.calledWith({slug: 'ghost-admin'}).should.be.true();
-                            clientObjStub.get.calledOnce.should.be.true();
-                            clientObjStub.get.calledWith('secret').should.be.true();
+                            getObjStub.get.calledOnce.should.be.true();
+                            getObjStub.get.calledWith('secret').should.be.true();
 
                             clientEditStub.calledOnce.should.be.true();
                             loggerStub.info.calledOnce.should.be.true();
                             loggerStub.warn.called.should.be.false();
                             sinon.assert.callOrder(
-                                clientOneStub, clientObjStub.get, loggerStub.info, clientEditStub
+                                clientOneStub, getObjStub.get, loggerStub.info, clientEditStub
                             );
 
                             done();
@@ -368,8 +345,8 @@ describe('Fixtures', function () {
 
                 describe('05-add-ghost-frontend-client', function () {
                     it('tries to add client correctly', function (done) {
-                        var clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve()),
-                            clientAddStub = sandbox.stub(models.Client, 'add').returns(Promise.resolve());
+                        var clientAddStub = sandbox.stub(models.Client, 'add').returns(Promise.resolve());
+                        clientOneStub.returns(Promise.resolve());
 
                         fixtures004[4]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
@@ -384,8 +361,7 @@ describe('Fixtures', function () {
                     });
 
                     it('does not try to add client if it already exists', function (done) {
-                        var clientOneStub = sandbox.stub(models.Client, 'findOne').returns(Promise.resolve({})),
-                            clientAddStub = sandbox.stub(models.Client, 'add').returns(Promise.resolve());
+                        var clientAddStub = sandbox.stub(models.Client, 'add').returns(Promise.resolve());
 
                         fixtures004[4]({}, loggerStub).then(function () {
                             clientOneStub.calledOnce.should.be.true();
@@ -400,13 +376,19 @@ describe('Fixtures', function () {
                 });
 
                 describe('06-clean-broken-tags', function () {
+                    var tagObjStub, tagCollStub, tagAllStub;
+
+                    beforeEach(function () {
+                        tagObjStub = {
+                            get: sandbox.stub(),
+                            save: sandbox.stub().returns(Promise.resolve)
+                        };
+                        tagCollStub = {each: sandbox.stub().callsArgWith(0, tagObjStub)};
+                        tagAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(tagCollStub));
+                    });
+
                     it('tries to clean broken tags correctly', function (done) {
-                        var tagObjStub = {
-                                get: sandbox.stub().returns(',hello'),
-                                save: sandbox.stub().returns(Promise.resolve)
-                            },
-                            tagCollStub = {each: sandbox.stub().callsArgWith(0, tagObjStub)},
-                            tagAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(tagCollStub));
+                        tagObjStub.get.returns(',hello');
 
                         fixtures004[5]({}, loggerStub).then(function () {
                             tagAllStub.calledOnce.should.be.true();
@@ -424,12 +406,7 @@ describe('Fixtures', function () {
                     });
 
                     it('tries can handle tags which end up empty', function (done) {
-                        var tagObjStub = {
-                                get: sandbox.stub().returns(','),
-                                save: sandbox.stub().returns(Promise.resolve)
-                            },
-                            tagCollStub = {each: sandbox.stub().callsArgWith(0, tagObjStub)},
-                            tagAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(tagCollStub));
+                        tagObjStub.get.returns(',');
 
                         fixtures004[5]({}, loggerStub).then(function () {
                             tagAllStub.calledOnce.should.be.true();
@@ -447,12 +424,7 @@ describe('Fixtures', function () {
                     });
 
                     it('does not change tags if not necessary', function (done) {
-                        var tagObjStub = {
-                                get: sandbox.stub().returns('hello'),
-                                save: sandbox.stub().returns(Promise.resolve)
-                            },
-                            tagCollStub = {each: sandbox.stub().callsArgWith(0, tagObjStub)},
-                            tagAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(tagCollStub));
+                        tagObjStub.get.returns('hello');
 
                         fixtures004[5]({}, loggerStub).then(function () {
                             tagAllStub.calledOnce.should.be.true();
@@ -462,7 +434,23 @@ describe('Fixtures', function () {
                             tagObjStub.save.called.should.be.false();
                             loggerStub.info.called.should.be.false();
                             loggerStub.warn.calledOnce.should.be.true();
-                            sinon.assert.callOrder(tagAllStub, tagCollStub.each, tagObjStub.get);
+                            sinon.assert.callOrder(tagAllStub, tagCollStub.each, tagObjStub.get, loggerStub.warn);
+
+                            done();
+                        }).catch(done);
+                    });
+
+                    it('does nothing if there are no tags', function (done) {
+                        tagAllStub.returns(Promise.resolve());
+
+                        fixtures004[5]({}, loggerStub).then(function () {
+                            tagAllStub.calledOnce.should.be.true();
+                            tagCollStub.each.called.should.be.false();
+                            tagObjStub.get.called.should.be.false();
+                            tagObjStub.save.called.should.be.false();
+                            loggerStub.info.called.should.be.false();
+                            loggerStub.warn.calledOnce.should.be.true();
+                            sinon.assert.callOrder(tagAllStub, loggerStub.warn);
 
                             done();
                         }).catch(done);
@@ -470,13 +458,31 @@ describe('Fixtures', function () {
                 });
 
                 describe('07-add-post-tag-order', function () {
-                    it('calls load on each post', function (done) {
-                        var postObjStub = {
-                                load: sandbox.stub()
-                            },
-                            postCollStub = {mapThen: sandbox.stub().callsArgWith(0, postObjStub).returns([])},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                    var tagOp1Stub, tagOp2Stub, tagObjStub, postObjStub, postCollStub, postAllStub;
 
+                    beforeEach(function () {
+                        tagOp1Stub = sandbox.stub().returns(Promise.resolve());
+                        tagOp2Stub = sandbox.stub().returns(Promise.resolve());
+                        tagObjStub = {
+                            pivot: {get: sandbox.stub()}
+                        };
+                        postCollStub = {mapThen: sandbox.stub()};
+                        postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+
+                        postObjStub = {
+                            load: sandbox.stub(),
+                            reduce: sandbox.stub(),
+                            // By returning an array from related, we can use native reduce to simulate a result
+                            related: sandbox.stub().returns([tagObjStub]),
+                            // Get called when executing sequence
+                            tags: sandbox.stub().returnsThis(),
+                            updatePivot: sandbox.stub().returns(Promise.resolve())
+                        };
+                    });
+
+                    it('calls load on each post', function (done) {
+                        // Fake mapThen behaviour
+                        postCollStub.mapThen.callsArgWith(0, postObjStub).returns([]);
                         fixtures004[6]({}, loggerStub).then(function () {
                             postAllStub.calledOnce.should.be.true();
                             postCollStub.mapThen.calledOnce.should.be.true();
@@ -492,7 +498,9 @@ describe('Fixtures', function () {
                     });
 
                     it('returns early, if no posts are found', function (done) {
-                        var postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve());
+                        // Fake mapThen behaviour
+                        postCollStub.mapThen.returns([]);
+                        postAllStub.returns(Promise.resolve());
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledOnce.should.be.true();
@@ -506,25 +514,23 @@ describe('Fixtures', function () {
 
                     it('executes sequence, if at least one tag is found', function (done) {
                         var tagOpStub = sandbox.stub().returns(Promise.resolve()),
-                            tagOpsArr = [tagOpStub],
-                            // By stubbing reduce, we can return an array directly without pretending to process tags
-                            postArrayReduceStub = {
-                                reduce: sandbox.stub().returns(tagOpsArr)
-                            },
-                            // By returning from mapThen, we can skip doing tag.load in this test
-                            postCollStub = {mapThen: sandbox.stub().returns(postArrayReduceStub)},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                            tagOpsArr = [tagOpStub];
+
+                        // By stubbing reduce, we can return an array directly without pretending to process tags
+                        postObjStub.reduce.returns(tagOpsArr);
+                        // By returning from mapThen, we can skip doing tag.load in this test
+                        postCollStub.mapThen.returns(postObjStub);
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledThrice.should.be.true();
                             loggerStub.warn.called.should.be.false();
                             postAllStub.calledOnce.should.be.true();
                             postCollStub.mapThen.calledOnce.should.be.true();
-                            postArrayReduceStub.reduce.calledOnce.should.be.true();
+                            postObjStub.reduce.calledOnce.should.be.true();
                             tagOpStub.calledOnce.should.be.true();
 
                             sinon.assert.callOrder(
-                                loggerStub.info, postAllStub, postCollStub.mapThen, postArrayReduceStub.reduce,
+                                loggerStub.info, postAllStub, postCollStub.mapThen, postObjStub.reduce,
                                 loggerStub.info, tagOpStub, loggerStub.info
                             );
 
@@ -533,28 +539,23 @@ describe('Fixtures', function () {
                     });
 
                     it('executes sequence, if more than one tag is found', function (done) {
-                        var tagOp1Stub = sandbox.stub().returns(Promise.resolve()),
-                            tagOp2Stub = sandbox.stub().returns(Promise.resolve()),
-                            tagOpsArr = [tagOp1Stub, tagOp2Stub],
-                            // By stubbing reduce, we can return an array directly without pretending to process tags
-                            postArrayReduceStub = {
-                                reduce: sandbox.stub().returns(tagOpsArr)
-                            },
-                            // By returning from mapThen, we can skip doing tag.load in this test
-                            postCollStub = {mapThen: sandbox.stub().returns(postArrayReduceStub)},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                        var tagOpsArr = [tagOp1Stub, tagOp2Stub];
+                        // By stubbing reduce, we can return an array directly without pretending to process tags
+                        postObjStub.reduce.returns(tagOpsArr);
+                        // By returning from mapThen, we can skip doing tag.load in this test
+                        postCollStub.mapThen.returns(postObjStub);
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledThrice.should.be.true();
                             loggerStub.warn.called.should.be.false();
                             postAllStub.calledOnce.should.be.true();
                             postCollStub.mapThen.calledOnce.should.be.true();
-                            postArrayReduceStub.reduce.calledOnce.should.be.true();
+                            postObjStub.reduce.calledOnce.should.be.true();
                             tagOp1Stub.calledOnce.should.be.true();
                             tagOp2Stub.calledOnce.should.be.true();
 
                             sinon.assert.callOrder(
-                                loggerStub.info, postAllStub, postCollStub.mapThen, postArrayReduceStub.reduce,
+                                loggerStub.info, postAllStub, postCollStub.mapThen, postObjStub.reduce,
                                 loggerStub.info, tagOp1Stub, tagOp2Stub, loggerStub.info
                             );
 
@@ -563,19 +564,9 @@ describe('Fixtures', function () {
                     });
 
                     it('does not execute sequence, if migrationHasRunFlag gets set to true', function (done) {
-                        var tagObjStub = {
-                                pivot: {
-                                    // If pivot gets a non-zero, migrationHasRunFlag gets set to true
-                                    get: sandbox.stub().returns(1)
-                                }
-                            },
-                            postObjStub = {
-                                // By returning an array from related, we can use real reduce to simulate a result here
-                                related: sandbox.stub().returns([tagObjStub])
-                            },
-                            // By returning from mapThen, we can skip doing tag.load in this test
-                            postCollStub = {mapThen: sandbox.stub().returns([postObjStub])},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                        tagObjStub.pivot.get.returns(1);
+                        // By returning from mapThen, we can skip doing tag.load in this test
+                        postCollStub.mapThen.returns([postObjStub]);
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledOnce.should.be.true();
@@ -595,23 +586,10 @@ describe('Fixtures', function () {
                     });
 
                     it('does execute sequence, if migrationHasRunFlag is false', function (done) {
-                        var tagObjStub = {
-                                pivot: {
-                                    // If pivot gets a non-zero, migrationHasRunFlag gets set to true
-                                    get: sandbox.stub().returns(0)
-                                }
-                            },
-                            postObjStub = {
-                                // By returning an array from related, we can use real reduce to simulate a result here
-                                related: sandbox.stub().returns([tagObjStub]),
-
-                                // Get called when executing the sequence
-                                tags: sandbox.stub().returnsThis(),
-                                updatePivot: sandbox.stub().returns(Promise.resolve())
-                            },
-                            // By returning from mapThen, we can skip doing tag.load in this test
-                            postCollStub = {mapThen: sandbox.stub().returns([postObjStub])},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                        // If pivot gets a non-zero, migrationHasRunFlag gets set to true
+                        tagObjStub.pivot.get.returns(0);
+                        // By returning from mapThen, we can skip doing tag.load in this test
+                        postCollStub.mapThen.returns([postObjStub]);
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledThrice.should.be.true();
@@ -634,23 +612,12 @@ describe('Fixtures', function () {
                     });
 
                     it('tries to add incremental sort_order to posts_tags', function (done) {
-                        var tagObjStub = {
-                                pivot: {
-                                    // If pivot gets a non-zero, migrationHasRunFlag gets set to true
-                                    get: sandbox.stub().returns(0)
-                                }
-                            },
-                            postObjStub = {
-                                // By returning an array from related, we can use real reduce to simulate a result here
-                                related: sandbox.stub().returns([tagObjStub, tagObjStub, tagObjStub]),
-
-                                // Get called when executing the sequence
-                                tags: sandbox.stub().returnsThis(),
-                                updatePivot: sandbox.stub().returns(Promise.resolve())
-                            },
+                        // If pivot gets a non-zero, migrationHasRunFlag gets set to true
+                        tagObjStub.pivot.get.returns(0);
+                        // By returning an array from related, we can use real reduce to simulate a result here
+                        postObjStub.related.returns([tagObjStub, tagObjStub, tagObjStub]);
                         // By returning from mapThen, we can skip doing tag.load in this test
-                            postCollStub = {mapThen: sandbox.stub().returns([postObjStub])},
-                            postAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(postCollStub));
+                        postCollStub.mapThen.returns([postObjStub]);
 
                         fixtures004[6]({}, loggerStub).then(function () {
                             loggerStub.info.calledThrice.should.be.true();
@@ -683,10 +650,14 @@ describe('Fixtures', function () {
                 });
 
                 describe('08-add-post-fixture', function () {
-                    it('tries to add a new post fixture correctly', function (done) {
-                        var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve()),
-                            postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve());
+                    var postOneStub, postAddStub;
 
+                    beforeEach(function () {
+                        postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve());
+                        postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve());
+                    });
+
+                    it('tries to add a new post fixture correctly', function (done) {
                         fixtures004[7]({}, loggerStub).then(function () {
                             postOneStub.calledOnce.should.be.true();
                             loggerStub.info.calledOnce.should.be.true();
@@ -699,8 +670,7 @@ describe('Fixtures', function () {
                     });
 
                     it('does not try to add new post fixture if it already exists', function (done) {
-                        var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve({})),
-                            postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve());
+                        postOneStub.returns(Promise.resolve({}));
 
                         fixtures004[7]({}, loggerStub).then(function () {
                             postOneStub.calledOnce.should.be.true();
@@ -813,10 +783,17 @@ describe('Fixtures', function () {
         });
 
         describe('Create Owner', function () {
+            var createOwner = populate.__get__('createOwner'),
+                roleOneStub, userAddStub;
+
+            beforeEach(function () {
+                roleOneStub = sandbox.stub(models.Role, 'findOne');
+                userAddStub = sandbox.stub(models.User, 'add');
+            });
+
             it('createOwner will add user if owner role is present', function (done) {
-                var createOwner = populate.__get__('createOwner'),
-                    roleOneStub = sandbox.stub(models.Role, 'findOne').returns(Promise.resolve({id: 1})),
-                    userAddStub = sandbox.stub(models.User, 'add').returns(Promise.resolve({}));
+                roleOneStub.returns(Promise.resolve({id: 1}));
+                userAddStub.returns(Promise.resolve({}));
 
                 createOwner(loggerStub).then(function () {
                     loggerStub.info.called.should.be.true();
@@ -829,9 +806,8 @@ describe('Fixtures', function () {
             });
 
             it('createOwner does not add user if owner role is not present', function (done) {
-                var createOwner = populate.__get__('createOwner'),
-                    roleOneStub = sandbox.stub(models.Role, 'findOne').returns(Promise.resolve()),
-                    userAddStub = sandbox.stub(models.User, 'add').returns(Promise.resolve({}));
+                roleOneStub.returns(Promise.resolve());
+                userAddStub.returns(Promise.resolve({}));
 
                 createOwner().then(function () {
                     roleOneStub.calledOnce.should.be.true();
@@ -843,20 +819,22 @@ describe('Fixtures', function () {
         });
 
         describe('Match Func', function () {
-            var matchFunc = populate.__get__('matchFunc');
+            var matchFunc = populate.__get__('matchFunc'),
+                getStub;
+
+            beforeEach(function () {
+                getStub = sandbox.stub();
+                getStub.withArgs('foo').returns('bar');
+                getStub.withArgs('fun').returns('baz');
+            });
 
             it('should match undefined with no args', function () {
-                var getStub = sandbox.stub();
-
                 matchFunc()({get: getStub}).should.be.true();
                 getStub.calledOnce.should.be.true();
                 getStub.calledWith(undefined).should.be.true();
             });
 
             it('should match key with match string', function () {
-                var getStub = sandbox.stub();
-                getStub.withArgs('foo').returns('bar');
-
                 matchFunc('foo', 'bar')({get: getStub}).should.be.true();
                 getStub.calledOnce.should.be.true();
                 getStub.calledWith('foo').should.be.true();
@@ -867,9 +845,6 @@ describe('Fixtures', function () {
             });
 
             it('should match value when key is 0', function () {
-                var getStub = sandbox.stub();
-                getStub.withArgs('foo').returns('bar');
-
                 matchFunc('foo', 0, 'bar')({get: getStub}).should.be.true();
                 getStub.calledOnce.should.be.true();
                 getStub.calledWith('foo').should.be.true();
@@ -880,10 +855,6 @@ describe('Fixtures', function () {
             });
 
             it('should match key & value when match is array', function () {
-                var getStub = sandbox.stub();
-                getStub.withArgs('foo').returns('bar');
-                getStub.withArgs('fun').returns('baz');
-
                 matchFunc(['foo', 'fun'], 'bar', 'baz')({get: getStub}).should.be.true();
                 getStub.calledTwice.should.be.true();
                 getStub.getCall(0).calledWith('fun').should.be.true();
@@ -896,10 +867,6 @@ describe('Fixtures', function () {
             });
 
             it('should match key only when match is array, but value is all', function () {
-                var getStub = sandbox.stub();
-                getStub.withArgs('foo').returns('bar');
-                getStub.withArgs('fun').returns('baz');
-
                 matchFunc(['foo', 'fun'], 'bar', 'all')({get: getStub}).should.be.true();
                 getStub.calledOnce.should.be.true();
                 getStub.calledWith('foo').should.be.true();
@@ -911,10 +878,6 @@ describe('Fixtures', function () {
             });
 
             it('should match key & value when match and value are arrays', function () {
-                var getStub = sandbox.stub();
-                getStub.withArgs('foo').returns('bar');
-                getStub.withArgs('fun').returns('baz');
-
                 matchFunc(['foo', 'fun'], 'bar', ['baz', 'buz'])({get: getStub}).should.be.true();
                 getStub.calledTwice.should.be.true();
                 getStub.getCall(0).calledWith('fun').should.be.true();


### PR DESCRIPTION
This removes some unnecessary code, improves quality of some of the tests, gets the coverage back to 100% and trims down the amount of code in the tests. There's also a change to the jQuery fixture update to make it consistent with the other settings fixture updates.

It's basically an odd collection of stuff I noticed whilst working on 005 migrations. 

refs #6621, #6622
- remove unneeded `return new Promise.resolve()` lines
- reduce code in tests
- improve quality of tests checking that all task functions are executed
- add missing test coverage
