### PR TITLE
Fix editor image perf and upload bug

### DIFF
--- a/core/client/app/helpers/gh-format-markdown.js
+++ b/core/client/app/helpers/gh-format-markdown.js
@@ -6,7 +6,7 @@ const {Helper} = Ember;
 
 let showdown = new Showdown.converter({extensions: ['ghostimagepreview', 'ghostgfm', 'footnotes', 'highlight']});
 
-export default Helper.helper(function (params) {
+export function formatMarkdown(params) {
     if (!params || !params.length) {
         return;
     }
@@ -29,4 +29,6 @@ export default Helper.helper(function (params) {
     // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
     return Ember.String.htmlSafe(escapedhtml);
-});
+}
+
+export default Helper.helper(formatMarkdown);

--- a/core/client/app/mixins/ed-editor-api.js
+++ b/core/client/app/mixins/ed-editor-api.js
@@ -1,6 +1,9 @@
 import Ember from 'ember';
 
-const {Mixin} = Ember;
+const {
+    Mixin,
+    run
+} = Ember;
 
 export default Mixin.create({
     /**
@@ -11,7 +14,7 @@ export default Mixin.create({
      * @returns {String}
      */
     getValue() {
-        return this.$().val();
+        return this.readDOMAttr('value');
     },
 
     /**
@@ -111,27 +114,29 @@ export default Mixin.create({
      * by providing selectionEnd.
      */
     replaceSelection(replacement, replacementStart, replacementEnd, cursorPosition) {
-        let $textarea = this.$();
+        run.schedule('afterRender', this, function () {
+            let $textarea = this.$();
 
-        cursorPosition = cursorPosition || 'collapseToEnd';
-        replacementEnd = replacementEnd || replacementStart;
+            cursorPosition = cursorPosition || 'collapseToEnd';
+            replacementEnd = replacementEnd || replacementStart;
 
-        $textarea.setSelection(replacementStart, replacementEnd);
+            $textarea.setSelection(replacementStart, replacementEnd);
 
-        if (['select', 'collapseToStart', 'collapseToEnd'].indexOf(cursorPosition) !== -1) {
-            $textarea.replaceSelectedText(replacement, cursorPosition);
-        } else {
-            $textarea.replaceSelectedText(replacement);
-            if (cursorPosition.hasOwnProperty('start')) {
-                $textarea.setSelection(cursorPosition.start, cursorPosition.end);
+            if (['select', 'collapseToStart', 'collapseToEnd'].indexOf(cursorPosition) !== -1) {
+                $textarea.replaceSelectedText(replacement, cursorPosition);
             } else {
-                $textarea.setSelection(cursorPosition, cursorPosition);
+                $textarea.replaceSelectedText(replacement);
+                if (cursorPosition.hasOwnProperty('start')) {
+                    $textarea.setSelection(cursorPosition.start, cursorPosition.end);
+                } else {
+                    $textarea.setSelection(cursorPosition, cursorPosition);
+                }
             }
-        }
 
-        $textarea.focus();
-        // Tell the editor it has changed, as programmatic replacements won't trigger this automatically
-        this._elementValueDidChange();
-        this.sendAction('onChange');
+            $textarea.focus();
+            // Tell the editor it has changed, as programmatic replacements won't trigger this automatically
+            this._elementValueDidChange();
+            this.sendAction('onChange');
+        });
     }
 });

--- a/core/client/app/templates/components/gh-ed-preview.hbs
+++ b/core/client/app/templates/components/gh-ed-preview.hbs
@@ -1,4 +1,4 @@
-{{gh-format-markdown markdown}}
+{{previewHTML}}
 
 {{#each imageUploadComponents as |uploader|}}
     {{#ember-wormhole to=uploader.destinationElementId}}

--- a/core/client/app/utils/ed-image-manager.js
+++ b/core/client/app/utils/ed-image-manager.js
@@ -18,7 +18,7 @@ function getSrcRange(content, index) {
     let replacement = {};
 
     if (index > -1) {
-        // [1] matches the alt test, and 2 matches the url between the ()
+        // [1] matches the alt text, and 2 matches the url between the ()
         // if the () are missing entirely, which is valid, [2] will be undefined and we'll need to treat this case
         // a little differently
         if (images[index][2] === undefined) {


### PR DESCRIPTION
no issue
- ~10x speedup in processing time taken on each keypress when there are many images/image upload components in the editor
  - edit DOM in memory before changing it in the page to avoid double-render
  - keep upload components around and re-assign them on re-render, adding or removing an image will still re-generate everything
- adds a throttle to the preview rendering so that renders don't get queued up
- fixes occasional bug where uploading an image didn't update the markdown correctly due to a timing issue
