### PR TITLE
Guard for currentUrl being undefined in navigation

### DIFF
--- a/core/server/helpers/navigation.js
+++ b/core/server/helpers/navigation.js
@@ -42,6 +42,10 @@ navigation = function (options) {
 
     // strips trailing slashes and compares urls
     function _isCurrentUrl(href, currentUrl) {
+        if (!currentUrl) {
+            return false;
+        }
+
         var strippedHref = href.replace(/\/+$/, ''),
             strippedCurrentUrl = currentUrl.replace(/\/+$/, '');
         return strippedHref === strippedCurrentUrl;

--- a/core/test/unit/server_helpers/navigation_spec.js
+++ b/core/test/unit/server_helpers/navigation_spec.js
@@ -70,6 +70,18 @@ describe('{{navigation}} helper', function () {
         rendered.string.should.be.equal('');
     });
 
+    it('can handle relativeUrl not being set (e.g. for images/assets)', function () {
+        var singleItem = {label: 'Foo', url: '/foo'},
+            rendered;
+        delete optionsData.data.root.relativeUrl;
+
+        optionsData.data.blog.navigation = [singleItem];
+        rendered = helpers.navigation(optionsData);
+        rendered.string.should.containEql('li');
+        rendered.string.should.containEql('nav-foo');
+        rendered.string.should.containEql('/foo');
+    });
+
     it('can render one item', function () {
         var singleItem = {label: 'Foo', url: '/foo'},
             testUrl = 'href="' + configUtils.config.url + '/foo"',


### PR DESCRIPTION
fixes #6937
- in certain cases, relativeUrl will not be set, e.g. for assets
- in this case, navigation will fail on the error.hbs template
