### PR TITLE
🎨  operate on separate nconf instance

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -1,4 +1,5 @@
-var nconf = require('nconf'),
+var Nconf = require('nconf'),
+    nconf = new Nconf.Provider(),
     path = require('path'),
     localUtils = require('./utils'),
     packageInfo = require('../../../package.json'),


### PR DESCRIPTION
refs #7488 and https://github.com/TryGhost/Ignition/issues/3#issuecomment-252248267

By default, when requiring `nconf` it can happen that multiple projects operate on the same `nconf` instance. `Nconf` get's cached and so each project, get's the same instance.
https://github.com/indexzero/nconf/blob/master/lib/nconf.js

So we need to create our own `nconf` instance.
