### PR TITLE
fix: model_events.js will cause errors for other tests

### DIFF
--- a/core/test/unit/model_events_spec.js
+++ b/core/test/unit/model_events_spec.js
@@ -1,6 +1,7 @@
 /*globals describe, before, afterEach, it*/
 var should          = require('should'),
     sinon           = require('sinon'),
+    rewire          = require('rewire'),
     sandbox         = sinon.sandbox.create(),
     events          = require('../../server/events'),
     Models          = require('../../server/models');
@@ -9,7 +10,15 @@ var should          = require('should'),
 should.equal(true, true);
 
 describe('Model Events', function () {
+    var eventsToRemember = {};
+
     before(function () {
+        sandbox.stub(events, 'on', function (name, callback) {
+            eventsToRemember[name] = callback;
+        });
+
+        rewire('../../server/models/base/events');
+
         // Loads all the models
         Models.init();
     });
@@ -22,8 +31,10 @@ describe('Model Events', function () {
         it('calls User edit when event is emitted', function (done) {
             // Setup
             var userModelSpy = sandbox.spy(Models.User, 'edit');
+
             // Test
-            events.emit('token.added', {get: function () { return 1; }});
+            eventsToRemember['token.added']({get: function () { return 1; }});
+
             // Assert
             userModelSpy.calledOnce.should.be.true();
             userModelSpy.calledWith(


### PR DESCRIPTION
same problem as https://github.com/TryGhost/Ghost/pull/6929

Every test which throws a general event, will cause problems for other tests.
So we throw an event only in the scope of the test file.
