### PR TITLE
allow windows flavor of zip mime type to be uploaded

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -278,11 +278,11 @@ ConfigManager.prototype.set = function (config) {
             },
             db: {
                 extensions: ['.json', '.zip'],
-                contentTypes: ['application/octet-stream', 'application/json', 'application/zip']
+                contentTypes: ['application/octet-stream', 'application/json', 'application/zip', 'application/x-zip-compressed']
             },
             themes: {
                 extensions: ['.zip'],
-                contentTypes: ['application/zip']
+                contentTypes: ['application/zip', 'application/x-zip-compressed']
             }
         },
         deprecatedItems: ['updateCheck', 'mail.fromaddress'],


### PR DESCRIPTION
refs #7292
- add 'application/x-zip-compressed' to allowed mime types for import
  and theme upload
