### PR TITLE
🐛  move overrides into core folder

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -1,6 +1,17 @@
 // # Bootup
 // This file needs serious love & refactoring
 
+/**
+ * make sure overrides get's called first!
+ * - keeping the overrides require here works for installing Ghost as npm!
+ *
+ * the call order is the following:
+ * - root index requires core module
+ * - core index requires server
+ * - overrides is the first package to load
+ */
+require('./overrides');
+
 // Module dependencies
 var express = require('express'),
     _ = require('lodash'),

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -1,12 +1,4 @@
-var moment = require('moment-timezone'),
-    _ = require('lodash'),
-    toPairs = require('lodash.topairs'),
-    fromPairs = require('lodash.frompairs'),
-    toString = require('lodash.tostring'),
-    pickBy = require('lodash.pickby'),
-    uniqBy = require('lodash.uniqby'),
-    orderBy = require('lodash.orderby'),
-    omitBy = require('lodash.omitby');
+var moment = require('moment-timezone');
 
 /**
  * force UTC
@@ -16,6 +8,16 @@ var moment = require('moment-timezone'),
  *   - be careful when you work with date operations, therefor always wrap a date into moment
  */
 moment.tz.setDefault('UTC');
+
+// jscs:disable
+var _ = require('lodash'),
+    toPairs = require('lodash.topairs'),
+    fromPairs = require('lodash.frompairs'),
+    toString = require('lodash.tostring'),
+    pickBy = require('lodash.pickby'),
+    uniqBy = require('lodash.uniqby'),
+    orderBy = require('lodash.orderby'),
+    omitBy = require('lodash.omitby');
 
 /**
  * lodash 4.x functions we use

--- a/index.js
+++ b/index.js
@@ -1,25 +1,14 @@
 // # Ghost Startup
 // Orchestrates the startup of Ghost when run from command line.
 
-var express,
-    ghost,
-    parentApp,
-    errors;
-
-require('./core/server/overrides');
+var ghost = require('./core'),
+    express = require('express'),
+    errors = require('./core/server/errors'),
+    parentApp = express();
 
 // Make sure dependencies are installed and file system permissions are correct.
 require('./core/server/utils/startup-check').check();
 
-// Proceed with startup
-express = require('express');
-ghost = require('./core');
-errors = require('./core/server/errors');
-
-// Create our parent express app instance.
-parentApp = express();
-
-// Call Ghost to get an instance of GhostServer
 ghost().then(function (ghostServer) {
     // Mount our Ghost instance on our desired subdirectory path if it exists.
     parentApp.use(ghostServer.config.paths.subdir, ghostServer.rootApp);


### PR DESCRIPTION
closes #7336

Ensure we only call overrides once.
Move overrides file into core folder and ensure it's still the first package to call.
