### PR TITLE
🚨  increase ping tries when forking process

### DIFF
--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -97,7 +97,7 @@ function forkGhost(newConfig, envName) {
                             /*jshint unused:false*/
                             pingTries = pingTries + 1;
                             // continue checking
-                            if (pingTries >= 50 && pingStop()) {
+                            if (pingTries >= 100 && pingStop()) {
                                 child.kill();
                                 reject(new Error('Timed out waiting for child process'));
                             }


### PR DESCRIPTION
no issue

possible fix for `frontend_spec` issues with travis.
when forking a node process, the database might get populated, maybe it just takes too long sometimes. that is just an assumption. good luck me.
