### PR TITLE
🐛  logging: error output format

### DIFF
--- a/core/server/logging/PrettyStream.js
+++ b/core/server/logging/PrettyStream.js
@@ -127,7 +127,7 @@ PrettyStream.prototype.write = function write(data) {
             }
         });
 
-        output += format('[%s] %s\n%\n',
+        output += format('[%s] %s\n%s\n',
             time,
             logLevel,
             bodyPretty

--- a/core/test/unit/logging/PrettyStream_spec.js
+++ b/core/test/unit/logging/PrettyStream_spec.js
@@ -25,7 +25,7 @@ describe('PrettyStream', function () {
             var ghostPrettyStream = new GhostPrettyStream({mode: 'short'});
 
             ghostPrettyStream.emit = function (eventName, data) {
-                data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n%\n \u001b[4mlevel:normal\u001b[24m\n\u001b[31mHey Jude!\u001b[39m\n');
+                data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[4mlevel:normal\u001b[24m\n\u001b[31mHey Jude!\u001b[39m\n\n');
                 done();
             };
 
@@ -106,7 +106,7 @@ describe('PrettyStream', function () {
             var ghostPrettyStream = new GhostPrettyStream({mode: 'long'});
 
             ghostPrettyStream.emit = function (eventName, data) {
-                data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n%\n \u001b[4mlevel:normal\u001b[24m\n\u001b[31mHey Jude!\u001b[39m\n');
+                data.should.eql('[2016-07-01 00:00:00] \u001b[31mERROR\u001b[39m\n\u001b[4mlevel:normal\u001b[24m\n\u001b[31mHey Jude!\u001b[39m\n\n');
                 done();
             };
 


### PR DESCRIPTION
no issue

A `s` was missing for the format.

So log looked like:

```
[2016-07-01 00:00:00] ERROR
%
 level:normal
Hey Jude!
```
