### PR TITLE
Use a custom transform to simplify navigation settings

### DIFF
--- a/core/client/app/models/navigation-item.js
+++ b/core/client/app/models/navigation-item.js
@@ -1,0 +1,27 @@
+import Ember from 'ember';
+import ValidationEngine from 'ghost/mixins/validation-engine';
+
+const {
+    computed,
+    isBlank
+} = Ember;
+
+export default Ember.Object.extend(ValidationEngine, {
+    label: '',
+    url: '',
+    isNew: false,
+
+    validationType: 'navItem',
+
+    isComplete: computed('label', 'url', function () {
+        let {label, url} = this.getProperties('label', 'url');
+
+        return !isBlank(label) && !isBlank(url);
+    }),
+
+    isBlank: computed('label', 'url', function () {
+        let {label, url} = this.getProperties('label', 'url');
+
+        return isBlank(label) && isBlank(url);
+    })
+});

--- a/core/client/app/models/setting.js
+++ b/core/client/app/models/setting.js
@@ -19,7 +19,7 @@ export default Model.extend(ValidationEngine, {
     ghost_head: attr('string'),
     ghost_foot: attr('string'),
     labs: attr('string'),
-    navigation: attr('string'),
+    navigation: attr('navigation-settings'),
     isPrivate: attr('boolean'),
     password: attr('string')
 });

--- a/core/client/app/templates/settings/navigation.hbs
+++ b/core/client/app/templates/settings/navigation.hbs
@@ -9,7 +9,7 @@
     <section class="view-container">
         <form id="settings-navigation" class="gh-blognav" novalidate="novalidate">
             {{#sortable-group onChange=(action 'reorderItems') as |group|}}
-                {{#each navigationItems as |navItem|}}
+                {{#each model.navigation as |navItem|}}
                     {{gh-navitem navItem=navItem baseUrl=blogUrl addItem="addItem" deleteItem="deleteItem" updateUrl="updateUrl" group=group}}
                 {{/each}}
             {{/sortable-group}}

--- a/core/client/app/transforms/navigation-settings.js
+++ b/core/client/app/transforms/navigation-settings.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import Transform from 'ember-data/transform';
+import NavigationItem from 'ghost/models/navigation-item';
+
+const {isArray} = Ember;
+const emberA = Ember.A;
+
+export default Transform.extend({
+    deserialize(serialized) {
+        let navItems, settingsArray;
+
+        try {
+            settingsArray = JSON.parse(serialized) || [];
+        } catch (e) {
+            settingsArray = [];
+        }
+
+        navItems = settingsArray.map((itemDetails) => {
+            return NavigationItem.create(itemDetails);
+        });
+
+        return emberA(navItems);
+    },
+
+    serialize(deserialized) {
+        let settingsArray;
+
+        if (isArray(deserialized)) {
+            settingsArray = deserialized.map((item) => {
+                let label = item.get('label').trim();
+                let url = item.get('url').trim();
+
+                return {label, url};
+            }).compact();
+        } else {
+            settingsArray = [];
+        }
+
+        return JSON.stringify(settingsArray);
+    }
+});

--- a/core/client/tests/integration/components/gh-navigation-test.js
+++ b/core/client/tests/integration/components/gh-navigation-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import { NavItem } from 'ghost/controllers/settings/navigation';
+import NavItem from 'ghost/models/navigation-item';
 
 const {run} = Ember;
 

--- a/core/client/tests/integration/components/gh-navitem-test.js
+++ b/core/client/tests/integration/components/gh-navitem-test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { describeComponent, it } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
-import { NavItem } from 'ghost/controllers/settings/navigation';
+import NavItem from 'ghost/models/navigation-item';
 
 const {run} = Ember;
 

--- a/core/client/tests/unit/models/navigation-item-test.js
+++ b/core/client/tests/unit/models/navigation-item-test.js
@@ -1,0 +1,67 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describeModule, it } from 'ember-mocha';
+
+describeModule(
+    'model:navigation-item',
+    'Unit: Model: navigation-item',
+    {
+        // Specify the other units that are required for this test.
+        needs: []
+    },
+    function() {
+        it('isComplete is true when label and url are filled', function () {
+            let model = this.subject();
+
+            model.set('label', 'test');
+            model.set('url', 'test');
+
+            expect(model.get('isComplete')).to.be.true;
+        });
+
+        it('isComplete is false when label is blank', function () {
+            let model = this.subject();
+
+            model.set('label', '');
+            model.set('url', 'test');
+
+            expect(model.get('isComplete')).to.be.false;
+        });
+
+        it('isComplete is false when url is blank', function () {
+            let model = this.subject();
+
+            model.set('label', 'test');
+            model.set('url', '');
+
+            expect(model.get('isComplete')).to.be.false;
+        });
+
+        it('isBlank is true when label and url are blank', function () {
+            let model = this.subject();
+
+            model.set('label', '');
+            model.set('url', '');
+
+            expect(model.get('isBlank')).to.be.true;
+        });
+
+        it('isBlank is false when label is present', function () {
+            let model = this.subject();
+
+            model.set('label', 'test');
+            model.set('url', '');
+
+            expect(model.get('isBlank')).to.be.false;
+        });
+
+        it('isBlank is false when url is present', function () {
+            let model = this.subject();
+
+            model.set('label', '');
+            model.set('url', 'test');
+
+            expect(model.get('isBlank')).to.be.false;
+        });
+    }
+);

--- a/core/client/tests/unit/transforms/navigation-settings-test.js
+++ b/core/client/tests/unit/transforms/navigation-settings-test.js
@@ -1,0 +1,42 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import { describeModule, it } from 'ember-mocha';
+import Ember from 'ember';
+import NavigationItem from 'ghost/models/navigation-item';
+
+const emberA = Ember.A;
+
+describeModule(
+    'transform:navigation-settings',
+    'Unit: Transform: navigation-settings',
+    {
+        // Specify the other units that are required for this test.
+        // needs: ['transform:foo']
+    },
+    function() {
+        it('deserializes navigation json', function () {
+            let transform = this.subject();
+            let serialized = '[{"label":"One","url":"/one"},{"label":"Two","url":"/two"}]';
+            let result = transform.deserialize(serialized);
+
+            expect(result.length).to.equal(2);
+            expect(result[0]).to.be.instanceof(NavigationItem);
+            expect(result[0].get('label')).to.equal('One');
+            expect(result[0].get('url')).to.equal('/one');
+            expect(result[1]).to.be.instanceof(NavigationItem);
+            expect(result[1].get('label')).to.equal('Two');
+            expect(result[1].get('url')).to.equal('/two');
+        });
+
+        it('serializes array of NavigationItems', function () {
+            let transform = this.subject();
+            let deserialized = emberA([
+                NavigationItem.create({label: 'One', url: '/one'}),
+                NavigationItem.create({label: 'Two', url: '/two'})
+            ]);
+            let result = transform.serialize(deserialized);
+
+            expect(result).to.equal('[{"label":"One","url":"/one"},{"label":"Two","url":"/two"}]');
+        });
+    }
+);

--- a/core/client/tests/unit/validators/nav-item-test.js
+++ b/core/client/tests/unit/validators/nav-item-test.js
@@ -5,7 +5,7 @@ import {
     it
 } from 'mocha';
 import validator from 'ghost/validators/nav-item';
-import { NavItem } from 'ghost/controllers/settings/navigation';
+import NavItem from 'ghost/models/navigation-item';
 
 const testInvalidUrl = function (url) {
     let navItem = NavItem.create({url});


### PR DESCRIPTION
no issue
- moves the `NavItem` object from the navigation controller to an explicit `NavigationItem` model file
- adds a custom transform `navigation-settings` that transforms the navigation settings JSON string to/from an array of `NavigationItem` objects
- simplifies the `settings/navigation` controller as it no longer has to export it's own internal model and handle serialization and deserialization

This pattern should also help simplify the apps/slack integration code if implemented there.
