### PR TITLE
Exclude fix for grunt coverage task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,7 +227,7 @@ var _              = require('lodash'),
                         mask: '**/*_spec.js',
                         coverageFolder: 'core/test/coverage/unit',
                         mochaOptions: ['--timeout=15000'],
-                        excludes: ['core/client/**', 'core/server/built']
+                        excludes: ['core/client', 'core/server/built']
                     }
                 },
                 coverage_all: {
@@ -241,7 +241,7 @@ var _              = require('lodash'),
                         coverageFolder: 'core/test/coverage/all',
                         mask: '**/*_spec.js',
                         mochaOptions: ['--timeout=15000'],
-                        excludes: ['core/client/**', 'core/server/built']
+                        excludes: ['core/client', 'core/server/built']
                     }
 
                 }


### PR DESCRIPTION
no issue
- fixes grunt coverage task which was erroring with the message: 'Fatal error: spawn Unknown system errno 7'
- using glob matching results in expanding to cover every file with -x in the mocha command,
  this was causing some sort of overflow type error.
- we can just exclude the directory and this is much quicker & makes more sense
