### PR TITLE
Fix dev setup instructions in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -199,6 +199,7 @@ Looking to get setup to work on Ghost? AWESOME! The [Ghost-Vagrant](https://gith
 1. `git clone https://github.com/TryGhost/Ghost.git`- clone the git repo
 1. `cd Ghost` - change into the project folder
 1. `npm install -g grunt-cli` - to make it possible to run grunt commands (see [developer tips](#developer-tips) for more info on Grunt)
+1. `npm install -g bower` - to allow installation of client-side dependencies from [Bower](https://bower.io/)
 1. `npm install` - you need all the dependencies, so do not use the `--production` flag mentioned in user install guides
 	* If the install fails with errors to do with "node-gyp rebuild" or "SQLite3", follow the SQLite3 install
 instructions below this list


### PR DESCRIPTION
Hi, I was just setting up Ghost for local development and found the Contributing guide to be slightly out-dated. The `shell:ember:init` task failed because `bower` was not found. The PR fixes that.

The recommended Node version for development could also be updated from 0.10.x to 4.2.x, but I wasn't sure if you'd want that - just let me know!
