### PR TITLE
fix: added missing client translation

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -25,6 +25,9 @@
                 "mail": {
                     "invitedByName": "{invitedByName} has invited you to join {blogName}"
                 }
+            },
+            "clients": {
+                "clientNotFound": "Client not found"
             }
         }
     },


### PR DESCRIPTION
no issue

`common.api.clients.clientNotFound` is not defined. (it is used in `api/clients` line 56)
