### PR TITLE
make back link actually link back #6984

### DIFF
--- a/core/server/apps/subscribers/lib/views/subscribe.hbs
+++ b/core/server/apps/subscribers/lib/views/subscribe.hbs
@@ -25,7 +25,7 @@
             <div class="gh-flow">
                 <header class="gh-flow-head">
                     <nav class="gh-flow-nav">
-                        <a href="{{@blog.url}}" class="gh-flow-back"><i class="icon-arrow-left"></i> Back</a>
+                        <a href="{{@blog.url}}" class="gh-flow-back" onclick="window.history.go(-1); return false;"><i class="icon-arrow-left"></i> Back</a>
                     </nav>
                 </header>
 


### PR DESCRIPTION
The back link in subscribe template linked to the home url instead of "back". This commit fixes the behavior to actually link back.
- closes #6984 
- doesn't include a test, but window.history.go(-1) is supported by all browsers
