### PR TITLE
🐛  Don't overwrite config.theme.title in GhostMail

### DIFF
--- a/core/server/mail/GhostMailer.js
+++ b/core/server/mail/GhostMailer.js
@@ -19,7 +19,8 @@ function GhostMailer() {
 }
 
 GhostMailer.prototype.from = function () {
-    var from = config.mail && (config.mail.from || config.mail.fromaddress);
+    var from = config.mail && (config.mail.from || config.mail.fromaddress),
+        defaultBlogTitle;
 
     // If we don't have a from address at all
     if (!from) {
@@ -29,10 +30,9 @@ GhostMailer.prototype.from = function () {
 
     // If we do have a from address, and it's just an email
     if (validator.isEmail(from)) {
-        if (!config.theme.title) {
-            config.theme.title = i18n.t('common.mail.title', {domain: this.getDomain()});
-        }
-        from = '"' + config.theme.title + '" <' + from + '>';
+        defaultBlogTitle = config.theme.title ? config.theme.title : i18n.t('common.mail.title', {domain: this.getDomain()});
+
+        from = '"' + defaultBlogTitle + '" <' + from + '>';
     }
 
     return from;


### PR DESCRIPTION
closes #7212

When no Blog title is set and there is a `from` mail adress without custom name set up in `config.js`, it will overwrite `config.theme.title` in `GhostMailer.from` and forces to have a (wrong) Blog title after sending a test mail or an invitation.
- Uses a variable `defaultBlogTitle` instead of overwriting `config.theme.title`, when no blog title is set and therefore `config.theme.title` has no value.
