### PR TITLE
make back link actually link back #6984

### DIFF
--- a/core/server/apps/subscribers/lib/views/subscribe.hbs
+++ b/core/server/apps/subscribers/lib/views/subscribe.hbs
@@ -25,7 +25,7 @@
             <div class="gh-flow">
                 <header class="gh-flow-head">
                     <nav class="gh-flow-nav">
-                        <a href="{{@blog.url}}" class="gh-flow-back"><i class="icon-arrow-left"></i> Back</a>
+                        <a href="{{#if subscribed_url}}{{subscribed_url}}{{else}}{{@blog.url}}{{/if}}" class="gh-flow-back"><i class="icon-arrow-left"></i> Back</a>
                     </nav>
                 </header>
 


### PR DESCRIPTION
This PR makes the back link on the subscribe page to link back to the referring page instead of linking back to /. It will still fall back to / if the referrer can't be read e.g. when the referrer policy is set to "origin".

closes #6984 
- the backlink had a static href to {{@blog.url}} which is now changed to {{#if subscribed_url}}{{subscribed_url}}{{else}}{{@blog.url}}{{/if}} to reflect the referring url.

Note: This will only work for when accessing the subscribe page via the form on the bottom of each post.
When navigating there via menu the link will fallback to the main page.
In #5522 `<meta name="referrer" content="origin">` was introduced which always sets the referrer as domain without the suffix.

To make the back button work via link referral `<meta name="referrer" content="origin">` has to be changed to `<meta name="referrer" content="origin-when-crossorigin">` to retain the actual referrer.

https://moz.com/blog/meta-referrer-tag . @kevinansfield thanks for pointing this out.

Followup Discussion here #7060
