### PR TITLE
🛠  ignore bunyan updates for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "bunyan",
       "glob",
       "mysql",
       "nodemailer",


### PR DESCRIPTION
no issue
- background: we would like to pin 1.8.1 bunyan, because they introduced a behaviour change in the newer versions, see https://github.com/TryGhost/Ignition/issues/16 and especially https://github.com/TryGhost/Ignition/pull/10/files#diff-f08c6314d89022ccf6260ff4794fd365R12
- because we would like to use Ghost-Ignition in Ghost soon, we can ignore bunyan updates in Ghost for now
- Ignition will take care about be able to update bunyan soon

We can close https://github.com/TryGhost/Ghost/pull/7630 when we have merged this.
