### PR TITLE
Update document title on blog title change

### DIFF
--- a/core/client/app/controllers/settings/general.js
+++ b/core/client/app/controllers/settings/general.js
@@ -86,6 +86,10 @@ export default Controller.extend(SettingsSaveMixin, {
         return this.get('model').save().then((model) => {
             config.set('blogTitle', model.get('title'));
 
+            // this forces the document title to recompute after
+            // a blog title change
+            this.send('collectTitleTokens', []);
+
             return model;
         }).catch((error) => {
             if (error) {

--- a/core/client/tests/acceptance/settings/general-test.js
+++ b/core/client/tests/acceptance/settings/general-test.js
@@ -89,6 +89,13 @@ describe('Acceptance: Settings - General', function () {
                 expect(find('input#permalinks').prop('checked'), 'date permalinks checkbox').to.be.false;
             });
 
+            fillIn('#settings-general input[name="general[title]"]', 'New Blog Title');
+            click('.view-header .btn.btn-blue');
+
+            andThen(() => {
+                expect(document.title, 'page title').to.equal('Settings - General - New Blog Title');
+            });
+
             click('.blog-logo');
 
             andThen(() => {


### PR DESCRIPTION
no issue
- force document.title to recompute when the blog title is changed in settings/general
