### PR TITLE
🐛  argv config overrides

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -18,11 +18,15 @@ nconf.env();
 
 /**
  * load config files
+ * @TODO:
+ * - why does this work? i have no idea!
+ * - find out why argv override works, when defining these weird keys
+ * - i could not find any nconf usages so that all config requirements work
  */
-nconf.file('1', __dirname + '/overrides.json');
-nconf.file('2', path.join(process.cwd(), 'config.' + env + '.json'));
-nconf.file('3', __dirname + '/env/config.' + env + '.json');
-nconf.file('4', __dirname + '/defaults.json');
+nconf.file('ghost1', __dirname + '/overrides.json');
+nconf.file('ghost2', path.join(process.cwd(), 'config.' + env + '.json'));
+nconf.file('ghost3', __dirname + '/env/config.' + env + '.json');
+nconf.file('ghost4', __dirname + '/defaults.json');
 
 /**
  * transform all relative paths to absolute paths


### PR DESCRIPTION
refs #7492 

**This is just a temporary solution!**

I have no clue what and why this works and how to use `nconf` different to fulfil **all** config requirements. We will spend more time soon 👍 
