### PR TITLE
🛠 Pin knex, bookshelf & lodash until later

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,9 @@
   },
   "greenkeeper": {
     "ignore": [
+      "bookshelf",
+      "knex",
+      "lodash",
       "glob",
       "mysql",
       "nodemailer",


### PR DESCRIPTION
This stops greenkeeper from making PRs for these

refs #7189, refs #7291
- We will upgrade these when we are able to locate and resolve the memory leak that is caused by upgrading them
