### PR TITLE
subscribe: fix keep original referrer and location if set

### DIFF
--- a/core/server/apps/subscribers/index.js
+++ b/core/server/apps/subscribers/index.js
@@ -11,34 +11,42 @@ var _          = require('lodash'),
     template   = require('../../helpers/template'),
     utils      = require('../../helpers/utils'),
 
-    params = ['error', 'success', 'email', 'referrer', 'location'],
+    params = ['error', 'success', 'email'],
 
     /**
-     * Dirrrrrty script
-     * <script type="text/javascript">
-     *   document.querySelector('.location').setAttribute('value', window.location.href);
-     *   document.querySelector('.referrer').setAttribute('value', document.referrer);
-     * </script>
+     * This helper script sets the referrer and current location if not existent.
+     *
+     * document.querySelector['.location']['value'] = document.querySelector('.location')['value'] || window.location.href;
      */
-    subscribeScript = '<script type="text/javascript">(function(g,h,o,s,t){' +
-    'h[o](\'.location\')[s]=g.location.href;h[o](\'.referrer\')[s]=h.referrer;' +
-    '})(window,document,\'querySelector\',\'value\');</script>';
+    subscribeScript =
+        '<script type="text/javascript">' +
+            '(function(g,h,o,s,t){' +
+                'h[o](\'.location\')[s]=h[o](\'.location\')[s] || g.location.href;' +
+                'h[o](\'.referrer\')[s]=h[o](\'.referrer\')[s] || h.referrer;' +
+            '})(window,document,\'querySelector\',\'value\');' +
+        '</script>';
 
-function makeHidden(name) {
+function makeHidden(name, extras) {
     return utils.inputTemplate({
         type: 'hidden',
         name: name,
         className: name,
-        extras: ''
+        extras: extras
     });
 }
 
 function subscribeFormHelper(options) {
-    var data = _.merge({}, options.hash, _.pick(options.data.root, params), {
-        action: path.join('/', config.paths.subdir, config.routeKeywords.subscribe, '/'),
-        script: new hbs.handlebars.SafeString(subscribeScript),
-        hidden: new hbs.handlebars.SafeString(makeHidden('confirm') + makeHidden('location') + makeHidden('referrer'))
-    });
+    var root = options.data.root,
+        data = _.merge({}, options.hash, _.pick(root, params), {
+            action: path.join('/', config.paths.subdir, config.routeKeywords.subscribe, '/'),
+            script: new hbs.handlebars.SafeString(subscribeScript),
+            hidden: new hbs.handlebars.SafeString(
+                makeHidden('confirm') +
+                makeHidden('location', root.subscribed_url ? 'value=' + root.subscribed_url : '') +
+                makeHidden('referrer', root.subscribed_referrer ? 'value=' + root.subscribed_referrer : '')
+            )
+        });
+
     return template.execute('subscribe_form', data, options);
 }
 


### PR DESCRIPTION
no issue
##### Use case

User is on a post and decides to subscribe, but when he enters his email it turns out the email is invalid or already in the db. We need to keep the old referrer and location. This PR cares about the case.
