### PR TITLE
🐛  generate correct apiUrl for scheduling

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -160,7 +160,7 @@ function init(options) {
 
         // scheduling can trigger api requests, that's why we initialize the module after the ghost server creation
         // scheduling module can create x schedulers with different adapters
-        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.url + config.urlFor('api')}));
+        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.urlFor('api', null, true)}));
     }).then(function () {
         return ghostServer;
     });


### PR DESCRIPTION
closes #7388 
- [x] publish a post with /blog
- [x] publish a post without /blog
