### PR TITLE
🎨 Return gscan warnings from theme API

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -84,7 +84,11 @@ themes = {
             })
             .then(function (settings) {
                 // gscan theme structure !== ghost theme structure
-                return {themes: [_.find(settings.availableThemes.value, {name: zip.shortName})]};
+                var themeObject = _.find(settings.availableThemes.value, {name: zip.shortName}) || {};
+                if (theme.results.warning.length > 0) {
+                    themeObject.warnings = _.cloneDeep(theme.results.warning);
+                }
+                return {themes: [themeObject]};
             })
             .finally(function () {
                 // remove zip upload from multer

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "0.30.0",
     "ghost-gql": "0.0.5",
     "glob": "5.0.15",
-    "gscan": "0.0.13",
+    "gscan": "0.0.14",
     "html-to-text": "2.1.3",
     "image-size": "0.5.0",
     "intl": "1.2.4",


### PR DESCRIPTION
- return warnings from gscan so we can let users know about potential issues

This also temporarily bumps gscan to point to a branch with a necessary change. This will need to be cleaned up before merging.

@kevinansfield this is the PR you need to build against to see if it's straightforward to do some of #7362.
