### PR TITLE
🐛  Fix: no code injection for amp context

### DIFF
--- a/core/server/apps/amp/tests/amp_content_spec.js
+++ b/core/server/apps/amp/tests/amp_content_spec.js
@@ -92,8 +92,7 @@ describe('{{amp_content}} helper', function () {
 
     it('sanitizes remaining and not valid tags', function (done) {
         var testData = {
-                html: '<audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3" controls="controls">' +
-                        '<form<input type="text" placeholder="Hi AMP tester"></form>' +
+                html: '<form<input type="text" placeholder="Hi AMP tester"></form>' +
                         '<script>some script here</script>' +
                         '<style> h1 {color:red;} p {color:blue;}</style>',
                 updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -138,7 +138,10 @@ function ghost_head(options) {
 
         return api.settings.read({key: 'ghost_head'});
     }).then(function (response) {
-        head.push(response.settings[0].value);
+        // no code injection for amp context!!!
+        if (!_.includes(context, 'amp')) {
+            head.push(response.settings[0].value);
+        }
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
         return new SafeString(head.join('\n    ').trim());

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -994,6 +994,38 @@ describe('{{ghost_head}} helper', function () {
                 done();
             }).catch(done);
         });
+
+        it('returns meta tag without injected code for amp context', function (done) {
+            var post = {
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at:  moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                author: {
+                    name: 'Author name',
+                    url: 'http//:testauthorurl.com',
+                    slug: 'Author',
+                    image: 'content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            };
+            helpers.ghost_head.call(
+                {safeVersion: '0.3', context: ['amp', 'post'], post: post},
+                {data: {root: {context: []}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
+                rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
+                rendered.string.should.not.match(/<style>body {background: red;}<\/style>/);
+
+                done();
+            }).catch(done);
+        });
     });
 
     describe('with Ajax Helper', function () {


### PR DESCRIPTION
no issue
- Adds a conditional in `{{ghost_head}}`, so no code injection will be included, for an `amp` context.
- Updates test to reflect this assertion.
