### PR TITLE
🎨 Use GhostAuth name and example emails

### DIFF
--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -63,16 +63,16 @@ strategies = {
 
     /**
      * Ghost Strategy
-     * patronusRefreshToken: will be null for now, because we don't need it right now
+     * ghostAuthRefreshToken: will be null for now, because we don't need it right now
      *
      * CASES:
      * - via invite token
      * - via normal auth
      * - via setup
      *
-     * @TODO: validate patronus profile?
+     * @TODO: validate GhostAuth profile?
      */
-    ghostStrategy: function ghostStrategy(req, patronusAccessToken, patronusRefreshToken, profile, done) {
+    ghostStrategy: function ghostStrategy(req, ghostAuthAccessToken, ghostAuthRefreshToken, profile, done) {
         var inviteToken = req.body.inviteToken,
             options = {context: {internal: true}},
             handleInviteToken, handleSetup;
@@ -135,9 +135,9 @@ strategies = {
 
                 return handleSetup();
             })
-            .then(function updatePatronusToken(user) {
+            .then(function updateGhostAuthToken(user) {
                 options.id = user.id;
-                return models.User.edit({patronus_access_token: patronusAccessToken}, options);
+                return models.User.edit({ghost_auth_access_token: ghostAuthAccessToken}, options);
             })
             .then(function returnResponse(user) {
                 done(null, user, profile);

--- a/core/server/auth/passport.js
+++ b/core/server/auth/passport.js
@@ -18,9 +18,9 @@ _private.registerClient = function registerClient(options) {
 
     return new Promise(function (resolve, reject) {
         var retry = function retry(retryCount, done) {
-            models.Client.findOne({name: 'Ghost Patronus'}, {context: {internal: true}})
+            models.Client.findOne({slug: 'ghost-auth'}, {context: {internal: true}})
                 .then(function (client) {
-                    // CASE: patronus client is already registered
+                    // CASE: Ghost Auth client is already registered
                     if (client) {
                         return done(null, {
                             client_id: client.get('uuid'),
@@ -31,8 +31,8 @@ _private.registerClient = function registerClient(options) {
                     return ghostOAuth2Strategy.registerClient({clientName: url})
                         .then(function addClient(credentials) {
                             return models.Client.add({
-                                name: 'Ghost Patronus',
-                                slug: 'patronus',
+                                name: 'Ghost Auth',
+                                slug: 'ghost-auth',
                                 uuid: credentials.client_id,
                                 secret: credentials.client_secret
                             }, {context: {internal: true}});
@@ -80,7 +80,7 @@ exports.init = function initPassport(options) {
         passport.use(new ClientPasswordStrategy(authStrategies.clientPasswordStrategy));
         passport.use(new BearerStrategy(authStrategies.bearerStrategy));
 
-        if (type !== 'patronus') {
+        if (type !== 'ghost') {
             return resolve({passport: passport.initialize()});
         }
 

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -26,6 +26,7 @@
         "active": "SchedulingDefault"
     },
     "auth": {
-        "type": "password"
+        "type": "ghost",
+        "url": "http://devauth.ghost.org:8080"
     }
 }

--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -8,9 +8,5 @@
     },
     "paths": {
         "contentPath": "content/"
-    },
-    "auth": {
-        "type": "patronus",
-        "url": "http://devauth.ghost.org:8080"
     }
 }

--- a/core/server/config/env/config.testing-mysql.json
+++ b/core/server/config/env/config.testing-mysql.json
@@ -12,5 +12,8 @@
             "database" : "ghost_testing"
         }
     },
+    "auth": {
+        "type": "password"
+    },
     "logging": false
 }

--- a/core/server/config/env/config.testing.json
+++ b/core/server/config/env/config.testing.json
@@ -9,5 +9,8 @@
     "server": {
         "port": 2369
     },
+    "auth": {
+        "type": "password"
+    },
     "logging": false
 }

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -21,7 +21,7 @@ adminControllers = {
                 fetch = {
                     configuration: api.configuration.read().then(function (res) { return res.configuration[0]; }),
                     client: api.clients.read({slug: 'ghost-admin'}).then(function (res) { return res.clients[0]; }),
-                    patronus: api.clients.read({slug: 'patronus'})
+                    ghostAuth: api.clients.read({slug: 'ghost-auth'})
                         .then(function (res) { return res.clients[0]; })
                         .catch(function () {
                             return;
@@ -34,8 +34,8 @@ adminControllers = {
                 configuration.clientId = {value: result.client.slug, type: 'string'};
                 configuration.clientSecret = {value: result.client.secret, type: 'string'};
 
-                if (result.patronus && config.get('auth:type') === 'patronus') {
-                    configuration.ghostAuthId = {value: result.patronus.uuid, type: 'string'};
+                if (result.ghostAuth && config.get('auth:type') === 'ghost') {
+                    configuration.ghostAuthId = {value: result.ghostAuth.uuid, type: 'string'};
                 }
 
                 debug('rendering default template');

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -29,7 +29,7 @@ module.exports = {
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
         name: {type: 'string', maxlength: 150, nullable: false},
         slug: {type: 'string', maxlength: 150, nullable: false, unique: true},
-        patronus_access_token: {type: 'string', nullable: true},
+        ghost_auth_access_token: {type: 'string', nullable: true},
         password: {type: 'string', maxlength: 60, nullable: false},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
         image: {type: 'text', maxlength: 2000, nullable: true},

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -131,7 +131,7 @@ User = ghostBookshelf.Model.extend({
         var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
         // remove password hash for security reasons
         delete attrs.password;
-        delete attrs.patronus_access_token;
+        delete attrs.ghost_auth_access_token;
 
         if (!options || !options.context || (!options.context.user && !options.context.internal)) {
             delete attrs.email;

--- a/core/test/integration/api/api_invites_spec.js
+++ b/core/test/integration/api/api_invites_spec.js
@@ -29,7 +29,7 @@ describe('Invites API', function () {
         describe('Add', function () {
             it('add invite 1', function (done) {
                 InvitesAPI.add({
-                    invites: [{email: 'kate+1@ghost.org', roles: [testUtils.roles.ids.editor]}]
+                    invites: [{email: 'test@example.com', roles: [testUtils.roles.ids.editor]}]
                 }, _.merge({}, {include: ['roles']}, testUtils.context.owner))
                     .then(function (response) {
                         response.invites.length.should.eql(1);
@@ -41,7 +41,7 @@ describe('Invites API', function () {
 
             it('add invite 2', function (done) {
                 InvitesAPI.add({
-                    invites: [{email: 'kate+2@ghost.org', roles: [testUtils.roles.ids.author]}]
+                    invites: [{email: 'test2@example.com', roles: [testUtils.roles.ids.author]}]
                 }, _.merge({}, {include: ['roles']}, testUtils.context.owner))
                     .then(function (response) {
                         response.invites.length.should.eql(1);
@@ -189,7 +189,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.owner]
                         }
                     ]
@@ -202,7 +202,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.admin]
                         }
                     ]
@@ -217,7 +217,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.editor]
                         }
                     ]
@@ -232,7 +232,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.author]
                         }
                     ]
@@ -247,7 +247,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.author.toString()]
                         }
                     ]
@@ -264,7 +264,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.owner]
                         }
                     ]
@@ -277,7 +277,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.admin]
                         }
                     ]
@@ -292,7 +292,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.editor]
                         }
                     ]
@@ -307,7 +307,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.author]
                         }
                     ]
@@ -324,7 +324,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.owner]
                         }
                     ]
@@ -337,7 +337,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.author]
                         }
                     ]
@@ -352,7 +352,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.owner]
                         }
                     ]
@@ -365,7 +365,7 @@ describe('Invites API', function () {
                 InvitesAPI.add({
                     invites: [
                         {
-                            email: 'kate+1@ghost.org',
+                            email: 'test@example.com',
                             roles: [testUtils.roles.ids.author]
                         }
                     ]

--- a/core/test/unit/auth/auth-strategies_spec.js
+++ b/core/test/unit/auth/auth-strategies_spec.js
@@ -212,14 +212,14 @@ describe('Auth Strategies', function () {
         });
 
         it('with invite, but with wrong invite token', function (done) {
-            var patronusAccessToken = '12345',
+            var ghostAuthAccessToken = '12345',
                 req = {body: {inviteToken: 'wrong'}},
-                profile = {email_address: 'kate@ghost.org'};
+                profile = {email_address: 'test@example.com'};
 
             userByEmailStub.returns(Promise.resolve(null));
             inviteStub.returns(Promise.reject(new errors.NotFoundError()));
 
-            authStrategies.ghostStrategy(req, patronusAccessToken, null, profile, function (err) {
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, profile, function (err) {
                 should.exist(err);
                 (err instanceof errors.NotFoundError).should.eql(true);
                 userByEmailStub.calledOnce.should.be.true();
@@ -229,9 +229,9 @@ describe('Auth Strategies', function () {
         });
 
         it('with correct invite token, but expired', function (done) {
-            var patronusAccessToken = '12345',
+            var ghostAuthAccessToken = '12345',
                 req = {body: {inviteToken: 'token'}},
-                profile = {email_address: 'kate@ghost.org'};
+                profile = {email_address: 'test@example.com'};
 
             userByEmailStub.returns(Promise.resolve(null));
             inviteStub.returns(Promise.resolve(Models.Invite.forge({
@@ -240,7 +240,7 @@ describe('Auth Strategies', function () {
                 expires: Date.now() - 1000
             })));
 
-            authStrategies.ghostStrategy(req, patronusAccessToken, null, profile, function (err) {
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, profile, function (err) {
                 should.exist(err);
                 (err instanceof errors.NotFoundError).should.eql(true);
                 userByEmailStub.calledOnce.should.be.true();
@@ -250,9 +250,9 @@ describe('Auth Strategies', function () {
         });
 
         it('with correct invite token', function (done) {
-            var patronusAccessToken = '12345',
+            var ghostAuthAccessToken = '12345',
                 req = {body: {inviteToken: 'token'}},
-                invitedProfile = {email_address: 'kate@ghost.org'},
+                invitedProfile = {email_address: 'test@example.com'},
                 invitedUser = {id: 2},
                 inviteModel = Models.Invite.forge({
                     id: 1,
@@ -266,7 +266,7 @@ describe('Auth Strategies', function () {
             inviteStub.returns(Promise.resolve(inviteModel));
             sandbox.stub(inviteModel, 'destroy').returns(Promise.resolve());
 
-            authStrategies.ghostStrategy(req, patronusAccessToken, null, invitedProfile, function (err, user, profile) {
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, invitedProfile, function (err, user, profile) {
                 should.not.exist(err);
                 should.exist(user);
                 should.exist(profile);
@@ -280,24 +280,24 @@ describe('Auth Strategies', function () {
         });
 
         it('setup', function (done) {
-            var patronusAccessToken = '12345',
+            var ghostAuthAccessToken = '12345',
                 req = {body: {}},
-                ownerProfile = {email_address: 'kate@ghost.org'},
+                ownerProfile = {email_address: 'test@example.com'},
                 owner = {id: 2};
 
             userByEmailStub.returns(Promise.resolve(null));
             userFindOneStub.returns(Promise.resolve(_.merge({}, {status: 'inactive'}, owner)));
-            userEditStub.withArgs({status: 'active', email: 'kate@ghost.org'}, {
+            userEditStub.withArgs({status: 'active', email: 'test@example.com'}, {
                 context: {internal: true},
                 id: owner.id
             }).returns(Promise.resolve(owner));
 
-            userEditStub.withArgs({patronus_access_token: patronusAccessToken}, {
+            userEditStub.withArgs({ghost_auth_access_token: ghostAuthAccessToken}, {
                 context: {internal: true},
                 id: owner.id
             }).returns(Promise.resolve(owner));
 
-            authStrategies.ghostStrategy(req, patronusAccessToken, null, ownerProfile, function (err, user, profile) {
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, ownerProfile, function (err, user, profile) {
                 should.not.exist(err);
                 userByEmailStub.calledOnce.should.be.true();
                 inviteStub.calledOnce.should.be.false();
@@ -311,18 +311,18 @@ describe('Auth Strategies', function () {
         });
 
         it('auth', function (done) {
-            var patronusAccessToken = '12345',
+            var ghostAuthAccessToken = '12345',
                 req = {body: {}},
-                ownerProfile = {email_address: 'kate@ghost.org'},
+                ownerProfile = {email_address: 'test@example.com'},
                 owner = {id: 2};
 
             userByEmailStub.returns(Promise.resolve(owner));
-            userEditStub.withArgs({patronus_access_token: patronusAccessToken}, {
+            userEditStub.withArgs({ghost_auth_access_token: ghostAuthAccessToken}, {
                 context: {internal: true},
                 id: owner.id
             }).returns(Promise.resolve(owner));
 
-            authStrategies.ghostStrategy(req, patronusAccessToken, null, ownerProfile, function (err, user, profile) {
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, ownerProfile, function (err, user, profile) {
                 should.not.exist(err);
                 userByEmailStub.calledOnce.should.be.true();
                 userEditStub.calledOnce.should.be.true();

--- a/core/test/unit/mail/utils_spec.js
+++ b/core/test/unit/mail/utils_spec.js
@@ -29,11 +29,11 @@ describe('Mail: Utils', function () {
         mail.utils.generateContent({
             template: 'welcome',
             data: {
-                ownerEmail: 'kate@ghost.org'
+                ownerEmail: 'test@example.com'
             }
         }).then(function (result) {
             return scope.ghostMailer.send({
-                to: 'kate@ghost.org',
+                to: 'test@example.com',
                 subject: 'lol',
                 html: result.html,
                 text: result.text
@@ -104,7 +104,7 @@ describe('Mail: Utils', function () {
             }
         }).then(function (result) {
             return scope.ghostMailer.send({
-                to: 'aileen@ghost.org',
+                to: 'jbloggs@example.com',
                 subject: 'The Newsletter Blog',
                 html: result.html,
                 text: result.text

--- a/core/test/unit/utils/read-csv_spec.js
+++ b/core/test/unit/utils/read-csv_spec.js
@@ -13,8 +13,8 @@ describe('read csv', function () {
             should.exist(result);
             result.length.should.eql(3);
             result[0].email.should.eql('email');
-            result[1].email.should.eql('hannah@ghost.org');
-            result[2].email.should.eql('kate@ghost.org');
+            result[1].email.should.eql('jbloggs@example.com');
+            result[2].email.should.eql('test@example.com');
             done();
         }).catch(done);
     });
@@ -26,8 +26,8 @@ describe('read csv', function () {
         }).then(function (result) {
             should.exist(result);
             result.length.should.eql(2);
-            result[0].email.should.eql('hannah@ghost.org');
-            result[1].email.should.eql('kate@ghost.org');
+            result[0].email.should.eql('jbloggs@example.com');
+            result[1].email.should.eql('test@example.com');
             should.not.exist(result[0].id);
 
             done();
@@ -44,9 +44,9 @@ describe('read csv', function () {
         }).then(function (result) {
             should.exist(result);
             result.length.should.eql(2);
-            result[0].email.should.eql('hannah@ghost.org');
+            result[0].email.should.eql('jbloggs@example.com');
             result[0].id.should.eql('1');
-            result[1].email.should.eql('kate@ghost.org');
+            result[1].email.should.eql('test@example.com');
             result[1].id.should.eql('2');
             done();
         }).catch(done);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -22,7 +22,7 @@ var _               = require('lodash'),
         // Post API swaps author_id to author, and always returns a computed 'url' property
         post:        _(schema.posts).keys().without('author_id').concat('author', 'url').value(),
         // User API always removes the password field
-        user:        _(schema.users).keys().without('password').without('patronus_access_token').value(),
+        user:        _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),
         // Tag API swaps parent_id to parent
         tag:         _(schema.tags).keys().without('parent_id').concat('parent').value(),
         setting:     _.keys(schema.settings),

--- a/core/test/utils/fixtures/csv/single-column-with-header.csv
+++ b/core/test/utils/fixtures/csv/single-column-with-header.csv
@@ -1,3 +1,3 @@
 email
-hannah@ghost.org
-kate@ghost.org
+jbloggs@example.com
+test@example.com

--- a/core/test/utils/fixtures/csv/two-columns-obscure-header.csv
+++ b/core/test/utils/fixtures/csv/two-columns-obscure-header.csv
@@ -1,3 +1,3 @@
 id,Email Address
-1,"hannah@ghost.org"
-2,kate@ghost.org
+1,"jbloggs@example.com"
+2,test@example.com

--- a/core/test/utils/fixtures/csv/two-columns-with-header.csv
+++ b/core/test/utils/fixtures/csv/two-columns-with-header.csv
@@ -1,3 +1,3 @@
 id,email
-1,"hannah@ghost.org"
-1,kate@ghost.org
+1,"jbloggs@example.com"
+1,test@example.com


### PR DESCRIPTION
This PR changes some references to the Auth project codename.

It also swaps the default auth method to be GhostAuth for all environments.

This is overridden for testing and can also be overridden in development mode. If you're developing other features, you may prefer to add a `config.development.json` file to your root directory, and add the following config:

```
"auth": {
      "type": "password"
}
```

This will switch Ghost to using old-style, local authentication.

refs #7452
- remove references to 'patronus' in favour of GhostAuth, Note: this will require databases to be deleted ;)
- remove email addresses from test data
