### PR TITLE
Fix broken editor when content contains wrapped images

### DIFF
--- a/core/client/app/components/gh-ed-preview.js
+++ b/core/client/app/components/gh-ed-preview.js
@@ -92,7 +92,7 @@ export default Component.extend({
             el.innerHTML = '';
             el.classList.remove('image-uploader');
 
-            fragment.replaceChild(el, oldEl);
+            oldEl.parentNode.replaceChild(el, oldEl);
         });
 
         this.set('previewHTML', fragment);


### PR DESCRIPTION
no issue
- don't assume that the upload element that is being replaced is top-level, target the element's parentNode rather than the overall fragment
