### PR TITLE
#6893 allows navigation links directing to another port of the blog url

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -204,11 +204,13 @@ function urlFor(context, data, absolute) {
             baseUrl = getBaseUrl(secure);
             hostname = baseUrl.split('//')[1] + ghostConfig.paths.subdir;
             if (urlPath.indexOf(hostname) > -1
-                && !urlPath.split(hostname)[0].match(/\.|mailto:/)) {
+                && !urlPath.split(hostname)[0].match(/\.|mailto:/)
+                && urlPath.split(hostname)[1].substring(0,1) !== ':') {
                 // make link relative to account for possible
                 // mismatch in http/https etc, force absolute
                 // do not do so if link is a subdomain of blog url
                 // or if hostname is inside of the slug
+                // or if slug is a port
                 urlPath = urlPath.split(hostname)[1];
                 if (urlPath.substring(0, 1) !== '/') {
                     urlPath = '/' + urlPath;

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -358,6 +358,12 @@ describe('Config', function () {
                 testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}, secure: true};
                 config.urlFor(testContext, testData).should.equal('https://my-ghost-blog.com/short-and-sweet/');
 
+                testData = {nav: {url: 'http://my-ghost-blog.com:3000/'}};
+                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/');
+
+                testData = {nav: {url: 'http://my-ghost-blog.com:3000/short-and-sweet/'}};
+                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
+
                 testData = {nav: {url: 'http://sub.my-ghost-blog.com/'}};
                 config.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
 


### PR DESCRIPTION
This pr fixes #6893. This allows the usage of blogurl:port inside the navigation.
- Closes #6893
- modified logic to allow urls in form of domain:port to be referenced in navigation
- added a test for a domain:port link
