### PR TITLE
🐛 re-run migration for sqlite/pg

### DIFF
--- a/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
+++ b/core/server/data/migration/fixtures/006/01-transform-dates-into-utc.js
@@ -39,18 +39,16 @@ module.exports = function transformDatesIntoUTC(options, logger) {
     return sequence([
         function databaseCheck() {
             // we have to change the sqlite format, because it stores dates as integer
-            if (ServerTimezoneOffset === 0 && config.database.client !== 'sqlite3') {
+            if (ServerTimezoneOffset === 0 && config.database.client === 'mysql') {
                 return Promise.reject(new Error('skip'));
             }
 
             if (config.database.isPostgreSQL()) {
-                return Promise.reject(new Error('skip'));
-            }
-
-            if (config.database.client === 'sqlite3') {
                 _private.noOffset = true;
-            } else {
+            } else if (config.database.client === 'mysql') {
                 _private.noOffset = false;
+            } else if (config.database.client === 'sqlite3') {
+                _private.noOffset = true;
             }
 
             logger.info(messagePrefix + '(could take a while)...');

--- a/core/server/data/migration/fixtures/008/01-fix-sqlite-format.js
+++ b/core/server/data/migration/fixtures/008/01-fix-sqlite-format.js
@@ -1,0 +1,53 @@
+var config = require('../../../../config'),
+    models = require(config.paths.corePath + '/server/models'),
+    transfomDatesIntoUTC = require(config.paths.corePath + '/server/data/migration/fixtures/006/01-transform-dates-into-utc'),
+    Promise = require('bluebird'),
+    messagePrefix = 'Fix sqlite format: ',
+    _private = {};
+
+_private.getTZOffsetMax = function getTZOffsetMax() {
+    return Math.max(Math.abs(new Date('2015-07-01').getTimezoneOffset()), Math.abs(new Date('2015-01-01').getTimezoneOffset()));
+};
+
+/**
+ * this migration script is a very special one for people who run their server in UTC and use sqlite3 or run their server in any TZ and use postgres
+ * 006/01-transform-dates-into-utc had a bug for this case, see what happen because this bug https://github.com/TryGhost/Ghost/issues/7192
+ */
+module.exports = function fixSqliteFormat(options, logger) {
+    var ServerTimezoneOffset = _private.getTZOffsetMax(),
+        settingsMigrations, settingsKey = '006/01';
+
+    // CASE: skip this script when using mysql
+    if (config.database.client === 'mysql') {
+        logger.warn(messagePrefix + 'This script only runs, when using sqlite/postgres as database.');
+        return Promise.resolve();
+    }
+
+    // CASE: skip this script if using sqlite, but server is not UTC
+    if (ServerTimezoneOffset !== 0 && config.database.client === 'sqlite3') {
+        logger.warn(messagePrefix + 'This script only runs, when your server runs in UTC and you are using sqlite.');
+        return Promise.resolve();
+    }
+
+    return models.Settings.findOne({key: 'migrations'}, options)
+        .then(function removeMigrationSettings(result) {
+            try {
+                settingsMigrations = JSON.parse(result.attributes.value) || {};
+            } catch (err) {
+                return Promise.reject(err);
+            }
+
+            // CASE: migration ran already
+            if (settingsMigrations.hasOwnProperty(settingsKey)) {
+                delete settingsMigrations[settingsKey];
+
+                return models.Settings.edit({
+                    key: 'migrations',
+                    value: JSON.stringify(settingsMigrations)
+                }, options);
+            }
+        })
+        .then(function () {
+            return transfomDatesIntoUTC(options, logger);
+        });
+};

--- a/core/server/data/migration/fixtures/008/01-fix-sqlite-format.js
+++ b/core/server/data/migration/fixtures/008/01-fix-sqlite-format.js
@@ -1,4 +1,5 @@
 var config = require('../../../../config'),
+    _ = require('lodash'),
     models = require(config.paths.corePath + '/server/models'),
     transfomDatesIntoUTC = require(config.paths.corePath + '/server/data/migration/fixtures/006/01-transform-dates-into-utc'),
     Promise = require('bluebird'),
@@ -9,25 +10,8 @@ _private.getTZOffsetMax = function getTZOffsetMax() {
     return Math.max(Math.abs(new Date('2015-07-01').getTimezoneOffset()), Math.abs(new Date('2015-01-01').getTimezoneOffset()));
 };
 
-/**
- * this migration script is a very special one for people who run their server in UTC and use sqlite3 or run their server in any TZ and use postgres
- * 006/01-transform-dates-into-utc had a bug for this case, see what happen because this bug https://github.com/TryGhost/Ghost/issues/7192
- */
-module.exports = function fixSqliteFormat(options, logger) {
-    var ServerTimezoneOffset = _private.getTZOffsetMax(),
-        settingsMigrations, settingsKey = '006/01';
-
-    // CASE: skip this script when using mysql
-    if (config.database.client === 'mysql') {
-        logger.warn(messagePrefix + 'This script only runs, when using sqlite/postgres as database.');
-        return Promise.resolve();
-    }
-
-    // CASE: skip this script if using sqlite, but server is not UTC
-    if (ServerTimezoneOffset !== 0 && config.database.client === 'sqlite3') {
-        logger.warn(messagePrefix + 'This script only runs, when your server runs in UTC and you are using sqlite.');
-        return Promise.resolve();
-    }
+_private.rerunDateMigration = function rerunDateMigration(options, logger) {
+    var settingsMigrations, settingsKey = '006/01';
 
     return models.Settings.findOne({key: 'migrations'}, options)
         .then(function removeMigrationSettings(result) {
@@ -49,5 +33,48 @@ module.exports = function fixSqliteFormat(options, logger) {
         })
         .then(function () {
             return transfomDatesIntoUTC(options, logger);
+        });
+};
+
+/**
+ * this migration script is a very special one for people who run their server in UTC and use sqlite3 or run their server in any TZ and use postgres
+ * 006/01-transform-dates-into-utc had a bug for this case, see what happen because this bug https://github.com/TryGhost/Ghost/issues/7192
+ */
+module.exports = function fixSqliteFormat(options, logger) {
+    var ServerTimezoneOffset = _private.getTZOffsetMax();
+
+    // CASE: skip this script when using mysql
+    if (config.database.client === 'mysql') {
+        logger.warn(messagePrefix + 'This script only runs, when using sqlite/postgres as database.');
+        return Promise.resolve();
+    }
+
+    // CASE: skip this script if using sqlite, but server is not UTC
+    if (ServerTimezoneOffset !== 0 && config.database.client === 'sqlite3') {
+        logger.warn(messagePrefix + 'This script only runs, when your server runs in UTC and you are using sqlite.');
+        return Promise.resolve();
+    }
+
+    // CASE: database is postgres, server is in ANY TZ, run 006/001 again
+    // we can't check the format for PG somehow, so we just run the migration again
+    if (config.database.isPostgreSQL()) {
+        return _private.rerunDateMigration(options, logger);
+    }
+
+    // CASE: sqlite3 and server is UTC, we check if the date migration was already running
+    return options.transacting.raw('select created_at from users')
+        .then(function (users) {
+            // safety measure
+            if (!users || !users.length) {
+                return;
+            }
+
+            // CASE: if type is string and sqlite, then it already has the correct date format
+            if (!_.isNumber(users[0].created_at)) {
+                logger.warn(messagePrefix + 'Your dates are in correct format.');
+                return;
+            }
+
+            return _private.rerunDateMigration(options, logger);
         });
 };

--- a/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
+++ b/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
@@ -3,12 +3,8 @@ var config = require('../../../../config'),
     models = require(config.paths.corePath + '/server/models'),
     transfomDatesIntoUTC = require(config.paths.corePath + '/server/data/migration/fixtures/006/01-transform-dates-into-utc'),
     Promise = require('bluebird'),
-    messagePrefix = 'Fix sqlite format: ',
+    messagePrefix = 'Fix sqlite/pg format: ',
     _private = {};
-
-_private.getTZOffsetMax = function getTZOffsetMax() {
-    return Math.max(Math.abs(new Date('2015-07-01').getTimezoneOffset()), Math.abs(new Date('2015-01-01').getTimezoneOffset()));
-};
 
 _private.rerunDateMigration = function rerunDateMigration(options, logger) {
     var settingsMigrations, settingsKey = '006/01';
@@ -41,17 +37,9 @@ _private.rerunDateMigration = function rerunDateMigration(options, logger) {
  * 006/01-transform-dates-into-utc had a bug for this case, see what happen because of this bug https://github.com/TryGhost/Ghost/issues/7192
  */
 module.exports = function fixSqliteFormat(options, logger) {
-    var ServerTimezoneOffset = _private.getTZOffsetMax();
-
     // CASE: skip this script when using mysql
     if (config.database.client === 'mysql') {
         logger.warn(messagePrefix + 'This script only runs, when using sqlite/postgres as database.');
-        return Promise.resolve();
-    }
-
-    // CASE: skip this script if using sqlite, but server is not UTC
-    if (ServerTimezoneOffset !== 0 && config.database.client === 'sqlite3') {
-        logger.warn(messagePrefix + 'This script only runs, when your server runs in UTC and you are using sqlite.');
         return Promise.resolve();
     }
 

--- a/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
+++ b/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
@@ -38,7 +38,7 @@ _private.rerunDateMigration = function rerunDateMigration(options, logger) {
 
 /**
  * this migration script is a very special one for people who run their server in UTC and use sqlite3 or run their server in any TZ and use postgres
- * 006/01-transform-dates-into-utc had a bug for this case, see what happen because this bug https://github.com/TryGhost/Ghost/issues/7192
+ * 006/01-transform-dates-into-utc had a bug for this case, see what happen because of this bug https://github.com/TryGhost/Ghost/issues/7192
  */
 module.exports = function fixSqliteFormat(options, logger) {
     var ServerTimezoneOffset = _private.getTZOffsetMax();

--- a/core/server/data/migration/fixtures/008/index.js
+++ b/core/server/data/migration/fixtures/008/index.js
@@ -1,3 +1,3 @@
 module.exports = [
-    require('./01-fix-sqlite-format')
+    require('./01-fix-sqlite-pg-format')
 ];

--- a/core/server/data/migration/fixtures/008/index.js
+++ b/core/server/data/migration/fixtures/008/index.js
@@ -1,0 +1,3 @@
+module.exports = [
+    require('./01-fix-sqlite-format')
+];

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -1377,8 +1377,9 @@ describe('Fixtures', function () {
 
                         it('skip sqlite and non UTC server timezone', function (done) {
                             configUtils.config.database.client = 'sqlite3';
+                            rawStub = sandbox.stub().returns(Promise.resolve([{created_at: moment().format('YYYY-MM-DD HH:mm:ss')}]));
 
-                            updateClient({}, loggerStub)
+                            updateClient({transacting: {raw:rawStub}}, loggerStub)
                                 .then(function () {
                                     loggerStub.warn.called.should.be.true();
                                     done();

--- a/core/test/unit/migration_fixture_spec.js
+++ b/core/test/unit/migration_fixture_spec.js
@@ -1273,8 +1273,8 @@ describe('Fixtures', function () {
                     fixtures008.should.be.an.Array().with.lengthOf(1);
                 });
 
-                describe('01-fix-sqlite-format', function () {
-                    var updateClient = rewire('../../server/data/migration/fixtures/008/01-fix-sqlite-format'),
+                describe('01-fix-sqlite-pg-format', function () {
+                    var updateClient = rewire('../../server/data/migration/fixtures/008/01-fix-sqlite-pg-format'),
                         serverTimezoneOffset = 60,
                         transfomDatesIntoUTCStub, rawStub, isPostgres = false, isPostgreSQLWasCalled = false;
 


### PR DESCRIPTION
closes #7192

With this PR people who were affected from non formatted sqlite/postgres dates, this PR will fix when they update to `0.11`.

Postgres: we have used ms format before (YYYY-MM-YY HH:mm:ss.ZZZ), but we need YYYY-MM-DD HH:mm:ss.
- add 008 migration
- added script to re-run 006/01

I decided against a hack to re-run the migration and instead i added a new migration script `008/01`. The reasons:
1. the code is too complex for a hack
2. i don't wanne touch this logic again and move the hack into a migration file
3. migration of 006/01 can take very long, thats why we treat it as real migration file
### TODO
- [x] do one manual test (change tz to utc, build db 0.8, checkout 0.9, run migration, see it skips and verify sqlite format is still integer....then run db with this branch) - tested with #7322 
- [x] tested: 0.8 ghost, server is UTC, see that migration runs 2 times, but no offset is changed at all. all dates are still the same
- [x] go over PR and check for tidy up
- [x] update postgres from ghost 0.7.0 to 0.11.0 and see that date migration ran twice. no offset happend
- [x] check format before executing 008
