### PR TITLE
🎨  Use `context` in meta as array [AMP preparation]

### DIFF
--- a/core/server/data/meta/author_fb_url.js
+++ b/core/server/data/meta/author_fb_url.js
@@ -1,12 +1,13 @@
-var getContextObject = require('./context_object.js');
+var getContextObject = require('./context_object.js'),
+    _                = require('lodash');
 
 function getAuthorFacebookUrl(data) {
-    var context = data.context ? data.context[0] : null,
+    var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if ((context === 'post' || context === 'page') && contextObject.author && contextObject.author.facebook) {
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.facebook) {
         return contextObject.author.facebook;
-    } else if (context === 'author' && contextObject.facebook) {
+    } else if (_.includes(context, 'author') && contextObject.facebook) {
         return contextObject.facebook;
     }
     return null;

--- a/core/server/data/meta/author_image.js
+++ b/core/server/data/meta/author_image.js
@@ -1,11 +1,12 @@
 var config           = require('../../config'),
-    getContextObject = require('./context_object.js');
+    getContextObject = require('./context_object.js'),
+    _                = require('lodash');
 
 function getAuthorImage(data, absolute) {
-    var context = data.context ? data.context[0] : null,
+    var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if ((context === 'post' || context === 'page') && contextObject.author && contextObject.author.image) {
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.image) {
         return config.urlFor('image', {image: contextObject.author.image}, absolute);
     }
     return null;

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -2,6 +2,7 @@ var config = require('../../config');
 
 function getAuthorUrl(data, absolute) {
     var context = data.context ? data.context[0] : null;
+
     if (data.author) {
         return config.urlFor('author', {author: data.author}, absolute);
     }

--- a/core/server/data/meta/context_object.js
+++ b/core/server/data/meta/context_object.js
@@ -1,12 +1,12 @@
-var config = require('../../config');
+var config = require('../../config'),
+    _      = require('lodash');
 
 function getContextObject(data, context) {
     var blog = config.theme,
         contextObject;
 
-    context = context === 'page' ? 'post' : context;
+    context = _.includes(context, 'page') ? 'post' : context;
     contextObject = data[context] || blog;
-
     return contextObject;
 }
 

--- a/core/server/data/meta/cover_image.js
+++ b/core/server/data/meta/cover_image.js
@@ -1,11 +1,12 @@
 var config           = require('../../config'),
-    getContextObject = require('./context_object.js');
+    getContextObject = require('./context_object.js'),
+    _                = require('lodash');
 
 function getCoverImage(data) {
-    var context = data.context ? data.context[0] : null,
+    var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if (context === 'home' || context === 'author') {
+    if (_.includes(context, 'home') || _.includes(context, 'author')) {
         if (contextObject.cover) {
             return config.urlFor('image', {image: contextObject.cover}, true);
         }

--- a/core/server/data/meta/creator_url.js
+++ b/core/server/data/meta/creator_url.js
@@ -1,11 +1,13 @@
-var getContextObject = require('./context_object.js');
+var getContextObject = require('./context_object.js'),
+    _                = require('lodash');
 
 function getCreatorTwitterUrl(data) {
-    var context = data.context ? data.context[0] : null,
+    var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
-    if ((context === 'post' || context === 'page') && contextObject.author && contextObject.author.twitter) {
+
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.twitter) {
         return contextObject.author.twitter;
-    } else if (context === 'author' && contextObject.twitter) {
+    } else if (_.includes(context, 'author') && contextObject.twitter) {
         return contextObject.twitter;
     }
     return null;


### PR DESCRIPTION
refs #6588

Instead of reading the first value of the context array, we're checking if it includes certain context values.
This is a preparation change for AMP, where the context will be delivered as `['amp', 'post']`.
