### PR TITLE
Show correct error message the first time account is locked

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -554,6 +554,12 @@ User = ghostBookshelf.Model.extend({
                 return bcryptCompare(object.password, user.get('password')).then(function then(matched) {
                     if (!matched) {
                         return Promise.resolve(self.setWarning(user, {validate: false})).then(function then(remaining) {
+                            if (remaining === 0) {
+                                // If remaining attempts = 0, the account has been locked, so show a locked account message
+                                return Promise.reject(new errors.NoPermissionError(
+                                    i18n.t('errors.models.user.accountLocked')));
+                            }
+
                             s = (remaining > 1) ? 's' : '';
                             return Promise.reject(new errors.UnauthorizedError(i18n.t('errors.models.user.incorrectPasswordAttempts', {remaining: remaining, s: s})));
 


### PR DESCRIPTION
closes #7251
- check if remaining attemps is 0, if so then show account locked error

Turns out this was a bug in the user model. Regardless, this fixes it
- [x] tests
