### PR TITLE
Return meta data as promise

### DIFF
--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -1,4 +1,5 @@
 var _ = require('lodash'),
+    Promise = require('bluebird'),
     config = require('../../config'),
     getUrl = require('./url'),
     getCanonicalUrl = require('./canonical_url'),
@@ -55,7 +56,10 @@ function getMetaData(data, root) {
     metaData.structuredData = getStructuredData(metaData);
     metaData.schema = getSchema(metaData, data);
 
-    return metaData;
+    // instead of Promise here, soon we'll have a call to a new function which augments the images with their image sizes
+    return new Promise(function (resolve) {
+        return resolve(metaData);
+    });
 }
 
 module.exports = getMetaData;

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -76,28 +76,36 @@ function ghost_head(options) {
         return;
     }
 
-    var metaData = getMetaData(this, options.data.root),
+    var metaData,
+        client,
         head = [],
         context = this.context ? this.context[0] : null,
         useStructuredData = !config.isPrivacyDisabled('useStructuredData'),
         safeVersion = this.safeVersion,
-        referrerPolicy = config.referrerPolicy ? config.referrerPolicy : 'origin-when-cross-origin';
+        referrerPolicy = config.referrerPolicy ? config.referrerPolicy : 'origin-when-cross-origin',
+        fetch = {
+            metaData: getMetaData(this, options.data.root),
+            client: getClient()
+        };
 
-    return getClient().then(function (client) {
+    return Promise.props(fetch).then(function (response) {
+        client = response.client;
+        metaData = response.metaData;
+
         if (context) {
             // head is our main array that holds our meta data
             head.push('<link rel="canonical" href="' +
-            escapeExpression(metaData.canonicalUrl) + '" />');
+                escapeExpression(metaData.canonicalUrl) + '" />');
             head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
 
             if (metaData.previousUrl) {
                 head.push('<link rel="prev" href="' +
-                escapeExpression(metaData.previousUrl) + '" />');
+                    escapeExpression(metaData.previousUrl) + '" />');
             }
 
             if (metaData.nextUrl) {
                 head.push('<link rel="next" href="' +
-                escapeExpression(metaData.nextUrl) + '" />');
+                    escapeExpression(metaData.nextUrl) + '" />');
             }
 
             if (context !== 'paged' && useStructuredData) {
@@ -118,10 +126,10 @@ function ghost_head(options) {
         }
 
         head.push('<meta name="generator" content="Ghost ' +
-        escapeExpression(safeVersion) + '" />');
+            escapeExpression(safeVersion) + '" />');
         head.push('<link rel="alternate" type="application/rss+xml" title="' +
-        escapeExpression(metaData.blog.title)  + '" href="' +
-        escapeExpression(metaData.rssUrl) + '" />');
+            escapeExpression(metaData.blog.title)  + '" href="' +
+            escapeExpression(metaData.rssUrl) + '" />');
 
         return api.settings.read({key: 'ghost_head'});
     }).then(function (response) {


### PR DESCRIPTION
refs #7095

In preparation to get asynchronous image-dimensions we need to promisify the `ghost_head` helper
- returns a new Promise from meta data
- uses `Promise.props()` to resolve `getClient()` and `getMetaData()`
