### PR TITLE
✨  Use migration to add AMP column in posts table

### DIFF
--- a/core/server/data/migration/008/01-add-amp-column-to-posts.js
+++ b/core/server/data/migration/008/01-add-amp-column-to-posts.js
@@ -1,0 +1,26 @@
+var Promise = require('bluebird'),
+    commands = require('../../schema').commands,
+    table = 'posts',
+    column = 'amp',
+    message = 'Adding column: ' + table + '.' + column;
+
+module.exports = function addAmpColumnToPosts(options, logger) {
+    var transaction = options.transacting;
+
+    return transaction.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                return Promise.reject(new Error('Table does not exist!'));
+            }
+
+            return transaction.schema.hasColumn(table, column);
+        })
+        .then(function (exists) {
+            if (!exists) {
+                logger.info(message);
+                return commands.addColumn(table, column, transaction);
+            } else {
+                logger.warn(message);
+            }
+        });
+};

--- a/core/server/data/migration/008/index.js
+++ b/core/server/data/migration/008/index.js
@@ -1,0 +1,4 @@
+module.exports = [
+    // Add amp column to posts
+    require('./01-add-amp-column-to-posts')
+];

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "databaseVersion": {
-            "defaultValue": "007"
+            "defaultValue": "008"
         },
         "dbHash": {
             "defaultValue": null

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -7,6 +7,7 @@ module.exports = {
         markdown: {type: 'text', maxlength: 16777215, fieldtype: 'medium', nullable: true},
         mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
         html: {type: 'text', maxlength: 16777215, fieldtype: 'medium', nullable: true},
+        amp: {type: 'text', maxlength: 16777215, fieldtype: 'medium', nullable: true},
         image: {type: 'text', maxlength: 2000, nullable: true},
         featured: {type: 'bool', nullable: false, defaultTo: false},
         page: {type: 'bool', nullable: false, defaultTo: false},

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -106,7 +106,7 @@ describe('server bootstrap', function () {
 
                     migration.update.execute.calledWith({
                         fromVersion: '006',
-                        toVersion: '007',
+                        toVersion: '008',
                         forceMigration: undefined
                     }).should.eql(true);
 


### PR DESCRIPTION
no issue

Uses migration to '008' to add an `amp` column to the `posts` table.
