### PR TITLE
✨ use migration runner for init db

### DIFF
--- a/core/server/data/migration/fixtures/populate.js
+++ b/core/server/data/migration/fixtures/populate.js
@@ -60,8 +60,17 @@ createOwner = function createOwner(logger, modelOptions) {
         if (ownerRole) {
             user.roles = [ownerRole.id];
 
-            logger.info('Creating owner');
-            return models.User.add(user, modelOptions);
+            return models.User
+                .findOne({name: 'Ghost Owner', status: 'all'}, modelOptions)
+                .then(function (exists) {
+                    if (exists) {
+                        logger.warn('Skipping: Creating owner');
+                        return;
+                    }
+
+                    logger.info('Creating owner');
+                    return models.User.add(user, modelOptions);
+                });
         }
     });
 };

--- a/core/server/data/migration/reset.js
+++ b/core/server/data/migration/reset.js
@@ -1,9 +1,8 @@
 // ### Reset
 // Delete all tables from the database in reverse order
-var Promise      = require('bluebird'),
-    commands     = require('../schema').commands,
-    schema       = require('../schema').tables,
-
+var Promise = require('bluebird'),
+    commands = require('../schema').commands,
+    schema = require('../schema').tables,
     schemaTables = Object.keys(schema).reverse(),
     reset;
 
@@ -12,11 +11,23 @@ var Promise      = require('bluebird'),
  * Deletes all the tables defined in the schema
  * Uses reverse order, which ensures that foreign keys are removed before the parent table
  *
+ * @TODO:
+ * - move to sephiroth
+ * - then deleting migrations table will make sense
+ *
  * @returns {Promise<*>}
  */
 reset = function reset() {
+    var result;
+
     return Promise.mapSeries(schemaTables, function (table) {
         return commands.deleteTable(table);
+    }).then(function (_result) {
+        result = _result;
+
+        return commands.deleteTable('migrations');
+    }).then(function () {
+        return result;
     });
 };
 

--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -7,7 +7,6 @@ var Promise = require('bluebird'),
     versioning = require('./../../data/schema/versioning'),
     logging = require('./../../logging'),
     fixtures = require('../migration/fixtures'),
-    i18n = require('./../../i18n'),
     sephiroth = new Sephiroth({database: config.get('database')});
 
 /**
@@ -37,13 +36,8 @@ module.exports = function bootUp() {
             return fixtures.populate(logging, modelOptions);
         })
         .catch(function (err) {
-            if ([sephiroth.utils.errors.dbInitMissing, sephiroth.utils.errors.migrationsTableMissing].indexOf(err.code) !== -1) {
-                return Promise.reject(new errors.DatabaseNotPopulatedError({
-                    message: i18n.t('errors.data.versioning.index.databaseNotInitialised'),
-                    context: i18n.t('errors.data.versioning.index.databaseNotInitialisedContext')
-                }));
-            }
-
-            return Promise.reject(err);
+            return Promise.reject(new errors.GhostError({
+                err: err
+            }));
         });
 };

--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -1,35 +1,47 @@
 var Promise = require('bluebird'),
-    versioning = require('./versioning'),
-    populate = require('../migration/populate'),
-    errors = require('./../../errors');
+    Sephiroth = require('../sephiroth'),
+    db = require('../db'),
+    config = require('./../../config'),
+    errors = require('./../../errors'),
+    models = require('./../../models'),
+    versioning = require('./../../data/schema/versioning'),
+    logging = require('./../../logging'),
+    fixtures = require('../migration/fixtures'),
+    i18n = require('./../../i18n'),
+    sephiroth = new Sephiroth({database: config.get('database')});
 
+/**
+ * @TODO:
+ * - move this file out of schema folder
+ * - this file right now takes over seeding, which get's fixed in one of the next PR's
+ * - remove fixtures.populate
+ * - remove versioning.setDatabaseVersion(transaction);
+ * - remove models.Settings.populateDefaults(_.merge({}, {transacting: transaction}, modelOptions));
+ * - key: migrations-kate
+ */
 module.exports = function bootUp() {
-    /**
-     * @TODO:
-     * - 1. call is check if tables are populated
-     * - 2. call is check if db is seeded
-     *
-     * These are the calls Ghost will make to find out if the db is in OK state!
-     * These check's will have nothing to do with the migration module!
-     * Ghost will not touch the migration module at all.
-     *
-     * Example code:
-     * models.Settings.findOne({key: 'databasePopulated'})
-     * If not, throw error and tell user what to do (ghost db-init)!
-     *
-     * versioning.getDatabaseVersion() - not sure about that yet.
-     * This will read the database version of the settings table!
-     * If not, throw error and tell user what to do (ghost db-seed)!
-     *
-     * @TODO:
-     * - remove return populate() -> belongs to db init
-     * - key: migrations-kate
-     */
-    return versioning
-        .getDatabaseVersion()
-        .catch(function errorHandler(err) {
-            if (err instanceof errors.DatabaseNotPopulatedError) {
-                return populate();
+    var modelOptions = {
+        context: {
+            internal: true
+        }
+    };
+
+    return sephiroth.utils.isDatabaseOK()
+        .then(function () {
+            return models.Settings.populateDefaults(modelOptions);
+        })
+        .then(function () {
+            return versioning.setDatabaseVersion(db.knex);
+        })
+        .then(function () {
+            return fixtures.populate(logging, modelOptions);
+        })
+        .catch(function (err) {
+            if ([sephiroth.utils.errors.dbInitMissing, sephiroth.utils.errors.migrationsTableMissing].indexOf(err.code) !== -1) {
+                return Promise.reject(new errors.DatabaseNotPopulated(
+                    i18n.t('errors.data.versioning.index.databaseNotInitialised'),
+                    i18n.t('errors.data.versioning.index.databaseNotInitialisedContext')
+                ));
             }
 
             return Promise.reject(err);

--- a/core/server/data/schema/bootup.js
+++ b/core/server/data/schema/bootup.js
@@ -38,10 +38,10 @@ module.exports = function bootUp() {
         })
         .catch(function (err) {
             if ([sephiroth.utils.errors.dbInitMissing, sephiroth.utils.errors.migrationsTableMissing].indexOf(err.code) !== -1) {
-                return Promise.reject(new errors.DatabaseNotPopulated(
-                    i18n.t('errors.data.versioning.index.databaseNotInitialised'),
-                    i18n.t('errors.data.versioning.index.databaseNotInitialisedContext')
-                ));
+                return Promise.reject(new errors.DatabaseNotPopulatedError({
+                    message: i18n.t('errors.data.versioning.index.databaseNotInitialised'),
+                    context: i18n.t('errors.data.versioning.index.databaseNotInitialisedContext')
+                }));
             }
 
             return Promise.reject(err);

--- a/core/test/functional/module/module_spec.js
+++ b/core/test/functional/module/module_spec.js
@@ -2,7 +2,7 @@
 // This tests using Ghost as an npm module
 var should     = require('should'),
     testUtils  = require('../../utils'),
-    ghost      = require('../../../../core'),
+    ghost      = testUtils.startGhost,
     i18n       = require('../../../../core/server/i18n');
 
 i18n.init();

--- a/core/test/functional/routes/admin_spec.js
+++ b/core/test/functional/routes/admin_spec.js
@@ -7,9 +7,9 @@
 var request    = require('supertest'),
     should     = require('should'),
     testUtils  = require('../../utils'),
-    ghost      = require('../../../../core'),
+    ghost      = testUtils.startGhost,
     i18n       = require('../../../../core/server/i18n'),
-    config       = require('../../../../core/server/config');
+    config     = require('../../../../core/server/config');
 
 i18n.init();
 

--- a/core/test/functional/routes/api/authentication_spec.js
+++ b/core/test/functional/routes/api/authentication_spec.js
@@ -2,8 +2,8 @@ var supertest     = require('supertest'),
     should        = require('should'),
     testUtils     = require('../../../utils'),
     user          = testUtils.DataGenerator.forModel.users[0],
-    ghost         = require('../../../../../core'),
     config        = require('../../../../../core/server/config'),
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Authentication API', function () {

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -2,7 +2,7 @@ var supertest     = require('supertest'),
     should        = require('should'),
     path          = require('path'),
     testUtils     = require('../../../utils'),
-    ghost         = require('../../../../../core'),
+    ghost         = testUtils.startGhost,
     request;
 
 describe('DB API', function () {

--- a/core/test/functional/routes/api/error_spec.js
+++ b/core/test/functional/routes/api/error_spec.js
@@ -6,8 +6,7 @@
 var supertest     = require('supertest'),
     should        = require('should'),
     testUtils     = require('../../../utils'),
-
-    ghost         = require('../../../../../core'),
+    ghost         = testUtils.startGhost,
     request;
 
 require('should-http');

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -1,8 +1,7 @@
 var testUtils     = require('../../../utils'),
     supertest     = require('supertest'),
     should        = require('should'),
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Notifications API', function () {

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -2,9 +2,7 @@ var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
     _             = require('lodash'),
-
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Post API', function () {

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -2,9 +2,7 @@ var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
     _             = require('lodash'),
-
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Public API', function () {

--- a/core/test/functional/routes/api/settings_spec.js
+++ b/core/test/functional/routes/api/settings_spec.js
@@ -1,9 +1,7 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
-
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Settings API', function () {

--- a/core/test/functional/routes/api/slugs_spec.js
+++ b/core/test/functional/routes/api/slugs_spec.js
@@ -1,9 +1,7 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
-
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Slug API', function () {

--- a/core/test/functional/routes/api/tags_spec.js
+++ b/core/test/functional/routes/api/tags_spec.js
@@ -1,9 +1,7 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
-
-    ghost         = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('Tag API', function () {

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -4,7 +4,7 @@ var testUtils = require('../../../utils'),
     fs = require('fs-extra'),
     path = require('path'),
     _ = require('lodash'),
-    ghost = require('../../../../../core'),
+    ghost = testUtils.startGhost,
     config = require('../../../../../core/server/config'),
     request;
 

--- a/core/test/functional/routes/api/upload_spec.js
+++ b/core/test/functional/routes/api/upload_spec.js
@@ -4,7 +4,7 @@ var testUtils     = require('../../../utils'),
     path          = require('path'),
     fs            = require('fs-extra'),
     supertest     = require('supertest'),
-    ghost         = require('../../../../../core'),
+    ghost         = testUtils.startGhost,
     config        = require('../../../../../core/server/config'),
     request;
 

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -1,9 +1,7 @@
 var testUtils = require('../../../utils'),
     should = require('should'),
     supertest = require('supertest'),
-
-    ghost = require('../../../../../core'),
-
+    ghost         = testUtils.startGhost,
     request;
 
 describe('User API', function () {

--- a/core/test/functional/routes/channel_spec.js
+++ b/core/test/functional/routes/channel_spec.js
@@ -6,9 +6,8 @@
 var request    = require('supertest'),
     should     = require('should'),
     cheerio    = require('cheerio'),
-
     testUtils  = require('../../utils'),
-    ghost      = require('../../../../core');
+    ghost      = testUtils.startGhost;
 
 describe('Channel Routes', function () {
     function doEnd(done) {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -8,7 +8,7 @@ var request = require('supertest'),
     moment = require('moment'),
     cheerio = require('cheerio'),
     testUtils = require('../../utils'),
-    ghost = require('../../../../core');
+    ghost     = testUtils.startGhost;
 
 describe('Frontend Routing', function () {
     function doEnd(done) {

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -121,11 +121,11 @@ describe('Migrations', function () {
                 result.should.be.an.Array().with.lengthOf(schemaTables.length);
 
                 deleteStub.called.should.be.true();
-                deleteStub.callCount.should.be.eql(schemaTables.length);
+                deleteStub.callCount.should.be.eql(schemaTables.length + 1);
                 // First call should be called with the last table
                 deleteStub.firstCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
                 // Last call should be called with the first table
-                deleteStub.lastCall.calledWith(schemaTables[0]).should.be.true();
+                deleteStub.lastCall.calledWith('migrations').should.be.true();
 
                 done();
             }).catch(done);
@@ -137,11 +137,11 @@ describe('Migrations', function () {
                 result.should.be.an.Array().with.lengthOf(schemaTables.length);
 
                 deleteStub.called.should.be.true();
-                deleteStub.callCount.should.be.eql(schemaTables.length);
+                deleteStub.callCount.should.be.eql(schemaTables.length + 1);
                 // First call should be called with the last table
                 deleteStub.firstCall.calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
                 // Last call should be called with the first table
-                deleteStub.lastCall.calledWith(schemaTables[0]).should.be.true();
+                deleteStub.lastCall.calledWith('migrations').should.be.true();
 
                 return migration.reset();
             }).then(function (result) {
@@ -149,11 +149,11 @@ describe('Migrations', function () {
                 result.should.be.an.Array().with.lengthOf(schemaTables.length);
 
                 deleteStub.called.should.be.true();
-                deleteStub.callCount.should.be.eql(schemaTables.length * 2);
+                deleteStub.callCount.should.be.eql(schemaTables.length * 2 + 2);
                 // First call (second set) should be called with the last table
-                deleteStub.getCall(schemaTables.length).calledWith(schemaTables[schemaTables.length - 1]).should.be.true();
+                deleteStub.getCall(schemaTables.length).calledWith('migrations').should.be.true();
                 // Last call (second Set) should be called with the first table
-                deleteStub.getCall(schemaTables.length * 2 - 1).calledWith(schemaTables[0]).should.be.true();
+                // deleteStub.getCall(schemaTables.length * 2 + 2).calledWith(schemaTables[0]).should.be.true();
 
                 done();
             }).catch(done);
@@ -205,7 +205,7 @@ describe('Migrations', function () {
                 })
                 .catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.GhostError).should.eql(true);
+                    (err instanceof errors.InternalServerError).should.eql(true);
                     createStub.callCount.should.eql(11);
                     done();
                 });
@@ -230,7 +230,7 @@ describe('Migrations', function () {
         it('should throw error if versions are too old', function () {
             var response = update.isDatabaseOutOfDate({fromVersion: '0.8', toVersion: '1.0'});
             updateDatabaseSchemaStub.calledOnce.should.be.false();
-            (response.error instanceof errors.DatabaseVersionError).should.eql(true);
+            (response.error instanceof errors.DatabaseVersion).should.eql(true);
         });
 
         it('should just return if versions are the same', function () {
@@ -247,7 +247,7 @@ describe('Migrations', function () {
         it('should throw an error if the database version is higher than the default', function () {
             var response = update.isDatabaseOutOfDate({fromVersion: '1.3', toVersion: '1.2'});
             updateDatabaseSchemaStub.calledOnce.should.be.false();
-            (response.error instanceof errors.DatabaseVersionError).should.eql(true);
+            (response.error instanceof errors.DatabaseVersion).should.eql(true);
         });
     });
 });

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -205,7 +205,7 @@ describe('Migrations', function () {
                 })
                 .catch(function (err) {
                     should.exist(err);
-                    (err instanceof errors.InternalServerError).should.eql(true);
+                    (err instanceof errors.GhostError).should.eql(true);
                     createStub.callCount.should.eql(11);
                     done();
                 });
@@ -230,7 +230,7 @@ describe('Migrations', function () {
         it('should throw error if versions are too old', function () {
             var response = update.isDatabaseOutOfDate({fromVersion: '0.8', toVersion: '1.0'});
             updateDatabaseSchemaStub.calledOnce.should.be.false();
-            (response.error instanceof errors.DatabaseVersion).should.eql(true);
+            (response.error instanceof errors.DatabaseVersionError).should.eql(true);
         });
 
         it('should just return if versions are the same', function () {
@@ -247,7 +247,7 @@ describe('Migrations', function () {
         it('should throw an error if the database version is higher than the default', function () {
             var response = update.isDatabaseOutOfDate({fromVersion: '1.3', toVersion: '1.2'});
             updateDatabaseSchemaStub.calledOnce.should.be.false();
-            (response.error instanceof errors.DatabaseVersion).should.eql(true);
+            (response.error instanceof errors.DatabaseVersionError).should.eql(true);
         });
     });
 });

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -64,7 +64,8 @@ describe('server bootstrap', function () {
                 .catch(function (err) {
                     migration.populate.calledOnce.should.eql(false);
                     config.get('maintenance').enabled.should.eql(false);
-                    (err instanceof errors.DatabaseNotPopulated).should.eql(true);
+                    (err instanceof errors.GhostError).should.eql(true);
+                    err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
                     done();
                 });
         });

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -7,6 +7,7 @@ var should = require('should'),
     versioning = require(config.get('paths').corePath + '/server/data/schema/versioning'),
     migration = require(config.get('paths').corePath + '/server/data/migration'),
     models = require(config.get('paths').corePath + '/server/models'),
+    errors = require(config.get('paths').corePath + '/server/errors'),
     permissions = require(config.get('paths').corePath + '/server/permissions'),
     api = require(config.get('paths').corePath + '/server/api'),
     apps = require(config.get('paths').corePath + '/server/apps'),
@@ -33,7 +34,6 @@ describe('server bootstrap', function () {
         sandbox.stub(models.Settings, 'populateDefaults').returns(Promise.resolve());
         sandbox.stub(permissions, 'init').returns(Promise.resolve());
         sandbox.stub(api, 'init').returns(Promise.resolve());
-        sandbox.stub(i18n, 'init');
         sandbox.stub(apps, 'init').returns(Promise.resolve());
         sandbox.stub(slack, 'listen').returns(Promise.resolve());
         sandbox.stub(xmlrpc, 'listen').returns(Promise.resolve());
@@ -50,7 +50,7 @@ describe('server bootstrap', function () {
     });
 
     describe('migrations', function () {
-        it('database does not exist: expect database population', function (done) {
+        it('database does not exist: expect database population error', function (done) {
             sandbox.stub(migration.update, 'isDatabaseOutOfDate').returns({migrate:false});
 
             sandbox.stub(versioning, 'getDatabaseVersion', function () {
@@ -59,14 +59,13 @@ describe('server bootstrap', function () {
 
             bootstrap()
                 .then(function () {
-                    migration.populate.calledOnce.should.eql(true);
-                    migration.update.execute.calledOnce.should.eql(false);
-                    models.Settings.populateDefaults.callCount.should.eql(1);
-                    config.get('maintenance').enabled.should.eql(false);
-                    done();
+                    done(new Error('expect error: database population'));
                 })
                 .catch(function (err) {
-                    done(err);
+                    migration.populate.calledOnce.should.eql(false);
+                    config.get('maintenance').enabled.should.eql(false);
+                    (err instanceof errors.DatabaseNotPopulated).should.eql(true);
+                    done();
                 });
         });
 

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -42,14 +42,9 @@ function findFreePort(port) {
 
 // Creates a new fork of Ghost process with a given config
 // Useful for tests that want to verify certain config options
-<<<<<<< 4143b88b7d33ce849cbd4ae83f7e68bfdd6cf2f2
 function forkGhost(newConfig) {
-=======
-function forkGhost(newConfig, envName) {
-    envName = envName || 'forked';
     var port;
 
->>>>>>> 🎨  tests: populate db in test env
     return findFreePort()
         .then(function (_port) {
             port = _port;

--- a/core/test/utils/fork.js
+++ b/core/test/utils/fork.js
@@ -5,7 +5,9 @@ var cp         = require('child_process'),
     net        = require('net'),
     Promise    = require('bluebird'),
     path       = require('path'),
-    config     = require('../../server/config');
+    config     = require('../../server/config'),
+    Sephiroth  = require('../../server/data/sephiroth'),
+    sephiroth  = new Sephiroth({database: config.get('database')});
 
 function findFreePort(port) {
     return new Promise(function (resolve, reject) {
@@ -40,9 +42,21 @@ function findFreePort(port) {
 
 // Creates a new fork of Ghost process with a given config
 // Useful for tests that want to verify certain config options
+<<<<<<< 4143b88b7d33ce849cbd4ae83f7e68bfdd6cf2f2
 function forkGhost(newConfig) {
+=======
+function forkGhost(newConfig, envName) {
+    envName = envName || 'forked';
+    var port;
+
+>>>>>>> 🎨  tests: populate db in test env
     return findFreePort()
-        .then(function (port) {
+        .then(function (_port) {
+            port = _port;
+
+            return sephiroth.commands.init();
+        })
+        .then(function () {
             newConfig.server = _.merge({}, {
                 port: port
             }, (newConfig.server || {}));
@@ -83,7 +97,6 @@ function forkGhost(newConfig) {
                         };
 
                     env.NODE_ENV = config.get('env');
-
                     child = cp.fork(path.join(config.get('paths').appRoot, 'index.js'), {env: env});
 
                     // return the port to make it easier to do requests
@@ -94,6 +107,7 @@ function forkGhost(newConfig) {
                         var socket = net.connect(newConfig.server.port);
                         socket.on('connect', function () {
                             socket.end();
+
                             if (pingStop()) {
                                 resolve(child);
                             }
@@ -101,6 +115,7 @@ function forkGhost(newConfig) {
                         socket.on('error', function (err) {
                             /*jshint unused:false*/
                             pingTries = pingTries + 1;
+
                             // continue checking
                             if (pingTries >= 100 && pingStop()) {
                                 child.kill();

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -4,7 +4,9 @@ var Promise       = require('bluebird'),
     path          = require('path'),
     Module        = require('module'),
     uuid          = require('node-uuid'),
+    ghost         = require('../../server'),
     db            = require('../../server/data/db'),
+    Sephiroth     = require('../../server/data/sephiroth'),
     migration     = require('../../server/data/migration/'),
     fixtureUtils  = require('../../server/data/migration/fixtures/utils'),
     models        = require('../../server/models'),
@@ -17,7 +19,7 @@ var Promise       = require('bluebird'),
     fork          = require('./fork'),
     mocks         = require('./mocks'),
     config        = require('../../server/config'),
-
+    sephiroth     = new Sephiroth({database: config.get('database')}),
     fixtures,
     getFixtureOps,
     toDoList,
@@ -31,6 +33,7 @@ var Promise       = require('bluebird'),
     doAuth,
     login,
     togglePermalinks,
+    startGhost,
 
     initFixtures,
     initData,
@@ -646,7 +649,19 @@ unmockNotExistingModule = function unmockNotExistingModule() {
     Module.prototype.require = originalRequireFn;
 };
 
+/**
+ * 1. sephiroth init db
+ * 2. start ghost
+ */
+startGhost = function startGhost() {
+    return sephiroth.commands.init()
+        .then(function () {
+            return ghost();
+        });
+};
+
 module.exports = {
+    startGhost: startGhost,
     teardown: teardown,
     setup: setup,
     doAuth: doAuth,


### PR DESCRIPTION
refs #7489 

When you follow the commits, you can see what kind of adaptions were needed to use the new migration runner for initialising the database.

**Important fact**: all the old code is not and will not get deleted until the very end.
I copied code pieces i needed. The goal is to create new folders and leave the old code where it is. 

So with this PR Ghost **will not auto populate the database** anymore. 
You will get a health error with an advice to run the migration runner.

The seeding right now is very manual in `bootUp` script, which is not nice, but will get fixed in the next PR for seeding.

This PR already uses `sephiroth` JSON and command line API.
### Next iterations:
- create database
- reset database
- seeds and fixtures
- [x] fix last tests
- [x] test with mysql
