### PR TITLE
⏱ 🛠  Add debug@2.2.0 & wire up in key places

### DIFF
--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -1,4 +1,5 @@
-var _             = require('lodash'),
+var debug         = require('debug')('ghost:admin:controller'),
+    _             = require('lodash'),
     Promise       = require('bluebird'),
     api           = require('../api'),
     config        = require('../config'),
@@ -12,6 +13,7 @@ adminControllers = {
     // Path: /ghost/
     // Method: GET
     index: function index(req, res) {
+        debug('index called');
         /*jslint unparam:true*/
 
         function renderIndex() {
@@ -36,6 +38,7 @@ adminControllers = {
                     configuration.ghostAuthId = {value: result.patronus.uuid, type: 'string'};
                 }
 
+                debug('rendering default template');
                 res.render('default', {
                     configuration: configuration
                 });

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -4,7 +4,8 @@
 
 /*global require, module */
 
-var api         = require('../../api'),
+var debug = require('debug')('ghost:channels:single'),
+    api         = require('../../api'),
     utils       = require('../../utils'),
     filters     = require('../../filters'),
     templates   = require('./templates'),
@@ -23,11 +24,13 @@ var api         = require('../../api'),
 * Returns a function that takes the post to be rendered.
 */
 function renderPost(req, res) {
+    debug('renderPost called');
     return function renderPost(post) {
         var view = templates.single(req.app.get('activeTheme'), post),
             response = formatResponse.single(post);
 
         setResponseContext(req, res, response);
+        debug('Rendering view: ' + view);
         res.render(view, response);
     };
 }

--- a/core/server/controllers/frontend/render-channel.js
+++ b/core/server/controllers/frontend/render-channel.js
@@ -1,4 +1,5 @@
-var _           = require('lodash'),
+var debug = require('debug')('ghost:channels:render'),
+    _           = require('lodash'),
     errors      = require('../../errors'),
     filters     = require('../../filters'),
     safeString  = require('../../utils/index').safeString,
@@ -11,6 +12,7 @@ var _           = require('lodash'),
     templates          = require('./templates');
 
 function renderChannel(req, res, next) {
+    debug('renderChannel called');
     // Parse the parameters we need from the URL
     var channelOpts = req.channelConfig,
         pageParam = req.params.page !== undefined ? req.params.page : 1,
@@ -53,6 +55,7 @@ function renderChannel(req, res, next) {
             result.posts = posts;
             result = formatResponse.channel(result);
             setResponseContext(req, res);
+            debug('Rendering view: ' + view);
             res.render(view, result);
         });
     }).catch(handleError(next));

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -1,6 +1,7 @@
 // # Ghost Server
 // Handles the creation of an HTTP Server for Ghost
-var Promise = require('bluebird'),
+var debug = require('debug')('ghost:server'),
+    Promise = require('bluebird'),
     chalk = require('chalk'),
     fs = require('fs'),
     path = require('path'),
@@ -36,6 +37,7 @@ function GhostServer(rootApp) {
  * @return {Promise} Resolves once Ghost has started
  */
 GhostServer.prototype.start = function (externalApp) {
+    debug('Starting...');
     var self = this,
         rootApp = externalApp ? externalApp : self.rootApp,
         socketConfig, socketValues = {
@@ -89,6 +91,7 @@ GhostServer.prototype.start = function (externalApp) {
         });
         self.httpServer.on('connection', self.connection.bind(self));
         self.httpServer.on('listening', function () {
+            debug('...Started');
             self.logStartMessages();
             resolve(self);
         });

--- a/index.js
+++ b/index.js
@@ -1,16 +1,18 @@
 // # Ghost Startup
 // Orchestrates the startup of Ghost when run from command line.
-
 var ghost = require('./core'),
+    debug = require('debug')('ghost:boot:index'),
     express = require('express'),
     errors = require('./core/server/errors'),
     utils = require('./core/server/utils'),
     parentApp = express();
 
+debug('Initialising Ghost');
 ghost().then(function (ghostServer) {
     // Mount our Ghost instance on our desired subdirectory path if it exists.
     parentApp.use(utils.url.getSubdir(), ghostServer.rootApp);
 
+    debug('Starting Ghost');
     // Let Ghost handle starting our server instance.
     ghostServer.start(parentApp);
 }).catch(function (err) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cookie-session": "1.2.0",
     "cors": "2.8.1",
     "csv-parser": "1.11.0",
+    "debug": "2.2.0",
     "downsize": "0.0.8",
     "express": "4.14.0",
     "express-hbs": "1.0.3",


### PR DESCRIPTION
I've been back and forth on whether to do this, to the point of making the branch and commit & then not submitting the PR on a few occasions.

However, I've been doing some playing around with the codebase for the alpha releases, and have gotten stuck on not having this in place to start with to provide some idea of benchmarks / comparison for startup & request times. I need to know if I'm making things better or worse 😁 

Therefore, I'd like to get this in so that I can use it in subsequent PRs for the alpha. Even if we decide not to stick with it long term, it will be useful for the refactorings done during the rest of the alpha phase. I also thing it would be good to try it out, see how it goes, and if we'd prefer to overwrite it with a logging system, finding some way to make it play nicely with the output from our dependencies (knex, express, etc) would be good.

The usage of `debug` in this PR is just a baseline to get started with, if we stick with it there are a lot more places that it can be added.

Here's an example of the output we get with this PR:

![](https://puu.sh/rvkre.png)

refs #2001, #7116
- added debug and wired it up:
  - across several key parts of the boot process
  - throughout the middleware loading
  - for requests
  - at render points for key routes
