### PR TITLE
add append option to content helper

### DIFF
--- a/core/server/data/meta/excerpt.js
+++ b/core/server/data/meta/excerpt.js
@@ -1,14 +1,15 @@
 var downsize = require('downsize');
+var stripTags = require('striptags');
 
 function getExcerpt(html, truncateOptions) {
     truncateOptions = truncateOptions || {};
     // Strip inline and bottom footnotes
     var excerpt = html.replace(/<a href="#fn.*?rel="footnote">.*?<\/a>/gi, '');
     excerpt = excerpt.replace(/<div class="footnotes"><ol>.*?<\/ol><\/div>/, '');
-    // Strip other html
-    excerpt = excerpt.replace(/<\/?[^>]+>/gi, '');
+
+    excerpt = stripTags(excerpt, '<a><abbr><b><bdi><bdo><blockquote><br><cite><code><data><dd><del><dfn><dl><dt><em><i><ins><kbd><li><mark><ol><p><pre><q><rp><rt><rtc><ruby><s><samp><small><span><strong><sub><sup><time><u><ul><var><wbr>');
+
     excerpt = excerpt.replace(/(\r\n|\n|\r)+/gm, ' ');
-    /*jslint regexp:false */
 
     if (!truncateOptions.words && !truncateOptions.characters) {
         truncateOptions.words = 50;

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -18,8 +18,13 @@ content = function (options) {
     _.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
-    if (typeof(options.hash.append) !== 'undefined') {
-        truncateOptions.append = options.hash.append;
+    
+    try {
+        if (typeof(options.hash.append) !== 'undefined') {
+            truncateOptions.append = options.hash.append;
+        }
+    } catch(e) {
+        //do absolutely nothing, because nothing needs to be done.
     }
     
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -18,8 +18,9 @@ content = function (options) {
     _.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
-
-    truncateOptions.append = options.hash.append;
+    if (typeof(options.hash.append) !== 'undefined') {
+        truncateOptions.append = options.hash.append;
+    }
     
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
         // Legacy function: {{content words="0"}} should return leading tags.

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -20,9 +20,7 @@ content = function (options) {
     });
     
     try {
-        if (typeof(options.hash.append) !== 'undefined') {
-            truncateOptions.append = options.hash.append;
-        }
+        truncateOptions.append = options.hash.append;
     } catch(e) {
         //do absolutely nothing, because nothing needs to be done.
     }

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -18,13 +18,13 @@ content = function (options) {
     _.keys(truncateOptions).map(function (key) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
-    
+
     try {
         truncateOptions.append = options.hash.append;
-    } catch(e) {
-        //do absolutely nothing, because nothing needs to be done.
+    } catch (e) {
+        // do absolutely nothing, because nothing needs to be done.
     }
-    
+
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
         // Legacy function: {{content words="0"}} should return leading tags.
         if (truncateOptions.hasOwnProperty('words') && truncateOptions.words === 0) {

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -1,5 +1,5 @@
 // # Content Helper
-// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}}`
+// Usage: `{{content}}`, `{{content words="20"}}`, `{{content characters="256"}}`, `{{content words="20" append="..."}}`
 //
 // Turns content html into a safestring so that the user doesn't have to
 // escape it or tell handlebars to leave it alone with a triple-brace.
@@ -19,6 +19,8 @@ content = function (options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
+    truncateOptions.append = options.hash.append;
+    
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
         // Legacy function: {{content words="0"}} should return leading tags.
         if (truncateOptions.hasOwnProperty('words') && truncateOptions.words === 0) {
@@ -26,7 +28,6 @@ content = function (options) {
                 downzero(this.html)
             );
         }
-
         return new hbs.handlebars.SafeString(
             downsize(this.html, truncateOptions)
         );

--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -1,5 +1,5 @@
 // # Excerpt Helper
-// Usage: `{{excerpt}}`, `{{excerpt words="50"}}`, `{{excerpt characters="256"}}`
+// Usage: `{{excerpt}}`, `{{excerpt words="50"}}`, `{{excerpt characters="256"}}`, `{{excerpt characters="21" append="..."}}`
 //
 // Attempts to remove all HTML from the string, and then shortens the result according to the provided option.
 //
@@ -17,6 +17,12 @@ function excerpt(options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
+    try{
+        truncateOptions.append = options.hash.append;
+    } catch (e) {
+        //do nothing, because nothing is good.
+    }
+    
     return new hbs.handlebars.SafeString(
         getMetaDataExcerpt(String(this.html), truncateOptions)
     );

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rss": "1.2.1",
     "semver": "5.1.0",
     "showdown-ghost": "0.3.6",
-    "striptags": "2.1.1";
+    "striptags": "2.1.1",
     "sqlite3": "3.1.1",
     "unidecode": "0.1.8",
     "validator": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "rss": "1.2.1",
     "semver": "5.1.0",
     "showdown-ghost": "0.3.6",
+    "striptags": "2.1.1";
     "sqlite3": "3.1.1",
     "unidecode": "0.1.8",
     "validator": "4.5.0",


### PR DESCRIPTION
just stopping with no append is silly. lez fix dis. I added an append option to the helper.
`{{content characters="250" append="..."}}`
`{{content characters="250" append="★"}}`
`{{content characters="250" append="A LONG TIME AGO..."}}`
`{{content words="40" append="limiting with words? ohhhhkay...."}}`
they all work. **well.**

it works with all the builds and tests that it says to run. i tested it with different ascii/hex/random things and it never failed.
