### PR TITLE
Prevents sameAs property to be filled with `null`

### DIFF
--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -15,6 +15,34 @@ function trimSchema(schema) {
     return schemaObject;
 }
 
+function trimSameAs(data, context) {
+    var sameAs = [];
+
+    if (context === 'post') {
+        if (data.post.author.website) {
+            sameAs.push(data.post.author.website);
+        }
+        if (data.post.author.facebook) {
+            sameAs.push(data.post.author.facebook);
+        }
+        if (data.post.author.twitter) {
+            sameAs.push(data.post.author.twitter);
+        }
+    } else if (context === 'author') {
+        if (data.author.website) {
+            sameAs.push(data.author.website);
+        }
+        if (data.author.facebook) {
+            sameAs.push(data.author.facebook);
+        }
+        if (data.author.twitter) {
+            sameAs.push(data.author.twitter);
+        }
+    }
+
+    return sameAs;
+}
+
 function getPostSchema(metaData, data) {
     var description = metaData.metaDescription ? escapeExpression(metaData.metaDescription) :
         (metaData.excerpt ? escapeExpression(metaData.excerpt) : null),
@@ -29,11 +57,7 @@ function getPostSchema(metaData, data) {
             name: escapeExpression(data.post.author.name),
             image: metaData.authorImage,
             url: metaData.authorUrl,
-            sameAs: [
-                data.post.author.website || null,
-                data.post.author.facebook || null,
-                data.post.author.twitter || null
-            ],
+            sameAs: trimSameAs(data, 'post'),
             description: data.post.author.bio ?
             escapeExpression(data.post.author.bio) :
             null
@@ -85,11 +109,7 @@ function getAuthorSchema(metaData, data) {
     var schema = {
         '@context': 'http://schema.org',
         '@type': 'Person',
-        sameAs: [
-            data.author.website || null,
-            data.author.facebook || null,
-            data.author.twitter || null
-        ],
+        sameAs: trimSameAs(data, 'author'),
         publisher: escapeExpression(metaData.blog.title),
         name: escapeExpression(data.author.name),
         url: metaData.authorUrl,

--- a/core/test/unit/metadata/schema_spec.js
+++ b/core/test/unit/metadata/schema_spec.js
@@ -93,11 +93,7 @@ describe('getSchema', function () {
             author: {
                 '@type': 'Person',
                 name: 'Post Author',
-                sameAs: [
-                    null,
-                    null,
-                    null
-                ],
+                sameAs: [],
                 url: 'http://mysite.com/author/me/'
             },
             dateModified: '2016-01-21T22:13:05.412Z',
@@ -170,7 +166,6 @@ describe('getSchema', function () {
             author: {
                 name: 'Author Name',
                 website: 'http://myblogsite.com/',
-                facebook: 'https://www.facebook.com/testuser',
                 twitter: 'https://twitter.com/testuser'
             }
         }, schema = getSchema(metadata, data);
@@ -183,7 +178,6 @@ describe('getSchema', function () {
             publisher: 'Blog Title',
             sameAs: [
                 'http://myblogsite.com/',
-                'https://www.facebook.com/testuser',
                 'https://twitter.com/testuser'
             ],
             url: 'http://mysite.com/author/me/'


### PR DESCRIPTION
no issue
- minor optical fix for schema.org metadata
- `sameAs` property in LD+JSON metadata was showing `null` value in array, if no data was provided
- instead of showing `null`, it will be empty. If no data (author website, facebook or twitter) is provided at all, it will be an empty array
