### PR TITLE
improvement: contentPath for production

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -24,6 +24,11 @@ config = {
         server: {
             host: '127.0.0.1',
             port: '2368'
+        },
+        // #### Paths
+        // Specify where your content directory lives
+        paths: {
+            contentPath: path.join(__dirname, '/content/')
         }
     },
 


### PR DESCRIPTION
Needed for dockerized ghost with external volume specified.

eg: `docker run -d -v $(pwd):/var/lib/ghost ghost:latest`

The `docker-entrypoint.sh` syncs to the `/var/lib/ghost` folder so it helps with the path pointed there by default.

Signed-off-by: Kenneth Lim kennethlimcp@gmail.com
