### PR TITLE
subscribers: fix adding subscriber from admin if collection is empty

### DIFF
--- a/core/server/models/subscriber.js
+++ b/core/server/models/subscriber.js
@@ -88,6 +88,12 @@ Subscriber = ghostBookshelf.Model.extend({
             if (subscriberWithEmail) {
                 return subscriberWithEmail;
             }
+        }).catch(function (error) {
+            if (error.message === 'NotFound' || error.message === 'EmptyResponse') {
+                return Promise.resolve();
+            }
+
+            return Promise.reject(error);
         });
     }
 });


### PR DESCRIPTION
no issue
- if subscribers collection is empty, fetch will throw an error
