### PR TITLE
Use ember-invoke-action for closure action handling

### DIFF
--- a/core/client/app/components/gh-editor.js
+++ b/core/client/app/components/gh-editor.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ShortcutsMixin from 'ghost/mixins/shortcuts';
 import imageManager from 'ghost/utils/ed-image-manager';
 import editorShortcuts from 'ghost/utils/editor-shortcuts';
+import {invokeAction} from 'ember-invoke-action';
 
 const {Component, computed, run} = Ember;
 const {equal} = computed;
@@ -52,9 +53,8 @@ export default Component.extend(ShortcutsMixin, {
     },
 
     willDestroyElement() {
-        if (this.get('onTeardown')) {
-            this.get('onTeardown')();
-        }
+        invokeAction(this, 'onTeardown');
+
         this.removeShortcuts();
     },
 

--- a/core/client/app/components/gh-fullscreen-modal.js
+++ b/core/client/app/components/gh-fullscreen-modal.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import LiquidTether from 'liquid-tether/components/liquid-tether';
+import {invokeAction} from 'ember-invoke-action';
 
 const {
     RSVP: {Promise},
@@ -50,8 +51,10 @@ const FullScreenModalComponent = LiquidTether.extend({
 
     actions: {
         close() {
+            // Because we return the promise from invokeAction, we have
+            // to check if "close" exists first
             if (this.get('close')) {
-                return this.get('close')();
+                return invokeAction(this, 'close');
             }
 
             return new Promise((resolve) => {
@@ -61,7 +64,7 @@ const FullScreenModalComponent = LiquidTether.extend({
 
         confirm() {
             if (this.get('confirm')) {
-                return this.get('confirm')();
+                return invokeAction(this, 'confirm');
             }
 
             return new Promise((resolve) => {

--- a/core/client/app/components/gh-navitem-url-input.js
+++ b/core/client/app/components/gh-navitem-url-input.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 const {TextField, computed, run} = Ember;
 
@@ -67,7 +68,7 @@ export default TextField.extend({
     },
 
     keyPress(event) {
-        this.get('clearErrors')();
+        invokeAction(this, 'clearErrors');
 
         // enter key
         if (event.keyCode === 13) {

--- a/core/client/app/components/gh-posts-list-item.js
+++ b/core/client/app/components/gh-posts-list-item.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import ActiveLinkWrapper from 'ghost/mixins/active-link-wrapper';
+import {invokeAction} from 'ember-invoke-action';
 
 const {
     $,
@@ -51,7 +52,7 @@ export default Component.extend(ActiveLinkWrapper, {
         this._super(...arguments);
         this.removeObserver('active', this, this.scrollIntoView);
         if (this.get('post.isDeleted') && this.get('onDelete')) {
-            this.get('onDelete')();
+            invokeAction(this, 'onDelete');
         }
     },
 

--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -1,6 +1,7 @@
 /* global key */
 import Ember from 'ember';
 import boundOneWay from 'ghost/utils/bound-one-way';
+import {invokeAction} from 'ember-invoke-action';
 
 const {
     Component,
@@ -128,7 +129,7 @@ export default Component.extend({
         },
 
         deleteTag() {
-            this.get('showDeleteTagModal')();
+            invokeAction(this, 'showDeleteTagModal');
         }
     }
 

--- a/core/client/app/components/gh-tag.js
+++ b/core/client/app/components/gh-tag.js
@@ -1,11 +1,12 @@
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 export default Ember.Component.extend({
     willDestroyElement() {
         this._super(...arguments);
 
         if (this.get('tag.isDeleted') && this.get('onDelete')) {
-            this.get('onDelete')();
+            invokeAction(this, 'onDelete');
         }
     }
 });

--- a/core/client/app/components/modals/base.js
+++ b/core/client/app/components/modals/base.js
@@ -1,5 +1,6 @@
 /* global key */
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 const {Component, run} = Ember;
 
@@ -49,7 +50,7 @@ export default Component.extend({
         },
 
         closeModal() {
-            this.get('closeModal')();
+            invokeAction(this, 'closeModal');
         }
     }
 });

--- a/core/client/app/components/modals/delete-tag.js
+++ b/core/client/app/components/modals/delete-tag.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import ModalComponent from 'ghost/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
 
 const {computed} = Ember;
 const {alias} = computed;
@@ -18,7 +19,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.get('confirm')().finally(() => {
+            invokeAction(this, 'confirm').finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/delete-user.js
+++ b/core/client/app/components/modals/delete-user.js
@@ -1,4 +1,5 @@
 import ModalComponent from 'ghost/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({
 
@@ -10,7 +11,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.get('confirm')().finally(() => {
+            invokeAction(this, 'confirm').finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/leave-editor.js
+++ b/core/client/app/components/modals/leave-editor.js
@@ -1,9 +1,10 @@
 import ModalComponent from 'ghost/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({
     actions: {
         confirm() {
-            this.get('confirm')().finally(() => {
+            invokeAction(this, 'confirm').finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/app/components/modals/transfer-owner.js
+++ b/core/client/app/components/modals/transfer-owner.js
@@ -1,4 +1,5 @@
 import ModalComponent from 'ghost/components/modals/base';
+import {invokeAction} from 'ember-invoke-action';
 
 export default ModalComponent.extend({
     user: null,
@@ -8,7 +9,7 @@ export default ModalComponent.extend({
         confirm() {
             this.set('submitting', true);
 
-            this.get('confirm')().finally(() => {
+            invokeAction(this, 'confirm').finally(() => {
                 this.send('closeModal');
             });
         }

--- a/core/client/package.json
+++ b/core/client/package.json
@@ -41,6 +41,7 @@
     "ember-data": "2.5.2",
     "ember-data-filter": "1.13.0",
     "ember-export-application-global": "1.0.5",
+    "ember-invoke-action": "1.3.0",
     "ember-load-initializers": "0.5.1",
     "ember-myth": "0.1.1",
     "ember-one-way-controls": "0.6.2",


### PR DESCRIPTION
no issue
- replace instances of `this.get('action')()` with more a more readable syntax
