### PR TITLE
improvement: rename and extend test utils fixture functions

### DIFF
--- a/core/test/functional/routes/channel_spec.js
+++ b/core/test/functional/routes/channel_spec.js
@@ -134,7 +134,7 @@ describe('Channel Routes', function () {
             // we then insert with max 11 which ensures we have 16 published posts
             before(function (done) {
                 testUtils.initData().then(function () {
-                    return testUtils.fixtures.insertPosts();
+                    return testUtils.fixtures.insertPostsAndTags();
                 }).then(function () {
                     return testUtils.fixtures.insertMorePosts(11);
                 }).then(function () {
@@ -280,7 +280,7 @@ describe('Channel Routes', function () {
             // Add enough posts to trigger pages
             before(function (done) {
                 testUtils.initData().then(function () {
-                    return testUtils.fixtures.insertPosts();
+                    return testUtils.fixtures.insertPostsAndTags();
                 }).then(function () {
                     return testUtils.fixtures.insertMorePosts(22);
                 }).then(function () {
@@ -451,7 +451,7 @@ describe('Channel Routes', function () {
                 }).then(function () {
                     return testUtils.fixtures.overrideOwnerUser('ghost-owner');
                 }).then(function () {
-                    return testUtils.fixtures.insertPosts();
+                    return testUtils.fixtures.insertPostsAndTags();
                 }).then(function () {
                     return testUtils.fixtures.insertMorePosts(9);
                 }).then(function () {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -31,7 +31,7 @@ describe('Frontend Routing', function () {
 
     function addPosts(done) {
         testUtils.initData().then(function () {
-            return testUtils.fixtures.insertPosts();
+            return testUtils.fixtures.insertPostsAndTags();
         }).then(function () {
             done();
         });
@@ -570,7 +570,7 @@ describe('Frontend Routing', function () {
     describe('Site Map', function () {
         before(function (done) {
             testUtils.initData().then(function () {
-                return testUtils.fixtures.insertPosts();
+                return testUtils.fixtures.insertPostsAndTags();
             }).then(function () {
                 done();
             }).catch(done);

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -47,7 +47,7 @@ describe('Tag Model', function () {
     });
 
     it('returns count.posts if include count.posts', function (done) {
-        testUtils.fixtures.insertPosts().then(function () {
+        testUtils.fixtures.insertPostsAndTags().then(function () {
             TagModel.findOne({slug: 'kitchen-sink'}, {include: 'count.posts'}).then(function (tag) {
                 should.exist(tag);
                 tag.toJSON().count.posts.should.equal(2);
@@ -59,7 +59,7 @@ describe('Tag Model', function () {
 
     describe('findPage', function () {
         beforeEach(function (done) {
-            testUtils.fixtures.insertPosts().then(function () {
+            testUtils.fixtures.insertPostsAndTags().then(function () {
                 done();
             }).catch(done);
         });
@@ -90,7 +90,7 @@ describe('Tag Model', function () {
 
     describe('findOne', function () {
         beforeEach(function (done) {
-            testUtils.fixtures.insertPosts().then(function () {
+            testUtils.fixtures.insertPostsAndTags().then(function () {
                 done();
             }).catch(done);
         });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -33,7 +33,11 @@ var Promise       = require('bluebird'),
 
 /** TEST FIXTURES **/
 fixtures = {
-    insertPosts: function insertPosts() {
+    insertPosts: function insertPosts(posts) {
+        return Promise.resolve(db.knex('posts').insert(posts));
+    },
+
+    insertPostsAndTags: function insertPosts() {
         return Promise.resolve(db.knex('posts').insert(DataGenerator.forKnex.posts)).then(function () {
             return db.knex('tags').insert(DataGenerator.forKnex.tags);
         }).then(function () {
@@ -278,9 +282,9 @@ fixtures = {
         });
     },
 
-    insertOne: function insertOne(obj, fn) {
+    insertOne: function insertOne(obj, fn, index) {
         return db.knex(obj)
-           .insert(DataGenerator.forKnex[fn](DataGenerator.Content[obj][0]));
+           .insert(DataGenerator.forKnex[fn](DataGenerator.Content[obj][index || 0]));
     },
 
     insertApps: function insertApps() {
@@ -399,7 +403,7 @@ toDoList = {
     tag: function insertTag() { return fixtures.insertOne('tags', 'createTag'); },
     subscriber: function insertSubscriber() { return fixtures.insertOne('subscribers', 'createSubscriber'); },
 
-    posts: function insertPosts() { return fixtures.insertPosts(); },
+    posts: function insertPosts() { return fixtures.insertPostsAndTags(); },
     'posts:mu': function insertMultiAuthorPosts() { return fixtures.insertMultiAuthorPosts(); },
     tags: function insertMoreTags() { return fixtures.insertMoreTags(); },
     apps: function insertApps() { return fixtures.insertApps(); },


### PR DESCRIPTION
no issue
- rename insertPosts to insertPostsAndTags
- add insertPosts
- extend insertOne to choose index
