### PR TITLE
Fix order of subtasks in `grunt init`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -795,7 +795,7 @@ var _              = require('lodash'),
         // `bower` does have some quirks, such as not running as root. If you have problems please try running
         // `grunt init --verbose` to see if there are any errors.
         grunt.registerTask('init', 'Prepare the project for development',
-            ['shell:ember:init', 'shell:bower', 'update_submodules', 'assets', 'default']);
+            ['update_submodules', 'shell:ember:init', 'shell:bower', 'assets', 'default']);
 
         // ### Basic Asset Building
         // Builds and moves necessary client assets. Prod additionally builds the ember app.


### PR DESCRIPTION
no issue
- moves the `update_submodules` task to be first to ensure the client code is in place ready for the ember/bower tasks
