### PR TITLE
Improved code of date helper

### DIFF
--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -3,37 +3,28 @@
 //
 // Formats a date using moment-timezone.js. Formats published_at by default but will also take a date as a parameter
 
-var moment          = require('moment-timezone'),
-    date,
-    timezone;
+var moment = require('moment-timezone'),
+    date;
 
 date = function (date, options) {
     if (!options && date.hasOwnProperty('hash')) {
         options = date;
-        date = undefined;
-        timezone = options.data.blog.timezone;
-
-        // set to published_at by default, if it's available
-        // otherwise, this will print the current date
-        if (this.published_at) {
-            date = moment(this.published_at).tz(timezone).format();
-        }
-    }
-
-    // ensure that context is undefined, not null, as that can cause errors
-    date = date === null ? undefined : date;
-
-    var f = options.hash.format || 'MMM DD, YYYY',
-        timeago = options.hash.timeago,
-        timeNow = moment().tz(timezone);
-
-    if (timeago) {
-        date = timezone ?  moment(date).tz(timezone).from(timeNow) : moment(date).fromNow();
+        date = moment(this.published_at || new Date());
     } else {
-        date = timezone ? moment(date).tz(timezone).format(f) : moment(date).format(f);
+        date = moment(date);
     }
 
-    return date;
+    var timezone = options.data.blog.timezone;
+
+    if (timezone) {
+        date = date.tz(timezone);
+    }
+
+    if (options.hash.timeago) {
+        return timezone ? date.from(moment.tz(timezone)) : date.fromNow();
+    }
+
+    return date.format(options.hash.format || 'MMM DD, YYYY');
 };
 
 module.exports = date;


### PR DESCRIPTION
Trying to fix https://github.com/TryGhost/Ghost/issues/7182, I have made some changes in the date helper. If it was calling this._published, two instances of Moment.js were being created to generate a result.
