### PR TITLE
improvement: improve db/connection.js readability

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,6 +1,5 @@
 var knex = require('knex'),
     config = require('../../config'),
-    dbConfig = config.database,
     knexInstance;
 
 function configure(dbConfig) {
@@ -47,8 +46,8 @@ function configure(dbConfig) {
     return dbConfig;
 }
 
-if (!knexInstance && dbConfig && dbConfig.client) {
-    knexInstance = knex(configure(dbConfig));
+if (!knexInstance && config.database && config.database.client) {
+    knexInstance = knex(configure(config.database));
 }
 
 module.exports = knexInstance;


### PR DESCRIPTION
no issue

This is a very small PR to improve the db/connection.js readability.
`dbConfig` variable was defined on top of the file and passed to the inner fn `configure`, which also defined the same variable name `dbConfig`.
