### PR TITLE
Fix loss of private settings when saving in certain circumstances

### DIFF
--- a/core/client/app/routes/settings/code-injection.js
+++ b/core/client/app/routes/settings/code-injection.js
@@ -14,7 +14,7 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     model() {
-        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
+        return this.store.query('setting', {type: 'blog,theme,private'}).then((records) => {
             return records.get('firstObject');
         });
     },

--- a/core/client/app/routes/settings/labs.js
+++ b/core/client/app/routes/settings/labs.js
@@ -15,7 +15,7 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     model() {
-        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
+        return this.store.query('setting', {type: 'blog,theme,private'}).then((records) => {
             return records.get('firstObject');
         });
     }

--- a/core/client/app/routes/settings/navigation.js
+++ b/core/client/app/routes/settings/navigation.js
@@ -17,7 +17,7 @@ export default AuthenticatedRoute.extend(styleBody, CurrentUserSettings, {
     },
 
     model() {
-        return this.store.query('setting', {type: 'blog,theme'}).then((records) => {
+        return this.store.query('setting', {type: 'blog,theme,private'}).then((records) => {
             return records.get('firstObject');
         });
     },

--- a/core/client/app/services/feature.js
+++ b/core/client/app/services/feature.js
@@ -46,7 +46,7 @@ export default Service.extend({
     }),
 
     fetch() {
-        return this.get('store').queryRecord('setting', {type: 'blog'}).then((settings) => {
+        return this.get('store').queryRecord('setting', {type: 'blog,theme,private'}).then((settings) => {
             this.set('_settings', settings);
             return true;
         });


### PR DESCRIPTION
no issue
- always ensure we load a full settings object so that we don't risk saving a partial settings object back to the server
- should fix the issues reported in Slack of disappearing private settings over time

Better long-term fix may be to add a settings service that can be used to fetch/save the settings, this would mean that there is only a single place where settings are loaded so we know that we always request/save a full object.
