### PR TITLE
🔥 Remove deprecated pageUrl helper

### DIFF
--- a/core/server/helpers/page_url.js
+++ b/core/server/helpers/page_url.js
@@ -8,11 +8,8 @@
 //
 // We use the name page_url to match the helper for consistency:
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-var logging         = require('../logging'),
-    i18n            = require('../i18n'),
-    getPaginatedUrl = require('../data/meta/paginated_url'),
-    page_url,
-    pageUrl;
+var getPaginatedUrl = require('../data/meta/paginated_url'),
+    page_url;
 
 page_url = function (page, options) {
     if (!options) {
@@ -22,22 +19,4 @@ page_url = function (page, options) {
     return getPaginatedUrl(page, options.data.root);
 };
 
-// ### Page URL Helper: DEPRECATED
-//
-// *Usage example:*
-// `{{pageUrl 2}}`
-//
-// Returns the URL for the page specified in the current object
-// context. This helper is deprecated and will be removed in future versions.
-//
-pageUrl = function (pageNum, options) {
-    logging.warn(i18n.t('warnings.helpers.page_url.isDeprecated'));
-
-    /*jshint unused:false*/
-    var self = this;
-
-    return page_url.call(self, pageNum, options);
-};
-
 module.exports = page_url;
-module.exports.deprecated = pageUrl;

--- a/core/test/unit/server_helpers/page_url_spec.js
+++ b/core/test/unit/server_helpers/page_url_spec.js
@@ -53,39 +53,3 @@ describe('{{page_url}} helper', function () {
         helpers.page_url(options).should.equal(helpers.page_url(1, options));
     });
 });
-
-describe('{{pageUrl}} helper [DEPRECATED]', function () {
-    var options = {data: {root: {pagination: {}}}};
-
-    before(function () {
-        utils.loadHelpers();
-    });
-
-    it('has loaded pageUrl helper', function () {
-        should.exist(handlebars.helpers.pageUrl);
-    });
-
-    it('should do the same thing as page_url when the relative URL is /', function () {
-        options.data.root.relativeUrl = '/';
-        options.data.root.pagination.next = 5;
-        options.data.root.pagination.prev = 7;
-
-        helpers.pageUrl(options).should.eql(helpers.page_url(options));
-        helpers.pageUrl(1, options).should.eql(helpers.page_url(1, options));
-        helpers.pageUrl(20, options).should.eql(helpers.page_url(20, options));
-        helpers.pageUrl('next', options).should.eql(helpers.page_url('next', options));
-        helpers.pageUrl('prev', options).should.eql(helpers.page_url('prev', options));
-    });
-
-    it('should do the same thing as page_url when the relative url has a path', function () {
-        options.data.root.relativeUrl = '/tag/pumpkin/';
-        options.data.root.pagination.next = 12;
-        options.data.root.pagination.prev = 9;
-
-        helpers.pageUrl(options).should.eql(helpers.page_url(options));
-        helpers.pageUrl(1, options).should.eql(helpers.page_url(1, options));
-        helpers.pageUrl(20, options).should.eql(helpers.page_url(20, options));
-        helpers.pageUrl('next', options).should.eql(helpers.page_url('next', options));
-        helpers.pageUrl('prev', options).should.eql(helpers.page_url('prev', options));
-    });
-});


### PR DESCRIPTION
closes #2217
- This helper has been deprecated in favour of `page_url` for more than 2 years!!!
- Ghost 1.0.0 is the end of all of this 💩
