### PR TITLE
[FR] hide preview #6825

### DIFF
--- a/core/client/app/components/gh-editor.js
+++ b/core/client/app/components/gh-editor.js
@@ -14,6 +14,7 @@ export default Component.extend(ShortcutsMixin, {
     activeTab: 'markdown',
     editor: null,
     editorDisabled: undefined,
+    previewIsHidden: false,
     editorScrollInfo: null, // updated when gh-ed-editor component scrolls
     height: null, // updated when markdown is rendered
     shouldFocusEditor: false,
@@ -89,6 +90,15 @@ export default Component.extend(ShortcutsMixin, {
 
         enableEditor() {
             this.set('editorDisabled', undefined);
+        },
+
+        togglePreview() {
+            this.set('previewIsHidden', !this.previewIsHidden);
+            if (this.previewIsHidden) {
+                this.$('.entry-markdown').addClass('fullsize-on-desktop');
+            } else {
+                this.$('.entry-markdown').removeClass('fullsize-on-desktop');
+            }
         },
 
         // The actual functionality is implemented in utils/ed-editor-shortcuts

--- a/core/client/app/components/gh-preview-toggle.js
+++ b/core/client/app/components/gh-preview-toggle.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+const {
+    Component,
+    computed,
+    inject: {service}
+} = Ember;
+
+/*
+ This cute little component has one job.
+
+ On desktop, it toggles the markdown preview tab.
+
+ */
+export default Component.extend({
+    classNames: ['gh-preview-toggle'],
+
+    mediaQueries: service(),
+    isMobile: computed.reads('mediaQueries.isMobile'),
+    maximise: false,
+
+    iconClass: computed('maximise', 'isMobile', function () {
+        if (this.get('maximise') && !this.get('isMobile')) {
+            return 'icon-maximise';
+        } else {
+            return 'icon-minimise';
+        }
+    }),
+
+    click() {
+        if (!this.get('isMobile')) {
+            this.toggleProperty('maximise');
+            this.sendAction('desktopAction');
+        }
+    }
+});

--- a/core/client/app/styles/layouts/main.css
+++ b/core/client/app/styles/layouts/main.css
@@ -342,6 +342,47 @@ body > .ember-view:not(.liquid-target-container) {
     }
 }
 
+/* Preview Toggle - Opens and closes the markdown preview
+/* ---------------------------------------------------------- */
+@media (min-width: 500px) {
+    .fullsize-on-desktop {
+        width: 100% !important;
+    }
+}
+@media (min-width: 1001px) {
+    .gh-preview-toggle {
+        display: flex !important;
+    }
+}
+
+.gh-preview-toggle {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    padding: 5px 10px;
+    width: 45px;
+    height: 27px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.gh-preview-toggle:hover {
+    cursor: pointer;
+}
+
+.gh-preview-toggle i {
+    transition: all 0.2s ease;
+    transform: rotate(180deg);
+
+    -moz-transform: rotate(180deg);
+    -ms-transform: rotate(180deg);
+    -o-transform: rotate(180deg);
+    -webkit-transform: rotate(180deg);
+}
+
+.gh-preview-toggle:hover i {
+    color: var(--blue);
+}
 
 /* Auto Nav - Opens and closes like OSX dock
 /* ---------------------------------------------------------- */

--- a/core/client/app/templates/components/gh-editor.hbs
+++ b/core/client/app/templates/components/gh-editor.hbs
@@ -6,6 +6,7 @@
             <a href="#" {{action 'selectTab' 'preview'}} class="{{if previewActive 'active'}}">Preview</a>
         </span>
         <a class="markdown-help-icon" href="" title="Markdown Help" {{action (route-action "toggleMarkdownHelpModal")}}><i class="icon-markdown"></i></a>
+        {{gh-preview-toggle desktopAction="togglePreview"}}
     </header>
     <section id="entry-markdown-content" class="entry-markdown-content">
         {{gh-ed-editor classNames="markdown-editor js-markdown-editor"
@@ -22,25 +23,27 @@
     </section>
 </section>
 
-<section class="entry-preview js-entry-preview {{if previewActive 'active'}}">
-    <header class="floatingheader">
-        <span class="desktop-tabs"><a target="_blank" href="{{previewUrl}}">Preview</a></span>
-        <span class="mobile-tabs">
-            <a href="#" {{action 'selectTab' 'markdown'}} class="{{if markdownActive 'active'}}">Markdown</a>
-            <a href="#" {{action 'selectTab' 'preview'}} class="{{if previewActive 'active'}}">Preview</a>
-        </span>
-        <span class="entry-word-count">{{gh-count-words value}}</span>
-    </header>
-    <section class="entry-preview-content js-entry-preview-content">
-        {{gh-ed-preview classNames="rendered-markdown js-rendered-markdown"
-                        markdown=value
-                        scrollPosition=scrollPosition
-                        updateHeight=(action "updateHeight")
-                        uploadStarted=(action "disableEditor")
-                        uploadFinished=(action "enableEditor")
-                        updateImageSrc=(action "handleImgUpload")}}
+{{#unless previewIsHidden}}
+    <section class="entry-preview js-entry-preview {{if previewActive 'active'}}">
+        <header class="floatingheader">
+            <span class="desktop-tabs"><a target="_blank" href="{{previewUrl}}">Preview</a></span>
+            <span class="mobile-tabs">
+                <a href="#" {{action 'selectTab' 'markdown'}} class="{{if markdownActive 'active'}}">Markdown</a>
+                <a href="#" {{action 'selectTab' 'preview'}} class="{{if previewActive 'active'}}">Preview</a>
+            </span>
+            <span class="entry-word-count">{{gh-count-words value}}</span>
+        </header>
+        <section class="entry-preview-content js-entry-preview-content">
+            {{gh-ed-preview classNames="rendered-markdown js-rendered-markdown"
+                            markdown=value
+                            scrollPosition=scrollPosition
+                            updateHeight=(action "updateHeight")
+                            uploadStarted=(action "disableEditor")
+                            uploadFinished=(action "enableEditor")
+                            updateImageSrc=(action "handleImgUpload")}}
+        </section>
     </section>
-</section>
+{{/unless}}
 
 {{#if showCopyHTMLModal}}
     {{gh-fullscreen-modal "copy-html"

--- a/core/client/app/templates/components/gh-preview-toggle.hbs
+++ b/core/client/app/templates/components/gh-preview-toggle.hbs
@@ -1,0 +1,1 @@
+<i class="{{iconClass}}" role="button"></i>

--- a/core/client/tests/unit/components/gh-editor-test.js
+++ b/core/client/tests/unit/components/gh-editor-test.js
@@ -14,6 +14,7 @@ describeComponent(
         needs: [
             'component:gh-ed-editor',
             'component:gh-ed-preview',
+            'component:gh-preview-toggle',
             'helper:gh-count-words',
             'helper:route-action',
             'service:notifications'


### PR DESCRIPTION
This commit adds functionality to hide and show the preview like requested in #6825
![hidepreview](https://cloud.githubusercontent.com/assets/4396533/15359043/bc25f454-1d07-11e6-98eb-33a93154d00e.gif)

Grunt validate fails with two tests, but I can't figure out why.
