### PR TITLE
[WIP] Improved session lengths, support for signing out of sessions remotely

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -1,5 +1,6 @@
 var _                = require('lodash'),
     validator        = require('validator'),
+    Promise          = require('bluebird'),
     pipeline         = require('../utils/pipeline'),
     dataProvider     = require('../models'),
     settings         = require('./settings'),
@@ -547,6 +548,38 @@ authentication = {
         tasks = [
             processArgs,
             revokeToken
+        ];
+
+        return pipeline(tasks, tokenDetails, localOptions);
+    },
+
+    /**
+     * Revokes all tokens except the currently active one. This is used to implement "Signoff all other web sessions".
+     * @param {Object} tokenDetails
+     * @param {Object} options
+     * @return {Promise<Object>} an object containing the revoked token.
+     */
+    revokeOtherTokens: function revokeToken(tokenDetails, options) {
+        var tasks,
+            localOptions = _.cloneDeep(options || {});
+
+        function processArgs(tokenDetails, options) {
+            return _.assign({}, tokenDetails, options);
+        }
+
+        function revokeInactiveToken(options) {
+            var destroyInactiveAccessTokens = dataProvider.Accesstoken.destroyInactiveTokensByUser(options),
+                destroyInactiveRefreshTokens = dataProvider.Refreshtoken.destroyInactiveTokensByUser(options);
+
+            return Promise.all(destroyInactiveAccessTokens, destroyInactiveRefreshTokens)
+            .catch(function () {
+                throw new errors.TokenRevocationError(i18n.t('errors.api.authentication.tokenRevocationFailed'));
+            });
+        }
+
+        tasks = [
+            processArgs,
+            revokeInactiveToken
         ];
 
         return pipeline(tasks, tokenDetails, localOptions);

--- a/core/server/models/base/token.js
+++ b/core/server/models/base/token.js
@@ -76,6 +76,25 @@ Basetoken = ghostBookshelf.Model.extend({
             .then(function then(model) {
                 return model.destroy(options);
             });
+    },
+
+    /**
+     * ### destroyByUser
+     * @param  {[type]} options has context and id. Context is the user doing the destroy, id is the user to destroy
+     */
+    destroyInactiveTokensByUser: function destroyByUser(options) {
+        var userId = options.id,
+            token  = options.token;
+
+        options = this.filterOptions(options, 'destroyByUser');
+
+        return ghostBookshelf.Collection.forge([], {model: this})
+        .query('where', 'token', '<>', token)
+        .andWhere('user_id', '=', userId)
+        .fetch(options)
+        .then(function then(collection) {
+            collection.invokeThen('destroy', options);
+        });
     }
 });
 

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -136,6 +136,7 @@ apiRoutes = function apiRoutes(middleware) {
         middleware.oauth.generateAccessToken
     );
     router.post('/authentication/revoke', authenticatePrivate, api.http(api.authentication.revoke));
+    router.del('/authentication/tokens', authenticatePrivate, api.http(api.authentication.revokeOtherTokens));
 
     // ## Uploads
     router.post('/uploads', authenticatePrivate, middleware.upload.single('uploadimage'), api.http(api.uploads.add));


### PR DESCRIPTION
closes #5202
## What's this about

Server side implementation of feature described in #5202. Feature requested on [ideas page](http://ideas.ghost.org/forums/285309-wishlist/suggestions/7643373-sign-out-everywhere).

It provides support for revoking a user's tokens remotely. Ghost-Admin will provide a button _Sign out of all other web sessions_ on user's profile page. Route implemented here will be consumed by this button.
## Implementation Details
- added DELETE /authentication/tokens which by default removes all except current active token of the calling user's session
- added destroyInactiveTokensByUser() to "token" base class
- new API method api.authentication.revokeOtherTokens
## TODO
- [ ] Add user-agent to tokens tables 
- [ ] A section in "Your Profile" page to show other active sessions of the user
- [ ] Increase TTL of tokens
