### PR TITLE
Ensure static page edit route redirects to editor

### DIFF
--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -66,11 +66,6 @@ frontendControllers = {
                 return next();
             }
 
-            // CASE: we only support /:slug format for pages
-            if (post.page && post.url !== req.path) {
-                return next();
-            }
-
             // CASE: last param is of url is /edit, redirect to admin
             if (lookup.isEditURL) {
                 return res.redirect(config.paths.subdir + '/ghost/editor/' + post.id + '/');

--- a/core/server/controllers/frontend/post-lookup.js
+++ b/core/server/controllers/frontend/post-lookup.js
@@ -19,26 +19,22 @@ function postLookup(postUrl) {
         matchFuncPost,
         matchFuncPage,
         postParams,
-        pageParams,
         params;
 
     // Convert saved permalink into a path-match function
     matchFuncPost = routeMatch(getEditFormat(postPermalink));
+    matchFuncPage = routeMatch(getEditFormat(pagePermalink));
+
     postParams = matchFuncPost(postPath);
 
     // Check if the path matches the permalink structure.
     // If there are no matches found, test to see if this is a page instead
-    if (postParams === false) {
-        matchFuncPage = routeMatch(getEditFormat(pagePermalink));
-        pageParams = matchFuncPage(postPath);
-    }
+    params = postParams || matchFuncPage(postPath);
 
-    // If there are still no matches then return empty.
-    if (pageParams === false) {
+    // if there are no matches for either then return empty
+    if (params === false) {
         return Promise.resolve();
     }
-
-    params = postParams || pageParams;
 
     // If params contains edit, and it is equal to 'edit' this is an edit URL
     if (params.edit && params.edit.toLowerCase() === 'edit') {
@@ -63,6 +59,11 @@ function postLookup(postUrl) {
 
         // CASE: we originally couldn't match the post based on date permalink and we tried to check if its a page
         if (!post.page && !postParams) {
+            return Promise.resolve();
+        }
+
+        // CASE: we only support /:slug format for pages
+        if (post.page && matchFuncPage(postPath) === false) {
             return Promise.resolve();
         }
 

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -240,6 +240,32 @@ describe('Frontend Routing', function () {
                 .expect(200)
                 .end(doEnd(done));
         });
+
+        describe('edit', function () {
+            it('should redirect without slash', function (done) {
+                request.get('/static-page-test/edit')
+                    .expect('Location', '/static-page-test/edit/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEnd(done));
+            });
+
+            it('should redirect to editor', function (done) {
+                request.get('/static-page-test/edit/')
+                    .expect('Location', /^\/ghost\/editor\/[0-9]\/$/)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect(302)
+                    .end(doEnd(done));
+            });
+
+            it('should 404 for non-edit parameter', function (done) {
+                request.get('/static-page-test/notedit/')
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+        });
     });
 
     describe('Post preview', function () {


### PR DESCRIPTION
closes #7168
- check for edit route before checking for slug
- add tests
