### PR TITLE
⬆️ Upgrade extract-zip to extract-zip-fork@1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "downsize": "0.0.8",
     "express": "4.14.0",
     "express-hbs": "1.0.3",
-    "extract-zip": "https://github.com/ErisDS/extract-zip/tarball/issue-30",
+    "extract-zip-fork": "1.5.1",
     "fs-extra": "0.30.0",
     "ghost-gql": "0.0.5",
     "glob": "5.0.15",


### PR DESCRIPTION
Changes us to using a normal semver npm dependency again
