### PR TITLE
Add helpers for facebook & twitter urls

### DIFF
--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -1,5 +1,6 @@
 var config = require('../../config'),
     hbs = require('express-hbs'),
+    socialUrls = require('../../utils/social-urls'),
     escapeExpression = hbs.handlebars.Utils.escapeExpression,
     _ = require('lodash');
 
@@ -23,20 +24,20 @@ function trimSameAs(data, context) {
             sameAs.push(data.post.author.website);
         }
         if (data.post.author.facebook) {
-            sameAs.push(data.post.author.facebook);
+            sameAs.push(socialUrls.facebookUrl(data.post.author.facebook));
         }
         if (data.post.author.twitter) {
-            sameAs.push(data.post.author.twitter);
+            sameAs.push(socialUrls.twitterUrl(data.post.author.twitter));
         }
     } else if (context === 'author') {
         if (data.author.website) {
             sameAs.push(data.author.website);
         }
         if (data.author.facebook) {
-            sameAs.push(data.author.facebook);
+            sameAs.push(socialUrls.facebookUrl(data.author.facebook));
         }
         if (data.author.twitter) {
-            sameAs.push(data.author.twitter);
+            sameAs.push(socialUrls.twitterUrl(data.author.twitter));
         }
     }
 

--- a/core/server/data/meta/structured_data.js
+++ b/core/server/data/meta/structured_data.js
@@ -1,14 +1,11 @@
+var socialUrls = require('../../utils/social-urls');
+
 function getStructuredData(metaData) {
     var structuredData,
-        card = 'summary',
-        twitterUser;
+        card = 'summary';
 
     if (metaData.coverImage) {
         card = 'summary_large_image';
-    }
-
-    if (metaData.creatorTwitter) {
-        twitterUser = '@' + metaData.creatorTwitter.match(/(?:https:\/\/)(?:twitter\.com)\/(?:#!\/)?@?([^\/]*)/)[1];
     }
 
     structuredData = {
@@ -21,8 +18,8 @@ function getStructuredData(metaData) {
         'article:published_time': metaData.publishedDate,
         'article:modified_time': metaData.modifiedDate,
         'article:tag': metaData.keywords,
-        'article:publisher': metaData.blog.facebook || undefined,
-        'article:author': metaData.authorFacebook || undefined,
+        'article:publisher': metaData.blog.facebook ? socialUrls.facebookUrl(metaData.blog.facebook) : undefined,
+        'article:author': metaData.authorFacebook ? socialUrls.facebookUrl(metaData.authorFacebook) : undefined,
         'twitter:card': card,
         'twitter:title': metaData.metaTitle,
         'twitter:description': metaData.metaDescription || metaData.excerpt,
@@ -33,7 +30,7 @@ function getStructuredData(metaData) {
         'twitter:label2': metaData.keywords ? 'Filed under' : undefined,
         'twitter:data2': metaData.keywords ? metaData.keywords.join(', ') : undefined,
         'twitter:site': metaData.blog.twitter || undefined,
-        'twitter:creator': twitterUser || undefined
+        'twitter:creator': metaData.creatorTwitter || undefined
     };
 
     // return structured data removing null or undefined keys

--- a/core/server/helpers/facebook_url.js
+++ b/core/server/helpers/facebook_url.js
@@ -1,0 +1,26 @@
+// # Facebook URL Helper
+// Usage: `{{facebook_url}}` or `{{facebook_url author.facebook}}`
+//
+// Output a url for a twitter username
+//
+// We use the name facebook_url to match the helper for consistency:
+// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+
+var socialUrls = require('../utils/social-urls'),
+    findKey    = require('./utils').findKey,
+    facebook_url;
+
+facebook_url = function (username, options) {
+    if (!options) {
+        options = username;
+        username = findKey('facebook', this, options.data.blog);
+    }
+
+    if (username) {
+        return socialUrls.facebookUrl(username);
+    }
+
+    return null;
+};
+
+module.exports = facebook_url;

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -17,6 +17,7 @@ coreHelpers.content  = require('./content');
 coreHelpers.date  = require('./date');
 coreHelpers.encode  = require('./encode');
 coreHelpers.excerpt  = require('./excerpt');
+coreHelpers.facebook_url = require('./facebook_url');
 coreHelpers.foreach = require('./foreach');
 coreHelpers.get = require('./get');
 coreHelpers.ghost_foot = require('./ghost_foot');
@@ -34,6 +35,7 @@ coreHelpers.prev_post = require('./prev_next');
 coreHelpers.next_post = require('./prev_next');
 coreHelpers.tags = require('./tags');
 coreHelpers.title = require('./title');
+coreHelpers.twitter_url = require('./twitter_url');
 coreHelpers.url = require('./url');
 
 // Specialist helpers for certain templates
@@ -110,6 +112,8 @@ registerHelpers = function (adminHbs) {
     registerThemeHelper('post_class', coreHelpers.post_class);
     registerThemeHelper('tags', coreHelpers.tags);
     registerThemeHelper('title', coreHelpers.title);
+    registerThemeHelper('twitter_url', coreHelpers.twitter_url);
+    registerThemeHelper('facebook_url', coreHelpers.facebook_url);
     registerThemeHelper('url', coreHelpers.url);
 
     // Async theme helpers

--- a/core/server/helpers/twitter_url.js
+++ b/core/server/helpers/twitter_url.js
@@ -1,0 +1,26 @@
+// # Twitter URL Helper
+// Usage: `{{twitter_url}}` or `{{twitter_url author.twitter}}`
+//
+// Output a url for a twitter username
+//
+// We use the name twitter_url to match the helper for consistency:
+// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+
+var socialUrls = require('../utils/social-urls'),
+    findKey    = require('./utils').findKey,
+    twitter_url;
+
+twitter_url = function twitter_url(username, options) {
+    if (!options) {
+        options = username;
+        username = findKey('twitter', this, options.data.blog);
+    }
+
+    if (username) {
+        return socialUrls.twitterUrl(username);
+    }
+
+    return null;
+};
+
+module.exports = twitter_url;

--- a/core/server/helpers/utils.js
+++ b/core/server/helpers/utils.js
@@ -6,7 +6,19 @@ utils = {
     linkTemplate: _.template('<a href="<%= url %>"><%= text %></a>'),
     scriptTemplate: _.template('<script src="<%= source %>?v=<%= version %>"></script>'),
     inputTemplate: _.template('<input class="<%= className %>" type="<%= type %>" name="<%= name %>" <%= extras %> />'),
-    isProduction: process.env.NODE_ENV === 'production'
+    isProduction: process.env.NODE_ENV === 'production',
+    // @TODO this can probably be made more generic and used in more places
+    findKey: function findKey(key, object, data) {
+        if (object && _.has(object, key) && !_.isEmpty(object[key])) {
+            return object[key];
+        }
+
+        if (data && _.has(data, key) && !_.isEmpty(data[key])) {
+            return data[key];
+        }
+
+        return null;
+    }
 };
 
 module.exports = utils;

--- a/core/server/utils/social-urls.js
+++ b/core/server/utils/social-urls.js
@@ -1,0 +1,9 @@
+module.exports.twitterUrl = function twitterUrl(username) {
+    // Creates the canonical twitter URL without the '@'
+    return 'https://twitter.com/' + username.replace(/^@/, '');
+};
+
+module.exports.facebookUrl = function facebookUrl(username) {
+    // Handles a starting slash, this shouldn't happen, but just in case
+    return 'https://www.facebook.com/' + username.replace(/^\//, '');
+};

--- a/core/test/unit/metadata/schema_spec.js
+++ b/core/test/unit/metadata/schema_spec.js
@@ -10,7 +10,7 @@ describe('getSchema', function () {
                 logo: 'http://mysite.com/author/image/url/logo.jpg'
             },
             authorImage: 'http://mysite.com/author/image/url/me.jpg',
-            authorFacebook: 'https://facebook.com/testuser',
+            authorFacebook: 'testuser',
             creatorTwitter: '@testuser',
             authorUrl: 'http://mysite.com/author/me/',
             metaTitle: 'Post Title',
@@ -27,8 +27,8 @@ describe('getSchema', function () {
                     name: 'Post Author',
                     website: 'http://myblogsite.com/',
                     bio: 'My author bio.',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             }
         }, schema = getSchema(metadata, data);
@@ -175,7 +175,7 @@ describe('getSchema', function () {
             author: {
                 name: 'Author Name',
                 website: 'http://myblogsite.com/',
-                twitter: 'https://twitter.com/testuser'
+                twitter: '@testuser'
             }
         }, schema = getSchema(metadata, data);
 

--- a/core/test/unit/metadata/structured_data_spec.js
+++ b/core/test/unit/metadata/structured_data_spec.js
@@ -7,7 +7,7 @@ describe('getStructuredData', function () {
         var metadata = {
             blog: {
                 title: 'Blog Title',
-                facebook: 'https://www.facebook.com/testuser',
+                facebook: 'testuser',
                 twitter: '@testuser'
             },
             authorName: 'Test User',
@@ -17,8 +17,8 @@ describe('getStructuredData', function () {
             publishedDate: '2015-12-25T05:35:01.234Z',
             modifiedDate: '2016-01-21T22:13:05.412Z',
             coverImage: 'http://mysite.com/content/image/mypostcoverimage.jpg',
-            authorFacebook: 'https://www.facebook.com/testpage',
-            creatorTwitter: 'https://twitter.com/twitterpage',
+            authorFacebook: 'testpage',
+            creatorTwitter: '@twitterpage',
             keywords: ['one', 'two', 'tag'],
             metaDescription: 'Post meta description'
         },  structuredData = getStructuredData(metadata);

--- a/core/test/unit/server_helpers/facebook_url_spec.js
+++ b/core/test/unit/server_helpers/facebook_url_spec.js
@@ -1,0 +1,48 @@
+/*globals describe, before, beforeEach, it*/
+var should         = require('should'),
+    hbs            = require('express-hbs'),
+    utils          = require('./utils'),
+
+// Stuff we are testing
+    handlebars      = hbs.handlebars,
+    helpers         = require('../../../server/helpers');
+
+describe('{{facebook_url}} helper', function () {
+    var options = {data: {blog: {}}};
+
+    before(function () {
+        utils.loadHelpers();
+    });
+
+    beforeEach(function () {
+        options.data.blog = {facebook: ''};
+    });
+
+    it('has loaded facebook_url helper', function () {
+        should.exist(handlebars.helpers.facebook_url);
+    });
+
+    it('should output the facebook url for @blog, if no other facebook username is provided', function () {
+        options.data.blog = {facebook: 'hey'};
+
+        helpers.facebook_url.call({}, options).should.equal('https://www.facebook.com/hey');
+    });
+
+    it('should output the facebook url for the local object, if it has one', function () {
+        options.data.blog = {facebook: 'hey'};
+
+        helpers.facebook_url.call({facebook: 'you/there'}, options).should.equal('https://www.facebook.com/you/there');
+    });
+
+    it('should output the facebook url for the provided username when it is explicitly passed in', function () {
+        options.data.blog = {facebook: 'hey'};
+
+        helpers.facebook_url.call({facebook: 'you/there'}, 'i/see/you/over/there', options)
+            .should.equal('https://www.facebook.com/i/see/you/over/there');
+    });
+
+    it('should return null if there are no facebook usernames', function () {
+        should.equal(helpers.facebook_url(options), null);
+    });
+});
+

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -124,8 +124,8 @@ describe('{{ghost_head}} helper', function () {
                     slug: 'Author',
                     image: '/content/images/test-author-image.png',
                     website: 'http://authorwebsite.com',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
                     bio: 'Author bio'
                 }
             };
@@ -301,8 +301,8 @@ describe('{{ghost_head}} helper', function () {
                 image: '/content/images/test-author-image.png',
                 cover: '/content/images/author-cover-image.png',
                 website: 'http://authorwebsite.com',
-                facebook: 'https://www.facebook.com/testuser',
-                twitter: 'https://twitter.com/testuser'
+                facebook: 'testuser',
+                twitter: '@testuser'
             }, authorBk = _.cloneDeep(author);
 
             helpers.ghost_head.call(
@@ -393,8 +393,8 @@ describe('{{ghost_head}} helper', function () {
                     image: '/content/images/test-author-image.png',
                     website: 'http://authorwebsite.com',
                     bio: 'Author bio',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             }, postBk = _.cloneDeep(post);
 
@@ -470,8 +470,8 @@ describe('{{ghost_head}} helper', function () {
                     slug: 'Author',
                     image: '/content/images/test-author-image.png',
                     website: 'http://authorwebsite.com',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             };
 
@@ -546,8 +546,8 @@ describe('{{ghost_head}} helper', function () {
                     slug: 'Author',
                     image: '/content/images/test-author-image.png',
                     website: 'http://authorwebsite.com',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             };
 
@@ -618,8 +618,8 @@ describe('{{ghost_head}} helper', function () {
                     slug: 'Author',
                     image: null,
                     website: 'http://authorwebsite.com',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             };
 
@@ -833,8 +833,8 @@ describe('{{ghost_head}} helper', function () {
                     slug: 'Author',
                     image: 'content/images/test-author-image.png',
                     website: 'http://authorwebsite.com',
-                    facebook: 'https://www.facebook.com/testuser',
-                    twitter: 'https://twitter.com/testuser'
+                    facebook: 'testuser',
+                    twitter: '@testuser'
                 }
             };
 

--- a/core/test/unit/server_helpers/twitter_url_spec.js
+++ b/core/test/unit/server_helpers/twitter_url_spec.js
@@ -1,0 +1,48 @@
+/*globals describe, before, beforeEach, it*/
+var should         = require('should'),
+    hbs            = require('express-hbs'),
+    utils          = require('./utils'),
+
+// Stuff we are testing
+    handlebars      = hbs.handlebars,
+    helpers         = require('../../../server/helpers');
+
+describe('{{twitter_url}} helper', function () {
+    var options = {data: {blog: {}}};
+
+    before(function () {
+        utils.loadHelpers();
+    });
+
+    beforeEach(function () {
+        options.data.blog = {twitter: ''};
+    });
+
+    it('has loaded twitter_url helper', function () {
+        should.exist(handlebars.helpers.twitter_url);
+    });
+
+    it('should output the twitter url for @blog, if no other twitter username is provided', function () {
+        options.data.blog = {twitter: '@hey'};
+
+        helpers.twitter_url.call({}, options).should.equal('https://twitter.com/hey');
+    });
+
+    it('should output the twitter url for the local object, if it has one', function () {
+        options.data.blog = {twitter: '@hey'};
+
+        helpers.twitter_url.call({twitter: '@youthere'}, options).should.equal('https://twitter.com/youthere');
+    });
+
+    it('should output the twitter url for the provided username when it is explicitly passed in', function () {
+        options.data.blog = {twitter: '@hey'};
+
+        helpers.twitter_url.call({twitter: '@youthere'}, '@iseeyouoverthere', options)
+            .should.equal('https://twitter.com/iseeyouoverthere');
+    });
+
+    it('should return null if there are no twitter usernames', function () {
+        should.equal(helpers.twitter_url(options), null);
+    });
+});
+

--- a/core/test/unit/social-urls_spec.js
+++ b/core/test/unit/social-urls_spec.js
@@ -1,0 +1,39 @@
+/*globals describe, it*/
+var should = require('should'),
+
+    // Stuff we are testing
+    socialUrls = require('../../server/utils/social-urls');
+
+describe('Social Urls', function () {
+    it('should have a twitter url function', function () {
+        should.exist(socialUrls.twitterUrl);
+    });
+
+    it('should have a facebook url function', function () {
+        should.exist(socialUrls.facebookUrl);
+    });
+
+    describe('twitter', function () {
+        it('should return a correct concatenated URL', function () {
+            socialUrls.twitterUrl('myusername').should.eql('https://twitter.com/myusername');
+        });
+
+        it('should return a url without an @ sign if one is provided', function () {
+            socialUrls.twitterUrl('@myusername').should.eql('https://twitter.com/myusername');
+        });
+    });
+
+    describe('facebook', function () {
+        it('should return a correct concatenated URL', function () {
+            socialUrls.facebookUrl('myusername').should.eql('https://www.facebook.com/myusername');
+        });
+
+        it('should return a correct concatenated URL for usernames with slashes', function () {
+            socialUrls.facebookUrl('page/xxx/123').should.eql('https://www.facebook.com/page/xxx/123');
+        });
+
+        it('should return a correct concatenated URL for usernames which start with a slash', function () {
+            socialUrls.facebookUrl('/page/xxx/123').should.eql('https://www.facebook.com/page/xxx/123');
+        });
+    });
+});


### PR DESCRIPTION
Note: this PR assumes that we are now saving usernames only in the database for twitter & facebook

Changing to have usernames only in twitter & Facebook settings/columns currently breaks the frontend as the structured data gets confused. 

refs #6534
- this PR assumes that we are now saving usernames only in the database for twitter & facebook
- adds a new social links utility which can generate twitter & facebook urls from the username
- adds a `{{twitter_url}}` and `{{facebook_url}}` helper which uses these
- adds a full suite of tests for the helpers & utils
