### PR TITLE
fix 6991 spam prevention test

### DIFF
--- a/core/test/unit/middleware/spam-prevention_spec.js
+++ b/core/test/unit/middleware/spam-prevention_spec.js
@@ -1,6 +1,7 @@
 /*globals describe, beforeEach, afterEach, it*/
 var should      = require('should'),
     sinon       = require('sinon'),
+    rewire      = require('rewire'),
     middleware  = require('../../../server/middleware').middleware;
 
 describe('Middleware: spamPrevention', function () {
@@ -19,6 +20,7 @@ describe('Middleware: spamPrevention', function () {
         spyNext = sinon.spy(function (param) {
             error = param;
         });
+        middleware.spamPrevention = rewire('../../../server/middleware/spam-prevention');
     });
 
     afterEach(function () {
@@ -85,7 +87,7 @@ describe('Middleware: spamPrevention', function () {
             // fast forward 1 hour
             process.hrtime.restore();
             stub = sinon.stub(process, 'hrtime', function () {
-                return [3700000, 10];
+                return [3610, 10];
             });
 
             middleware.spamPrevention.signin(req, null, spyNext);


### PR DESCRIPTION
A small fix for issue #6991 
- add preconditions in 'beforeEach' in 'core/test/unit/middleware/spam-prevention_spec.js'
- change "fast forward 1 hour" to "3600 seconds" strictly.

Test has passed on Amazon AMI linux and OS X EI Caption.
