### PR TITLE
Avoid use of this.attrs for closure actions

### DIFF
--- a/core/client/app/components/gh-datetime-input.js
+++ b/core/client/app/components/gh-datetime-input.js
@@ -17,7 +17,7 @@ export default Component.extend(TextInputMixin, {
     didReceiveAttrs() {
         let datetime = this.get('datetime') || moment();
 
-        if (!this.attrs.update) {
+        if (!this.get('update')) {
             throw new Error(`You must provide an \`update\` action to \`{{${this.templateName}}}\`.`);
         }
 
@@ -27,6 +27,6 @@ export default Component.extend(TextInputMixin, {
     focusOut() {
         let datetime = this.get('datetime');
 
-        this.attrs.update(datetime);
+        this.get('update')(datetime);
     }
 });

--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -32,7 +32,7 @@ export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
 
         this.setFocus();
 
-        this.attrs.setEditor(this);
+        this.get('setEditor')(this);
 
         run.scheduleOnce('afterRender', this, this.afterRenderEvent);
     },
@@ -45,7 +45,7 @@ export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
 
     actions: {
         toggleCopyHTMLModal(generatedHTML) {
-            this.attrs.toggleCopyHTMLModal(generatedHTML);
+            this.get('toggleCopyHTMLModal')(generatedHTML);
         }
     }
 });

--- a/core/client/app/components/gh-editor.js
+++ b/core/client/app/components/gh-editor.js
@@ -52,8 +52,8 @@ export default Component.extend(ShortcutsMixin, {
     },
 
     willDestroyElement() {
-        if (this.attrs.onTeardown) {
-            this.attrs.onTeardown();
+        if (this.get('onTeardown')) {
+            this.get('onTeardown')();
         }
         this.removeShortcuts();
     },

--- a/core/client/app/components/gh-fullscreen-modal.js
+++ b/core/client/app/components/gh-fullscreen-modal.js
@@ -50,8 +50,8 @@ const FullScreenModalComponent = LiquidTether.extend({
 
     actions: {
         close() {
-            if (this.attrs.close) {
-                return this.attrs.close();
+            if (this.get('close')) {
+                return this.get('close')();
             }
 
             return new Promise((resolve) => {
@@ -60,8 +60,8 @@ const FullScreenModalComponent = LiquidTether.extend({
         },
 
         confirm() {
-            if (this.attrs.confirm) {
-                return this.attrs.confirm();
+            if (this.get('confirm')) {
+                return this.get('confirm')();
             }
 
             return new Promise((resolve) => {

--- a/core/client/app/components/gh-navitem-url-input.js
+++ b/core/client/app/components/gh-navitem-url-input.js
@@ -67,7 +67,7 @@ export default TextField.extend({
     },
 
     keyPress(event) {
-        this.attrs.clearErrors();
+        this.get('clearErrors')();
 
         // enter key
         if (event.keyCode === 13) {

--- a/core/client/app/components/gh-posts-list-item.js
+++ b/core/client/app/components/gh-posts-list-item.js
@@ -50,8 +50,8 @@ export default Component.extend(ActiveLinkWrapper, {
     willDestroyElement() {
         this._super(...arguments);
         this.removeObserver('active', this, this.scrollIntoView);
-        if (this.get('post.isDeleted') && this.attrs.onDelete) {
-            this.attrs.onDelete();
+        if (this.get('post.isDeleted') && this.get('onDelete')) {
+            this.get('onDelete')();
         }
     },
 

--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -108,15 +108,15 @@ export default Component.extend({
 
     actions: {
         setProperty(property, value) {
-            this.attrs.setProperty(property, value);
+            this.get('setProperty')(property, value);
         },
 
         setCoverImage(image) {
-            this.attrs.setProperty('image', image);
+            this.get('setProperty')('image', image);
         },
 
         clearCoverImage() {
-            this.attrs.setProperty('image', '');
+            this.get('setProperty')('image', '');
         },
 
         setUploaderReference() {
@@ -132,7 +132,7 @@ export default Component.extend({
         },
 
         deleteTag() {
-            this.attrs.showDeleteTagModal();
+            this.get('showDeleteTagModal')();
         }
     }
 

--- a/core/client/app/components/gh-tag.js
+++ b/core/client/app/components/gh-tag.js
@@ -4,8 +4,8 @@ export default Ember.Component.extend({
     willDestroyElement() {
         this._super(...arguments);
 
-        if (this.get('tag.isDeleted') && this.attrs.onDelete) {
-            this.attrs.onDelete();
+        if (this.get('tag.isDeleted') && this.get('onDelete')) {
+            this.get('onDelete')();
         }
     }
 });

--- a/core/client/app/components/modals/base.js
+++ b/core/client/app/components/modals/base.js
@@ -49,7 +49,7 @@ export default Component.extend({
         },
 
         closeModal() {
-            this.attrs.closeModal();
+            this.get('closeModal')();
         }
     }
 });

--- a/core/client/app/components/modals/delete-tag.js
+++ b/core/client/app/components/modals/delete-tag.js
@@ -18,7 +18,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.attrs.confirm().finally(() => {
+            this.get('confirm')().finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/delete-user.js
+++ b/core/client/app/components/modals/delete-user.js
@@ -10,7 +10,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.attrs.confirm().finally(() => {
+            this.get('confirm')().finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/leave-editor.js
+++ b/core/client/app/components/modals/leave-editor.js
@@ -3,7 +3,7 @@ import ModalComponent from 'ghost/components/modals/base';
 export default ModalComponent.extend({
     actions: {
         confirm() {
-            this.attrs.confirm().finally(() => {
+            this.get('confirm').finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/transfer-owner.js
+++ b/core/client/app/components/modals/transfer-owner.js
@@ -8,7 +8,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.attrs.confirm().finally(() => {
+            this.get('confirm')().finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/mixins/ed-editor-scroll.js
+++ b/core/client/app/mixins/ed-editor-scroll.js
@@ -61,7 +61,7 @@ export default Mixin.create({
      */
     scrollHandler() {
         this.set('scrollThrottle', run.throttle(this, () => {
-            this.attrs.updateScrollInfo(this.getScrollInfo());
+            this.get('updateScrollInfo')(this.getScrollInfo());
         }, 10));
     },
 

--- a/core/client/app/utils/link-component.js
+++ b/core/client/app/utils/link-component.js
@@ -6,8 +6,8 @@ LinkComponent.reopen({
     active: computed('attrs.params', '_routing.currentState', function () {
         let isActive = this._super(...arguments);
 
-        if (typeof this.attrs.alternateActive === 'function') {
-            this.attrs.alternateActive(isActive);
+        if (typeof this.get('alternateActive') === 'function') {
+            this.get('alternateActive')(isActive);
         }
 
         return isActive;

--- a/core/client/tests/integration/components/transfer-owner-test.js
+++ b/core/client/tests/integration/components/transfer-owner-test.js
@@ -1,0 +1,39 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+    describeComponent,
+    it
+} from 'ember-mocha';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+import sinon from 'sinon';
+
+const {RSVP, run} = Ember;
+
+describeComponent(
+    'transfer-owner',
+    'Integration: Component: modals/transfer-owner',
+    {
+        integration: true
+    },
+    function() {
+        it('triggers confirm action', function() {
+            let confirm = sinon.stub();
+            let closeModal = sinon.spy();
+
+            confirm.returns(RSVP.resolve({}));
+
+            this.on('confirm', confirm);
+            this.on('closeModal', closeModal);
+
+            this.render(hbs`{{modals/transfer-owner confirm=(action 'confirm') closeModal=(action 'closeModal')}}`);
+
+            run(() => {
+                this.$('.btn.btn-red').click();
+            });
+
+            expect(confirm.calledOnce, 'confirm called').to.be.true;
+            expect(closeModal.calledOnce, 'closeModal called').to.be.true;
+        });
+    }
+);


### PR DESCRIPTION
no issue
- `this.attrs` is a glimmer-component thing (which doesn't exist in Ghost yet), to avoid confusion we should avoid using it. A couple of references:
  - https://locks.svbtle.com/to-attrs-or-not-to-attrs
  - https://github.com/cibernox/ember-power-select/issues/233#issuecomment-170352572
