### PR TITLE
fix: date permalink test

### DIFF
--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -553,14 +553,13 @@ describe('Frontend Routing', function () {
                     should.exist(res.headers.date);
 
                     var content = res.text,
-                        today = new Date(),
-                        dd = ('0' + today.getDate()).slice(-2),
-                        mm = ('0' + (today.getMonth() + 1)).slice(-2),
-                        yyyy = today.getFullYear(),
+                        todayMoment = moment(),
+                        dd = todayMoment.format('DD'),
+                        mm = todayMoment.format('MM'),
+                        yyyy = todayMoment.format('YYYY'),
                         postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
 
                     content.indexOf(postLink).should.be.above(0);
-
                     done();
                 });
         });


### PR DESCRIPTION
closes #7044

Date permalinks are created by default with TZ `UTC`.
Thats why it was failing randomly in any TZ depending on the current time in your TZ.
This PR will fix the issue, by comparing with a UTC based date.
