### PR TITLE
Don't add trailing slash to end of url with parameters

### DIFF
--- a/core/client/app/initializers/trailing-history.js
+++ b/core/client/app/initializers/trailing-history.js
@@ -4,7 +4,13 @@ const {HistoryLocation} = Ember;
 
 let trailingHistory = HistoryLocation.extend({
     formatURL() {
-        return this._super(...arguments).replace(/\/?$/, '/');
+        let url = this._super(...arguments);
+
+        if (url.indexOf('?') > 0) {
+            return url.replace(/([^\/])\?/, '$1/?');
+        } else {
+            return url.replace(/\/?$/, '/');
+        }
     }
 });
 


### PR DESCRIPTION
no issue
- updates the `TrailingHistory` locationType so that trailing slashes aren't added to the end of URLs with parameters but instead matches how the server-side redirects to trailing-slash URLs
- before: `/subscribers?order=created_at/`
- after: `/subscribers/?order=created_at`

This fixes problems with Ember reading query params with trailing slashes.
