### PR TITLE
🐛  GhostError needs to inherit from Error

### DIFF
--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -166,6 +166,7 @@ var errors = {
     }
 };
 
+util.inherits(GhostError, Error);
 _.each(errors, function (error) {
     util.inherits(error, GhostError);
 });

--- a/core/test/unit/errors_spec.js
+++ b/core/test/unit/errors_spec.js
@@ -4,6 +4,11 @@ var errors = require('../../server/errors'),
 should.equal(true, true);
 
 describe('Errors', function () {
+    it('Ensure we inherit from Error', function () {
+        var ghostError = new errors.GhostError();
+        (ghostError instanceof Error).should.eql(true);
+    });
+
     describe('Inherite from other error', function () {
         it('default', function () {
             var someError = new Error(), ghostError;


### PR DESCRIPTION
no issue

This line was missing 👍 
GhostError now inherits from Error.
