### PR TITLE
"url" field is undefined when restricting returned fields via the API

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -393,6 +393,10 @@ Post = ghostBookshelf.Model.extend({
         return this.morphMany('AppField', 'relatable');
     },
 
+    defaultColumnsToFetch: function defaultColumnsToFetch() {
+        return ['id', 'published_at', 'slug', 'author_id'];
+    },
+
     toJSON: function toJSON(options) {
         options = options || {};
 

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -2,6 +2,7 @@ var Promise       = require('bluebird'),
     should        = require('should'),
     _             = require('lodash'),
     testUtils     = require('../../utils'),
+    configUtils   = require('../../utils/configUtils'),
     errors        = require('../../../server/errors'),
     db            = require('../../../server/data/db'),
     models        = require('../../../server/models'),
@@ -45,6 +46,16 @@ describe('Post API', function () {
     should.exist(PostAPI);
 
     describe('Browse', function () {
+        beforeEach(function () {
+            configUtils.set({theme: {
+                permalinks: '/:slug/'
+            }});
+        });
+
+        afterEach(function () {
+            configUtils.restore();
+        });
+
         it('can fetch all posts with internal context in correct order', function (done) {
             PostAPI.browse({context: {internal: true}}).then(function (results) {
                 should.exist(results.posts);
@@ -354,6 +365,18 @@ describe('Post API', function () {
                 should.exist(results.posts[0].published_at);
                 should.exist(results.posts[0].slug);
                 should.not.exist(results.posts[0].title);
+
+                done();
+            }).catch(done);
+        });
+
+        it('with context.user can fetch url and author fields', function (done) {
+            PostAPI.browse({context: {user: 1}, status: 'all', limit: 5}).then(function (results) {
+                should.exist(results.posts);
+
+                should.exist(results.posts[0].url);
+                should.notEqual(results.posts[0].url, 'undefined');
+                should.exist(results.posts[0].author);
 
                 done();
             }).catch(done);


### PR DESCRIPTION
Closes #6625 

`GET /posts` query with `?field=url` as query string returns "undefined" as url value. The `url` property is constructed from id, published_dt, and slug. Post instances are loaded with attributes given in `fields` parameter. If the `fields` parameter doesn't contain `id`, `published_dt`, and `slug`, URL can't be constructed and undefined is returned.

Fix was to load the 3 required properties when `field` parameter contains `url`. Response is sent after filtering out any properties that were not requested.
- "url" and "author" fields depend on {id, published_at, slug, author_id} to construct post url.
- results are transformed by filtering out additional properties to return just the requested fields
