### PR TITLE
Fix access-rules plugin description comment

### DIFF
--- a/core/server/models/plugins/access-rules.js
+++ b/core/server/models/plugins/access-rules.js
@@ -1,6 +1,6 @@
 // # Access Rules
 //
-// Extends Bookshelf.Model.force to take a 'context' option which provides information on how this query should
+// Extends Bookshelf.Model.forge to take a 'context' option which provides information on how this query should
 // be treated in terms of data access rules - currently just detecting public requests
 module.exports = function (Bookshelf) {
     var model = Bookshelf.Model,


### PR DESCRIPTION
The plugin extends `Bookshelf.Model.forge` not` Bookshelf.Model.force`