### PR TITLE
fix: populateSettings as transaction

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -171,7 +171,8 @@
         },
         "general": {
             "moreInfo": "\nMore info: {info}",
-            "requiredOnFuture": "This will be required in future. Please see {link}"
+            "requiredOnFuture": "This will be required in future. Please see {link}",
+            "database": "Database problem, please try again or contact our support."
         },
         "httpServer": {
             "addressInUse": {


### PR DESCRIPTION
no issue
- if two function calls happen to `populateDefaults` in `models/settings.js`, it can happen that they try both to update the database
- in this case the database would throw a unique constraint error (or other errors too)
- solve this issue by executing get and insert in a transactional operation

To reproduce the error (without this PR):
1. Clear the SQLite DB
2. Checkout commit 77464c59bd294d588cf5ff68c342ec91411520b8
3. Start & setup blog
4. Checkout master
5. Start blog and see a SQLite constraint error
- [x] error handling
