### PR TITLE
Recommend Node v4 & use as default

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Any other info e.g. Why do you consider this to be a bug? What did you expect to
 ### Technical details:
 
 * Ghost Version: master (latest commit: a761de2079dca4df49567b1bddac492f25033985)
-* Node Version: 0.10.16
+* Node Version: 4.4.7
 * Browser: Chrome 48.0.2564.109 on Mac OS X 10.10.4
 * Database: SQLite / MySQL / postgres
 ```
@@ -188,7 +188,7 @@ Looking to get setup to work on Ghost? AWESOME! The [Ghost-Vagrant](https://gith
 
 **What you'll need:**
 
-- Node version 0.10.x & npm
+- A supported Node.js version & npm  (see [Supported Node Versions](http://support.ghost.org/supported-node-versions/))
 - phantomjs 2.1.x
 ([instructions](https://github.com/TryGhost/Ghost/wiki/Functional-testing-with-PhantomJS-and-CasperJS)) for running tests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 # When changing node version also update it on lines 34, 36 and 46.
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
+  - "0.12"
+  - "0.10"
+  - "6"
 sudo: false
 cache:
   directories:
@@ -23,10 +24,13 @@ env:
     - DB=pg NODE_ENV=testing-pg
 matrix:
   include:
-    - node_js: "0.10"
+    - node_js: "4"
       env: TEST_SUITE=lint
+  allow_failures:
+    - node_js: "6"
+  fast_finish: true
 branches:
-  exclude:
+  except:
     - /^greenkeeper-.+$/
 before_install:
   - if [ $DB == "mysql" ]; then mysql -e 'create database ghost_testing'; fi
@@ -34,7 +38,7 @@ before_install:
 after_success:
   - |
       if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-        if [[ "$DB" = "sqlite3" && "$TRAVIS_NODE_VERSION" = "0.10" ]]; then
+        if [[ "$DB" = "sqlite3" && "$TRAVIS_NODE_VERSION" = "4" ]]; then
           echo "Generate coverage..."
           grunt coverage
           npm install -g codeclimate-test-reporter

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 
 # Quick Start Install
 
-Make sure you've installed Node.js - We recommend the latest **Node v0.10.x** release. For other versions [click here](http://support.ghost.org/supported-node-versions/). May contain nuts.
+Make sure you've installed Node.js - We recommend the latest **Node v4 LTS** release. For other versions [click here](http://support.ghost.org/supported-node-versions/). May contain nuts.
 
 1. Download the [latest release](https://ghost.org/developers/) of Ghost
 1. Unzip in the location you want to install
@@ -39,8 +39,8 @@ More [install docs](http://support.ghost.org/installation/) here in case you got
 Install Node.js. (See [Supported Node.js versions](http://support.ghost.org/supported-node-versions/))
 
 ```bash
-# Node v0.10.x - recommended
-# Node v0.12.x and v4.2+ LTS - supported
+# Node v4.2+ LTS - recommended
+# Node v0.10.x and v0.12.x - supported
 #
 # Choose wisely
 ```


### PR DESCRIPTION
Some of these changes are purely cosmetic e.g. the Node version in the Contributing guide bug report, some of them are documentation updates E.g. changes in the README and others are functional e.g. changes to .travis.yml

With this PR, we switch over our recommendation from Node.js 0.10 to v4 LTS. This means that v4 is our default environment now: what we use for development, testing & in production.

Node.js 0.10 is still supported and expected to work until 1st October 2016.

With this PR we also and Node v6 as an allowed failure (and the build does fail right now). So that we can start to figure out what needs to be done to ensure we have support for it when it is declared LTS also on 1st October 2016.

**Note:** This pulls in the latest Ghost-Admin master which has similar changes

refs #7098
- Use Node.js v4 as our default build environment
- Add Node.js v6 as an allowed failure
- Update contributor guidelines and readme
- Fix issue with branch exceptions
