### PR TITLE
🐛  fix circular dependency in new bootUp script

### DIFF
--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -1,6 +1,6 @@
 var Promise = require('bluebird'),
     versioning = require('./versioning'),
-    migrations = require('../migration'),
+    populate = require('../migration/populate'),
     errors = require('./../../errors');
 
 module.exports = function bootUp() {
@@ -19,7 +19,7 @@ module.exports = function bootUp() {
         // We don't use .catch here, as it would catch the error from the successHandler
         function errorHandler(err) {
             if (err instanceof errors.DatabaseNotPopulated) {
-                return migrations.populate();
+                return populate();
             }
 
             return Promise.reject(err);


### PR DESCRIPTION
closes #7440

The new `bootup` script was invented in `1.0.0-alpha.1`.
It created a circular dependency to the migrations folder.

`data/schema/bootup.js` requires migration folder.
`data/migration` requires schema folder.

I think the `bootup` script is in a wrong folder. I will re-consider this when working more on migrations this week.
