### PR TITLE
deps: lodash@4.13.1

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -108,7 +108,7 @@ updateSettingsCache = function (settings) {
  * @returns {*}
  */
 settingsFilter = function (settings, filter) {
-    return _.object(_.filter(_.pairs(settings), function (setting) {
+    return _.fromPairs(_.filter(_.toPairs(settings), function (setting) {
         if (filter) {
             return _.some(filter.split(','), function (f) {
                 return setting[1].type === f;

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -289,7 +289,7 @@ utils = {
                 return;
             }
 
-            object[docName][index] = _.omit(object[docName][index], _.isNull);
+            object[docName][index] = _.omitBy(object[docName][index], _.isNull);
         });
 
         if (editId && object[docName][0].id && parseInt(editId, 10) !== parseInt(object[docName][0].id, 10)) {
@@ -305,7 +305,7 @@ utils = {
         var type = fileData.mimetype,
             ext = path.extname(fileData.name).toLowerCase();
 
-        if (_.contains(types, type) && _.contains(extensions, ext)) {
+        if (_.includes(types, type) && _.includes(extensions, ext)) {
             return true;
         }
         return false;

--- a/core/server/apps/index.js
+++ b/core/server/apps/index.js
@@ -67,7 +67,7 @@ module.exports = {
                 },
                 loadPromises = _.map(appsToLoad, function (app) {
                     // If already installed, just activate the app
-                    if (_.contains(installedApps, app)) {
+                    if (_.includes(installedApps, app)) {
                         return loader.activateAppByName(app).then(function (loadedApp) {
                             return recordLoadedApp(app, loadedApp);
                         });

--- a/core/server/apps/loader.js
+++ b/core/server/apps/loader.js
@@ -11,7 +11,7 @@ var path = require('path'),
     loader;
 
 function isInternalApp(name) {
-    return _.contains(config.internalApps, name);
+    return _.includes(config.internalApps, name);
 }
 
 // Get the full path to an app by name

--- a/core/server/apps/sandbox.js
+++ b/core/server/apps/sandbox.js
@@ -44,7 +44,7 @@ AppSandbox.prototype.loadModule = function loadModuleSandboxed(modulePath) {
     // Set a new proxy require function
     currentModule.require = function requireProxy(module) {
         // check whitelist, plugin config, etc.
-        if (_.contains(self.opts.blacklist, module)) {
+        if (_.includes(self.opts.blacklist, module)) {
             throw new Error(i18n.t('errors.apps.unsafeAppRequire.error', {msg: module}));
         }
 

--- a/core/server/data/import/index.js
+++ b/core/server/data/import/index.js
@@ -71,7 +71,7 @@ handleErrors = function handleErrors(errorList) {
 checkDuplicateAttributes = function checkDuplicateAttributes(data, comparedValue, attribs) {
     // Check if any objects in data have the same attribute values
     return _.find(data, function (datum) {
-        return _.all(attribs, function (attrib) {
+        return _.every(attribs, function (attrib) {
             return datum[attrib] === comparedValue[attrib];
         });
     });

--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -18,7 +18,7 @@ updatedSettingKeys = {
 
 areEmpty = function (object) {
     var fields = _.toArray(arguments).slice(1),
-        areEmpty = _.all(fields, function (field) {
+        areEmpty = _.every(fields, function (field) {
             return _.isEmpty(object[field]);
         });
 
@@ -26,7 +26,7 @@ areEmpty = function (object) {
 };
 
 stripProperties = function stripProperties(properties, data) {
-    data = _.clone(data, true);
+    data = _.cloneDeep(data);
     _.each(data, function (obj) {
         _.each(properties, function (property) {
             delete obj[property];
@@ -139,7 +139,7 @@ utils = {
     },
 
     preProcessRolesUsers: function preProcessRolesUsers(tableData, owner, roles) {
-        var validRoles = _.pluck(roles, 'name');
+        var validRoles = _.map(roles, 'name');
         if (!tableData.roles || !tableData.roles.length) {
             tableData.roles = roles;
         }

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -49,21 +49,21 @@ _.extend(ImportManager.prototype, {
      * @returns {string[]}
      */
     getExtensions: function () {
-        return _.flatten(_.union(_.pluck(this.handlers, 'extensions'), defaults.extensions));
+        return _.flatten(_.union(_.map(this.handlers, 'extensions'), defaults.extensions));
     },
     /**
      * Get an array of all the mime types for which we have handlers
      * @returns {string[]}
      */
     getTypes: function () {
-        return _.flatten(_.union(_.pluck(this.handlers, 'types'), defaults.types));
+        return _.flatten(_.union(_.map(this.handlers, 'types'), defaults.types));
     },
     /**
      * Get an array of directories for which we have handlers
      * @returns {string[]}
      */
     getDirectories: function () {
-        return _.flatten(_.union(_.pluck(this.handlers, 'directories'), defaults.directories));
+        return _.flatten(_.union(_.map(this.handlers, 'directories'), defaults.directories));
     },
     /**
      * Convert items into a glob string
@@ -122,7 +122,7 @@ _.extend(ImportManager.prototype, {
      * @returns Boolean
      */
     isZip: function (ext) {
-        return _.contains(defaults.extensions, ext);
+        return _.includes(defaults.extensions, ext);
     },
     /**
      * Checks the content of a zip folder to see if it is valid.
@@ -276,7 +276,7 @@ _.extend(ImportManager.prototype, {
      */
     processFile: function (file, ext) {
         var fileHandler = _.find(this.handlers, function (handler) {
-            return _.contains(handler.extensions, ext);
+            return _.includes(handler.extensions, ext);
         });
 
         return fileHandler.loadFile([_.pick(file, 'name', 'path')]).then(function (loadedData) {

--- a/core/server/data/meta/description.js
+++ b/core/server/data/meta/description.js
@@ -7,15 +7,15 @@ function getDescription(data, root) {
 
     if (data.meta_description) {
         description = data.meta_description;
-    } else if (_.contains(context, 'paged')) {
+    } else if (_.includes(context, 'paged')) {
         description = '';
-    } else if (_.contains(context, 'home')) {
+    } else if (_.includes(context, 'home')) {
         description = config.theme.description;
-    } else if (_.contains(context, 'author') && data.author) {
+    } else if (_.includes(context, 'author') && data.author) {
         description = data.author.meta_description || data.author.bio;
-    } else if (_.contains(context, 'tag') && data.tag) {
+    } else if (_.includes(context, 'tag') && data.tag) {
         description = data.tag.meta_description || data.tag.description;
-    } else if ((_.contains(context, 'post') || _.contains(context, 'page')) && data.post) {
+    } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
         description = data.post.meta_description;
     }
 

--- a/core/server/data/meta/title.js
+++ b/core/server/data/meta/title.js
@@ -13,13 +13,13 @@ function getTitle(data, root) {
     }
     if (data.meta_title) {
         title = data.meta_title;
-    } else if (_.contains(context, 'home')) {
+    } else if (_.includes(context, 'home')) {
         title = blog.title;
-    } else if (_.contains(context, 'author') && data.author) {
+    } else if (_.includes(context, 'author') && data.author) {
         title = data.author.name + pageString + ' - ' + blog.title;
-    } else if (_.contains(context, 'tag') && data.tag) {
+    } else if (_.includes(context, 'tag') && data.tag) {
         title = data.tag.meta_title || data.tag.name + pageString + ' - ' + blog.title;
-    } else if ((_.contains(context, 'post') || _.contains(context, 'page')) && data.post) {
+    } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
         title = data.post.meta_title || data.post.title;
     } else {
         title = blog.title + pageString;

--- a/core/server/data/schema/clients/mysql.js
+++ b/core/server/data/schema/clients/mysql.js
@@ -24,13 +24,13 @@ getTables = function getTables() {
 
 getIndexes = function getIndexes(table) {
     return doRawAndFlatten('SHOW INDEXES from ' + table, function (response) {
-        return _.pluck(response[0], 'Key_name');
+        return _.map(response[0], 'Key_name');
     });
 };
 
 getColumns = function getColumns(table) {
     return doRawAndFlatten('SHOW COLUMNS FROM ' + table, function (response) {
-        return _.pluck(response[0], 'Field');
+        return _.map(response[0], 'Field');
     });
 };
 

--- a/core/server/data/schema/clients/pg.js
+++ b/core/server/data/schema/clients/pg.js
@@ -11,7 +11,7 @@ var _  = require('lodash'),
 
 doRawFlattenAndPluck = function doRaw(query, name) {
     return db.knex.raw(query).then(function (response) {
-        return _.flatten(_.pluck(response.rows, name));
+        return _.flatten(_.map(response.rows, name));
     });
 };
 

--- a/core/server/data/schema/clients/sqlite3.js
+++ b/core/server/data/schema/clients/sqlite3.js
@@ -17,7 +17,7 @@ doRaw = function doRaw(query, fn) {
 
 getTables = function getTables() {
     return doRaw('select * from sqlite_master where type = "table"', function (response) {
-        return _.reject(_.pluck(response, 'tbl_name'), function (name) {
+        return _.reject(_.map(response, 'tbl_name'), function (name) {
             return name === 'sqlite_sequence';
         });
     });
@@ -25,13 +25,13 @@ getTables = function getTables() {
 
 getIndexes = function getIndexes(table) {
     return doRaw('pragma index_list("' + table + '")', function (response) {
-        return _.flatten(_.pluck(response, 'name'));
+        return _.flatten(_.map(response, 'name'));
     });
 };
 
 getColumns = function getColumns(table) {
     return doRaw('pragma table_info("' + table + '")', function (response) {
-        return _.flatten(_.pluck(response, 'name'));
+        return _.flatten(_.map(response, 'name'));
     });
 };
 

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -81,7 +81,7 @@ function deleteTable(table) {
 function getTables() {
     var client = db.knex.client.config.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.includes(_.keys(clients), client)) {
         return clients[client].getTables();
     }
 
@@ -91,7 +91,7 @@ function getTables() {
 function getIndexes(table) {
     var client = db.knex.client.config.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.includes(_.keys(clients), client)) {
         return clients[client].getIndexes(table);
     }
 
@@ -101,7 +101,7 @@ function getIndexes(table) {
 function getColumns(table) {
     var client = db.knex.client.config.client;
 
-    if (_.contains(_.keys(clients), client)) {
+    if (_.includes(_.keys(clients), client)) {
         return clients[client].getColumns(table);
     }
 

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -34,7 +34,7 @@ validator.extend('empty', function empty(str) {
 });
 
 validator.extend('notContains', function notContains(str, badString) {
-    return !_.contains(str, badString);
+    return !_.includes(str, badString);
 });
 
 validator.extend('isEmptyOrURL', function isEmptyOrURL(str) {

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -143,7 +143,7 @@ generateFeed = function generateFeed(data) {
                 guid: post.uuid,
                 url: itemUrl,
                 date: post.published_at,
-                categories: _.pluck(post.tags, 'name'),
+                categories: _.map(post.tags, 'name'),
                 author: post.author ? post.author.name : null,
                 custom_elements: []
             },

--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -80,7 +80,7 @@ _.extend(BaseSiteMapGenerator.prototype, {
             // Sort nodes by timestamp
             sortedNodes = _.sortBy(timedNodes, 'ts'),
             // Grab just the nodes
-            urlElements = _.pluck(sortedNodes, 'node'),
+            urlElements = _.map(sortedNodes, 'node'),
             data = {
                 // Concat the elements to the _attr declaration
                 urlset: [XMLNS_DECLS].concat(urlElements)

--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -6,7 +6,7 @@ var _       = require('lodash'),
 module.exports = function handler(blogApp) {
     var resourceTypes = ['posts', 'authors', 'tags', 'pages'],
         verifyResourceType = function verifyResourceType(req, res, next) {
-            if (!_.contains(resourceTypes, req.params.resource)) {
+            if (!_.includes(resourceTypes, req.params.resource)) {
                 return res.sendStatus(404);
             }
 

--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -23,23 +23,23 @@ body_class = function (options) {
 
     if (post) {
         // To be removed from pages by #2597 when we're ready to deprecate this
-        // i.e. this should be if (_.contains(context, 'post') && post) { ... }
+        // i.e. this should be if (_.includes(context, 'post') && post) { ... }
         classes.push('post-template');
     }
 
-    if (_.contains(context, 'home')) {
+    if (_.includes(context, 'home')) {
         classes.push('home-template');
-    } else if (_.contains(context, 'page') && page) {
+    } else if (_.includes(context, 'page') && page) {
         classes.push('page-template');
         // To be removed by #2597 when we're ready to deprecate this
         classes.push('page');
-    } else if (_.contains(context, 'tag') && this.tag) {
+    } else if (_.includes(context, 'tag') && this.tag) {
         classes.push('tag-template');
         classes.push('tag-' + this.tag.slug);
-    } else if (_.contains(context, 'author') && this.author) {
+    } else if (_.includes(context, 'author') && this.author) {
         classes.push('author-template');
         classes.push('author-' + this.author.slug);
-    } else if (_.contains(context, 'private')) {
+    } else if (_.includes(context, 'private')) {
         classes.push('private-template');
     }
 
@@ -47,7 +47,7 @@ body_class = function (options) {
         classes = classes.concat(tags.map(function (tag) { return 'tag-' + tag.slug; }));
     }
 
-    if (_.contains(context, 'paged')) {
+    if (_.includes(context, 'paged')) {
         classes.push('paged');
         // To be removed from pages by #2597 when we're ready to deprecate this
         classes.push('archive-template');

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -105,7 +105,7 @@ get = function get(resource, options) {
         return Promise.resolve();
     }
 
-    if (!_.contains(resources, resource)) {
+    if (!_.includes(resources, resource)) {
         data.error = i18n.t('warnings.helpers.get.invalidResource');
         errors.logWarn(data.error);
         return Promise.resolve(options.inverse(self, {data: data}));

--- a/core/server/helpers/has.js
+++ b/core/server/helpers/has.js
@@ -12,7 +12,7 @@ has = function (options) {
     options = options || {};
     options.hash = options.hash || {};
 
-    var tags = _.pluck(this.tags, 'name'),
+    var tags = _.map(this.tags, 'name'),
         author = this.author ? this.author.name : null,
         tagList = options.hash.tag || false,
         authorList = options.hash.author || false,
@@ -37,7 +37,7 @@ has = function (options) {
             return v.trim().toLocaleLowerCase();
         });
 
-        return _.contains(authorList, author.toLocaleLowerCase());
+        return _.includes(authorList, author.toLocaleLowerCase());
     }
 
     if (!tagList && !authorList) {

--- a/core/server/helpers/is.js
+++ b/core/server/helpers/is.js
@@ -20,7 +20,7 @@ is = function (context, options) {
         return expr.split(',').map(function (v) {
             return v.trim();
         }).reduce(function (p, c) {
-            return p || _.contains(currentContext, c);
+            return p || _.includes(currentContext, c);
         }, false);
     }
 

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -28,7 +28,7 @@ tags = function (options) {
 
     function createTagList(tags) {
         if (labs.isSet('internalTags')) {
-            tags = _.filter(tags, 'visibility', 'public');
+            tags = _.filter(tags, ['visibility', 'public']);
         }
 
         if (autolink) {
@@ -39,7 +39,7 @@ tags = function (options) {
                 });
             });
         }
-        return _(tags).pluck('name').each(_.escape);
+        return _(tags).map('name').each(_.escape);
     }
 
     if (this.tags && this.tags.length) {

--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -7,7 +7,7 @@ var _       = require('lodash'),
 function isBlackListedFileType(file) {
     var blackListedFileTypes = ['.hbs', '.md', '.json'],
         ext = path.extname(file);
-    return _.contains(blackListedFileTypes, ext);
+    return _.includes(blackListedFileTypes, ext);
 }
 
 function forwardToExpressStatic(req, res, next) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -199,7 +199,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             if (key.substring(0, 7) !== '_pivot_') {
                 // if include is set, expand to full object
                 var fullKey = _.isEmpty(options.baseKey) ? key : options.baseKey + '.' + key;
-                if (_.contains(self.include, fullKey)) {
+                if (_.includes(self.include, fullKey)) {
                     attrs[key] = relation.toJSON(_.extend({}, options, {baseKey: fullKey, include: self.include}));
                 }
             }
@@ -509,7 +509,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             // Some keywords cannot be changed
             slugList = _.union(slugList, config.slugs.protected);
 
-            return _.contains(slugList, slug) ? slug + '-' + baseName : slug;
+            return _.includes(slugList, slug) ? slug + '-' + baseName : slug;
         }).then(function then(slug) {
             // if slug is empty after trimming use the model name
             if (!slug) {

--- a/core/server/models/base/utils.js
+++ b/core/server/models/base/utils.js
@@ -15,7 +15,7 @@ tagUpdate = {
             return false;
         }
         return TagModel.forge()
-            .query('whereIn', 'name', _.pluck(tagsToMatch, 'name')).fetchAll(options);
+            .query('whereIn', 'name', _.map(tagsToMatch, 'name')).fetchAll(options);
     },
 
     detachTagFromPost: function detachTagFromPost(post, tag, options) {
@@ -62,7 +62,7 @@ tagUpdate = {
             return false;
         }
         // Return if no item is not the same (double negative is horrible)
-        return !_.any(tags1, function (tag1, index) {
+        return !_.some(tags1, function (tag1, index) {
             return !tagUpdate.tagsAreEqual(tag1, tags2[index]);
         });
     }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -286,14 +286,14 @@ Post = ghostBookshelf.Model.extend({
                     if (newTags.length === 0) {
                         return false;
                     }
-                    return _.any(newTags, function (newTag) {
+                    return _.some(newTags, function (newTag) {
                         return baseUtils.tagUpdate.tagsAreEqual(currentTag, newTag);
                     });
                 });
 
                 // Tags from the new tag array which don't exist in the DB should be created
-                tagsToCreate = _.pluck(_.reject(newTags, function (newTag) {
-                    return _.any(existingTags, function (existingTag) {
+                tagsToCreate = _.map(_.reject(newTags, function (newTag) {
+                    return _.some(existingTags, function (existingTag) {
                         return baseUtils.tagUpdate.tagsAreEqual(existingTag, newTag);
                     });
                 }), 'name');
@@ -434,7 +434,7 @@ Post = ghostBookshelf.Model.extend({
         if (options.staticPages && options.staticPages !== 'all') {
             // convert string true/false to boolean
             if (!_.isBoolean(options.staticPages)) {
-                options.staticPages = _.contains(['true', '1'], options.staticPages);
+                options.staticPages = _.includes(['true', '1'], options.staticPages);
             }
             options.where.statements.push({prop: 'page', op: '=', value: options.staticPages});
             delete options.staticPages;
@@ -447,7 +447,7 @@ Post = ghostBookshelf.Model.extend({
         // the status provided.
         if (options.status && options.status !== 'all') {
             // make sure that status is valid
-            options.status = _.contains(['published', 'draft'], options.status) ? options.status : 'published';
+            options.status = _.includes(['published', 'draft'], options.status) ? options.status : 'published';
             options.where.statements.push({prop: 'status', op: '=', value: options.status});
             delete options.status;
         } else if (options.status === 'all') {
@@ -508,8 +508,8 @@ Post = ghostBookshelf.Model.extend({
     findOne: function findOne(data, options) {
         options = options || {};
 
-        var withNext = _.contains(options.include, 'next'),
-            withPrev = _.contains(options.include, 'previous'),
+        var withNext = _.includes(options.include, 'next'),
+            withPrev = _.includes(options.include, 'previous'),
             nextRelations = _.transform(options.include, function (relations, include) {
                 if (include === 'next.tags') {
                     relations.push('tags');

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -61,16 +61,16 @@ Role = ghostBookshelf.Model.extend({
         }
 
         if (action === 'assign' && loadedPermissions.user) {
-            if (_.any(loadedPermissions.user.roles, {name: 'Owner'})) {
+            if (_.some(loadedPermissions.user.roles, {name: 'Owner'})) {
                 checkAgainst = ['Owner', 'Administrator', 'Editor', 'Author'];
-            } else if (_.any(loadedPermissions.user.roles, {name: 'Administrator'})) {
+            } else if (_.some(loadedPermissions.user.roles, {name: 'Administrator'})) {
                 checkAgainst = ['Administrator', 'Editor', 'Author'];
-            } else if (_.any(loadedPermissions.user.roles, {name: 'Editor'})) {
+            } else if (_.some(loadedPermissions.user.roles, {name: 'Editor'})) {
                 checkAgainst = ['Author'];
             }
 
             // Role in the list of permissible roles
-            hasUserPermission = roleModelOrId && _.contains(checkAgainst, roleModelOrId.get('name'));
+            hasUserPermission = roleModelOrId && _.includes(checkAgainst, roleModelOrId.get('name'));
         }
 
         if (hasUserPermission && hasAppPermission) {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -48,13 +48,13 @@ User = ghostBookshelf.Model.extend({
             model.emitChange('added');
 
             // active is the default state, so if status isn't provided, this will be an active user
-            if (!model.get('status') || _.contains(activeStates, model.get('status'))) {
+            if (!model.get('status') || _.includes(activeStates, model.get('status'))) {
                 model.emitChange('activated');
             }
         });
         this.on('updated', function onUpdated(model) {
             model.statusChanging = model.get('status') !== model.updated('status');
-            model.isActive = _.contains(activeStates, model.get('status'));
+            model.isActive = _.includes(activeStates, model.get('status'));
 
             if (model.statusChanging) {
                 model.emitChange(model.isActive ? 'activated' : 'deactivated');
@@ -67,7 +67,7 @@ User = ghostBookshelf.Model.extend({
             model.emitChange('edited');
         });
         this.on('destroyed', function onDestroyed(model) {
-            if (_.contains(activeStates, model.previous('status'))) {
+            if (_.includes(activeStates, model.previous('status'))) {
                 model.emitChange('deactivated');
             }
 
@@ -475,16 +475,16 @@ User = ghostBookshelf.Model.extend({
         if (action === 'edit') {
             // Owner can only be editted by owner
             if (loadedPermissions.user && userModel.hasRole('Owner')) {
-                hasUserPermission = _.any(loadedPermissions.user.roles, {name: 'Owner'});
+                hasUserPermission = _.some(loadedPermissions.user.roles, {name: 'Owner'});
             }
             // Users with the role 'Editor' and 'Author' have complex permissions when the action === 'edit'
             // We now have all the info we need to construct the permissions
-            if (loadedPermissions.user && _.any(loadedPermissions.user.roles, {name: 'Author'})) {
+            if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Author'})) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = hasUserPermission || context.user === userModel.get('id');
             }
 
-            if (loadedPermissions.user && _.any(loadedPermissions.user.roles, {name: 'Editor'})) {
+            if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Editor'})) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = context.user === userModel.get('id');
 
@@ -500,7 +500,7 @@ User = ghostBookshelf.Model.extend({
             }
 
             // Users with the role 'Editor' have complex permissions when the action === 'destroy'
-            if (loadedPermissions.user && _.any(loadedPermissions.user.roles, {name: 'Editor'})) {
+            if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Editor'})) {
                 // If this is the same user that requests the operation allow it.
                 hasUserPermission = context.user === userModel.get('id');
 
@@ -768,7 +768,7 @@ User = ghostBookshelf.Model.extend({
 
             // check if user has the owner role
             var currentRoles = contextUser.toJSON(options).roles;
-            if (!_.any(currentRoles, {id: ownerRole.id})) {
+            if (!_.some(currentRoles, {id: ownerRole.id})) {
                 return Promise.reject(new errors.NoPermissionError(i18n.t('errors.models.user.onlyOwnerCanTransferOwnerRole')));
             }
 
@@ -779,7 +779,7 @@ User = ghostBookshelf.Model.extend({
                 user = results[1],
                 currentRoles = user.toJSON(options).roles;
 
-            if (!_.any(currentRoles, {id: adminRole.id})) {
+            if (!_.some(currentRoles, {id: adminRole.id})) {
                 return Promise.reject(new errors.ValidationError('errors.models.user.onlyAdmCanBeAssignedOwnerRole'));
             }
 

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -1,11 +1,4 @@
-var moment = require('moment-timezone'),
-    _ = require('lodash'),
-    toString = require('lodash.tostring');
-
-/**
- * the version of lodash included in Ghost (3.10.1) does not have _.toString - it is added in a later version.
- */
-_.toString = toString;
+var moment = require('moment-timezone');
 
 /**
  * force UTC
@@ -15,4 +8,3 @@ _.toString = toString;
  *   - be careful when you work with date operations, therefor always wrap a date into moment
  */
 moment.tz.setDefault('UTC');
-

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -16,7 +16,7 @@ var _                   = require('lodash'),
 function hasActionsMap() {
     // Just need to find one key in the actionsMap
 
-    return _.any(exported.actionsMap, function (val, key) {
+    return _.some(exported.actionsMap, function (val, key) {
         /*jslint unparam:true*/
         return Object.hasOwnProperty.call(exported.actionsMap, key);
     });
@@ -179,16 +179,16 @@ CanThisResult.prototype.buildObjectTypeHandlers = function (objTypes, actType, c
                         return modelId === permObjId;
                     };
 
-                if (loadedPermissions.user && _.any(loadedPermissions.user.roles, {name: 'Owner'})) {
+                if (loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Owner'})) {
                     hasUserPermission = true;
                 } else if (!_.isEmpty(userPermissions)) {
-                    hasUserPermission = _.any(userPermissions, checkPermission);
+                    hasUserPermission = _.some(userPermissions, checkPermission);
                 }
 
                 // Check app permissions if they were passed
                 hasAppPermission = true;
                 if (!_.isNull(appPermissions)) {
-                    hasAppPermission = _.any(appPermissions, checkPermission);
+                    hasAppPermission = _.some(appPermissions, checkPermission);
                 }
 
                 // Offer a chance for the TargetModel to override the results

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -33,7 +33,7 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array().with.lengthOf(3);
 
                     // None of the items returned should be the post with id 4, as that was excluded
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.not.containEql(4);
 
                     // Should not contain draft
@@ -45,7 +45,7 @@ describe('Filter Param Spec', function () {
 
                     // Each post should have a tag which matches either 'photo' or 'video'
                     _.each(result.posts, function (post) {
-                        var slugs = _.pluck(post.tags, 'slug');
+                        var slugs = _.map(post.tags, 'slug');
                         slugs.should.matchAny(/photo|video/);
                     });
 
@@ -82,7 +82,7 @@ describe('Filter Param Spec', function () {
                     // We should have 5 matching items
                     result.posts.should.be.an.Array().with.lengthOf(9);
 
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([14, 11, 9, 8, 7, 6, 5, 3, 2]);
 
                     _.each(result.posts, function (post) {
@@ -155,17 +155,17 @@ describe('Filter Param Spec', function () {
 
                     // Each post must either be featured or have the tag 'audio'
                     _.each(result.posts, function (post) {
-                        var tags = _.pluck(post.tags, 'slug');
+                        var tags = _.map(post.tags, 'slug');
                         // This construct ensures we get an assertion or a failure
                         if (!_.isEmpty(post.image)) {
                             post.image.should.not.be.empty();
                         } else {
-                            tags = _.pluck(post.tags, 'slug');
+                            tags = _.map(post.tags, 'slug');
                             tags.should.containEql('audio');
                         }
                     });
 
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([14, 12, 11, 9, 8, 7]);
 
                     // 3. The meta object should contain the right details
@@ -197,7 +197,7 @@ describe('Filter Param Spec', function () {
                     // We should have 2 matching items
                     result.users.should.be.an.Array().with.lengthOf(2);
 
-                    ids = _.pluck(result.users, 'id');
+                    ids = _.map(result.users, 'id');
                     ids.should.eql([1, 2]);
 
                     // TODO: add the order
@@ -252,7 +252,7 @@ describe('Filter Param Spec', function () {
                     // We should have 2 matching items
                     result.users.should.be.an.Array().with.lengthOf(2);
 
-                    ids = _.pluck(result.users, 'id');
+                    ids = _.map(result.users, 'id');
                     ids.should.eql([2, 1]);
 
                     should.exist(result.users[0].website);
@@ -286,7 +286,7 @@ describe('Filter Param Spec', function () {
                     // We should have 3 matching items
                     result.tags.should.be.an.Array().with.lengthOf(3);
 
-                    ids = _.pluck(result.tags, 'id');
+                    ids = _.map(result.tags, 'id');
                     ids.should.containEql(4);
                     ids.should.containEql(3);
                     ids.should.containEql(2);
@@ -406,7 +406,7 @@ describe('Filter Param Spec', function () {
                     return tag.name === 'Special';
                 }).count.posts.should.eql(3);
 
-                ids = _.pluck(result.tags, 'id');
+                ids = _.map(result.tags, 'id');
                 ids.should.eql([4, 3, 1, 2, 6, 5]);
 
                 // 3. The meta object should contain the right details
@@ -493,7 +493,7 @@ describe('Filter Param Spec', function () {
                     return user.slug === 'camhowe';
                 }).count.posts.should.eql(0);
 
-                ids = _.pluck(result.users, 'id');
+                ids = _.map(result.users, 'id');
                 ids.should.eql([3, 2, 1]);
 
                 // 3. The meta object should contain the right details
@@ -534,7 +534,7 @@ describe('Filter Param Spec', function () {
                     // We should have 4 matching items
                     result.posts.should.be.an.Array().with.lengthOf(4);
 
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([11, 9, 3, 2]);
 
                     // 3. The meta object should contain the right details
@@ -566,7 +566,7 @@ describe('Filter Param Spec', function () {
                     // We should have 5 matching items
                     result.posts.should.be.an.Array().with.lengthOf(5);
 
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([13, 12, 11, 10, 9]);
 
                     // 3. The meta object should contain the right details
@@ -600,7 +600,7 @@ describe('Filter Param Spec', function () {
                     // We should have 5 matching items
                     result.posts.should.be.an.Array().with.lengthOf(15);
 
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([20, 18, 17, 16, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4]);
 
                     // 3. The meta object should contain the right details
@@ -633,11 +633,11 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array().with.lengthOf(3);
 
                     // All posts should be marked as featured 'true'
-                    featured = _.pluck(result.posts, 'featured');
+                    featured = _.map(result.posts, 'featured');
                     featured.should.matchEach(true);
 
                     // Match exact items
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([14, 8, 5]);
 
                     // 3. The meta object should contain the right details
@@ -670,11 +670,11 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array().with.lengthOf(15);
 
                     // All posts should be marked as featured 'false'
-                    featured = _.pluck(result.posts, 'featured');
+                    featured = _.map(result.posts, 'featured');
                     featured.should.matchEach(false);
 
                     // Match exact items
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([20, 18, 17, 16, 13, 12, 11, 10, 9, 7, 6, 4, 3, 2, 1]);
 
                     // 3. The meta object should contain the right details
@@ -709,11 +709,11 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array().with.lengthOf(18);
 
                     // All posts should be marked as page 'false'
-                    page = _.pluck(result.posts, 'page');
+                    page = _.map(result.posts, 'page');
                     page.should.matchEach(false);
 
                     // Match exact items
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([20, 18, 17, 16, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 
                     // 3. The meta object should contain the right details
@@ -747,11 +747,11 @@ describe('Filter Param Spec', function () {
                     result.posts.should.be.an.Array().with.lengthOf(2);
 
                     // All posts should be marked as page 'true'
-                    page = _.pluck(result.posts, 'page');
+                    page = _.map(result.posts, 'page');
                     page.should.matchEach(true);
 
                     // Match exact items
-                    ids = _.pluck(result.posts, 'id');
+                    ids = _.map(result.posts, 'id');
                     ids.should.eql([21, 15]);
 
                     // 3. The meta object should contain the right details

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -214,7 +214,7 @@ describe('Post API', function () {
                 results.posts.length.should.be.eql(2);
 
                 _.each(results.posts, function (post) {
-                    var slugs = _.pluck(post.tags, 'slug');
+                    var slugs = _.map(post.tags, 'slug');
                     slugs.should.containEql('kitchen-sink');
                 });
 
@@ -343,12 +343,12 @@ describe('Post API', function () {
             var posts, expectedTitles;
 
             posts = _(testUtils.DataGenerator.Content.posts).reject('page').reject({status: 'scheduled'}).value();
-            expectedTitles = _(posts).pluck('title').sortBy().value();
+            expectedTitles = _(posts).map('title').sortBy().value();
 
             PostAPI.browse({context: {user: 1}, status: 'all', order: 'title asc', fields: 'title'}).then(function (results) {
                 should.exist(results.posts);
 
-                var titles = _.pluck(results.posts, 'title');
+                var titles = _.map(results.posts, 'title');
                 titles.should.eql(expectedTitles);
 
                 done();
@@ -359,12 +359,12 @@ describe('Post API', function () {
             var posts, expectedTitles;
 
             posts = _(testUtils.DataGenerator.Content.posts).reject('page').reject({status: 'scheduled'}).value();
-            expectedTitles = _(posts).pluck('title').sortBy().reverse().value();
+            expectedTitles = _(posts).map('title').sortBy().reverse().value();
 
             PostAPI.browse({context: {user: 1}, status: 'all', order: 'title DESC', fields: 'title'}).then(function (results) {
                 should.exist(results.posts);
 
-                var titles = _.pluck(results.posts, 'title');
+                var titles = _.map(results.posts, 'title');
                 titles.should.eql(expectedTitles);
 
                 done();
@@ -375,12 +375,12 @@ describe('Post API', function () {
             var posts, expectedTitles;
 
             posts = _(testUtils.DataGenerator.Content.posts).reject('page').reject({status: 'scheduled'}).value();
-            expectedTitles = _(posts).pluck('title').sortBy().value();
+            expectedTitles = _(posts).map('title').sortBy().value();
 
             PostAPI.browse({context: {user: 1}, status: 'all', order: 'bunny DESC, title ASC', fields: 'title'}).then(function (results) {
                 should.exist(results.posts);
 
-                var titles = _.pluck(results.posts, 'title');
+                var titles = _.map(results.posts, 'title');
                 titles.should.eql(expectedTitles);
 
                 done();

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -273,7 +273,7 @@ describe('Tags API', function () {
                 .then(function (results) {
                     should.exist(results);
 
-                    expectedTags = _(results.tags).pluck('slug').filter(onlyFixtures).sortBy().value();
+                    expectedTags = _(results.tags).map('slug').filter(onlyFixtures).sortBy().value();
 
                     return TagAPI.browse({context: {user: 1}, order: 'slug asc'});
                 })
@@ -282,7 +282,7 @@ describe('Tags API', function () {
 
                     should.exist(results);
 
-                    tags = _(results.tags).pluck('slug').filter(onlyFixtures).value();
+                    tags = _(results.tags).map('slug').filter(onlyFixtures).value();
                     tags.should.eql(expectedTags);
                 })
                 .then(done)
@@ -296,7 +296,7 @@ describe('Tags API', function () {
                 .then(function (results) {
                     should.exist(results);
 
-                    expectedTags = _(results.tags).pluck('slug').filter(onlyFixtures).sortBy().reverse().value();
+                    expectedTags = _(results.tags).map('slug').filter(onlyFixtures).sortBy().reverse().value();
 
                     return TagAPI.browse({context: {user: 1}, order: 'slug desc'});
                 })
@@ -305,7 +305,7 @@ describe('Tags API', function () {
 
                     should.exist(results);
 
-                    tags = _(results.tags).pluck('slug').filter(onlyFixtures).value();
+                    tags = _(results.tags).map('slug').filter(onlyFixtures).value();
                     tags.should.eql(expectedTags);
                 })
                 .then(done)

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -147,7 +147,7 @@ describe('Users API', function () {
                 .then(function (results) {
                     should.exist(results);
 
-                    expectedUsers = _(results.users).pluck('slug').sortBy().value();
+                    expectedUsers = _(results.users).map('slug').sortBy().value();
 
                     return UserAPI.browse(_.extend({}, testUtils.context.admin, {order: 'slug asc'}));
                 })
@@ -156,7 +156,7 @@ describe('Users API', function () {
 
                     should.exist(results);
 
-                    users = _.pluck(results.users, 'slug');
+                    users = _.map(results.users, 'slug');
                     users.should.eql(expectedUsers);
                 })
                 .then(done)
@@ -170,7 +170,7 @@ describe('Users API', function () {
                 .then(function (results) {
                     should.exist(results);
 
-                    expectedUsers = _(results.users).pluck('slug').sortBy().reverse().value();
+                    expectedUsers = _(results.users).map('slug').sortBy().reverse().value();
 
                     return UserAPI.browse(_.extend({}, testUtils.context.admin, {order: 'slug desc'}));
                 })
@@ -179,7 +179,7 @@ describe('Users API', function () {
 
                     should.exist(results);
 
-                    users = _.pluck(results.users, 'slug');
+                    users = _.map(results.users, 'slug');
                     users.should.eql(expectedUsers);
                 })
                 .then(done)

--- a/core/test/integration/export_spec.js
+++ b/core/test/integration/export_spec.js
@@ -40,7 +40,7 @@ describe('Exporter', function () {
 
             exportData.meta.version.should.equal(DEF_DB_VERSION);
 
-            dbVersionSetting = _.findWhere(exportData.data.settings, {key: 'databaseVersion'});
+            dbVersionSetting = _.find(exportData.data.settings, {key: 'databaseVersion'});
 
             should.exist(dbVersionSetting);
 

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -99,7 +99,7 @@ describe('Import', function () {
                 // Check we imported all posts_tags associations
                 importResult.data.data.posts_tags.length.should.equal(2);
                 // Check the post_tag.tag_id was updated when we removed duplicate tag
-                _.all(importResult.data.data.posts_tags, function (postTag) {
+                _.every(importResult.data.data.posts_tags, function (postTag) {
                     return postTag.tag_id !== 2;
                 });
 
@@ -147,7 +147,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
@@ -203,10 +203,10 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // activeTheme should NOT have been overridden
-                _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
+                _.find(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
@@ -264,7 +264,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                    _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -309,7 +309,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                    _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -367,10 +367,10 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 // activeTheme should NOT have been overridden
-                _.findWhere(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
+                _.find(settings, {key: 'activeTheme'}).value.should.equal('casper', 'Wrong theme');
 
                 // test tags
                 tags.length.should.equal(exportData.data.tags.length, 'no new tags');
@@ -427,7 +427,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                    _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -471,7 +471,7 @@ describe('Import', function () {
 
                     // test settings
                     settings.length.should.be.above(0, 'Wrong number of settings');
-                    _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                    _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                     done();
                 });
@@ -521,7 +521,7 @@ describe('Import', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -711,7 +711,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -936,7 +936,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);
@@ -1173,7 +1173,7 @@ describe('Import (new test structure)', function () {
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');
-                _.findWhere(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
+                _.find(settings, {key: 'databaseVersion'}).value.should.equal(DEF_DB_VERSION, 'Wrong database version');
 
                 done();
             }).catch(done);

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -35,7 +35,7 @@ describe('Database Migration (special functions)', function () {
             this.obj.roles.should.be.an.Array();
 
             // Ensure the roles are in id order
-            roleNames = _(this.obj.roles).sortBy('id').pluck('name').value();
+            roleNames = _(this.obj.roles).sortBy('id').map('name').value();
             roleNames.should.eql(roles);
         });
 
@@ -271,4 +271,3 @@ describe('Database Migration (special functions)', function () {
         });
     });
 });
-

--- a/core/test/unit/sitemap_spec.js
+++ b/core/test/unit/sitemap_spec.js
@@ -392,7 +392,7 @@ describe('Sitemap', function () {
                     })),
                     hasImage;
 
-                hasImage = _.any(urlNode.url, function (node) {
+                hasImage = _.some(urlNode.url, function (node) {
                     return !_.isUndefined(node['image:image']);
                 });
 
@@ -478,7 +478,7 @@ describe('Sitemap', function () {
                     })),
                     hasImage;
 
-                hasImage = _.any(urlNode.url, function (node) {
+                hasImage = _.some(urlNode.url, function (node) {
                     return !_.isUndefined(node['image:image']);
                 });
 
@@ -500,7 +500,7 @@ describe('Sitemap', function () {
                     })),
                     hasImage;
 
-                hasImage = _.any(urlNode.url, function (node) {
+                hasImage = _.some(urlNode.url, function (node) {
                     return !_.isUndefined(node['image:image']);
                 });
 
@@ -522,7 +522,7 @@ describe('Sitemap', function () {
                     })),
                     hasImage;
 
-                hasImage = _.any(urlNode.url, function (node) {
+                hasImage = _.some(urlNode.url, function (node) {
                     return !_.isUndefined(node['image:image']);
                 });
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -61,7 +61,7 @@ fixtures = {
         }).then(function () {
             return db.knex('users').select('id');
         }).then(function (results) {
-            authors = _.pluck(results, 'id');
+            authors = _.map(results, 'id');
 
             // Let's insert posts with random authors
             for (i = 0; i < max; i += 1) {
@@ -85,8 +85,8 @@ fixtures = {
                 db.knex('tags').select('id')
             ]);
         }).then(function (results) {
-            var posts = _.pluck(results[0], 'id'),
-                tags = _.pluck(results[1], 'id'),
+            var posts = _.map(results[0], 'id'),
+                tags = _.map(results[1], 'id'),
                 promises = [],
                 i;
 
@@ -162,10 +162,10 @@ fixtures = {
             db.knex('posts').orderBy('id', 'asc').select('id'),
             db.knex('tags').select('id', 'name')
         ]).then(function (results) {
-            var posts = _.pluck(results[0], 'id'),
+            var posts = _.map(results[0], 'id'),
                 injectionTagId = _.chain(results[1])
-                    .where({name: 'injection'})
-                    .pluck('id')
+                    .filter({name: 'injection'})
+                    .map('id')
                     .value()[0],
                 promises = [],
                 i;

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "intl-messageformat": "1.3.0",
     "jsonpath": "0.2.4",
     "knex": "0.10.0",
-    "lodash": "3.10.1",
-    "lodash.tostring": "4.1.3",
+    "lodash": "4.13.1",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
     "morgan": "1.7.0",
@@ -111,7 +110,6 @@
     "ignore": [
       "bower",
       "glob",
-      "lodash",
       "mysql",
       "nodemailer",
       "pg",


### PR DESCRIPTION
closes #6911
- update lodash to v4
- remove lodash.tostring override
- remove lodash from greenkeeper ignore
## Big lodash changes made:

`_.contains` -> `_.includes`
`_.pluck` -> `_.map`
`_.all` -> `_.every`
`_.any` -> `_.some`
`_.findWhere` -> `_.find`
#### Minor lodash changes made

`_.clone(obj, true)` -> `_.cloneDeep(obj)`
`_.object`, `_.pairs` -> `_.fromPairs`, `_.toPairs`
`_.filter(obj, key, value)` -> `_.filter(obj, [key, value])`
