### PR TITLE
#6769 allow manifest.json to be served from theme directory. Implement…

### DIFF
--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -10,6 +10,12 @@ function isBlackListedFileType(file) {
     return _.includes(blackListedFileTypes, ext);
 }
 
+function isWhiteListedFile(file) {
+    var whiteListedFiles = ['manifest.json'],
+        base = path.basename(file);
+    return _.includes(whiteListedFiles, base);
+}
+
 function forwardToExpressStatic(req, res, next) {
     if (!req.app.get('activeTheme')) {
         next();
@@ -23,7 +29,7 @@ function forwardToExpressStatic(req, res, next) {
 
 function staticTheme() {
     return function blackListStatic(req, res, next) {
-        if (isBlackListedFileType(req.path)) {
+        if (!isWhiteListedFile(req.path) && isBlackListedFileType(req.path)) {
             return next();
         }
         return forwardToExpressStatic(req, res, next);

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -82,4 +82,25 @@ describe('staticTheme', function () {
             done();
         });
     });
+
+    it('should not call next if file is on whitelist', function (done) {
+        var req = {
+                path: 'manifest.json',
+                app: {
+                    get: function () { return 'casper'; }
+                }
+            },
+            activeThemeStub,
+            sandbox = sinon.sandbox.create();
+
+        activeThemeStub = sandbox.spy(req.app, 'get');
+
+        staticTheme(null)(req, null, function (reqArg, res, next2) {
+            /*jshint unused:false */
+            sandbox.restore();
+            next.called.should.be.false();
+            activeThemeStub.called.should.be.true();
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Allow manifest.json to be served from theme directory. Implemented via whitelist.
- closes #6769 
- added a whitelist function
- added a test against manifest.json
