### PR TITLE
deps: ember@2.5.1

### DIFF
--- a/core/client/bower.json
+++ b/core/client/bower.json
@@ -4,7 +4,7 @@
     "blueimp-md5": "2.3.0",
     "codemirror": "5.13.2",
     "devicejs": "0.2.7",
-    "ember": "2.5.0",
+    "ember": "2.5.1",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
     "ember-mocha": "0.8.11",

--- a/core/client/config/deprecation-workflow.js
+++ b/core/client/config/deprecation-workflow.js
@@ -1,7 +1,6 @@
 window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
     workflow: [
-        {handler: 'silence', matchMessage: 'Usage of `Ember.merge` is deprecated, use `Ember.assign` instead.'},
         {handler: 'silence', matchMessage: 'Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object.'},
         {handler: 'silence', matchMessage: 'You modified (-join-classes "ember-view" "form-group" (-normalize-class "errorClass" errorClass activeClass=undefined inactiveClass=undefined)) twice in a single render. This was unreliable in Ember 1.x and will be removed in Ember 3.0'}
     ]


### PR DESCRIPTION
- removes Ember.merge deprecation

[Release notes](https://github.com/emberjs/ember.js/releases/tag/v2.5.1)
