### PR TITLE
fix: choose user role when login from test env

### DIFF
--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -1,13 +1,14 @@
-var testUtils     = require('../../../utils'),
-    should        = require('should'),
-    supertest     = require('supertest'),
+var testUtils = require('../../../utils'),
+    should = require('should'),
+    supertest = require('supertest'),
 
-    ghost         = require('../../../../../core'),
+    ghost = require('../../../../../core'),
 
     request;
 
 describe('User API', function () {
-    var accesstoken = '';
+    var ownerAccessToken = '',
+        editorAccessToken = '';
 
     before(function (done) {
         // starting ghost automatically populates the db
@@ -17,7 +18,13 @@ describe('User API', function () {
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
-            accesstoken = token;
+            ownerAccessToken = token;
+
+            // 2 === editor
+            request.userIndex = 2;
+            return testUtils.doAuth(request);
+        }).then(function (token) {
+            editorAccessToken = token;
             done();
         }).catch(done);
     });
@@ -28,351 +35,374 @@ describe('User API', function () {
         }).catch(done);
     });
 
-    describe('Browse', function () {
-        it('returns dates in ISO 8601 format', function (done) {
-            request.get(testUtils.API.getApiQuery('users/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+    describe('As Owner', function () {
+        describe('Browse', function () {
+            it('returns dates in ISO 8601 format', function (done) {
+                request.get(testUtils.API.getApiQuery('users/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
 
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    testUtils.API.checkResponse(jsonResponse, 'users');
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        testUtils.API.checkResponse(jsonResponse, 'users');
 
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
-                    testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true();
-                    testUtils.API.isISO8601(jsonResponse.users[0].created_at).should.be.true();
-                    testUtils.API.isISO8601(jsonResponse.users[0].updated_at).should.be.true();
+                        testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true();
+                        testUtils.API.isISO8601(jsonResponse.users[0].created_at).should.be.true();
+                        testUtils.API.isISO8601(jsonResponse.users[0].updated_at).should.be.true();
 
-                    done();
-                });
+                        done();
+                    });
+            });
+
+            it('can retrieve all users', function (done) {
+                request.get(testUtils.API.getApiQuery('users/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        testUtils.API.checkResponse(jsonResponse, 'users');
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
+            it('can retrieve all users with roles', function (done) {
+                request.get(testUtils.API.getApiQuery('users/?include=roles'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        testUtils.API.checkResponse(jsonResponse, 'users');
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', 'roles');
+                        done();
+                    });
+            });
         });
 
-        it('can retrieve all users', function (done) {
-            request.get(testUtils.API.getApiQuery('users/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+        describe('Read', function () {
+            it('can retrieve a user by "me"', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    testUtils.API.checkResponse(jsonResponse, 'users');
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
 
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                    done();
-                });
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
+            it('can retrieve a user by id', function (done) {
+                request.get(testUtils.API.getApiQuery('users/1/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
+            it('can retrieve a user by slug', function (done) {
+                request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
+            it('can retrieve a user by email', function (done) {
+                request.get(testUtils.API.getApiQuery('users/email/jbloggs%40example.com/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
+            it('can retrieve a user with role', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/?include=roles'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                        testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role');
+                        done();
+                    });
+            });
+
+            it('can retrieve a user with role and permissions', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/?include=roles,roles.permissions'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                        testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role', ['permissions']);
+                        // testUtils.API.checkResponse(jsonResponse.users[0].roles[0].permissions[0], 'permission');
+
+                        done();
+                    });
+            });
+
+            it('can retrieve a user by slug with role and permissions', function (done) {
+                request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/?include=roles,roles.permissions'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
+                        testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role', ['permissions']);
+                        // testUtils.API.checkResponse(jsonResponse.users[0].roles[0].permissions[0], 'permission');
+
+                        done();
+                    });
+            });
+
+            it('can\'t retrieve non existent user by id', function (done) {
+                request.get(testUtils.API.getApiQuery('users/99/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
+                        done();
+                    });
+            });
+
+            it('can\'t retrieve non existent user by slug', function (done) {
+                request.get(testUtils.API.getApiQuery('users/slug/blargh/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.errors);
+                        testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
+                        done();
+                    });
+            });
         });
 
-        it('can retrieve all users with roles', function (done) {
-            request.get(testUtils.API.getApiQuery('users/?include=roles'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
+        describe('Edit', function () {
+            it('can edit a user', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
 
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    testUtils.API.checkResponse(jsonResponse, 'users');
+                        var jsonResponse = res.body,
+                            changedValue = 'http://joe-bloggs.ghost.org',
+                            dataToSend;
+                        should.exist(jsonResponse.users[0]);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
 
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', 'roles');
-                    done();
-                });
+                        dataToSend = {
+                            users: [
+                                {website: changedValue}
+                            ]
+                        };
+
+                        request.put(testUtils.API.getApiQuery('users/me/'))
+                            .set('Authorization', 'Bearer ' + ownerAccessToken)
+                            .send(dataToSend)
+                            .expect('Content-Type', /json/)
+                            .expect('Cache-Control', testUtils.cacheRules.private)
+                            .expect(200)
+                            .end(function (err, res) {
+                                if (err) {
+                                    return done(err);
+                                }
+
+                                var putBody = res.body;
+                                res.headers['x-cache-invalidate'].should.eql('/*');
+                                should.exist(putBody.users[0]);
+                                putBody.users[0].website.should.eql(changedValue);
+                                putBody.users[0].email.should.eql(jsonResponse.users[0].email);
+                                testUtils.API.checkResponse(putBody.users[0], 'user');
+                                done();
+                            });
+                    });
+            });
+
+            it('can\'t edit a user with invalid accesstoken', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        var jsonResponse = res.body,
+                            changedValue = 'joe-bloggs.ghost.org';
+
+                        should.exist(jsonResponse.users[0]);
+                        jsonResponse.users[0].website = changedValue;
+
+                        request.put(testUtils.API.getApiQuery('users/me/'))
+                            .set('Authorization', 'Bearer ' + 'invalidtoken')
+                            .send(jsonResponse)
+                            .expect(401)
+                            .end(function (err, res) {
+                                /*jshint unused:false*/
+                                if (err) {
+                                    return done(err);
+                                }
+
+                                done();
+                            });
+                    });
+            });
         });
     });
 
-    describe('Read', function () {
-        it('can retrieve a user by "me"', function (done) {
+    describe('As Editor', function () {
+        it('can\'t edit a user', function (done) {
             request.get(testUtils.API.getApiQuery('users/me/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
+                .set('Authorization', 'Bearer ' + editorAccessToken)
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
+                .expect(401)
+                .end(function (err) {
                     if (err) {
                         return done(err);
                     }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                    done();
-                });
-        });
-
-        it('can retrieve a user by id', function (done) {
-            request.get(testUtils.API.getApiQuery('users/1/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                    done();
-                });
-        });
-
-        it('can retrieve a user by slug', function (done) {
-            request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                    done();
-                });
-        });
-
-        it('can retrieve a user by email', function (done) {
-            request.get(testUtils.API.getApiQuery('users/email/jbloggs%40example.com/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                    done();
-                });
-        });
-
-        it('can retrieve a user with role', function (done) {
-            request.get(testUtils.API.getApiQuery('users/me/?include=roles'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
-                    testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role');
-                    done();
-                });
-        });
-
-        it('can retrieve a user with role and permissions', function (done) {
-            request.get(testUtils.API.getApiQuery('users/me/?include=roles,roles.permissions'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
-                    testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role', ['permissions']);
-                    // testUtils.API.checkResponse(jsonResponse.users[0].roles[0].permissions[0], 'permission');
 
                     done();
-                });
-        });
-
-        it('can retrieve a user by slug with role and permissions', function (done) {
-            request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/?include=roles,roles.permissions'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse.users);
-                    should.not.exist(jsonResponse.meta);
-
-                    jsonResponse.users.should.have.length(1);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['roles']);
-                    testUtils.API.checkResponse(jsonResponse.users[0].roles[0], 'role', ['permissions']);
-                    // testUtils.API.checkResponse(jsonResponse.users[0].roles[0].permissions[0], 'permission');
-
-                    done();
-                });
-        });
-
-        it('can\'t retrieve non existent user by id', function (done) {
-            request.get(testUtils.API.getApiQuery('users/99/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(404)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.errors);
-                    testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
-                    done();
-                });
-        });
-
-        it('can\'t retrieve non existent user by slug', function (done) {
-            request.get(testUtils.API.getApiQuery('users/slug/blargh/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(404)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    var jsonResponse = res.body;
-                    should.exist(jsonResponse);
-                    should.exist(jsonResponse.errors);
-                    testUtils.API.checkResponseValue(jsonResponse.errors[0], ['message', 'errorType']);
-                    done();
-                });
-        });
-    });
-    describe('Edit', function () {
-        it('can edit a user', function (done) {
-            request.get(testUtils.API.getApiQuery('users/me/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    var jsonResponse = res.body,
-                        changedValue = 'http://joe-bloggs.ghost.org',
-                        dataToSend;
-                    should.exist(jsonResponse.users[0]);
-                    testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-
-                    dataToSend = {users: [
-                        {website: changedValue}
-                    ]};
-
-                    request.put(testUtils.API.getApiQuery('users/me/'))
-                        .set('Authorization', 'Bearer ' + accesstoken)
-                        .send(dataToSend)
-                        .expect('Content-Type', /json/)
-                        .expect('Cache-Control', testUtils.cacheRules.private)
-                        .expect(200)
-                        .end(function (err, res) {
-                            if (err) {
-                                return done(err);
-                            }
-
-                            var putBody = res.body;
-                            res.headers['x-cache-invalidate'].should.eql('/*');
-                            should.exist(putBody.users[0]);
-                            putBody.users[0].website.should.eql(changedValue);
-                            putBody.users[0].email.should.eql(jsonResponse.users[0].email);
-                            testUtils.API.checkResponse(putBody.users[0], 'user');
-                            done();
-                        });
-                });
-        });
-
-        it('can\'t edit a user with invalid accesstoken', function (done) {
-            request.get(testUtils.API.getApiQuery('users/me/'))
-                .set('Authorization', 'Bearer ' + accesstoken)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    var jsonResponse = res.body,
-                        changedValue = 'joe-bloggs.ghost.org';
-
-                    should.exist(jsonResponse.users[0]);
-                    jsonResponse.users[0].website = changedValue;
-
-                    request.put(testUtils.API.getApiQuery('users/me/'))
-                        .set('Authorization', 'Bearer ' + 'invalidtoken')
-                        .send(jsonResponse)
-                        .expect(401)
-                        .end(function (err, res) {
-                            /*jshint unused:false*/
-                            if (err) {
-                                return done(err);
-                            }
-
-                            done();
-                        });
                 });
         });
     });

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -91,24 +91,28 @@ DataGenerator.Content = {
     // Password = Sl1m3rson
     users: [
         {
+            // owner
             name: 'Joe Bloggs',
             slug: 'joe-bloggs',
             email: 'jbloggs@example.com',
             password: '$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKZL6'
         },
         {
+            // editor
             name: 'Smith Wellingsworth',
             slug: 'smith-wellingsworth',
             email: 'swellingsworth@example.com',
             password: '$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKZL6'
         },
         {
+            // author
             name: 'Jimothy Bogendath',
             slug: 'jimothy-bogendath',
             email: 'jbOgendAth@example.com',
             password: '$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKZL6'
         },
         {
+            // administrator
             name: 'Slimer McEctoplasm',
             slug: 'slimer-mcectoplasm',
             email: 'smcectoplasm@example.com',

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -522,6 +522,7 @@ doAuth = function doAuth() {
 
     // Remove request from this list
     delete options[0];
+
     // No DB setup, but override the owner
     options = _.merge({'owner:post': true}, _.transform(options, function (result, val) {
         if (val) {
@@ -537,7 +538,7 @@ doAuth = function doAuth() {
 };
 
 login = function login(request) {
-    var user = DataGenerator.forModel.users[0];
+    var user = DataGenerator.forModel.users[request.userIndex || 0];
 
     return new Promise(function (resolve, reject) {
         request.post('/ghost/api/v0.1/authentication/token/')


### PR DESCRIPTION
no issue

It was not possible to execute functional tests with a specific user. This is important when we write more and more functional tests. Especially when our permission system switches to ABAC, we might concentrate more on functional tests and unit tests only.

With this PR you can choose for which user you would like to create an access token to make requests to our API.

There was no nice solution right now without refactoring too much. The only option i had was doing this: https://github.com/TryGhost/Ghost/pull/7213/files#diff-c0ca38a20a3111c7fe2e8ff00ee8a2bbR24
