### PR TITLE
Markdown card

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express-hbs": "1.0.3",
     "extract-zip-fork": "1.5.1",
     "fs-extra": "0.30.0",
-    "ghost-editor": "0.0.10",
+    "ghost-editor": "0.0.11",
     "ghost-gql": "0.0.5",
     "glob": "5.0.15",
     "gscan": "0.0.15",


### PR DESCRIPTION
Refs #7429
Depends on: https://github.com/TryGhost/Ghost-Admin/pull/333
Just a quick update in lieu of a larger overhaul to come through next PR:
- Added mobiledoc card, this uses the mobiledoc editor from within Ghost. In the future we'll pull this out and replace it with a textarea as the preview is too small to fit in the content.
- Made the HTML editor a codemirror editor (pulled in from ghost-admin to save duplicating libraries).
- Ghost-Admin now passes the paths for the ghost-api and the image directory for tools.
- Fixed the scrolling issue.
- Added an obnoxious label on top of each card so you know what they do.
