### PR TITLE
Add bower installation instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Install grunt. No prizes here.
 npm install -g grunt-cli
 ```
 
+Install bower. No prizes here either.
+
+```bash
+npm install -g bower
+```
+
 Install Ghost. If you're running locally, use [master](https://github.com/TryGhost/Ghost/tree/master). For production, use [stable](https://github.com/TryGhost/Ghost/tree/stable). :no_entry_sign::rocket::microscope:
 
 ```bash


### PR DESCRIPTION
Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [ ] The build will pass (run `npm test`).
  - doc change only

More info can be found by clicking the "guidelines for contributing" link above.

Bower seems to be necessary for npm init to succeed. Previously I encountered the following error:

```Running "shell:bower-install" (shell) task
/bin/sh: bower: command not found
Warning: Command failed: /bin/sh: bower: command not found
 Use --force to continue.

Aborted due to warnings.
Warning: Failed running "grunt init" in "core/client". Use --force to continue.```
