### PR TITLE
🔥 Drop support for Node.js v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - "4"
   - "0.12"
-  - "0.10"
   - "6"
 sudo: false
 cache:

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -215,8 +215,7 @@ describe('Themes API', function () {
                 });
         });
 
-        // @TODO: does not pass in travis with 0.10.x, but local it works
-        it.skip('upload different field name', function (done) {
+        it('upload different field name', function (done) {
             scope.uploadTheme({
                 themePath: path.join(__dirname, '/../../../utils/fixtures/csv/single-column-with-header.csv'),
                 fieldName: 'wrong'

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.10.0 || ~0.12.0 || ^4.2.0 || ^6.9.0"
+    "node": "~0.12.0 || ^4.2.0 || ^6.9.0"
   },
   "dependencies": {
     "amperize": "0.3.1",


### PR DESCRIPTION
refs #7466
- Node.js v0.10 will be EOL on 31st October.
- This removes official support from Ghost
