### PR TITLE
🎨 public config endpoint

### DIFF
--- a/core/server/admin/controller.js
+++ b/core/server/admin/controller.js
@@ -1,8 +1,6 @@
 var debug         = require('debug')('ghost:admin:controller'),
     _             = require('lodash'),
-    Promise       = require('bluebird'),
     api           = require('../api'),
-    config        = require('../config'),
     logging       = require('../logging'),
     updateCheck   = require('../update-check'),
     i18n          = require('../i18n');

--- a/core/server/admin/controller.js
+++ b/core/server/admin/controller.js
@@ -14,35 +14,6 @@ module.exports = function adminController(req, res) {
     /*jslint unparam:true*/
     debug('index called');
 
-    function renderIndex() {
-        var configuration,
-            fetch = {
-                configuration: api.configuration.read().then(function (res) { return res.configuration[0]; }),
-                client: api.clients.read({slug: 'ghost-admin'}).then(function (res) { return res.clients[0]; }),
-                ghostAuth: api.clients.read({slug: 'ghost-auth'})
-                    .then(function (res) { return res.clients[0]; })
-                    .catch(function () {
-                        return;
-                    })
-            };
-
-        return Promise.props(fetch).then(function renderIndex(result) {
-            configuration = result.configuration;
-
-            configuration.clientId = {value: result.client.slug, type: 'string'};
-            configuration.clientSecret = {value: result.client.secret, type: 'string'};
-
-            if (result.ghostAuth && config.get('auth:type') === 'ghost') {
-                configuration.ghostAuthId = {value: result.ghostAuth.uuid, type: 'string'};
-            }
-
-            debug('rendering default template');
-            res.render('default', {
-                configuration: configuration
-            });
-        });
-    }
-
     updateCheck().then(function then() {
         return updateCheck.showUpdateNotification();
     }).then(function then(updateVersion) {
@@ -64,6 +35,6 @@ module.exports = function adminController(req, res) {
             }
         });
     }).finally(function noMatterWhat() {
-        renderIndex();
+        res.render('default');
     }).catch(logging.logError);
 };

--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -59,7 +59,7 @@ function apiRoutes() {
     apiRouter.options('*', cors);
 
     // ## Configuration
-    apiRouter.get('/configuration', authenticatePrivate, api.http(api.configuration.read));
+    apiRouter.get('/configuration', api.http(api.configuration.read));
     apiRouter.get('/configuration/:key', authenticatePrivate, api.http(api.configuration.read));
     apiRouter.get('/configuration/timezones', authenticatePrivate, api.http(api.configuration.read));
 

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -8,13 +8,6 @@ var _                  = require('lodash'),
 
     configuration;
 
-function labsFlag(key) {
-    return {
-        value: (config[key] === true),
-        type: 'bool'
-    };
-}
-
 function fetchAvailableTimezones() {
     var timezones = require('../data/timezones.json');
     return timezones;
@@ -31,12 +24,12 @@ function getAboutConfig() {
 
 function getBaseConfig() {
     return {
-        fileStorage:    {value: (config.fileStorage !== false), type: 'bool'},
-        useGravatar:    {value: !config.isPrivacyDisabled('useGravatar'), type: 'bool'},
-        publicAPI:      labsFlag('publicAPI'),
-        blogUrl:        {value: config.get('url').replace(/\/$/, ''), type: 'string'},
-        blogTitle:      {value: config.get('theme').title, type: 'string'},
-        routeKeywords:  {value: JSON.stringify(config.get('routeKeywords')), type: 'json'}
+        fileStorage:    config.get('fileStorage') !== false,
+        useGravatar:    !config.isPrivacyDisabled('useGravatar'),
+        publicAPI:      config.get('publicAPI') === true,
+        blogUrl:        config.get('url').replace(/\/$/, ''),
+        blogTitle:      config.get('theme').title,
+        routeKeywords:  JSON.stringify(config.get('routeKeywords'))
     };
 }
 
@@ -46,8 +39,6 @@ function getBaseConfig() {
  * We need to load the client credentials dynamically.
  * For example: on bootstrap ghost-auth get's created and if we load them here in parallel,
  * it can happen that we won't get any client credentials or wrong credentials.
- *
- * @TODO: remove {value: .., type: ..} pattern?
  *
  * **See:** [API Methods](index.js.html#api%20methods)
  */
@@ -74,12 +65,12 @@ configuration = {
                 .then(function (result) {
                     var configuration = getBaseConfig();
 
-                    configuration.clientId = {value: result.ghostAdmin.get('slug'), type: 'string'};
-                    configuration.clientSecret = {value: result.ghostAdmin.get('secret'), type: 'string'};
+                    configuration.clientId = result.ghostAdmin.get('slug');
+                    configuration.clientSecret = result.ghostAdmin.get('secret');
 
                     if (result.ghostAuth) {
-                        configuration.ghostAuthId = {value: result.ghostAuth.get('uuid'), type: 'string'};
-                        configuration.ghostAuthUrl = {value: config.get('auth:url'), type: 'string'};
+                        configuration.ghostAuthId = result.ghostAuth.get('uuid');
+                        configuration.ghostAuthUrl = config.get('auth:url');
                     }
 
                     return {configuration: [configuration]};

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -29,7 +29,7 @@ function getBaseConfig() {
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        config.get('url').replace(/\/$/, ''),
         blogTitle:      config.get('theme').title,
-        routeKeywords:  JSON.stringify(config.get('routeKeywords'))
+        routeKeywords:  config.get('routeKeywords')
     };
 }
 

--- a/core/test/functional/routes/api/configuration_spec.js
+++ b/core/test/functional/routes/api/configuration_spec.js
@@ -1,0 +1,41 @@
+var testUtils     = require('../../../utils'),
+    should        = require('should'),
+    supertest     = require('supertest'),
+    ghost         = testUtils.startGhost,
+    request;
+
+describe('Configuration API', function () {
+    var accesstoken = '';
+
+    before(function (done) {
+        // starting ghost automatically populates the db
+        // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
+        ghost().then(function (ghostServer) {
+            request = supertest.agent(ghostServer.rootApp);
+        }).then(function () {
+            return testUtils.doAuth(request, 'posts');
+        }).then(function (token) {
+            accesstoken = token;
+            done();
+        }).catch(done);
+    });
+
+    after(function (done) {
+        testUtils.clearData().then(function () {
+            done();
+        }).catch(done);
+    });
+
+    describe('success', function () {
+        it('can retrieve public configuration', function (done) {
+            request.get(testUtils.API.getApiQuery('configuration/'))
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    should.exist(res.body.configuration);
+                    done();
+                });
+        });
+    });
+});

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -29,7 +29,7 @@ describe('Configuration API', function () {
             props = response.configuration[0];
 
             props.blogUrl.should.eql('http://127.0.0.1:2369');
-            props.routeKeywords.should.eql(JSON.stringify({
+            props.routeKeywords.should.eql({
                 tag: 'tag',
                 author: 'author',
                 page: 'page',
@@ -37,7 +37,7 @@ describe('Configuration API', function () {
                 private: 'private',
                 subscribe: 'subscribe',
                 amp: 'amp'
-            }));
+            });
 
             props.fileStorage.should.eql(true);
             props.useGravatar.should.eql(true);

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -1,10 +1,10 @@
-var testUtils         = require('../../utils'),
-    configUtils       = require('../../utils/configUtils'),
-    should            = require('should'),
-    rewire            = require('rewire'),
+var testUtils = require('../../utils'),
+    configUtils = require('../../utils/configUtils'),
+    should = require('should'),
+    rewire = require('rewire'),
 
     // Stuff we are testing
-    ConfigurationAPI  = rewire('../../../server/api/configuration');
+    ConfigurationAPI = rewire('../../../server/api/configuration');
 
 describe('Configuration API', function () {
     // Keep the DB clean
@@ -28,28 +28,29 @@ describe('Configuration API', function () {
             response.configuration.should.be.an.Array().with.lengthOf(1);
             props = response.configuration[0];
 
-            // Check the structure
-            props.should.have.property('blogUrl').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('blogTitle').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('routeKeywords').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('fileStorage').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('useGravatar').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('publicAPI').which.is.an.Object().with.properties('type', 'value');
+            props.blogUrl.should.eql('http://127.0.0.1:2369');
+            props.routeKeywords.should.eql(JSON.stringify({
+                tag: 'tag',
+                author: 'author',
+                page: 'page',
+                preview: 'p',
+                private: 'private',
+                subscribe: 'subscribe',
+                amp: 'amp'
+            }));
 
-            props.should.have.property('clientId').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('clientSecret').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('ghostAuthId').which.is.an.Object().with.properties('type', 'value');
-            props.should.have.property('ghostAuthUrl').which.is.an.Object().with.properties('type', 'value');
+            props.fileStorage.should.eql(true);
+            props.useGravatar.should.eql(true);
+            props.publicAPI.should.eql(false);
+            props.clientId.should.eql('ghost-admin');
+            props.clientSecret.should.eql('not_available');
+            props.ghostAuthUrl.should.eql('http://devauth.ghost.org:8080');
 
-            // Check a few values
-            props.blogUrl.should.have.property('value', 'http://127.0.0.1:2369');
-            props.fileStorage.should.have.property('value', true);
-            props.clientId.should.have.property('value', 'ghost-admin');
+            // value not available, because settings API was not called yet
+            props.hasOwnProperty('blogTitle').should.eql(true);
 
-            should.exist(props.ghostAuthId.value);
-            should.exist(props.ghostAuthUrl.value);
-            should.exist(props.clientSecret.value);
-            should.exist(props.clientId.value);
+            // uuid
+            props.hasOwnProperty('ghostAuthId').should.eql(true);
 
             done();
         }).catch(done);

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -1,4 +1,5 @@
 var testUtils         = require('../../utils'),
+    configUtils       = require('../../utils/configUtils'),
     should            = require('should'),
     rewire            = require('rewire'),
 
@@ -8,11 +9,17 @@ var testUtils         = require('../../utils'),
 describe('Configuration API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
-    afterEach(testUtils.teardown);
+    beforeEach(testUtils.setup('clients'));
+    afterEach(function () {
+        configUtils.restore();
+        return testUtils.teardown();
+    });
 
     should.exist(ConfigurationAPI);
 
     it('can read basic config and get all expected properties', function (done) {
+        configUtils.set('auth:type', 'ghost');
+
         ConfigurationAPI.read().then(function (response) {
             var props;
 
@@ -29,9 +36,20 @@ describe('Configuration API', function () {
             props.should.have.property('useGravatar').which.is.an.Object().with.properties('type', 'value');
             props.should.have.property('publicAPI').which.is.an.Object().with.properties('type', 'value');
 
+            props.should.have.property('clientId').which.is.an.Object().with.properties('type', 'value');
+            props.should.have.property('clientSecret').which.is.an.Object().with.properties('type', 'value');
+            props.should.have.property('ghostAuthId').which.is.an.Object().with.properties('type', 'value');
+            props.should.have.property('ghostAuthUrl').which.is.an.Object().with.properties('type', 'value');
+
             // Check a few values
             props.blogUrl.should.have.property('value', 'http://127.0.0.1:2369');
             props.fileStorage.should.have.property('value', true);
+            props.clientId.should.have.property('value', 'ghost-admin');
+
+            should.exist(props.ghostAuthId.value);
+            should.exist(props.ghostAuthUrl.value);
+            should.exist(props.clientSecret.value);
+            should.exist(props.clientId.value);
 
             done();
         }).catch(done);

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -442,7 +442,8 @@ DataGenerator.forKnex = (function () {
 
     clients = [
         createClient({name: 'Ghost Admin', slug: 'ghost-admin', type: 'ua'}),
-        createClient({name: 'Ghost Scheduler', slug: 'ghost-scheduler', type: 'web'})
+        createClient({name: 'Ghost Scheduler', slug: 'ghost-scheduler', type: 'web'}),
+        createClient({name: 'Ghost Auth', slug: 'ghost-auth', type: 'web'})
     ];
 
     roles_users = [


### PR DESCRIPTION
closes #7628 

With this PR we expose a public configuration endpoint.
When `/ghost` is requested, we don't load and render the configurations into the template anymore. Instead, Ghost-Admin can request the public configuration endpoint.

Background: Ghost needs to share as much as possible configuration information with Ghost-Admin. There is no need to make an extra configuration database call when the Ghost Admin template is requested. If we expose an endpoint, which can be used asynchronously, the request will load faster. Furthermore, we are adding the Ghost Auth Url to Ghost-Admin. Furthermore we are getting rid of rendering the configuration properties into `env-*` meta tags.

Further thinking: If we are removing the update check in the Admin App endpoint, this endpoint will load even more faster. 
### TODO
- [x] wait for Ghost-Admin
- [x] how to change core/server/views/defaults.hbs - it's in ignored files
- [x] discuss @TODO: remove {value: .., type: ..} pattern?
