### PR TITLE
subscribe: delete null values from incoming objects

### DIFF
--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -118,7 +118,7 @@ subscribers = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            utils.validate(docName) ,
+            utils.validate(docName),
             utils.handlePermissions(docName, 'add'),
             doQuery
         ];

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -118,7 +118,7 @@ subscribers = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            utils.validate(docName),
+            utils.validate(docName) ,
             utils.handlePermissions(docName, 'add'),
             doQuery
         ];

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -283,6 +283,15 @@ utils = {
             }
         }
 
+        // will remove unwanted null values
+        _.each(object[docName], function (value, index) {
+            if (!_.isObject(object[docName][index])) {
+                return;
+            }
+
+            object[docName][index] = _.omit(object[docName][index], _.isNull);
+        });
+
         if (editId && object[docName][0].id && parseInt(editId, 10) !== parseInt(object[docName][0].id, 10)) {
             return errors.logAndRejectError(new errors.BadRequestError(i18n.t('errors.api.utils.invalidIdProvided')));
         }

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -68,6 +68,7 @@ function handleSource(req, res, next) {
 
 function storeSubscriber(req, res, next) {
     req.body.status = 'subscribed';
+
     return api.subscribers.add({subscribers: [req.body]}, {context: {external: true}})
         .then(function () {
             res.locals.success = true;

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -365,6 +365,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         data = this.filterData(data);
         options = this.filterOptions(options, 'add');
         var model = this.forge(data);
+
         // We allow you to disable timestamps when importing posts so that the new posts `updated_at` value is the same
         // as the import json blob. More details refer to https://github.com/TryGhost/Ghost/issues/1696
         if (options.importing) {

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -370,6 +370,25 @@ describe('API Utils', function () {
                 done();
             }).catch(done);
         });
+
+        it('will delete null values from object', function (done) {
+            var object = {test: [{id: 1, key: null}]};
+
+            apiUtils.checkObject(_.cloneDeep(object), 'test').then(function (data) {
+                should.not.exist(data.test[0].key);
+                should.exist(data.test[0].id);
+                done();
+            }).catch(done);
+        });
+
+        it('will delete null values from object', function (done) {
+            var object = {test: ['something']};
+
+            apiUtils.checkObject(_.cloneDeep(object), 'test').then(function (data) {
+                data.test[0].should.eql('something');
+                done();
+            }).catch(done);
+        });
     });
 
     describe('checkFileExists', function () {


### PR DESCRIPTION
the status of a new subscriber instance wasn't stored, even that we defined a default value in the model.
the problem was actually deeper then expected, we dont delete null values from incoming objects.
the implementation of the defaults fn keeps null values, i can understand this behaviour.
