### PR TITLE
🐛 send correct token expiration time

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -157,7 +157,7 @@ authentication = {
             return {
                 access_token: localAccessToken,
                 refresh_token: localRefreshToken,
-                expires_in: accessExpires
+                expires_in: globalUtils.ONE_HOUR_S
             };
         });
     },


### PR DESCRIPTION
no issue

When using Ghost OAuth, exchanging the authorization code for an access token was returning a token along with an `expires_in` property containing a JavaScript date representation rather than the number of seconds the token is valid for. This was resulting in the client expecting it's access token to be valid until the year 48796(!) and so never attempting to refresh it's access_token.
- return token expiration time of 3600 seconds / 1hr
