### PR TITLE
🐛  add missing schedulerUrl option

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -129,6 +129,7 @@ function init(options) {
         // scheduling module can create x schedulers with different adapters
         debug('Server done');
         return scheduling.init({
+            schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
             apiUrl: utils.url.apiUrl(),
             internalPath: config.get('paths').internalSchedulingPath,


### PR DESCRIPTION
no issue
- while refactoring the config module, schedulerUrl option was accidentally deleted
- let's re-add it 😇
