### PR TITLE
🎨  add knexMigratorFilePath for knex-migrator initialisation

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -30,7 +30,9 @@ var debug = require('debug')('ghost:boot:init'),
     scheduling = require('./scheduling'),
     readDirectory = require('./utils/read-directory'),
     utils = require('./utils'),
-    knexMigrator = new KnexMigrator(),
+    knexMigrator = new KnexMigrator({
+        knexMigratorFilePath: config.get('paths:appRoot')
+    }),
     dbHash;
 
 function initDbHashAndFirstRun() {


### PR DESCRIPTION
no issue

If we don't pass our root path, it can happen that knex-migrator get's the wrong path when looking for the `.knex-migrator` file
