### PR TITLE
Fixes #6935 - Let Bluebird know Promise is not runaway

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -255,8 +255,9 @@ ConfigManager.prototype.load = function (configFilePath) {
             Promise.resolve(pendingConfig).then(function () {
                 return self.validate();
             }).then(function (rawConfig) {
-                resolve(self.init(rawConfig));
-            }).catch(reject);
+                return self.init(rawConfig);
+            }).then(resolve)
+            .catch(reject);
         });
     });
 };


### PR DESCRIPTION
This is a simple fix to let Bluebird know that we don't have a runaway promise. [http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it](http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it).

Bluebird flagged that `self.init` returns a Promise, but that Promise isn't returned into the original chain.  By including a `return null`, we can tell Bluebird that we meant to do that.

I considered using a promisified version of `fs.stat`, but decided against it because I think the function would have been less understandable.  `load` uses the `err` in `fs.stat`'s callback to determine if the file exists.  A promisified version of this would have had to have parallel logic paths in a `then` and `catch` handler, and that seemed less clear to me than just adding this `return null`.  
