### PR TITLE
fix post btn css

### DIFF
--- a/core/client/app/styles/components/splitbuttons.css
+++ b/core/client/app/styles/components/splitbuttons.css
@@ -48,7 +48,6 @@
 .splitbtn .dropdown-toggle.btn-sm {
     padding-right: 10px;
     padding-left: 10px;
-    height: 31px;
 }
 
 .splitbtn .dropdown-toggle.btn-lg {

--- a/core/client/app/styles/patterns/buttons.css
+++ b/core/client/app/styles/patterns/buttons.css
@@ -61,7 +61,6 @@ fieldset[disabled] .btn {
 }
 
 .btn i {
-    display: inline-block;
     vertical-align: middle;
 }
 


### PR DESCRIPTION
The splitbutton has different height due to different font size.(different smallest font size in different browser language env). This should fix it. 

![image](https://cloud.githubusercontent.com/assets/302560/14423938/f268b3f8-0010-11e6-863a-532874caacc6.png)
