### PR TITLE
🐛 add missing dependency lodash.orderBy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,10 @@
 // **Usage instructions:** can be found in the [Custom Tasks](#custom%20tasks) section or by running `grunt --help`.
 //
 // **Debug tip:** If you have any problems with any Grunt tasks, try running them with the `--verbose` command
-var _              = require('lodash'),
+
+// jshint unused: false
+var overrides      = require('./core/server/overrides'),
+    _              = require('lodash'),
     chalk          = require('chalk'),
     fs             = require('fs-extra'),
     path           = require('path'),

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -5,6 +5,7 @@ var moment = require('moment-timezone'),
     toString = require('lodash.tostring'),
     pickBy = require('lodash.pickby'),
     uniqBy = require('lodash.uniqby'),
+    orderBy = require('lodash.orderby'),
     omitBy = require('lodash.omitby');
 
 /**
@@ -25,3 +26,4 @@ _.toString = toString;
 _.omitBy = omitBy;
 _.uniqBy = uniqBy;
 _.pickBy = pickBy;
+_.orderBy = orderBy;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lodash": "3.10.1",
     "lodash.frompairs": "4.0.1",
     "lodash.omitby": "4.6.0",
+    "lodash.orderby": "4.6.0",
     "lodash.pickby": "4.6.0",
     "lodash.topairs": "4.3.0",
     "lodash.tostring": "4.1.4",


### PR DESCRIPTION
no issue

In the Gruntfile there is a usage of `_.orderBy`. When we downgraded to lodash 3.x again, this lodash 4.x dependency was not installed.
