### PR TITLE
fix: put default timezone into config

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -61,7 +61,7 @@ updateConfigCache = function () {
             permalinks: (settingsCache.permalinks && settingsCache.permalinks.value) || '/:slug/',
             twitter: (settingsCache.twitter && settingsCache.twitter.value) || '',
             facebook: (settingsCache.facebook && settingsCache.facebook.value) || '',
-            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || 'Europe/Dublin'
+            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.theme.timezone
         },
         labs: labsValue
     });

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -184,7 +184,10 @@ ConfigManager.prototype.set = function (config) {
         },
         theme: {
             // normalise the URL by removing any trailing slash
-            url: this._config.url ? this._config.url.replace(/\/$/, '') : ''
+            url: this._config.url ? this._config.url.replace(/\/$/, '') : '',
+
+            // default timezone
+            timezone: 'Etc/UTC'
         },
         routeKeywords: {
             tag: 'tag',

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -45,7 +45,7 @@ describe('Config', function () {
             var themeConfig = config.theme;
 
             // This will fail if there are any extra keys
-            themeConfig.should.have.keys('url', 'title', 'description', 'logo', 'cover');
+            themeConfig.should.have.keys('url', 'title', 'description', 'logo', 'cover', 'timezone');
         });
 
         it('should have the correct values for each key', function () {
@@ -393,8 +393,8 @@ describe('Config', function () {
         });
 
         describe('urlPathForPost', function () {
-            it('permalink is /:slug/', function () {
-                configUtils.set({theme: {permalinks: '/:slug/', timezone: 'Europe/Dublin'}});
+            it('permalink is /:slug/, timezone is default', function () {
+                config.theme.permalinks = '/:slug/';
 
                 var testData = testUtils.DataGenerator.Content.posts[2],
                     postLink = '/short-and-sweet/';
@@ -403,7 +403,9 @@ describe('Config', function () {
             });
 
             it('permalink is /:year/:month/:day/:slug, blog timezone is Los Angeles', function () {
-                configUtils.set({theme: {permalinks: '/:year/:month/:day/:slug/', timezone: 'America/Los_Angeles'}});
+                config.theme.timezone = 'America/Los_Angeles';
+                config.theme.permalinks = '/:year/:month/:day/:slug/';
+
                 var testData = testUtils.DataGenerator.Content.posts[2],
                     postLink = '/2016/05/17/short-and-sweet/';
 
@@ -412,7 +414,8 @@ describe('Config', function () {
             });
 
             it('post is page, no permalink usage allowed at all', function () {
-                configUtils.set({theme: {permalinks: '/:year/:month/:day/:slug/', timezone: 'America/Los_Angeles'}});
+                config.theme.timezone = 'America/Los_Angeles';
+                config.theme.permalinks = '/:year/:month/:day/:slug/';
 
                 var testData = testUtils.DataGenerator.Content.posts[5],
                     postLink = '/static-page-test/';
@@ -421,7 +424,8 @@ describe('Config', function () {
             });
 
             it('permalink is /:year/:id:/:author', function () {
-                configUtils.set({theme: {permalinks: '/:year/:id/:author/', timezone: 'America/Los_Angeles'}});
+                config.theme.timezone = 'America/Los_Angeles';
+                config.theme.permalinks = '/:year/:id/:author/';
 
                 var testData = _.merge(testUtils.DataGenerator.Content.posts[2], {id: 3}, {author: {slug: 'joe-blog'}}),
                     postLink = '/2015/3/joe-blog/';
@@ -431,7 +435,8 @@ describe('Config', function () {
             });
 
             it('permalink is /:year/:id:/:author', function () {
-                configUtils.set({theme: {permalinks: '/:year/:id/:author/', timezone: 'Europe/Berlin'}});
+                config.theme.timezone = 'Europe/Berlin';
+                config.theme.permalinks = '/:year/:id/:author/';
 
                 var testData = _.merge(testUtils.DataGenerator.Content.posts[2], {id: 3}, {author: {slug: 'joe-blog'}}),
                     postLink = '/2016/3/joe-blog/';


### PR DESCRIPTION
related to https://github.com/TryGhost/Ghost/issues/6975

The `config.theme.timezone` can be undefined, when settings are not loaded from the database (see https://github.com/TryGhost/Ghost/blob/master/core/server/api/settings.js#L64). This can cause problems/bugs when creating permalinks, for example `moment.tz(date, undefined)` can cause writing wrong tests, which might be green on your computer, but not on a computer in a different TZ.

This PR will define the default blog TZ in config. The default blog TZ gets overridden when the user changes the TZ in the admin section. 
