### PR TITLE
🎨  run database population in transaction

### DIFF
--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -56,7 +56,7 @@ createOwner = function createOwner(logger, modelOptions) {
         password:         coreUtils.uid(50)
     };
 
-    return models.Role.findOne({name: 'Owner'}).then(function (ownerRole) {
+    return models.Role.findOne({name: 'Owner'}, modelOptions).then(function (ownerRole) {
         if (ownerRole) {
             user.roles = [ownerRole.id];
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -466,7 +466,13 @@ getFixtureOps = function getFixtureOps(toDos) {
     // Database initialisation
     if (toDos.init || toDos.default) {
         fixtureOps.push(function initDB() {
-            return migration.populate({tablesOnly: tablesOnly});
+            return new Promise(function initDb(resolve, reject) {
+                migration.populate({tablesOnly: tablesOnly})
+                    .then(function () {
+                        resolve();
+                    })
+                    .catch(reject);
+            });
         });
 
         delete toDos.default;


### PR DESCRIPTION
refs #6574, refs #7432

Populate database in a transaction.
We had issues in the past, that if a Ghost container get's destroyed before the population could finish, the database was left in a corrupt state.
