### PR TITLE
Add synchronous labs flags to feature service

### DIFF
--- a/core/client/tests/integration/components/gh-feature-flag-test.js
+++ b/core/client/tests/integration/components/gh-feature-flag-test.js
@@ -4,7 +4,7 @@ import {
   it
 } from 'ember-mocha';
 import hbs from 'htmlbars-inline-precompile';
-import FeatureService, {feature} from 'ghost/services/feature';
+import {feature} from 'ghost/services/feature';
 import Pretender from 'pretender';
 import wait from 'ember-test-helpers/wait';
 
@@ -32,10 +32,8 @@ function stubSettings(server, labs) {
     });
 }
 
-function addTestFlag() {
-    FeatureService.reopen({
-        testFlag: feature('testFlag')
-    });
+function addTestFlag(test) {
+    feature(test.container.lookup('service:feature'), 'testFlag');
 }
 
 describeComponent(
@@ -57,7 +55,7 @@ describeComponent(
 
         it('renders properties correctly', function () {
             stubSettings(server, {testFlag: true});
-            addTestFlag();
+            addTestFlag(this);
 
             this.render(hbs`{{gh-feature-flag "testFlag"}}`);
             expect(this.$()).to.have.length(1);
@@ -66,7 +64,7 @@ describeComponent(
 
         it('renders correctly when flag is set to true', function () {
             stubSettings(server, {testFlag: true});
-            addTestFlag();
+            addTestFlag(this);
 
             this.render(hbs`{{gh-feature-flag "testFlag"}}`);
             expect(this.$()).to.have.length(1);
@@ -78,7 +76,7 @@ describeComponent(
 
         it('renders correctly when flag is set to false', function () {
             stubSettings(server, {testFlag: false});
-            addTestFlag();
+            addTestFlag(this);
 
             this.render(hbs`{{gh-feature-flag "testFlag"}}`);
             expect(this.$()).to.have.length(1);
@@ -90,7 +88,7 @@ describeComponent(
 
         it('updates to reflect changes in flag property', function () {
             stubSettings(server, {testFlag: true});
-            addTestFlag();
+            addTestFlag(this);
 
             this.render(hbs`{{gh-feature-flag "testFlag"}}`);
             expect(this.$()).to.have.length(1);

--- a/core/client/tests/integration/services/feature-test.js
+++ b/core/client/tests/integration/services/feature-test.js
@@ -4,7 +4,7 @@ import {
 } from 'ember-mocha';
 import Pretender from 'pretender';
 import wait from 'ember-test-helpers/wait';
-import FeatureService, {feature} from 'ghost/services/feature';
+import {feature} from 'ghost/services/feature';
 import Ember from 'ember';
 import { errorOverride, errorReset } from 'ghost/tests/helpers/adapter-error';
 
@@ -46,10 +46,8 @@ function stubSettings(server, labs, validSave = true, validSettings = true) {
     });
 }
 
-function addTestFlag() {
-    FeatureService.reopen({
-        testFlag: feature('testFlag')
-    });
+function addTestFlag(featureService) {
+    feature(featureService, 'testFlag');
 }
 
 describeModule(
@@ -100,9 +98,10 @@ describeModule(
 
         it('returns false for set flag with config false and labs false', function (done) {
             stubSettings(server, {testFlag: false});
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
+
             service.get('config').set('testFlag', false);
 
             let testFlag, labsTestFlag;
@@ -124,9 +123,10 @@ describeModule(
 
         it('returns true for set flag with config true and labs false', function (done) {
             stubSettings(server, {testFlag: false});
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
+
             service.get('config').set('testFlag', true);
 
             let testFlag, labsTestFlag;
@@ -148,9 +148,10 @@ describeModule(
 
         it('returns true for set flag with config false and labs true', function (done) {
             stubSettings(server, {testFlag: true});
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
+
             service.get('config').set('testFlag', false);
 
             let testFlag, labsTestFlag;
@@ -172,9 +173,10 @@ describeModule(
 
         it('returns true for set flag with config true and labs true', function (done) {
             stubSettings(server, {testFlag: true});
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
+
             service.get('config').set('testFlag', true);
 
             let testFlag, labsTestFlag;
@@ -196,9 +198,9 @@ describeModule(
 
         it('saves correctly', function (done) {
             stubSettings(server, {testFlag: false});
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
 
             run(() => {
                 service.get('testFlag').then((testFlag) => {
@@ -220,11 +222,29 @@ describeModule(
             });
         });
 
-        it('notifies for server errors', function (done) {
-            stubSettings(server, {testFlag: false}, false);
-            addTestFlag();
+        it('provides correct flagSync property', function (done) {
+            stubSettings(server, {testFlag: true});
 
             let service = this.subject();
+            addTestFlag(service);
+
+            run(() => {
+                // force property to compute
+                service.get('testFlagSync');
+            });
+
+            return wait().then(() => {
+                expect(service.get('testFlagSync')).to.be.true;
+
+                done();
+            });
+        });
+
+        it('notifies for server errors', function (done) {
+            stubSettings(server, {testFlag: false}, false);
+
+            let service = this.subject();
+            addTestFlag(service);
 
             run(() => {
                 service.get('testFlag').then((testFlag) => {
@@ -250,9 +270,9 @@ describeModule(
 
         it('notifies for validation errors', function (done) {
             stubSettings(server, {testFlag: false}, true, false);
-            addTestFlag();
 
             let service = this.subject();
+            addTestFlag(service);
 
             run(() => {
                 service.get('testFlag').then((testFlag) => {


### PR DESCRIPTION
no issue
- used in cases where an `{{#if}}` block depends on a flag and needs a synchronous property to observe

when doing work on the internal tags pr in #6771, there was a couple of places where the template directly depended on an labs flag via an `{{#if}}` block expression. The problem came about because the feature service only provides a computed promise, which doesn't play nice with if blocks. This PR adds a synchronous version of the flag that will update when the flag updates.

**Note**: it is a little bit hacky in that it forces a computed property to compute without actually needing the value. That was the way I could think of to support synchronous properties, but if there's a better way to go about this I'm completely open 😄 
