### PR TITLE
move origin to config and default to origin-when-cross-origin #7060

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -33,6 +33,11 @@ config = {
         // Change this to your Ghost blog's published URL.
         url: 'http://localhost:2368',
 
+        // Example refferer policy
+        // Visit https://www.w3.org/TR/referrer-policy/ for instructions
+        // default 'origin-when-cross-origin',
+        // referrerPolicy: 'origin-when-cross-origin',
+
         // Example mail config
         // Visit http://support.ghost.org/mail for instructions
         // ```

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -80,14 +80,15 @@ function ghost_head(options) {
         head = [],
         context = this.context ? this.context[0] : null,
         useStructuredData = !config.isPrivacyDisabled('useStructuredData'),
-        safeVersion = this.safeVersion;
+        safeVersion = this.safeVersion,
+        referrerPolicy = config.referrerPolicy ? config.referrerPolicy : 'origin-when-cross-origin';
 
     return getClient().then(function (client) {
         if (context) {
             // head is our main array that holds our meta data
             head.push('<link rel="canonical" href="' +
             escapeExpression(metaData.canonicalUrl) + '" />');
-            head.push('<meta name="referrer" content="origin" />');
+            head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
 
             if (metaData.previousUrl) {
                 head.push('<link rel="prev" href="' +

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -83,7 +83,7 @@ describe('{{ghost_head}} helper', function () {
             ).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
-                rendered.string.should.match(/<meta name="referrer" content="origin" \/>/);
+                rendered.string.should.match(/<meta name="referrer" content="origin-when-cross-origin" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Ghost" \/>/);
@@ -135,7 +135,7 @@ describe('{{ghost_head}} helper', function () {
             ).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/about\/" \/>/);
-                rendered.string.should.match(/<meta name="referrer" content="origin" \/>/);
+                rendered.string.should.match(/<meta name="referrer" content="origin-when-cross-origin" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="About" \/>/);
@@ -800,6 +800,32 @@ describe('{{ghost_head}} helper', function () {
                     done();
                 }).catch(done);
             });
+        });
+    });
+
+    describe('with changed origin in config file', function () {
+        beforeEach(function () {
+            configUtils.set({
+                url: 'http://testurl.com/blog/',
+                theme: {
+                    title: 'Ghost',
+                    description: 'blog description',
+                    cover: '/content/images/blog-cover.png'
+                },
+                referrerPolicy: 'origin'
+            });
+        });
+
+        it('contains the changed origin', function (done) {
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['paged', 'index']},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<meta name="referrer" content="origin" \/>/);
+
+                done();
+            }).catch(done);
         });
     });
 


### PR DESCRIPTION
This pr makes the referrer policy configurable via config.js by adding a 'referrer-policy' field to it.
The change is already planned, but I needed it ASAP for multilingualism tests.
@kevinansfield If this suits your requirements, I'd be happy to add tests to make it mergable.
If you had another idea on solving this, just close the pr :)

Please include a description of your change & check your PR against this list, thanks!
- closes #7060
- is needed for #6984 to actually work
- [x] modified the tests to accept the new "origin-when-cross-origin" https://www.w3.org/TR/referrer-policy/#referrer-policy-origin-when-cross-origin default 
- [x] added new tests
