### PR TITLE
🐛 Allow migrations to run if theme is not present

### DIFF
--- a/core/server/data/migration/update.js
+++ b/core/server/data/migration/update.js
@@ -71,7 +71,7 @@ migrateToDatabaseVersion = function migrateToDatabaseVersion(version, logger, mo
                     resolve();
                 })
                 .catch(function (err) {
-                    logger.warn('rolling back because of: ' + err.stack);
+                    logger.warn('rolling back because of an Error:\n' + err.message + '\n' + err.stack);
 
                     transaction.rollback();
                 });

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -72,7 +72,7 @@ Settings = ghostBookshelf.Model.extend({
         });
     },
 
-    validate: function validate() {
+    validate: function validate(model, attributes, options) {
         var self = this,
             setting = this.toJSON();
 
@@ -81,7 +81,7 @@ Settings = ghostBookshelf.Model.extend({
         }).then(function () {
             var themeName = setting.value || '';
 
-            if (setting.key !== 'activeTheme') {
+            if (setting.key !== 'activeTheme' || options.importing) {
                 return;
             }
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -563,7 +563,7 @@
                     "valueMustBeBoolean": "Value in [settings.key] must be one of true, false, 0 or 1.",
                     "valueExceedsMaxLength": "Value in [{tableName}.{columnKey}] exceeds maximum length of {maxlength} characters.",
                     "valueIsNotInteger": "Value in [{tableName}.{columnKey}] is not an integer.",
-                    "themeCannotBeActivated": "{themeName} cannot be activated because it is not currently installed.",
+                    "themeCannotBeActivated": "The theme \"{themeName}\" cannot be activated because it is not currently installed.",
                     "validationFailed": "Validation ({validationName}) failed for {key}"
                 }
             }


### PR DESCRIPTION
I had a problem upgrading some old databases. The output looked like this (relevant section only):

```
Migrations: Updating database to 006
Migrations: No database migration tasks found for this version
Migrations: Running fixture updates
Migrations: Transforming dates to UTC: (could take a while)...
Migrations: Transforming dates to UTC: Updated datetime fields for Posts
Migrations: Transforming dates to UTC: Updated datetime fields for Users
Skipping Migrations: Transforming dates to UTC: No Subscribers found
Skipping Migrations: rolling back because of: Error
    at Error.ValidationError (/Users/hannah/Ghost/Ghost/core/server/errors/validation-error.js:6:18)
    at then (/Users/hannah/Ghost/Ghost/core/server/data/validation/index.js:149:35)
    at tryCatcher (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromiseCtx (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:604:10)
    at Async._drainQueue (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:143:12)
    at Async._drainQueues (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

The error message here is not clear, however if I follow the trace to validation/index.js#149 I find that this error is because the theme in the settings table is not installed!

This PR does two things.
1. It improves the error messages we get, by including the message as well as the stack (I also slightly changed the wording of this particular error, as it wasn't clearly talking about a theme)
2. It disables the theme validation check when importing.

The error message looked like this in the middle:

```
Skipping Migrations: rolling back because of an Error:
The theme "Support" cannot be activated because it is not currently installed.
Error
    at Error.ValidationError (/Users/hannah/Ghost/Ghost/core/server/errors/validation-error.js:6:18)
    at then (/Users/hannah/Ghost/Ghost/core/server/data/validation/index.js:149:35)
    at tryCatcher (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromiseCtx (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/promise.js:604:10)
    at Async._drainQueue (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:143:12)
    at Async._drainQueues (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/hannah/Ghost/Ghost/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```

Ghost will always start without the active theme and give you a warning + an error if you try to load a blog page. This issue can be resolved afterwards.

IMO not having a theme shouldn't impact on the ability of an import or migration to complete successfully.
