### PR TITLE
fix: refresh settings cache for migration 006

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -74,7 +74,8 @@ updateConfigCache = function () {
  * @param {Object} settings
  * @returns {Settings}
  */
-updateSettingsCache = function (settings) {
+updateSettingsCache = function (settings, options) {
+    options = options || {};
     settings = settings || {};
 
     if (!_.isEmpty(settings)) {
@@ -87,7 +88,7 @@ updateSettingsCache = function (settings) {
         return Promise.resolve(settingsCache);
     }
 
-    return dataProvider.Settings.findAll()
+    return dataProvider.Settings.findAll(options)
         .then(function (result) {
             settingsCache = readSettingsResult(result.models);
 

--- a/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
+++ b/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
@@ -1,5 +1,6 @@
 var config = require('../../../../config'),
     models = require(config.paths.corePath + '/server/models'),
+    api = require(config.paths.corePath + '/server/api'),
     sequence = require(config.paths.corePath + '/server/utils/sequence'),
     moment = require('moment'),
     _ = require('lodash'),
@@ -199,6 +200,9 @@ module.exports = function transformDatesIntoUTC(options, logger) {
                 key: 'migrations',
                 value: JSON.stringify(settingsMigrations)
             }, options);
+        },
+        function updateSettingsCache() {
+            return api.settings.updateSettingsCache(null, options);
         }]
     ).catch(function (err) {
         if (err.message === 'skip') {

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -8,6 +8,7 @@ var should  = require('should'),
     // Stuff we are testing
     configUtils   = require('../utils/configUtils'),
     models        = require('../../server/models'),
+    api           = require('../../server/api'),
     notifications = require('../../server/api/notifications'),
     versioning    = require('../../server/data/schema/versioning'),
     update        = rewire('../../server/data/migration/fixtures/update'),
@@ -1035,6 +1036,7 @@ describe('Fixtures', function () {
                                     model.set('id', Date.now());
                                     model.set('created_at', createdAt);
                                     model.set('key', model.id.toString());
+                                    model.set('name', modelType);
 
                                     newModels[model.id] = model;
                                     return Promise.resolve({models: [model]});
@@ -1048,6 +1050,8 @@ describe('Fixtures', function () {
 
                                 sandbox.stub(models[modelType], 'edit').returns(Promise.resolve({}));
                             });
+
+                            sandbox.stub(api.settings, 'updateSettingsCache').returns(Promise.resolve({}));
                         });
 
                         it('sqlite: no UTC update, only format', function (done) {


### PR DESCRIPTION
no issue

If migration fixture 006/001 (transform dates) runs, it can happen that the settings cache is out of date and ember will get an outdated settings object. We are editing 2 setting entries, that's why we need to force clearing the settings cache.

We have deleted `populateSettings` in one of the previous PR's, which should have updated the cache after running migrations.
