### PR TITLE
🛠  knex-migrator 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "intl-messageformat": "1.3.0",
     "jsonpath": "0.2.7",
     "knex": "0.12.5",
-    "knex-migrator": "0.0.5",
+    "knex-migrator": "0.0.6",
     "lodash": "4.16.4",
     "mobiledoc-html-renderer": "0.3.0",
     "moment": "2.15.1",


### PR DESCRIPTION
no issue
- manual PR, because GK is too slow to push the version bump

Changes:
- add missing `lodash` dependency
