### PR TITLE
fix: error handling when login via test env

### DIFF
--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -549,6 +549,10 @@ login = function login(request) {
                 client_id: 'ghost-admin',
                 client_secret: 'not_available'
             }).then(function then(res) {
+                if (res.statusCode !== 200) {
+                    return reject(res.body);
+                }
+
                 resolve(res.body.access_token);
             }, reject);
     });


### PR DESCRIPTION
no issue

When you choose a non existent user (email+pwd) for login via the test env, no error is shown.
