### PR TITLE
Remove io.js reference from startup-check

### DIFF
--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -33,8 +33,7 @@ checks = {
         var semver = require('semver');
 
         if (process.env.GHOST_NODE_VERSION_CHECK !== 'false' &&
-            !semver.satisfies(process.versions.node, packages.engines.node) &&
-            !semver.satisfies(process.versions.node, packages.engines.iojs)) {
+            !semver.satisfies(process.versions.node, packages.engines.node)) {
             console.error('\x1B[31mERROR: Unsupported version of Node');
             console.error('\x1B[31mGhost needs Node version ' + packages.engines.node +
                           ' you are using version ' + process.versions.node + '\033[0m\n');


### PR DESCRIPTION
No need to be checking `engines` for io.js since it has been removed.
