### PR TITLE
Image-size util to return image dimensions

### DIFF
--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -1,0 +1,99 @@
+// Supported formats of https://github.com/image-size/image-size:
+// BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG
+// ***
+// Takes the url of the image and an optional timeout
+// getImageSizeFromUrl returns an Object like this
+// {
+//     height: 50,
+//     url: 'http://myblog.com/images/cat.jpg',
+//     width: 50
+// };
+// if the dimensions can be fetched and returns the url back, if not.
+// ***
+// In case we get a locally stored image or a not complete url (like //www.gravatar.com/andsoon),
+// we add the protocol to the incomplete one and use urlFor() to get the absolute URL.
+// If the request fails or image-size is not able to read the file, we return the original URL.
+
+var sizeOf = require('image-size'),
+    url = require('url'),
+    Promise = require('bluebird'),
+    http = require('http'),
+    https = require('https'),
+    config = require('../config'),
+    dimensions,
+    request,
+    prot;
+
+/**
+ * @description read image dimensions from URL
+ * @param {String} imagePath
+ * @param {Number} timeout
+ * @returns {Promise<Object>} imageObject
+ * Always returns {string} imagePath
+ */
+module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, timeout) {
+    return new Promise(function imageSizeRequest(resolve) {
+        var timer,
+            imageObject = {},
+            timerEnded = false,
+            options;
+
+        imageObject.url = imagePath;
+
+        // check if we got an url without any protocol
+        if (imagePath.indexOf('http') === -1) {
+            // our gravatar urls start with '//' in that case add 'http:'
+            if (imagePath.indexOf('//') === 0) {
+                // it's a gravatar url
+                imagePath = 'http:' + imagePath;
+            } else {
+                // get absolute url for image
+                imagePath = config.urlFor('image', {image: imagePath}, true);
+            }
+        }
+
+        options = url.parse(imagePath);
+
+        prot = imagePath.indexOf('https') === 0 ? https : http;
+        options.headers = {'User-Agent': 'Mozilla/5.0'};
+
+        request = prot.get(options, function (res) {
+            var chunks = [];
+            clearTimeout(timer);
+
+            res.on('data', function (chunk) {
+                chunks.push(chunk);
+            });
+
+            res.on('end', function () {
+                if (res.statusCode === 200 && !timerEnded) {
+                    try {
+                        dimensions = sizeOf(Buffer.concat(chunks));
+
+                        imageObject.width = dimensions.width;
+                        imageObject.height = dimensions.height;
+
+                        return resolve(imageObject);
+                    } catch (err) {
+                        // @ToDo: add real error handling here as soon as we have error logging
+                        return resolve(imagePath);
+                    }
+                } else {
+                    return resolve(imagePath);
+                }
+            });
+        }).on('error', function () {
+            clearTimeout(timer);
+            // just resolve with no image url
+            if (!timerEnded) {
+                return resolve(imagePath);
+            }
+        });
+        timer = setTimeout(function () {
+            timerEnded = true;
+            request.abort();
+
+            return resolve(imagePath);
+        }, timeout || 2000);
+    });
+};

--- a/core/test/unit/utils/image-size-from-url_spec.js
+++ b/core/test/unit/utils/image-size-from-url_spec.js
@@ -1,0 +1,218 @@
+var should = require('should'),
+    Promise = require('bluebird'),
+    rewire = require('rewire'),
+    nock = require('nock'),
+    sinon = require('sinon'),
+    config = require('../../../server/config'),
+
+    // Stuff we are testing
+    imageSize = rewire('../../../server/utils/image-size-from-url');
+
+describe('Image Size', function () {
+    var sizeOfStub,
+        result,
+        requestMock;
+
+    beforeEach(function () {
+        sizeOfStub = sinon.stub();
+    });
+
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('should have an image size function', function () {
+        should.exist(imageSize);
+    });
+
+    it('should return image dimensions with http request', function (done) {
+        var url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg',
+            expectedImageObject =
+                {
+                    height: 50,
+                    url: 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg',
+                    width: 50
+                };
+
+        requestMock = nock('http://img.stockfresh.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(200);
+
+        sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('should return image dimensions with https request', function (done) {
+        var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256',
+            expectedImageObject =
+                {
+                    height: 256,
+                    url: 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256',
+                    width: 256
+                };
+        requestMock = nock('https://static.wixstatic.com')
+            .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
+            .reply(200);
+
+        sizeOfStub.returns({width: 256, height: 256, type: 'png'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('should return image dimensions for gravatar images request', function (done) {
+        var url = '//www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x',
+            expectedImageObject =
+                {
+                    height: 250,
+                    url: '//www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x',
+                    width: 250
+                };
+        requestMock = nock('http://www.gravatar.com')
+            .get('/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x')
+            .reply(200);
+
+        sizeOfStub.returns({width: 250, height: 250, type: 'jpg'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('should return image dimensions relative url request', function (done) {
+        var url = '/content/images/cat.jpg',
+            urlForStub,
+            expectedImageObject =
+                {
+                    height: 100,
+                    url: '/content/images/cat.jpg',
+                    width: 100
+                };
+
+        urlForStub = sinon.stub(config, 'urlFor');
+        urlForStub.withArgs('image').returns('http://myblog.com/content/images/cat.jpg');
+
+        requestMock = nock('http://myblog.com')
+            .get('/content/images/cat.jpg')
+            .reply(200);
+
+        sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('can handle an error', function (done) {
+        var url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
+
+        nock('http://noimagehere.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(404);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            should.exist(res);
+            should.not.exist(res.width);
+            should.not.exist(res.height);
+            should.not.exist(res.url);
+            res.should.be.equal(url);
+            done();
+        }).catch(done);
+    });
+
+    it('will timeout', function (done) {
+        var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256';
+        nock('https://static.wixstatic.com')
+            .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
+            .delay(11)
+            .reply(200);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url, 10)).then(function (res) {
+            should.exist(res);
+            should.not.exist(res.width);
+            should.not.exist(res.height);
+            should.not.exist(res.url);
+            res.should.be.equal(url);
+            done();
+        }).catch(done);
+    });
+
+    it('returns image url if \`image-size`\ module throws error', function (done) {
+        var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256',
+
+        requestMock = nock('https://static.wixstatic.com')
+            .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
+            .reply(200);
+
+        sizeOfStub.throws('error');
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.not.exist(res.width);
+            should.not.exist(res.height);
+            should.not.exist(res.url);
+            res.should.be.equal(url);
+            done();
+        }).catch(done);
+    });
+
+    it('returns image url if request errors', function (done) {
+        var url = 'https://notarealwebsite.com/images/notapicture.jpg',
+
+        requestMock = nock('https://notarealwebsite.com')
+            .get('/images/notapicture.jpg')
+            .replyWithError({message: 'something awful happened', code: 'AWFUL_ERROR'});
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.not.exist(res.width);
+            should.not.exist(res.height);
+            should.not.exist(res.url);
+            res.should.be.equal(url);
+            done();
+        }).catch(done);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ghost-gql": "0.0.5",
     "glob": "5.0.15",
     "html-to-text": "2.1.3",
+    "image-size": "0.5.0",
     "intl": "1.2.4",
     "intl-messageformat": "1.3.0",
     "jsonpath": "0.2.6",


### PR DESCRIPTION
refs #7095

The util returns an object like this

```
{
    height: 50,
    url: 'http://myblog.com/images/cat.jpg',
    width: 50
};
```

if the dimensions can be fetched and returns the url back, if not.

In case we get a locally stored image or a not complete url (like `//www.gravatar.com/andsoon`), we add the protocol to the incomplete one and use `urlFor()` to get the absolute URL. If the request fails or `image-size` is not able to read the file, we return the original URL.
- adds 'image-size' module to dependencies
- adds `getImageSizeFromUrl` function that returns image dimensions
- adds unit test
