### PR TITLE
🎨  decrease timeout for scheduling

### DIFF
--- a/core/server/scheduling/SchedulingDefault.js
+++ b/core/server/scheduling/SchedulingDefault.js
@@ -170,7 +170,7 @@ SchedulingDefault.prototype._execute = function (jobs) {
                     });
                 });
             })();
-        }, diff - 200);
+        }, diff - 70);
     });
 };
 


### PR DESCRIPTION
refs #7555

Since Node v6.8.0 (was released today), tests start to fail for scheduling.
Node made some improvements for `setImmediate`, see https://github.com/nodejs/node/pull/8655.
Either we mis-use Node, or Node has introduced a bug.

This is a temporary fix **only** to make travis green!!!
- this fix should not have a any bad effect on scheduling
- we just let the job awake a bit later
- the job logic is strong enough to catch the job if setTimeout awakes too late (that can happen, because setTimeout is not accurate) - `if (moment().diff(moment(Number(timestamp))) <= self.beforePingInMs)`
