### PR TITLE
deps: moment-timezone@0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "3.10.1",
     "lodash.tostring": "4.1.3",
     "moment": "2.13.0",
-    "moment-timezone": "0.5.1",
+    "moment-timezone": "0.5.4",
     "morgan": "1.7.0",
     "multer": "1.1.0",
     "netjet": "1.1.1",


### PR DESCRIPTION
This dependency had a duplication in a merge somewhere and was then downgraded by mistake in [this commit](https://github.com/TryGhost/Ghost/commit/fa7cb3538962789c787f3c5e42c1439ae84fd03a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2) 

No Issue
- update moment-timezone dependency that was downgraded in error
