### PR TITLE
Upgrade knex version

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -96,7 +96,8 @@ config = {
                     'PRAGMA locking_mode=EXCLUSIVE;' +
                     'BEGIN EXCLUSIVE; COMMIT;', done);
                 }
-            }
+            },
+            useNullAsDefault: true
         },
         server: {
             host: '127.0.0.1',

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "intl": "1.2.4",
     "intl-messageformat": "1.3.0",
     "jsonpath": "0.2.6",
-    "knex": "0.10.0",
+    "knex": "0.11.10",
     "lodash": "4.14.2",
     "moment": "2.14.1",
     "moment-timezone": "0.5.5",


### PR DESCRIPTION
- add `useNullAsDefault` flag to sqlite test config to fix breaking
  sqlite builds
- fixes npm install issue with lodash dependency

The `useNullAsDefault` flag needs to exist because of our current test setup. Initially we were going to wait to upgrade knex until we could re-think the test setup, but because the 0.10 version of knex causes issues with a lodash dependency, it became necessary to upgrade knex, and to re-look at the test setup at somepoint in the future.
