### PR TITLE
🐛 Reactivate theme on override + cache clear

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -43,6 +43,10 @@ init = function init() {
     return settings.updateSettingsCache();
 };
 
+function isActiveThemeOverride(method, endpoint, result) {
+    return method === 'POST' && endpoint === 'themes' && result.themes && result.themes[0] && result.themes[0].active === true;
+}
+
 /**
  * ### Cache Invalidation Header
  * Calculate the header string for the X-Cache-Invalidate: header.
@@ -67,7 +71,12 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
         hasStatusChanged,
         wasPublishedUpdated;
 
-    if (['POST', 'PUT', 'DELETE'].indexOf(method) > -1) {
+    if (isActiveThemeOverride(method, endpoint, result)) {
+        // Special case for if we're overwriting an active theme
+        // @TODO: remove this crazy DIRTY HORRIBLE HACK
+        req.app.set('activeTheme', null);
+        return INVALIDATE_ALL;
+    } else if (['POST', 'PUT', 'DELETE'].indexOf(method) > -1) {
         if (endpoint === 'schedules' && subdir === 'posts') {
             return INVALIDATE_ALL;
         }


### PR DESCRIPTION
This contains a horrible dirty hack which we will need to factor out in the near future. 

I've left the `req.app.set('activeTheme', null);` inside the cache invalidation header generation, due to that being a location that has already got the method, endpoint and result to do calculations whilst also having access to `req`. This is totally not cool, but it's quick and will get the issue fixed for us today.

Longer term, I think the whole theme loading & reloading concept needs revisiting. 

fixes #7350
- When the active theme is overridden, ensure that the activateTheme middleware gets called by removing the `req.app.activeTheme` value.
- Additionally, ensure that the full cache is invalidated
