### PR TITLE
I would like to explicitly control any/every config setting ...

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -154,7 +154,7 @@ ConfigManager.prototype.set = function (config) {
         storagePath = path.join(contentPath, 'storage');
     }
 
-    _.merge(this._config, {
+    _.defaultsDeep(this._config, {
         ghostVersion: packageInfo.version,
         paths: {
             appRoot:          appRoot,


### PR DESCRIPTION
I think it should be possible to control every config setting explicitly, in my particular use case I wish to specify a `themePath` that points to a directory that is part of a git repo (this directory is obviously therefore not a sub-directory of Ghost's configured `contentPath`)  (i.e. I want to treat my theme(s) as "deployed code" rather than as "content").

currently one can specify a `contentPath` and Ghost forces the values `themePath`, `appPath` and `imagesPath` to be sub-directories of `contentPath`.

my suggestion is to simply allow any/every attribute in the "config tree" to be specified explicitly by using `_.defaultsDeep()` rather than `_.assign()`.

my changes "work" for my use-case, but I imagine there might be need for more changes in order to make this robust (for instance some settings could be problematic, e.g. `imagesRelPath` which seems to make the assumption that `imagePath` is a sub-dir of `contentPath` - although this could be a red-herring)
