### PR TITLE
post-scheduling: delete job but time is null

### DIFF
--- a/core/server/scheduling/SchedulingDefault.js
+++ b/core/server/scheduling/SchedulingDefault.js
@@ -111,6 +111,10 @@ SchedulingDefault.prototype._addJob = function (object) {
 };
 
 SchedulingDefault.prototype._deleteJob = function (object) {
+    if (!object.time) {
+        return;
+    }
+
     var deleteKey = object.url + '_' + moment(object.time).valueOf();
 
     if (!this.deletedJobs[deleteKey]) {

--- a/core/test/unit/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/scheduling/SchedulingDefault_spec.js
@@ -151,6 +151,11 @@ describe('Scheduling Default Adapter', function () {
             })();
         });
 
+        it('delete job (unschedule): time is null', function () {
+            scope.adapter._deleteJob({time: null, url: '/test'});
+            Object.keys(scope.adapter.deletedJobs).length.should.eql(0);
+        });
+
         it('pingUrl (PUT)', function (done) {
             var app = express(),
                 server = http.createServer(app),


### PR DESCRIPTION
no issue

This is a fix for the `default-scheduler`.
When a post never had a `published_at` value, the `oldTime` for removing the job would be null. And in this case we would try to delete a job with an invalidate date.
