### PR TITLE
fix: url for post path when post is not published

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -104,7 +104,7 @@ function createUrl(urlPath, absolute, secure) {
 function urlPathForPost(post) {
     var output = '',
         permalinks = ghostConfig.theme.permalinks,
-        publishedAtMoment = moment.tz(post.published_at, ghostConfig.theme.timezone),
+        publishedAtMoment = moment.tz(post.published_at || Date.now(), ghostConfig.theme.timezone),
         tags = {
             year:   function () { return publishedAtMoment.format('YYYY'); },
             month:  function () { return publishedAtMoment.format('MM'); },

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -1,6 +1,7 @@
 var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),
+    moment         = require('moment'),
     path           = require('path'),
     fs             = require('fs'),
     _              = require('lodash'),
@@ -452,6 +453,20 @@ describe('Config', function () {
                     postLink = '/2016/3/joe-blog/';
 
                 testData.published_at = new Date('2016-01-01T00:00:00.000Z');
+                config.urlPathForPost(testData).should.equal(postLink);
+            });
+
+            it('post is not published yet', function () {
+                config.theme.permalinks = '/:year/:month/:day/:slug/';
+
+                var testData = _.merge(testUtils.DataGenerator.Content.posts[2], {id: 3, published_at: null}),
+                    nowMoment = moment(),
+                    postLink = '/YYYY/MM/DD/short-and-sweet/';
+
+                postLink = postLink.replace('YYYY', nowMoment.format('YYYY'));
+                postLink = postLink.replace('MM', nowMoment.format('MM'));
+                postLink = postLink.replace('DD', nowMoment.format('DD'));
+
                 config.urlPathForPost(testData).should.equal(postLink);
             });
         });


### PR DESCRIPTION
closes #6999 

When post is not published, then `published_at` is null and the url would contain `Invalidate Date`.
We agreed on taking "now" when `published_at` is null.
