### PR TITLE
Fix upgrade notification type value

### DIFF
--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -46,9 +46,10 @@ notifications = {
      *
      * ```
      *  msg = { notifications: [{
-         *      type: 'error', // this can be 'error', 'success', 'warn' and 'info'
+         *      status: 'alert', // A String. Can be 'alert' or 'notification'
+         *      type: 'error', // A String. Can be 'error', 'success', 'warn' or 'info'
          *      message: 'This is an error', // A string. Should fit in one line.
-         *      location: 'bottom', // A string where this notification should appear. can be 'bottom' or 'top'
+         *      location: '', // A String. Should be unique key to the notification, usually takes the form of "noun.verb.message", eg: "user.invite.already-invited"
          *      dismissible: true // A Boolean. Whether the notification is dismissible or not.
          *      custom: true // A Boolean. Whether the notification is a custom message intended for particular Ghost versions.
          *  }] };

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -40,10 +40,10 @@ adminControllers = {
             }
 
             var notification = {
-                type: 'upgrade',
-                location: 'settings-about-upgrade',
-                dismissible: false,
                 status: 'alert',
+                type: 'info',
+                location: 'upgrade.new-version-available',
+                dismissible: false,
                 message: i18n.t('notices.controllers.newVersionAvailable',
                                 {version: updateVersion, link: '<a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a>'})};
 

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -62,8 +62,8 @@ function createCustomNotification(message) {
     }
 
     var notification = {
+        status: 'alert',
         type: 'info',
-        location: 'top',
         custom: true,
         uuid: message.id,
         dismissible: true,

--- a/core/test/integration/api/api_notifications_spec.js
+++ b/core/test/integration/api/api_notifications_spec.js
@@ -152,8 +152,9 @@ describe('Notifications API', function () {
 
     it('can destroy a custom notification and add its uuid to seenNotifications (owner)', function (done) {
         var customNotification = {
+            status: 'alert',
             type: 'info',
-            location: 'top',
+            location: 'test.to-be-deleted',
             custom: true,
             uuid: uuid.v4(),
             dismissible: true,


### PR DESCRIPTION
refs #7305
- change the `type` property of upgrade notifications to `info` to match the standard alert types
- update usage of notification's `status` and `location` properties to better match current usage
  - the old `top` and `bottom` values for `location` are no longer relevant as the `status` property is used by the client to adjust the display accordingly. `location` is now used as the key/identifier in the client to prevent multiple alerts for the same action being displayed
