### PR TITLE
Add `ImageObject` with image dimensions

### DIFF
--- a/core/server/data/meta/image-dimensions.js
+++ b/core/server/data/meta/image-dimensions.js
@@ -1,0 +1,58 @@
+var getCachedImageSizeFromUrl = require('../../utils/cached-image-size-from-url'),
+    Promise                   = require('bluebird'),
+    _                         = require('lodash');
+
+/**
+ * Get Image dimensions
+ * @param {object} metaData
+ * @returns {object} metaData
+ * @description for image properties in meta data (coverImage, authorImage and blog.logo), `getCachedImageSizeFromUrl` is
+ * called to receive image width and height
+ */
+function getImageDimensions(metaData) {
+    var fetch = {
+            coverImage: getCachedImageSizeFromUrl(metaData.coverImage.url),
+            authorImage: getCachedImageSizeFromUrl(metaData.authorImage.url),
+            logo: getCachedImageSizeFromUrl(metaData.blog.logo.url)
+        };
+
+    return Promise.props(fetch).then(function (resolve) {
+        var imageObj = {};
+
+        imageObj = {
+            coverImage: resolve.coverImage,
+            authorImage: resolve.authorImage,
+            logo: resolve.logo
+        };
+
+        _.forEach(imageObj, function (key, value) {
+            if (_.has(key, 'width') && _.has(key, 'height')) {
+                // We have some restrictions for publisher.logo:
+                // The image needs to be <=600px wide and <=60px high (ideally exactly 600px x 60px).
+                // Unless we have proper image-handling (see https://github.com/TryGhost/Ghost/issues/4453),
+                // we will not output an ImageObject if the logo doesn't fit in the dimensions.
+                if (value === 'logo') {
+                    if (key.height <= 60 && key.width <= 600) {
+                        _.assign(metaData.blog[value], {
+                            dimensions: {
+                                width: key.width,
+                                height: key.height
+                            }
+                        });
+                    }
+                } else {
+                    _.assign(metaData[value], {
+                        dimensions: {
+                            width: key.width,
+                            height: key.height
+                        }
+                    });
+                }
+            }
+        });
+
+        return metaData;
+    });
+}
+
+module.exports = getImageDimensions;

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -2,6 +2,7 @@ var _ = require('lodash'),
     Promise = require('bluebird'),
     config = require('../../config'),
     getUrl = require('./url'),
+    getImageDimensions = require('./image-dimensions'),
     getCanonicalUrl = require('./canonical_url'),
     getPaginatedUrl = require('./paginated_url'),
     getAuthorUrl = require('./author_url'),
@@ -30,8 +31,12 @@ function getMetaData(data, root) {
         rssUrl: getRssUrl(data, true),
         metaTitle: getTitle(data, root),
         metaDescription: getDescription(data, root),
-        coverImage: getCoverImage(data, true),
-        authorImage: getAuthorImage(data, true),
+        coverImage: {
+            url: getCoverImage(data, true)
+        },
+        authorImage: {
+            url: getAuthorImage(data, true)
+        },
         authorFacebook: getAuthorFacebook(data),
         creatorTwitter: getCreatorTwitter(data),
         keywords: getKeywords(data),
@@ -41,8 +46,9 @@ function getMetaData(data, root) {
         blog: _.cloneDeep(config.theme)
     };
 
-    metaData.blog.logo = metaData.blog.logo ?
-        config.urlFor('image', {image: metaData.blog.logo}, true) : config.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true);
+    metaData.blog.logo = {};
+    metaData.blog.logo.url = config.theme.logo ?
+        config.urlFor('image', {image: config.theme.logo}, true) : config.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true);
 
     // TODO: cleanup these if statements
     if (data.post && data.post.html) {
@@ -53,12 +59,11 @@ function getMetaData(data, root) {
         metaData.authorName = data.post.author.name;
     }
 
-    metaData.structuredData = getStructuredData(metaData);
-    metaData.schema = getSchema(metaData, data);
+    return Promise.props(getImageDimensions(metaData)).then(function () {
+        metaData.structuredData = getStructuredData(metaData);
+        metaData.schema = getSchema(metaData, data);
 
-    // instead of Promise here, soon we'll have a call to a new function which augments the images with their image sizes
-    return new Promise(function (resolve) {
-        return resolve(metaData);
+        return metaData;
     });
 }
 

--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -4,6 +4,25 @@ var config = require('../../config'),
     escapeExpression = hbs.handlebars.Utils.escapeExpression,
     _ = require('lodash');
 
+function schemaImageObject(metaDataVal) {
+    var imageObject;
+    if (!metaDataVal) {
+        return null;
+    }
+    if (!metaDataVal.dimensions) {
+        return metaDataVal.url;
+    }
+
+    imageObject = {
+        '@type': 'ImageObject',
+        url: metaDataVal.url,
+        width: metaDataVal.dimensions.width,
+        height: metaDataVal.dimensions.height
+    };
+
+    return imageObject;
+}
+
 // Creates the final schema object with values that are not null
 function trimSchema(schema) {
     var schemaObject = {};
@@ -13,6 +32,7 @@ function trimSchema(schema) {
             schemaObject[key] = value;
         }
     });
+
     return schemaObject;
 }
 
@@ -55,12 +75,12 @@ function getPostSchema(metaData, data) {
         publisher: {
             '@type': 'Organization',
             name: escapeExpression(metaData.blog.title),
-            logo: metaData.blog.logo || null
+            logo: schemaImageObject(metaData.blog.logo) || null
         },
         author: {
             '@type': 'Person',
             name: escapeExpression(data.post.author.name),
-            image: metaData.authorImage,
+            image: schemaImageObject(metaData.authorImage),
             url: metaData.authorUrl,
             sameAs: trimSameAs(data, 'post'),
             description: data.post.author.bio ?
@@ -71,10 +91,14 @@ function getPostSchema(metaData, data) {
         url: metaData.url,
         datePublished: metaData.publishedDate,
         dateModified: metaData.modifiedDate,
-        image: metaData.coverImage,
+        image: schemaImageObject(metaData.coverImage),
         keywords: metaData.keywords && metaData.keywords.length > 0 ?
             metaData.keywords.join(', ') : null,
-        description: description
+        description: description,
+        mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': metaData.blog.url || null
+        }
     };
     schema.author = trimSchema(schema.author);
     return trimSchema(schema);
@@ -84,9 +108,17 @@ function getHomeSchema(metaData) {
     var schema = {
         '@context': 'https://schema.org',
         '@type': 'Website',
-        publisher: escapeExpression(metaData.blog.title),
+        publisher: {
+            '@type': 'Organization',
+            name: escapeExpression(metaData.blog.title),
+            logo: schemaImageObject(metaData.blog.logo) || null
+        },
         url: metaData.url,
-        image: metaData.coverImage,
+        image: schemaImageObject(metaData.coverImage),
+        mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': metaData.blog.url || null
+        },
         description: metaData.metaDescription ?
         escapeExpression(metaData.metaDescription) :
         null
@@ -98,10 +130,18 @@ function getTagSchema(metaData, data) {
     var schema = {
         '@context': 'https://schema.org',
         '@type': 'Series',
-        publisher: escapeExpression(metaData.blog.title),
+        publisher: {
+            '@type': 'Organization',
+            name: escapeExpression(metaData.blog.title),
+            logo: schemaImageObject(metaData.blog.logo) || null
+        },
         url: metaData.url,
-        image: metaData.coverImage,
+        image: schemaImageObject(metaData.coverImage),
         name: data.tag.name,
+        mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': metaData.blog.url || null
+        },
         description: metaData.metaDescription ?
         escapeExpression(metaData.metaDescription) :
         null
@@ -117,7 +157,11 @@ function getAuthorSchema(metaData, data) {
         sameAs: trimSameAs(data, 'author'),
         name: escapeExpression(data.author.name),
         url: metaData.authorUrl,
-        image: metaData.coverImage,
+        image: schemaImageObject(metaData.coverImage),
+        mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': metaData.blog.url || null
+        },
         description: metaData.metaDescription ?
         escapeExpression(metaData.metaDescription) :
         null

--- a/core/server/data/meta/structured_data.js
+++ b/core/server/data/meta/structured_data.js
@@ -4,7 +4,7 @@ function getStructuredData(metaData) {
     var structuredData,
         card = 'summary';
 
-    if (metaData.coverImage) {
+    if (metaData.coverImage.url) {
         card = 'summary_large_image';
     }
 
@@ -14,7 +14,7 @@ function getStructuredData(metaData) {
         'og:title': metaData.metaTitle,
         'og:description': metaData.metaDescription || metaData.excerpt,
         'og:url': metaData.canonicalUrl,
-        'og:image': metaData.coverImage,
+        'og:image': metaData.coverImage.url,
         'article:published_time': metaData.publishedDate,
         'article:modified_time': metaData.modifiedDate,
         'article:tag': metaData.keywords,
@@ -24,7 +24,7 @@ function getStructuredData(metaData) {
         'twitter:title': metaData.metaTitle,
         'twitter:description': metaData.metaDescription || metaData.excerpt,
         'twitter:url': metaData.canonicalUrl,
-        'twitter:image': metaData.coverImage,
+        'twitter:image': metaData.coverImage.url,
         'twitter:label1': metaData.authorName ? 'Written by' : undefined,
         'twitter:data1': metaData.authorName,
         'twitter:label2': metaData.keywords ? 'Filed under' : undefined,
@@ -32,6 +32,11 @@ function getStructuredData(metaData) {
         'twitter:site': metaData.blog.twitter || undefined,
         'twitter:creator': metaData.creatorTwitter || undefined
     };
+
+    if (metaData.coverImage.dimensions) {
+        structuredData['og:image:width'] = metaData.coverImage.dimensions.width;
+        structuredData['og:image:height'] = metaData.coverImage.dimensions.height;
+    }
 
     // return structured data removing null or undefined keys
     return Object.keys(structuredData).reduce(function (data, key) {

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -1,0 +1,37 @@
+var imageSizeCache          = {},
+    size                    = require('./image-size-from-url'),
+    Promise                 = require('bluebird'),
+    getImageSizeFromUrl     = size.getImageSizeFromUrl;
+
+/**
+ * Get cached image size from URL
+ * Always returns {object} imageSizeCache
+ * @param {string} url
+ * @returns {Promise<Object>} imageSizeCache
+ * @description Takes a url and returns image width and height from cache if available.
+ * If not in cache, `getImageSizeFromUrl` is called and returns the dimensions in a Promise.
+ */
+function getCachedImageSizeFromUrl(url) {
+    if (!url || url === undefined || url === null) {
+        return;
+    }
+
+    // image size is not in cache
+    if (!imageSizeCache[url]) {
+        return getImageSizeFromUrl(url).then(function (res) {
+            imageSizeCache[url] = res;
+
+            return Promise.resolve(imageSizeCache[url]);
+        }).catch(function () {
+            // @ToDo: add real error handling here as soon as we have error logging
+            // logger.error({err:err});
+
+            // in case of error we just attach the url
+            return Promise.resolve(imageSizeCache[url] = url);
+        });
+    }
+    // returns image size from cache
+    return Promise.resolve(imageSizeCache[url]);
+}
+
+module.exports = getCachedImageSizeFromUrl;

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -27,7 +27,7 @@ var sizeOf       = require('image-size'),
 /**
  * @description read image dimensions from URL
  * @param {String} imagePath
- * @param {Number} timeout
+ * @param {Number} timeout (optional)
  * @returns {Promise<Object>} imageObject or error
  */
 module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, timeout) {
@@ -84,12 +84,16 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, tim
                 }
             });
         }).on('socket', function (socket) {
-            socket.setTimeout(timeout);
-            socket.on('timeout', function () {
-                request.abort();
-            });
+            // don't set timeout if no timeout give as argument
+            if (timeout) {
+                socket.setTimeout(timeout);
+                socket.on('timeout', function () {
+                    request.abort();
+                });
+            }
         }).on('error', function (err) {
             // @ToDo: add real error handling here as soon as we have error logging
+
             return reject(err);
         });
     });

--- a/core/test/unit/metadata/image-dimensions_spec.js
+++ b/core/test/unit/metadata/image-dimensions_spec.js
@@ -1,0 +1,133 @@
+var should         = require('should'),
+    sinon          = require('sinon'),
+    rewire         = require('rewire'),
+
+// Stuff we are testing
+    getImageDimensions          = rewire('../../../server/data/meta/image-dimensions'),
+    getCachedImageSizeFromUrl   = rewire('../../../server/utils/cached-image-size-from-url'),
+
+    sandbox = sinon.sandbox.create();
+
+describe('getImageDimensions', function () {
+    var sizeOfStub;
+
+    beforeEach(function () {
+        sizeOfStub = sandbox.stub();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        getCachedImageSizeFromUrl.__set__('imageSizeCache', {});
+    });
+
+    it('should return dimension for images', function (done) {
+        var metaData = {
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg'
+            },
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg'
+            },
+            blog: {
+                logo: {
+                    url: 'http://mysite.com/author/image/url/logo.jpg'
+                }
+            }
+        };
+
+        sizeOfStub.returns({
+            width: 50,
+            height: 50,
+            type: 'jpg'
+        });
+
+        getImageDimensions.__set__('getCachedImageSizeFromUrl', sizeOfStub);
+
+        getImageDimensions(metaData).then(function (result) {
+            should.exist(result);
+            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.blog.logo.url).should.be.true();
+            result.coverImage.should.have.property('dimensions');
+            result.coverImage.should.have.property('url');
+            result.blog.logo.should.have.property('dimensions');
+            result.blog.logo.should.have.property('url');
+            result.authorImage.should.have.property('dimensions');
+            result.authorImage.should.have.property('url');
+            done();
+        }).catch(done);
+    });
+
+    it('should return metaData if url is undefined or null', function (done) {
+        var metaData = {
+            coverImage: {
+                url: undefined
+            },
+            authorImage: {
+                url: null
+            },
+            blog: {
+                logo: {
+                    url: 'noUrl'
+                }
+            }
+        };
+
+        sizeOfStub.returns({});
+
+        getImageDimensions.__set__('getCachedImageSizeFromUrl', sizeOfStub);
+
+        getImageDimensions(metaData).then(function (result) {
+            console.log('result:', result);
+            should.exist(result);
+            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.blog.logo.url).should.be.true();
+            result.coverImage.should.not.have.property('dimensions');
+            result.blog.logo.should.not.have.property('dimensions');
+            result.authorImage.should.not.have.property('dimensions');
+            result.coverImage.should.have.property('url');
+            result.blog.logo.should.have.property('url');
+            result.authorImage.should.have.property('url');
+            done();
+        }).catch(done);
+    });
+
+    it('should not return dimension for publisher.logo only if logo is too big', function (done) {
+        var metaData = {
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg'
+            },
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg'
+            },
+            blog: {
+                logo: {
+                    url: 'http://mysite.com/author/image/url/logo.jpg'
+                }
+            }
+        };
+
+        sizeOfStub.returns({
+            width: 480,
+            height: 80,
+            type: 'jpg'
+        });
+
+        getImageDimensions.__set__('getCachedImageSizeFromUrl', sizeOfStub);
+
+        getImageDimensions(metaData).then(function (result) {
+            should.exist(result);
+            sizeOfStub.calledWith(metaData.coverImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.authorImage.url).should.be.true();
+            sizeOfStub.calledWith(metaData.blog.logo.url).should.be.true();
+            result.coverImage.should.have.property('dimensions');
+            result.blog.logo.should.not.have.property('dimensions');
+            result.authorImage.should.have.property('dimensions');
+            result.coverImage.should.have.property('url');
+            result.blog.logo.should.have.property('url');
+            result.authorImage.should.have.property('url');
+            done();
+        }).catch(done);
+    });
+});

--- a/core/test/unit/metadata/schema_spec.js
+++ b/core/test/unit/metadata/schema_spec.js
@@ -2,13 +2,26 @@ var getSchema = require('../../../server/data/meta/schema'),
     should = require('should');
 
 describe('getSchema', function () {
-    it('should return post schema if context starts with post', function () {
+    it('should return post schema if context starts with post', function (done) {
         var metadata = {
             blog: {
                 title: 'Blog Title',
-                logo: 'http://mysite.com/author/image/url/logo.jpg'
+                url: 'http://mysite.com',
+                logo: {
+                    url: 'http://mysite.com/author/image/url/logo.jpg',
+                    dimensions: {
+                        width: 500,
+                        height: 500
+                    }
+                }
             },
-            authorImage: 'http://mysite.com/author/image/url/me.jpg',
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             authorFacebook: 'testuser',
             creatorTwitter: '@testuser',
             authorUrl: 'http://mysite.com/author/me/',
@@ -16,7 +29,13 @@ describe('getSchema', function () {
             url: 'http://mysite.com/post/my-post-slug/',
             publishedDate: '2015-12-25T05:35:01.234Z',
             modifiedDate: '2016-01-21T22:13:05.412Z',
-            coverImage: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             keywords: ['one', 'two', 'tag'],
             metaDescription: 'Post meta description'
         },  data = {
@@ -38,7 +57,12 @@ describe('getSchema', function () {
             author: {
                 '@type': 'Person',
                 description: 'My author bio.',
-                image: 'http://mysite.com/author/image/url/me.jpg',
+                image: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/me.jpg',
+                    width: 500,
+                    height: 500
+                },
                 name: 'Post Author',
                 sameAs: [
                     'http://myblogsite.com/',
@@ -51,18 +75,33 @@ describe('getSchema', function () {
             datePublished: '2015-12-25T05:35:01.234Z',
             description: 'Post meta description',
             headline: 'Post Title',
-            image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            image: {
+                '@type': 'ImageObject',
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                width: 500,
+                height: 500
+            },
             keywords: 'one, two, tag',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': 'http://mysite.com'
+            },
             publisher: {
                 '@type': 'Organization',
                 name: 'Blog Title',
-                logo: 'http://mysite.com/author/image/url/logo.jpg'
+                logo: {
+                    '@type': 'ImageObject',
+                    url: 'http://mysite.com/author/image/url/logo.jpg',
+                    width: 500,
+                    height: 500
+                }
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
+        done();
     });
 
-    it('should return post schema removing null or undefined values', function () {
+    it('should return post schema removing null or undefined values', function (done) {
         var metadata = {
             blog: {
                 title: 'Blog Title'
@@ -104,6 +143,10 @@ describe('getSchema', function () {
             datePublished: '2015-12-25T05:35:01.234Z',
             description: 'Post meta description',
             headline: 'Post Title',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': null
+            },
             publisher: {
                 '@type': 'Organization',
                 name: 'Blog Title',
@@ -111,6 +154,79 @@ describe('getSchema', function () {
             },
             url: 'http://mysite.com/post/my-post-slug/'
         });
+        done();
+    });
+
+    it('should return image url instead of ImageObjects if no dimensions supplied', function (done) {
+        var metadata = {
+            blog: {
+                title: 'Blog Title',
+                url: 'http://mysite.com',
+                logo: {
+                    url: 'http://mysite.com/author/image/url/logo.jpg'
+                }
+            },
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg'
+            },
+            authorFacebook: 'testuser',
+            creatorTwitter: '@testuser',
+            authorUrl: 'http://mysite.com/author/me/',
+            metaTitle: 'Post Title',
+            url: 'http://mysite.com/post/my-post-slug/',
+            publishedDate: '2015-12-25T05:35:01.234Z',
+            modifiedDate: '2016-01-21T22:13:05.412Z',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg'
+            },
+            keywords: ['one', 'two', 'tag'],
+            metaDescription: 'Post meta description'
+        },  data = {
+            context: ['post'],
+            post: {
+                author: {
+                    name: 'Post Author',
+                    website: 'http://myblogsite.com/',
+                    bio: 'My author bio.',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            }
+        }, schema = getSchema(metadata, data);
+
+        should.deepEqual(schema, {
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            author: {
+                '@type': 'Person',
+                description: 'My author bio.',
+                image: 'http://mysite.com/author/image/url/me.jpg',
+                name: 'Post Author',
+                sameAs: [
+                    'http://myblogsite.com/',
+                    'https://www.facebook.com/testuser',
+                    'https://twitter.com/testuser'
+                ],
+                url: 'http://mysite.com/author/me/'
+            },
+            dateModified: '2016-01-21T22:13:05.412Z',
+            datePublished: '2015-12-25T05:35:01.234Z',
+            description: 'Post meta description',
+            headline: 'Post Title',
+            image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            keywords: 'one, two, tag',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': 'http://mysite.com'
+            },
+            publisher: {
+                '@type': 'Organization',
+                name: 'Blog Title',
+                logo: 'http://mysite.com/author/image/url/logo.jpg'
+            },
+            url: 'http://mysite.com/post/my-post-slug/'
+        });
+        done();
     });
 
     it('should return home schema if context starts with home', function () {
@@ -119,7 +235,13 @@ describe('getSchema', function () {
                 title: 'Blog Title'
             },
             url: 'http://mysite.com/post/my-post-slug/',
-            coverImage: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             metaDescription: 'This is the theme description'
         },  data = {
             context: ['home']
@@ -129,8 +251,21 @@ describe('getSchema', function () {
             '@context': 'https://schema.org',
             '@type': 'Website',
             description: 'This is the theme description',
-            image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
-            publisher: 'Blog Title',
+            image: {
+                '@type': 'ImageObject',
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                width: 500,
+                height: 500
+            },
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': null
+            },
+            publisher: {
+                '@type': 'Organization',
+                name: 'Blog Title',
+                logo: null
+            },
             url: 'http://mysite.com/post/my-post-slug/'
         });
     });
@@ -141,7 +276,13 @@ describe('getSchema', function () {
                 title: 'Blog Title'
             },
             url: 'http://mysite.com/post/my-post-slug/',
-            coverImage: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             metaDescription: 'This is the tag description!'
         },  data = {
             context: ['tag'],
@@ -154,9 +295,22 @@ describe('getSchema', function () {
             '@context': 'https://schema.org',
             '@type': 'Series',
             description: 'This is the tag description!',
-            image: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            image: {
+                '@type': 'ImageObject',
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                width: 500,
+                height: 500
+            },
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': null
+            },
             name: 'Great Tag',
-            publisher: 'Blog Title',
+            publisher: {
+                '@type': 'Organization',
+                name: 'Blog Title',
+                logo: null
+            },
             url: 'http://mysite.com/post/my-post-slug/'
         });
     });
@@ -164,9 +318,16 @@ describe('getSchema', function () {
     it('should return author schema if context starts with author', function () {
         var metadata = {
             blog: {
-                title: 'Blog Title'
+                title: 'Blog Title',
+                url: 'http://mysite.com'
             },
-            authorImage: 'http://mysite.com/author/image/url/me.jpg',
+            authorImage: {
+                url: 'http://mysite.com/author/image/url/me.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             authorUrl: 'http://mysite.com/author/me/',
             metaDescription: 'This is the author description!'
         },  data = {
@@ -182,6 +343,10 @@ describe('getSchema', function () {
             '@context': 'https://schema.org',
             '@type': 'Person',
             description: 'This is the author description!',
+            mainEntityOfPage: {
+                '@type': 'WebPage',
+                '@id': 'http://mysite.com'
+            },
             name: 'Author Name',
             sameAs: [
                 'http://myblogsite.com/',

--- a/core/test/unit/metadata/structured_data_spec.js
+++ b/core/test/unit/metadata/structured_data_spec.js
@@ -2,7 +2,7 @@ var getStructuredData = require('../../../server/data/meta/structured_data'),
     should = require('should');
 
 describe('getStructuredData', function () {
-    it('should return structured data from metadata', function () {
+    it('should return structured data from metadata', function (done) {
         var metadata = {
             blog: {
                 title: 'Blog Title',
@@ -15,7 +15,13 @@ describe('getStructuredData', function () {
             canonicalUrl: 'http://mysite.com/post/my-post-slug/',
             publishedDate: '2015-12-25T05:35:01.234Z',
             modifiedDate: '2016-01-21T22:13:05.412Z',
-            coverImage: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            coverImage: {
+                url: 'http://mysite.com/content/image/mypostcoverimage.jpg',
+                dimensions: {
+                    width: 500,
+                    height: 500
+                }
+            },
             authorFacebook: 'testpage',
             creatorTwitter: '@twitterpage',
             keywords: ['one', 'two', 'tag'],
@@ -30,6 +36,8 @@ describe('getStructuredData', function () {
             'article:author': 'https://www.facebook.com/testpage',
             'og:description': 'Post meta description',
             'og:image': 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            'og:image:width': 500,
+            'og:image:height': 500,
             'og:site_name': 'Blog Title',
             'og:title': 'Post Title',
             'og:type': 'article',
@@ -46,9 +54,10 @@ describe('getStructuredData', function () {
             'twitter:site': '@testuser',
             'twitter:creator': '@twitterpage'
         });
+        done();
     });
 
-    it('should return structured data from metadata with no nulls', function () {
+    it('should return structured data from metadata with no nulls', function (done) {
         var metadata = {
             blog: {
                 title: 'Blog Title',
@@ -62,7 +71,9 @@ describe('getStructuredData', function () {
             modifiedDate: '2016-01-21T22:13:05.412Z',
             authorFacebook: null,
             creatorTwitter: null,
-            coverImage: undefined,
+            coverImage: {
+                url: undefined
+            },
             keywords: null,
             metaDescription: null
         },  structuredData = getStructuredData(metadata);
@@ -79,5 +90,6 @@ describe('getStructuredData', function () {
             'twitter:title': 'Post Title',
             'twitter:url': 'http://mysite.com/post/my-post-slug/'
         });
+        done();
     });
 });

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -100,7 +100,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Website"/);
-                rendered.string.should.match(/"publisher": "Ghost"/);
+                rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/"/);
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/blog-cover.png"/);
                 rendered.string.should.match(/"description": "blog description"/);
@@ -197,7 +197,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
-                rendered.string.should.match(/"publisher": "Ghost"/);
+                rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/tag\/tagtitle\/"/);
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
@@ -238,7 +238,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
-                rendered.string.should.match(/"publisher": "Ghost"/);
+                rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
                 rendered.string.should.match(/"url": "http:\/\/testurl.com\/tag\/tagtitle\/"/);
                 rendered.string.should.match(/"image": "http:\/\/testurl.com\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);

--- a/core/test/unit/utils/cached-image-size-from-url_spec.js
+++ b/core/test/unit/utils/cached-image-size-from-url_spec.js
@@ -1,0 +1,86 @@
+var should         = require('should'),
+    sinon          = require('sinon'),
+    Promise        = require('bluebird'),
+    rewire         = require('rewire'),
+
+// Stuff we are testing
+    getCachedImageSizeFromUrl = rewire('../../../server/utils/cached-image-size-from-url'),
+
+    sandbox = sinon.sandbox.create();
+
+describe('getCachedImageSizeFromUrl', function () {
+    var sizeOfStub,
+        cachedImagedSize;
+
+    beforeEach(function () {
+        sizeOfStub = sandbox.stub();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        getCachedImageSizeFromUrl.__set__('imageSizeCache', {});
+    });
+
+    it('should read from cache, if dimensions for image are fetched already', function (done) {
+        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
+
+        sizeOfStub.returns(new Promise.resolve({
+            width: 50,
+            height: 50,
+            type: 'jpg'
+        }));
+
+        getCachedImageSizeFromUrl.__set__('getImageSizeFromUrl', sizeOfStub);
+
+        getCachedImageSizeFromUrl(url).then(function () {
+            // first call to get result from `getImageSizeFromUrl`
+            cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
+            should.exist(cachedImagedSize);
+            cachedImagedSize.should.have.property(url);
+            should.exist(cachedImagedSize[url].width);
+            cachedImagedSize[url].width.should.be.equal(50);
+            should.exist(cachedImagedSize[url].height);
+            cachedImagedSize[url].height.should.be.equal(50);
+            // second call to check if values get returned from cache
+            getCachedImageSizeFromUrl(url).then(function () {
+                cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
+                should.exist(cachedImagedSize);
+                cachedImagedSize.should.have.property(url);
+                should.exist(cachedImagedSize[url].width);
+                cachedImagedSize[url].width.should.be.equal(50);
+                should.exist(cachedImagedSize[url].height);
+                cachedImagedSize[url].height.should.be.equal(50);
+
+                done();
+            });
+        }).catch(done);
+    });
+
+    it('can handle image-size errors', function (done) {
+        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
+
+        sizeOfStub.returns(new Promise.reject('error'));
+
+        getCachedImageSizeFromUrl.__set__('getImageSizeFromUrl', sizeOfStub);
+
+        getCachedImageSizeFromUrl(url)
+        .then(function () {
+            cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
+            should.exist(cachedImagedSize);
+            cachedImagedSize.should.have.property(url);
+            should.not.exist(cachedImagedSize[url].width);
+            should.not.exist(cachedImagedSize[url].height);
+            done();
+        }).catch(done);
+    });
+
+    it('should return null if url is undefined', function (done) {
+        var url = null,
+            result;
+
+        result = getCachedImageSizeFromUrl(url);
+
+        should.not.exist(result);
+        done();
+    });
+});


### PR DESCRIPTION
closes #7095

follow-up of #7123

In preparation of AMP support and to improve our schema.org JSON-LD and structured data, I made the following changes:
- Changes the following properties to be `Objects`, which have a `url` property by default and a `dimensions` property, if `width` and `height` are available:
  - `metaData.coverImage`
  - `metaData.authorImage`
  - `metaData.blog.logo`
- Checks cache by calling `getCachedImageSizeFromUrl`. If image dimensions were fetched already, returns them from cache instead of fetching them again.
- Uses `getImageSizeFromUrl` #7151 to fetch `width` and `height` properties for images if image dimensions were not available in cache.
- If we have image dimensions on hand, the output in our JSON-LD changes from normal urls to be full `ImageObjects`. Applies to all images and logos.
- Special case for `publisher.logo` as it has size restrictions: if the image doesn't fulfil the restrictions (<=600 width and <=60 height), we simply output the url instead, so like before.
- Adds new property for schema.org JSON-LD: `mainEntityOfPage` as an Object.
- Adds additional Open Graph data (if we have the image size): `og:image:width` and `og:image:height`
- Adds/updates tests
