### PR TITLE
Refresh assetHash on theme activation

### DIFF
--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -60,6 +60,8 @@ themeHandler = {
 
         // clear the view cache
         blogApp.cache = {};
+        // reset the asset hash
+        config.assetHash = null;
 
         // set view engine
         hbsOptions = {


### PR DESCRIPTION
Ok, this is YAFPR\* for theme refreshes. 

Sooo @kevinansfield pointed out to me that the reason people were probably still struggling with theme refreshes is that we don't clear asset hashes on theme _**activation**_. I'd been focused on overrides, because they were the new feature.

Theme activation has been a feature forever, but of course, on Ghost(Pro) we limit people to 1 theme at a time, so they have had to upload a new theme (which involved a full restart & cache-clear) in between activations. Clearly no one else is using the power combo of heavy caching & flipping between themes to detect this bug 😱 

The fix is soooo tiny, I'd really like someone else to take a look at this to see if I'm not missing something else. @kirrg001 & @kevinansfield any thoughts? Reckon I've got it this time? 🙏

closes #7423
- asset hashes have never been refreshed properly!
- Ghost(Pro)'s 1-theme-only limitation has been hiding this bug for 3 years 🙄

\* _Fix or Fucking, take your pick_ 😁
