### PR TITLE
Disallow preview pages tracking

### DIFF
--- a/core/shared/robots.txt
+++ b/core/shared/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Sitemap: {{blog-url}}/sitemap.xml
 Disallow: /ghost/
+Disallow: /p/


### PR DESCRIPTION
Hi!

Today I've discovered a small glitch (it seems to be so fir me) about preview pages indexing. I am using Google Analytics and Yandex.Metrika services on my blog.

Not so far, when writing a new post, I opened a preview page, URL of which consists of something like `http://blog.com/p/...`. After visiting this page appeared on my statistics.

Because of that, I suggest adding it to the **robots.txt** disallow as it intends to be in the admin area's scope which we had blocked for search engines.

Thanks :)
