### PR TITLE
fix: delete lodash.pickBy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "jsonpath": "0.2.4",
     "knex": "0.10.0",
     "lodash": "4.13.1",
-    "lodash.pickby": "4.4.0",
     "moment": "2.13.0",
     "moment-timezone": "0.5.4",
     "morgan": "1.7.0",


### PR DESCRIPTION
no issue

now that we have lodash 4.x. as dependency, we can remove lodash.pickBy.
