### PR TITLE
improvement: validate timezones

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -49,6 +49,7 @@
         "activeTimezone": {
             "defaultValue": "Etc/UTC",
             "validations": {
+                "isTimezone": true,
                 "isNull": false
             }
         },

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -1,6 +1,7 @@
 var schema    = require('../schema').tables,
     _         = require('lodash'),
     validator = require('validator'),
+    moment    = require('moment'),
     assert    = require('assert'),
     Promise   = require('bluebird'),
     errors    = require('../../errors'),
@@ -35,6 +36,10 @@ validator.extend('empty', function empty(str) {
 
 validator.extend('notContains', function notContains(str, badString) {
     return !_.includes(str, badString);
+});
+
+validator.extend('isTimezone', function isTimezone(str) {
+    return moment.tz.zone(str) ? true : false;
 });
 
 validator.extend('isEmptyOrURL', function isEmptyOrURL(str) {

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -194,4 +194,35 @@ describe('Settings API', function () {
             done();
         }).catch(done);
     });
+
+    it('set activeTimezone: unknown timezone', function (done) {
+        return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'activeTimezone', value: 'MFG'}]}, {})
+            .then(function () {
+                done(new Error('We expect that the activeTimezone cannot be stored'));
+            }).catch(function (errors) {
+                should.exist(errors);
+                errors.length.should.eql(1);
+                errors[0].errorType.should.eql('ValidationError');
+                done();
+            }).catch(done);
+    });
+
+    it('set activeTimezone: unknown timezone', function (done) {
+        return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'activeTimezone', value: 'MFG'}]}, {})
+            .then(function () {
+                done(new Error('We expect that the activeTimezone cannot be stored'));
+            }).catch(function (errors) {
+                should.exist(errors);
+                errors.length.should.eql(1);
+                errors[0].errorType.should.eql('ValidationError');
+                done();
+            }).catch(done);
+    });
+
+    it('set activeTimezone: known timezone', function (done) {
+        return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'activeTimezone', value: 'Etc/UTC'}]}, {})
+            .then(function () {
+                done();
+            }).catch(done);
+    });
 });


### PR DESCRIPTION
no issue

Validate timezones before saving to the database.
Right now: it is possible to set any value for `activeTimezone`. That results in an unwanted state of  `moment`, because it complains that the given timezone is unknown. This PR adds validation to the schema - so you can only save timezones which are available (we check against the timezones json file)
