### PR TITLE
Removes internal tags from sitemap

### DIFF
--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -26,6 +26,7 @@ _.extend(TagsMapGenerator.prototype, {
             context: {
                 internal: true
             },
+            filter: 'visibility:public',
             limit: 'all'
         }).then(function (resp) {
             return resp.tags;


### PR DESCRIPTION
Internal tags will no longer show up at [http://localhost:2368/sitemap-tags.xml].(http://localhost:2368/sitemap-tags.xml)

closes #7186
