### PR TITLE
Update wording on the "update available" notice

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -530,7 +530,7 @@
     },
     "notices": {
         "controllers": {
-            "newVersionAvailable": "Ghost {version} is available! Hot Damn. {link} to upgrade."
+            "newVersionAvailable": "Ghost {version} is available! Hot Damn. {link} for instructions on how to upgrade."
         },
         "index": {
             "welcomeToGhost": "Welcome to Ghost.",


### PR DESCRIPTION
Updates the wording on the "update available" notice to reflect more accurately what will happen when the user actually clicks the link.

---
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

Closes #7563
