### PR TITLE
Ember-CLI 2.5 update

### DIFF
--- a/core/client/package.json
+++ b/core/client/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "2.4.2",
     "ember-ajax": "0.7.1",
-    "ember-cli": "2.4.3",
+    "ember-cli": "2.5.0",
     "ember-cli-app-version": "1.0.0",
     "ember-cli-babel": "5.1.6",
     "ember-cli-content-security-policy": "0.4.0",
@@ -30,6 +30,7 @@
     "ember-cli-fastclick": "1.0.3",
     "ember-cli-htmlbars": "1.0.3",
     "ember-cli-htmlbars-inline-precompile": "0.3.1",
+    "ember-cli-jshint": "1.0.0",
     "ember-cli-mirage": "0.1.13",
     "ember-cli-mocha": "0.10.1",
     "ember-cli-pretender": "0.6.0",


### PR DESCRIPTION
no issue
- update ember-cli to 2.5 [release notes](https://github.com/ember-cli/ember-cli/releases/tag/v2.5.0)
