### PR TITLE
Do not show internal tags in RSS feed

### DIFF
--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -1,17 +1,18 @@
-var _           = require('lodash'),
-    crypto      = require('crypto'),
+var crypto      = require('crypto'),
     downsize    = require('downsize'),
     RSS         = require('rss'),
     config      = require('../../../config'),
     errors      = require('../../../errors'),
     filters     = require('../../../filters'),
     processUrls = require('../../../utils/make-absolute-urls'),
+    labs        = require('../../../utils/labs'),
 
     // Really ugly temporary hack for location of things
     fetchData   = require('../../../controllers/frontend/fetch-data'),
 
     generate,
     generateFeed,
+    generateTags,
     getFeedXml,
     feedCache = {};
 
@@ -77,6 +78,19 @@ getFeedXml = function getFeedXml(path, data) {
     return feedCache[path].xml;
 };
 
+generateTags = function generateTags(data) {
+    if (data.tags) {
+        return data.tags.reduce(function (tags, tag) {
+            if (tag.visibility !== 'internal' || !labs.isSet('internalTags')) {
+                tags.push(tag.name);
+            }
+            return tags;
+        }, []);
+    }
+
+    return [];
+};
+
 generateFeed = function generateFeed(data) {
     var feed = new RSS({
         title: data.title,
@@ -100,7 +114,7 @@ generateFeed = function generateFeed(data) {
                 guid: post.uuid,
                 url: itemUrl,
                 date: post.published_at,
-                categories: _.map(post.tags, 'name'),
+                categories: generateTags(post),
                 author: post.author ? post.author.name : null,
                 custom_elements: []
             },


### PR DESCRIPTION
Duplicates same logic for now to remove internal tags from RSS as sitemap.

closes #7367
- checks tags are visibile if internal tags are enabled in labs
- dirty quick update to tests
