### PR TITLE
Add browser testing via Saucelabs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: required
-dist: trusty
 language: node_js
 # When changing node version also update it on lines 34, 36 and 46.
 node_js:
@@ -11,15 +9,6 @@ cache:
     - node_modules
     - core/client/node_modules
     - core/client/bower_components
-addons:
-  firefox: "latest"
-  postgresql: "9.3"
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - mysql-server
-      - google-chrome-stable
 env:
   global:
     - GITHUB_OAUTH_KEY=003a44d58f12089d0c0261338298af3813330949
@@ -38,8 +27,6 @@ matrix:
 before_install:
   - if [ $DB == "mysql" ]; then mysql -u root -e 'create database ghost_testing'; fi
   - if [ $DB == "pg" ]; then psql -c 'create database ghost_testing;' -U postgres; fi
-before_script:
-  - if [ $TEST_SUITE == "client" ]; then export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3; fi
 after_success:
   - |
       if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -279,6 +279,12 @@ var _              = require('lodash'),
 
                             case 'test':
                                 return emberPath + ' test --silent';
+
+                            case 'sauce-start':
+                                return emberPath + ' sauce:connect';
+
+                            case 'sauce-stop':
+                                return emberPath + ' sauce:disconnect';
                         }
                     },
                     options: {
@@ -529,7 +535,7 @@ var _              = require('lodash'),
             if (process.env.TEST_SUITE === 'server') {
                 grunt.task.run(['init', 'test-server']);
             } else if (process.env.TEST_SUITE === 'client') {
-                grunt.task.run(['init', 'test-client']);
+                grunt.task.run(['init', 'shell:ember:sauce-start', 'test-client', 'shell:ember:sauce-stop']);
             } else if (process.env.TEST_SUITE === 'lint') {
                 grunt.task.run(['shell:ember:init', 'shell:bower', 'lint']);
             } else {

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -34,6 +34,7 @@
     "ember-cli-mocha": "0.10.1",
     "ember-cli-pretender": "0.6.0",
     "ember-cli-release": "0.2.8",
+    "ember-cli-sauce": "1.4.4",
     "ember-cli-selectize": "0.4.3",
     "ember-cli-sri": "2.1.0",
     "ember-cli-uglify": "1.2.0",

--- a/core/client/testem.js
+++ b/core/client/testem.js
@@ -1,14 +1,50 @@
-/*jshint node:true*/
-module.exports = {
-    'framework': 'mocha',
-    'test_page': 'tests/index.html?hidepassed',
-    'disable_watching': true,
-    'launch_in_ci': [
-        'Chrome',
-        'Firefox'
-    ],
-    'launch_in_dev': [
-        'Chrome',
-        'Firefox'
-    ]
-};
+/*jshint node:true */
+/* jscs:disable disallowVar, disallowMultipleVarDecl */
+/* jscs:disable requireTemplateStringsForConcatenation, requireCamelCaseOrUpperCaseIdentifiers */
+
+var ciBrowsers = [],
+    testem = {
+        framework: 'mocha',
+        test_page: 'tests/index.html?hidepassed',
+        disable_watching: true,
+        launch_in_dev: ['Chrome', 'Firefox'],
+        launchers: {}
+    };
+
+function saucelabsBrowser(browser, os) {
+    var key = 'SL_' + browser.toLowerCase().replace(' ', '_'), // normalize multi-word browsers
+        launcher = {
+            exe: 'ember',
+            args: [
+                'sauce:launch',
+                '-b',
+                browser,
+                '--vi',
+                'public',
+                '-p',
+                os,
+                '--at',
+                '--no-ct',
+                '--u'
+            ],
+            protocol: 'browser'
+        };
+
+    testem.launchers[key] = launcher;
+
+    return key;
+}
+
+if (process.env.CI === 'true') {
+    ciBrowsers = [
+        saucelabsBrowser('chrome', 'linux'),
+        saucelabsBrowser('firefox', 'linux'),
+        saucelabsBrowser('internet explorer', 'Windows 10')
+    ];
+} else {
+    ciBrowsers = ['Chrome', 'Firefox'];
+}
+
+testem.launch_in_ci = ciBrowsers;
+
+module.exports = testem;


### PR DESCRIPTION
This enables saucelabs testing so that Travis doesn't have to do browser testing.

It allows us to run on Ubuntu Precise still, and enables a wider range of browser testing.
