### PR TITLE
Move grunt-cli to npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ git clone git://github.com/tryghost/ghost.git
 cd ghost
 ```
 
-Install grunt. No prizes here.
-
-```bash
-npm install -g grunt-cli
-```
-
 Install Ghost. If you're running locally, use [master](https://github.com/TryGhost/Ghost/tree/master). For production, use [stable](https://github.com/TryGhost/Ghost/tree/stable). :no_entry_sign::rocket::microscope:
 
 ```bash
@@ -67,13 +61,13 @@ npm install
 Build the things!
 
 ```bash
-grunt init
+npm run build
 ```
 
 Minify that shit for production?
 
 ```bash
-grunt prod
+npm run minify
 ```
 
 Start your engines.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "license": "MIT",
   "main": "./core/index",
   "scripts": {
+    "build": "grunt init",
+    "minify": "grunt prod",
     "preinstall": "node core/server/utils/npm/preinstall.js",
     "start": "node index",
     "test": "grunt validate --verbose"


### PR DESCRIPTION
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

Installing global modules is an antipattern; you can't control your versions (what happens when grunt-cli has a breaking change and you don't have a version locked down? or another project also uses global grunt-cli, but requires an old version?) and some devs are a little squeamish about installing globally anyways.

npm has a neat trick in that it'll resolve paths to locally installed modules when you use npm scripts: adding `build: "grunt build"` to scripts, for example, will first look for it in the local `node_modules` and _then_ in the globals.

So, all that said, this patch updates package.json and the README to point at a local grunt instead of gobal.
