### PR TITLE
Fix unit test bugs

### DIFF
--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -7,7 +7,7 @@ var should         = require('should'),
     _              = require('lodash'),
 
     testUtils      = require('../utils'),
-	i18n            = require('../../server/i18n'),
+    i18n            = require('../../server/i18n'),
 
     // Thing we are testing
     configUtils    = require('../utils/configUtils'),
@@ -261,7 +261,7 @@ describe('Config', function () {
 
             it('should return url for a post from post object', function () {
                 var testContext = 'post',
-                    testData = {post: testUtils.DataGenerator.Content.posts[2]};
+                    testData = {post: _.cloneDeep(testUtils.DataGenerator.Content.posts[2])};
 
                 // url is now provided on the postmodel, permalinkSetting tests are in the model_post_spec.js test
                 testData.post.url = '/short-and-sweet/';

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -311,7 +311,8 @@ describe('Error handling', function () {
     });
 
     describe('Rendering', function () {
-        var sandbox;
+        var app,
+            sandbox;
 
         before(function () {
             configUtils.set({
@@ -340,6 +341,7 @@ describe('Error handling', function () {
         });
 
         beforeEach(function () {
+            app = express();
             sandbox = sinon.sandbox.create();
         });
 
@@ -349,10 +351,9 @@ describe('Error handling', function () {
 
         it('Renders end-of-middleware 404 errors correctly', function (done) {
             var req = {method: 'GET'},
-                res = express.response;
+                res = app.response;
 
-            sandbox.stub(express.response, 'render', function (view, options, fn) {
-                /*jshint unused:false */
+            sandbox.stub(res, 'render', function (view, options/*, fn*/) {
                 view.should.match(/user-error\.hbs/);
 
                 // Test that the message is correct
@@ -364,15 +365,15 @@ describe('Error handling', function () {
                 done();
             });
 
-            sandbox.stub(express.response, 'status', function (status) {
-                res.statusCode = status;
-                return res;
+            sandbox.stub(res, 'status', function (status) {
+                this.statusCode = status;
+                return this;
             });
 
             sandbox.stub(res, 'set', function (value) {
                 // Test that the headers are correct
                 value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-                return res;
+                return this;
             });
 
             errors.error404(req, res, done);
@@ -381,10 +382,9 @@ describe('Error handling', function () {
         it('Renders thrown 404 errors correctly', function (done) {
             var err = new Error('A thing was not found'),
                 req = {method: 'GET'},
-                res = express.response;
+                res = app.response;
 
-            sandbox.stub(express.response, 'render', function (view, options, fn) {
-                /*jshint unused:false */
+            sandbox.stub(res, 'render', function (view, options/*, fn*/) {
                 view.should.match(/user-error\.hbs/);
 
                 // Test that the message is correct
@@ -396,15 +396,15 @@ describe('Error handling', function () {
                 done();
             });
 
-            sandbox.stub(express.response, 'status', function (status) {
-                res.statusCode = status;
-                return res;
+            sandbox.stub(res, 'status', function (status) {
+                this.statusCode = status;
+                return this;
             });
 
             sandbox.stub(res, 'set', function (value) {
                 // Test that the headers are correct
                 value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-                return res;
+                return this;
             });
 
             err.status = 404;
@@ -414,10 +414,9 @@ describe('Error handling', function () {
         it('Renders thrown errors correctly', function (done) {
             var err = new Error('I am a big bad error'),
                 req = {method: 'GET'},
-                res = express.response;
+                res = app.response;
 
-            sandbox.stub(express.response, 'render', function (view, options, fn) {
-                /*jshint unused:false */
+            sandbox.stub(res, 'render', function (view, options/*, fn*/) {
                 view.should.match(/user-error\.hbs/);
 
                 // Test that the message is correct
@@ -432,12 +431,12 @@ describe('Error handling', function () {
             sandbox.stub(res, 'set', function (value) {
                 // Test that the headers are correct
                 value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-                return res;
+                return this;
             });
 
-            sandbox.stub(express.response, 'status', function (status) {
-                res.statusCode = status;
-                return res;
+            sandbox.stub(res, 'status', function (status) {
+                this.statusCode = status;
+                return this;
             });
 
             errors.error500(err, req, res, null);
@@ -446,10 +445,9 @@ describe('Error handling', function () {
         it('Renders 500 errors correctly', function (done) {
             var err = new Error('I am a big bad error'),
                 req = {method: 'GET'},
-                res = express.response;
+                res = app.response;
 
-            sandbox.stub(express.response, 'render', function (view, options, fn) {
-                /*jshint unused:false */
+            sandbox.stub(res, 'render', function (view, options/*, fn*/) {
                 view.should.match(/user-error\.hbs/);
 
                 // Test that the message is correct
@@ -461,15 +459,15 @@ describe('Error handling', function () {
                 done();
             });
 
-            sandbox.stub(express.response, 'status', function (status) {
-                res.statusCode = status;
-                return res;
+            sandbox.stub(res, 'status', function (status) {
+                this.statusCode = status;
+                return this;
             });
 
             sandbox.stub(res, 'set', function (value) {
                 // Test that the headers are correct
                 value['Cache-Control'].should.eql('no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0');
-                return res;
+                return this;
             });
 
             err.statusCode = 500;

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -27,7 +27,8 @@ describe('RSS', function () {
     var sandbox, req, res, posts;
 
     before(function () {
-        posts = _.filter(testUtils.DataGenerator.forKnex.posts, function filter(post) {
+        posts = _.cloneDeep(testUtils.DataGenerator.forKnex.posts);
+        posts = _.filter(posts, function filter(post) {
             return post.status === 'published' && post.page === false;
         });
 


### PR DESCRIPTION
- Stub moment instead of using a fake clock.
- Do not mutate fixture data.
- Do not modify express.response.

This allows all the tests to be run in a single process, which means we can run a unified coverage task.
