### PR TITLE
feature: storage adapter for images and themes

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -96,7 +96,6 @@ ConfigManager.prototype.set = function (config) {
         activeStorageAdapter,
         activeSchedulingAdapter,
         contentPath,
-        storagePath,
         schedulingPath,
         subdir,
         assetHash;
@@ -153,11 +152,25 @@ ConfigManager.prototype.set = function (config) {
     this._config.scheduling = this._config.scheduling || {};
     activeSchedulingAdapter = this._config.scheduling.active || defaultSchedulingAdapter;
 
-    // we support custom adapters located in content folder
-    if (activeStorageAdapter === defaultStorageAdapter) {
-        storagePath = path.join(corePath, '/server/storage/');
+    // storage.active can be an object like {images: 'my-custom-image-storage-adapter', themes: 'local-file-storage'}
+    // we ensure that passing a string to storage.active still works, but internal it's always an object
+    if (_.isString(activeStorageAdapter)) {
+        this._config.storage = _.merge(this._config.storage, {
+            active: {
+                images: activeStorageAdapter,
+                themes: defaultStorageAdapter
+            }
+        });
     } else {
-        storagePath = path.join(contentPath, 'storage');
+        // ensure there is a default image storage adapter
+        if (!this._config.storage.active.images) {
+            this._config.storage.active.images = defaultSchedulingAdapter;
+        }
+
+        // ensure there is a default theme storage adapter
+        if (!this._config.storage.active.themes) {
+            this._config.storage.active.themes = defaultSchedulingAdapter;
+        }
     }
 
     if (activeSchedulingAdapter === defaultSchedulingAdapter) {
@@ -175,7 +188,10 @@ ConfigManager.prototype.set = function (config) {
             configExample:    path.join(appRoot, 'config.example.js'),
             corePath:         corePath,
 
-            storage:          path.join(storagePath, activeStorageAdapter),
+            storagePath: {
+                default: path.join(corePath, '/server/storage/'),
+                custom:  path.join(contentPath, 'storage/')
+            },
 
             contentPath:      contentPath,
             themePath:        path.resolve(contentPath, 'themes'),
@@ -195,9 +211,6 @@ ConfigManager.prototype.set = function (config) {
         scheduling: {
             active: activeSchedulingAdapter,
             path: schedulingPath
-        },
-        storage: {
-            active: activeStorageAdapter
         },
         theme: {
             // normalise the URL by removing any trailing slash

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -70,7 +70,7 @@ describe('Config', function () {
                 'subdir',
                 'config',
                 'configExample',
-                'storage',
+                'storagePath',
                 'contentPath',
                 'corePath',
                 'themePath',
@@ -145,13 +145,18 @@ describe('Config', function () {
 
     describe('Storage', function () {
         it('should default to local-file-store', function () {
-            var storagePath = path.join(config.paths.corePath, '/server/storage/', 'local-file-store');
+            config.paths.should.have.property('storagePath', {
+                default: path.join(config.paths.corePath, '/server/storage/'),
+                custom:  path.join(config.paths.contentPath, 'storage/')
+            });
 
-            config.paths.should.have.property('storage', storagePath);
-            config.storage.should.have.property('active', 'local-file-store');
+            config.storage.should.have.property('active', {
+                images: 'local-file-store',
+                themes: 'local-file-store'
+            });
         });
 
-        it('should allow setting a custom active storage', function () {
+        it('should allow setting a custom active storage as string', function () {
             var storagePath = path.join(config.paths.contentPath, 'storage', 's3');
 
             configUtils.set({
@@ -161,9 +166,47 @@ describe('Config', function () {
                 }
             });
 
-            config.paths.should.have.property('storage', storagePath);
-            config.storage.should.have.property('active', 's3');
+            config.storage.should.have.property('active', {
+                images: 's3',
+                themes: 'local-file-store'
+            });
+
             config.storage.should.have.property('s3', {});
+        });
+
+        it('should allow setting a custom active storage as object', function () {
+            var storagePath = path.join(config.paths.contentPath, 'storage', 's3');
+
+            configUtils.set({
+                storage: {
+                    active: {
+                        themes: 's3'
+                    }
+                }
+            });
+
+            config.storage.should.have.property('active', {
+                images: 'local-file-store',
+                themes: 's3'
+            });
+        });
+
+        it('should allow setting a custom active storage as object', function () {
+            var storagePath = path.join(config.paths.contentPath, 'storage', 's3');
+
+            configUtils.set({
+                storage: {
+                    active: {
+                        images: 's2',
+                        themes: 's3'
+                    }
+                }
+            });
+
+            config.storage.should.have.property('active', {
+                images: 's2',
+                themes: 's3'
+            });
         });
     });
 

--- a/core/test/unit/storage/index_spec.js
+++ b/core/test/unit/storage/index_spec.js
@@ -1,0 +1,66 @@
+var fs = require('fs-extra'),
+    should = require('should'),
+    configUtils = require('../../utils/configUtils'),
+    storage = require('../../../server/storage'),
+    errors = require('../../../server/errors'),
+    localFileStorage = require('../../../server/storage/local-file-store');
+
+// to stop jshint complaining
+should.equal(true, true);
+
+describe('storage: index_spec', function () {
+    describe('default ghost storage config', function () {
+        it('load without a type', function () {
+            var chosenStorage = storage.getStorage();
+            (chosenStorage instanceof localFileStorage).should.eql(true);
+        });
+
+        it('load with themes type', function () {
+            var chosenStorage = storage.getStorage('themes');
+            (chosenStorage instanceof localFileStorage).should.eql(true);
+        });
+
+        it('load with unknown type', function () {
+            try {
+                storage.getStorage('theme');
+            } catch (err) {
+                (err instanceof errors.IncorrectUsage).should.eql(true);
+            }
+        });
+    });
+
+    describe('custom ghost storage config', function () {
+        it('images storage adapter is custom, themes is default', function () {
+            configUtils.set({
+                storage: {
+                    active: {
+                        images: 'custom-adapter'
+                    }
+                }
+            });
+
+            var jsFile = '' +
+                'var util = require(\'util\');' +
+                'var StorageBase = require(__dirname + \'/../../core/server/storage/base\');' +
+                'var AnotherAdapter = function (){ StorageBase.call(this); };' +
+                'util.inherits(AnotherAdapter, StorageBase);' +
+                'AnotherAdapter.prototype.exists = function (){};' +
+                'AnotherAdapter.prototype.save = function (){};' +
+                'module.exports = AnotherAdapter', chosenStorage;
+
+            if (!fs.existsSync(configUtils.config.paths.storagePath.custom)) {
+                fs.mkdirSync(configUtils.config.paths.storagePath.custom);
+            }
+
+            fs.writeFileSync(configUtils.config.paths.storagePath.custom + 'custom-adapter.js', jsFile);
+
+            chosenStorage = storage.getStorage('themes');
+            (chosenStorage instanceof localFileStorage).should.eql(true);
+
+            chosenStorage = storage.getStorage('images');
+            (chosenStorage instanceof localFileStorage).should.eql(false);
+
+            fs.unlinkSync(configUtils.config.paths.storagePath.custom + 'custom-adapter.js');
+        });
+    });
+});


### PR DESCRIPTION
refs #2852 

Right now it was only possible to configure the storage configuration like:

```
storage: {
  active: 's3'
  s3: {...options..}
}
```

The whole storage implementation/configuration was strongly designed for images only.

With theme uploads (see #7209), we upload themes to Ghost. 
Some custom adapters only offer the ability to store images, that's why we need a way to configure a separate theme adapter or take the default.

When you have this configured for storage:

```
storage: {
  active: 's3',
  s3: {}
}
```

It will still work with the only difference that we will define that the default theme storage is the default storage (local file storage).
You can change this behaviour:

```
storage: {
  active: { images: 's3', themes: 's3' }
  s3: {}
}
```

I have tested this code with `https://github.com/spanishdict/ghost-s3-compat`, worked
