### PR TITLE
Ember Dependency Updates

### DIFF
--- a/core/client/app/instance-initializers/jquery-ajax-oauth-prefilter.js
+++ b/core/client/app/instance-initializers/jquery-ajax-oauth-prefilter.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-const {merge} = Ember;
+const {assign} = Ember;
 
 export default {
     name: 'jquery-ajax-oauth-prefilter',
@@ -14,7 +14,7 @@ export default {
                 let headerObject = {};
 
                 headerObject[headerName] = headerValue;
-                options.headers = merge(options.headers || {}, headerObject);
+                options.headers = assign(options.headers || {}, headerObject);
             });
         });
     }

--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -4,7 +4,7 @@
     "blueimp-md5": "2.3.0",
     "codemirror": "5.13.2",
     "devicejs": "0.2.7",
-    "ember": "2.4.4",
+    "ember": "2.5.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-mocha": "0.8.11",

--- a/core/client/config/deprecation-workflow.js
+++ b/core/client/config/deprecation-workflow.js
@@ -1,6 +1,7 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
     workflow: [
+        {handler: 'silence', matchMessage: 'Usage of `Ember.merge` is deprecated, use `Ember.assign` instead.'},
         {handler: 'silence', matchMessage: 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.'},
         {handler: 'silence', matchMessage: 'You modified (-join-classes "ember-view" "form-group" (-normalize-class "errorClass" errorClass activeClass=undefined inactiveClass=undefined)) twice in a single render. This was unreliable in Ember 1.x and will be removed in Ember 3.0'}
     ]

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -37,7 +37,7 @@
     "ember-cli-selectize": "0.4.3",
     "ember-cli-sri": "2.1.0",
     "ember-cli-uglify": "1.2.0",
-    "ember-data": "2.4.3",
+    "ember-data": "2.5.2",
     "ember-data-filter": "1.13.0",
     "ember-export-application-global": "1.0.5",
     "ember-load-initializers": "0.5.1",

--- a/core/client/tests/helpers/start-app.js
+++ b/core/client/tests/helpers/start-app.js
@@ -2,14 +2,14 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
-const {merge, run} = Ember;
+const {assign, run} = Ember;
 
 export default function startApp(attrs) {
-    let attributes = merge({}, config.APP);
+    let attributes = assign({}, config.APP);
     let application;
 
     // use defaults, but you can override;
-    attributes = merge(attributes, attrs);
+    attributes = assign(attributes, attrs);
 
     run(function () {
         application = Application.create(attributes);


### PR DESCRIPTION
no issue
- Updates Ember & Ember-Data to latest versions
- replace sparse usage of `Ember.merge` with `Ember.assign`

Ember 2.5: [blog post](http://emberjs.com/blog/2016/04/11/ember-2-5-released.html) and [release notes](https://github.com/emberjs/ember.js/releases/tag/v2.5.0)
Ember-Data 2.5: release notes [here](https://github.com/emberjs/data/releases/tag/v2.5.0) and [here](https://github.com/emberjs/data/releases/tag/v2.5.2)

_Note: Adds a deprecation workflow handler that is present due to ember-simple-auth, can be removed once that gets updated_
