### PR TITLE
🐛 Short log still needs data.msg

### DIFF
--- a/core/server/logging/PrettyStream.js
+++ b/core/server/logging/PrettyStream.js
@@ -116,9 +116,6 @@ PrettyStream.prototype.write = function write(data) {
                 bodyPretty += colorize('white', value) + '\n';
             }
         });
-    } else {
-        // print string
-        bodyPretty += data.msg;
     }
 
     try {
@@ -135,6 +132,12 @@ PrettyStream.prototype.write = function write(data) {
             output += format('[%s] %s\n',
                 time,
                 logLevel
+            );
+        } else if (data.msg) {
+            output += format('[%s] %s %s\n',
+                time,
+                logLevel,
+                data.msg
             );
         } else {
             output += format('[%s] %s\n',


### PR DESCRIPTION
- to see the problem, migrate a fresh DB in short mode
- this would output [INFO] but no info!
