### PR TITLE
🛠 Make it easy to test preparing dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -701,6 +701,10 @@ var _              = require('lodash'),
         grunt.registerTask('prod', 'Build JS & templates for production',
             ['subgrunt:prod', 'uglify:prod', 'master-warn']);
 
+        grunt.registerTask('deps', 'Prepare dependencies',
+            ['shell:dedupe', 'shell:prune', 'shell:shrinkwrap']
+        );
+
         // ### Live reload
         // `grunt dev` - build assets on the fly whilst developing
         //
@@ -811,7 +815,7 @@ var _              = require('lodash'),
                     dest: '<%= paths.releaseBuild %>/'
                 });
 
-                grunt.task.run(['init', 'prod', 'clean:release',  'shell:dedupe', 'shell:prune', 'shell:shrinkwrap', 'copy:release', 'compress:release']);
+                grunt.task.run(['init', 'prod', 'clean:release', 'deps', 'copy:release', 'compress:release']);
             }
         );
     };


### PR DESCRIPTION
- as part of a release, we run npm dedupe, npm prune and npm shrinkwrap. In certain cases this can change which dependencies are used
- with this change `grunt deps` will run those 3 tasks so it's easier to test what happens
