### PR TITLE
🐛  fix changePassword bug

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -683,7 +683,7 @@ User = ghostBookshelf.Model.extend({
             ne2Password = object.ne2Password,
             userId = parseInt(object.user_id),
             oldPassword = object.oldPassword,
-            isLoggedInUser = object.user_id === options.context.user,
+            isLoggedInUser = userId === options.context.user,
             user;
 
         // If the two passwords do not match

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -560,6 +560,20 @@ describe('User Model', function run() {
                     done();
                 });
             });
+
+            it('wrong old password', function (done) {
+                UserModel.changePassword({
+                    newPassword: '12345678',
+                    ne2Password: '12345678',
+                    oldPassword: '123456789',
+                    user_id: '1'
+                }, testUtils.context.owner).then(function () {
+                    done(new Error('expected error!'));
+                }).catch(function (err) {
+                    (err instanceof errors.ValidationError).should.eql(true);
+                    done();
+                });
+            });
         });
 
         describe('success', function () {


### PR DESCRIPTION
no issue
- comparison for isLoggedInUser did not work when `userId` was a string
- parsing of int was missing
