### PR TITLE
🎨  use nullable(false) for knex schema builder

### DIFF
--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -21,7 +21,7 @@ function addTableColumn(tableName, table, columnName) {
     if (columnSpec.hasOwnProperty('nullable') && columnSpec.nullable === true) {
         column.nullable();
     } else {
-        column.notNullable();
+        column.nullable(false);
     }
     if (columnSpec.hasOwnProperty('primary') && columnSpec.primary === true) {
         column.primary();


### PR DESCRIPTION
refs #7470

We have some random errors when running tests.

One of them is:

```
RangeError: Maximum call stack size exceeded
    at ColumnBuilder.(anonymous function) [as notNullable] (/home/travis/build/TryGhost/Ghost/node_modules/knex/lib/schema/columnbuilder.js:48:47)
```

I looked at the implementation of knex and they do:
`if (method === 'notNullable') return this.nullable(false);`

At this line, node get's stuck and calls this function over and over again until stack error occurs.

Quick fix: let's not use `notNullable` and instead use `this.nullable(false)` directly to avoid using this code.

@tgriesser might be interesting for you
