### PR TITLE
Pre-populate setup values from config

### DIFF
--- a/core/client/app/routes/setup.js
+++ b/core/client/app/routes/setup.js
@@ -31,10 +31,23 @@ export default Route.extend(styleBody, {
         // If user is not logged in, check the state of the setup process via the API
         return this.get('ajax').request(authUrl)
             .then((result) => {
-                let setup = result.setup[0].status;
+                let [setup] = result.setup;
 
-                if (setup) {
+                if (setup.status) {
                     return this.transitionTo('signin');
+                } else {
+                    let controller = this.controllerFor('setup/two');
+                    if (setup.title) {
+                        controller.set('blogTitle', setup.title.replace(/&apos;/gim, '\''));
+                    }
+
+                    if (setup.name) {
+                        controller.set('name', setup.name.replace(/&apos;/gim, '\''));
+                    }
+
+                    if (setup.email) {
+                        controller.set('email', setup.email);
+                    }
                 }
             });
     },

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -377,7 +377,13 @@ authentication = {
         }
 
         function formatResponse(isSetup) {
-            return {setup: [{status: isSetup}]};
+            return {setup: [{
+                status: isSetup,
+                // Pre-populate from config if, and only if the values exist in config.
+                title: config.title || undefined,
+                name: config.user_name || undefined,
+                email: config.user_email || undefined
+            }]};
         }
 
         tasks = [

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -136,8 +136,6 @@ describe('Database Migration (special functions)', function () {
             permissions[34].name.should.eql('Delete clients');
             permissions[34].should.be.AssignedToRoles(['Administrator', 'Editor', 'Author']);
 
-            console.log(permissions[38]);
-
             // Subscribers
             permissions[35].name.should.eql('Browse subscribers');
             permissions[35].should.be.AssignedToRoles(['Administrator']);


### PR DESCRIPTION
This is a patch we've been applying on Ghost(Pro) to pre-populate the settings screen for blog creation. I don't really like having to patch Ghost for Pro, I'd much prefer to have this in the open in core so everyone can see and perhaps even benefit from the code we have.

no issue
- Check for title, user_name and user_email in the top level of config.
- If they exist, return them as part of the setup check, so that the setup screen can be prepopulated
