### PR TITLE
More action cleanup

### DIFF
--- a/core/client/app/components/gh-datetime-input.js
+++ b/core/client/app/components/gh-datetime-input.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import TextInputMixin from 'ghost/mixins/text-input';
 import boundOneWay from 'ghost/utils/bound-one-way';
 import {formatDate} from 'ghost/utils/date-formatting';
+import {invokeAction} from 'ember-invoke-action';
 
 const {Component} = Ember;
 
@@ -27,6 +28,6 @@ export default Component.extend(TextInputMixin, {
     focusOut() {
         let datetime = this.get('datetime');
 
-        this.get('update')(datetime);
+        invokeAction(this, 'update', datetime);
     }
 });

--- a/core/client/app/components/gh-ed-editor.js
+++ b/core/client/app/components/gh-ed-editor.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import EditorAPI from 'ghost/mixins/ed-editor-api';
 import EditorShortcuts from 'ghost/mixins/ed-editor-shortcuts';
 import EditorScroll from 'ghost/mixins/ed-editor-scroll';
+import {invokeAction} from 'ember-invoke-action';
 
 const {TextArea, run} = Ember;
 
@@ -32,7 +33,7 @@ export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
 
         this.setFocus();
 
-        this.get('setEditor')(this);
+        invokeAction(this, 'setEditor', this);
 
         run.scheduleOnce('afterRender', this, this.afterRenderEvent);
     },
@@ -45,7 +46,7 @@ export default TextArea.extend(EditorAPI, EditorShortcuts, EditorScroll, {
 
     actions: {
         toggleCopyHTMLModal(generatedHTML) {
-            this.get('toggleCopyHTMLModal')(generatedHTML);
+            invokeAction(this, 'toggleCopyHTMLModal', generatedHTML);
         }
     }
 });

--- a/core/client/app/components/gh-search-input/trigger.js
+++ b/core/client/app/components/gh-search-input/trigger.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 const {run, isBlank, Component} = Ember;
 
@@ -21,7 +22,7 @@ export default Component.extend({
                 run.scheduleOnce('afterRender', this, isBlank(term) ? this.close : this.open);
             }
 
-            this.get('select.actions.search')(term);
+            invokeAction(this, 'select.actions.search', term);
         },
 
         focusInput() {

--- a/core/client/app/components/gh-tag-settings-form.js
+++ b/core/client/app/components/gh-tag-settings-form.js
@@ -109,15 +109,15 @@ export default Component.extend({
 
     actions: {
         setProperty(property, value) {
-            this.get('setProperty')(property, value);
+            invokeAction(this, 'setProperty', property, value);
         },
 
         setCoverImage(image) {
-            this.get('setProperty')('image', image);
+            invokeAction(this, 'setProperty', 'image', image);
         },
 
         clearCoverImage() {
-            this.get('setProperty')('image', '');
+            invokeAction(this, 'setProperty', 'image', '');
         },
 
         openMeta() {

--- a/core/client/app/mixins/ed-editor-scroll.js
+++ b/core/client/app/mixins/ed-editor-scroll.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 const {Mixin, run} = Ember;
 
@@ -61,7 +62,7 @@ export default Mixin.create({
      */
     scrollHandler() {
         this.set('scrollThrottle', run.throttle(this, () => {
-            this.get('updateScrollInfo')(this.getScrollInfo());
+            invokeAction(this, 'updateScrollInfo', this.getScrollInfo());
         }, 10));
     },
 

--- a/core/client/app/utils/link-component.js
+++ b/core/client/app/utils/link-component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {invokeAction} from 'ember-invoke-action';
 
 const {LinkComponent, computed} = Ember;
 
@@ -7,7 +8,7 @@ LinkComponent.reopen({
         let isActive = this._super(...arguments);
 
         if (typeof this.get('alternateActive') === 'function') {
-            this.get('alternateActive')(isActive);
+            invokeAction(this, 'alternateActive', isActive);
         }
 
         return isActive;


### PR DESCRIPTION
let this be lesson in why I should make sure I find _all_ the instances of something I'm replacing the first time around 😁 

refs #6748 
- converts remaining actions to the `invokeAction` syntax
