### PR TITLE
Fix/delete by author

### DIFF
--- a/core/server/models/base/token.js
+++ b/core/server/models/base/token.js
@@ -36,7 +36,7 @@ Basetoken = ghostBookshelf.Model.extend({
             .query('where', 'expires', '<', Date.now())
             .fetch(options)
             .then(function then(collection) {
-                collection.invokeThen('destroy', options);
+                return collection.invokeThen('destroy', options);
             });
     },
     /**
@@ -53,7 +53,7 @@ Basetoken = ghostBookshelf.Model.extend({
                 .query('where', 'user_id', '=', userId)
                 .fetch(options)
                 .then(function then(collection) {
-                    collection.invokeThen('destroy', options);
+                    return collection.invokeThen('destroy', options);
                 });
         }
 


### PR DESCRIPTION
closes #7137 

Deleting the content from the database runs in a transaction. see
https://github.com/TryGhost/Ghost/blob/master/core/server/api/users.js#L390

`destroyByAuthor` is one of the operations we trigger to delete all the conent, see https://github.com/TryGhost/Ghost/blob/master/core/server/models/post.js#L647

The post model has a specific hook for deleting content to delete the relations as well, see https://github.com/TryGhost/Ghost/blob/master/core/server/models/post.js#L122

This hook is part of the transaction. But the `options` are ignored. `(model/*, attr, options*/)` 
We use the `options` to forward the transaction reference, which we need to pass into the bookshelf queries. So `return model.load('tags').call('related', 'tags').call('detach')` does not forward the transaction and that's why it stucks when deleting the content.
