### PR TITLE
Refresh assetHash on theme activation

### DIFF
--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -60,6 +60,8 @@ themeHandler = {
 
         // clear the view cache
         blogApp.cache = {};
+        // reset the asset hash
+        config.assetHash = null;
 
         // set view engine
         hbsOptions = {


### PR DESCRIPTION
Alpha version of #7457

refs #7423
- asset hashes have never been refreshed properly!
- Ghost(Pro)'s 1-theme-only limitation has been hiding this bug for 3 years 🙄
