### PR TITLE
post-scheduling: forward UTC timestamp to scheduler adapters

### DIFF
--- a/core/server/scheduling/post-scheduling/index.js
+++ b/core/server/scheduling/post-scheduling/index.js
@@ -13,11 +13,11 @@ _private.normalize = function normalize(options) {
         client = options.client;
 
     return {
-        time: object.get('published_at'),
+        time: moment(object.get('published_at')).valueOf(),
         url: apiUrl + '/schedules/posts/' + object.get('id') + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
         extra: {
             httpMethod: 'PUT',
-            oldTime: object.updated('published_at') || null
+            oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null
         }
     };
 };

--- a/core/test/integration/api/api_schedules_spec.js
+++ b/core/test/integration/api/api_schedules_spec.js
@@ -231,10 +231,9 @@ describe('Schedules API', function () {
                     slug: 'fourth'
                 }));
 
-                Promise.all(scope.posts.map(function (post) {
+                Promise.mapSeries(scope.posts, function (post) {
                     return models.Post.add(post, {context: {internal: true}});
-                })).then(function (result) {
-                    // returns id 1 and 2, but hard to check, because PG returns a different order
+                }).then(function (result) {
                     result.length.should.eql(4);
                     return done();
                 }).catch(done);

--- a/core/test/unit/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/scheduling/post-scheduling/index_spec.js
@@ -3,6 +3,7 @@
 var should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),
+    moment = require('moment'),
     config = require(__dirname + '/../../../../server/config'),
     testUtils = require(config.paths.corePath + '/test/utils'),
     errors = require(config.paths.corePath + '/server/errors'),
@@ -71,7 +72,7 @@ describe('Scheduling: Post Scheduling', function () {
                     scope.adapter.schedule.called.should.eql(true);
 
                     scope.adapter.schedule.calledWith({
-                        time: scope.post.get('published_at'),
+                        time: moment(scope.post.get('published_at')).valueOf(),
                         url: scope.apiUrl + '/schedules/posts/' + scope.post.get('id') + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
                         extra: {
                             httpMethod: 'PUT',


### PR DESCRIPTION
is related to #6861 and https://github.com/TryGhost/Ghost/issues/6413

While writing the documentation for scheduling, i noticed that we don't forward a UTC timestamp to the chosen adapter. To avoid problems with third party adapters, i changed this behaviour.

We keep converting the `time` parameter (again) into a UTC timestamp in the default scheduler as safety protection.
