### PR TITLE
🎨  use apiUrl helper for scheduling initialisation

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -233,7 +233,15 @@ function urlFor(context, data, absolute) {
     return createUrl(urlPath, absolute, secure);
 }
 
-function apiUrl() {
+/**
+ * CASE: generate api url for CORS
+ *   - we delete the http protocol if your blog runs with http and https (configured by nginx)
+ *   - in that case your config.js configures Ghost with http and no admin ssl force
+ *   - the browser then reads the protocol dynamically
+ */
+function apiUrl(options) {
+    options = options || {cors: false};
+
     // @TODO unify this with urlFor
     var url;
 
@@ -244,7 +252,11 @@ function apiUrl() {
     } else if (ghostConfig.url.match(/^https:/)) {
         url = ghostConfig.url;
     } else {
-        url = ghostConfig.url.replace(/^.*?:\/\//g, '//');
+        if (options.cors === false) {
+            url = ghostConfig.url;
+        } else {
+            url = ghostConfig.url.replace(/^.*?:\/\//g, '//');
+        }
     }
 
     return url.replace(/\/$/, '') + apiPath + '/';

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -160,7 +160,7 @@ function init(options) {
 
         // scheduling can trigger api requests, that's why we initialize the module after the ghost server creation
         // scheduling module can create x schedulers with different adapters
-        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.urlFor('api', null, true)}));
+        return scheduling.init(_.extend(config.scheduling, {apiUrl: config.apiUrl()}));
     }).then(function () {
         return ghostServer;
     });

--- a/core/server/middleware/serve-shared-file.js
+++ b/core/server/middleware/serve-shared-file.js
@@ -27,7 +27,7 @@ function serveSharedFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, config.url.replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, config.apiUrl());
+                        buf = buf.toString().replace(apiRegex, config.apiUrl({cors: true}));
                     }
                     content = {
                         headers: {

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -609,12 +609,20 @@ describe('Config', function () {
                 config.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
             });
 
-            it('should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
+            it('CORS: should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
                 configUtils.set({
                     url: 'http://my-ghost-blog.com'
                 });
 
-                config.apiUrl().should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+                config.apiUrl({cors: true}).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+            });
+
+            it('should return protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
+                configUtils.set({
+                    url: 'http://my-ghost-blog.com'
+                });
+
+                config.apiUrl().should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
             });
         });
     });

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -6,6 +6,7 @@ var should     = require('should'),
 
 should.equal(true, true);
 
+// @TODO: ghostUrl.init was obviously written for this test, get rid of it! (write a route test instead)
 describe('Ghost Ajax Helper', function () {
     beforeEach(function () {
         configUtils.set({
@@ -30,7 +31,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -40,7 +41,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         ghostUrl.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -50,7 +51,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -60,7 +61,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         var rendered = ghostUrl.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -98,7 +99,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -117,7 +118,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -136,7 +137,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -155,7 +156,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: configUtils.config.apiUrl()
+            url: configUtils.config.apiUrl({cors: true})
         });
 
         var rendered = ghostUrl.url.api('posts', {limit: 3}),


### PR DESCRIPTION
no issue

In #7389 we fixed scheduling running on a subdirectory.
With this PR we replace how we generate the admin url.
We are using `apiUrl` instead of `urlFor('api',....)`.

To re-use `apiUrl` i needed a little extension to this function, because it was originally designed for generating the admin url for CORS only.
