### PR TITLE
🐛 fix direct blog migration and permission fixture options

### DIFF
--- a/core/server/data/migration/fixtures/update.js
+++ b/core/server/data/migration/fixtures/update.js
@@ -4,7 +4,17 @@
 // E.g. if we update to version 004, all the tasks in /004/ are executed
 
 var Promise = require('bluebird'),
-    sequence = require('../../../utils/sequence'),
+    _ = require('lodash'),
+    sequence = function sequence(tasks, modelOptions, logger) {
+        // utils/sequence.js does not offer an option to pass cloned arguments
+        return Promise.reduce(tasks, function (results, task) {
+            return task(_.cloneDeep(modelOptions), logger)
+                .then(function (result) {
+                    results.push(result);
+                    return results;
+                });
+        }, []);
+    },
     update;
 
 /**

--- a/core/server/data/migration/update.js
+++ b/core/server/data/migration/update.js
@@ -1,14 +1,23 @@
 // # Update Database
 // Handles migrating a database between two different database versions
 var Promise = require('bluebird'),
+    _ = require('lodash'),
     backup = require('./backup'),
     fixtures = require('./fixtures'),
     errors = require('../../errors'),
     i18n = require('../../i18n'),
     db = require('../../data/db'),
-    sequence = require('../../utils/sequence'),
     versioning = require('../schema').versioning,
-
+    sequence = function sequence(tasks, modelOptions, logger) {
+        // utils/sequence.js does not offer an option to pass cloned arguments
+        return Promise.reduce(tasks, function (results, task) {
+            return task(_.cloneDeep(modelOptions), logger)
+                .then(function (result) {
+                    results.push(result);
+                    return results;
+                });
+        }, []);
+    },
     updateDatabaseSchema,
     migrateToDatabaseVersion,
     execute, logger, isDatabaseOutOfDate;

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -16,7 +16,6 @@ var express = require('express'),
     models = require('./models'),
     permissions = require('./permissions'),
     apps = require('./apps'),
-    sitemap = require('./data/xml/sitemap'),
     xmlrpc = require('./data/xml/xmlrpc'),
     slack = require('./data/slack'),
     GhostServer = require('./ghost-server'),
@@ -86,6 +85,10 @@ function init(options) {
                     }).then(function () {
                         config.maintenance.enabled = maintenanceState;
                     }).catch(function (err) {
+                        if (!err) {
+                            return;
+                        }
+
                         errors.logErrorAndExit(err, err.context, err.help);
                     });
                 } else if (response.error) {
@@ -115,8 +118,6 @@ function init(options) {
             initDbHashAndFirstRun(),
             // Initialize apps
             apps.init(),
-            // Initialize sitemaps
-            sitemap.init(),
             // Initialize xmrpc ping
             xmlrpc.listen(),
             // Initialize slack ping

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -11,7 +11,6 @@ var should = require('should'),
     api = require(config.paths.corePath + '/server/api'),
     apps = require(config.paths.corePath + '/server/apps'),
     i18n = require(config.paths.corePath + '/server/i18n'),
-    sitemap = require(config.paths.corePath + '/server/data/xml/sitemap'),
     xmlrpc = require(config.paths.corePath + '/server/data/xml/xmlrpc'),
     slack = require(config.paths.corePath + '/server/data/slack'),
     scheduling = require(config.paths.corePath + '/server/scheduling'),
@@ -37,7 +36,6 @@ describe('server bootstrap', function () {
         sandbox.stub(apps, 'init').returns(Promise.resolve());
         sandbox.stub(slack, 'listen').returns(Promise.resolve());
         sandbox.stub(xmlrpc, 'listen').returns(Promise.resolve());
-        sandbox.stub(sitemap, 'init').returns(Promise.resolve());
         sandbox.stub(scheduling, 'init').returns(Promise.resolve());
 
         resetMiddlewareStub = bootstrap.__set__('middleware', middlewareStub);


### PR DESCRIPTION
This PR contains two fixes:
1. direct blog migration (see #7297)
2. change permission fixture options for migration scripts (see #7317)
### TODO
- [x] think about if we need a test
- [x] tidy up
- [x] upgrade from 0.7 to 0.10
- [x] upgrade from 0.8 to 0.10
- [x] upgrade from 0.9 to 0.10
