### PR TITLE
Changed formatting of run time to human readable

### DIFF
--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -5,7 +5,8 @@ var Promise = require('bluebird'),
     fs = require('fs'),
     errors = require('./errors'),
     config = require('./config'),
-    i18n   = require('./i18n');
+    i18n   = require('./i18n'),
+    moment = require('moment');
 
 /**
  * ## GhostServer
@@ -190,8 +191,7 @@ GhostServer.prototype.logStartMessages = function () {
         } else {
             console.log(
                 i18n.t('notices.httpServer.ghostWasRunningFor'),
-                Math.round(process.uptime()),
-                i18n.t('common.time.seconds')
+                moment.duration(process.uptime(), 'seconds').humanize()
             );
         }
         process.exit(0);


### PR DESCRIPTION
When Gost exits, it prints "Ghost was running for xx seconds".

In cases when it would be running for a longed period of time, this information would become hard to decipher, so here's more human readable exit message.
