### PR TITLE
fix: prev next posts

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -551,7 +551,7 @@ Post = ghostBookshelf.Model.extend({
 
         return ghostBookshelf.Model.findOne.call(this, data, options).then(function then(post) {
             if ((withNext || withPrev) && post && !post.page) {
-                var publishedAt = post.get('published_at'),
+                var publishedAt = moment(post.get('published_at')).format('YYYY-MM-DD HH:mm:ss'),
                     prev,
                     next;
 


### PR DESCRIPTION
closes #7015

Because our test `api_posts_spec.js` had insert wrong date formats (see #6930), we didn't discover this bug testwise. 
The problem was that `next` and `previous` posts make a `andWhere` query and compare wrong formatted dates with the database. That's why it was always returning the `welcome ghost` post.

Thanks again to @qianduan for reporting!
