### PR TITLE
Improve code for handling fixture migrations

### DIFF
--- a/core/server/data/migration/fixtures/fixtures.json
+++ b/core/server/data/migration/fixtures/fixtures.json
@@ -48,18 +48,18 @@
         {
             "name": "Role",
             "entries": [
-            {
-                "name":             "Administrator",
-                "description":      "Administrators"
-            },
-            {
-                "name":             "Editor",
-                "description":      "Editors"
-            },
-            {
-                "name":             "Author",
-                "description":      "Authors"
-            },
+                {
+                    "name":             "Administrator",
+                    "description":      "Administrators"
+                },
+                {
+                    "name":             "Editor",
+                    "description":      "Editors"
+                },
+                {
+                    "name":             "Author",
+                    "description":      "Authors"
+                },
                 {
                     "name":             "Owner",
                     "description":      "Blog Owner"

--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -2,7 +2,6 @@
 // This module handles populating fixtures on a fresh install.
 // This is done automatically, by reading the fixtures.json file
 // All models, and relationships inside the file are then setup.
-
 var Promise      = require('bluebird'),
     models       = require('../../../models'),
     coreUtils    = require('../../../utils'),

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -30,7 +30,8 @@ Role = ghostBookshelf.Model.extend({
             // whitelists for the `options` hash argument on methods, by method name.
             // these are the only options that can be passed to Bookshelf / Knex.
             validOptions = {
-                findOne: ['withRelated']
+                findOne: ['withRelated'],
+                findAll: ['withRelated']
             };
 
         if (validOptions[methodName]) {

--- a/core/test/unit/migration_fixture_utils_spec.js
+++ b/core/test/unit/migration_fixture_utils_spec.js
@@ -1,0 +1,289 @@
+/*global describe, it, beforeEach, afterEach */
+var should  = require('should'),
+    sinon   = require('sinon'),
+    Promise = require('bluebird'),
+    rewire  = require('rewire'),
+
+    models  = require('../../server/models'),
+
+    fixtureUtils = rewire('../../server/data/migration/fixtures/utils'),
+    fixtures     = require('../../server/data/migration/fixtures/fixtures'),
+    sandbox = sinon.sandbox.create();
+
+describe('Utils', function () {
+    var loggerStub;
+
+    beforeEach(function () {
+        loggerStub = {
+            info: sandbox.stub(),
+            warn: sandbox.stub()
+        };
+
+        models.init();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('Match Func', function () {
+        var matchFunc = fixtureUtils.__get__('matchFunc'),
+            getStub;
+
+        beforeEach(function () {
+            getStub = sandbox.stub();
+            getStub.withArgs('foo').returns('bar');
+            getStub.withArgs('fun').returns('baz');
+        });
+
+        it('should match undefined with no args', function () {
+            matchFunc()({get: getStub}).should.be.true();
+            getStub.calledOnce.should.be.true();
+            getStub.calledWith(undefined).should.be.true();
+        });
+
+        it('should match key with match string', function () {
+            matchFunc('foo', 'bar')({get: getStub}).should.be.true();
+            getStub.calledOnce.should.be.true();
+            getStub.calledWith('foo').should.be.true();
+
+            matchFunc('foo', 'buz')({get: getStub}).should.be.false();
+            getStub.calledTwice.should.be.true();
+            getStub.secondCall.calledWith('foo').should.be.true();
+        });
+
+        it('should match value when key is 0', function () {
+            matchFunc('foo', 0, 'bar')({get: getStub}).should.be.true();
+            getStub.calledOnce.should.be.true();
+            getStub.calledWith('foo').should.be.true();
+
+            matchFunc('foo', 0, 'buz')({get: getStub}).should.be.false();
+            getStub.calledTwice.should.be.true();
+            getStub.secondCall.calledWith('foo').should.be.true();
+        });
+
+        it('should match key & value when match is array', function () {
+            matchFunc(['foo', 'fun'], 'bar', 'baz')({get: getStub}).should.be.true();
+            getStub.calledTwice.should.be.true();
+            getStub.getCall(0).calledWith('fun').should.be.true();
+            getStub.getCall(1).calledWith('foo').should.be.true();
+
+            matchFunc(['foo', 'fun'], 'baz', 'bar')({get: getStub}).should.be.false();
+            getStub.callCount.should.eql(4);
+            getStub.getCall(2).calledWith('fun').should.be.true();
+            getStub.getCall(3).calledWith('foo').should.be.true();
+        });
+
+        it('should match key only when match is array, but value is all', function () {
+            matchFunc(['foo', 'fun'], 'bar', 'all')({get: getStub}).should.be.true();
+            getStub.calledOnce.should.be.true();
+            getStub.calledWith('foo').should.be.true();
+
+            matchFunc(['foo', 'fun'], 'all', 'bar')({get: getStub}).should.be.false();
+            getStub.callCount.should.eql(3);
+            getStub.getCall(1).calledWith('fun').should.be.true();
+            getStub.getCall(2).calledWith('foo').should.be.true();
+        });
+
+        it('should match key & value when match and value are arrays', function () {
+            matchFunc(['foo', 'fun'], 'bar', ['baz', 'buz'])({get: getStub}).should.be.true();
+            getStub.calledTwice.should.be.true();
+            getStub.getCall(0).calledWith('fun').should.be.true();
+            getStub.getCall(1).calledWith('foo').should.be.true();
+
+            matchFunc(['foo', 'fun'], 'bar', ['biz', 'buz'])({get: getStub}).should.be.false();
+            getStub.callCount.should.eql(4);
+            getStub.getCall(2).calledWith('fun').should.be.true();
+            getStub.getCall(3).calledWith('foo').should.be.true();
+        });
+    });
+
+    describe('Add Fixtures For Model', function () {
+        it('should call add for main post fixture', function (done) {
+            var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve()),
+                postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
+
+            fixtureUtils.addFixturesForModel(fixtures.models[0]).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Object();
+                result.should.have.property('expected',  1);
+                result.should.have.property('done',  1);
+
+                postOneStub.calledOnce.should.be.true();
+                postAddStub.calledOnce.should.be.true();
+
+                done();
+            });
+        });
+
+        it('should not call add for main post fixture if it is already found', function (done) {
+            var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve({})),
+                postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
+            fixtureUtils.addFixturesForModel(fixtures.models[0]).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Object();
+                result.should.have.property('expected',  1);
+                result.should.have.property('done',  0);
+
+                postOneStub.calledOnce.should.be.true();
+                postAddStub.calledOnce.should.be.false();
+
+                done();
+            });
+        });
+    });
+
+    describe('Add Fixtures For Relation', function () {
+        it('should call attach for permissions-roles', function (done) {
+            var fromItem = {
+                    related: sandbox.stub().returnsThis(),
+                    findWhere: sandbox.stub().returns(),
+                    permissions: sandbox.stub().returnsThis(),
+                    attach: sandbox.stub().returns(Promise.resolve([{}]))
+                },
+                toItem = [{get: sandbox.stub()}],
+                dataMethodStub = {
+                    filter: sandbox.stub().returns(toItem),
+                    find: sandbox.stub().returns(fromItem)
+                },
+                permsAllStub = sandbox.stub(models.Permission, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                rolesAllStub = sandbox.stub(models.Role, 'findAll').returns(Promise.resolve(dataMethodStub));
+
+            fixtureUtils.addFixturesForRelation(fixtures.relations[0]).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Object();
+                result.should.have.property('expected',  22);
+                result.should.have.property('done',  22);
+
+                // Permissions & Roles
+                permsAllStub.calledOnce.should.be.true();
+                rolesAllStub.calledOnce.should.be.true();
+                dataMethodStub.filter.callCount.should.eql(22);
+                dataMethodStub.find.callCount.should.eql(3);
+
+                fromItem.related.callCount.should.eql(22);
+                fromItem.findWhere.callCount.should.eql(22);
+                toItem[0].get.callCount.should.eql(44);
+
+                fromItem.permissions.callCount.should.eql(22);
+                fromItem.attach.callCount.should.eql(22);
+                fromItem.attach.calledWith(toItem).should.be.true();
+
+                done();
+            }).catch(done);
+        });
+
+        it('should call attach for posts-tags', function (done) {
+            var fromItem = {
+                    related: sandbox.stub().returnsThis(),
+                    findWhere: sandbox.stub().returns(),
+                    tags: sandbox.stub().returnsThis(),
+                    attach: sandbox.stub().returns(Promise.resolve([{}]))
+                },
+                toItem = [{get: sandbox.stub()}],
+                dataMethodStub = {
+                    filter: sandbox.stub().returns(toItem),
+                    find: sandbox.stub().returns(fromItem)
+                },
+
+                postsAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                tagsAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
+
+            fixtureUtils.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Object();
+                result.should.have.property('expected',  1);
+                result.should.have.property('done',  1);
+
+                // Posts & Tags
+                postsAllStub.calledOnce.should.be.true();
+                tagsAllStub.calledOnce.should.be.true();
+                dataMethodStub.filter.calledOnce.should.be.true();
+                dataMethodStub.find.calledOnce.should.be.true();
+
+                fromItem.related.calledOnce.should.be.true();
+                fromItem.findWhere.calledOnce.should.be.true();
+                toItem[0].get.calledOnce.should.be.true();
+
+                fromItem.tags.calledOnce.should.be.true();
+                fromItem.attach.calledOnce.should.be.true();
+                fromItem.attach.calledWith(toItem).should.be.true();
+
+                done();
+            }).catch(done);
+        });
+
+        it('will not call attach for posts-tags if already present', function (done) {
+            var fromItem = {
+                    related: sandbox.stub().returnsThis(),
+                    findWhere: sandbox.stub().returns({}),
+                    tags: sandbox.stub().returnsThis(),
+                    attach: sandbox.stub().returns(Promise.resolve({}))
+                },
+                toItem = [{get: sandbox.stub()}],
+                dataMethodStub = {
+                    filter: sandbox.stub().returns(toItem),
+                    find: sandbox.stub().returns(fromItem)
+                },
+
+                postsAllStub = sandbox.stub(models.Post, 'findAll').returns(Promise.resolve(dataMethodStub)),
+                tagsAllStub = sandbox.stub(models.Tag, 'findAll').returns(Promise.resolve(dataMethodStub));
+
+            fixtureUtils.addFixturesForRelation(fixtures.relations[1]).then(function (result) {
+                should.exist(result);
+                result.should.be.an.Object();
+                result.should.have.property('expected',  1);
+                result.should.have.property('done',  0);
+
+                // Posts & Tags
+                postsAllStub.calledOnce.should.be.true();
+                tagsAllStub.calledOnce.should.be.true();
+                dataMethodStub.filter.calledOnce.should.be.true();
+                dataMethodStub.find.calledOnce.should.be.true();
+
+                fromItem.related.calledOnce.should.be.true();
+                fromItem.findWhere.calledOnce.should.be.true();
+                toItem[0].get.calledOnce.should.be.true();
+
+                fromItem.tags.called.should.be.false();
+                fromItem.attach.called.should.be.false();
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('findModelFixtureEntry', function () {
+        it('should fetch a single fixture entry', function () {
+            var foundFixture = fixtureUtils.findModelFixtureEntry('Client', {slug: 'ghost-admin'});
+            foundFixture.should.be.an.Object();
+            foundFixture.should.eql({
+                name:             'Ghost Admin',
+                slug:             'ghost-admin',
+                status:           'enabled'
+            });
+        });
+    });
+
+    describe('findModelFixtures', function () {
+        it('should fetch a fixture with multiple entries', function () {
+            var foundFixture = fixtureUtils.findModelFixtures('Permission', {object_type: 'db'});
+            foundFixture.should.be.an.Object();
+            foundFixture.entries.should.be.an.Array().with.lengthOf(3);
+            foundFixture.entries[0].should.eql({
+                name: 'Export database',
+                action_type: 'exportContent',
+                object_type: 'db'
+            });
+        });
+    });
+
+    describe('findPermissionRelationsForObject', function () {
+        it('should fetch a fixture with multiple entries', function () {
+            var foundFixture = fixtureUtils.findPermissionRelationsForObject('db');
+            foundFixture.should.be.an.Object();
+            foundFixture.entries.should.be.an.Object();
+            foundFixture.entries.should.have.property('Administrator', {db: 'all'});
+        });
+    });
+});

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -316,7 +316,7 @@ fixtures = {
     },
 
     permissionsFor: function permissionsFor(obj) {
-        var permsToInsert = fixtureUtils.findPermissionModelForObject('Permission', {object_type: obj}).entries,
+        var permsToInsert = fixtureUtils.findModelFixtures('Permission', {object_type: obj}).entries,
             permsRolesToInsert = fixtureUtils.findPermissionRelationsForObject(obj).entries,
             actions = [],
             permissionsRoles = [],


### PR DESCRIPTION
I've been working on adding new fixtures to `permissions` and `permissions_roles` for clients. We also need to do this for several API endpoints that are missing them (see #3911) and for any new endpoints we add, e.g. for #6399.

Therefore, I've been working with a view to minimise the code in each migration, and keep the body of the work in the utils class, which is also properly tested. 

With these changes, the additional work to add the permissions becomes minimal. 

refs #6301, #4176
- always check existence of items before attempting to create them, in order to prevent duplicates
- provide stats on how many object creations are expected vs done
- split out and improve fixture utils tests (100% covers utils)
