### PR TITLE
fix: Empty Sitemap.xml

### DIFF
--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -17,11 +17,26 @@ module.exports = function handler(blogApp) {
         };
 
     blogApp.get('/sitemap.xml', function sitemapXML(req, res) {
+        var siteMapXml = sitemap.getIndexXml();
+
         res.set({
             'Cache-Control': 'public, max-age=' + utils.ONE_HOUR_S,
             'Content-Type': 'text/xml'
         });
-        res.send(sitemap.getIndexXml());
+
+         if (!siteMapXml) {
+            sitemap.init()
+                .then(function () {
+                    siteMapXml = sitemap.getIndexXml();
+                    res.send(siteMapXml);
+                })
+                .catch(function (err) {
+                    next(err);
+                });
+        } else {
+            res.send(siteMapXml);
+        }
+
     });
 
     blogApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res, next) {

--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -16,7 +16,7 @@ module.exports = function handler(blogApp) {
             return sitemap.getSiteMapXml(type, page);
         };
 
-    blogApp.get('/sitemap.xml', function sitemapXML(req, res) {
+    blogApp.get('/sitemap.xml', function sitemapXML(req, res, next) {
         var siteMapXml = sitemap.getIndexXml();
 
         res.set({
@@ -24,7 +24,8 @@ module.exports = function handler(blogApp) {
             'Content-Type': 'text/xml'
         });
 
-         if (!siteMapXml) {
+        // CASE: returns null if sitemap is not initialized as below
+        if (!siteMapXml) {
             sitemap.init()
                 .then(function () {
                     siteMapXml = sitemap.getIndexXml();
@@ -36,7 +37,6 @@ module.exports = function handler(blogApp) {
         } else {
             res.send(siteMapXml);
         }
-
     });
 
     blogApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res, next) {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -683,7 +683,10 @@ describe('Frontend Routing', function () {
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(doEnd(done));
+                .end(function (err, res) {
+                    res.text.should.match(/sitemapindex/);
+                    doEnd(done)(err, res);
+                });
         });
 
         it('should serve sitemap-posts.xml', function (done) {
@@ -691,7 +694,10 @@ describe('Frontend Routing', function () {
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(doEnd(done));
+                .end(function (err, res) {
+                    res.text.should.match(/urlset/);
+                    doEnd(done)(err, res);
+                });
         });
 
         it('should serve sitemap-pages.xml', function (done) {
@@ -699,7 +705,10 @@ describe('Frontend Routing', function () {
                 .expect(200)
                 .expect('Cache-Control', testUtils.cacheRules.hour)
                 .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(doEnd(done));
+                .end(function (err, res) {
+                    res.text.should.match(/urlset/);
+                    doEnd(done)(err, res);
+                });
         });
 
         // TODO: Other pages and verify content


### PR DESCRIPTION
Closes: #7341 
A similar fix for the various `sitemap-resources` was merged previously, reference: #7320  
This fix replicates the functionality for the root sitemap.xml file. 
