### PR TITLE
Subscribers: Adding subscribe context

### DIFF
--- a/core/server/controllers/frontend/context.js
+++ b/core/server/controllers/frontend/context.js
@@ -15,6 +15,7 @@ var config = require('../../config'),
 
     // Context patterns, should eventually come from Channel configuration
     privatePattern = new RegExp('^\\/' + config.routeKeywords.private + '\\/'),
+    subscribePattern = new RegExp('^\\/' + config.routeKeywords.subscribe + '\\/'),
     rssPattern = new RegExp('^\\/rss\\/'),
     homePattern = new RegExp('^\\/$');
 
@@ -49,6 +50,8 @@ function setResponseContext(req, res, data) {
         res.locals.context.push(req.channelConfig.name);
     } else if (privatePattern.test(res.locals.relativeUrl)) {
         res.locals.context.push('private');
+    } else if (subscribePattern.test(res.locals.relativeUrl)) {
+        res.locals.context.push('subscribe');
     } else if (data && data.post && data.post.page) {
         res.locals.context.push('page');
     } else if (data && data.post) {

--- a/core/test/unit/controllers/frontend/context_spec.js
+++ b/core/test/unit/controllers/frontend/context_spec.js
@@ -351,6 +351,21 @@ describe('Contexts', function () {
         });
     });
 
+    describe('Subscribe', function () {
+        it('should correctly identify /subscribe/ as the subscribe route', function () {
+            // Setup test
+            setupContext('/subscribe/');
+
+            // Execute test
+            setResponseContext(req, res, data);
+
+            // Check context
+            should.exist(res.locals.context);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            res.locals.context[0].should.eql('subscribe');
+        });
+    });
+
     describe('RSS', function () {
         // NOTE: this works, but is never used in reality, as setResponseContext isn't called
         // for RSS feeds at the moment.


### PR DESCRIPTION
- ensure that the `/subscribe/` route gets a context set correctly
- update context tests§
