### PR TITLE
fix: update_check_spec setup, serve-shared-file_spec setup

### DIFF
--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -1,11 +1,11 @@
 /*globals describe, before, beforeEach, afterEach, after, it*/
-var testUtils       = require('../utils'),
-    should          = require('should'),
-    rewire          = require('rewire'),
+var testUtils   = require('../utils'),
+    should      = require('should'),
+    rewire      = require('rewire'),
 
     // Stuff we are testing
-    packageInfo     = require('../../../package'),
-    updateCheck     = rewire('../../server/update-check');
+    packageInfo = require('../../../package'),
+    updateCheck = rewire('../../server/update-check');
 
 describe('Update Check', function () {
     var environmentsOrig;
@@ -19,7 +19,7 @@ describe('Update Check', function () {
         updateCheck.__set__('allowedCheckEnvironments', environmentsOrig);
     });
 
-    beforeEach(testUtils.setup('owner', 'posts'));
+    beforeEach(testUtils.setup('owner', 'posts', 'perms:setting', 'perms:user', 'perms:init'));
 
     afterEach(testUtils.teardown);
 

--- a/core/test/unit/middleware/serve-shared-file_spec.js
+++ b/core/test/unit/middleware/serve-shared-file_spec.js
@@ -1,9 +1,11 @@
 /*globals describe, it, beforeEach, afterEach */
 var fs              = require('fs'),
     sinon           = require('sinon'),
+    should          = require('should'),
     serveSharedFile = require('../../../server/middleware/serve-shared-file'),
-
     sandbox = sinon.sandbox.create();
+
+should.equal(true, true);
 
 describe('serveSharedFile', function () {
     var res, req, next;


### PR DESCRIPTION
Hey!

i fixed two small test setup mistakes, there is no issue i can refer to, because i discovered them by coincidence.

The two tests i fixed were green when running all tests, because js file cache was already setup by other tests. When you run them in single mode, they failed.

Especially for update_check_spec.js it was hard to find the reason, because this is the error output before my fix:

```
Unhandled rejection TypeError: Cannot read property 'type' of undefined
    at checkSettingPermissions (/Users/kirrg001/dev/ghost/core/server/api/settings.js:262:24)
    at /Users/kirrg001/dev/ghost/core/server/api/settings.js:279:28
    at tryCatcher (/Users/kirrg001/dev/ghost/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler 
    ....
```

So it was hard to understand why settings is undefined. And server/update-check.js 81 returns already an error with the initial problem:

```
{ hash:
   PromiseInspection {
     _bitField: 16777217,
     _settledValueField: [Error: No actions map found, please call permissions.init() before use.] },
```

I am not yet super familiar with your code, but this looks to me like the execution should never jump to success case in line 81 in update-check.js, because of a thrown error by permissions module. Tell me if i am wrong.
