### PR TITLE
Database versions

### DIFF
--- a/core/server/data/migration/populate.js
+++ b/core/server/data/migration/populate.js
@@ -3,9 +3,11 @@
 var Promise = require('bluebird'),
     _ = require('lodash'),
     commands = require('../schema').commands,
+    versioning = require('../schema').versioning,
     fixtures = require('./fixtures'),
     db = require('../../data/db'),
     logging = require('../../logging'),
+    models = require('../../models'),
     errors = require('../../errors'),
     schema = require('../schema').tables,
     schemaTables = Object.keys(schema),
@@ -40,6 +42,12 @@ populate = function populate(options) {
         return Promise.mapSeries(schemaTables, function createTable(table) {
             logger.info('Creating table: ' + table);
             return commands.createTable(table, transaction);
+        }).then(function () {
+            // @TODO: move to seed
+            return models.Settings.populateDefaults(_.merge({}, {transacting: transaction}, modelOptions));
+        }).then(function () {
+            // @TODO: move to seed
+            return versioning.setDatabaseVersion(transaction);
         }).then(function populateFixtures() {
             if (tablesOnly) {
                 return;

--- a/core/server/data/migration/populate.js
+++ b/core/server/data/migration/populate.js
@@ -43,10 +43,14 @@ populate = function populate(options) {
             logger.info('Creating table: ' + table);
             return commands.createTable(table, transaction);
         }).then(function () {
-            // @TODO: move to seed
+            // @TODO:
+            //  - key: migrations-kate
+            //  - move to seed
             return models.Settings.populateDefaults(_.merge({}, {transacting: transaction}, modelOptions));
         }).then(function () {
-            // @TODO: move to seed
+            // @TODO:
+            //  - key: migrations-kate
+            //  - move to seed
             return versioning.setDatabaseVersion(transaction);
         }).then(function populateFixtures() {
             if (tablesOnly) {

--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -4,20 +4,29 @@ var Promise = require('bluebird'),
     errors = require('./../../errors');
 
 module.exports = function bootUp() {
+    /**
+     * @TODO:
+     * - 1. call is check if tables are populated
+     * - 2. call is check if db is seeded
+     *
+     * These are the calls Ghost will make to find out if the db is in OK state!
+     * These check's will have nothing to do with the migration module!
+     * Ghost will not touch the migration module at all.
+     *
+     * Example code:
+     * models.Settings.findOne({key: 'databasePopulated'})
+     * If not, throw error and tell user what to do (ghost db-init)!
+     *
+     * versioning.getDatabaseVersion() - not sure about that yet.
+     * This will read the database version of the settings table!
+     * If not, throw error and tell user what to do (ghost db-seed)!
+     *
+     * @TODO:
+     * - remove return populate() -> belongs to db init
+     */
     return versioning
         .getDatabaseVersion()
-        .then(function successHandler(result) {
-            if (!/^alpha/.test(result)) {
-                // This database was not created with Ghost alpha, and is not compatible
-                throw new errors.DatabaseVersionError({
-                    message: 'Your database version is not compatible with Ghost 1.0.0 Alpha (master branch)',
-                    context: 'Want to keep your DB? Use Ghost < 1.0.0 or the "stable" branch. Otherwise please delete your DB and restart Ghost',
-                    help: 'More information on the Ghost 1.0.0 Alpha at https://support.ghost.org/v1-0-alpha'
-                });
-            }
-        },
-        // We don't use .catch here, as it would catch the error from the successHandler
-        function errorHandler(err) {
+        .catch(function errorHandler(err) {
             if (err instanceof errors.DatabaseNotPopulatedError) {
                 return populate();
             }

--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -23,6 +23,7 @@ module.exports = function bootUp() {
      *
      * @TODO:
      * - remove return populate() -> belongs to db init
+     * - key: migrations-kate
      */
     return versioning
         .getDatabaseVersion()

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "databaseVersion": {
-            "defaultValue": "alpha.1"
+            "defaultValue": null
         },
         "dbHash": {
             "defaultValue": null

--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -89,6 +89,12 @@ var errors = {
             errorType: 'DatabaseNotPopulatedError'
         }, options));
     },
+    DatabaseNotSeededError: function DatabaseNotSeededError(options) {
+        GhostError.call(this, _.merge({
+            statusCode: 500,
+            errorType: 'DatabaseNotSeededError'
+        }, options));
+    },
     UnauthorizedError: function UnauthorizedError(options) {
         GhostError.call(this, _.merge({
             statusCode: 401,

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -440,6 +440,7 @@
                 "index": {
                     "dbVersionNotRecognized": "Database version is not recognized",
                     "databaseNotPopulated": "Database is not populated.",
+                    "databaseNotSeeded": "Database is not seeded.",
                     "cannotMigrate": {
                         "error": "Unable to upgrade from version 0.4.2 or earlier.",
                         "context": "Please upgrade to 0.7.1 first."

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -1,8 +1,6 @@
 var testUtils = require('../../utils'),
     should    = require('should'),
     _         = require('lodash'),
-
-    // Stuff we are testing
     dbAPI          = require('../../../server/api/db'),
     ModelTag       = require('../../../server/models/tag'),
     ModelPost      = require('../../../server/models/post');

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -10,6 +10,7 @@ var testUtils       = require('../../utils'),
     ghostBookshelf  = require('../../../server/models/base'),
     PostModel       = require('../../../server/models/post').Post,
     TagModel        = require('../../../server/models/tag').Tag,
+    models          = require('../../../server/models'),
     events          = require('../../../server/events'),
     errors          = require('../../../server/errors'),
     DataGenerator   = testUtils.DataGenerator,
@@ -26,6 +27,17 @@ describe('Post Model', function () {
 
     beforeEach(function () {
         eventSpy = sandbox.spy(events, 'emit');
+
+        /**
+         * @TODO:
+         * - key: migrations-kate
+         * - this is not pretty
+         * - eventSpy get's now more events then expected
+         * - because on migrations.populate we trigger populateDefaults
+         * - how to solve? eventSpy must be local and not global?
+         */
+        models.init();
+        sandbox.stub(models.Settings, 'populateDefaults').returns(Promise.resolve());
     });
 
     afterEach(function () {

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -10,6 +10,7 @@ var testUtils   = require('../../utils'),
     gravatar    = require('../../../server/utils/gravatar'),
     UserModel   = require('../../../server/models/user').User,
     RoleModel   = require('../../../server/models/role').Role,
+    models      = require('../../../server/models'),
     events      = require('../../../server/events'),
     context     = testUtils.context.admin,
     sandbox     = sinon.sandbox.create();
@@ -29,6 +30,17 @@ describe('User Model', function run() {
 
     beforeEach(function () {
         eventSpy = sandbox.spy(events, 'emit');
+
+        /**
+         * @TODO:
+         * - key: migrations-kate
+         * - this is not pretty
+         * - eventSpy get's now more events then expected
+         * - because on migrations.populate we trigger populateDefaults
+         * - how to solve? eventSpy must be local and not global?
+         */
+        models.init();
+        sandbox.stub(models.Settings, 'populateDefaults').returns(Promise.resolve());
     });
 
     describe('Registration', function runRegistration() {

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -125,44 +125,5 @@ describe('server bootstrap', function () {
                     done(err);
                 });
         });
-
-        // @TODO remove these temporary tests ;)
-        it('TEMP: database does exist: expect alpha error', function (done) {
-            sandbox.stub(migration.update, 'isDatabaseOutOfDate').returns({migrate:false});
-            sandbox.spy(migration.update, 'execute');
-
-            sandbox.stub(versioning, 'getDatabaseVersion', function () {
-                return Promise.resolve('006');
-            });
-
-            bootstrap()
-                .then(function () {
-                    done('This should not be called');
-                })
-                .catch(function (err) {
-                    err.errorType.should.eql('DatabaseVersionError');
-                    err.message.should.eql('Your database version is not compatible with Ghost 1.0.0 Alpha (master branch)');
-                    done();
-                });
-        });
-
-        it('TEMP: database does exist: expect alpha error', function (done) {
-            sandbox.stub(migration.update, 'isDatabaseOutOfDate').returns({migrate:true});
-            sandbox.stub(migration.update, 'execute').returns(Promise.resolve());
-
-            sandbox.stub(versioning, 'getDatabaseVersion', function () {
-                return Promise.resolve('006');
-            });
-
-            bootstrap()
-                .then(function () {
-                    done('This should not be called');
-                })
-                .catch(function (err) {
-                    err.errorType.should.eql('DatabaseVersionError');
-                    err.message.should.eql('Your database version is not compatible with Ghost 1.0.0 Alpha (master branch)');
-                    done();
-                });
-        });
     });
 });

--- a/core/test/unit/versioning_spec.js
+++ b/core/test/unit/versioning_spec.js
@@ -1,13 +1,13 @@
-var should  = require('should'),
-    sinon   = require('sinon'),
+var should = require('should'),
+    sinon = require('sinon'),
     Promise = require('bluebird'),
 
     // Stuff we are testing
     versioning = require('../../server/data/schema').versioning,
-    db         = require('../../server/data/db'),
-    errors     = require('../../server/errors'),
+    db = require('../../server/data/db'),
+    errors = require('../../server/errors'),
 
-    sandbox    = sinon.sandbox.create();
+    sandbox = sinon.sandbox.create();
 
 describe('Versioning', function () {
     afterEach(function () {
@@ -17,25 +17,26 @@ describe('Versioning', function () {
     describe('getMigrationVersions', function () {
         it('should output a single item if the from and to versions are the same', function () {
             should.exist(versioning.getMigrationVersions);
-            versioning.getMigrationVersions('003', '003').should.eql(['003']);
-            versioning.getMigrationVersions('004', '004').should.eql(['004']);
+            versioning.getMigrationVersions('1.0', '1.0').should.eql([]);
+            versioning.getMigrationVersions('1.2', '1.2').should.eql([]);
         });
 
         it('should output an empty array if the toVersion is higher than the fromVersion', function () {
-            versioning.getMigrationVersions('003', '002').should.eql([]);
+            versioning.getMigrationVersions('1.2', '1.1').should.eql([]);
         });
 
         it('should output all the versions between two versions', function () {
-            versioning.getMigrationVersions('003', '004').should.eql(['003', '004']);
-            versioning.getMigrationVersions('003', '005').should.eql(['003', '004', '005']);
-            versioning.getMigrationVersions('003', '006').should.eql(['003', '004', '005', '006']);
-            versioning.getMigrationVersions('010', '011').should.eql(['010', '011']);
+            versioning.getMigrationVersions('1.0', '1.1').should.eql(['1.1']);
+            versioning.getMigrationVersions('1.0', '1.2').should.eql(['1.1', '1.2']);
+            versioning.getMigrationVersions('1.2', '1.5').should.eql(['1.3', '1.4', '1.5']);
+            versioning.getMigrationVersions('2.1', '2.2').should.eql(['2.2']);
         });
     });
 
     describe('getNewestDatabaseVersion', function () {
         it('should return the correct version', function () {
-            var currentVersion = require('../../server/data/schema').defaultSettings.core.databaseVersion.defaultValue;
+            var currentVersion = '1.0';
+
             // This function has an internal cache, so we call it twice.
             // First, to check that it fetches the correct version from default-settings.json.
             versioning.getNewestDatabaseVersion().should.eql(currentVersion);
@@ -59,7 +60,11 @@ describe('Versioning', function () {
             };
 
             // this MUST use sinon, not sandbox, see sinonjs/sinon#781
-            knexStub = sinon.stub(db, 'knex', {get: function () { return knexMock; }});
+            knexStub = sinon.stub(db, 'knex', {
+                get: function () {
+                    return knexMock;
+                }
+            });
         });
 
         afterEach(function () {
@@ -89,12 +94,12 @@ describe('Versioning', function () {
         it('should lookup & return version, if settings table exists', function (done) {
             // Setup
             knexMock.schema.hasTable.returns(new Promise.resolve(true));
-            queryMock.first.returns(new Promise.resolve({value: '001'}));
+            queryMock.first.returns(new Promise.resolve({value: '1.0'}));
 
             // Execute
             versioning.getDatabaseVersion().then(function (version) {
                 should.exist(version);
-                version.should.eql('001');
+                version.should.eql('1.0');
 
                 knexStub.get.calledTwice.should.be.true();
                 knexMock.schema.hasTable.calledOnce.should.be.true();
@@ -155,6 +160,21 @@ describe('Versioning', function () {
                 done();
             }).catch(done);
         });
+
+        it('database does exist: expect alpha error', function (done) {
+            knexMock.schema.hasTable.returns(new Promise.resolve(true));
+            queryMock.first.returns(new Promise.resolve({value: '008'}));
+
+            versioning.getDatabaseVersion()
+                .then(function () {
+                    done('Should throw an error if version is not a number');
+                })
+                .catch(function (err) {
+                    err.errorType.should.eql('DatabaseVersion');
+                    err.message.should.eql('Your database version is not compatible with Ghost 1.0.0 Alpha (master branch)');
+                    done();
+                });
+        });
     });
 
     describe('setDatabaseVersion', function () {
@@ -169,7 +189,11 @@ describe('Versioning', function () {
             knexMock = sandbox.stub().returns(queryMock);
 
             // this MUST use sinon, not sandbox, see sinonjs/sinon#781
-            knexStub = sinon.stub(db, 'knex', {get: function () { return knexMock; }});
+            knexStub = sinon.stub(db, 'knex', {
+                get: function () {
+                    return knexMock;
+                }
+            });
         });
 
         afterEach(function () {

--- a/core/test/unit/versioning_spec.js
+++ b/core/test/unit/versioning_spec.js
@@ -170,7 +170,7 @@ describe('Versioning', function () {
                     done('Should throw an error if version is not a number');
                 })
                 .catch(function (err) {
-                    err.errorType.should.eql('DatabaseVersion');
+                    (err instanceof errors.DatabaseVersionError).should.eql(true);
                     err.message.should.eql('Your database version is not compatible with Ghost 1.0.0 Alpha (master branch)');
                     done();
                 });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -457,6 +457,10 @@ toDoList = {
   *  * `perms:obj` - initialise permissions for a particular object type
   *  * `users:roles` - create a full suite of users, one per role
  * @param {Object} toDos
+ *
+ * @TODO:
+ *  - key: migrations-kate
+ *  - call migration-runner
  */
 getFixtureOps = function getFixtureOps(toDos) {
     // default = default fixtures, if it isn't present, init with tables only


### PR DESCRIPTION
refs #7489 

Already explained the change in #7489 , but here some details to the implementation and the bigger idea:

The database version reflects always the Ghost version. So when you are on `1.4` and you update to `1.6` and this version contains 3 migration files, they get executed and when successful your database version will get set to `1.6`. Otherwise all migration scripts roll back (everything happens in one transaction) and your blog starts with `1.4`. So no need to add the `-X` postfix, i think there is no benefit?

The big idea is: By default your database version is `null`. Null signals that your database was not fully seeded yet. 
1. population of tables
   We ensure that population of tables was successful by adding a something to the database, which we can later check on bootstrap. For example: add a key into settings table: database populated. (mysql does not support rolling back table creation). Alternatively we can check if all tables exists, but that would slow down the bootstrap process, so i checking a property in the db should be fine.
2. seeding the database
   Populate default settings, add owner, add welcome post and finally set database version to `X.X`.
   This might be a migration script. (not fully designed yet in my head)

Both might be implemented as migration scripts. I's not fully designed yet in my head. But i can think of something like:
- migrations
  - init
    - 1-tables
    - 2-seed
  - 1.0
  - 1.1

A big challenge for the next PR's is, to make small changes and take care of the test env. We have a lot of tests around migrations and the way we insert data into db in test env relies on fixtures. We'll see.

This PR only contains the preparation for Database Versioning changes.
I've added a key `migrations-kate`, so i can easily find all `TODO's` for the next PR's.
