### PR TITLE
Removing very old fix for woff files

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -99,9 +99,6 @@ function init(options) {
 
         // ##Configuration
 
-        // return the correct mime type for woff files
-        express.static.mime.define({'application/font-woff': ['woff']});
-
         // enabled gzip compression by default
         if (config.server.compress !== false) {
             blogApp.use(compress());


### PR DESCRIPTION
I added this fix for the woff mime type, I think before the first public release even. The underlying issue was fixed [forever ago](https://github.com/broofa/node-mime/pull/60) so this is really just some cleanup.

There's never been a test for this, but a quick inspection of the Casper theme in chrome after this change shows the mimetype is correctly output as `application/font-woff` and not the incorrect `application/x-font-woff` which was the original issue.

![](http://puu.sh/oRHDP.png)

no issue
- This was fix a looong, loooonng, looooooooooonnnnnnng time ago: https://github.com/broofa/node-mime/pull/60
