### PR TITLE
update excerpt to do what is suggested in #5060

### DIFF
--- a/core/server/data/meta/excerpt.js
+++ b/core/server/data/meta/excerpt.js
@@ -1,14 +1,15 @@
 var downsize = require('downsize');
+var stripTags = require('striptags');
 
 function getExcerpt(html, truncateOptions) {
     truncateOptions = truncateOptions || {};
     // Strip inline and bottom footnotes
     var excerpt = html.replace(/<a href="#fn.*?rel="footnote">.*?<\/a>/gi, '');
     excerpt = excerpt.replace(/<div class="footnotes"><ol>.*?<\/ol><\/div>/, '');
-    // Strip other html
-    excerpt = excerpt.replace(/<\/?[^>]+>/gi, '');
+
+    excerpt = stripTags(excerpt, '<a><abbr><b><bdi><bdo><blockquote><br><cite><code><data><dd><del><dfn><dl><dt><em><i><ins><kbd><li><mark><ol><p><pre><q><rp><rt><rtc><ruby><s><samp><small><span><strong><sub><sup><time><u><ul><var><wbr>');
+
     excerpt = excerpt.replace(/(\r\n|\n|\r)+/gm, ' ');
-    /*jslint regexp:false */
 
     if (!truncateOptions.words && !truncateOptions.characters) {
         truncateOptions.words = 50;


### PR DESCRIPTION
will now strip all tags except
`a, abbr, b, bdi, bdo, blockquote, br, cite, code, data, dd, del, dfn, dl, dt, em, i, ins, kbd, li, mark, ol, p, pre, q, rp, rt, rtc, ruby, s, samp, small, span, strong, sub, sup, time, u, ul, var, wbr`
requires the package `striptags` to be added to the package.json
