### PR TITLE
🎨 do not load themes in ConfigManager

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -9,7 +9,8 @@ var Promise = require('bluebird'),
     events = require('../events'),
     storage = require('../storage'),
     settings = require('./settings'),
-    utils = require('./utils'),
+    apiUtils = require('./utils'),
+    utils = require('./../utils'),
     i18n = require('../i18n'),
     themes;
 
@@ -19,6 +20,13 @@ var Promise = require('bluebird'),
  * **See:** [API Methods](index.js.html#api%20methods)
  */
 themes = {
+    loadThemes: function () {
+        return utils.readThemes(config.paths.themePath)
+            .then(function (result) {
+                config.paths.availableThemes = result;
+            });
+    },
+
     upload: function upload(options) {
         options = options || {};
 
@@ -36,7 +44,7 @@ themes = {
             throw new errors.ValidationError(i18n.t('errors.api.themes.overrideCasper'));
         }
 
-        return utils.handlePermissions('themes', 'add')(options)
+        return apiUtils.handlePermissions('themes', 'add')(options)
             .then(function () {
                 return gscan.checkZip(zip, {keepExtractedDir: true});
             })
@@ -74,7 +82,7 @@ themes = {
                 // force reload of availableThemes
                 // right now the logic is in the ConfigManager
                 // if we create a theme collection, we don't have to read them from disk
-                return config.loadThemes();
+                return themes.loadThemes();
             })
             .then(function () {
                 // the settings endpoint is used to fetch the availableThemes
@@ -113,7 +121,7 @@ themes = {
             return Promise.reject(new errors.BadRequestError(i18n.t('errors.api.themes.invalidRequest')));
         }
 
-        return utils.handlePermissions('themes', 'read')(options)
+        return apiUtils.handlePermissions('themes', 'read')(options)
             .then(function () {
                 events.emit('theme.downloaded', themeName);
                 return storageAdapter.serve({isTheme: true, name: themeName});
@@ -129,7 +137,7 @@ themes = {
             theme,
             storageAdapter = storage.getStorage('themes');
 
-        return utils.handlePermissions('themes', 'destroy')(options)
+        return apiUtils.handlePermissions('themes', 'destroy')(options)
             .then(function () {
                 if (name === 'casper') {
                     throw new errors.ValidationError(i18n.t('errors.api.themes.destroyCasper'));
@@ -145,7 +153,7 @@ themes = {
                 return storageAdapter.delete(name, config.paths.themePath);
             })
             .then(function () {
-                return config.loadThemes();
+                return themes.loadThemes();
             })
             .then(function () {
                 return settings.updateSettingsCache();

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -10,7 +10,6 @@ var path          = require('path'),
 
     validator     = require('validator'),
     readDirectory = require('../utils/read-directory'),
-    readThemes    = require('../utils/read-themes'),
     errors        = require('../errors'),
     configUrl     = require('./url'),
     packageInfo   = require('../../../package.json'),
@@ -78,21 +77,9 @@ ConfigManager.prototype.init = function (rawConfig) {
     // just the object appropriate for this NODE_ENV
     self.set(rawConfig);
 
-    return self.loadThemes()
-        .then(function () {
-            return self.loadApps();
-        })
+    return self.loadApps()
         .then(function () {
             return self._config;
-        });
-};
-
-ConfigManager.prototype.loadThemes = function () {
-    var self = this;
-
-    return readThemes(self._config.paths.themePath)
-        .then(function (result) {
-            self._config.paths.availableThemes = result;
         });
 };
 
@@ -232,7 +219,6 @@ ConfigManager.prototype.set = function (config) {
             adminViews:       path.join(corePath, '/server/views/'),
             helperTemplates:  path.join(corePath, '/server/helpers/tpl/'),
 
-            availableThemes:  this._config.paths.availableThemes || {},
             availableApps:    this._config.paths.availableApps || {},
             clientAssets:     path.join(corePath, '/built/assets/')
         },

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -64,6 +64,8 @@ function init(options) {
     return config.load(options.config).then(function () {
         return config.checkDeprecated();
     }).then(function () {
+        return api.themes.loadThemes();
+    }).then(function () {
         models.init();
     }).then(function () {
         return versioning.getDatabaseVersion()

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -102,7 +102,8 @@ utils = {
 
     readCSV: require('./read-csv'),
     removeOpenRedirectFromUrl: require('./remove-open-redirect-from-url'),
-    zipFolder: require('./zip-folder')
+    zipFolder: require('./zip-folder'),
+    readThemes: require('./read-themes')
 };
 
 module.exports = utils;

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -110,7 +110,6 @@ describe('Config', function () {
                 'imagesRelPath',
                 'adminViews',
                 'helperTemplates',
-                'availableThemes',
                 'availableApps',
                 'clientAssets'
             );


### PR DESCRIPTION
refs #6982

We are going to replace our ConfigManager with a simple nconf setup.
This PR removes loading themes inside the ConfigManager.
To avoid a bigger refactoring, i decided to move the logic into api/themes.
When we want to get rid of having the `availableThemes` config, a lot of code needs to change. But this can be done when we start working on Themes V2.

I didn't do a lot of testing, just made the general theme operations: upload/download/delete/activate.
