### PR TITLE
🎨  add logs folder to content folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ b-cov
 !core/test/utils/fixtures/**/*.csv
 
 pids
-logs
 results
 
 npm-debug.log
@@ -47,6 +46,7 @@ Session.vim
 /core/server/data/export/exported*
 /content/tmp/*
 /content/data/*
+/content/logs/*
 /content/apps/**/*
 /content/themes/**/*
 /content/images/**/*

--- a/content/logs/README.md
+++ b/content/logs/README.md
@@ -1,0 +1,3 @@
+# Content / Logs
+
+This is the default log file location when Ghost runs in Production.


### PR DESCRIPTION
refs #7116

It's not a nice experience to start Ghost in Production mode and to get an error that the `content/logs` folder does not exist. This location is the default location for log files in Production.
- see comment https://github.com/TryGhost/Ghost/issues/7116#issuecomment-256598791
- add README.md

@ErisDS any better idea for the .gitignore change?I needed to add this specific line:
`!/content/logs/README.md`. Without this line, git complained about that this file is part of the gitignore file.
