### PR TITLE
Return computed columns when used in "columns"

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -275,7 +275,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         var self = this,
             itemCollection = this.forge(null, {context: options.context}),
-            tableName      = _.result(this.prototype, 'tableName');
+            tableName      = _.result(this.prototype, 'tableName'),
+            allColumns = options.columns;
 
         // Set this to true or pass ?debug=true as an API option to get output
         itemCollection.debug = options.debug && process.env.NODE_ENV !== 'production';
@@ -308,6 +309,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         return itemCollection.fetchPage(options).then(function formatResponse(response) {
             var data = {};
+
+            // re-add any computed properties that were stripped out before the call to fetchPage
+            options.columns = allColumns;
             data[tableName] = response.collection.toJSON(options);
             data.meta = {pagination: response.pagination};
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -131,6 +131,37 @@ describe('Post Model', function () {
                     }).catch(done);
             });
 
+            it('returns computed fields when columns are asked for explicitly', function (done) {
+                PostModel.findPage({columns: ['id', 'slug', 'url', 'markdown']}).then(function (results) {
+                    should.exist(results);
+
+                    var post = extractFirstPost(results.posts);
+
+                    post.url.should.equal('/html-ipsum/');
+
+                    // If a computed property is inadvertently passed into a "fetch" operation,
+                    // there's a bug in bookshelf where the model will come back with it as
+                    // a column enclosed in quotes.
+                    should.not.exist(post['"url"']);
+
+                    done();
+                }).catch(done);
+            });
+
+            it('ignores columns that do not exist', function (done) {
+                PostModel.findPage({columns: ['id', 'slug', 'doesnotexist']}).then(function (results) {
+                    should.exist(results);
+
+                    var post = extractFirstPost(results.posts);
+
+                    post.id.should.equal(1);
+                    post.slug.should.equal('html-ipsum');
+                    should.not.exist(post.doesnotexist);
+
+                    done();
+                }).catch(done);
+            });
+
             it('can findPage, with various options', function (done) {
                 testUtils.fixtures.insertMorePosts().then(function () {
                     return testUtils.fixtures.insertMorePostsTags();


### PR DESCRIPTION
Closes #6625
- Adds a failing test for not returning computed columns as well
  as for the bookshelf bug where extra columns passed into a fetch
  will result in the model having an extra "quoted" column.
- Filter model attributes for passing into "fetch" but used the
  entire list of columns for `toJSON`.
