### PR TITLE
🎨  optimise log output when running migrations

### DIFF
--- a/core/server/data/migration/fixtures/update.js
+++ b/core/server/data/migration/fixtures/update.js
@@ -24,6 +24,7 @@ update = function update(tasks, logger, modelOptions) {
     logger.info('Running fixture updates');
 
     if (!tasks.length) {
+        logger.info('No fixture migration tasks found for this version');
         return Promise.resolve();
     }
 

--- a/core/server/data/migration/update.js
+++ b/core/server/data/migration/update.js
@@ -37,6 +37,7 @@ logger = {
  */
 updateDatabaseSchema = function (tasks, logger, modelOptions) {
     if (!tasks.length) {
+        logger.info('No database migration tasks found for this version');
         return Promise.resolve();
     }
 

--- a/core/server/data/schema/versioning.js
+++ b/core/server/data/schema/versioning.js
@@ -72,16 +72,15 @@ function getMigrationVersions(fromVersion, toVersion) {
  *
  * @param {String} version
  * @param {String} relPath
- * @param {Function} logger
  * @returns {Array}
  */
-function getVersionTasks(version, relPath, logger) {
+function getVersionTasks(version, relPath) {
     var tasks = [];
 
     try {
         tasks = require(path.join(relPath, version));
     } catch (e) {
-        logger.info('No tasks found for version', version);
+        // ignore
     }
 
     return tasks;

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -1530,8 +1530,8 @@ describe('Migrations', function () {
             var updateDatabaseSchema = update.__get__('updateDatabaseSchema');
 
             it('should not do anything if there are no tasks', function (done) {
-                updateDatabaseSchema([], {}, loggerStub).then(function () {
-                    loggerStub.info.called.should.be.false();
+                updateDatabaseSchema([], loggerStub).then(function () {
+                    loggerStub.info.called.should.be.true();
                     loggerStub.warn.called.should.be.false();
                     done();
                 }).catch(done);

--- a/core/test/unit/versioning_spec.js
+++ b/core/test/unit/versioning_spec.js
@@ -182,33 +182,21 @@ describe('Versioning', function () {
     });
 
     describe('getUpdateTasks', function () {
-        var logStub;
-
-        beforeEach(function () {
-            logStub = {
-                info: sandbox.stub(),
-                warn: sandbox.stub()
-            };
-        });
-
+        var logStub = {};
         it('`getUpdateFixturesTasks` returns empty array if no tasks are found', function () {
             versioning.getUpdateFixturesTasks('999', logStub).should.eql([]);
-            logStub.info.calledOnce.should.be.true();
         });
 
         it('`getUpdateFixturesTasks` returns 8 items for 004', function () {
             versioning.getUpdateFixturesTasks('004', logStub).should.be.an.Array().with.lengthOf(8);
-            logStub.info.calledOnce.should.be.false();
         });
 
         it('`getUpdateDatabaseTasks` returns empty array if no tasks are found', function () {
             versioning.getUpdateDatabaseTasks('999', logStub).should.eql([]);
-            logStub.info.calledOnce.should.be.true();
         });
 
         it('`getUpdateDatabaseTasks` returns 5 items for 004', function () {
             versioning.getUpdateDatabaseTasks('004', logStub).should.be.an.Array().with.lengthOf(5);
-            logStub.info.calledOnce.should.be.false();
         });
     });
 });


### PR DESCRIPTION
no issue
- optimise the log output for migration tasks
- the order of print outs was wrong when printing the available tasks related to the current version
- https://github.com/TryGhost/Ghost/blob/master/core/server/data/schema/versioning.js#L80 Was not working, because we pushed comma separated arguments. It never showed the version.

Before: (after fixing the comma separated bug)
<img width="1440" alt="screen shot 2016-09-29 at 13 18 52" src="https://cloud.githubusercontent.com/assets/1160712/18952300/658a1700-8649-11e6-8847-64a705922b23.png">

After:
<img width="1440" alt="screen shot 2016-09-29 at 13 21 01" src="https://cloud.githubusercontent.com/assets/1160712/18952317/7234b8ca-8649-11e6-92c2-e130a7d84df4.png">
