### PR TITLE
🎨  Add support for short one-line log format

### DIFF
--- a/core/server/logging/GhostLogger.js
+++ b/core/server/logging/GhostLogger.js
@@ -8,6 +8,7 @@ function GhostLogger(options) {
     this.level = options.level || 'info';
     this.mode = options.mode || 'short';
     this.path = options.path || 'ghost.log';
+    this.format = options.format || 'short';
     this.rotation = options.rotation || false;
     this.loggers = {};
 
@@ -113,7 +114,7 @@ GhostLogger.prototype.setStreams = function setStreams() {
         }
 
         if (transport === 'stdout') {
-            prettyStdOut = new GhostPrettyStream();
+            prettyStdOut = new GhostPrettyStream(self.format);
             prettyStdOut.pipe(process.stdout);
 
             streams.push({

--- a/core/server/logging/GhostLogger.js
+++ b/core/server/logging/GhostLogger.js
@@ -8,7 +8,6 @@ function GhostLogger(options) {
     this.level = options.level || 'info';
     this.mode = options.mode || 'short';
     this.path = options.path || 'ghost.log';
-    this.format = options.format || 'short';
     this.rotation = options.rotation || false;
     this.loggers = {};
 
@@ -114,7 +113,7 @@ GhostLogger.prototype.setStreams = function setStreams() {
         }
 
         if (transport === 'stdout') {
-            prettyStdOut = new GhostPrettyStream(self.format);
+            prettyStdOut = new GhostPrettyStream({mode: self.mode});
             prettyStdOut.pipe(process.stdout);
 
             streams.push({

--- a/core/server/logging/PrettyStream.js
+++ b/core/server/logging/PrettyStream.js
@@ -40,7 +40,8 @@ var _ = require('lodash'),
     };
 
 
-function PrettyStream() {
+function PrettyStream(format) {
+    this.format = format;
 }
 util.inherits(PrettyStream, Stream);
 
@@ -59,7 +60,8 @@ PrettyStream.prototype.write = function write(data) {
         }
     }
 
-    var body = {},
+    var output = '',
+        body = {},
         time = moment(data.time).format('YYYY-MM-DD HH:mm:ss'),
         logLevel = __private__.levelFromName[data.level].toUpperCase(),
         codes = __private__.colors[__private__.colorForLevel[data.level]],
@@ -74,12 +76,11 @@ PrettyStream.prototype.write = function write(data) {
     if (data.req && data.res) {
         _.each(data.req, function (value, key) {
             if (['headers', 'query', 'body'].indexOf(key) !== -1 && !_.isEmpty(value)) {
-                bodyPretty += colorize('yellow', key.toUpperCase()) + '\n';
+                bodyPretty += '\n' + colorize('yellow', key.toUpperCase()) + '\n';
                 bodyPretty += prettyjson.render(value, {}) + '\n';
             }
         });
 
-        bodyPretty += '\n';
         if (data.err) {
             if (data.err.level) {
                 bodyPretty += colorize('yellow', 'ERROR (' + data.err.level + ')') + '\n';
@@ -100,7 +101,7 @@ PrettyStream.prototype.write = function write(data) {
             }
 
             if (key === 'level') {
-                bodyPretty += colorize('underline', key + ':' + value) + '\n\n';
+                bodyPretty += colorize('underline', key + ':' + value) + '\n';
             }
             else if (key === 'message') {
                 bodyPretty += colorize('red', value) + '\n';
@@ -122,33 +123,36 @@ PrettyStream.prototype.write = function write(data) {
 
     try {
         if (data.req && data.res) {
-            this.emit('data', format('[%s] %s --> %s %s (%s) \n%s\n\n',
+            output += format('[%s] %s %s %s (%s)\n',
                 time,
                 logLevel,
                 data.req.method,
                 data.req.url,
-                data.res.statusCode,
-                colorize('grey', bodyPretty)
-            ));
+                data.res.statusCode
+            );
+
         } else if (data.err) {
-            this.emit('data', format('[%s] %s \n%s\n\n',
+            output += format('[%s] %s\n',
                 time,
-                logLevel,
-                colorize('grey', bodyPretty)
-            ));
+                logLevel
+            );
         } else {
-            this.emit('data', format('[%s] %s %s\n',
+            output += format('[%s] %s\n',
                 time,
-                logLevel,
-                colorize('grey', bodyPretty)
-            ));
+                logLevel
+            );
         }
+
+        if (this.format !== 'short' && bodyPretty) {
+            output += format('%s\n', colorize('grey', bodyPretty));
+        }
+
+        this.emit('data', output);
     } catch (err) {
         this.emit('data', err);
     }
 
     return true;
 };
-
 
 module.exports = PrettyStream;

--- a/core/server/logging/PrettyStream.js
+++ b/core/server/logging/PrettyStream.js
@@ -127,7 +127,7 @@ PrettyStream.prototype.write = function write(data) {
                 time,
                 logLevel,
                 data.req.method,
-                data.req.url,
+                data.req.originalUrl,
                 data.res.statusCode
             );
 

--- a/core/server/logging/PrettyStream.js
+++ b/core/server/logging/PrettyStream.js
@@ -40,8 +40,8 @@ var _ = require('lodash'),
     };
 
 
-function PrettyStream(format) {
-    this.format = format;
+function PrettyStream(options) {
+    this.mode = options.mode || 'short';
 }
 util.inherits(PrettyStream, Stream);
 
@@ -143,7 +143,7 @@ PrettyStream.prototype.write = function write(data) {
             );
         }
 
-        if (this.format !== 'short' && bodyPretty) {
+        if (this.mode !== 'short' && bodyPretty) {
             output += format('%s\n', colorize('grey', bodyPretty));
         }
 

--- a/core/server/logging/index.js
+++ b/core/server/logging/index.js
@@ -2,7 +2,7 @@ var config = require('../config'),
     GhostLogger = require('./GhostLogger'),
     adapter = new GhostLogger({
         env: config.get('env'),
-        mode: process.env.NODE_MODE,
+        mode: process.env.NODE_MODE || config.get('logging:mode'),
         level: process.env.NODE_LEVEL || config.get('logging:level'),
         transports: config.get('logging:transports'),
         rotation: config.get('logging:rotation'),


### PR DESCRIPTION
## Why did I do this?

I've been playing around with a branch trying to refactor middleware/index.js, same branch from which #7484 was born and which I hope will eventually close #4172 ('m SO close).

As I've been testing & playing I found the long log format, that included headers, body, queries etc, had too much stuff for me to be able to clearly see what was happening. All of that information will be SUPER useful when working on the API, but when working on the admin, themes & middleware and watching debug statements, it's too noisy.

I did half of this commit (removed some of the logging) so that I could see what I was doing, and then figured I might as well spend another 5 minutes turning it into config and a PR.
## What does it do?

This is a dirty PR, but it does result in a one-line log format, which is the default.

I believe this is the most sensible default - e.g. for dev mode which is people playing with Ghost, developing Ghost and maybe developing themes, adapters or apps.

Changing "format" to anything other than "short" will result in the original format (with a few empty lines removed). 

refs #7116
- The long format logs were making it hard to see the debug statements
- Seeing headers for every asset is a bit much
- "short" format doesn't output bodyPretty
- This needs love as there's no reason to calculate bodyPretty if we aren't using it
- The default output should be discussed
