### PR TITLE
Remove support for old io.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ^4.2.0",
-    "iojs": "~1.2.0"
+    "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
   },
   "dependencies": {
     "bcryptjs": "2.3.0",


### PR DESCRIPTION
- io.js and node have merged again
- we only ever had support for a single random version of io.js anyway
