### PR TITLE
nconf separator

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -12,7 +12,9 @@ nconf.argv();
 /**
  * env arguments
  */
-nconf.env();
+nconf.env({
+    separator: '__'
+});
 
 /**
  * load config files


### PR DESCRIPTION
If you want to set properties for our configuration values using
environment variables on the command line, Linux and MacOS return an
invalid identifier error.

```
$ export database:connection:host=127.0.0.1
-bash: export: `database:connection:host=127.0.0.1': not a valid
identifier
```

According to the nconf documentation a custom separator can be set. The
docs suggest `'__'` which this PR adds.
