### PR TITLE
improvement: add mocks helper module for test env

### DIFF
--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -14,6 +14,7 @@ var Promise       = require('bluebird'),
     filterData    = require('./fixtures/filter-param'),
     API           = require('./api'),
     fork          = require('./fork'),
+    mocks         = require('./mocks'),
     config        = require('../../server/config'),
 
     fixtures,
@@ -595,6 +596,8 @@ module.exports = {
     initFixtures: initFixtures,
     initData: initData,
     clearData: clearData,
+
+    mocks: mocks,
 
     fixtures: fixtures,
 

--- a/core/test/utils/mocks/index.js
+++ b/core/test/utils/mocks/index.js
@@ -1,0 +1,1 @@
+exports.utils = require('./utils');

--- a/core/test/utils/mocks/utils.js
+++ b/core/test/utils/mocks/utils.js
@@ -1,0 +1,20 @@
+var Module = require('module'),
+    originalRequireFn = Module.prototype.require;
+
+/**
+ * helper fn to mock non existent modules
+ * mocks.utils.mockNotExistingModule(/pattern/, mockedModule)
+ */
+exports.mockNotExistingModule = function mockNotExistingModule(modulePath, module) {
+    Module.prototype.require = function (path) {
+        if (path.match(modulePath)) {
+            return module;
+        }
+
+        return originalRequireFn.apply(this, arguments);
+    };
+};
+
+exports.unmockNotExistingModule = function unmockNotExistingModule() {
+    Module.prototype.require = originalRequireFn;
+};


### PR DESCRIPTION
no issue

With this PR you can mock non existent modules.

```
mocks.utils.mockNotExistingModule(/server\/api\/my-module/, { doSomething: 'do-something' })
```

The purpose is if you develop a bigger feature, sometimes you rely on other new modules.  With this mock helper functions you can easily mock them without pulling changes in your branch.
