### PR TITLE
🐛  Change default referrer policy

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -81,7 +81,7 @@ function ghost_head(options) {
         context = this.context ? this.context[0] : null,
         useStructuredData = !config.isPrivacyDisabled('useStructuredData'),
         safeVersion = this.safeVersion,
-        referrerPolicy = config.referrerPolicy ? config.referrerPolicy : 'origin-when-cross-origin';
+        referrerPolicy = config.referrerPolicy ? config.referrerPolicy : 'no-referrer-when-downgrade';
 
     return getClient().then(function (client) {
         if (context) {

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -83,7 +83,7 @@ describe('{{ghost_head}} helper', function () {
             ).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
-                rendered.string.should.match(/<meta name="referrer" content="origin-when-cross-origin" \/>/);
+                rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Ghost" \/>/);
@@ -135,7 +135,7 @@ describe('{{ghost_head}} helper', function () {
             ).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/about\/" \/>/);
-                rendered.string.should.match(/<meta name="referrer" content="origin-when-cross-origin" \/>/);
+                rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="About" \/>/);


### PR DESCRIPTION
closes #7235

Changes the default referrer policy to `no-referrer-when-downgrade` because Safari can't deal with `origin-when-crossorigin`.
