### PR TITLE
🛠 Make greenkeeper ignore grunt dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,24 @@
       "glob",
       "mysql",
       "nodemailer",
-      "showdown-ghost"
+      "showdown-ghost",
+      "grunt",
+      "grunt-bg-shell",
+      "grunt-cli",
+      "grunt-contrib-clean",
+      "grunt-contrib-compress",
+      "grunt-contrib-copy",
+      "grunt-contrib-jshint",
+      "grunt-contrib-uglify",
+      "grunt-contrib-watch",
+      "grunt-docker",
+      "grunt-express-server",
+      "grunt-jscs",
+      "grunt-mocha-cli",
+      "grunt-mocha-istanbul",
+      "grunt-shell",
+      "grunt-subgrunt",
+      "grunt-update-submodules"
     ]
   }
 }


### PR DESCRIPTION
Same as https://github.com/TryGhost/Ghost-Admin/pull/296

It makes no sense for us to be bugged with greenkeeper update notifications (And travis builds) for grunt dependencies when we're phasing them out.

closes #7436
- We're moving away from grunt, so lets not worry about version bumps for now
