### PR TITLE
Make amp work when blog is running in subdirectory

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -33,7 +33,7 @@ function controller(req, res, next) {
 }
 
 function getPostData(req, res, next) {
-    postLookup(req.originalUrl)
+    postLookup(res.locals.relativeUrl)
         .then(function (result) {
             if (result && result.post) {
                 req.body.post = result.post;

--- a/core/server/apps/amp/tests/router_spec.js
+++ b/core/server/apps/amp/tests/router_spec.js
@@ -141,10 +141,13 @@ describe('AMP getPostData', function () {
     var res, req, postLookupStub, next;
 
     beforeEach(function () {
-        res = {};
+        res = {
+            locals: {
+                relativeUrl: '/welcome-to-ghost/amp/'
+            }
+        };
 
         req = {
-            originalUrl: '/welcome-to-ghost/amp/',
             body: {
                 post: {}
             }

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -555,6 +555,12 @@ describe('Frontend Routing', function () {
                 .end(doEnd(done));
         });
 
+        it('/blog/welcome-to-ghost/amp/ should 200', function (done) {
+            request.get('/blog/welcome-to-ghost/amp/')
+                .expect(200)
+                .end(doEnd(done));
+        });
+
         it('should uncapitalise correctly with 301 to subdir', function (done) {
             request.get('/blog/AAA/')
                 .expect('Location', '/blog/aaa/')


### PR DESCRIPTION
closes #7352
- use relative url instead of absolute url for post lookup
- add test that passes w/these changes

TODO:
- [x] ensure 404s work correctly for amp posts not in a subdirectory
- [x] ensure 404s work correctly for amp posts in a subdirectory
