### PR TITLE
🔥 Remove the contributor list from Gruntfile

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,6 @@ var overrides      = require('./core/server/overrides'),
     chalk          = require('chalk'),
     fs             = require('fs-extra'),
     path           = require('path'),
-    Promise        = require('bluebird'),
-    Git            = require('git-wrapper'),
 
     escapeChar     = process.platform.match(/^win/) ? '^' : '\\',
     cwd            = process.cwd().replace(/( |\(|\))/g, escapeChar + '$1'),
@@ -702,78 +700,6 @@ var overrides      = require('./core/server/overrides'),
         // Note that the current implementation of watch only works with casper, not other themes.
         grunt.registerTask('dev', 'Dev Mode; watch files and restart server on changes',
            ['bgShell:client', 'express:dev', 'watch']);
-
-        // ### Contributors
-        // `grunt contributors:<tag-name>` - generate a comma-separated list of contributors for a Ghost release.
-        //
-        // You must supply a tag name to us
-        //
-        grunt.registerTask('contributors', 'Generate a list of contributors for a release', function () {
-            var getContribList = require('gh-contrib-list'),
-                oauthKey = process.env.GITHUB_OAUTH_KEY,
-                thisGit = new Git(),
-                clientGit = new Git({'git-dir': path.resolve(cwd + '/core/client/.git')}),
-                done = this.async();
-
-            function mergeContribs(first, second) {
-                _.each(second, function (contributor) {
-                    var contributorInFirst = _.find(first, ['id', contributor.id]);
-
-                    if (contributorInFirst) {
-                        contributorInFirst.commitCount += contributor.commitCount;
-                    } else {
-                        first.push(contributor);
-                    }
-                });
-
-                return _.orderBy(first, ['commitCount'], ['desc']);
-            }
-
-            if (!this.args) {
-                grunt.log.error('You must supply a tag name. Please run like this: `grunt contributors:<tag-name>`');
-            }
-
-            return Promise.props({
-                ghost: Promise.promisify(thisGit.exec, {context: thisGit})('rev-list', {n: 1}, this.args),
-                admin: Promise.promisify(clientGit.exec, {context: clientGit})('rev-list', {n: 1}, this.args)
-            }).then(function (props) {
-                return Promise.join(
-                    getContribList({
-                        user: 'tryghost',
-                        repo: 'ghost',
-                        oauthKey: oauthKey,
-                        commit: props.ghost.trim(),
-                        removeGreenkeeper: true,
-                        retry: true
-                    }),
-                    getContribList({
-                        user: 'tryghost',
-                        repo: 'ghost-admin',
-                        oauthKey: oauthKey,
-                        commit: props.admin.trim(),
-                        removeGreenkeeper: true,
-                        retry: true
-                    })
-                );
-            }).then(function (results) {
-                var contributors = mergeContribs(results[0], results[1]);
-
-                grunt.log.writeln(_.map(contributors, 'name').join(', '));
-                done();
-            }).catch(function (error) {
-                grunt.log.error(error);
-
-                if (error.http_status) {
-                    grunt.log.writeln('GitHub API request returned status: ' + error.http_status);
-                }
-
-                if (error.ratelimit_limit) {
-                    grunt.log.writeln('Rate limit data: limit: %d, remaining: %d, reset: %s', error.ratelimit_limit, error.ratelimit_remaining, require('moment').unix(error.ratelimit_reset).fromNow());
-                }
-
-                done(false);
-            });
-        });
 
         // ### Release
         // Run `grunt release` to create a Ghost release zip file.

--- a/package.json
+++ b/package.json
@@ -87,8 +87,6 @@
     "mysql": "2.11.1"
   },
   "devDependencies": {
-    "gh-contrib-list": "0.1.2",
-    "git-wrapper": "0.1.1",
     "grunt": "1.0.1",
     "grunt-bg-shell": "2.3.3",
     "grunt-cli": "1.2.0",


### PR DESCRIPTION
In line with #7427, we're working towards getting rid of our Gruntfile. The contrib list task is used purely as part of the release, in order to generate a nice list of people who contributed to put in the release notes.

I did a little bit of experimentation with the original `git shortlog -sn` method and managed to find a way to build this list as a set of shell commands.

For anyone who is interested, the new method looks a bit like this:

E.g. for contrib list between 0.11.0 and now
- `git shortlog -sn 0.11.0.. > who.txt && cd core/client && git shortlog -sn 0.11.0.. >> ../../who.txt && cd ../../`
- `awk '!/Greenkeeper/{a[$2 " " $3]+=$1}END{for(i in a){print a[i], i}}' who.txt | sort -rn | awk '{a[NR] = $2 " " $3}END{for(i=1;i<=NR;i++){printf("%s", i == 1 ? a[i] : (i < NR ? ", " a[i] : " and " a[i]));}}' && rm who.txt`

This will output a list of comma separated names with the last name prefixed with `and` - the same as we use in the blog posts.

I'm an awk noob, but had quite a bit of fun writing this. Very interested in hearing any suggestions for improvements.

refs #7427
- Moving all release-specific code out of the core repository
- Also found a different way to do this, without needing API access :)
