### PR TITLE
🎨 make sqlite filename absolute

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -30,8 +30,10 @@ nconf.file('ghost4', __dirname + '/defaults.json');
 
 /**
  * transform all relative paths to absolute paths
+ * transform sqlite filename path for Ghost-CLI
  */
-localUtils.makePathsAbsolute.bind(nconf)();
+localUtils.makePathsAbsolute.bind(nconf)(nconf.get('paths'), 'paths');
+localUtils.makePathsAbsolute.bind(nconf)(nconf.get('database:connection'), 'database:connection');
 
 /**
  * values we have to set manual

--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -17,7 +17,7 @@ exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
 /**
  * transform all relative paths to absolute paths
  * @TODO: imagesRelPath is a dirty little attribute (especially when looking at the usages)
- * @TODO: re-write this function a little bit so we don't have to path the parent, that is hard to understand
+ * @TODO: re-write this function a little bit so we don't have to add the parent path - that is hard to understand
  *
  * Path must be string.
  * Path must match minimum one / or \

--- a/core/test/unit/config/index_spec.js
+++ b/core/test/unit/config/index_spec.js
@@ -6,14 +6,14 @@ var should         = require('should'),
     fs             = require('fs'),
     _              = require('lodash'),
 
-    testUtils      = require('../utils'),
-    i18n           = require('../../server/i18n'),
-    utils          = require('../../server/utils'),
+    testUtils      = require('../../utils'),
+    i18n           = require('../../../server/i18n'),
+    utils          = require('../../../server/utils'),
     /*jshint unused:false*/
-    db             = require('../../server/data/db/connection'),
+    db             = require('../../../server/data/db/connection'),
 
     // Thing we are testing
-    configUtils    = require('../utils/configUtils'),
+    configUtils    = require('../../utils/configUtils'),
     config         = configUtils.config;
 
 i18n.init();
@@ -106,9 +106,10 @@ describe('Config', function () {
 
         it('should have the correct values for each key', function () {
             var pathConfig = config.get('paths'),
-                appRoot = path.resolve(__dirname, '../../../');
+                appRoot = path.resolve(__dirname, '../../../../');
 
             pathConfig.should.have.property('appRoot', appRoot);
+            pathConfig.should.have.property('imagesRelPath', 'content/images');
         });
 
         it('should allow specific properties to be user defined', function () {

--- a/core/test/unit/config/utils_spec.js
+++ b/core/test/unit/config/utils_spec.js
@@ -1,0 +1,83 @@
+var configUtils = require('../../../server/config/utils'),
+    should = require('should');
+
+should.equal(true, true);
+
+describe('UNIT: Config utils', function () {
+    describe('makePathsAbsolute', function () {
+        it('ensure we change paths only', function () {
+            var changedKey = [],
+                obj = {
+                    database: {
+                        client: 'mysql',
+                        connection: {
+                            filename: 'content/data/ghost.db'
+                        }
+                    }
+                };
+
+            this.set = function (key, value) {
+                changedKey.push([key, value]);
+            };
+
+            configUtils.makePathsAbsolute.bind(this)(obj.database, 'database');
+
+            changedKey.length.should.eql(1);
+            changedKey[0][0].should.eql('database:connection:filename');
+            changedKey[0][1].should.not.eql('content/data/ghost.db');
+        });
+
+        it('ensure it skips non strings', function () {
+            var changedKey = [],
+                obj = {
+                    database: {
+                        test: 10
+                    }
+                };
+
+            this.set = function (key, value) {
+                changedKey.push([key, value]);
+            };
+
+            configUtils.makePathsAbsolute.bind(this)(obj.database, 'database');
+            changedKey.length.should.eql(0);
+        });
+
+        it('ensure we don\' change absolute paths', function () {
+            var changedKey = [],
+                obj = {
+                    database: {
+                        client: 'mysql',
+                        connection: {
+                            filename: '/content/data/ghost.db'
+                        }
+                    }
+                };
+
+            this.set = function (key, value) {
+                changedKey.push([key, value]);
+            };
+
+            configUtils.makePathsAbsolute.bind(this)(obj.database, 'database');
+            changedKey.length.should.eql(0);
+        });
+
+        it('match paths on windows', function () {
+            var changedKey = [],
+                obj = {
+                    database: {
+                        filename: 'content\\data\\ghost.db'
+                    }
+                };
+
+            this.set = function (key, value) {
+                changedKey.push([key, value]);
+            };
+
+            configUtils.makePathsAbsolute.bind(this)(obj.database, 'database');
+            changedKey.length.should.eql(1);
+            changedKey[0][0].should.eql('database:filename');
+            changedKey[0][1].should.not.eql('content\\data\\ghost.db');
+        });
+    });
+});


### PR DESCRIPTION
no issue

When Ghost-CLI inits the database of the current GhostVersion (in `/current`), then it uses `knex-migrator` to do that. Knex migrator is reading the `.knex-migrator` file of the current Ghost version. This returns a relative path to the database location.

The problem: `knex-migrator` will init the database in the root folder of Ghost-CLI `/content/data` instead of `/current/content/data` . And when you start Ghost (ghost start), it always complains that the database is not initialised, because it expects the database in a different location.
