### PR TITLE
Let ember determine jquery version

### DIFF
--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -11,7 +11,6 @@
     "Faker": "3.1.0",
     "fastclick": "1.0.6",
     "google-caja": "5669.0.0",
-    "jquery": "2.1.4",
     "jquery-deparam": "~0.5.0",
     "jquery-file-upload": "9.5.6",
     "jquery-ui": "1.11.4",


### PR DESCRIPTION
no issue
- there's no longer any need to pin the jQuery version as ember now specifies which jquery versions it supports, with the current ember version this moves us from `2.1.4` to `2.2.3`
