### PR TITLE
Enable ability to mock endpoints in development mode

### DIFF
--- a/core/client/app/mirage/config.js
+++ b/core/client/app/mirage/config.js
@@ -52,6 +52,22 @@ export default function () {
     this.namespace = 'ghost/api/v0.1';    // make this `api`, for example, if your API is namespaced
     // this.timing = 400;      // delay for each request, automatically set to 0 during testing
 
+    // Mock endpoints here to override real API requests during development
+
+    // keep this line, it allows all other API requests to hit the real server
+    this.passthrough();
+
+    // add any external domains to make sure those get passed through too
+    this.passthrough('https://count.ghost.org/');
+    this.passthrough('http://www.gravatar.com/**');
+}
+
+// Mock all endpoints here as there is no real API during testing
+export function testConfig() {
+    // this.urlPrefix = '';    // make this `http://localhost:8080`, for example, if your API is on a different server
+    this.namespace = 'ghost/api/v0.1';    // make this `api`, for example, if your API is namespaced
+    // this.timing = 400;      // delay for each request, automatically set to 0 during testing
+
     /* Authentication ------------------------------------------------------- */
 
     this.post('/authentication/token', function () {
@@ -326,10 +342,3 @@ export default function () {
         };
     });
 }
-
-/*
-You can optionally export a config that is only loaded during tests
-export function testConfig() {
-
-}
-*/

--- a/core/client/config/environment.js
+++ b/core/client/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function (environment) {
         ENV.APP.LOG_TRANSITIONS = true;
         ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
         ENV.APP.LOG_VIEW_LOOKUPS = true;
+        // Enable mirage here in order to mock API endpoints during development
         ENV['ember-cli-mirage'] = {
             enabled: false
         };


### PR DESCRIPTION
no issue
- moves existing mirage config into the `testConfig()` function to retain full mocks during testing
- configure mirage to passthrough all requests when in development mode

Our existing mirage config that we use for testing was set up as the default/development config which meant that we had to explicitly disable it when in development mode - this has the unfortunate side-effect of removing the ability mock endpoints when developing new features.

This PR moves everything we currently have into the "test" config and sets up a new mirage development config where endpoints can be overridden with mocks and any requests that aren't handled by a mock will be passed through to the real API.
