### PR TITLE
🎨  optimise error to inherit from in GhostError prototype

### DIFF
--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
 
 function GhostError(options) {
     options = options || {};
+    var self = this;
 
     if (_.isString(options)) {
         throw new Error('Please instantiate Errors with the option pattern. e.g. new errors.GhostError({message: ...})');
@@ -37,9 +38,15 @@ function GhostError(options) {
     this.hideStack = options.hideStack;
 
     // error to inherit from, override!
+    // nested objects are getting copied over in one piece (can be changed, but not needed right now)
     if (options.err) {
-        this.message = options.err.message;
-        this.stack = options.err.stack;
+        Object.getOwnPropertyNames(options.err).forEach(function (property) {
+            if (['errorType', 'name', 'statusCode'].indexOf(property) !== -1) {
+                return;
+            }
+
+            self[property] = options.err[property] || self[property];
+        });
     }
 }
 

--- a/core/test/unit/errors_spec.js
+++ b/core/test/unit/errors_spec.js
@@ -1,0 +1,66 @@
+var errors = require('../../server/errors'),
+    should = require('should');
+
+should.equal(true, true);
+
+describe('Errors', function () {
+    describe('Inherite from other error', function () {
+        it('default', function () {
+            var someError = new Error(), ghostError;
+
+            someError.message = 'test';
+            someError.context = 'test';
+            someError.help = 'test';
+
+            ghostError = new errors.GhostError({err: someError});
+            ghostError.message.should.eql(someError.message);
+            ghostError.context.should.eql(someError.context);
+            ghostError.help.should.eql(someError.help);
+        });
+
+        it('has nested object', function () {
+            var someError = new Error(), ghostError;
+
+            someError.message = 'test';
+            someError.obj = {
+                a: 'b'
+            };
+
+            ghostError = new errors.GhostError({
+                err: someError
+            });
+
+            ghostError.message.should.eql(someError.message);
+            ghostError.obj.should.eql(someError.obj);
+        });
+
+        it('with custom attribute', function () {
+            var someError = new Error(), ghostError;
+
+            someError.message = 'test';
+            someError.context = 'test';
+
+            ghostError = new errors.GhostError({
+                err: someError,
+                context: 'context'
+            });
+
+            ghostError.message.should.eql(someError.message);
+            ghostError.context.should.eql('test');
+        });
+
+        it('with custom attribute', function () {
+            var someError = new Error(), ghostError;
+
+            someError.message = 'test';
+
+            ghostError = new errors.GhostError({
+                err: someError,
+                context: 'context'
+            });
+
+            ghostError.message.should.eql(someError.message);
+            ghostError.context.should.eql('context');
+        });
+    });
+});


### PR DESCRIPTION
refs #7116
- add errors_spec.js
- inherit all given attribute values

Error to inherit from in GhostError prototype was not optimised. 
We want to get as much as possible attribute values from the error to inherit from.
