### PR TITLE
🐛  Return reg. HTML on Amperize time-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
   },
   "dependencies": {
-    "amperize": "https://github.com/AileenCGN/amperize/tarball/fixed-layout-for-small-images",
+    "amperize": "https://github.com/AileenCGN/amperize/tarball/error-handling-on-timeout",
     "archiver": "1.0.1",
     "bcryptjs": "2.3.0",
     "bluebird": "3.4.1",


### PR DESCRIPTION
no issue

`{{amp_content}}` helper can handle error now, if returned from `Amperize` module. In case of on error, we return the unprocessed HTML, which will then get validated by the `Sanitize` functionality.

Todo:
- [ ] add test
- [x] produce error in amperize module on timeout
- [x] change dep for amperize
