### PR TITLE
✨ 💄 Use {{amp_ghost_head}} helper

### DIFF
--- a/core/server/apps/amp/lib/helpers/index.js
+++ b/core/server/apps/amp/lib/helpers/index.js
@@ -1,11 +1,16 @@
 var ampContentHelper   = require('./amp_content'),
     ampComponentsHelper = require('./amp_components'),
+    registerAsyncThemeHelper = require('../../../../helpers').registerAsyncThemeHelper,
+    ghostHead = require('../../../../helpers/ghost_head'),
     registerAmpHelpers;
 
 registerAmpHelpers = function (ghost) {
     ghost.helpers.registerAsync('amp_content', ampContentHelper);
 
     ghost.helpers.register('amp_components', ampComponentsHelper);
+
+    // we use the {{ghost_head}} helper, but call it {{amp_ghost_head}}, so it's consistent
+    registerAsyncThemeHelper('amp_ghost_head', ghostHead);
 };
 
 module.exports = registerAmpHelpers;

--- a/core/server/apps/amp/lib/views/amp.hbs
+++ b/core/server/apps/amp/lib/views/amp.hbs
@@ -15,7 +15,7 @@
     {{!-- Brand icon --}}
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
 
-    {{ghost_head}}
+    {{amp_ghost_head}}
 
     {{!-- Styles'n'Scripts --}}
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,600,400" />


### PR DESCRIPTION
no issue

For more consistency regarding the helpers for AMP - we're using `{{amp_content}}` and `{{amp_components}}`, but were also using `{{ghost_head}}`, which is not very consistent - I thought it would be better to have an 'amp'-named helper for the head data as well.
- registers `{{amp_ghost_head}}` helper, but uses `{{ghost_head}}` code, which is already modified for `amp` context
- uses `{{amp_ghost_head}}` in `amp.hbs` instead of `{{ghost_head}}`
