### PR TITLE
🐛 Refresh assetHash on theme override

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -73,8 +73,9 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
 
     if (isActiveThemeOverride(method, endpoint, result)) {
         // Special case for if we're overwriting an active theme
-        // @TODO: remove this crazy DIRTY HORRIBLE HACK
+        // @TODO: remove these crazy DIRTY HORRIBLE HACKSSS
         req.app.set('activeTheme', null);
+        config.assetHash = null;
         return INVALIDATE_ALL;
     } else if (['POST', 'PUT', 'DELETE'].indexOf(method) > -1) {
         if (endpoint === 'schedules' && subdir === 'posts') {

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -3,12 +3,12 @@
 var path          = require('path'),
     Promise       = require('bluebird'),
     chalk         = require('chalk'),
-    crypto        = require('crypto'),
     fs            = require('fs'),
     url           = require('url'),
     _             = require('lodash'),
 
     validator     = require('validator'),
+    generateAssetHash = require('../utils/asset-hash'),
     readDirectory = require('../utils/read-directory'),
     readThemes    = require('../utils/read-themes'),
     errors        = require('../errors'),
@@ -170,8 +170,7 @@ ConfigManager.prototype.set = function (config) {
     // Otherwise default to default content path location
     contentPath = this._config.paths.contentPath || path.resolve(appRoot, 'content');
 
-    assetHash = this._config.assetHash ||
-        (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10);
+    assetHash = this._config.assetHash || generateAssetHash();
 
     // read storage adapter from config file or attach default adapter
     this._config.storage = this._config.storage || {};

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,4 +1,5 @@
-var config = require('../../config');
+var config = require('../../config'),
+    generateAssetHash = require('../../utils/asset-hash');
 
 function getAssetUrl(path, isAdmin, minify) {
     var output = '';
@@ -24,6 +25,10 @@ function getAssetUrl(path, isAdmin, minify) {
     output += path;
 
     if (!path.match(/^favicon\.ico$/)) {
+        if (!config.assetHash) {
+            config.set({assetHash: generateAssetHash()});
+        }
+
         output = output + '?v=' + config.assetHash;
     }
 

--- a/core/server/utils/asset-hash.js
+++ b/core/server/utils/asset-hash.js
@@ -1,0 +1,6 @@
+var crypto        = require('crypto'),
+    packageInfo   = require('../../../package.json');
+
+module.exports = function generateAssetHash() {
+    return (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10);
+};


### PR DESCRIPTION
This fix has two parts:
1. set the assetHash to be null when the active theme is overridden.
2. ensure that the assetHash is regenerated if it is null when it is needed.

I moved the asset hash generation code out into a util so I didn't need to duplicate the line. In master, this won't require duplication because of the config refactors. 

refs #7423
- Extend our dirty theme override cache clear hack to also reset the asset hash
- This needs a rewrite for Ghost 1.0.0
