### PR TITLE
⬆️ Updating extract-zip to bugfixed version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "downsize": "0.0.8",
     "express": "4.14.0",
     "express-hbs": "1.0.2",
-    "extract-zip": "1.5.0",
+    "extract-zip": "https://github.com/ErisDS/extract-zip/tarball/issue-30",
     "fs-extra": "0.30.0",
     "ghost-gql": "0.0.5",
     "glob": "5.0.15",


### PR DESCRIPTION
- This version has a fix for maxogden/extract-zip#30, where directories are not always identified correctly
