### PR TITLE
deps: express-hbs@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cors": "2.7.1",
     "downsize": "0.0.8",
     "express": "4.13.4",
-    "express-hbs": "0.8.4",
+    "express-hbs": "1.0.0",
     "extract-zip": "1.4.1",
     "fs-extra": "0.26.5",
     "ghost-gql": "0.0.4",


### PR DESCRIPTION
This PR includes upgrading to handlebars v4 and is a breaking update to the theme API:

The breaking changes affect very rare use-cases, which should have very minimal impact.
## handlebars change: `../` now behaves more naturally.

The full explanation of this change is here: https://github.com/wycats/handlebars.js/issues/1028.

Impact: anywhere in theme templates or partials where there is a usage of `../` in a nested block must be reviewed. In most cases, it will be instances of multiple `../`'s e.g. `{{../../pagination.total}}` that felt unnatural in the first place.

Incidences of this causing breakage should be very rare. In most cases, I've seen Ghost themes work around this issue rather than use the unnatural syntax (Casper's tag.hbs is an example of this). In a survey of themes on Ghost(Pro) only one affected blog was located.
## handlebars change: `=` is now HTML escaped

More explanation [here](https://github.com/wycats/handlebars.js/pull/1083) and in the [handlebars v4 compatibility notes](https://github.com/wycats/handlebars.js/blob/master/release-notes.md#v400---september-1st-2015). This is a fix for a security vulnerability.

Impact: Ghost templates must always use quotes for HTML attributes which come from a handlebars helper. E.g. `<div class="{{page_class}}">`. Anywhere where quotes are not used, and the value includes an `=`, the `=` will now be HTML escaped. This will cause minor rendering issues, E.g. using `<a ... title={{tag.name}}>...` where the tag name is `foo = bar` would result in HTML like: `<a .. title="foo" &#x3d;="" bar="">...`. This is wrong but doesn't stop the page loading or link working.

Using quotes for HTML attributes is already considered best practice and `=` is not a common character in things like tag names and post titles, where this would most likely be a problem for Ghost. Further still, the escaping will likely cause minor HTML rendering issues. Incidences of this causing problems are expected to be rare.
## express-hbs change: partials now require the `.hbs` extension

Previously, there was no enforcement around the file extension used for partial files. The extension is now enforced as being the same as that configured in `extname`. For Ghost, this means that all partials must use the `.hbs` extension the same as template files. 

Impact: anyone with a theme using an extension other than `.hbs` for partials must update their theme or the partial will not be found after upgrading Ghost to 0.8. This fixes #2459.

Ghost theme docs have never suggested that this could or should be otherwise, so incidences of this causing issues should be very rare. 
