### PR TITLE
[WIP] Error handling split - first pass

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -233,8 +233,8 @@ module.exports = function setupApiApp() {
     apiApp.use(apiRoutes());
 
     // API error handling
-    // @TODO: split the API error handling into its own thing?
-    apiApp.use(errorHandler);
+    apiApp.use(errorHandler.resourceNotFound);
+    apiApp.use(errorHandler.handleJSONResponse);
 
     return apiApp;
 };

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -5,9 +5,7 @@ var debug           = require('debug')('ghost:middleware'),
 
     // app requires
     config          = require('../config'),
-    errors          = require('../errors'),
     helpers         = require('../helpers'),
-    i18n            = require('../i18n'),
     logging         = require('../logging'),
     routes          = require('../routes'),
     storage         = require('../storage'),
@@ -109,6 +107,7 @@ module.exports = function setupMiddleware(blogApp) {
     debug('Themes done');
 
     // Static content/assets
+    // @TODO make sure all of these have a local 404 error handler
     // Favicon
     blogApp.use(serveSharedFile('favicon.ico', 'image/x-icon', utils.ONE_DAY_S));
     // Ghost-Url
@@ -125,7 +124,7 @@ module.exports = function setupMiddleware(blogApp) {
     // Admin only config
     blogApp.use('/ghost/assets', serveStatic(
         config.get('paths').clientAssets,
-        {maxAge: utils.ONE_YEAR_MS}
+        {maxAge: utils.ONE_YEAR_MS, fallthrough: false}
     ));
 
     // Theme static assets/files
@@ -181,10 +180,7 @@ module.exports = function setupMiddleware(blogApp) {
     blogApp.use(routes.frontend());
 
     // ### Error handlers
-    blogApp.use(function pageNotFound(req, res, next) {
-        next(new errors.NotFoundError({message: i18n.t('errors.errors.pageNotFound')}));
-    });
-
-    blogApp.use(errorHandler);
+    blogApp.use(errorHandler.pageNotFound);
+    blogApp.use(errorHandler.handleHTMLResponse);
     debug('Middleware end');
 };

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -474,7 +474,8 @@
             "whilstTryingToRender": "whilst trying to render an error page for the error: ",
             "renderingErrorPage": "Rendering Error Page",
             "caughtProcessingError": "Ghost caught a processing error in the middleware layer.",
-            "pageNotFound": "Page not found"
+            "pageNotFound": "Page not found",
+            "resourceNotFound": "Resource not found"
         }
     },
     "warnings": {

--- a/core/test/functional/routes/admin_spec.js
+++ b/core/test/functional/routes/admin_spec.js
@@ -61,6 +61,22 @@ describe('Admin Routing', function () {
         }).catch(done);
     });
 
+    describe('Assets', function () {
+        it('should return 404 for unknown assets', function (done) {
+            request.get('/ghost/assets/not-found.js')
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(404)
+                .end(doEnd(done));
+        });
+
+        it('should retrieve built assets', function (done) {
+            request.get('/ghost/assets/vendor.js')
+                .expect('Cache-Control', testUtils.cacheRules.year)
+                .expect(200)
+                .end(doEnd(done));
+        });
+    });
+
     describe('Legacy Redirects', function () {
         it('should redirect /logout/ to /ghost/signout/', function (done) {
             request.get('/logout/')

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -319,13 +319,6 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
 
-            it('should retrieve built assets', function (done) {
-                request.get('/ghost/assets/vendor.js')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(200)
-                    .end(doEnd(done));
-            });
-
             it('should retrieve default robots.txt', function (done) {
                 request.get('/robots.txt')
                     .expect('Cache-Control', testUtils.cacheRules.hour)

--- a/core/test/utils/assertions.js
+++ b/core/test/utils/assertions.js
@@ -1,0 +1,19 @@
+var should = require('should'),
+    errorProps = ['message', 'errorType'];
+
+should.Assertion.add('JSONErrorObject', function () {
+    this.params = {operator: 'to be a valid JSON Error Object'};
+    this.obj.should.be.an.Object();
+    this.obj.should.have.properties(errorProps);
+});
+
+should.Assertion.add('JSONErrorResponse', function () {
+    this.params = {operator: 'to be a valid JSON Error Response'};
+
+    this.obj.should.have.property('errors').which.is.an.Array();
+    this.obj.errors.length.should.be.above(0);
+
+    this.obj.errors.forEach(function (err) {
+        err.should.be.a.JSONErrorObject();
+    });
+});

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -39,6 +39,9 @@ var Promise       = require('bluebird'),
     initData,
     clearData;
 
+// Require additional assertions which help us keep our tests small and clear
+require('./assertions');
+
 /** TEST FIXTURES **/
 fixtures = {
     insertPosts: function insertPosts(posts) {


### PR DESCRIPTION
I originally planned to have an error handler just for the api in `middleware/api/error-handler.js`.

However, both the API/JSON and HTML error handlers need some shared logic (the wrapping of the error in GhostError). Therefore, I would have to duplicate code.

So I thought of doing it how it is shown in this PR: Create a middleware stack for each type of error handling.

What do you think @kirrg001? Is this too hidden away?

Another option is to move the shared code into a function/util, call it from both the JSON & HTML handlers, and then expose the 4 functions (pageNotFound, resourceNotFound, handleJSONError, handleHTMLError) as public API.
