### PR TITLE
URL parsing error when the URL has port.

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -211,7 +211,11 @@ function urlFor(context, data, absolute) {
                 // or if hostname is inside of the slug
                 urlPath = urlPath.split(hostname)[1];
                 if (urlPath.substring(0, 1) !== '/') {
-                    urlPath = '/' + urlPath;
+                    if (urlPath.substring(0, 1) !== ':') {
+                        urlPath = '/' + urlPath;
+                    } else {
+                        urlPath = data.nav.url;
+                    }
                 }
                 absolute = true;
             }

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -377,6 +377,11 @@ describe('Config', function () {
                 testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
                 config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
+                configUtils.set({url: 'http://my-ghost-blog.com'});
+                testData = {nav: {url: 'http://my-ghost-blog.com:3000/short-and-sweet/'}};
+                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
+                config.urlFor(testContext, testData).should.not.equal('http://my-ghost-blog.com/:3000/short-and-sweet/');
+
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
                 testData = {nav: {url: 'mailto:marshmallow@my-ghost-blog.com'}};
                 config.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');


### PR DESCRIPTION
URL parsing error when the URL has port and hostname is the same as the site. 
Checks if the URL has port, if so adds the hostname again.

https://github.com/TryGhost/Ghost/issues/6893
Test OK and Test case Ok.
