### PR TITLE
🎨  register events in base model

### DIFF
--- a/core/server/models/accesstoken.js
+++ b/core/server/models/accesstoken.js
@@ -13,12 +13,8 @@ Accesstoken = Basetoken.extend({
         events.emit('token' + '.' + event, this);
     },
 
-    initialize: function initialize() {
-        ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
-
-        this.on('created', function onCreated(model) {
-            model.emitChange('added');
-        });
+    onCreated: function onCreated(model) {
+        model.emitChange('added');
     }
 });
 

--- a/core/server/models/app.js
+++ b/core/server/models/app.js
@@ -5,11 +5,11 @@ var ghostBookshelf = require('./base'),
 App = ghostBookshelf.Model.extend({
     tableName: 'apps',
 
-    saving: function saving(newPage, attr, options) {
+    onSaving: function onSaving(newPage, attr, options) {
         /*jshint unused:false*/
         var self = this;
 
-        ghostBookshelf.Model.prototype.saving.apply(this, arguments);
+        ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
 
         if (this.hasChanged('slug') || !this.get('slug')) {
             // Pass the new slug through the generator to strip illegal characters, detect duplicates

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -79,7 +79,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             this.include = _.clone(options.include);
         }
 
-        ['creating', 'created', 'updated', 'destroying', 'destroyed', 'saved']
+        ['fetching', 'fetched', 'creating', 'created', 'updating', 'updated', 'destroying', 'destroyed', 'saved']
             .forEach(function (eventName) {
                 var functionName = 'on' + eventName[0].toUpperCase() + eventName.slice(1);
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -79,25 +79,41 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             this.include = _.clone(options.include);
         }
 
-        this.on('creating', this.creating, this);
-        this.on('saving', function onSaving(model, attributes, options) {
-            return Promise.resolve(self.saving(model, attributes, options)).then(function then() {
-                return self.validate(model, attributes, options);
+        ['creating', 'created', 'updated', 'destroying', 'destroyed', 'saved']
+            .forEach(function (eventName) {
+                var functionName = 'on' + eventName[0].toUpperCase() + eventName.slice(1);
+
+                if (!self[functionName]) {
+                    return;
+                }
+
+                self.on(eventName, function eventTriggered() {
+                    return this[functionName].apply(this, arguments);
+                });
             });
+
+        this.on('saving', function onSaving() {
+            var self = this,
+                args = arguments;
+
+            return Promise.resolve(self.onSaving.apply(self, args))
+                .then(function validated() {
+                    return Promise.resolve(self.onValidate.apply(self, args));
+                });
         });
     },
 
-    validate: function validate() {
+    onValidate: function onValidate() {
         return validation.validateSchema(this.tableName, this.toJSON());
     },
 
-    creating: function creating(newObj, attr, options) {
+    onCreating: function onCreating(newObj, attr, options) {
         if (!this.get('created_by')) {
             this.set('created_by', this.contextUser(options));
         }
     },
 
-    saving: function saving(newObj, attr, options) {
+    onSaving: function onSaving(newObj, attr, options) {
         // Remove any properties which don't belong on the model
         this.attributes = this.pick(this.permittedAttributes());
         // Store the previous attributes so we can tell what was updated later

--- a/core/server/models/base/token.js
+++ b/core/server/models/base/token.js
@@ -17,14 +17,11 @@ Basetoken = ghostBookshelf.Model.extend({
 
     // override for base function since we don't have
     // a created_by field for sessions
-    creating: function creating(newObj, attr, options) {
-        /*jshint unused:false*/
-    },
+    onCreating: function onCreating() {},
 
     // override for base function since we don't have
     // a updated_by field for sessions
-    saving: function saving(newObj, attr, options) {
-        /*jshint unused:false*/
+    onSaving: function onSaving() {
         // Remove any properties which don't belong on the model
         this.attributes = this.pick(this.permittedAttributes());
     }

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -55,24 +55,22 @@ Settings = ghostBookshelf.Model.extend({
         events.emit('settings' + '.' + event, this);
     },
 
-    initialize: function initialize() {
-        ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
-
-        this.on('created', function (model) {
-            model.emitChange('added');
-            model.emitChange(model.attributes.key + '.' + 'added');
-        });
-        this.on('updated', function (model) {
-            model.emitChange('edited');
-            model.emitChange(model.attributes.key + '.' + 'edited');
-        });
-        this.on('destroyed', function (model) {
-            model.emitChange('deleted');
-            model.emitChange(model.attributes.key + '.' + 'deleted');
-        });
+    onDestroyed: function onDestroyed(model) {
+        model.emitChange('deleted');
+        model.emitChange(model.attributes.key + '.' + 'deleted');
     },
 
-    validate: function validate() {
+    onCreated: function onCreated(model) {
+        model.emitChange('added');
+        model.emitChange(model.attributes.key + '.' + 'added');
+    },
+
+    onUpdated: function onUpdated(model) {
+        model.emitChange('edited');
+        model.emitChange(model.attributes.key + '.' + 'edited');
+    },
+
+    onValidate: function onValidate() {
         var self = this,
             setting = this.toJSON();
 

--- a/core/server/models/subscriber.js
+++ b/core/server/models/subscriber.js
@@ -13,23 +13,24 @@ Subscriber = ghostBookshelf.Model.extend({
     emitChange: function emitChange(event) {
         events.emit('subscriber' + '.' + event, this);
     },
+
     defaults: function defaults() {
         return {
             uuid: uuid.v4(),
             status: 'subscribed'
         };
     },
-    initialize: function initialize() {
-        ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
-        this.on('created', function onCreated(model) {
-            model.emitChange('added');
-        });
-        this.on('updated', function onUpdated(model) {
-            model.emitChange('edited');
-        });
-        this.on('destroyed', function onDestroyed(model) {
-            model.emitChange('deleted');
-        });
+
+    onCreated: function onCreated(model) {
+        model.emitChange('added');
+    },
+
+    onUpdated: function onUpdated(model) {
+        model.emitChange('edited');
+    },
+
+    onDestroyed: function onDestroyed(model) {
+        model.emitChange('deleted');
     }
 }, {
 

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -12,26 +12,23 @@ Tag = ghostBookshelf.Model.extend({
         events.emit('tag' + '.' + event, this);
     },
 
-    initialize: function initialize() {
-        ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
-
-        this.on('created', function onCreated(model) {
-            model.emitChange('added');
-        });
-        this.on('updated', function onUpdated(model) {
-            model.emitChange('edited');
-        });
-        this.on('destroyed', function onDestroyed(model) {
-            model.emitChange('deleted');
-        });
+    onCreated: function onCreated(model) {
+        model.emitChange('added');
     },
 
-    saving: function saving(newPage, attr, options) {
-        /*jshint unused:false*/
+    onUpdated: function onUpdated(model) {
+        model.emitChange('edited');
+    },
 
+    onDestroyed: function onDestroyed(model) {
+        model.emitChange('deleted');
+    },
+
+    onSaving: function onSaving(newPage, attr, options) {
+        /*jshint unused:false*/
         var self = this;
 
-        ghostBookshelf.Model.prototype.saving.apply(this, arguments);
+        ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
 
         if (this.hasChanged('slug') || !this.get('slug')) {
             // Pass the new slug through the generator to strip illegal characters, detect duplicates


### PR DESCRIPTION
refs #7432

All models had implemented it's own `initialize` fn to listen for model events.
That was confusing.

We can now register hook functions per model. And the base model registers the events smart and easy.

**Important**: we only listen on the event, if the model has defined a hook fn to not slow down the performance. 

This is just a small clean up PR. No logic has changed.
