### PR TITLE
fix: support successful import/export with user id 0

### DIFF
--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -77,6 +77,9 @@ utils = {
                 // if we don't have user data and the id is 1, we assume this means the owner
                 existingUsers[owner.email].importId = userToMap;
                 userMap[userToMap] = existingUsers[owner.email].realId;
+            } else if (userToMap === 0) {
+                // CASE: external context
+                userMap[userToMap] = '0';
             } else {
                 throw new errors.DataImportError(
                     i18n.t('errors.data.import.utils.dataLinkedToUnknownUser', {userToMap: userToMap}), 'user.id', userToMap


### PR DESCRIPTION
When we export blog data via the Ghost Admin interface, then import again and the JSON file contains `0` for a user_id reference (for example in updated_by field), the importer logic will throw the following exception:

```
ERROR: Attempting to import data linked to unknown user id
 Error
    at Error.DataImportError (/core/server/errors/data-import-error.js:6:18)
    at /core/server/data/import/utils.js:84:23
```

no issue
- support successful import/export with user id 0
- tested with sqlite3 and mysql
