### PR TITLE
Use moment-timezone when using .tz()

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -1,7 +1,7 @@
 var schema    = require('../schema').tables,
     _         = require('lodash'),
     validator = require('validator'),
-    moment    = require('moment'),
+    moment    = require('moment-timezone'),
     assert    = require('assert'),
     Promise   = require('bluebird'),
     errors    = require('../../errors'),

--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -3,7 +3,7 @@
 //
 // Formats a date using moment-timezone.js. Formats published_at by default but will also take a date as a parameter
 
-var moment          = require('moment-timezone'),
+var moment = require('moment-timezone'),
     date,
     timezone;
 


### PR DESCRIPTION
Similar to #7643, I searched the master branch for uses of moment.tz()

refs #7449, refs #7514, refs #7643

- We've had a couple of issues raised, and a few people in #help all report the same error:
> Cannot read property 'zone' of undefined
When starting Ghost.

I'm not sure why this seems to work sometimes, and not others, however it would seem that we
should require moment-timezone anywhere we want to use timezone features.

This PR fixes the LOC shown in #7449 as the problem line + I searched for any other potential problems