### PR TITLE
fix: delete null values from incoming objects

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -283,6 +283,15 @@ utils = {
             }
         }
 
+        // will remove unwanted null values
+        _.each(object[docName], function (value, index) {
+            if (!_.isObject(object[docName][index])) {
+                return;
+            }
+
+            object[docName][index] = _.omit(object[docName][index], _.isNull);
+        });
+
         if (editId && object[docName][0].id && parseInt(editId, 10) !== parseInt(object[docName][0].id, 10)) {
             return errors.logAndRejectError(new errors.BadRequestError(i18n.t('errors.api.utils.invalidIdProvided')));
         }

--- a/core/test/unit/api_utils_spec.js
+++ b/core/test/unit/api_utils_spec.js
@@ -370,6 +370,25 @@ describe('API Utils', function () {
                 done();
             }).catch(done);
         });
+
+        it('will delete null values from object', function (done) {
+            var object = {test: [{id: 1, key: null}]};
+
+            apiUtils.checkObject(_.cloneDeep(object), 'test').then(function (data) {
+                should.not.exist(data.test[0].key);
+                should.exist(data.test[0].id);
+                done();
+            }).catch(done);
+        });
+
+        it('will not break if the expected object is a string', function (done) {
+            var object = {test: ['something']};
+
+            apiUtils.checkObject(_.cloneDeep(object), 'test').then(function (data) {
+                data.test[0].should.eql('something');
+                done();
+            }).catch(done);
+        });
     });
 
     describe('checkFileExists', function () {


### PR DESCRIPTION
no issue

we don't delete null values from incoming objects and this causes a problem that default values defined in the model will not be used. the implementation of the defaults fn keeps null values.
