### PR TITLE
🎨  one token endpoint

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -185,12 +185,6 @@ function apiRoutes() {
         auth.oauth.generateAccessToken
     );
 
-    apiRouter.post('/authentication/ghost', [
-        auth.authenticate.authenticateClient,
-        auth.authenticate.authenticateGhostUser,
-        api.http(api.authentication.createTokens)
-    ]);
-
     apiRouter.post('/authentication/revoke', authenticatePrivate, api.http(api.authentication.revoke));
 
     // ## Uploads

--- a/core/server/auth/authenticate.js
+++ b/core/server/auth/authenticate.js
@@ -105,29 +105,6 @@ authenticate = {
                 }));
             }
         )(req, res, next);
-    },
-
-    // ### Authenticate Ghost.org User
-    authenticateGhostUser: function authenticateGhostUser(req, res, next) {
-        req.query.code = req.body.authorizationCode;
-
-        if (!req.query.code) {
-            return next(new errors.UnauthorizedError({message: i18n.t('errors.middleware.auth.accessDenied')}));
-        }
-
-        passport.authenticate('ghost', {session: false, failWithError: false}, function authenticate(err, user, info) {
-            if (err) {
-                return next(err);
-            }
-
-            if (!user) {
-                return next(new errors.UnauthorizedError({message: i18n.t('errors.middleware.auth.accessDenied')}));
-            }
-
-            req.authInfo = info;
-            req.user = user;
-            next();
-        })(req, res, next);
     }
 };
 

--- a/core/server/auth/oauth.js
+++ b/core/server/auth/oauth.js
@@ -87,8 +87,6 @@ function exchangeAuthorizationCode(req, res, next) {
 
         authenticationAPI.createTokens({}, {context: {client_id: req.client.id, user: user.id}})
             .then(function then(response) {
-                spamPrevention.resetCounter(user.get('email'));
-
                 res.json({
                     access_token: response.access_token,
                     refresh_token: response.refresh_token,
@@ -126,9 +124,19 @@ oauth = {
             exchangeRefreshToken));
 
         /**
-         * We forward the authorization code to Ghost.org, so no need to call exchange.authorizationCode
-         * exchange.authorizationCode wraps the req and res object, which is used by passport!
-         * See exchangeAuthorizationCode!
+         * Exchange authorization_code for an access token.
+         * We forward to authorization code to Ghost.org.
+         *
+         * oauth2orize offers a default implementation via exchange.authorizationCode, but this function
+         * wraps the express request and response. So no chance to get access to it.
+         * We use passport to communicate with Ghost.org. Passport's module design requires the express req/res.
+         *
+         * For now it's OK to not use exchange.authorizationCode. You can read through the implementation here:
+         * https://github.com/jaredhanson/oauth2orize/blob/master/lib/exchange/authorizationCode.js
+         * As you can see, it does some validation and set's some headers, not very very important,
+         * but it's part of the oauth2 spec.
+         *
+         * @TODO: How to use exchange.authorizationCode in combination of passport?
          */
         oauthServer.exchange('authorization_code', exchangeAuthorizationCode);
     },

--- a/core/server/middleware/api/spam-prevention.js
+++ b/core/server/middleware/api/spam-prevention.js
@@ -27,7 +27,7 @@ spamPrevention = {
 
         if (req.body.username && req.body.grant_type === 'password') {
             loginSecurity.push({ip: remoteAddress, time: currentTime, email: req.body.username});
-        } else if (req.body.grant_type === 'refresh_token') {
+        } else if (req.body.grant_type === 'refresh_token' || req.body.grant_type === 'authorization_code') {
             return next();
         } else {
             return next(new errors.BadRequestError({message: i18n.t('errors.middleware.spamprevention.noUsername')}));


### PR DESCRIPTION
refs #7562
- delete /authentication/ghost
- Ghost-Admin will use /authentication/token for all use cases (password, refresh token and ghost.org authorization code)
- add new grant_type `authorization_code`

We can't use the `oauthorize.exchange.authorizationCode` function, because this wraps the express req/res and passport needs access to it. Because Ghost is just forwarding the `authorization_code` to Ghost.org, it's OK to not use `oauthorize.exchange.authorizationCode`.
