### PR TITLE
allow api requests from ngrok-tunnelled websites in development

### DIFF
--- a/core/server/middleware/auth.js
+++ b/core/server/middleware/auth.js
@@ -59,6 +59,7 @@ function isValidOrigin(origin, client) {
         || origin === url.parse(config.urlSSL ? config.urlSSL : '').hostname
         // @TODO do this in dev mode only, once we can auto-configure the url #2240
         || (origin === 'localhost')
+        || (process.env.NODE_ENV === 'development' && /\.ngrok\./.test(origin))
     )) {
         return true;
     } else {


### PR DESCRIPTION
no issue
- adds a check to middleware/auth that allows requests to the ghost api from ngrok tunnels (while in development mode). This makes it easier for testing.
