### PR TITLE
Don't populate settings defaults twice on startup

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -77,8 +77,6 @@ function init(options) {
                     forceMigration: process.env.FORCE_MIGRATION
                 }).then(function () {
                     config.maintenance.enabled = false;
-                }).then(function () {
-                    return models.Settings.populateDefaults();
                 }).catch(function (err) {
                     errors.logErrorAndExit(err, err.context, err.help);
                 });

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -90,7 +90,7 @@ describe('server bootstrap', function () {
                         forceMigration: undefined
                     }).should.eql(true);
 
-                    models.Settings.populateDefaults.callCount.should.eql(2);
+                    models.Settings.populateDefaults.callCount.should.eql(1);
                     migration.populate.calledOnce.should.eql(false);
                     config.maintenance.enabled.should.eql(false);
 


### PR DESCRIPTION
Slight regression that throws an error whenever a new setting is added. (only on the first boot of the blog, doesn't happen after that).

To reproduce the error (without this PR):
1. Clear the SQLite DB
2. Checkout commit 77464c59bd294d588cf5ff68c342ec91411520b8
3. Start & setup blog
4. Checkout master
5. Start blog and see a SQLite constraint error

With these changes that doesn't happen.
