### PR TITLE
✨ Use node-archiver to create zips

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -74,15 +74,6 @@ themes = {
                 }
             })
             .then(function () {
-                return storageAdapter.exists(config.paths.themePath + '/' + zip.name);
-            })
-            .then(function (zipExists) {
-                // delete existing theme zip
-                if (zipExists) {
-                    return storageAdapter.delete(zip.name, config.paths.themePath);
-                }
-            })
-            .then(function () {
                 // store extracted theme
                 return storageAdapter.save({
                     name: zip.shortName,
@@ -144,7 +135,6 @@ themes = {
      */
     destroy: function destroy(options) {
         var name = options.name,
-            zipName = name + '.zip',
             theme,
             storageAdapter = storage.getStorage('themes');
 
@@ -161,9 +151,6 @@ themes = {
                 }
 
                 return storageAdapter.delete(name, config.paths.themePath);
-            })
-            .then(function () {
-                return storageAdapter.delete(zipName, config.paths.themePath);
             })
             .then(function () {
                 return config.loadThemes();

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -1,7 +1,5 @@
 var unidecode  = require('unidecode'),
     _          = require('lodash'),
-    readCSV    = require('./read-csv'),
-    removeOpenRedirectFromUrl = require('./remove-open-redirect-from-url'),
     utils,
     getRandomInt;
 
@@ -102,8 +100,9 @@ utils = {
         res.redirect(301, path);
     },
 
-    readCSV: readCSV,
-    removeOpenRedirectFromUrl: removeOpenRedirectFromUrl
+    readCSV: require('./read-csv'),
+    removeOpenRedirectFromUrl: require('./remove-open-redirect-from-url'),
+    zipFolder: require('./zip-folder')
 };
 
 module.exports = utils;

--- a/core/server/utils/zip-folder.js
+++ b/core/server/utils/zip-folder.js
@@ -1,0 +1,20 @@
+var archiver = require('archiver'),
+    fs = require('fs');
+
+module.exports = function zipFolder(folderToZip, destination, callback) {
+    var output = fs.createWriteStream(destination),
+        archive = archiver.create('zip', {});
+
+    output.on('close', function () {
+        callback(null, archive.pointer());
+    });
+
+    archive.on('error', function (err) {
+        callback(err, null);
+    });
+
+    archive.directory(folderToZip, '/');
+    archive.pipe(output);
+    archive.finalize();
+};
+

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "amperize": "0.3.0",
+    "archiver": "1.0.1",
     "bcryptjs": "2.3.0",
     "bluebird": "3.4.1",
     "body-parser": "1.15.2",


### PR DESCRIPTION
closes #7266, closes #7267
- Adds node-archiver as a dependency
- Adds new zip-folder utility
- Switch out exec 'zip' for zip folder utility
- Store generated zips in os.tmpdir
- Don't delete zips from content/themes when uploading
- Fixes path resolution for delete
