### PR TITLE
post-scheduling: flat config for scheduling

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -94,10 +94,10 @@ ConfigManager.prototype.set = function (config) {
         defaultStorageAdapter = 'local-file-store',
         defaultSchedulingAdapter = 'SchedulingDefault',
         activeStorageAdapter,
-        activePostSchedulingAdapter,
+        activeSchedulingAdapter,
         contentPath,
         storagePath,
-        postSchedulingPath,
+        schedulingPath,
         subdir,
         assetHash;
 
@@ -151,8 +151,7 @@ ConfigManager.prototype.set = function (config) {
 
     // read scheduling adapter(s) from config file or attach default adapter
     this._config.scheduling = this._config.scheduling || {};
-    this._config.scheduling.postScheduling = this._config.scheduling.postScheduling || {};
-    activePostSchedulingAdapter = this._config.scheduling.postScheduling.active || defaultSchedulingAdapter;
+    activeSchedulingAdapter = this._config.scheduling.active || defaultSchedulingAdapter;
 
     // we support custom adapters located in content folder
     if (activeStorageAdapter === defaultStorageAdapter) {
@@ -161,10 +160,10 @@ ConfigManager.prototype.set = function (config) {
         storagePath = path.join(contentPath, 'storage');
     }
 
-    if (activePostSchedulingAdapter === defaultSchedulingAdapter) {
-        postSchedulingPath = path.join(corePath, '/server/scheduling/');
+    if (activeSchedulingAdapter === defaultSchedulingAdapter) {
+        schedulingPath = path.join(corePath, '/server/scheduling/');
     } else {
-        postSchedulingPath = path.join(contentPath, '/scheduling/');
+        schedulingPath = path.join(contentPath, '/scheduling/');
     }
 
     _.merge(this._config, {
@@ -193,10 +192,8 @@ ConfigManager.prototype.set = function (config) {
             clientAssets:     path.join(corePath, '/built/assets/')
         },
         scheduling: {
-            postScheduling: {
-                active: activePostSchedulingAdapter,
-                path: postSchedulingPath
-            }
+            active: activeSchedulingAdapter,
+            path: schedulingPath
         },
         storage: {
             active: activeStorageAdapter

--- a/core/server/scheduling/index.js
+++ b/core/server/scheduling/index.js
@@ -1,5 +1,4 @@
-var _ = require('lodash'),
-    postScheduling = require(__dirname + '/post-scheduling');
+var postScheduling = require(__dirname + '/post-scheduling');
 
 /**
  * scheduling modules:
@@ -8,5 +7,5 @@ var _ = require('lodash'),
 exports.init = function init(options) {
     options = options || {};
 
-    return postScheduling.init(_.pick(options, 'postScheduling', 'apiUrl'));
+    return postScheduling.init(options);
 };

--- a/core/server/scheduling/post-scheduling/index.js
+++ b/core/server/scheduling/post-scheduling/index.js
@@ -36,10 +36,8 @@ _private.loadScheduledPosts = function () {
 };
 
 exports.init = function init(options) {
-    options = options || {};
-
-    var config = options.postScheduling,
-        apiUrl = options.apiUrl,
+    var config = options || {},
+        apiUrl = config.apiUrl,
         adapter = null,
         client = null;
 

--- a/core/test/unit/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/scheduling/post-scheduling/index_spec.js
@@ -64,8 +64,7 @@ describe('Scheduling: Post Scheduling', function () {
         describe('success', function () {
             it('will be scheduled', function (done) {
                 postScheduling.init({
-                    apiUrl: scope.apiUrl,
-                    postScheduling: {}
+                    apiUrl: scope.apiUrl
                 }).then(function () {
                     scope.events['post.scheduled'](scope.post);
                     scope.adapter.schedule.called.should.eql(true);
@@ -90,8 +89,7 @@ describe('Scheduling: Post Scheduling', function () {
                 ];
 
                 postScheduling.init({
-                    apiUrl: scope.apiUrl,
-                    postScheduling: {}
+                    apiUrl: scope.apiUrl
                 }).then(function () {
                     scope.adapter.reschedule.calledTwice.should.eql(true);
                     done();


### PR DESCRIPTION
is related to #6861 and https://github.com/TryGhost/Ghost/issues/6413

When we started implementing post scheduling, we began with a nested config, but we discussed that we only need a flat config for scheduling. So you can have one adapter for all scheduling cases (newsletter, posts etc...)
