### PR TITLE
💄 Ensure all middleware use named functions

### DIFF
--- a/core/server/middleware/maintenance.js
+++ b/core/server/middleware/maintenance.js
@@ -2,7 +2,7 @@ var config = require('../config'),
     i18n   = require('../i18n'),
     errors = require('../errors');
 
-module.exports = function (req, res, next) {
+module.exports = function maintenance(req, res, next) {
     if (config.get('maintenance').enabled) {
         return next(new errors.Maintenance(
             i18n.t('errors.general.maintenance')

--- a/core/server/middleware/validation/upload.js
+++ b/core/server/middleware/validation/upload.js
@@ -7,7 +7,7 @@ module.exports = function upload(options) {
     var type = options.type;
 
     // if we finish the data/importer logic, we forward the request to the specified importer
-    return function (req, res, next) {
+    return function uploadValidation(req, res, next) {
         var extensions = (config.get('uploads')[type] && config.get('uploads')[type].extensions) || [],
             contentTypes = (config.get('uploads')[type] && config.get('uploads')[type].contentTypes) || [];
 


### PR DESCRIPTION
This is a quick little commit to name two middleware functions that were previously anonymous.

Super useful when inspecting and debugging the middleware stack, which I have been doing with a little stack printing tool I wrote: https://github.com/ErisDS/middleware-stack-printer

A full stack print for the home route in Ghost (with this change) can be [found in this gist](https://gist.github.com/ErisDS/9804a94a346ec6d811e4bbd7758f879e). 
It's kinda huge 😳 

no issue
- anonymous functions are hard to debug in memory traces etc
- having anonymous middleware functions makes it hard to inspect or debug the middleware stack (something I like to do)
- these 2 are the only ones atm, including all 3rd party middleware
