### PR TITLE
🎨 do not load apps in ConfigManager

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -9,7 +9,6 @@ var path          = require('path'),
     _             = require('lodash'),
 
     validator     = require('validator'),
-    readDirectory = require('../utils/read-directory'),
     errors        = require('../errors'),
     configUrl     = require('./url'),
     packageInfo   = require('../../../package.json'),
@@ -69,27 +68,12 @@ ConfigManager.prototype.getSocket = function () {
 };
 
 ConfigManager.prototype.init = function (rawConfig) {
-    var self = this;
-
     // Cache the config.js object's environment
     // object so we can later refer to it.
     // Note: this is not the entirety of config.js,
     // just the object appropriate for this NODE_ENV
-    self.set(rawConfig);
-
-    return self.loadApps()
-        .then(function () {
-            return self._config;
-        });
-};
-
-ConfigManager.prototype.loadApps = function () {
-    var self = this;
-
-    return readDirectory(self._config.paths.appPath)
-        .then(function (result) {
-            self._config.paths.availableApps = result;
-        });
+    this.set(rawConfig);
+    return this._config;
 };
 
 /**
@@ -219,7 +203,6 @@ ConfigManager.prototype.set = function (config) {
             adminViews:       path.join(corePath, '/server/views/'),
             helperTemplates:  path.join(corePath, '/server/helpers/tpl/'),
 
-            availableApps:    this._config.paths.availableApps || {},
             clientAssets:     path.join(corePath, '/built/assets/')
         },
         maintenance: {},

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -21,6 +21,7 @@ var express = require('express'),
     GhostServer = require('./ghost-server'),
     scheduling = require('./scheduling'),
     validateThemes = require('./utils/validate-themes'),
+    readDirectory = require('./utils/read-directory'),
     dbHash;
 
 function initDbHashAndFirstRun() {
@@ -63,6 +64,11 @@ function init(options) {
     // Load our config.js file from the local file system.
     return config.load(options.config).then(function () {
         return config.checkDeprecated();
+    }).then(function loadApps() {
+        return readDirectory(config.paths.appPath)
+            .then(function (result) {
+                config.paths.availableApps = result;
+            });
     }).then(function () {
         return api.themes.loadThemes();
     }).then(function () {

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -110,7 +110,6 @@ describe('Config', function () {
                 'imagesRelPath',
                 'adminViews',
                 'helperTemplates',
-                'availableApps',
                 'clientAssets'
             );
         });


### PR DESCRIPTION
refs #6982

Do not load apps in ConfigManager. This is simple source out. 
In future thinking we can improve how we load and manage apps, but for now we want to replace the ConfigManager and that's why we need to source out some of the logical pieces. The easiest solution was to put it into the bootstrap process, because we need to refactor the bootstrap file anyway.
