### PR TITLE
Move Node v6 to be officially supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-# When changing node version also update it on lines 34, 36 and 46.
 node_js:
   - "4"
   - "0.12"
@@ -26,8 +25,6 @@ matrix:
   include:
     - node_js: "4"
       env: TEST_SUITE=lint
-  allow_failures:
-    - node_js: "6"
   fast_finish: true
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ^4.2.0"
+    "node": "~0.10.0 || ~0.12.0 || ^4.2.0 || ^6.9.0"
   },
   "dependencies": {
     "amperize": "0.3.1",


### PR DESCRIPTION
Trying to think if I missed anything 🤔 
- Node v6 has been declared LTS
- We will now officially support this version, although v4 remains recommended (as it is by Node themselves)

refs #7466

TODO:
- [ ] Update http://support.ghost.org/supported-node-versions/ once this has been released
