### PR TITLE
Allow table content to be selectable

### DIFF
--- a/core/client/app/styles/patterns/tables.css
+++ b/core/client/app/styles/patterns/tables.css
@@ -18,6 +18,7 @@ table td,
     vertical-align: middle;
     text-align: left;
     line-height: 20px;
+    user-select: text;
 }
 
 


### PR DESCRIPTION
no issue
- overrides the global `user-select: none` style for `th` and `td` elements
