### PR TITLE
Update tags & foreach to respect `visibility`

### DIFF
--- a/core/server/helpers/foreach.js
+++ b/core/server/helpers/foreach.js
@@ -6,20 +6,48 @@ var hbs             = require('express-hbs'),
     _               = require('lodash'),
     errors          = require('../errors'),
     i18n            = require('../i18n'),
+    labs            = require('../utils/labs'),
+    utils           = require('./utils'),
 
     hbsUtils        = hbs.handlebars.Utils,
     foreach;
 
-foreach = function (itemType, options) {
+function filterItemsByVisibility(items, options) {
+    var visibility = utils.parseVisibility(options);
+
+    if (!labs.isSet('internalTags') || _.includes(visibility, 'all')) {
+        return items;
+    }
+
+    function visibilityFilter(item) {
+        // If the item doesn't have a visibility property && options.hash.visibility wasn't set
+        // We return the item, else we need to be sure that this item has the property
+        if (!item.visibility && !options.hash.visibility || _.includes(visibility, item.visibility)) {
+            return item;
+        }
+    }
+
+    // We don't want to change the structure of what is returned
+    return _.isArray(items) ? _.filter(items, visibilityFilter) : _.pickBy(items, visibilityFilter);
+}
+
+foreach = function (items, options) {
     if (!options) {
         errors.logWarn(i18n.t('warnings.helpers.foreach.iteratorNeeded'));
     }
+
+    if (hbsUtils.isFunction(items)) {
+        items = items.call(this);
+    }
+
+    // Exclude items which should not be visible in the theme
+    items = filterItemsByVisibility(items, options);
 
     // Initial values set based on parameters sent through. If nothing sent, set to defaults
     var fn = options.fn,
         inverse = options.inverse,
         columns = options.hash.columns,
-        length = _.size(itemType),
+        length = _.size(items),
         limit = parseInt(options.hash.limit, 10) || length,
         from = parseInt(options.hash.from, 10) || 1,
         to = parseInt(options.hash.to, 10) || length,
@@ -35,10 +63,6 @@ foreach = function (itemType, options) {
 
     if (options.data && options.ids) {
         contextPath = hbsUtils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
-    }
-
-    if (hbsUtils.isFunction(itemType)) {
-        itemType = itemType.call(this);
     }
 
     if (options.data) {
@@ -61,9 +85,9 @@ foreach = function (itemType, options) {
             }
         }
 
-        output = output + fn(itemType[field], {
+        output = output + fn(items[field], {
             data: data,
-            blockParams: hbsUtils.blockParams([itemType[field], field], [contextPath + field, null])
+            blockParams: hbsUtils.blockParams([items[field], field], [contextPath + field, null])
         });
     }
 
@@ -88,8 +112,8 @@ foreach = function (itemType, options) {
         });
     }
 
-    if (itemType && typeof itemType === 'object') {
-        iterateCollection(itemType);
+    if (items && typeof items === 'object') {
+        iterateCollection(items);
     }
 
     if (length === 0) {

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -17,37 +17,51 @@ tags = function (options) {
     options = options || {};
     options.hash = options.hash || {};
 
-    var autolink  = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
-        separator = _.isString(options.hash.separator) ? options.hash.separator : ', ',
-        prefix    = _.isString(options.hash.prefix) ? options.hash.prefix : '',
-        suffix    = _.isString(options.hash.suffix) ? options.hash.suffix : '',
-        limit     = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
-        from      = options.hash.from ? parseInt(options.hash.from, 10) : 1,
-        to        = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
-        output = '';
+    var autolink   = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
+        separator  = _.isString(options.hash.separator) ? options.hash.separator : ', ',
+        prefix     = _.isString(options.hash.prefix) ? options.hash.prefix : '',
+        suffix     = _.isString(options.hash.suffix) ? options.hash.suffix : '',
+        limit      = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
+        from       = options.hash.from ? parseInt(options.hash.from, 10) : 1,
+        to         = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
+        visibility = utils.parseVisibility(options),
+        output     = '';
 
     function createTagList(tags) {
-        if (labs.isSet('internalTags')) {
-            tags = _.filter(tags, 'visibility', 'public');
-        }
+        return _.reduce(tags, function (tagArray, tag) {
+            // If labs.internalTags is set && visibility is not set to all
+            // Then, if tag has a visibility property, and that visibility property is also not explicitly allowed, skip tag
+            // or if there is no visibility property, and options.hash.visibility was set, skip tag
+            if (labs.isSet('internalTags') && !_.includes(visibility, 'all')) {
+                if (
+                    (tag.visibility && !_.includes(visibility, tag.visibility) && !_.includes(visibility, 'all')) ||
+                    (!!options.hash.visibility && !_.includes(visibility, 'all') && !tag.visibility)
+                ) {
+                    // Skip this tag
+                    return tagArray;
+                }
+            }
 
-        if (autolink) {
-            return _.map(tags, function (tag) {
-                return utils.linkTemplate({
-                    url: config.urlFor('tag', {tag: tag}),
-                    text: _.escape(tag.name)
-                });
-            });
-        }
-        return _(tags).pluck('name').each(_.escape);
+            var tagOutput = autolink ? utils.linkTemplate({
+                url: config.urlFor('tag', {tag: tag}),
+                text: _.escape(tag.name)
+            }) : _.escape(tag.name);
+
+            tagArray.push(tagOutput);
+
+            return tagArray;
+        }, []);
     }
 
     if (this.tags && this.tags.length) {
         output = createTagList(this.tags);
         from -= 1; // From uses 1-indexed, but array uses 0-indexed.
-        to = to || limit + from || this.tags.length;
+        to = to || limit + from || output.length;
+        output = output.slice(from, to).join(separator);
+    }
 
-        output = prefix + output.slice(from, to).join(separator) + suffix;
+    if (output) {
+        output = prefix + output + suffix;
     }
 
     return new hbs.handlebars.SafeString(output);

--- a/core/server/helpers/utils.js
+++ b/core/server/helpers/utils.js
@@ -18,6 +18,13 @@ utils = {
         }
 
         return null;
+    },
+    parseVisibility: function parseVisibility(options) {
+        if (!options.hash.visibility) {
+            return ['public'];
+        }
+
+        return _.map(options.hash.visibility.split(','), _.trim);
     }
 };
 

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -1,11 +1,13 @@
 var moment = require('moment-timezone'),
     _ = require('lodash'),
+    pickBy = require('lodash.pickby'),
     toString = require('lodash.tostring');
 
 /**
  * the version of lodash included in Ghost (3.10.1) does not have _.toString - it is added in a later version.
  */
 _.toString = toString;
+_.pickBy = pickBy;
 
 /**
  * force UTC

--- a/core/test/unit/server_helpers/foreach_spec.js
+++ b/core/test/unit/server_helpers/foreach_spec.js
@@ -7,6 +7,7 @@ var should         = require('should'),
 
 // Stuff we are testing
     handlebars     = hbs.handlebars,
+    labs           = require('../../../server/utils/labs'),
     helpers        = require('../../../server/helpers');
 
 describe('{{#foreach}} helper', function () {
@@ -495,6 +496,116 @@ describe('{{#foreach}} helper', function () {
 
             shouldCompileToExpected(templateString, arrayHash, expected);
             shouldCompileToExpected(templateString, objectHash, expected);
+        });
+
+        describe('Internal Tags', function () {
+            var tagArrayHash = {
+                    tags: [
+                        {name: 'first', visibility: 'public'},
+                        {name: 'second', visibility: 'public'},
+                        {name: 'third', visibility: 'internal'},
+                        {name: 'fourth', visibility: 'public'},
+                        {name: 'fifth'}
+                    ]
+                },
+                tagObjectHash = {
+                    tags: {
+                        first: {name: 'first', visibility: 'public'},
+                        second: {name: 'second', visibility: 'public'},
+                        third: {name: 'third', visibility: 'internal'},
+                        fourth: {name: 'fourth', visibility: 'public'},
+                        fifth: {name: 'fifth'}
+                    }
+                };
+
+            // @TODO: remove these once internal tags are out of beta
+            describe('Labs flag', function () {
+                it('will output internal tags when the labs flag IS NOT set', function () {
+                    sandbox.stub(labs, 'isSet').returns(false);
+
+                    var templateString = '<ul>{{#foreach tags}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 first</li><li>1 second</li><li>2 third</li><li>3 fourth</li><li>4 fifth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('will NOT output internal tags when the labs flag IS set', function () {
+                    sandbox.stub(labs, 'isSet').returns(true);
+
+                    var templateString = '<ul>{{#foreach tags}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 first</li><li>1 second</li><li>2 fourth</li><li>3 fifth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+            });
+
+            describe('Enabled', function () {
+                beforeEach(function () {
+                    sandbox.stub(labs, 'isSet').returns(true);
+                });
+
+                it('will not output internal tags by default', function () {
+                    var templateString = '<ul>{{#foreach tags}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 first</li><li>1 second</li><li>2 fourth</li><li>3 fifth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('should still correctly apply from & limit tags', function () {
+                    var templateString = '<ul>{{#foreach tags from="2" limit="2"}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>1 second</li><li>2 fourth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('should output all tags with visibility="all"', function () {
+                    var templateString = '<ul>{{#foreach tags visibility="all"}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 first</li><li>1 second</li><li>2 third</li><li>3 fourth</li><li>4 fifth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('should output all tags with visibility property set with visibility="public,internal"', function () {
+                    var templateString = '<ul>{{#foreach tags visibility="public,internal"}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 first</li><li>1 second</li><li>2 third</li><li>3 fourth</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('should output all tags with visibility="internal"', function () {
+                    var templateString = '<ul>{{#foreach tags visibility="internal"}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul><li>0 third</li></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+
+                it('should output nothing if all tags are internal', function () {
+                    var tagArrayHash = {
+                            tags: [
+                                {name: 'first', visibility: 'internal'},
+                                {name: 'second', visibility: 'internal'}
+                            ]
+                        },
+                        tagObjectHash = {
+                            tags: {
+                                first: {name: 'first', visibility: 'internal'},
+                                second: {name: 'second', visibility: 'internal'}
+                            }
+                        },
+                        templateString = '<ul>{{#foreach tags}}<li>{{@index}} {{name}}</li>{{/foreach}}</ul>',
+                        expected = '<ul></ul>';
+
+                    shouldCompileToExpected(templateString, tagObjectHash, expected);
+                    shouldCompileToExpected(templateString, tagArrayHash, expected);
+                });
+            });
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jsonpath": "0.2.4",
     "knex": "0.10.0",
     "lodash": "3.10.1",
+    "lodash.pickby": "4.4.0",
     "lodash.tostring": "4.1.3",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",


### PR DESCRIPTION
@acburdine this PR is based off of yours - we can merge yours first tho 👍 

This PR adds and uses `lodash.pickby` because it correctly filters an object whilst still returning an object. All other lodash options (to the best of my knowledge) will return an array, thus changing the behaviour of the `{{foreach}}` helper. We really do need to [upgrade lodash soon](https://github.com/TryGhost/Ghost/issues/6911)!

This implementation very carefully maintains the data structure passed to the `{{#foreach}}` helper, with the exception of removing items which should not be output.

With this PR, both `{{tags}}` and `{{#foreach}}` will, in the case that the internalTags labs flag is set,  correctly respect the `visibility` property. By default, only items with no visibility property, or with the property set to `public` will be output by both helpers.

If a visibility attribute is explicitly provided, then only items which have a visibility property which also matches the value of the attribute will be output. If the visibility property is set to `all`, all items will be output (including those that do not have a visibility property).

This somewhat confusing (but I think correct from a UX perspective) logic is fully covered by the tests. 

To explain the cases, imagine one of the helpers is passed 3 items:
- A is public
- B is marked internal 
- C where the visibility property is missing 

_With respect to C the case here is items fetched from the API with only specific fields returned. I can't think of a case where the response would be mixed, the property should either be set or not set. The reason for the added handling is, if a `visibility` attribute is passed in to a set of objects that don't have that property, it should return nothing (i.e. there is no match) not return everything._

With the labs flag checked, the following will happen:

Case 1: Default
Output: A, C 

Case 2: `visibility="public"` (explicitly provided)
Output: A 

Case 3: `visibility="internal"`
Output: B

Case 4: `visibility="public, internal"`
Output: A, B

Case 5: `visibility="all"`
Output: A, B, C 

I imagine, there _might_ be a case for negatives, e.g. `-public`, buuut I'd rather ship this version under beta, get it tested by real users, and see if we find real use cases before we add more complex logic.

refs #6165
- adds lodash.pickby@4.4.0
- new helper util for understanding a visibility attribute
- generalises visibility handling for `{{tags}}` helper
- adds visibility handling to `{{foreach}}` helper
- adds tests which check behaviour + labs flag
