### PR TITLE
🎨  unique constraint for permission and role name

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -55,7 +55,7 @@ module.exports = {
     roles: {
         id: {type: 'increments', nullable: false, primary: true},
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
-        name: {type: 'string', maxlength: 150, nullable: false},
+        name: {type: 'string', maxlength: 150, nullable: false, unique: true},
         description: {type: 'string', maxlength: 200, nullable: true},
         created_at: {type: 'dateTime',  nullable: false},
         created_by: {type: 'integer',  nullable: false},
@@ -70,7 +70,7 @@ module.exports = {
     permissions: {
         id: {type: 'increments', nullable: false, primary: true},
         uuid: {type: 'string', maxlength: 36, nullable: false, validations: {isUUID: true}},
-        name: {type: 'string', maxlength: 150, nullable: false},
+        name: {type: 'string', maxlength: 150, nullable: false, unique: true},
         object_type: {type: 'string', maxlength: 150, nullable: false},
         action_type: {type: 'string', maxlength: 150, nullable: false},
         object_id: {type: 'integer', nullable: true},

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -27,7 +27,7 @@ describe('Themes API', function () {
         ghost().then(function (ghostServer) {
             request = supertest.agent(ghostServer.rootApp);
         }).then(function () {
-            return testUtils.doAuth(request, 'perms:theme', 'perms:init', 'users:roles:no-owner');
+            return testUtils.doAuth(request, 'perms:init', 'users:no-owner');
         }).then(function (token) {
             scope.ownerAccessToken = token;
 

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -14,7 +14,7 @@ describe('User API', function () {
         ghost().then(function (ghostServer) {
             request = supertest.agent(ghostServer.rootApp);
         }).then(function () {
-            return testUtils.doAuth(request, 'users:roles:no-owner');
+            return testUtils.doAuth(request, 'users:no-owner');
         }).then(function (token) {
             ownerAccessToken = token;
 

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -518,7 +518,7 @@ describe('Authentication API', function () {
         });
 
         describe('Not Owner', function () {
-            beforeEach(testUtils.setup('roles', 'users:roles', 'settings', 'perms:setting', 'perms:init', 'perms:user'));
+            beforeEach(testUtils.setup('users:roles', 'settings', 'perms:setting', 'perms:init', 'perms:user'));
 
             it('should report that setup has been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {
@@ -551,7 +551,7 @@ describe('Authentication API', function () {
         });
 
         describe('Owner', function () {
-            beforeEach(testUtils.setup('roles', 'users:roles', 'settings', 'perms:setting', 'perms:init'));
+            beforeEach(testUtils.setup('users:roles', 'settings', 'perms:setting', 'perms:init'));
 
             it('should report that setup has been completed', function (done) {
                 AuthAPI.isSetup().then(function (result) {

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -204,11 +204,10 @@ fixtures = {
         user = DataGenerator.forKnex.createBasic(user);
         user = _.extend({}, user, {status: 'inactive'});
 
-        return db.knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
-            return db.knex('users').insert(user);
-        }).then(function () {
-            return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
-        });
+        return db.knex('users').insert(user)
+            .then(function () {
+                return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users[0]);
+            });
     },
 
     insertOwnerUser: function insertOwnerUser() {
@@ -242,14 +241,13 @@ fixtures = {
         });
     },
 
-    createUsersWithRolesWithoutOwner: function createUsersWithRolesWithoutOwner() {
+    createUsersWithoutOwner: function createUsersWithoutOwner() {
         var usersWithoutOwner = DataGenerator.forKnex.users.slice(1);
 
-        return db.knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
-            return db.knex('users').insert(usersWithoutOwner);
-        }).then(function () {
-            return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users);
-        });
+        return db.knex('users').insert(usersWithoutOwner)
+            .then(function () {
+                return db.knex('roles_users').insert(DataGenerator.forKnex.roles_users);
+            });
     },
 
     createExtraUsers: function createExtraUsers() {
@@ -437,7 +435,7 @@ toDoList = {
         return models.Settings.populateDefaults().then(function () { return SettingsAPI.updateSettingsCache(); });
     },
     'users:roles': function createUsersWithRoles() { return fixtures.createUsersWithRoles(); },
-    'users:roles:no-owner': function createUsersWithRoles() { return fixtures.createUsersWithRolesWithoutOwner(); },
+    'users:no-owner': function createUsersWithoutOwner() { return fixtures.createUsersWithoutOwner(); },
     users: function createExtraUsers() { return fixtures.createExtraUsers(); },
     'user:token': function createTokensForUser() { return fixtures.createTokensForUser(); },
     owner: function insertOwnerUser() { return fixtures.insertOwnerUser(); },
@@ -497,7 +495,7 @@ getFixtureOps = function getFixtureOps(toDos) {
             fixtureOps.push(toDoList[tmp[0]](tmp[1]));
         } else {
             if (!toDoList[toDo]) {
-                throw new Error('setup todo does not exist - spell mistake?');
+                throw new Error('setup todo does not exist - spell mistake? --> ' + toDo);
             }
 
             fixtureOps.push(toDoList[toDo]);


### PR DESCRIPTION
no issue

I saw tests adding permissions and roles twice. (see screenshots)

![twice](https://cloud.githubusercontent.com/assets/1160712/20004846/e0e5291a-a28e-11e6-8168-16bb61b3379e.png)


That happened because the setup in the test was mis-used and there is no restriction for static resources to create duplicates. We also have a unique constraint for settings keys.

With this PR i suggest to make name unique.