### PR TITLE
🐛  Refresh assetHash on theme override

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -76,6 +76,7 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
         // Special case for if we're overwriting an active theme
         // @TODO: remove this crazy DIRTY HORRIBLE HACK
         req.app.set('activeTheme', null);
+        config.set('assetHash', null);
         return INVALIDATE_ALL;
     } else if (['POST', 'PUT', 'DELETE'].indexOf(method) > -1) {
         if (endpoint === 'schedules' && subdir === 'posts') {

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,6 +1,5 @@
 var config = require('../../config'),
-    utils = require('../../utils'),
-    crypto = require('crypto');
+    utils = require('../../utils');
 
 function getAssetUrl(path, isAdmin, minify) {
     var output = '';
@@ -27,7 +26,7 @@ function getAssetUrl(path, isAdmin, minify) {
 
     if (!path.match(/^favicon\.ico$/)) {
         if (!config.get('assetHash')) {
-            config.set('assetHash', (crypto.createHash('md5').update(config.get('ghostVersion') + Date.now()).digest('hex')).substring(0, 10));
+            config.set('assetHash', utils.generateAssetHash());
         }
 
         output = output + '?v=' + config.get('assetHash');

--- a/core/server/utils/asset-hash.js
+++ b/core/server/utils/asset-hash.js
@@ -1,0 +1,6 @@
+var crypto        = require('crypto'),
+    packageInfo   = require('../../../package.json');
+
+module.exports = function generateAssetHash() {
+    return (crypto.createHash('md5').update(packageInfo.version + Date.now()).digest('hex')).substring(0, 10);
+};

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -104,6 +104,7 @@ utils = {
     removeOpenRedirectFromUrl: require('./remove-open-redirect-from-url'),
     zipFolder: require('./zip-folder'),
     readThemes: require('./read-themes'),
+    generateAssetHash: require('./asset-hash'),
     url: require('./url')
 };
 


### PR DESCRIPTION
This is the same fix as #7424, but for the master branch just to keep the two in sync a bit. I'm looking at a wider rework of this code as part of the scheduled theme audit.

closes #7423
- Extend our dirty theme override cache clear hack to also reset the asset hash
  _ This brings alpha into line with the LTS branch
- This still needs a rewrite for Ghost 1.0.0 🙄
