### PR TITLE
🐛 Allow .zip file upload for file import

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -277,8 +277,8 @@ ConfigManager.prototype.set = function (config) {
                 contentTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/svg+xml']
             },
             db: {
-                extensions: ['.json'],
-                contentTypes: ['application/octet-stream', 'application/json']
+                extensions: ['.json', '.zip'],
+                contentTypes: ['application/octet-stream', 'application/json', 'application/zip']
             },
             themes: {
                 extensions: ['.zip'],


### PR DESCRIPTION
closes #7277

Adds `.zip` to `extensions` and `application/zip` to `contentTypes` in config, specifically for uploads to `db`, to allow .zip-file file uploads from labs.
