### PR TITLE
Revert to old Travis infrastructure and remove client tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
-sudo: required
-dist: trusty
 language: node_js
 # When changing node version also update it on lines 34, 36 and 46.
 node_js:
   - "0.10"
   - "0.12"
   - "4"
+sudo: false
 cache:
   directories:
     - node_modules
     - core/client/node_modules
     - core/client/bower_components
 addons:
-  firefox: "latest"
   postgresql: "9.3"
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - mysql-server
-      - google-chrome-stable
 env:
   global:
     - GITHUB_OAUTH_KEY=003a44d58f12089d0c0261338298af3813330949
@@ -32,14 +24,10 @@ env:
 matrix:
   include:
     - node_js: "0.10"
-      env: TEST_SUITE=client
-    - node_js: "0.10"
       env: TEST_SUITE=lint
 before_install:
-  - if [ $DB == "mysql" ]; then mysql -u root -e 'create database ghost_testing'; fi
+  - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_testing'; fi
   - if [ $DB == "pg" ]; then psql -c 'create database ghost_testing;' -U postgres; fi
-before_script:
-  - if [ $TEST_SUITE == "client" ]; then export DISPLAY=:99; sh -e /etc/init.d/xvfb start; sleep 3; fi
 after_success:
   - |
       if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then


### PR DESCRIPTION
no issue
- moves us back to the older but faster Travis infrastructure
- removes the client tests and related setup as they are now handled in the Ghost-Admin repo
