### PR TITLE
[WIP] 🐛  re-arrange logic for database population

### DIFF
--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -61,7 +61,14 @@ createOwner = function createOwner(logger, modelOptions) {
             user.roles = [ownerRole.id];
 
             logger.info('Creating owner');
-            return models.User.add(user, modelOptions);
+            return models.User.findOne({name: 'Ghost Owner', status: 'all'}, modelOptions)
+                .then(function (exists) {
+                   if (exists) {
+                       return;
+                   }
+
+                    return models.User.add(user, modelOptions);
+                });
         }
     });
 };

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -66,10 +66,16 @@ function dropUnique(table, column, transaction) {
 }
 
 function createTable(table, transaction) {
-    return (transaction || db.knex).schema.createTableIfNotExists(table, function (t) {
-        var columnKeys = _.keys(schema[table]);
-        _.each(columnKeys, function (column) {
-            return addTableColumn(table, t, column);
+    return (transaction || db.knex).schema.hasTable(table).then(function (exists) {
+        if (exists) {
+            return;
+        }
+
+        return (transaction || db.knex).schema.createTable(table, function (t) {
+            var columnKeys = _.keys(schema[table]);
+            _.each(columnKeys, function (column) {
+                return addTableColumn(table, t, column);
+            });
         });
     });
 }

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "databaseVersion": {
-            "defaultValue": "009"
+            "defaultValue": "010"
         },
         "dbHash": {
             "defaultValue": null
@@ -17,6 +17,9 @@
         },
         "migrations": {
             "defaultValue": "{}"
+        },
+        "databasePopulated": {
+            "defaultValue": false
         }
     },
     "blog": {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -94,6 +94,7 @@ function init(options) {
             })
             .catch(function (err) {
                 if (err instanceof errors.DatabaseNotPopulated) {
+                    // populated means: either has not all tables or missing default/fixture values!
                     return migrations.populate();
                 }
 


### PR DESCRIPTION
refs #7448, refs #6574, refs #7432
- transactions won't work for mysql when creating tables (see http://stackoverflow.com/questions/4692690/is-it-possible-to-roll-back-create-table-and-alter-table-statements-in-major-sql)
- the logic depends on that fact, so let's re-arrange the logic a bit
- optimise the check of: when is a database populated and when not
- add a settings entry: databasePopulated
- if this attribute is NOT set, the database is not fully populated
- db versions before 010 just skip
- extend the logic to always check if data already exists --> for fixtures
- createTableIfNotExists fix --> needs maybe optimisation, but it works like this (the problem is that addTableColumn re-creates the indexes as far as i understood)
#### TODO
- [ ] audit
- [ ] more testing
- [ ] fix tests
- [ ] decide if the fix is needed for 1.0
