### PR TITLE
[WIP] subscribe: store post id

### DIFF
--- a/core/server/apps/subscribers/index.js
+++ b/core/server/apps/subscribers/index.js
@@ -35,15 +35,21 @@ function makeHidden(name, extras) {
     });
 }
 
+/**
+ * post id is in the post model (root.post) in case he is on /name-of-post
+ * post id is in root (root.post_id) in case of validation error (he is already on /subscribe)
+ */
 function subscribeFormHelper(options) {
     var root = options.data.root,
+        postId = root.post ? root.post.id : (root.post_id ? root.post_id : null),
         data = _.merge({}, options.hash, _.pick(root, params), {
             action: path.join('/', config.paths.subdir, config.routeKeywords.subscribe, '/'),
             script: new hbs.handlebars.SafeString(subscribeScript),
             hidden: new hbs.handlebars.SafeString(
                 makeHidden('confirm') +
                 makeHidden('location', root.subscribed_url ? 'value=' + root.subscribed_url : '') +
-                makeHidden('referrer', root.subscribed_referrer ? 'value=' + root.subscribed_referrer : '')
+                makeHidden('referrer', root.subscribed_referrer ? 'value=' + root.subscribed_referrer : ''),
+                makeHidden('post_id', 'value=' + postId)
             )
         });
 

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -1,4 +1,5 @@
 var path                = require('path'),
+    lodash              = require('lodash'),
     express             = require('express'),
     subscribeRouter     = express.Router(),
 
@@ -47,7 +48,16 @@ function handleSource(req, res, next) {
     req.body.subscribed_referrer = req.body.referrer;
     delete req.body.location;
     delete req.body.referrer;
-    // do something here to get post_id
+
+    if (req.body.post_id) {
+        if (lodash.isString(req.body.post_id)) {
+            req.body.post_id = Number(req.body.post_id);
+        }
+        if (isNaN(req.body.post_id)) {
+            delete req.body.post_id;
+        }
+    }
+
     next();
 }
 


### PR DESCRIPTION
no issue
- store post id for subscriber entry if available
## TODO
- [ ] getting post id from root works, but we will use a lookup fn (reverse URL lookup)
- [ ] wait for lookup fn integration from hannah
- [ ] use lookup fn to get post id for subscriber endpoints and subscriber app
