### PR TITLE
Allow "@" in image name for RetinaJS support

### DIFF
--- a/core/server/storage/base.js
+++ b/core/server/storage/base.js
@@ -39,7 +39,7 @@ StorageBase.prototype.generateUnique = function (store, dir, name, ext, i) {
 
 StorageBase.prototype.getUniqueFileName = function (store, image, targetDir) {
     var ext = path.extname(image.name),
-        name = path.basename(image.name, ext).replace(/[\W]/gi, '-'),
+        name = path.basename(image.name, ext).replace(/[^\w@]/gi, '-'),
         self = this;
 
     return self.generateUnique(store, targetDir, name, ext, 0);

--- a/core/test/unit/storage_local-file-store_spec.js
+++ b/core/test/unit/storage_local-file-store_spec.js
@@ -74,6 +74,15 @@ describe('Local File System Storage', function () {
         }).catch(done);
     });
 
+    it('should allow "@" symbol to image for Apple hi-res (retina) modifier', function (done) {
+        image.name = 'photo@2x.jpg';
+        localFileStore.save(image).then(function (url) {
+            url.should.equal('/content/images/2013/09/photo@2x.jpg');
+
+            done();
+        }).catch(done);
+    });
+
     it('should send correct path to image when date is in Jan 2014', function (done) {
         fakeDate(1, 2014);
 


### PR DESCRIPTION
Hello,

I was lately playing with [RetinaJS](https://github.com/imulus/retinajs) Ghost [integration](http://blog.eexit.net/ghost-retinajs-integration/) and I noticed your image uploader would strip the `@`  char which is annoying.

This PR allows this character with the test that goes along. Hope this is okay with you all.

Thanks,
