### PR TITLE
Frontend router: swap order of apps & catch-all route

### DIFF
--- a/core/server/routes/frontend.js
+++ b/core/server/routes/frontend.js
@@ -31,9 +31,6 @@ frontendRoutes = function frontendRoutes() {
     // Channels
     router.use(channels.router());
 
-    // Default
-    router.get('*', frontend.single);
-
     // setup routes for internal apps
     // @TODO: refactor this to be a proper app route hook for internal & external apps
     config.internalApps.forEach(function (appName) {
@@ -42,6 +39,9 @@ frontendRoutes = function frontendRoutes() {
             app.setupRoutes(router);
         }
     });
+
+    // Default
+    router.get('*', frontend.single);
 
     return router;
 };


### PR DESCRIPTION
This small change swaps over the order in which the app routes, and catch-all `*` routes are processed. 

This will have an impact on the behaviour of all of our internal apps. Both the private blogging and subscribers apps have a route where they render their own template. Private blogging has `/private/` which renders `private.hbs` and subscribers has a similar `/subscribe/` route (and in future `/unsubscribe/`).

Because these routes weren't listed in our reserved words list, it is possible for a blog to already have a post or a page that lives at `/private/` or, perhaps more likely `/subscribe/`. Prior to this change, their already setup page would be rendered instead of the app's page. After this change, the app's own route will be correctly rendered.

This is effectively a bug fix, because if you enable these features then you would expect them to work.

Moving forward, this change is absolutely required for the AMP app, because the route for that app is `*/amp/`. If the app routes aren't processed first, then this will not work.

---

no issue
- Changes the order of the frontend routes, so `*` default routes are called last
