### PR TITLE
🚨  increase mocha timeout globally

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -137,7 +137,7 @@ var overrides      = require('./core/server/overrides'),
                 options: {
                     ui: 'bdd',
                     reporter: grunt.option('reporter') || 'spec',
-                    timeout: '15000',
+                    timeout: '30000',
                     save: grunt.option('reporter-output'),
                     require: ['core/server/overrides']
                 },


### PR DESCRIPTION
no issue

We sometimes see timeout errors for migration teardown in travis.
Another assumption to fix random errors in travis. 15s feels already long, but let's give it a shotski.
