### PR TITLE
🐛 Ensure sitemap items are valid

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -220,8 +220,8 @@ posts = {
                 data = _.defaults({status: 'all'}, options),
                 fetchOpts = _.defaults({require: true, columns: 'id'}, options);
 
-            return Post.findOne(data, fetchOpts).then(function (post) {
-                return post.destroy(options).return(null);
+            return Post.findOne(data, fetchOpts).then(function () {
+                return Post.destroy(options).return(null);
             }).catch(Post.NotFoundError, function () {
                 throw new errors.NotFoundError(i18n.t('errors.api.posts.postNotFound'));
             });

--- a/core/server/data/xml/sitemap/manager.js
+++ b/core/server/data/xml/sitemap/manager.js
@@ -69,14 +69,7 @@ _.extend(SiteMapManager.prototype, {
         }
 
         return this[type].siteMapContent;
-    },
-
-    _refreshAllPosts: _.throttle(function () {
-        this.posts.refreshAllPosts();
-    }, 3000, {
-        leading: false,
-        trailing: true
-    })
+    }
 });
 
 module.exports = SiteMapManager;

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -18,6 +18,7 @@ _.extend(PageMapGenerator.prototype, {
         var self = this;
         this.dataEvents.on('page.published', self.addOrUpdateUrl.bind(self));
         this.dataEvents.on('page.published.edited', self.addOrUpdateUrl.bind(self));
+        // Note: This is called if a published post is deleted
         this.dataEvents.on('page.unpublished', self.removeUrl.bind(self));
     },
 
@@ -26,16 +27,21 @@ _.extend(PageMapGenerator.prototype, {
             context: {
                 internal: true
             },
+            filter: 'visibility:public',
             status: 'published',
             staticPages: true,
             limit: 'all'
         }).then(function (resp) {
             var homePage = {
-                    id: 0,
-                    name: 'home'
-                };
+                id: 0,
+                name: 'home'
+            };
             return [homePage].concat(resp.posts);
         });
+    },
+
+    validateDatum: function (datum) {
+        return datum.name === 'home' || (datum.page === true && datum.visibility === 'public');
     },
 
     getUrlForDatum: function (post) {

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -18,6 +18,7 @@ _.extend(PostMapGenerator.prototype, {
         var self = this;
         this.dataEvents.on('post.published', self.addOrUpdateUrl.bind(self));
         this.dataEvents.on('post.published.edited', self.addOrUpdateUrl.bind(self));
+        // Note: This is called if a published post is deleted
         this.dataEvents.on('post.unpublished', self.removeUrl.bind(self));
     },
 
@@ -26,12 +27,17 @@ _.extend(PostMapGenerator.prototype, {
             context: {
                 internal: true
             },
+            filter: 'visibility:public',
             status: 'published',
             staticPages: false,
             limit: 'all'
         }).then(function (resp) {
             return resp.posts;
         });
+    },
+
+    validateDatum: function (datum) {
+        return datum.page === false && datum.visibility === 'public';
     },
 
     getUrlForDatum: function (post) {

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -33,6 +33,10 @@ _.extend(TagsMapGenerator.prototype, {
         });
     },
 
+    validateDatum: function (datum) {
+        return datum.visibility === 'public';
+    },
+
     getUrlForDatum: function (tag) {
         return config.urlFor('tag', {tag: tag}, true);
     },

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -2,7 +2,9 @@ var _      = require('lodash'),
     api    = require('../../../api'),
     config = require('../../../config'),
     validator        = require('validator'),
-    BaseMapGenerator = require('./base-generator');
+    BaseMapGenerator = require('./base-generator'),
+    // @TODO: figure out a way to get rid of this
+    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function UserMapGenerator(opts) {
@@ -27,10 +29,16 @@ _.extend(UserMapGenerator.prototype, {
             context: {
                 internal: true
             },
+            filter: 'visibility:public',
+            status: 'active',
             limit: 'all'
         }).then(function (resp) {
             return resp.users;
         });
+    },
+
+    validateDatum: function (datum) {
+        return datum.visibility === 'public' && _.includes(activeStates, datum.status);
     },
 
     getUrlForDatum: function (user) {
@@ -43,8 +51,7 @@ _.extend(UserMapGenerator.prototype, {
     },
 
     validateImageUrl: function (imageUrl) {
-        return imageUrl &&
-            validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
+        return imageUrl && validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
     }
 });
 

--- a/core/test/unit/sitemap/generator_spec.js
+++ b/core/test/unit/sitemap/generator_spec.js
@@ -1,0 +1,368 @@
+var _           = require('lodash'),
+    should      = require('should'),
+    sinon       = require('sinon'),
+    Promise     = require('bluebird'),
+    validator   = require('validator'),
+
+    // Stuff we are testing
+    config         = require('../../../server/config'),
+    api            = require('../../../server/api'),
+    BaseGenerator  = require('../../../server/data/xml/sitemap/base-generator'),
+    PostGenerator  = require('../../../server/data/xml/sitemap/post-generator'),
+    PageGenerator  = require('../../../server/data/xml/sitemap/page-generator'),
+    TagGenerator   = require('../../../server/data/xml/sitemap/tag-generator'),
+    UserGenerator  = require('../../../server/data/xml/sitemap/user-generator'),
+
+    sandbox = sinon.sandbox.create();
+
+should.Assertion.add('ValidUrlNode', function (options) {
+    // Check urlNode looks correct
+    var urlNode = this.obj,
+        flatNode;
+    urlNode.should.be.an.Object().with.key('url');
+    urlNode.url.should.be.an.Array();
+
+    if (options.withImage) {
+        urlNode.url.should.have.lengthOf(5);
+    } else {
+        urlNode.url.should.have.lengthOf(4);
+    }
+
+    /**
+     * A urlNode looks something like:
+     * { url:
+     *   [ { loc: 'http://127.0.0.1:2369/author/' },
+     *     { lastmod: '2014-12-22T11:54:00.100Z' },
+     *     { changefreq: 'weekly' },
+     *     { priority: 0.6 },
+     *     { 'image:image': [
+     *       { 'image:loc': 'post-100.jpg' },
+     *       { 'image:caption': 'post-100.jpg' }
+     *     ] }
+     *  ] }
+     */
+    flatNode = _.extend.apply(_, urlNode.url);
+
+    if (options.withImage) {
+        flatNode.should.be.an.Object().with.keys('loc', 'lastmod', 'changefreq', 'priority', 'image:image');
+    } else {
+        flatNode.should.be.an.Object().with.keys('loc', 'lastmod', 'changefreq', 'priority');
+    }
+});
+
+describe('Generators', function () {
+    var stubUrl = function (generator) {
+            sandbox.stub(generator, 'getUrlForDatum', function (datum) {
+                return 'http://my-ghost-blog.com/url/' + datum.id;
+            });
+            sandbox.stub(generator, 'getUrlForImage', function (image) {
+                return 'http://my-ghost-blog.com/images/' + image;
+            });
+
+            return generator;
+        },
+        makeFakeDatum = function (id) {
+            return {
+                id: id,
+                created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + id,
+                visibility: 'public'
+            };
+        },
+        generator;
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('BaseGenerator', function () {
+        beforeEach(function () {
+            generator = new BaseGenerator();
+        });
+
+        it('can initialize with empty siteMapContent', function (done) {
+            generator.init().then(function () {
+                should.exist(generator.siteMapContent);
+
+                validator.contains(generator.siteMapContent, '<loc>').should.equal(false);
+
+                done();
+            }).catch(done);
+        });
+
+        it('can initialize with non-empty siteMapContent', function (done) {
+            stubUrl(generator);
+
+            sandbox.stub(generator, 'getData', function () {
+                return Promise.resolve([
+                    makeFakeDatum(100),
+                    makeFakeDatum(200),
+                    makeFakeDatum(300)
+                ]);
+            });
+
+            generator.init().then(function () {
+                var idxFirst,
+                    idxSecond,
+                    idxThird;
+
+                should.exist(generator.siteMapContent);
+
+                // TODO: We should validate the contents against the XSD:
+                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
+
+                // Validate order newest to oldest
+                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
+                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
+                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
+
+                idxFirst.should.be.below(idxSecond);
+                idxSecond.should.be.below(idxThird);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('PostGenerator', function () {
+        beforeEach(function () {
+            generator = new PostGenerator();
+        });
+
+        it('uses 0.9 priority for featured posts', function () {
+            generator.getPriorityForDatum({
+                featured: true
+            }).should.equal(0.9);
+        });
+
+        it('uses 0.8 priority for all other (non-featured) posts', function () {
+            generator.getPriorityForDatum({
+                featured: false
+            }).should.equal(0.8);
+        });
+
+        it('does not create a node for a post with visibility that is not public', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                visibility: 'private',
+                page: false
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('does not create a node for a page', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                page: true
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('adds an image:image element if post has a cover image', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                image: 'post-100.jpg',
+                page: false
+            }));
+
+            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        });
+
+        it('can initialize with non-empty siteMapContent', function (done) {
+            stubUrl(generator);
+
+            sandbox.stub(generator, 'getData', function () {
+                return Promise.resolve([
+                    _.extend(makeFakeDatum(100), {
+                        image: 'post-100.jpg',
+                        page: false
+                    }),
+                    _.extend(makeFakeDatum(200), {
+                        page: false
+                    }),
+                    _.extend(makeFakeDatum(300), {
+                        image: 'post-300.jpg',
+                        page: false
+                    })
+                ]);
+            });
+
+            generator.init().then(function () {
+                var idxFirst,
+                    idxSecond,
+                    idxThird;
+
+                should.exist(generator.siteMapContent);
+
+                // TODO: We should validate the contents against the XSD:
+                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
+                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
+
+                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-100.jpg</image:loc>');
+                // This should NOT be present
+                generator.siteMapContent.should.not.containEql('<image:loc>http://my-ghost-blog.com/images/post-200.jpg</image:loc>');
+                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-300.jpg</image:loc>');
+
+                // Validate order newest to oldest
+                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
+                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
+                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
+
+                idxFirst.should.be.below(idxSecond);
+                idxSecond.should.be.below(idxThird);
+
+                done();
+            }).catch(done);
+        });
+    });
+
+    describe('PageGenerator', function () {
+        beforeEach(function () {
+            generator = new PageGenerator();
+        });
+
+        it('has a home item even if pages are empty', function (done) {
+            // Fake the api call to return no posts
+            sandbox.stub(api.posts, 'browse', function () {
+                return Promise.resolve({posts: []});
+            });
+
+            generator.init().then(function () {
+                should.exist(generator.siteMapContent);
+
+                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('home', true) + '</loc>');
+                // <loc> should exist exactly one time
+                generator.siteMapContent.indexOf('<loc>').should.eql(generator.siteMapContent.lastIndexOf('<loc>'));
+
+                done();
+            }).catch(done);
+        });
+
+        it('has a home item when pages are not empty', function (done) {
+            // Fake the api call to return no posts
+            sandbox.stub(api.posts, 'browse', function () {
+                return Promise.resolve({
+                    posts: [_.extend(makeFakeDatum(100), {
+                        page: true,
+                        url: 'magic'
+                    })]
+                });
+            });
+
+            generator.init().then(function () {
+                should.exist(generator.siteMapContent);
+
+                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('home', true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('page', {url: 'magic'}, true) + '</loc>');
+
+                done();
+            }).catch(done);
+        });
+
+        it('uses 1 priority for home page', function () {
+            generator.getPriorityForDatum({
+                name: 'home'
+            }).should.equal(1);
+        });
+        it('uses 0.8 priority for static pages', function () {
+            generator.getPriorityForDatum({}).should.equal(0.8);
+        });
+
+        it('does not create a node for a page with visibility that is not public', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                visibility: 'internal',
+                page: true
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('does not create a node for a post', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                page: false
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('adds an image:image element if page has an image', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                image: 'page-100.jpg',
+                page: true
+            }));
+
+            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        });
+    });
+
+    describe('TagGenerator', function () {
+        beforeEach(function () {
+            generator = new TagGenerator();
+        });
+
+        it('uses 0.6 priority for all tags', function () {
+            generator.getPriorityForDatum({}).should.equal(0.6);
+        });
+
+        it('does not create a node for a tag with visibility that is not public', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                visibility: 'internal'
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('adds an image:image element if tag has an image', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                image: 'tag-100.jpg'
+            }));
+
+            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        });
+    });
+
+    describe('UserGenerator', function () {
+        beforeEach(function () {
+            generator = new UserGenerator();
+        });
+
+        it('uses 0.6 priority for author links', function () {
+            generator.getPriorityForDatum({}).should.equal(0.6);
+        });
+
+        it('does not create a node for invited users', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                cover: 'user-100.jpg',
+                status: 'invited'
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('does not create a node for a user with visibility that is not public', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                cover: 'user-100.jpg',
+                status: 'active',
+                visibility: 'notpublic'
+            }));
+
+            urlNode.should.be.false();
+        });
+
+        it('adds an image:image element if user has a cover image', function () {
+            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
+                cover: '/content/images/2016/01/user-100.jpg',
+                status: 'active'
+            }));
+
+            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        });
+    });
+});


### PR DESCRIPTION
This PR fixes #7186 and also prevents invited users from appearing in the user sitemap and pages from appearing in the post sitemap.

There are a lot of bugs in the sitemap generation code, this fixes the worst ones I could find. The code & tests both need revisiting but that's a bigger job than for today.

closes #7186
- Add a concept of validity to each generator
- Refactor base generator to handle invalid (empty) nodes for both events & the initial generation
- Update the tests a bit, to fix some bugs in the tests
- TODO: this needs a total overhaul :(
