### PR TITLE
🐛  optimise 008 date migration fixture

### DIFF
--- a/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
+++ b/core/server/data/migration/fixtures/008/01-fix-sqlite-pg-format.js
@@ -1,68 +1,38 @@
 var config = require('../../../../config'),
-    _ = require('lodash'),
     models = require(config.paths.corePath + '/server/models'),
     transfomDatesIntoUTC = require(config.paths.corePath + '/server/data/migration/fixtures/006/01-transform-dates-into-utc'),
     Promise = require('bluebird'),
-    messagePrefix = 'Fix sqlite/pg format: ',
-    _private = {};
-
-_private.rerunDateMigration = function rerunDateMigration(options, logger) {
-    var settingsMigrations, settingsKey = '006/01';
-
-    return models.Settings.findOne({key: 'migrations'}, options)
-        .then(function removeMigrationSettings(result) {
-            try {
-                settingsMigrations = JSON.parse(result.attributes.value) || {};
-            } catch (err) {
-                return Promise.reject(err);
-            }
-
-            // CASE: migration ran already
-            if (settingsMigrations.hasOwnProperty(settingsKey)) {
-                delete settingsMigrations[settingsKey];
-
-                return models.Settings.edit({
-                    key: 'migrations',
-                    value: JSON.stringify(settingsMigrations)
-                }, options);
-            }
-        })
-        .then(function () {
-            return transfomDatesIntoUTC(options, logger);
-        });
-};
+    messagePrefix = 'Fix sqlite/pg format: ';
 
 /**
  * this migration script is a very special one for people who run their server in UTC and use sqlite3 or run their server in any TZ and use postgres
  * 006/01-transform-dates-into-utc had a bug for this case, see what happen because of this bug https://github.com/TryGhost/Ghost/issues/7192
  */
 module.exports = function fixSqliteFormat(options, logger) {
+    var settingsMigrations, settingsKey = '006/01';
+
     // CASE: skip this script when using mysql
     if (config.database.client === 'mysql') {
         logger.warn(messagePrefix + 'This script only runs, when using sqlite/postgres as database.');
         return Promise.resolve();
     }
 
-    // CASE: database is postgres, server is in ANY TZ, run 006/001 again
-    // we can't check the format for PG somehow, so we just run the migration again
-    if (config.database.isPostgreSQL()) {
-        return _private.rerunDateMigration(options, logger);
-    }
-
-    // CASE: sqlite3 and server is UTC, we check if the date migration was already running
-    return options.transacting.raw('select created_at from users')
-        .then(function (users) {
-            // safety measure
-            if (!users || !users.length) {
-                return;
+    // CASE: sqlite3 and postgres need's to re-run 006 date migrations
+    //       because we had a bug that both database types were skipped when their server was running in UTC
+    //       but we need to change the date format in that case as well, but without offset!
+    return models.Settings.findOne({key: 'migrations'}, options)
+        .then(function fetchedMigrationsSettings(result) {
+            try {
+                settingsMigrations = JSON.parse(result.attributes.value) || {};
+            } catch (err) {
+                return Promise.reject(err);
             }
 
-            // CASE: if type is string and sqlite, then it already has the correct date format
-            if (!_.isNumber(users[0].created_at)) {
+            if (settingsMigrations.hasOwnProperty(settingsKey)) {
                 logger.warn(messagePrefix + 'Your dates are in correct format.');
                 return;
             }
 
-            return _private.rerunDateMigration(options, logger);
+            return transfomDatesIntoUTC(options, logger);
         });
 };


### PR DESCRIPTION
finally refs #7351

The written date fixture migration in `0.11`, which should trigger a re-run of `006` date migration was not strong enough. This PR pushes an optimisation.

Another PR will follow to fix the issue for people who already updated to `0.11`.
#### TODO
- [x] think about if all makes sense
- [x] test another time
