### PR TITLE
Add email validation in case of profile update

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -308,12 +308,14 @@ User = ghostBookshelf.Model.extend({
 
     /**
      * ### Edit
+     *
+     * Note: In case of login the last_login attribute gets updated.
+     *
      * @extends ghostBookshelf.Model.edit to handle returning the full object
      * **See:** [ghostBookshelf.Model.edit](base.js.html#edit)
      */
     edit: function edit(data, options) {
-        var self = this,
-            roleId;
+        var self = this;
 
         if (data.roles && data.roles.length > 1) {
             return Promise.reject(
@@ -323,6 +325,22 @@ User = ghostBookshelf.Model.extend({
 
         options = options || {};
         options.withRelated = _.union(options.withRelated, options.include);
+
+        if (data.email && data.id) {
+            return this.getByEmail(data.email, {id: data.id}).then(function then(user) {
+                if (user) {
+                    return Promise.reject(new errors.ValidationError(i18n.t('errors.models.user.userUpdateError.emailIsAlreadyInUse')));
+                }
+                return self.update.call(self, data, options);
+            });
+        } else {
+            return self.update.call(self, data, options);
+        }
+    },
+
+    update: function update(data, options) {
+        var self = this,
+            roleId;
 
         return ghostBookshelf.Model.edit.call(this, data, options).then(function then(user) {
             if (!data.roles) {
@@ -810,6 +828,9 @@ User = ghostBookshelf.Model.extend({
 
         return Users.forge(options).fetch(options).then(function then(users) {
             var userWithEmail = users.find(function findUser(user) {
+                if (options.id && parseInt(options.id) === user.get('id')) {
+                    return false;
+                }
                 return user.get('email').toLowerCase() === email.toLowerCase();
             });
             if (userWithEmail) {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -237,6 +237,7 @@
                 "userIsInactive": "The user with that email address is inactive.",
                 "incorrectPasswordAttempts": "Your password is incorrect. <br /> {remaining} attempt{s} remaining!",
                 "userUpdateError": {
+                    "emailIsAlreadyInUse": "Email is already in use",
                     "context": "Error thrown from user update during login",
                     "help": "Visit and save your profile after logging in to check for problems."
                 },


### PR DESCRIPTION
issue #7256
- add email check in edit if necessary
- edit method is refactored
- getByEmail can accept "id" option.
- add emailIsAlreadyInUse property to translations

Signed-off-by: Ádám Gólya adam.stork@gmail.com
