### PR TITLE
Allow domain name to be referenced on an external page in the navigation

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -204,11 +204,11 @@ function urlFor(context, data, absolute) {
             baseUrl = getBaseUrl(secure);
             hostname = baseUrl.split('//')[1] + ghostConfig.paths.subdir;
             if (urlPath.indexOf(hostname) > -1
-                && urlPath.indexOf('.' + hostname) === -1
-                && urlPath.indexOf('mailto:') !== 0) {
+                && !urlPath.split(hostname)[0].match(/\.|mailto:/)) {
                 // make link relative to account for possible
                 // mismatch in http/https etc, force absolute
                 // do not do so if link is a subdomain of blog url
+                // or if hostname is inside of the slug
                 urlPath = urlPath.split(hostname)[1];
                 if (urlPath.substring(0, 1) !== '/') {
                     urlPath = '/' + urlPath;

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -364,6 +364,12 @@ describe('Config', function () {
                 testData = {nav: {url: '#this-anchor'}};
                 config.urlFor(testContext, testData).should.equal('#this-anchor');
 
+                testData = {nav: {url: 'http://some-external-page.com/my-ghost-blog.com'}};
+                config.urlFor(testContext, testData).should.equal('http://some-external-page.com/my-ghost-blog.com');
+
+                testData = {nav: {url: 'http://some-external-page.com/stuff-my-ghost-blog.com-around'}};
+                config.urlFor(testContext, testData).should.equal('http://some-external-page.com/stuff-my-ghost-blog.com-around');
+
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
                 config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');


### PR DESCRIPTION
Allow domain name to be referenced on an external page in the navigation

closes #6939
- added a test for the specific issue
- modified the url generation to allow the url in an external pages slug

Don't really get why the tests were failing and now aren't any more - didn't change a thing :/
