### PR TITLE
Allow maintenance mode to be set in config.js

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -324,7 +324,8 @@ errors = {
         function renderErrorInt(errorView) {
             var stack = null;
 
-            if (statusCode !== 404 && process.env.NODE_ENV !== 'production' && err.stack) {
+            // Not Found and Maintenance Errors don't need a stack trace
+            if (statusCode !== 404 && statusCode !== 503 && process.env.NODE_ENV !== 'production' && err.stack) {
                 stack = parseStack(err.stack);
             }
 

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -69,6 +69,7 @@ function init(options) {
     }).then(function () {
         return versioning.getDatabaseVersion()
             .then(function (currentVersion) {
+                var maintenanceState = config.maintenance.enabled || false;
                 config.maintenance.enabled = true;
 
                 migrations.update({
@@ -76,7 +77,7 @@ function init(options) {
                     toVersion: versioning.getNewestDatabaseVersion(),
                     forceMigration: process.env.FORCE_MIGRATION
                 }).then(function () {
-                    config.maintenance.enabled = false;
+                    config.maintenance.enabled = maintenanceState;
                 }).catch(function (err) {
                     errors.logErrorAndExit(err, err.context, err.help);
                 });

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -197,7 +197,9 @@ setupMiddleware = function setupMiddleware(blogApp) {
 
     // Mount admin express app to /ghost and set up routes
     adminApp.use(redirectToSetup);
+    adminApp.use(maintenance);
     adminApp.use(routes.admin());
+
     blogApp.use('/ghost', adminApp);
 
     // send 503 error page in case of maintenance

--- a/core/server/middleware/maintenance.js
+++ b/core/server/middleware/maintenance.js
@@ -1,9 +1,12 @@
-var config = require(__dirname + '/../config'),
-    errors = require(config.paths.corePath + '/server/errors');
+var config = require('../config'),
+    i18n   = require('../i18n'),
+    errors = require('../errors');
 
 module.exports = function (req, res, next) {
     if (config.maintenance.enabled) {
-        return next(new errors.Maintenance());
+        return next(new errors.Maintenance(
+            i18n.t('errors.general.maintenance')
+        ));
     }
 
     next();

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -170,6 +170,7 @@
             }
         },
         "general": {
+            "maintenance": "Ghost is currently undergoing maintenance, please wait a moment then retry.",
             "moreInfo": "\nMore info: {info}",
             "requiredOnFuture": "This will be required in future. Please see {link}"
         },


### PR DESCRIPTION
This change makes it possible to test maintenance mode by setting the following in config.js:

```
maintenance: {
  enabled: true
}
```

However, I have a hunch that setting maintenance mode regardless of whether there is going to be a migration can cause the first request on boot to be a Maintenance Error.

I think we need to change this to only set maintenance mode if there is work to be done.

refs #6976, #7019, #7125
- Ensure maintenance mode flag is set back to what is in config.js rather than defaulted to false on boot
- Remove stack trace from 503 errors
- Add error message to 503 error
- Ensure error page is rendered for Ghost-Admin on reload with 503
