### PR TITLE
Switch to using https for schema.org

### DIFF
--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -49,7 +49,7 @@ function getPostSchema(metaData, data) {
         schema;
 
     schema = {
-        '@context': 'http://schema.org',
+        '@context': 'https://schema.org',
         '@type': 'Article',
         publisher: {
             '@type': 'Organization',
@@ -81,7 +81,7 @@ function getPostSchema(metaData, data) {
 
 function getHomeSchema(metaData) {
     var schema = {
-        '@context': 'http://schema.org',
+        '@context': 'https://schema.org',
         '@type': 'Website',
         publisher: escapeExpression(metaData.blog.title),
         url: metaData.url,
@@ -95,7 +95,7 @@ function getHomeSchema(metaData) {
 
 function getTagSchema(metaData, data) {
     var schema = {
-        '@context': 'http://schema.org',
+        '@context': 'https://schema.org',
         '@type': 'Series',
         publisher: escapeExpression(metaData.blog.title),
         url: metaData.url,
@@ -111,7 +111,7 @@ function getTagSchema(metaData, data) {
 
 function getAuthorSchema(metaData, data) {
     var schema = {
-        '@context': 'http://schema.org',
+        '@context': 'https://schema.org',
         '@type': 'Person',
         sameAs: trimSameAs(data, 'author'),
         name: escapeExpression(data.author.name),

--- a/core/test/unit/metadata/schema_spec.js
+++ b/core/test/unit/metadata/schema_spec.js
@@ -34,7 +34,7 @@ describe('getSchema', function () {
         }, schema = getSchema(metadata, data);
 
         should.deepEqual(schema, {
-            '@context': 'http://schema.org',
+            '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
                 '@type': 'Person',
@@ -93,7 +93,7 @@ describe('getSchema', function () {
         }, schema = getSchema(metadata, data);
 
         should.deepEqual(schema, {
-            '@context': 'http://schema.org',
+            '@context': 'https://schema.org',
             '@type': 'Article',
             author: {
                 '@type': 'Person',
@@ -127,7 +127,7 @@ describe('getSchema', function () {
         }, schema = getSchema(metadata, data);
 
         should.deepEqual(schema, {
-            '@context': 'http://schema.org',
+            '@context': 'https://schema.org',
             '@type': 'Website',
             description: 'This is the theme description',
             image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
@@ -152,7 +152,7 @@ describe('getSchema', function () {
         }, schema = getSchema(metadata, data);
 
         should.deepEqual(schema, {
-            '@context': 'http://schema.org',
+            '@context': 'https://schema.org',
             '@type': 'Series',
             description: 'This is the tag description!',
             image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
@@ -180,7 +180,7 @@ describe('getSchema', function () {
         }, schema = getSchema(metadata, data);
 
         should.deepEqual(schema, {
-            '@context': 'http://schema.org',
+            '@context': 'https://schema.org',
             '@type': 'Person',
             description: 'This is the author description!',
             name: 'Author Name',

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -99,7 +99,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Website"/);
                 rendered.string.should.match(/"publisher": "Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/"/);
@@ -153,7 +153,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);
@@ -196,7 +196,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": "Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/tag\/tagtitle\/"/);
@@ -237,7 +237,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": "Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/tag\/tagtitle\/"/);
@@ -326,7 +326,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"sameAs": \[\n        "http:\/\/authorwebsite.com",\n        "https:\/\/www.facebook.com\/testuser",\n        "https:\/\/twitter.com\/testuser"\n    \]/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/author\/AuthorName\/"/);
@@ -426,7 +426,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:image:src" content="http:\/\/testurl.com\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);
@@ -445,7 +445,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog description"/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
 
@@ -505,7 +505,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:image:src" content="http:\/\/testurl.com\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);
@@ -518,13 +518,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost &quot;test&quot;"/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/post\/"/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog &quot;test&quot; description"/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
 
@@ -578,7 +578,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:image:src" content="http:\/\/testurl.com\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);
@@ -590,13 +590,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/post\/"/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/test-image.png"/);
                 rendered.string.should.not.match(/"keywords":/);
                 rendered.string.should.match(/"description": "blog description"/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
 
@@ -653,7 +653,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.not.match(/<meta name="twitter:image:src"/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
-                rendered.string.should.match(/"@context": "http:\/\/schema.org"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);


### PR DESCRIPTION
closes #6846
- Using http causes mixed content warnings, using https does not
- Both http & https validate according to Google's validator
