### PR TITLE
change default order for posts

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -348,9 +348,12 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         if (options.order) {
             options.order = self.parseOrderOption(options.order, options.include);
+        } else if (self.orderDefaultRaw) {
+            options.orderRaw = self.orderDefaultRaw();
         } else {
             options.order = self.orderDefaultOptions();
         }
+
         return itemCollection.fetchPage(options).then(function formatResponse(response) {
             var data = {};
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -429,6 +429,16 @@ Post = ghostBookshelf.Model.extend({
         };
     },
 
+    orderDefaultRaw: function () {
+        return '' +
+            'CASE WHEN posts.status = \'scheduled\' THEN 1 ' +
+            'WHEN posts.status = \'draft\' THEN 2 ' +
+            'ELSE 3 END ASC,' +
+            'posts.published_at DESC,' +
+            'posts.updated_at DESC,' +
+            'posts.id DESC';
+    },
+
     /**
      * @deprecated in favour of filter
      */

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -77,7 +77,6 @@ describe('Post Model', function () {
                 PostModel.findAll().then(function (results) {
                     should.exist(results);
                     results.length.should.be.above(1);
-
                     done();
                 }).catch(done);
             });

--- a/core/test/unit/models_plugins/pagination_spec.js
+++ b/core/test/unit/models_plugins/pagination_spec.js
@@ -192,7 +192,7 @@ describe('pagination', function () {
                 toQuery: sandbox.stub()
             };
             mockQuery.clone.returns(mockQuery);
-            mockQuery.select.returns([{aggregate: 1}]);
+            mockQuery.select.returns(Promise.resolve([{aggregate: 1}]));
 
             model = function () {};
 
@@ -340,7 +340,7 @@ describe('pagination', function () {
 
         it('returns expected response even when aggregate is empty', function (done) {
             // override aggregate response
-            mockQuery.select.returns([]);
+            mockQuery.select.returns(Promise.resolve([]));
             paginationUtils.parseOptions.returns({});
 
             bookshelf.Model.prototype.fetchPage().then(function (result) {
@@ -349,19 +349,6 @@ describe('pagination', function () {
                 result.collection.should.be.an.Object();
                 result.pagination.should.be.an.Object();
 
-                done();
-            });
-        });
-
-        it('will output sql statements in debug mode', function (done) {
-            model.prototype.debug = true;
-            mockQuery.select.returns({toQuery: function () {}});
-            paginationUtils.parseOptions.returns({});
-
-            var consoleSpy = sandbox.spy(console, 'log');
-
-            bookshelf.Model.prototype.fetchPage().then(function () {
-                consoleSpy.calledOnce.should.be.true();
                 done();
             });
         });


### PR DESCRIPTION
closes #6932 

Since we have scheduled posts, we force returning the following order to the admin:
`scheduled, draft, published`
#### TODO
- [x] try to combine `findPage` fn of post model and base model
- [x] manual browser test
- [x] fix postgres
