### PR TITLE
Misc Middleware cleanup

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -2,6 +2,7 @@
 // RESTful API for browsing the configuration
 var _                  = require('lodash'),
     config             = require('../config'),
+    ghostVersion       = require('../utils/ghost-version'),
     Promise            = require('bluebird'),
 
     configuration;
@@ -20,7 +21,7 @@ function fetchAvailableTimezones() {
 
 function getAboutConfig() {
     return {
-        version: config.get('ghostVersion'),
+        version: ghostVersion.full,
         environment: process.env.NODE_ENV,
         database: config.get('database').client,
         mail: _.isObject(config.get('mail')) ? config.get('mail').transport : ''

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -1,7 +1,6 @@
 var nconf = require('nconf'),
     path = require('path'),
     localUtils = require('./utils'),
-    packageInfo = require('../../../package.json'),
     env = process.env.NODE_ENV || 'development';
 
 /**
@@ -33,9 +32,7 @@ localUtils.makePathsAbsolute.bind(nconf)();
 
 /**
  * values we have to set manual
- * @TODO: ghost-cli?
  */
-nconf.set('ghostVersion', packageInfo.version);
 nconf.set('env', env);
 
 module.exports = nconf;

--- a/core/server/data/schema/versioning.js
+++ b/core/server/data/schema/versioning.js
@@ -2,8 +2,8 @@ var path = require('path'),
     Promise = require('bluebird'),
     db = require('../db'),
     errors = require('../../errors'),
-    config = require('../../config'),
-    i18n = require('../../i18n');
+    i18n = require('../../i18n'),
+    ghostVersion = require('../../utils/ghost-version');
 
 /**
  * Database version has always two digits
@@ -52,7 +52,7 @@ function getDatabaseVersion() {
 }
 
 function getNewestDatabaseVersion() {
-    return config.get('ghostVersion').slice(0, 3);
+    return ghostVersion.safe;
 }
 
 /**

--- a/core/server/middleware/ghost-locals.js
+++ b/core/server/middleware/ghost-locals.js
@@ -1,0 +1,15 @@
+var config = require('../config');
+
+// ### GhostLocals Middleware
+// Expose the standard locals that every external page should have available,
+// separating between the theme and the admin
+module.exports = function ghostLocals(req, res, next) {
+    // Make sure we have a locals value.
+    res.locals = res.locals || {};
+    res.locals.version = config.get('ghostVersion');
+    res.locals.safeVersion = config.get('ghostVersion').match(/^(\d+\.)?(\d+)/)[0];
+    // relative path from the URL
+    res.locals.relativeUrl = req.path;
+
+    next();
+};

--- a/core/server/middleware/ghost-locals.js
+++ b/core/server/middleware/ghost-locals.js
@@ -1,13 +1,14 @@
-var config = require('../config');
+var ghostVersion = require('../utils/ghost-version');
 
 // ### GhostLocals Middleware
-// Expose the standard locals that every external page should have available,
-// separating between the theme and the admin
+// Expose the standard locals that every request will need to have available
 module.exports = function ghostLocals(req, res, next) {
     // Make sure we have a locals value.
     res.locals = res.locals || {};
-    res.locals.version = config.get('ghostVersion');
-    res.locals.safeVersion = config.get('ghostVersion').match(/^(\d+\.)?(\d+)/)[0];
+    // The current Ghost version
+    res.locals.version = ghostVersion.full;
+    // The current Ghost version, but only major.minor
+    res.locals.safeVersion = ghostVersion.safe;
     // relative path from the URL
     res.locals.relativeUrl = req.path;
 

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -8,7 +8,6 @@ var debug           = require('debug')('ghost:middleware'),
     multer          = require('multer'),
     tmpdir          = require('os').tmpdir,
     serveStatic     = require('express').static,
-    slashes         = require('connect-slashes'),
     routes          = require('../routes'),
     config          = require('../config'),
     storage         = require('../storage'),
@@ -21,11 +20,11 @@ var debug           = require('debug')('ghost:middleware'),
     checkSSL         = require('./check-ssl'),
     decideIsAdmin    = require('./decide-is-admin'),
     redirectToSetup  = require('./redirect-to-setup'),
+    prettyURLs      = require('./pretty-urls'),
     serveSharedFile  = require('./serve-shared-file'),
     spamPrevention   = require('./spam-prevention'),
     staticTheme      = require('./static-theme'),
     themeHandler     = require('./theme-handler'),
-    uncapitalise     = require('./uncapitalise'),
     maintenance      = require('./maintenance'),
     errorHandler     = require('./error-handler'),
     versionMatch     = require('./api/version-match'),
@@ -170,13 +169,8 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // site map
     sitemapHandler(blogApp);
 
-    // Add in all trailing slashes
-    blogApp.use(slashes(true, {
-        headers: {
-            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
-        }
-    }));
-    blogApp.use(uncapitalise);
+    // Add in all trailing slashes & remove uppercase
+    blogApp.use(prettyURLs);
 
     // Body parsing
     blogApp.use(bodyParser.json({limit: '1mb'}));

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -53,8 +53,7 @@ middleware = {
 setupMiddleware = function setupMiddleware(blogApp) {
     debug('Middleware start');
 
-    var corePath = config.get('paths').corePath,
-        adminApp = express(),
+    var adminApp = express(),
         adminHbs = hbs.create();
 
     // ##Configuration
@@ -136,13 +135,6 @@ setupMiddleware = function setupMiddleware(blogApp) {
     blogApp.use(serveSharedFile('sitemap.xsl', 'text/xsl', utils.ONE_DAY_S));
     // Serve robots.txt if not found in theme
     blogApp.use(serveSharedFile('robots.txt', 'text/plain', utils.ONE_HOUR_S));
-
-    // Static assets
-    blogApp.use('/shared', serveStatic(
-        path.join(corePath, '/shared'),
-        {maxAge: utils.ONE_HOUR_MS, fallthrough: false}
-    ));
-
     // Serve blog images using the storage adapter
     blogApp.use('/content/images', storage.getStorage().serve());
 

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -20,6 +20,7 @@ var debug           = require('debug')('ghost:middleware'),
     checkSSL         = require('./check-ssl'),
     decideIsAdmin    = require('./decide-is-admin'),
     redirectToSetup  = require('./redirect-to-setup'),
+    ghostLocals     = require('./ghost-locals'),
     prettyURLs      = require('./pretty-urls'),
     serveSharedFile  = require('./serve-shared-file'),
     spamPrevention   = require('./spam-prevention'),
@@ -111,6 +112,10 @@ setupMiddleware = function setupMiddleware(blogApp) {
         }));
     }
 
+    // This sets global res.locals which are needed everywhere
+    blogApp.use(ghostLocals);
+
+    // Static content/assets
     // Favicon
     blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
 
@@ -183,9 +188,6 @@ setupMiddleware = function setupMiddleware(blogApp) {
     adminApp.use(cacheControl('private'));
     // API shouldn't be cached
     blogApp.use(routes.apiBaseUri, cacheControl('private'));
-
-    // local data
-    blogApp.use(themeHandler.ghostLocals);
 
     debug('General middleware done');
 

--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -1,0 +1,19 @@
+// Pretty URL redirects
+//
+// These are two pieces of middleware that handle ensuring that
+// URLs get formatted correctly.
+// Slashes ensures that we get trailing slashes
+// Uncapitalise changes case to lowercase
+// @TODO optimise this to reduce the number of redirects required to get to a pretty URL
+// @TODO move this to being used by routers?
+var slashes = require('connect-slashes'),
+    utils = require('../utils');
+
+module.exports = [
+    slashes(true, {
+        headers: {
+            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
+        }
+    }),
+    require('./uncapitalise')
+];

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -10,20 +10,6 @@ var _      = require('lodash'),
     themeHandler;
 
 themeHandler = {
-    // ### GhostLocals Middleware
-    // Expose the standard locals that every external page should have available,
-    // separating between the theme and the admin
-    ghostLocals: function ghostLocals(req, res, next) {
-        // Make sure we have a locals value.
-        res.locals = res.locals || {};
-        res.locals.version = config.get('ghostVersion');
-        res.locals.safeVersion = config.get('ghostVersion').match(/^(\d+\.)?(\d+)/)[0];
-        // relative path from the URL
-        res.locals.relativeUrl = req.path;
-
-        next();
-    },
-
     // ### configHbsForContext Middleware
     // Setup handlebars for the current context (admin or theme)
     configHbsForContext: function configHbsForContext(req, res, next) {

--- a/core/server/middleware/uncapitalise.js
+++ b/core/server/middleware/uncapitalise.js
@@ -5,15 +5,20 @@
 // App: Admin|Blog|API
 //
 // Detect upper case in req.path.
+//
+//  Example req:
+//  req.originalUrl = /blog/ghost/signin/?asdAD=asdAS
+//  req.url = /ghost/signin/?asdAD=asdAS
+//  req.baseUrl = /blog
+//  req.path =  /ghost/signin/
 
 var utils = require('../utils'),
     uncapitalise;
 
 uncapitalise = function uncapitalise(req, res, next) {
-    /*jslint unparam:true*/
-    var pathToTest = req.path,
-        isSignupOrReset = req.path.match(/(\/ghost\/(signup|reset)\/)/i),
-        isAPI = req.path.match(/(\/ghost\/api\/v[\d\.]+\/.*?\/)/i),
+    var pathToTest = (req.baseUrl ? req.baseUrl : '') + req.path,
+        isSignupOrReset = pathToTest.match(/^(.*\/ghost\/(signup|reset)\/)/i),
+        isAPI = pathToTest.match(/^(.*\/ghost\/api\/v[\d\.]+\/.*?\/)/i),
         redirectPath;
 
     if (isSignupOrReset) {
@@ -30,10 +35,8 @@ uncapitalise = function uncapitalise(req, res, next) {
      * That encoding isn't useful here, as it triggers an extra uncapitalise redirect, so we decode the path first
      */
     if (/[A-Z]/.test(decodeURIComponent(pathToTest))) {
-        // Adding baseUrl ensures subdirectories are kept
         redirectPath = (
-          (req.baseUrl ? req.baseUrl : '') +
-          utils.removeOpenRedirectFromUrl(req.url.replace(pathToTest, pathToTest.toLowerCase()))
+          utils.removeOpenRedirectFromUrl((req.originalUrl || req.url).replace(pathToTest, pathToTest.toLowerCase()))
         );
 
         res.set('Cache-Control', 'public, max-age=' + utils.ONE_YEAR_S);

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -30,13 +30,13 @@ var crypto   = require('crypto'),
     url      = require('url'),
     api      = require('./api'),
     config   = require('./config'),
-    logging   = require('./logging'),
+    logging  = require('./logging'),
     errors   = require('./errors'),
     i18n     = require('./i18n'),
+    currentVersion = require('./utils/ghost-version').full,
     internal = {context: {internal: true}},
     allowedCheckEnvironments = ['development', 'production'],
-    checkEndpoint = 'updates.ghost.org',
-    currentVersion = config.get('ghostVersion');
+    checkEndpoint = 'updates.ghost.org';
 
 function updateCheckError(err) {
     api.settings.edit(

--- a/core/server/utils/ghost-version.js
+++ b/core/server/utils/ghost-version.js
@@ -1,0 +1,8 @@
+var packageInfo = require('../../../package.json'),
+    version = packageInfo.version;
+
+module.exports = {
+    full: version,
+    safe: version.match(/^(\d+\.)?(\d+)/)[0]
+};
+

--- a/core/test/unit/middleware/ghost-locals_spec.js
+++ b/core/test/unit/middleware/ghost-locals_spec.js
@@ -1,0 +1,27 @@
+var sinon        = require('sinon'),
+    should       = require('should'),
+    ghostLocals  = require('../../../server/middleware/ghost-locals');
+
+describe('Theme Handler', function () {
+    var req, res, next;
+
+    beforeEach(function () {
+        req = sinon.spy();
+        res = sinon.spy();
+        next = sinon.spy();
+    });
+
+    describe('ghostLocals', function () {
+        it('sets all locals', function () {
+            req.path = '/awesome-post';
+
+            ghostLocals(req, res, next);
+
+            res.locals.should.be.an.Object();
+            should.exist(res.locals.version);
+            should.exist(res.locals.safeVersion);
+            res.locals.relativeUrl.should.equal(req.path);
+            next.called.should.be.true();
+        });
+    });
+});

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -26,20 +26,6 @@ describe('Theme Handler', function () {
         configUtils.restore();
     });
 
-    describe('ghostLocals', function () {
-        it('sets all locals', function () {
-            req.path = '/awesome-post';
-
-            themeHandler.ghostLocals(req, res, next);
-
-            res.locals.should.be.an.Object();
-            should.exist(res.locals.version);
-            should.exist(res.locals.safeVersion);
-            res.locals.relativeUrl.should.equal(req.path);
-            next.called.should.be.true();
-        });
-    });
-
     describe('activateTheme', function () {
         it('should activate new theme with partials', function () {
             var fsStub = sandbox.stub(fs, 'stat', function (path, cb) {


### PR DESCRIPTION
A set of small and hopefully un-opinionated cleanup commits, which are a precursor to larger, more opinionated refactors like #7484.
- collecting the two url-related middleware into a package called prettyUrls, will make it easier to include this in multiple places later on, when we treat admin, api & blog as separate apps
- the uncapitalise middleware needed modifications so that it will work when mounted in a sub-app
- ghostlocals was incorrectly lumped in as being theme-specific, when it's actually global middleware that will be needed for all of Ghost
- the ghostVersion logic doesn't need to be in config 🎉 
- static asset handling was littered throughout middleware/index.js making it hard to track, grouping it together helps to determine what belongs before and after assets
- again I've found some static asset handling we aren't using and deleted it

I'm putting these forward as a package of small changes which help lay the ground work for completing #4172.

The remaining work will come in separate PRs 😁  Next: API refactoring
