### PR TITLE
fixes: storage base getUniqueFileName

### DIFF
--- a/core/server/storage/base.js
+++ b/core/server/storage/base.js
@@ -1,5 +1,5 @@
-var moment  = require('moment'),
-    path    = require('path');
+var moment = require('moment'),
+    path = require('path');
 
 function StorageBase() {
 }
@@ -7,7 +7,7 @@ function StorageBase() {
 StorageBase.prototype.getTargetDir = function (baseDir) {
     var m = moment(),
         month = m.format('MM'),
-        year =  m.format('YYYY');
+        year = m.format('YYYY');
 
     if (baseDir) {
         return path.join(baseDir, year, month);
@@ -25,7 +25,11 @@ StorageBase.prototype.generateUnique = function (store, dir, name, ext, i) {
         append = '-' + i;
     }
 
-    filename = path.join(dir, name + append + ext);
+    if (ext) {
+        filename = path.join(dir, name + append + ext);
+    } else {
+        filename = path.join(dir, name + append);
+    }
 
     return store.exists(filename).then(function (exists) {
         if (exists) {
@@ -38,11 +42,17 @@ StorageBase.prototype.generateUnique = function (store, dir, name, ext, i) {
 };
 
 StorageBase.prototype.getUniqueFileName = function (store, image, targetDir) {
-    var ext = path.extname(image.name),
-        name = path.basename(image.name, ext).replace(/[^\w@]/gi, '-'),
-        self = this;
+    var ext = path.extname(image.name), name;
 
-    return self.generateUnique(store, targetDir, name, ext, 0);
+    // poor extension validation
+    // .1 is not a valid extension
+    if (!ext.match(/.\d/)) {
+        name = path.basename(image.name, ext).replace(/[^\w@.]/gi, '-');
+        return this.generateUnique(store, targetDir, name, ext, 0);
+    } else {
+        name = path.basename(image.name).replace(/[^\w@.]/gi, '-');
+        return this.generateUnique(store, targetDir, name, null, 0);
+    }
 };
 
 module.exports = StorageBase;

--- a/core/test/unit/storage_local-file-store_spec.js
+++ b/core/test/unit/storage_local-file-store_spec.js
@@ -149,6 +149,35 @@ describe('Local File System Storage', function () {
         }).catch(done);
     });
 
+    describe('validate extentions', function () {
+        it('name contains a .\d as extension', function (done) {
+            localFileStore.save({
+                name: 'test-1.1.1'
+            }).then(function (url) {
+                should.exist(url.match(/test-1.1.1/));
+                done();
+            }).catch(done);
+        });
+
+        it('name contains a .zip as extension', function (done) {
+            localFileStore.save({
+                name: 'test-1.1.1.zip'
+            }).then(function (url) {
+                should.exist(url.match(/test-1.1.1.zip/));
+                done();
+            }).catch(done);
+        });
+
+        it('name contains a .jpeg as extension', function (done) {
+            localFileStore.save({
+                name: 'test-1.1.1.jpeg'
+            }).then(function (url) {
+                should.exist(url.match(/test-1.1.1.jpeg/));
+                done();
+            }).catch(done);
+        });
+    });
+
     describe('when a custom content path is used', function () {
         beforeEach(function () {
             var configPaths = configUtils.defaultConfig.paths;


### PR DESCRIPTION
no issue

If you save a file named `test-1.1.1` the base storage adapter transforms it into `test-1-1`.
Because:
1. it detects `.1` as extension
2. it transforms all non letters into `-`
