### PR TITLE
Allow Ember to specify jQuery version

### DIFF
--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -11,7 +11,6 @@
     "Faker": "3.1.0",
     "fastclick": "1.0.6",
     "google-caja": "5669.0.0",
-    "jquery": "2.1.4",
     "jquery-deparam": "~0.5.0",
     "jquery-file-upload": "9.5.6",
     "jquery-ui": "1.11.4",

--- a/core/client/tests/acceptance/settings/navigation-test.js
+++ b/core/client/tests/acceptance/settings/navigation-test.js
@@ -117,7 +117,7 @@ describe('Acceptance: Settings - Navigation', function () {
                 ).to.equal(3);
 
                 expect(
-                    find('.gh-blognav-item:last .response:visible').length,
+                    find('.gh-blognav-item:last .error').length,
                     'number of invalid fields in new item'
                 ).to.equal(1);
             });


### PR DESCRIPTION
replaces #6717 
- drops explicit jquery version dependency
- fix slight acceptance test bug

@kevinansfield I'm surprised this specific change triggered this test bug, but I updated it to make a bit more sense.
