### PR TITLE
Improve `PaginationRoute` mixin

### DIFF
--- a/core/client/app/routes/posts.js
+++ b/core/client/app/routes/posts.js
@@ -1,9 +1,9 @@
 import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import PaginationRouteMixin from 'ghost/mixins/pagination-route';
+import PaginationMixin from 'ghost/mixins/pagination';
 
-export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationRouteMixin, {
+export default AuthenticatedRoute.extend(ShortcutsRoute, PaginationMixin, {
     titleToken: 'Content',
 
     paginationModel: 'post',

--- a/core/client/app/routes/settings/tags.js
+++ b/core/client/app/routes/settings/tags.js
@@ -3,9 +3,9 @@ import Ember from 'ember';
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
 import ShortcutsRoute from 'ghost/mixins/shortcuts-route';
-import PaginationRoute from 'ghost/mixins/pagination-route';
+import PaginationMixin from 'ghost/mixins/pagination';
 
-export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationRoute, ShortcutsRoute, {
+export default AuthenticatedRoute.extend(CurrentUserSettings, PaginationMixin, ShortcutsRoute, {
     titleToken: 'Settings - Tags',
 
     paginationModel: 'tag',

--- a/core/client/app/routes/team/index.js
+++ b/core/client/app/routes/team/index.js
@@ -1,9 +1,9 @@
 import AuthenticatedRoute from 'ghost/routes/authenticated';
 import CurrentUserSettings from 'ghost/mixins/current-user-settings';
-import PaginationRouteMixin from 'ghost/mixins/pagination-route';
+import PaginationMixin from 'ghost/mixins/pagination';
 import styleBody from 'ghost/mixins/style-body';
 
-export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, PaginationRouteMixin, {
+export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, PaginationMixin, {
     titleToken: 'Team',
 
     classNames: ['view-team'],


### PR DESCRIPTION
no issue
- returns the promise/result from `loadNextPage` so that it's return value can be utilised in closure actions
- sets the `isLoading` property in `loadFirstPage` to match `loadNextPage` behaviour
- reset the `isLoading` property even if the request fails
- adds a `didReceivePaginationMeta` hook so that consumers of the mixin can use the metadata values without having to rely on observers
  - eg. pulling the `total` into a separate property that can be manipulated when items are added/removed but still reset to the sever's total value the next time a page is loaded
- renames the `pagination-route` mixin to simply `pagination` as it's not tied to routes and works equally well in other objects that need to paginate an API resource
