### PR TITLE
🎨 source out url utils from ConfigManager

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -7,6 +7,7 @@
 var _              = require('lodash'),
     Promise        = require('bluebird'),
     config         = require('../config'),
+    utils          = require('../utils'),
     configuration  = require('./configuration'),
     db             = require('./db'),
     mail           = require('./mail'),
@@ -108,7 +109,7 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
  * @return {String} Resolves to header string
  */
 locationHeader = function locationHeader(req, result) {
-    var apiRoot = config.urlFor('api'),
+    var apiRoot = utils.url.urlFor('api'),
         location,
         newObject;
 

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -82,7 +82,7 @@ privateBlogging = {
             if (isVerified) {
                 return next();
             } else {
-                url = config.urlFor({relativeUrl: privateRoute});
+                url = utils.url.urlFor({relativeUrl: privateRoute});
                 url += req.url === '/' ? '' : '?r=' + encodeURIComponent(req.url);
                 return res.redirect(url);
             }
@@ -92,7 +92,7 @@ privateBlogging = {
     // This is here so a call to /private/ after a session is verified will redirect to home;
     isPrivateSessionAuth: function isPrivateSessionAuth(req, res, next) {
         if (!res.isPrivateBlog) {
-            return res.redirect(config.urlFor('home', true));
+            return res.redirect(utils.url.urlFor('home', true));
         }
 
         var hash = req.session.token || '',
@@ -101,7 +101,7 @@ privateBlogging = {
         return verifySessionHash(salt, hash).then(function then(isVerified) {
             if (isVerified) {
                 // redirect to home if user is already authenticated
-                return res.redirect(config.urlFor('home', true));
+                return res.redirect(utils.url.urlFor('home', true));
             } else {
                 return next();
             }
@@ -127,7 +127,7 @@ privateBlogging = {
                 req.session.token = hasher.digest('hex');
                 req.session.salt = salt;
 
-                return res.redirect(config.urlFor({relativeUrl: decodeURIComponent(forward)}));
+                return res.redirect(utils.url.urlFor({relativeUrl: decodeURIComponent(forward)}));
             } else {
                 res.error = {
                     message: i18n.t('errors.middleware.privateblogging.wrongPassword')

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -10,7 +10,6 @@ var path          = require('path'),
 
     validator     = require('validator'),
     errors        = require('../errors'),
-    configUrl     = require('./url'),
     packageInfo   = require('../../../package.json'),
     i18n          = require('../i18n'),
     appRoot       = path.resolve(__dirname, '../../../'),
@@ -25,13 +24,6 @@ function ConfigManager(config) {
      * @type {Object}
      */
     this._config = {};
-
-    // Allow other modules to be externally accessible.
-    this.urlJoin = configUrl.urlJoin;
-    this.urlFor = configUrl.urlFor;
-    this.urlPathForPost = configUrl.urlPathForPost;
-    this.apiUrl = configUrl.apiUrl;
-    this.getBaseUrl = configUrl.getBaseUrl;
 
     // If we're given an initial config object then we can set it.
     if (config && _.isObject(config)) {
@@ -263,11 +255,6 @@ ConfigManager.prototype.set = function (config) {
             publishAPostBySchedulerToleranceInMinutes: 2
         }
     });
-
-    // Also pass config object to
-    // configUrl object to maintain
-    // clean dependency tree
-    configUrl.setConfig(this._config);
 
     // For now we're going to copy the current state of this._config
     // so it's directly accessible on the instance.

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -6,6 +6,7 @@
 
 var api         = require('../../api'),
     config      = require('../../config'),
+    utils       = require('../../utils'),
     filters     = require('../../filters'),
     templates   = require('./templates'),
     handleError = require('./error'),
@@ -48,7 +49,7 @@ frontendControllers = {
             }
 
             if (post.status === 'published') {
-                return res.redirect(301, config.urlFor('post', {post: post}));
+                return res.redirect(301, utils.url.urlFor('post', {post: post}));
             }
 
             setRequestIsSecure(req, post);

--- a/core/server/data/meta/amp_url.js
+++ b/core/server/data/meta/amp_url.js
@@ -1,4 +1,4 @@
-var config = require('../../config'),
+var utils  = require('../../utils'),
     getUrl = require('./url'),
     _      = require('lodash');
 
@@ -6,7 +6,7 @@ function getAmplUrl(data) {
     var context = data.context ? data.context : null;
 
     if (_.includes(context, 'post') && !_.includes(context, 'amp')) {
-        return config.urlJoin(config.getBaseUrl(false),
+        return utils.url.urlJoin(utils.url.getBaseUrl(false),
             getUrl(data, false)) + 'amp/';
     }
     return null;

--- a/core/server/data/meta/author_image.js
+++ b/core/server/data/meta/author_image.js
@@ -1,4 +1,4 @@
-var config           = require('../../config'),
+var utils            = require('../../utils'),
     getContextObject = require('./context_object.js'),
     _                = require('lodash');
 
@@ -7,7 +7,7 @@ function getAuthorImage(data, absolute) {
         contextObject = getContextObject(data, context);
 
     if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.image) {
-        return config.urlFor('image', {image: contextObject.author.image}, absolute);
+        return utils.url.urlFor('image', {image: contextObject.author.image}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -1,4 +1,4 @@
-var config = require('../../config');
+var utils            = require('../../utils');
 
 function getAuthorUrl(data, absolute) {
     var context = data.context ? data.context[0] : null;
@@ -6,10 +6,10 @@ function getAuthorUrl(data, absolute) {
     context = context === 'amp' ? 'post' : context;
 
     if (data.author) {
-        return config.urlFor('author', {author: data.author}, absolute);
+        return utils.url.urlFor('author', {author: data.author}, absolute);
     }
     if (data[context] && data[context].author) {
-        return config.urlFor('author', {author: data[context].author}, absolute);
+        return utils.url.urlFor('author', {author: data[context].author}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/canonical_url.js
+++ b/core/server/data/meta/canonical_url.js
@@ -1,8 +1,8 @@
-var config = require('../../config'),
+var utils  = require('../../utils'),
     getUrl = require('./url');
 
 function getCanonicalUrl(data) {
-    var url = config.urlJoin(config.getBaseUrl(false),
+    var url = utils.url.urlJoin(utils.url.getBaseUrl(false),
         getUrl(data, false));
 
     if (url.indexOf('/amp/')) {

--- a/core/server/data/meta/cover_image.js
+++ b/core/server/data/meta/cover_image.js
@@ -1,4 +1,4 @@
-var config           = require('../../config'),
+var utils            = require('../../utils'),
     getContextObject = require('./context_object.js'),
     _                = require('lodash');
 
@@ -8,11 +8,11 @@ function getCoverImage(data) {
 
     if (_.includes(context, 'home') || _.includes(context, 'author')) {
         if (contextObject.cover) {
-            return config.urlFor('image', {image: contextObject.cover}, true);
+            return utils.url.urlFor('image', {image: contextObject.cover}, true);
         }
     } else {
         if (contextObject.image) {
-            return config.urlFor('image', {image: contextObject.image}, true);
+            return utils.url.urlFor('image', {image: contextObject.image}, true);
         }
     }
     return null;

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     Promise = require('bluebird'),
     config = require('../../config'),
+    utils = require('../../utils'),
     getUrl = require('./url'),
     getImageDimensions = require('./image-dimensions'),
     getCanonicalUrl = require('./canonical_url'),
@@ -50,7 +51,7 @@ function getMetaData(data, root) {
 
     metaData.blog.logo = {};
     metaData.blog.logo.url = config.theme.logo ?
-        config.urlFor('image', {image: config.theme.logo}, true) : config.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true);
+        utils.url.urlFor('image', {image: config.theme.logo}, true) : utils.url.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true);
 
     // TODO: cleanup these if statements
     if (data.post && data.post.html) {

--- a/core/server/data/meta/paginated_url.js
+++ b/core/server/data/meta/paginated_url.js
@@ -1,5 +1,6 @@
 var _      = require('lodash'),
-    config = require('../../config');
+    config = require('../../config'),
+    utils = require('../../utils');
 
 function getPaginatedUrl(page, data, absolute) {
     // If we don't have enough information, return null right away
@@ -29,7 +30,7 @@ function getPaginatedUrl(page, data, absolute) {
     // baseUrl can be undefined, if there was nothing preceding the pagePath (e.g. first page of the index channel)
     newRelativeUrl = baseUrl ? baseUrl + newRelativeUrl : newRelativeUrl;
 
-    return config.urlFor({relativeUrl:  newRelativeUrl, secure: data.secure}, absolute);
+    return utils.url.urlFor({relativeUrl:  newRelativeUrl, secure: data.secure}, absolute);
 }
 
 module.exports = getPaginatedUrl;

--- a/core/server/data/meta/rss_url.js
+++ b/core/server/data/meta/rss_url.js
@@ -1,7 +1,7 @@
-var config = require('../../config');
+var utils = require('../../utils');
 
 function getRssUrl(data, absolute) {
-    return config.urlFor('rss', {secure: data.secure}, absolute);
+    return utils.url.urlFor('rss', {secure: data.secure}, absolute);
 }
 
 module.exports = getRssUrl;

--- a/core/server/data/meta/url.js
+++ b/core/server/data/meta/url.js
@@ -1,5 +1,5 @@
 var schema = require('../schema').checks,
-    config = require('../../config');
+    utils = require('../../utils');
 
 // This cleans the url from any `/amp` postfixes, so we'll never
 // output a url with `/amp` in the end, except for the needed `amphtml`
@@ -13,23 +13,23 @@ function sanitizeAmpUrl(url) {
 
 function getUrl(data, absolute) {
     if (schema.isPost(data)) {
-        return config.urlFor('post', {post: data, secure: data.secure}, absolute);
+        return utils.url.urlFor('post', {post: data, secure: data.secure}, absolute);
     }
 
     if (schema.isTag(data)) {
-        return config.urlFor('tag', {tag: data, secure: data.secure}, absolute);
+        return utils.url.urlFor('tag', {tag: data, secure: data.secure}, absolute);
     }
 
     if (schema.isUser(data)) {
-        return config.urlFor('author', {author: data, secure: data.secure}, absolute);
+        return utils.url.urlFor('author', {author: data, secure: data.secure}, absolute);
     }
 
     if (schema.isNav(data)) {
-        return config.urlFor('nav', {nav: data, secure: data.secure}, absolute);
+        return utils.url.urlFor('nav', {nav: data, secure: data.secure}, absolute);
     }
 
     // sanitize any trailing `/amp` in the url
-    return sanitizeAmpUrl(config.urlFor(data, {}, absolute));
+    return sanitizeAmpUrl(utils.url.urlFor(data, {}, absolute));
 }
 
 module.exports = getUrl;

--- a/core/server/data/slack/index.js
+++ b/core/server/data/slack/index.js
@@ -2,7 +2,7 @@ var https           = require('https'),
     errors          = require('../../errors'),
     url             = require('url'),
     Promise         = require('bluebird'),
-    config          = require('../../config'),
+    utils           = require('../../utils'),
     events          = require('../../events'),
     api             = require('../../api/settings'),
     i18n            = require('../../i18n'),
@@ -47,7 +47,7 @@ function ping(post) {
 
     // If this is a post, we want to send the link of the post
     if (schema.isPost(post)) {
-        message = config.urlFor('post', {post: post}, true);
+        message = utils.url.urlFor('post', {post: post}, true);
     } else {
         message = post.message;
     }
@@ -72,7 +72,7 @@ function ping(post) {
             slackData = {
                 text: message,
                 unfurl_links: true,
-                icon_url: config.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true),
+                icon_url: utils.url.urlFor({relativeUrl: '/ghost/img/ghosticon.jpg'}, {}, true),
                 username: 'Ghost'
             };
 

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -3,6 +3,7 @@ var _           = require('lodash'),
     downsize    = require('downsize'),
     RSS         = require('rss'),
     config      = require('../../../config'),
+    utils       = require('../../../utils'),
     errors      = require('../../../errors'),
     filters     = require('../../../filters'),
     processUrls = require('../../../utils/make-absolute-urls'),
@@ -92,7 +93,7 @@ generateFeed = function generateFeed(data) {
     });
 
     data.results.posts.forEach(function forEach(post) {
-        var itemUrl = config.urlFor('post', {post: post, secure: data.secure}, true),
+        var itemUrl = utils.url.urlFor('post', {post: post, secure: data.secure}, true),
             htmlContent = processUrls(post.html, data.siteUrl, itemUrl),
             item = {
                 title: post.title,
@@ -107,7 +108,7 @@ generateFeed = function generateFeed(data) {
             imageUrl;
 
         if (post.image) {
-            imageUrl = config.urlFor('image', {image: post.image, secure: data.secure}, true);
+            imageUrl = utils.url.urlFor('image', {image: post.image, secure: data.secure}, true);
 
             // Add a media content tag
             item.custom_elements.push({
@@ -162,8 +163,8 @@ generate = function generate(req, res, next) {
         }
 
         data.version = res.locals.safeVersion;
-        data.siteUrl = config.urlFor('home', {secure: req.secure}, true);
-        data.feedUrl = config.urlFor({relativeUrl: baseUrl, secure: req.secure}, true);
+        data.siteUrl = utils.url.urlFor('home', {secure: req.secure}, true);
+        data.feedUrl = utils.url.urlFor({relativeUrl: baseUrl, secure: req.secure}, true);
         data.secure = req.secure;
 
         return getFeedXml(req.originalUrl, data).then(function then(feedXml) {

--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -1,9 +1,9 @@
 var _         = require('lodash'),
     xml       = require('xml'),
     moment    = require('moment'),
-    config    = require('../../../config'),
+    utils     = require('../../../utils'),
     events    = require('../../../events'),
-    utils     = require('./utils'),
+    localUtils  = require('./utils'),
     Promise   = require('bluebird'),
     path      = require('path'),
     CHANGE_FREQ = 'weekly',
@@ -92,7 +92,7 @@ _.extend(BaseSiteMapGenerator.prototype, {
             };
 
         // Return the xml
-        return utils.getDeclarations() + xml(data);
+        return localUtils.getDeclarations() + xml(data);
     },
 
     updateXmlFromNodes: function (urlElements) {
@@ -133,11 +133,11 @@ _.extend(BaseSiteMapGenerator.prototype, {
     },
 
     getUrlForDatum: function () {
-        return config.urlFor('home', true);
+        return utils.url.urlFor('home', true);
     },
 
     getUrlForImage: function (image) {
-        return config.urlFor('image', {image: image}, true);
+        return utils.url.urlFor('image', {image: image}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/index-generator.js
+++ b/core/server/data/xml/sitemap/index-generator.js
@@ -1,8 +1,8 @@
 var _       = require('lodash'),
     xml     = require('xml'),
     moment  = require('moment'),
-    config  = require('../../../config'),
-    utils   = require('./utils'),
+    utils  = require('../../../utils'),
+    localUtils   = require('./utils'),
     RESOURCES,
     XMLNS_DECLS;
 
@@ -28,14 +28,14 @@ _.extend(SiteMapIndexGenerator.prototype, {
             };
 
         // Return the xml
-        return utils.getDeclarations() + xml(data);
+        return localUtils.getDeclarations() + xml(data);
     },
 
     generateSiteMapUrlElements: function () {
         var self = this;
 
         return _.map(RESOURCES, function (resourceType) {
-            var url = config.urlFor({
+            var url = utils.url.urlFor({
                     relativeUrl: '/sitemap-' + resourceType + '.xml'
                 }, true),
                 lastModified = self[resourceType].lastModified;

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    config = require('../../../config'),
+    utils  = require('../../../utils'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -46,10 +46,10 @@ _.extend(PageMapGenerator.prototype, {
 
     getUrlForDatum: function (post) {
         if (post.id === 0 && !_.isEmpty(post.name)) {
-            return config.urlFor(post.name, true);
+            return utils.url.urlFor(post.name, true);
         }
 
-        return config.urlFor('post', {post: post}, true);
+        return utils.url.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    config = require('../../../config'),
+    utils  = require('../../../utils'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -41,7 +41,7 @@ _.extend(PostMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (post) {
-        return config.urlFor('post', {post: post}, true);
+        return utils.url.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    config = require('../../../config'),
+    utils  = require('../../../utils'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -38,7 +38,7 @@ _.extend(TagsMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (tag) {
-        return config.urlFor('tag', {tag: tag}, true);
+        return utils.url.urlFor('tag', {tag: tag}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    config = require('../../../config'),
+    utils  = require('../../../utils'),
     validator        = require('validator'),
     BaseMapGenerator = require('./base-generator'),
     // @TODO: figure out a way to get rid of this
@@ -42,7 +42,7 @@ _.extend(UserMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (user) {
-        return config.urlFor('author', {author: user}, true);
+        return utils.url.urlFor('author', {author: user}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/utils.js
+++ b/core/server/data/xml/sitemap/utils.js
@@ -1,13 +1,13 @@
-var config = require('../../../config'),
-    utils;
+var utils = require('../../../utils'),
+    sitemapsUtils;
 
-utils = {
+sitemapsUtils = {
     getDeclarations: function () {
-        var baseUrl = config.urlFor('sitemap_xsl', true);
+        var baseUrl = utils.url.urlFor('sitemap_xsl', true);
         baseUrl = baseUrl.replace(/^(http:|https:)/, '');
         return '<?xml version="1.0" encoding="UTF-8"?>' +
             '<?xml-stylesheet type="text/xsl" href="' + baseUrl + '"?>';
     }
 };
 
-module.exports = utils;
+module.exports = sitemapsUtils;

--- a/core/server/data/xml/xmlrpc.js
+++ b/core/server/data/xml/xmlrpc.js
@@ -2,6 +2,7 @@ var _               = require('lodash'),
     http            = require('http'),
     xml             = require('xml'),
     config          = require('../../config'),
+    utils           = require('../../utils'),
     errors          = require('../../errors'),
     events          = require('../../events'),
     i18n            = require('../../i18n'),
@@ -19,7 +20,7 @@ pingList = [{
 function ping(post) {
     var pingXML,
         title = post.title,
-        url = config.urlFor('post', {post: post}, true);
+        url = utils.url.urlFor('post', {post: post}, true);
 
     // Only ping when in production and not a page
     if (process.env.NODE_ENV !== 'production' || post.page || config.isPrivacyDisabled('useRpcPing')) {

--- a/core/server/helpers/author.js
+++ b/core/server/helpers/author.js
@@ -12,8 +12,8 @@
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
-    config          = require('../config'),
-    utils           = require('./utils'),
+    utils          = require('../utils'),
+    localUtils     = require('./utils'),
     author;
 
 author = function (options) {
@@ -26,8 +26,8 @@ author = function (options) {
 
     if (this.author && this.author.name) {
         if (autolink) {
-            output = utils.linkTemplate({
-                url: config.urlFor('author', {author: this.author}),
+            output = localUtils.linkTemplate({
+                url: utils.url.urlFor('author', {author: this.author}),
                 text: _.escape(this.author.name)
             });
         } else {

--- a/core/server/helpers/image.js
+++ b/core/server/helpers/image.js
@@ -4,14 +4,14 @@
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 
-var config = require('../config'),
+var utils  = require('../utils'),
     image;
 
 image = function (options) {
     var absolute = options && options.hash.absolute;
 
     if (this.image) {
-        return config.urlFor('image', {image: this.image}, absolute);
+        return utils.url.urlFor('image', {image: this.image}, absolute);
     }
 };
 

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -8,9 +8,9 @@
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
-    config          = require('../config'),
+    utils           = require('../utils'),
     labs            = require('../utils/labs'),
-    utils           = require('./utils'),
+    localUtils      = require('./utils'),
     tags;
 
 tags = function (options) {
@@ -24,7 +24,7 @@ tags = function (options) {
         limit      = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
         from       = options.hash.from ? parseInt(options.hash.from, 10) : 1,
         to         = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
-        visibility = utils.parseVisibility(options),
+        visibility = localUtils.parseVisibility(options),
         output     = '';
 
     function createTagList(tags) {
@@ -42,8 +42,8 @@ tags = function (options) {
                 }
             }
 
-            var tagOutput = autolink ? utils.linkTemplate({
-                url: config.urlFor('tag', {tag: tag}),
+            var tagOutput = autolink ? localUtils.linkTemplate({
+                url: utils.url.urlFor('tag', {tag: tag}),
                 text: _.escape(tag.name)
             }) : _.escape(tag.name);
 

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -22,6 +22,7 @@ var express = require('express'),
     scheduling = require('./scheduling'),
     validateThemes = require('./utils/validate-themes'),
     readDirectory = require('./utils/read-directory'),
+    utils = require('./utils'),
     dbHash;
 
 function initDbHashAndFirstRun() {
@@ -69,7 +70,7 @@ function init(options) {
             .then(function (result) {
                 config.paths.availableApps = result;
             });
-    }).then(function () {
+    }).then(function loadThemes() {
         return api.themes.loadThemes();
     }).then(function () {
         models.init();
@@ -157,7 +158,7 @@ function init(options) {
 
         // scheduling can trigger api requests, that's why we initialize the module after the ghost server creation
         // scheduling module can create x schedulers with different adapters
-        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.url + config.urlFor('api')}));
+        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.url + utils.url.urlFor('api')}));
     }).then(function () {
         return ghostServer;
     });

--- a/core/server/middleware/serve-shared-file.js
+++ b/core/server/middleware/serve-shared-file.js
@@ -1,7 +1,8 @@
 var crypto = require('crypto'),
     fs     = require('fs'),
     path   = require('path'),
-    config = require('../config');
+    config = require('../config'),
+    utils  = require('../utils');
 
 // ### ServeSharedFile Middleware
 // Handles requests to robots.txt and favicon.ico (and caches them)
@@ -27,7 +28,7 @@ function serveSharedFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, config.url.replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, config.apiUrl());
+                        buf = buf.toString().replace(apiRegex, utils.url.apiUrl());
                     }
                     content = {
                         headers: {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -10,6 +10,7 @@ var _              = require('lodash'),
     ghostBookshelf = require('./base'),
     events         = require('../events'),
     config         = require('../config'),
+    utils          = require('../utils'),
     baseUtils      = require('./base/utils'),
     i18n           = require('../i18n'),
     Post,
@@ -408,7 +409,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {
-            attrs.url = config.urlPathForPost(attrs);
+            attrs.url = utils.url.urlPathForPost(attrs);
         }
 
         return attrs;

--- a/core/server/scheduling/post-scheduling/index.js
+++ b/core/server/scheduling/post-scheduling/index.js
@@ -1,6 +1,6 @@
 var Promise = require('bluebird'),
     moment = require('moment'),
-    utils = require(__dirname + '/../utils'),
+    localUtils = require(__dirname + '/../utils'),
     events = require(__dirname + '/../../events'),
     errors = require(__dirname + '/../../errors'),
     models = require(__dirname + '/../../models'),
@@ -53,7 +53,7 @@ exports.init = function init(options) {
         .then(function (_client) {
             client = _client;
 
-            return utils.createAdapter(config);
+            return localUtils.createAdapter(config);
         })
         .then(function (_adapter) {
             adapter = _adapter;

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -19,7 +19,7 @@ var sizeOf       = require('image-size'),
     Promise      = require('bluebird'),
     http         = require('http'),
     https        = require('https'),
-    config       = require('../config'),
+    utils        = require('../utils'),
     dimensions,
     request,
     requestHandler;
@@ -45,7 +45,7 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, tim
                 imagePath = 'http:' + imagePath;
             } else {
                 // get absolute url for image
-                imagePath = config.urlFor('image', {image: imagePath}, true);
+                imagePath = utils.url.urlFor('image', {image: imagePath}, true);
             }
         }
 

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -103,7 +103,8 @@ utils = {
     readCSV: require('./read-csv'),
     removeOpenRedirectFromUrl: require('./remove-open-redirect-from-url'),
     zipFolder: require('./zip-folder'),
-    readThemes: require('./read-themes')
+    readThemes: require('./read-themes'),
+    url: require('./url')
 };
 
 module.exports = utils;

--- a/core/server/utils/make-absolute-urls.js
+++ b/core/server/utils/make-absolute-urls.js
@@ -1,6 +1,6 @@
 var cheerio  = require('cheerio'),
     url      = require('url'),
-    config   = require('../config');
+    utils  = require('../utils');
 
 /**
  * Make absolute URLs
@@ -46,7 +46,7 @@ function makeAbsoluteUrls(html, siteUrl, itemUrl) {
             // if the relative URL begins with a '/' use the blog URL (including sub-directory)
             // as the base URL, otherwise use the post's URL.
             baseUrl = attributeValue[0] === '/' ? siteUrl : itemUrl;
-            attributeValue = config.urlJoin(baseUrl, attributeValue);
+            attributeValue = utils.url.urlJoin(baseUrl, attributeValue);
             el.attr(attributeName, attributeValue);
         });
     });

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -3,28 +3,18 @@
 
 var moment            = require('moment-timezone'),
     _                 = require('lodash'),
-    ghostConfig = '',
+    config            = require('./../config'),
     // @TODO: unify this with routes.apiBaseUrl
     apiPath = '/ghost/api/v0.1';
 
-// ## setConfig
-// Simple utility function to allow
-// passing of the ghostConfig
-// object here to be used locally
-// to ensure clean dependency graph
-// (i.e. no circular dependencies).
-function setConfig(config) {
-    ghostConfig = config;
-}
-
 function getBaseUrl(secure) {
-    if (secure && ghostConfig.urlSSL) {
-        return ghostConfig.urlSSL;
+    if (secure && config.urlSSL) {
+        return config.urlSSL;
     } else {
         if (secure) {
-            return ghostConfig.url.replace('http://', 'https://');
+            return config.url.replace('http://', 'https://');
         } else {
-            return ghostConfig.url;
+            return config.url;
         }
     }
 }
@@ -32,7 +22,7 @@ function getBaseUrl(secure) {
 function urlJoin() {
     var args = Array.prototype.slice.call(arguments),
         prefixDoubleSlash = false,
-        subdir = ghostConfig.paths.subdir.replace(/^\/|\/+$/, ''),
+        subdir = config.paths.subdir.replace(/^\/|\/+$/, ''),
         subdirRegex,
         url;
 
@@ -89,7 +79,7 @@ function createUrl(urlPath, absolute, secure) {
     if (absolute) {
         base = getBaseUrl(secure);
     } else {
-        base = ghostConfig.paths.subdir;
+        base = config.paths.subdir;
     }
 
     return urlJoin(base, urlPath);
@@ -103,8 +93,8 @@ function createUrl(urlPath, absolute, secure) {
  */
 function urlPathForPost(post) {
     var output = '',
-        permalinks = ghostConfig.theme.permalinks,
-        publishedAtMoment = moment.tz(post.published_at || Date.now(), ghostConfig.theme.timezone),
+        permalinks = config.theme.permalinks,
+        publishedAtMoment = moment.tz(post.published_at || Date.now(), config.theme.timezone),
         tags = {
             year:   function () { return publishedAtMoment.format('YYYY'); },
             month:  function () { return publishedAtMoment.format('MM'); },
@@ -179,20 +169,20 @@ function urlFor(context, data, absolute) {
             urlPath = data.post.url;
             secure = data.secure;
         } else if (context === 'tag' && data.tag) {
-            urlPath = urlJoin('/', ghostConfig.routeKeywords.tag, data.tag.slug, '/');
+            urlPath = urlJoin('/', config.routeKeywords.tag, data.tag.slug, '/');
             secure = data.tag.secure;
         } else if (context === 'author' && data.author) {
-            urlPath = urlJoin('/', ghostConfig.routeKeywords.author, data.author.slug, '/');
+            urlPath = urlJoin('/', config.routeKeywords.author, data.author.slug, '/');
             secure = data.author.secure;
         } else if (context === 'image' && data.image) {
             urlPath = data.image;
-            imagePathRe = new RegExp('^' + ghostConfig.paths.subdir + '/' + ghostConfig.paths.imagesRelPath);
+            imagePathRe = new RegExp('^' + config.paths.subdir + '/' + config.paths.imagesRelPath);
             absolute = imagePathRe.test(data.image) ? absolute : false;
             secure = data.image.secure;
 
             if (absolute) {
                 // Remove the sub-directory from the URL because ghostConfig will add it back.
-                urlPath = urlPath.replace(new RegExp('^' + ghostConfig.paths.subdir), '');
+                urlPath = urlPath.replace(new RegExp('^' + config.paths.subdir), '');
                 baseUrl = getBaseUrl(secure).replace(/\/$/, '');
                 urlPath = baseUrl + urlPath;
             }
@@ -202,7 +192,7 @@ function urlFor(context, data, absolute) {
             urlPath = data.nav.url;
             secure = data.nav.secure || secure;
             baseUrl = getBaseUrl(secure);
-            hostname = baseUrl.split('//')[1] + ghostConfig.paths.subdir;
+            hostname = baseUrl.split('//')[1] + config.paths.subdir;
             if (urlPath.indexOf(hostname) > -1
                 && !urlPath.split(hostname)[0].match(/\.|mailto:/)
                 && urlPath.split(hostname)[1].substring(0,1) !== ':') {
@@ -237,20 +227,19 @@ function apiUrl() {
     // @TODO unify this with urlFor
     var url;
 
-    if (ghostConfig.forceAdminSSL) {
-        url = (ghostConfig.urlSSL || ghostConfig.url).replace(/^.*?:\/\//g, 'https://');
-    } else if (ghostConfig.urlSSL) {
-        url = ghostConfig.urlSSL.replace(/^.*?:\/\//g, 'https://');
-    } else if (ghostConfig.url.match(/^https:/)) {
-        url = ghostConfig.url;
+    if (config.forceAdminSSL) {
+        url = (config.urlSSL || config.url).replace(/^.*?:\/\//g, 'https://');
+    } else if (config.urlSSL) {
+        url = config.urlSSL.replace(/^.*?:\/\//g, 'https://');
+    } else if (config.url.match(/^https:/)) {
+        url = config.url;
     } else {
-        url = ghostConfig.url.replace(/^.*?:\/\//g, '//');
+        url = config.url.replace(/^.*?:\/\//g, '//');
     }
 
     return url.replace(/\/$/, '') + apiPath + '/';
 }
 
-module.exports.setConfig = setConfig;
 module.exports.urlJoin = urlJoin;
 module.exports.urlFor = urlFor;
 module.exports.urlPathForPost = urlPathForPost;

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -8,6 +8,7 @@ var should         = require('should'),
 
     testUtils      = require('../utils'),
     i18n           = require('../../server/i18n'),
+    utils          = require('../../server/utils'),
     /*jshint unused:false*/
     db             = require('../../server/data/db/connection'),
 
@@ -242,103 +243,103 @@ describe('Config', function () {
         describe('urlJoin', function () {
             it('should deduplicate slashes', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                config.urlJoin('/', '/my/', '/blog/').should.equal('/my/blog/');
-                config.urlJoin('/', '//my/', '/blog/').should.equal('/my/blog/');
-                config.urlJoin('/', '/', '/').should.equal('/');
+                utils.url.urlJoin('/', '/my/', '/blog/').should.equal('/my/blog/');
+                utils.url.urlJoin('/', '//my/', '/blog/').should.equal('/my/blog/');
+                utils.url.urlJoin('/', '/', '/').should.equal('/');
             });
 
             it('should not deduplicate slashes in protocol', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                config.urlJoin('http://myurl.com', '/rss').should.equal('http://myurl.com/rss');
-                config.urlJoin('https://myurl.com/', '/rss').should.equal('https://myurl.com/rss');
+                utils.url.urlJoin('http://myurl.com', '/rss').should.equal('http://myurl.com/rss');
+                utils.url.urlJoin('https://myurl.com/', '/rss').should.equal('https://myurl.com/rss');
             });
 
             it('should permit schemeless protocol', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                config.urlJoin('/', '/').should.equal('/');
-                config.urlJoin('//myurl.com', '/rss').should.equal('//myurl.com/rss');
-                config.urlJoin('//myurl.com/', '/rss').should.equal('//myurl.com/rss');
-                config.urlJoin('//myurl.com//', 'rss').should.equal('//myurl.com/rss');
-                config.urlJoin('', '//myurl.com', 'rss').should.equal('//myurl.com/rss');
+                utils.url.urlJoin('/', '/').should.equal('/');
+                utils.url.urlJoin('//myurl.com', '/rss').should.equal('//myurl.com/rss');
+                utils.url.urlJoin('//myurl.com/', '/rss').should.equal('//myurl.com/rss');
+                utils.url.urlJoin('//myurl.com//', 'rss').should.equal('//myurl.com/rss');
+                utils.url.urlJoin('', '//myurl.com', 'rss').should.equal('//myurl.com/rss');
             });
 
             it('should deduplicate subdir', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlJoin('blog', 'blog/about').should.equal('blog/about');
-                config.urlJoin('blog/', 'blog/about').should.equal('blog/about');
+                utils.url.urlJoin('blog', 'blog/about').should.equal('blog/about');
+                utils.url.urlJoin('blog/', 'blog/about').should.equal('blog/about');
                 configUtils.set({url: 'http://my-ghost-blog.com/my/blog'});
-                config.urlJoin('my/blog', 'my/blog/about').should.equal('my/blog/about');
-                config.urlJoin('my/blog/', 'my/blog/about').should.equal('my/blog/about');
+                utils.url.urlJoin('my/blog', 'my/blog/about').should.equal('my/blog/about');
+                utils.url.urlJoin('my/blog/', 'my/blog/about').should.equal('my/blog/about');
             });
         });
 
         describe('urlFor', function () {
             it('should return the home url with no options', function () {
-                config.urlFor().should.equal('/');
+                utils.url.urlFor().should.equal('/');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor().should.equal('/blog/');
+                utils.url.urlFor().should.equal('/blog/');
                 configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-                config.urlFor().should.equal('/blog/');
+                utils.url.urlFor().should.equal('/blog/');
             });
 
             it('should return home url when asked for', function () {
                 var testContext = 'home';
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext).should.equal('/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+                utils.url.urlFor(testContext).should.equal('/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
-                config.urlFor(testContext).should.equal('/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+                utils.url.urlFor(testContext).should.equal('/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext).should.equal('/blog/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+                utils.url.urlFor(testContext).should.equal('/blog/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-                config.urlFor(testContext).should.equal('/blog/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+                utils.url.urlFor(testContext).should.equal('/blog/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
             });
 
             it('should return rss url when asked for', function () {
                 var testContext = 'rss';
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext).should.equal('/rss/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/rss/');
+                utils.url.urlFor(testContext).should.equal('/rss/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/rss/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext).should.equal('/blog/rss/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/rss/');
+                utils.url.urlFor(testContext).should.equal('/blog/rss/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/rss/');
             });
 
             it('should return url for a random path when asked for', function () {
                 var testContext = {relativeUrl: '/about/'};
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext).should.equal('/about/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/about/');
+                utils.url.urlFor(testContext).should.equal('/about/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/about/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext).should.equal('/blog/about/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+                utils.url.urlFor(testContext).should.equal('/blog/about/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
             });
 
             it('should deduplicate subdirectories in paths', function () {
                 var testContext = {relativeUrl: '/blog/about/'};
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext).should.equal('/blog/about/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+                utils.url.urlFor(testContext).should.equal('/blog/about/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext).should.equal('/blog/about/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+                utils.url.urlFor(testContext).should.equal('/blog/about/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-                config.urlFor(testContext).should.equal('/blog/about/');
-                config.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+                utils.url.urlFor(testContext).should.equal('/blog/about/');
+                utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
             });
 
             it('should return url for a post from post object', function () {
@@ -348,16 +349,16 @@ describe('Config', function () {
                 // url is now provided on the postmodel, permalinkSetting tests are in the model_post_spec.js test
                 testData.post.url = '/short-and-sweet/';
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext, testData).should.equal('/short-and-sweet/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('/short-and-sweet/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
                 testData.post.url = '/blog-one/';
-                config.urlFor(testContext, testData).should.equal('/blog/blog-one/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/blog-one/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
             });
 
             it('should return url for a tag when asked for', function () {
@@ -365,12 +366,12 @@ describe('Config', function () {
                     testData = {tag: testUtils.DataGenerator.Content.tags[0]};
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
+                utils.url.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
             });
 
             it('should return url for an author when asked for', function () {
@@ -378,12 +379,12 @@ describe('Config', function () {
                     testData = {author: testUtils.DataGenerator.Content.users[0]};
 
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
+                utils.url.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-                config.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
             });
 
             it('should return url for an image when asked for', function () {
@@ -393,28 +394,28 @@ describe('Config', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com'});
 
                 testData = {image: '/content/images/my-image.jpg'};
-                config.urlFor(testContext, testData).should.equal('/content/images/my-image.jpg');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/content/images/my-image.jpg');
+                utils.url.urlFor(testContext, testData).should.equal('/content/images/my-image.jpg');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/content/images/my-image.jpg');
 
                 testData = {image: 'http://placekitten.com/500/200'};
-                config.urlFor(testContext, testData).should.equal('http://placekitten.com/500/200');
-                config.urlFor(testContext, testData, true).should.equal('http://placekitten.com/500/200');
+                utils.url.urlFor(testContext, testData).should.equal('http://placekitten.com/500/200');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://placekitten.com/500/200');
 
                 testData = {image: '/blog/content/images/my-image2.jpg'};
-                config.urlFor(testContext, testData).should.equal('/blog/content/images/my-image2.jpg');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/content/images/my-image2.jpg');
                 // We don't make image urls absolute if they don't look like images relative to the image path
-                config.urlFor(testContext, testData, true).should.equal('/blog/content/images/my-image2.jpg');
+                utils.url.urlFor(testContext, testData, true).should.equal('/blog/content/images/my-image2.jpg');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
 
                 testData = {image: '/content/images/my-image3.jpg'};
-                config.urlFor(testContext, testData).should.equal('/content/images/my-image3.jpg');
+                utils.url.urlFor(testContext, testData).should.equal('/content/images/my-image3.jpg');
                 // We don't make image urls absolute if they don't look like images relative to the image path
-                config.urlFor(testContext, testData, true).should.equal('/content/images/my-image3.jpg');
+                utils.url.urlFor(testContext, testData, true).should.equal('/content/images/my-image3.jpg');
 
                 testData = {image: '/blog/content/images/my-image4.jpg'};
-                config.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
-                config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/content/images/my-image4.jpg');
+                utils.url.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
+                utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/content/images/my-image4.jpg');
             });
 
             it('should return a url for a nav item when asked for it', function () {
@@ -424,51 +425,51 @@ describe('Config', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com', urlSSL: 'https://my-ghost-blog.com'});
 
                 testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}};
-                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
 
                 testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}, secure: true};
-                config.urlFor(testContext, testData).should.equal('https://my-ghost-blog.com/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('https://my-ghost-blog.com/short-and-sweet/');
 
                 testData = {nav: {url: 'http://my-ghost-blog.com:3000/'}};
-                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/');
+                utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/');
 
                 testData = {nav: {url: 'http://my-ghost-blog.com:3000/short-and-sweet/'}};
-                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
 
                 testData = {nav: {url: 'http://sub.my-ghost-blog.com/'}};
-                config.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
+                utils.url.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
 
                 testData = {nav: {url: '//sub.my-ghost-blog.com/'}};
-                config.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/');
+                utils.url.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/');
 
                 testData = {nav: {url: 'mailto:sub@my-ghost-blog.com/'}};
-                config.urlFor(testContext, testData).should.equal('mailto:sub@my-ghost-blog.com/');
+                utils.url.urlFor(testContext, testData).should.equal('mailto:sub@my-ghost-blog.com/');
 
                 testData = {nav: {url: '#this-anchor'}};
-                config.urlFor(testContext, testData).should.equal('#this-anchor');
+                utils.url.urlFor(testContext, testData).should.equal('#this-anchor');
 
                 testData = {nav: {url: 'http://some-external-page.com/my-ghost-blog.com'}};
-                config.urlFor(testContext, testData).should.equal('http://some-external-page.com/my-ghost-blog.com');
+                utils.url.urlFor(testContext, testData).should.equal('http://some-external-page.com/my-ghost-blog.com');
 
                 testData = {nav: {url: 'http://some-external-page.com/stuff-my-ghost-blog.com-around'}};
-                config.urlFor(testContext, testData).should.equal('http://some-external-page.com/stuff-my-ghost-blog.com-around');
+                utils.url.urlFor(testContext, testData).should.equal('http://some-external-page.com/stuff-my-ghost-blog.com-around');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/blog'});
                 testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
-                config.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
+                utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
                 configUtils.set({url: 'http://my-ghost-blog.com/'});
                 testData = {nav: {url: 'mailto:marshmallow@my-ghost-blog.com'}};
-                config.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
+                utils.url.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
             });
 
             it('should return other known paths when requested', function () {
                 configUtils.set({url: 'http://my-ghost-blog.com'});
-                config.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
-                config.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
+                utils.url.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
+                utils.url.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
 
-                config.urlFor('api').should.equal('/ghost/api/v0.1');
-                config.urlFor('api', true).should.equal('http://my-ghost-blog.com/ghost/api/v0.1');
+                utils.url.urlFor('api').should.equal('/ghost/api/v0.1');
+                utils.url.urlFor('api', true).should.equal('http://my-ghost-blog.com/ghost/api/v0.1');
             });
         });
 
@@ -479,7 +480,7 @@ describe('Config', function () {
                 var testData = testUtils.DataGenerator.Content.posts[2],
                     postLink = '/short-and-sweet/';
 
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('permalink is /:year/:month/:day/:slug, blog timezone is Los Angeles', function () {
@@ -490,7 +491,7 @@ describe('Config', function () {
                     postLink = '/2016/05/17/short-and-sweet/';
 
                 testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('permalink is /:year/:month/:day/:slug, blog timezone is Asia Tokyo', function () {
@@ -501,7 +502,7 @@ describe('Config', function () {
                     postLink = '/2016/05/18/short-and-sweet/';
 
                 testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('post is page, no permalink usage allowed at all', function () {
@@ -511,7 +512,7 @@ describe('Config', function () {
                 var testData = testUtils.DataGenerator.Content.posts[5],
                     postLink = '/static-page-test/';
 
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('permalink is /:year/:id:/:author', function () {
@@ -522,7 +523,7 @@ describe('Config', function () {
                     postLink = '/2015/3/joe-blog/';
 
                 testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('permalink is /:year/:id:/:author', function () {
@@ -533,7 +534,7 @@ describe('Config', function () {
                     postLink = '/2016/3/joe-blog/';
 
                 testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
 
             it('post is not published yet', function () {
@@ -547,7 +548,7 @@ describe('Config', function () {
                 postLink = postLink.replace('MM', nowMoment.format('MM'));
                 postLink = postLink.replace('DD', nowMoment.format('DD'));
 
-                config.urlPathForPost(testData).should.equal(postLink);
+                utils.url.urlPathForPost(testData).should.equal(postLink);
             });
         });
 
@@ -558,7 +559,7 @@ describe('Config', function () {
                     forceAdminSSL: true
                 });
 
-                config.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return https config.urlSSL if forceAdminSSL set and urlSSL is misconfigured', function () {
@@ -568,7 +569,7 @@ describe('Config', function () {
                     forceAdminSSL: true
                 });
 
-                config.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return https config.urlSSL if forceAdminSSL set', function () {
@@ -578,7 +579,7 @@ describe('Config', function () {
                     forceAdminSSL: true
                 });
 
-                config.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return https config.urlSSL if set and misconfigured & forceAdminSSL is NOT set', function () {
@@ -587,7 +588,7 @@ describe('Config', function () {
                     urlSSL: 'http://other-ghost-blog.com'
                 });
 
-                config.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return https config.urlSSL if set & forceAdminSSL is NOT set', function () {
@@ -596,7 +597,7 @@ describe('Config', function () {
                     urlSSL: 'https://other-ghost-blog.com'
                 });
 
-                config.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return https config.url if config.url is https & forceAdminSSL is NOT set', function () {
@@ -604,7 +605,7 @@ describe('Config', function () {
                     url: 'https://my-ghost-blog.com'
                 });
 
-                config.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
             });
 
             it('should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
@@ -612,7 +613,7 @@ describe('Config', function () {
                     url: 'http://my-ghost-blog.com'
                 });
 
-                config.apiUrl().should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+                utils.url.apiUrl().should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
             });
         });
     });

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -1,8 +1,8 @@
 /* globals describe, beforeEach, afterEach, it */
-var should     = require('should'),
-    ghostUrl   = require('../../shared/ghost-url'),
-
-    configUtils    = require('../utils/configUtils');
+var should = require('should'),
+    ghostUrl = require('../../shared/ghost-url'),
+    configUtils = require('../utils/configUtils'),
+    utils = require('../../server/utils');
 
 should.equal(true, true);
 
@@ -30,7 +30,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -40,7 +40,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         ghostUrl.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -50,7 +50,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -60,7 +60,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         var rendered = ghostUrl.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -98,7 +98,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -117,7 +117,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -136,7 +136,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -152,10 +152,11 @@ describe('Ghost Ajax Helper', function () {
         configUtils.set({
             url: 'https://testblog.com/blog/'
         });
+
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: utils.url.apiUrl()
         });
 
         var rendered = ghostUrl.url.api('posts', {limit: 3}),

--- a/core/test/unit/sitemap/generator_spec.js
+++ b/core/test/unit/sitemap/generator_spec.js
@@ -5,8 +5,8 @@ var _           = require('lodash'),
     validator   = require('validator'),
 
     // Stuff we are testing
-    config         = require('../../../server/config'),
     api            = require('../../../server/api'),
+    utils          = require('../../../server/utils'),
     BaseGenerator  = require('../../../server/data/xml/sitemap/base-generator'),
     PostGenerator  = require('../../../server/data/xml/sitemap/post-generator'),
     PageGenerator  = require('../../../server/data/xml/sitemap/page-generator'),
@@ -237,7 +237,7 @@ describe('Generators', function () {
             generator.init().then(function () {
                 should.exist(generator.siteMapContent);
 
-                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('home', true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('home', true) + '</loc>');
                 // <loc> should exist exactly one time
                 generator.siteMapContent.indexOf('<loc>').should.eql(generator.siteMapContent.lastIndexOf('<loc>'));
 
@@ -259,8 +259,8 @@ describe('Generators', function () {
             generator.init().then(function () {
                 should.exist(generator.siteMapContent);
 
-                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('home', true) + '</loc>');
-                generator.siteMapContent.should.containEql('<loc>' + config.urlFor('page', {url: 'magic'}, true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('home', true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('page', {url: 'magic'}, true) + '</loc>');
 
                 done();
             }).catch(done);

--- a/core/test/unit/slack_spec.js
+++ b/core/test/unit/slack_spec.js
@@ -7,15 +7,15 @@ var _               = require('lodash'),
     testUtils       = require('../utils'),
     url             = require('url'),
 
-// Stuff we test
+    // Stuff we test
     slack          = rewire('../../server/data/slack'),
     events         = require('../../server/events'),
     api            = require('../../server/api/settings'),
-    config         = require('../../server/config'),
+    utils          = require('../../server/utils'),
     schema         = require('../../server/data/schema').checks,
 
     sandbox        = sinon.sandbox.create(),
-// Test data
+    // Test data
     slackObjNoUrl =
         {
             id: 17,
@@ -151,7 +151,7 @@ describe('Slack', function () {
 
         beforeEach(function () {
             isPostStub = sandbox.stub(schema, 'isPost');
-            urlForStub = sandbox.stub(config, 'urlFor');
+            urlForStub = sandbox.stub(utils.url, 'urlFor');
             urlForStub.withArgs('post').returns('http://myblog.com/post');
             urlForStub.returns('http://myblog.com/someImageurl.jpg');
             settingsObj = {settings: [], meta: {}};

--- a/core/test/unit/utils/image-size-from-url_spec.js
+++ b/core/test/unit/utils/image-size-from-url_spec.js
@@ -3,7 +3,7 @@ var should = require('should'),
     rewire = require('rewire'),
     nock = require('nock'),
     sinon = require('sinon'),
-    config = require('../../../server/config'),
+    utils  = require('../../../server/utils'),
 
     // Stuff we are testing
     imageSize = rewire('../../../server/utils/image-size-from-url');
@@ -124,7 +124,7 @@ describe('Image Size', function () {
                     width: 100
                 };
 
-        urlForStub = sinon.stub(config, 'urlFor');
+        urlForStub = sinon.stub(utils.url, 'urlFor');
         urlForStub.withArgs('image').returns('http://myblog.com/content/images/cat.jpg');
 
         requestMock = nock('http://myblog.com')


### PR DESCRIPTION
refs #6982 

We attached url utils to the ConfigManager, but these functions are utils and belong to our utils folder.

The diff is big, but it just replaced all usages of the old way to the new way (from `config.apiUrl` to `utils.url.apiUrl`. By moving the url utils into the utils folder, i also removed the problem of the circular dependency, see https://github.com/TryGhost/Ghost/compare/playground...kirrg001:1.0.0-dev/source-out-utils-from-config?expand=1#diff-cd05364c5a86a778de20a7395ec49c03L16

This refactoring is a preparation for getting rid of the ConfigManager.
