### PR TITLE
Fix initial loading of a route with an invalid session

### DIFF
--- a/core/client/app/routes/application.js
+++ b/core/client/app/routes/application.js
@@ -32,6 +32,7 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         this._super(...arguments);
 
         if (this.get('session.isAuthenticated')) {
+            this.set('appLoadTransition', transition);
             transition.send('loadServerNotifications');
 
             // return the feature loading promise so that we block until settings
@@ -59,9 +60,15 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
     },
 
     sessionInvalidated() {
-        run.scheduleOnce('routerTransitions', this, function () {
-            this.send('authorizationFailed');
-        });
+        let transition = this.get('appLoadTransition');
+
+        if (transition) {
+            transition.send('authorizationFailed');
+        } else {
+            run.scheduleOnce('routerTransitions', this, function () {
+                this.send('authorizationFailed');
+            });
+        }
     },
 
     actions: {
@@ -82,6 +89,7 @@ export default Route.extend(ApplicationRouteMixin, ShortcutsRoute, {
         },
 
         didTransition() {
+            this.set('appLoadTransition', null);
             this.send('closeMenus');
         },
 


### PR DESCRIPTION
no issue
- if the session is "authenticated" but is invalid, the initial load of the app would fail. It could be replicated by:
  1. Authenticating in a running ghost instance
  2. Stopping ghost
  3. Deleting the database
  4. Re-starting ghost
  5. Closing the browser
  6. Re-opening the browser and visiting http://localhost:2368/ghost
- this fix stores the `transition` object for the duration of the initial load so that `sessionInvalidated` method can trigger actions before the transition has finished
