### PR TITLE
#6948: ensure we initialise hbs and theme on bootstrap

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -52,6 +52,7 @@ updateConfigCache = function () {
 
     config.set({
         theme: {
+            activeTheme: settingsCache.activeTheme.value,
             title: (settingsCache.title && settingsCache.title.value) || '',
             description: (settingsCache.description && settingsCache.description.value) || '',
             logo: (settingsCache.logo && settingsCache.logo.value) || '',

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -1,20 +1,21 @@
 var bodyParser      = require('body-parser'),
     compress        = require('compression'),
-    config          = require('../config'),
-    errors          = require('../errors'),
     express         = require('express'),
     hbs             = require('express-hbs'),
     logger          = require('morgan'),
+    multer          = require('multer'),
+    netjet          = require('netjet'),
     path            = require('path'),
-    routes          = require('../routes'),
     serveStatic     = require('express').static,
     slashes         = require('connect-slashes'),
-    storage         = require('../storage'),
+    tmpdir          = require('os').tmpdir,
     passport        = require('passport'),
+    config          = require('../config'),
+    errors          = require('../errors'),
+    routes          = require('../routes'),
+    storage         = require('../storage'),
     utils           = require('../utils'),
     sitemapHandler  = require('../data/xml/sitemap/handler'),
-    multer          = require('multer'),
-    tmpdir          = require('os').tmpdir,
     authStrategies   = require('./auth-strategies'),
     auth             = require('./auth'),
     cacheControl     = require('./cache-control'),
@@ -28,7 +29,6 @@ var bodyParser      = require('body-parser'),
     themeHandler     = require('./theme-handler'),
     uncapitalise     = require('./uncapitalise'),
     cors             = require('./cors'),
-    netjet           = require('netjet'),
     labs             = require('./labs'),
     helpers          = require('../helpers'),
 
@@ -124,7 +124,7 @@ setupMiddleware = function setupMiddleware(blogApp) {
 
     // First determine whether we're serving admin or theme content
     blogApp.use(decideIsAdmin);
-    blogApp.use(themeHandler.updateActiveTheme);
+    blogApp.use(themeHandler.updateActiveTheme(blogApp));
     blogApp.use(themeHandler.configHbsForContext);
 
     // Admin only config

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -128,19 +128,34 @@ describe('Theme Handler', function () {
     });
 
     describe('updateActiveTheme', function () {
-        it('updates the active theme if changed', function (done) {
+        it('sets active theme on bootstrap', function () {
+            should.not.exist(blogApp.get('activeTheme'));
+
             var activateThemeSpy = sandbox.spy(themeHandler, 'activateTheme');
-            sandbox.stub(api.settings, 'read').withArgs(sandbox.match.has('key', 'activeTheme')).returns(Promise.resolve({
-                settings: [{
-                    key: 'activeKey',
-                    value: 'casper'
-                }]
-            }));
-            blogApp.set('activeTheme', 'not-casper');
+            configUtils.set({theme: {activeTheme: 'casper'}});
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
-            themeHandler.updateActiveTheme(req, res, function () {
-                activateThemeSpy.called.should.be.true();
+            themeHandler.updateActiveTheme(blogApp);
+            activateThemeSpy.calledOnce.should.eql(true);
+            blogApp.get('activeTheme').should.eql('casper');
+        });
+
+        it('updates the active theme if changed', function (done) {
+            var activateThemeSpy = sandbox.spy(themeHandler, 'activateTheme');
+
+            sandbox.stub(api.settings, 'read').withArgs(sandbox.match.has('key', 'activeTheme')).returns(Promise.resolve({
+                settings: [{
+                    key: 'activateTheme',
+                    value: 'new-theme'
+                }]
+            }));
+
+            configUtils.set({theme: {activeTheme: 'casper'}});
+            configUtils.set({paths: {availableThemes: {casper: {}, 'new-theme': {}}}});
+
+            themeHandler.updateActiveTheme(blogApp)(req, res, function () {
+                activateThemeSpy.calledTwice.should.be.true();
+                blogApp.get('activeTheme').should.eql('new-theme');
                 done();
             });
         });
@@ -149,15 +164,17 @@ describe('Theme Handler', function () {
             var activateThemeSpy = sandbox.spy(themeHandler, 'activateTheme');
             sandbox.stub(api.settings, 'read').withArgs(sandbox.match.has('key', 'activeTheme')).returns(Promise.resolve({
                 settings: [{
-                    key: 'activeKey',
+                    key: 'activateTheme',
                     value: 'casper'
                 }]
             }));
-            blogApp.set('activeTheme', 'casper');
+
+            configUtils.set({theme: {activeTheme: 'casper'}});
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
-            themeHandler.updateActiveTheme(req, res, function () {
-                activateThemeSpy.called.should.be.false();
+            themeHandler.updateActiveTheme(blogApp)(req, res, function () {
+                activateThemeSpy.calledOnce.should.be.true();
+                blogApp.get('activeTheme').should.eql('casper');
                 done();
             });
         });
@@ -172,13 +189,14 @@ describe('Theme Handler', function () {
                     value: 'rasper'
                 }]
             }));
-            blogApp.set('activeTheme', 'not-casper');
+
+            configUtils.set({theme: {activeTheme: 'casper'}});
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
-            themeHandler.updateActiveTheme(req, res, function (err) {
+            themeHandler.updateActiveTheme(blogApp)(req, res, function (err) {
                 should.exist(err);
                 errorSpy.called.should.be.true();
-                activateThemeSpy.called.should.be.false();
+                activateThemeSpy.calledOnce.should.be.true();
                 err.message.should.eql('The currently active theme "rasper" is missing.');
                 done();
             });
@@ -195,13 +213,14 @@ describe('Theme Handler', function () {
                     value: 'rasper'
                 }]
             }));
+
             res.isAdmin = true;
-            blogApp.set('activeTheme', 'not-casper');
+            configUtils.set({theme: {activeTheme: 'casper'}});
             configUtils.set({paths: {availableThemes: {casper: {}}}});
 
-            themeHandler.updateActiveTheme(req, res, function () {
+            themeHandler.updateActiveTheme(blogApp)(req, res, function () {
                 errorSpy.called.should.be.false();
-                activateThemeSpy.called.should.be.false();
+                activateThemeSpy.calledOnce.should.be.true();
                 warnSpy.called.should.be.true();
                 warnSpy.calledWith('The currently active theme "rasper" is missing.').should.be.true();
                 done();


### PR DESCRIPTION
closes #6948
- the hbs engine was never initialised  when server starts
- when you request a page which does not exist, express jumps directly into the error handlers
- delete some dynamic hbs engine setters in theme handler
##### tested
- delete database and see it works for fresh installs
- change a theme
- serve initial request as not found error
##### TODO
- [x] tests
