### PR TITLE
🐛 Provide a default statusCode for errors

### DIFF
--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -89,7 +89,7 @@ module.exports = function errorHandler(err, req, res, next) {
     }
 
     req.err = err;
-    res.statusCode = err.statusCode;
+    res.statusCode = err.statusCode || 500;
 
     // never cache errors
     res.set({


### PR DESCRIPTION
Before this PR, if there's an unhandled error I get this:

```
_http_server.js:192
    throw new RangeError(`Invalid status code: ${statusCode}`);
    ^

RangeError: Invalid status code: 0
    at ServerResponse.writeHead (_http_server.js:192:11)
    at ServerResponse.writeHead (/Users/hannah/Ghost/Ghost/node_modules/compression/node_modules/on-headers/index.js:55:19)
    at ServerResponse._implicitHeader (_http_server.js:157:8)
    at ServerResponse.end (/Users/hannah/Ghost/Ghost/node_modules/compression/index.js:102:14)
    at ServerResponse.send (/Users/hannah/Ghost/Ghost/node_modules/express/lib/response.js:205:10)
    at renderResponse (/Users/hannah/Ghost/Ghost/core/server/middleware/error-handler.js:50:28)
    at _stackRenderer (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:526:9)
    at /Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:503:7
    at Function.Waiter.done (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/async.js:68:12)
    at renderTemplate (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:494:11)
    at render (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:531:5)
    at renderIt (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:593:18)
    at /Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:616:11
    at parseLayout (/Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:467:7)
    at /Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:582:7
    at /Users/hannah/Ghost/Ghost/node_modules/express-hbs/lib/hbs.js:570:14
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```

After this PR I get:

```
ERROR
Failed to lookup view "default" in views directory "/Users/hannah/Ghost/Ghost/core/server/views/"
Error: Failed to lookup view "default" in views directory "/Users/hannah/Ghost/Ghost/core/server/views/"
    at EventEmitter.render (/Users/hannah/Ghost/Ghost/node_modules/express/lib/application.js:579:17)
    at ServerResponse.render (/Users/hannah/Ghost/Ghost/node_modules/express/lib/response.js:960:7)
    at renderIndex (/Users/hannah/Ghost/Ghost/core/server/controllers/admin.js:42:21)
    at tryCatcher (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:691:18)
    at Promise._fulfill (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:636:18)
    at PropertiesPromiseArray.PromiseArray._resolve (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise_array.js:125:19)
    at PropertiesPromiseArray._promiseFulfilled (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/props.js:78:14)
    at Promise._settlePromise (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:572:26)
    at Promise._settlePromise0 (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

refs #7431, #7116
- this prevents us from getting errors from _http_server if the error we catch doesn't have a status code 💃
