### PR TITLE
Fix leave editor modal

### DIFF
--- a/core/client/app/components/modals/leave-editor.js
+++ b/core/client/app/components/modals/leave-editor.js
@@ -3,7 +3,7 @@ import ModalComponent from 'ghost/components/modals/base';
 export default ModalComponent.extend({
     actions: {
         confirm() {
-            this.get('confirm').finally(() => {
+            this.get('confirm')().finally(() => {
                 this.send('closeModal');
             });
         }


### PR DESCRIPTION
no issue
- following up from 6680, fixes a missing set of parentheses

@kevinansfield this brings up an interesting point. In the interest of readability, would it make sense to change this:

``` js
this.get('someAction')();
```

 to something more like this?

``` js
let someAction = this.get('someAction');

someAction();
```

Maybe not necessarily for all of them, but for the ones that have something like a `.finally()` or `.then()` afterwards, I feel like it would make it more readable.
