### PR TITLE
Support for custom notifications

### DIFF
--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -4,6 +4,7 @@ var Promise            = require('bluebird'),
     _                  = require('lodash'),
     permissions        = require('../permissions'),
     errors             = require('../errors'),
+    settings           = require('./settings'),
     utils              = require('./utils'),
     pipeline           = require('../utils/pipeline'),
     canThis            = permissions.canThis,
@@ -46,6 +47,7 @@ notifications = {
          *      message: 'This is an error', // A string. Should fit in one line.
          *      location: 'bottom', // A string where this notification should appear. can be 'bottom' or 'top'
          *      dismissible: true // A Boolean. Whether the notification is dismissible or not.
+         *      custom: true // A Boolean. Whether the notification is a custom message intended for particular Ghost versions.
          *  }] };
      * ```
      */
@@ -121,6 +123,20 @@ notifications = {
         var tasks;
 
         /**
+         * Adds the uuid of notification to "seenNotifications" array.
+         * @param {Object} notification
+         * @return {*|Promise}
+         */
+        function markAsSeen(notification) {
+            var context = {internal: true};
+            return settings.read({key: 'seenNotifications', context: context}).then(function then(response) {
+                var seenNotifications = JSON.parse(response.settings[0].value);
+                seenNotifications = _.uniqBy(seenNotifications.concat([notification.uuid]));
+                return settings.edit({settings: [{key: 'seenNotifications', value: seenNotifications}]}, {context: context});
+            });
+        }
+
+        /**
          * ### Handle Permissions
          * We need to be an authorised user to perform this action
          * @param {Object} options
@@ -153,6 +169,10 @@ notifications = {
                 return element.id === parseInt(options.id, 10);
             });
             notificationCounter = notificationCounter - 1;
+
+            if (notification.custom) {
+                return markAsSeen(notification);
+            }
         }
 
         tasks = [

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -12,6 +12,9 @@
         "displayUpdateNotification": {
             "defaultValue": null
         },
+        "seenNotifications": {
+            "defaultValue": "[]"
+        },
         "migrations": {
             "defaultValue": "{}"
         }

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -51,6 +51,37 @@ function updateCheckError(error) {
     );
 }
 
+/**
+ * If the custom message is intended for current version, create and store a custom notification.
+ * @param {Object} message {id: uuid, version: '0.9.x', content: '' }
+ * @return {*|Promise}
+ */
+function createCustomNotification(message) {
+    if (!semver.satisfies(currentVersion, message.version)) {
+        return Promise.resolve();
+    }
+
+    var notification = {
+        type: 'info',
+        location: 'top',
+        custom: true,
+        uuid: message.id,
+        dismissible: true,
+        message: message.content
+    },
+    getAllNotifications = api.notifications.browse({context: {internal: true}}),
+    getSeenNotifications = api.settings.read(_.extend({key: 'seenNotifications'}, internal));
+
+    return Promise.join(getAllNotifications, getSeenNotifications, function joined(all, seen) {
+        var isSeen      = _.includes(JSON.parse(seen.settings[0].value || []), notification.uuid),
+            isDuplicate = _.some(all.notifications, {message: notification.message});
+
+        if (!isSeen && !isDuplicate) {
+            return api.notifications.add({notifications: [notification]}, {context: {internal: true}});
+        }
+    });
+}
+
 function updateCheckData() {
     var data = {},
         mailConfig = config.mail;
@@ -109,7 +140,8 @@ function updateCheckRequest() {
         reqData = JSON.stringify(reqData);
 
         headers = {
-            'Content-Length': reqData.length
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(reqData)
         };
 
         return new Promise(function p(resolve, reject) {
@@ -148,26 +180,30 @@ function updateCheckRequest() {
     });
 }
 
-// ## Update Check Response
-// Handles the response from the update check
-// Does two things with the information received:
-// 1. Updates the time we can next make a check
-// 2. Checks if the version in the response is new, and updates the notification setting
+/**
+ * Handles the response from the update check
+ * Does three things with the information received:
+ * 1. Updates the time we can next make a check
+ * 2. Checks if the version in the response is new, and updates the notification setting
+ * 3. Create custom notifications is response from UpdateCheck as "messages" array which has the following structure:
+ *
+ * "messages": [{
+ *   "id": ed9dc38c-73e5-4d72-a741-22b11f6e151a,
+ *   "version": "0.5.x",
+ *   "content": "<p>Hey there! 0.6 is available, visit <a href=\"https://ghost.org/download\">Ghost.org</a> to grab your copy now<!/p>"
+ * ]}
+ *
+ * @param {Object} response
+ * @return {Promise}
+ */
 function updateCheckResponse(response) {
-    var ops = [];
-
-    ops.push(
-        api.settings.edit(
-            {settings: [{key: 'nextUpdateCheck', value: response.next_check}]},
-            internal
-        ),
-        api.settings.edit(
-            {settings: [{key: 'displayUpdateNotification', value: response.version}]},
-            internal
-        )
-    );
-
-    return Promise.all(ops);
+    return Promise.all([
+        api.settings.edit({settings: [{key: 'nextUpdateCheck', value: response.next_check}]}, internal),
+        api.settings.edit({settings: [{key: 'displayUpdateNotification', value: response.version}]}, internal)
+    ]).then(function () {
+        var messages = response.messages || [];
+        return Promise.map(messages, createCustomNotification);
+    });
 }
 
 function updateCheck() {

--- a/core/test/integration/api/api_notifications_spec.js
+++ b/core/test/integration/api/api_notifications_spec.js
@@ -1,15 +1,17 @@
 var testUtils        = require('../../utils'),
     should           = require('should'),
     _                = require('lodash'),
+    uuid             = require('node-uuid'),
 
     // Stuff we are testing
-    NotificationsAPI = require('../../../server/api/notifications');
+    NotificationsAPI = require('../../../server/api/notifications'),
+    SettingsAPI      = require('../../../server/api/settings');
 
 describe('Notifications API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup('users:roles', 'perms:notification', 'perms:init'));
+    beforeEach(testUtils.setup('settings', 'users:roles', 'perms:setting', 'perms:notification', 'perms:init'));
 
     should.exist(NotificationsAPI);
 
@@ -142,6 +144,32 @@ describe('Notifications API', function () {
                 _.extend({}, testUtils.context.owner, {id: notification.id})
             ).then(function (result) {
                 should.not.exist(result);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    it('can destroy a custom notification and add its uuid to seenNotifications (owner)', function (done) {
+        var customNotification = {
+            type: 'info',
+            location: 'top',
+            custom: true,
+            uuid: uuid.v4(),
+            dismissible: true,
+            message: 'Hello, this is dog'
+        };
+
+        NotificationsAPI.add({notifications: [customNotification]}, testUtils.context.internal).then(function (result) {
+            var notification = result.notifications[0];
+
+            NotificationsAPI.destroy(
+            _.extend({}, testUtils.context.internal, {id: notification.id})
+            ).then(function () {
+                return SettingsAPI.read(_.extend({key: 'seenNotifications'}, testUtils.context.internal));
+            }).then(function (response) {
+                should.exist(response);
+                response.settings[0].value.should.containEql(customNotification.uuid);
 
                 done();
             }).catch(done);

--- a/core/test/integration/update_check_spec.js
+++ b/core/test/integration/update_check_spec.js
@@ -1,47 +1,105 @@
-var testUtils   = require('../utils'),
+var _           = require('lodash'),
+    testUtils   = require('../utils'),
     should      = require('should'),
     rewire      = require('rewire'),
+    uuid        = require('node-uuid'),
 
     // Stuff we are testing
-    packageInfo = require('../../../package'),
-    updateCheck = rewire('../../server/update-check');
+    packageInfo      = require('../../../package'),
+    updateCheck      = rewire('../../server/update-check'),
+    NotificationsAPI = require('../../server/api/notifications');
 
 describe('Update Check', function () {
-    var environmentsOrig;
+    describe('Reporting to UpdateCheck', function () {
+        var environmentsOrig;
 
-    before(function () {
-        environmentsOrig = updateCheck.__get__('allowedCheckEnvironments');
-        updateCheck.__set__('allowedCheckEnvironments', ['development', 'production', 'testing']);
+        before(function () {
+            environmentsOrig = updateCheck.__get__('allowedCheckEnvironments');
+            updateCheck.__set__('allowedCheckEnvironments', ['development', 'production', 'testing']);
+        });
+
+        after(function () {
+            updateCheck.__set__('allowedCheckEnvironments', environmentsOrig);
+        });
+
+        beforeEach(testUtils.setup('owner', 'posts', 'perms:setting', 'perms:user', 'perms:init'));
+
+        afterEach(testUtils.teardown);
+
+        it('should report the correct data', function (done) {
+            var updateCheckData = updateCheck.__get__('updateCheckData');
+
+            updateCheckData().then(function (data) {
+                should.exist(data);
+                data.ghost_version.should.equal(packageInfo.version);
+                data.node_version.should.equal(process.versions.node);
+                data.env.should.equal(process.env.NODE_ENV);
+                data.database_type.should.match(/sqlite3|pg|mysql/);
+                data.blog_id.should.be.a.String();
+                data.blog_id.should.not.be.empty();
+                data.theme.should.be.equal('casper');
+                data.apps.should.be.a.String();
+                data.blog_created_at.should.be.a.Number();
+                data.user_count.should.be.above(0);
+                data.post_count.should.be.above(0);
+                data.npm_version.should.be.a.String();
+                data.npm_version.should.not.be.empty();
+
+                done();
+            }).catch(done);
+        });
     });
 
-    after(function () {
-        updateCheck.__set__('allowedCheckEnvironments', environmentsOrig);
-    });
+    describe('Custom Notifications', function () {
+        var currentVersionOrig;
 
-    beforeEach(testUtils.setup('owner', 'posts', 'perms:setting', 'perms:user', 'perms:init'));
+        before(function () {
+            currentVersionOrig = updateCheck.__get__('currentVersion');
+            updateCheck.__set__('currentVersion', '0.9.0');
+        });
 
-    afterEach(testUtils.teardown);
+        after(function () {
+            updateCheck.__set__('currentVersion', currentVersionOrig);
+        });
 
-    it('should report the correct data', function (done) {
-        var updateCheckData = updateCheck.__get__('updateCheckData');
+        beforeEach(testUtils.setup('owner', 'posts', 'settings', 'perms:setting', 'perms:notification', 'perms:user', 'perms:init'));
 
-        updateCheckData().then(function (data) {
-            should.exist(data);
-            data.ghost_version.should.equal(packageInfo.version);
-            data.node_version.should.equal(process.versions.node);
-            data.env.should.equal(process.env.NODE_ENV);
-            data.database_type.should.match(/sqlite3|pg|mysql/);
-            data.blog_id.should.be.a.String();
-            data.blog_id.should.not.be.empty();
-            data.theme.should.be.equal('casper');
-            data.apps.should.be.a.String();
-            data.blog_created_at.should.be.a.Number();
-            data.user_count.should.be.above(0);
-            data.post_count.should.be.above(0);
-            data.npm_version.should.be.a.String();
-            data.npm_version.should.not.be.empty();
+        afterEach(testUtils.teardown);
 
-            done();
-        }).catch(done);
+        it('should create a custom notification for target version', function (done) {
+            var createCustomNotification = updateCheck.__get__('createCustomNotification'),
+                message = {
+                    id: uuid.v4(),
+                    version: '0.9.x',
+                    content: '<p>Hey there! This is for 0.9.0 version</p>'
+                };
+
+            createCustomNotification(message).then(function () {
+                return NotificationsAPI.browse(testUtils.context.internal);
+            }).then(function (results) {
+                should.exist(results);
+                should.exist(results.notifications);
+                results.notifications.length.should.be.above(0);
+                should.exist(_.find(results.notifications, {uuid: message.id}));
+                done();
+            }).catch(done);
+        });
+
+        it('should not create notifications meant for other versions', function (done) {
+            var createCustomNotification = updateCheck.__get__('createCustomNotification'),
+                message = {
+                    id: uuid.v4(),
+                    version: '0.5.x',
+                    content: '<p>Hey there! This is for 0.5.0 version</p>'
+                };
+
+            createCustomNotification(message).then(function () {
+                return NotificationsAPI.browse(testUtils.context.internal);
+            }).then(function (results) {
+                should.not.exist(_.find(results.notifications, {uuid: message.id}));
+                done();
+            }).catch(done);
+        });
     });
 });
+


### PR DESCRIPTION
closes #5071

This PR addresses **Add support for custom messages** section described in [#5071](https://github.com/TryGhost/Ghost/issues/5071). 

(NOTE: The section **Move the "update available" notification to the about page** is addressed in a [different PR in Ghost-Admin repo](https://github.com/TryGhost/Ghost-Admin/pull/102))

As described in #5071 we wish to send notifications for specific versions of Ghost. These notifications can be dismissed. Once they are dismissed, they are not shown again. For this purpose, UpdateCheck service was upgraded to send responses like so:

```
{
  "version": "0.5.0",
  "next_check": 1427366737,
  "messages": [{
    "id": ed9dc38c-73e5-4d72-a741-22b11f6e151a,
    "version": "0.5.x",
    "content": "<p>Hey there! 0.6 is available, visit <a href=\"https://ghost.org/download\">Ghost.org</a> to grab your copy now<!/p>" 
  ]}
}
```

In the above example, a blog running on Ghost version 0.5.x would display `content` a banner on the top. All other Ghost versions ignore `messages` field.

To accomplish this, a new `core` property `seenNotifications` is added to `settings` table.

If a response from UpdateCheck has `messages` property, iterate over them and construct  notifications intended for current version. If a custom notification is dismissed, its uuid is added to `seenNotification` array to prevent showing the same message again.
## TODO
- [x] Test fixtures. `grunt validate` fails with "Unable to find setting to update: seenNotifications". However, `grunt test:integration/api/api_notifications_spec.js` and `grunt test:integration/update_check_spec.js` pass.
