### PR TITLE
Fix subscriber uploads from windows

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -270,7 +270,7 @@ ConfigManager.prototype.set = function (config) {
         uploads: {
             subscribers: {
                 extensions: ['.csv'],
-                contentTypes: ['text/csv', 'application/csv']
+                contentTypes: ['text/csv', 'application/csv', 'application/octet-stream']
             },
             images: {
                 extensions: ['.jpg', '.jpeg', '.gif', '.png', '.svg', '.svgz'],


### PR DESCRIPTION
no issue
- allow 'application/octet-stream' as a valid content type for an
  uploaded subscriber csv
