### PR TITLE
update: developer installation README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Install grunt. No prizes here.
 npm install -g grunt-cli
 ```
 
+Install bower. Life couldn't be any easier.
+
+```bash
+npm i -g bower
+```
+
 Install Ghost. If you're running locally, use [master](https://github.com/TryGhost/Ghost/tree/master). For production, use [stable](https://github.com/TryGhost/Ghost/tree/stable). :no_entry_sign::rocket::microscope:
 
 ```bash


### PR DESCRIPTION
With node `v0.10.35` and following the instructions for the `developer` local copy, installing via `npm i` wasn't enough to bring in `bower` correctly. I updated the `README` with having `bower` installed globally (similar to `grunt`) for easy installation.

---

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

More info can be found by clicking the "guidelines for contributing" link above.
