### PR TITLE
fix: 6975 permalink test

### DIFF
--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -346,12 +346,7 @@ describe('Post Model', function () {
             });
 
             it('can findOne, returning a dated permalink', function (done) {
-                var firstPost = 1,
-                    today = testUtils.DataGenerator.Content.posts[0].published_at,
-                    dd = ('0' + today.getDate()).slice(-2),
-                    mm = ('0' + (today.getMonth() + 1)).slice(-2),
-                    yyyy = today.getFullYear(),
-                    postLink = '/' + yyyy + '/' + mm + '/' + dd + '/html-ipsum/';
+                var firstPost = 1;
 
                 configUtils.set({theme: {
                     permalinks: '/:year/:month/:day/:slug/'
@@ -361,7 +356,10 @@ describe('Post Model', function () {
                     .then(function (result) {
                         should.exist(result);
                         firstPost = result.toJSON();
-                        firstPost.url.should.equal(postLink);
+
+                        // published_at of post 1 is 2015-01-01 00:00:00
+                        // default blog TZ is UTC
+                        firstPost.url.should.equal('/2015/01/01/html-ipsum/');
 
                         done();
                     }).catch(done);

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -413,6 +413,17 @@ describe('Config', function () {
                 config.urlPathForPost(testData).should.equal(postLink);
             });
 
+            it('permalink is /:year/:month/:day/:slug, blog timezone is Asia Tokyo', function () {
+                config.theme.timezone = 'Asia/Tokyo';
+                config.theme.permalinks = '/:year/:month/:day/:slug/';
+
+                var testData = testUtils.DataGenerator.Content.posts[2],
+                    postLink = '/2016/05/18/short-and-sweet/';
+
+                testData.published_at = new Date('2016-05-18T06:30:00.000Z');
+                config.urlPathForPost(testData).should.equal(postLink);
+            });
+
             it('post is page, no permalink usage allowed at all', function () {
                 config.theme.timezone = 'America/Los_Angeles';
                 config.theme.permalinks = '/:year/:month/:day/:slug/';


### PR DESCRIPTION
closes #6975 

This is a very small fix so that the test `integration/model/model_posts_spec.js` is not red anymore when running it in a different server TZ.

The test itself was getting a local JS Date back from the data generator, created a permalink from this local date and tries to compare it with a permalink which is created based on your blog TZ.

You can find more tests for permalinks inside https://github.com/TryGhost/Ghost/blob/master/core/test/unit/config_spec.js#L395, but i also added one more test case inside this PR.

I ran the tests with server TZ `Europe/Berlin` and `America/New_York`.
