### PR TITLE
🐛  fix 006 transform dates for sqlite server offset 0

### DIFF
--- a/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
+++ b/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
@@ -38,7 +38,8 @@ module.exports = function transformDatesIntoUTC(options, logger) {
 
     return sequence([
         function databaseCheck() {
-            if (ServerTimezoneOffset === 0) {
+            // we have to change the sqlite format, because it stores dates as integer
+            if (ServerTimezoneOffset === 0 && config.database.client !== 'sqlite3') {
                 return Promise.reject(new Error('skip'));
             }
 

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -984,8 +984,21 @@ describe('Fixtures', function () {
                             });
                         });
 
-                        it('server offset is 0', function (done) {
+                        it('server offset is 0 and mysql', function (done) {
                             migrationsSettingsValue = '{}';
+                            configUtils.config.database.client = 'mysql';
+
+                            updateClient({}, loggerStub)
+                                .then(function () {
+                                    loggerStub.warn.called.should.be.true();
+                                    done();
+                                })
+                                .catch(done);
+                        });
+
+                        it('server offset is 0 and postgresql', function (done) {
+                            migrationsSettingsValue = '{}';
+                            configUtils.config.database.client = 'pg';
 
                             updateClient({}, loggerStub)
                                 .then(function () {
@@ -1054,6 +1067,25 @@ describe('Fixtures', function () {
                             });
 
                             sandbox.stub(api.settings, 'updateSettingsCache').returns(Promise.resolve({}));
+                        });
+
+                        it('server offset is 0 and sqlite', function (done) {
+                            serverTimezoneOffset = 0;
+                            createdAt = moment(1464798678537).toDate();
+                            configUtils.config.database.client = 'sqlite3';
+
+                            moment(createdAt).format('YYYY-MM-DD HH:mm:ss').should.eql('2016-06-01 16:31:18');
+
+                            updateClient({}, loggerStub)
+                                .then(function () {
+                                    _.each(newModels, function (model) {
+                                        moment(model.get('created_at')).format('YYYY-MM-DD HH:mm:ss').should.eql('2016-06-01 16:31:18');
+                                    });
+
+                                    migrationsSettingsWasUpdated.should.eql(true);
+                                    done();
+                                })
+                                .catch(done);
                         });
 
                         it('sqlite: no UTC update, only format', function (done) {


### PR DESCRIPTION
refs #7192 

This is the first fix to the related issue.
The migration script for transforming dates missed one case: if your server timezone offset is 0 and you are using sqlite, then the migration was skipped. But for sqlite we need to update the date format in the database (from date integer to YYYY-MM-DD HH:mm:ss).
With this PR we don't skip this case.

I will create another PR, which cares about the people who were affected by this use case. 
- tested: setup a blog with 0.8 and sqlite, change server TZ to UTC, ensure dates are in correct format
