### PR TITLE
🔥 Remove the deprecated body classes

### DIFF
--- a/core/server/helpers/body_class.js
+++ b/core/server/helpers/body_class.js
@@ -8,8 +8,6 @@
 
 var hbs             = require('express-hbs'),
     _               = require('lodash'),
-    // @TODO Fix this
-    template        = require('../controllers/frontend/templates'),
     body_class;
 
 body_class = function (options) {
@@ -17,22 +15,15 @@ body_class = function (options) {
         context = options.data.root.context,
         post = this.post,
         tags = this.post && this.post.tags ? this.post.tags : this.tags || [],
-        page = this.post && this.post.page ? this.post.page : this.page || false,
-        activeTheme = options.data.root.settings.activeTheme,
-        view;
-
-    if (post) {
-        // To be removed from pages by #2597 when we're ready to deprecate this
-        // i.e. this should be if (_.includes(context, 'post') && post) { ... }
-        classes.push('post-template');
-    }
+        page = this.post && this.post.page ? this.post.page : this.page || false;
 
     if (_.includes(context, 'home')) {
         classes.push('home-template');
+    } else if (_.includes(context, 'post') && post) {
+        classes.push('post-template');
     } else if (_.includes(context, 'page') && page) {
         classes.push('page-template');
-        // To be removed by #2597 when we're ready to deprecate this
-        classes.push('page');
+        classes.push('page-' + this.post.slug);
     } else if (_.includes(context, 'tag') && this.tag) {
         classes.push('tag-template');
         classes.push('tag-' + this.tag.slug);
@@ -49,19 +40,6 @@ body_class = function (options) {
 
     if (_.includes(context, 'paged')) {
         classes.push('paged');
-        // To be removed from pages by #2597 when we're ready to deprecate this
-        classes.push('archive-template');
-    }
-
-    if (post && page) {
-        view = template.single(activeTheme, post).split('-');
-
-        if (view[0] === 'page' && view.length > 1) {
-            classes.push(view.join('-'));
-            // To be removed by #2597 when we're ready to deprecate this
-            view.splice(1, 0, 'template');
-            classes.push(view.join('-'));
-        }
     }
 
     classes = _.reduce(classes, function (memo, item) { return memo + ' ' + item; }, '');

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -86,7 +86,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/page/4'}
             );
 
-            rendered.string.should.equal('paged archive-template');
+            rendered.string.should.equal('paged');
         });
 
         it('tag page', function () {
@@ -104,7 +104,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/tag/foo/page/2', tag: {slug: 'foo'}}
             );
 
-            rendered.string.should.equal('tag-template tag-foo paged archive-template');
+            rendered.string.should.equal('tag-template tag-foo paged');
         });
 
         it('author page', function () {
@@ -122,7 +122,7 @@ describe('{{body_class}} helper', function () {
                 {relativeUrl: '/author/bar/page/2', author: {slug: 'bar'}}
             );
 
-            rendered.string.should.equal('author-template author-bar paged archive-template');
+            rendered.string.should.equal('author-template author-bar paged');
         });
 
         it('private route for password protection', function () {
@@ -146,19 +146,19 @@ describe('{{body_class}} helper', function () {
         it('a static page', function () {
             var rendered = callBodyClassWithContext(
                 ['page'],
-                {relativeUrl: '/about', post: {page: true}}
+                {relativeUrl: '/about', post: {page: true, slug: 'about'}}
             );
 
-            rendered.string.should.equal('post-template page-template page');
+            rendered.string.should.equal('page-template page-about');
         });
 
-        it('a static page with custom template', function () {
+        it('a static page with custom template (is now the same as one without)', function () {
             var rendered = callBodyClassWithContext(
                 ['page'],
                 {relativeUrl: '/about', post: {page: true, slug: 'about'}}
             );
 
-            rendered.string.should.equal('post-template page-template page page-about page-template-about');
+            rendered.string.should.equal('page-template page-about');
         });
     });
 });


### PR DESCRIPTION
**Note**: we need to get Casper updated and merged into both LTS and master for this change.

Reopening this, instead of merging #5160, because the codebase has changed so much since that PR was opened that the changes are a bit different.

Also, the original idea was to keep the implementation of the `page-{{slug}}` classes the same - that is, they were only added based on whether or not a custom template was present.

The idea behind that was based on the idea that it's hard to pass a body-class up to a layout template like `default.hbs`. However, this can be achieved quite easily with the `{{block}}` & `{{contentFor}}` helpers ([see this blog post for how](https://dev.ghost.org/ghost-theme-tips-defining-content-blocks/)). 

Further still, in the time since this was specced, we've added tag and author pages, both of which always get a class with their slug.

Therefore, this PR removes some super hairy code, simplifies the output and makes it consistent.

closes #2597
- Remove .archive-template
- Remove .page
- Don't output .post-template on pages
- Use `page-slug` instead of `page-template-slug`
- Always output `page-slug` irrelevant of whether or not there is a custom template
