### PR TITLE
Add CORS whitelist origins at runtime

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -12,6 +12,7 @@ var bodyParser      = require('body-parser'),
     sitemapHandler  = require('../data/xml/sitemap/handler'),
     multer          = require('multer'),
     tmpdir          = require('os').tmpdir,
+    url             = require('url'),
     authStrategies   = require('./auth-strategies'),
     auth             = require('./auth'),
     cacheControl     = require('./cache-control'),
@@ -29,6 +30,9 @@ var bodyParser      = require('body-parser'),
     ClientPasswordStrategy  = require('passport-oauth2-client-password').Strategy,
     BearerStrategy          = require('passport-http-bearer').Strategy,
 
+    corsOpts = {
+        whitelist: [].concat(config.urlSSL && url.parse(config.url).hostname)
+    },
     middleware,
     setupMiddleware;
 
@@ -43,7 +47,7 @@ middleware = {
         requiresAuthorizedUser: auth.requiresAuthorizedUser,
         requiresAuthorizedUserPublicAPI: auth.requiresAuthorizedUserPublicAPI,
         errorHandler: errors.handleAPIError,
-        cors: cors
+        cors: cors(corsOpts)
     }
 };
 

--- a/core/server/utils/runtime.js
+++ b/core/server/utils/runtime.js
@@ -1,0 +1,27 @@
+var os = require('os');
+
+/**
+ * Gather a list of local ipv4 addresses
+ * @return {Array<String>}
+ */
+function getIPs() {
+    var ifaces = os.networkInterfaces(),
+        ips = [];
+
+    Object.keys(ifaces).forEach(function (ifname) {
+        ifaces[ifname].forEach(function (iface) {
+            // only support IPv4
+            if (iface.family !== 'IPv4') {
+                return;
+            }
+
+            ips.push(iface.address);
+        });
+    });
+
+    return ips;
+}
+
+module.exports = {
+    getIPs: getIPs
+};

--- a/core/test/unit/middleware/cors_spec.js
+++ b/core/test/unit/middleware/cors_spec.js
@@ -1,10 +1,10 @@
 /*globals describe, it, beforeEach, afterEach */
 var sinon = require('sinon'),
     should = require('should'),
-    cors = require('../../../server/middleware/cors');
+    setupCORS = require('../../../server/middleware/cors');
 
 describe('cors', function () {
-    var res, req, next, sandbox;
+    var res, req, next, sandbox, cors;
 
     beforeEach(function () {
         sandbox = sinon.sandbox.create();
@@ -27,6 +27,8 @@ describe('cors', function () {
         };
 
         next = sandbox.spy();
+
+        cors = setupCORS();
     });
 
     afterEach(function () {
@@ -134,6 +136,26 @@ describe('cors', function () {
 
         next.called.should.be.true();
         should.not.exist(res.headers['Access-Control-Allow-Origin']);
+
+        done();
+    });
+
+    it('should allow whitelist origins to be added at runtime', function (done) {
+        var origin = 'https://other.example.com',
+            options = {
+                whitelist: [origin]
+            };
+
+        req.get = sinon.stub().withArgs('origin').returns(origin);
+        res.get = sinon.stub().withArgs('origin').returns(origin);
+        req.headers.origin = origin;
+
+        cors = setupCORS(options);
+
+        cors(req, res, next);
+
+        next.called.should.be.true();
+        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
 
         done();
     });


### PR DESCRIPTION
Reworks the CORS whitelisting so origins can be added at runtime. Alternate approach to #6739, done in a way that doesn't require pulling in config to the cors middleware.

Let's discuss.
