### PR TITLE
Remove select-all on click for PSM slug input

### DIFF
--- a/core/client/app/templates/post-settings-menu.hbs
+++ b/core/client/app/templates/post-settings-menu.hbs
@@ -25,7 +25,7 @@
                 {{/if}}
 
                 <span class="input-icon icon-link">
-                    {{gh-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" focus-out="updateSlug" selectOnClick="true" stopEnterKeyDownPropagation="true"}}
+                    {{gh-input class="post-setting-slug" id="url" value=slugValue name="post-setting-slug" focus-out="updateSlug" stopEnterKeyDownPropagation="true"}}
                 </span>
                 {{gh-url-preview slug=slugValue tagName="p" classNames="description"}}
             </div>


### PR DESCRIPTION
Removes select-all behavior on click for PSM slug input by removing selectOnClick.

issue #6655
-remove selectOnClick from input
