### PR TITLE
Node version check w/o semver

### DIFF
--- a/core/server/utils/npm/preinstall.js
+++ b/core/server/utils/npm/preinstall.js
@@ -1,0 +1,47 @@
+var validVersions = process.env.npm_package_engines_node.split(' || '),
+    currentVersion = process.versions.node,
+    foundMatch = false,
+    majMinRegex = /(\d+\.\d+)/,
+    majorRegex = /^\d+/,
+    minorRegex = /\d+$/,
+    exitCodes = {
+        NODE_VERSION_UNSUPPORTED: 231
+    };
+
+function doError() {
+    console.error('\x1B[31mERROR: Unsupported version of Node');
+    console.error('\x1B[37mGhost supports LTS Node versions: ' + process.env.npm_package_engines_node);
+    console.error('You are currently using version: ' + process.versions.node + '\033[0m');
+    console.error('\x1B[32mThis check can be overridden, see http://support.ghost.org/supported-node-versions/ for more info\033[0m');
+
+    process.exit(exitCodes.NODE_VERSION_UNSUPPORTED);
+}
+
+if (process.env.GHOST_NODE_VERSION_CHECK === 'false') {
+    console.log('\x1B[33mSkipping Node version check\033[0m');
+} else {
+    try {
+        currentVersion = currentVersion.match(majMinRegex)[0];
+
+        validVersions.forEach(function (version) {
+            var matchChar = version.charAt(0),
+                versionString = version.match(majMinRegex)[0];
+
+            if (
+                (matchChar === '~' && currentVersion === versionString)
+                || (matchChar === '^'
+                    && currentVersion.match(majorRegex)[0] === versionString.match(majorRegex)[0]
+                    && currentVersion.match(minorRegex)[0] >= versionString.match(minorRegex)[0]
+                )
+            ) {
+                foundMatch = true;
+            }
+        });
+
+        if (foundMatch !== true) {
+            doError();
+        }
+    } catch (e) {
+        doError();
+    }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "./core/index",
   "scripts": {
-    "preinstall": "npm install semver && node -e \"require('./core/server/utils/startup-check.js').nodeVersion()\"",
+    "preinstall": "node core/server/utils/npm/preinstall.js",
     "start": "node index",
     "test": "grunt validate --verbose"
   },


### PR DESCRIPTION
This PR is an attempt to reduce the amount of friction users have with installing Ghost.

The other option rather than doing this would be simply to remove this check.

Unfortunately, different versions of `npm` all handle `preinstall` quite differently. The order of operations are completely different between npm@2 and npm@3. Further still, using `npm install` inside of a `preinstall` script runs into permissions issues frequently.

This PR removes the need for npm installing `semver` and also removes the require of `package.json` from the check that is run during the preinstall.

I'm then using a very simple strategy to attempt to match the current node version with one of the version strings in `package.json#engines`:
- clean up the node version string to be just the first two digits: `x.x` - major & minor, as these are the only ones we ever want to match against.
- for each version in engines:
  - detect the first char as `~` or `^` as we have to do different matches for these
  - also simplify the string to major & minor
  - for ~ check the strings are identical (0.10 or 0.12)
  - for ^ check the first number is the same (4) and the second number is the same or greater (2+)

This should also work when we remove `~0.10.0` and add `^6.??.0` in October.

I have tested this on my mac using both npm@2 and npm@3. I have tested both running `npm install` inside Ghost, and proxied testing `npm install ghost` by using a local package as described [here](http://podefr.tumblr.com/post/30488475488/locally-test-your-npm-modules-without-publishing).

I don't really know how to replicate the issues which result in the error `npm WARN cannot run in wd` - these are usually to do with needing sudo or some other permission issue?

If anyone has an idea what to test to see if this code is less painful, I'd be grateful.

---

closes #6691
- removes dependency on semver & package.json in preinstall script
- has a simplified proxy of semver to look for the right version numbers
