### PR TITLE
deps: ember-sinon@0.5.0

### DIFF
--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -27,7 +27,6 @@
     "rangyinputs": "1.2.0",
     "selectize": "~0.12.1",
     "showdown-ghost": "0.3.6",
-    "sinonjs": "1.14.1",
     "validator-js": "3.39.0",
     "xregexp": "2.0.0"
   }

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -46,7 +46,7 @@
     "ember-resolver": "2.0.3",
     "ember-route-action-helper": "0.3.0",
     "ember-simple-auth": "1.0.1",
-    "ember-sinon": "0.3.0",
+    "ember-sinon": "0.5.0",
     "ember-sortable": "1.7.0",
     "ember-suave": "1.2.3",
     "ember-watson": "0.7.0",


### PR DESCRIPTION
no issue
- pulls sinon.js from NPM instead of bower - https://github.com/csantero/ember-sinon/releases/tag/v0.5.0
- contains dependency updates and ember-cli changes - https://github.com/csantero/ember-sinon/compare/v0.3.0...v0.5.0
