### PR TITLE
improvement: set activeTimezone when transforming dates

### DIFF
--- a/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
+++ b/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
@@ -186,6 +186,13 @@ module.exports = function transformDatesIntoUTC(options, logger) {
                 });
             });
         },
+        function setActiveTimezone() {
+            var timezone = config.forceTimezoneOnMigration || moment.tz.guess();
+            return models.Settings.edit({
+                key: 'activeTimezone',
+                value: timezone
+            }, options);
+        },
         function addMigrationSettingsEntry() {
             settingsMigrations[settingsKey] = moment().format();
             return models.Settings.edit({

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -1018,6 +1018,7 @@ describe('Fixtures', function () {
                             serverTimezoneOffset = -60;
                             migrationsSettingsValue = '{}';
 
+                            // stub for checkIfMigrationAlreadyRan
                             sandbox.stub(models.Settings.prototype, 'fetch', function () {
                                 // CASE: we update migrations settings entry
                                 if (this.get('key') === 'migrations') {
@@ -1026,14 +1027,6 @@ describe('Fixtures', function () {
                                 }
 
                                 return Promise.resolve(newModels[Number(this.get('key'))]);
-                            });
-
-                            sandbox.stub(models.Base.Model.prototype, 'save', function (data) {
-                                if (data.key !== 'migrations') {
-                                    should.exist(data.created_at);
-                                }
-
-                                return Promise.resolve({});
                             });
 
                             _.each(['Post', 'User', 'Subscriber', 'Settings', 'Role', 'Permission', 'Tag', 'App', 'AppSetting', 'AppField', 'Client'], function (modelType) {


### PR DESCRIPTION
no issue

Set `activeTimezone` settings property, when running 006 migration.
Right now: we only have a default active timezone (for the blog) configured - which is UTC timezone. But when your ghost server runs in a non UTC timezone, then your blog would be in UTC and all your `published_at` posts dates get shifted to UTC timezone. This can be very confusing.

So we are setting the `activeTimezone` settings property to the server timezone (or to the one which is configured in `config.js`), when running the migration. 

Only tested manual.
