### PR TITLE
✨  Support for audio in AMP

### DIFF
--- a/core/server/apps/amp/lib/helpers/amp_components.js
+++ b/core/server/apps/amp/lib/helpers/amp_components.js
@@ -25,10 +25,9 @@ function ampComponents() {
         components.push('<script async custom-element="amp-iframe" src="https://cdn.ampproject.org/v0/amp-iframe-0.1.js"></script>');
     }
 
-    // audio will be supported soon by `amperize`
-    // if (html.indexOf('<audio') !== -1) {
-    //     components.push('<script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>');
-    // }
+    if (html.indexOf('<audio') !== -1) {
+        components.push('<script async custom-element="amp-audio" src="https://cdn.ampproject.org/v0/amp-audio-0.1.js"></script>');
+    }
 
     return new hbs.handlebars.SafeString(components.join('\n'));
 }

--- a/core/server/apps/amp/lib/helpers/amp_content.js
+++ b/core/server/apps/amp/lib/helpers/amp_content.js
@@ -6,7 +6,6 @@
 //
 // Converts normal HTML into AMP HTML with Amperize module and uses a cache to return it from
 // there if available. The cacheId is a combination of `updated_at` and the `slug`.
-
 var hbs                  = require('express-hbs'),
     Promise              = require('bluebird'),
     Amperize             = require('amperize'),
@@ -14,7 +13,9 @@ var hbs                  = require('express-hbs'),
     sanitizeHtml         = require('sanitize-html'),
     amperize             = new Amperize(),
     amperizeCache        = {},
-    allowedAMPTags       = [];
+    allowedAMPTags       = [],
+    cleanHTML,
+    ampHTML;
 
 allowedAMPTags = ['html', 'body', 'article', 'section', 'nav', 'aside', 'h1', 'h2',
                 'h3', 'h4', 'h5', 'h6', 'header', 'footer', 'address', 'p', 'hr',
@@ -22,8 +23,8 @@ allowedAMPTags = ['html', 'body', 'article', 'section', 'nav', 'aside', 'h1', 'h
                 'figcaption', 'div', 'main', 'a', 'em', 'strong', 'small', 's', 'cite',
                 'q', 'dfn', 'abbr', 'data', 'time', 'code', 'var', 'samp', 'kbd', 'sub',
                 'sup', 'i', 'b', 'u', 'mark', 'ruby', 'rb', 'rt', 'rtc', 'rp', 'bdi',
-                'bdo', 'span', 'br', 'wbr', 'ins', 'del', 'source', 'svg', 'g', 'path',
-                'glyph', 'glyphref', 'marker', 'view', 'circle', 'line', 'polygon',
+                'bdo', 'span', 'br', 'wbr', 'ins', 'del', 'source', 'track', 'svg', 'g',
+                'path', 'glyph', 'glyphref', 'marker', 'view', 'circle', 'line', 'polygon',
                 'polyline', 'rect', 'text', 'textpath', 'tref', 'tspan', 'clippath',
                 'filter', 'lineargradient', 'radialgradient', 'mask', 'pattern', 'vkern',
                 'hkern', 'defs', 'use', 'symbol', 'desc', 'title', 'table', 'caption',
@@ -61,13 +62,13 @@ function ampContent() {
         };
 
     return Promise.props(amperizeHTML).then(function (result) {
-        var ampHTML = result.amperize || '',
-            cleanHTML;
+        ampHTML = result.amperize || '';
 
         // let's sanitize our html!!!
         cleanHTML = sanitizeHtml(ampHTML, {
             allowedTags: allowedAMPTags,
-            allowedAttributes: false
+            allowedAttributes: false,
+            selfClosing: ['source', 'track']
         });
 
         return new hbs.handlebars.SafeString(cleanHTML);

--- a/core/server/apps/amp/tests/amp_components_spec.js
+++ b/core/server/apps/amp/tests/amp_components_spec.js
@@ -32,20 +32,19 @@ describe('{{amp_components}} helper', function () {
         rendered.should.match(/<script async custom-element="amp-iframe" src="https:\/\/cdn.ampproject.org\/v0\/amp-iframe-0.1.js"><\/script>/);
     });
 
-    // audio will be supported soon by `amperize`
-    // it('adds script tag for an audio tag', function () {
-    //     var post = {
-    //             html: '<audio src="myaudiofile.mp3"/>'
-    //         },
-    //         rendered;
-    //
-    //     rendered = ampComponentsHelper.call(
-    //         {relativeUrl: '/post/amp/', safeVersion: '0.3', context: ['amp', 'post'], post: post},
-    //         {data: {root: {context: ['amp', 'post']}}});
-    //
-    //     should.exist(rendered);
-    //     rendered.should.match(/<script async custom-element="amp-audio" src="https:\/\/cdn.ampproject.org\/v0\/amp-audio-0.1.js"><\/script>/);
-    // });
+    it('adds script tag for an audio tag', function () {
+        var post = {
+                html: '<audio src="myaudiofile.mp3"/>'
+            },
+            rendered;
+
+        rendered = ampComponentsHelper.call(
+            {relativeUrl: '/post/amp/', safeVersion: '0.3', context: ['amp', 'post'], post: post},
+            {data: {root: {context: ['amp', 'post']}}});
+
+        should.exist(rendered);
+        rendered.should.match(/<script async custom-element="amp-audio" src="https:\/\/cdn.ampproject.org\/v0\/amp-audio-0.1.js"><\/script>/);
+    });
 
     it('returns if no html is provided', function () {
         var post = {},

--- a/core/server/apps/amp/tests/amp_content_spec.js
+++ b/core/server/apps/amp/tests/amp_content_spec.js
@@ -92,8 +92,7 @@ describe('{{amp_content}} helper', function () {
 
     it('sanitizes remaining and not valid tags', function (done) {
         var testData = {
-                html: '<audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3" controls="controls">' +
-                        '<form<input type="text" placeholder="Hi AMP tester"></form>' +
+                html: '<form<input type="text" placeholder="Hi AMP tester"></form>' +
                         '<script>some script here</script>' +
                         '<style> h1 {color:red;} p {color:blue;}</style>',
                 updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
@@ -122,7 +121,7 @@ describe('{{amp_content}} helper', function () {
         }).catch(done);
     });
 
-    it('can transforms img tags to amp-img', function (done) {
+    it('can transform img tags to amp-img', function (done) {
         var testData = {
                 html: '<img src="https://ghost.org/images/ghost.png" alt="The Ghost Logo" />',
                 updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
@@ -137,6 +136,45 @@ describe('{{amp_content}} helper', function () {
             done();
         }).catch(done);
     });
-    // TODO: stub Amperize to test returned errors
-    it('can handle amperize error');
+
+    it('can transform audio tags to amp-audio', function (done) {
+        var testData = {
+                html: '<audio controls="controls" width="auto" height="50" autoplay="mobile">Your browser does not support the <code>audio</code> element.<source src="foo.wav" type="audio/wav"></audio>' +
+                        '<audio src="http://foo.ogg"><track kind="captions" src="http://foo.en.vtt" srclang="en" label="English"><track kind="captions" src="http://foo.sv.vtt" srclang="sv" label="Svenska"></audio>',
+                updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
+                id: 1
+            },
+            expectedResult = '<amp-audio controls="controls" width="auto" height="50" autoplay="mobile">Your browser does not support the <code>audio</code> element.<source src="foo.wav" type="audio/wav" /></amp-audio>' +
+                                '<amp-audio src="https://foo.ogg"><track kind="captions" src="https://foo.en.vtt" srclang="en" label="English" /><track kind="captions" src="https://foo.sv.vtt" srclang="sv" label="Svenska" /></amp-audio>',
+            ampResult = ampContentHelper.call(testData);
+
+        ampResult.then(function (rendered) {
+            should.exist(rendered);
+            rendered.string.should.equal(expectedResult);
+            done();
+        }).catch(done);
+    });
+
+    it('can handle incomplete HTML tags', function (done) {
+        var testData = {
+                html: '<img><///img>',
+                updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
+                id: 1
+            },
+            ampResult = ampContentHelper.call(testData),
+            sanitizedHTML,
+            ampedHTML;
+
+        ampResult.then(function (rendered) {
+            sanitizedHTML = ampContentHelper.__get__('cleanHTML');
+            ampedHTML = ampContentHelper.__get__('ampHTML');
+            should.exist(rendered);
+            rendered.string.should.equal('');
+            should.exist(ampedHTML);
+            ampedHTML.should.be.equal('<img>');
+            should.exist(sanitizedHTML);
+            sanitizedHTML.should.be.equal('');
+            done();
+        }).catch(done);
+    });
 });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
   },
   "dependencies": {
-    "amperize": "https://github.com/jbhannah/amperize#98343579b3a350302c6e4a787ad9ac3faae7d143",
+    "amperize": "0.3.0",
     "bcryptjs": "2.3.0",
     "bluebird": "3.4.1",
     "body-parser": "1.15.2",


### PR DESCRIPTION
no issue
- Amperize dependency is no (temporary) pointing to `aileencgn/amperize#audio-support-again` until PR [#67](https://github.com/jbhannah/amperize/pull/67) gets merged
- Adds necessary script tag for amp-audio, if `audio` tag is detected in HTML
- Transforms `audio` to `amp-audio`
