### PR TITLE
Move sqlite => optional deps and mysql => required deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "moment": "2.15.2",
     "moment-timezone": "0.5.9",
     "multer": "1.2.0",
+    "mysql": "2.11.1",
     "nconf": "0.8.4",
     "netjet": "1.1.3",
     "node-uuid": "1.4.7",
@@ -77,14 +78,13 @@
     "sanitize-html": "1.13.0",
     "semver": "5.3.0",
     "showdown-ghost": "0.3.6",
-    "sqlite3": "3.1.8",
     "superagent": "2.3.0",
     "unidecode": "0.1.8",
     "validator": "5.7.0",
     "xml": "1.0.1"
   },
   "optionalDependencies": {
-    "mysql": "2.11.1"
+    "sqlite3": "3.1.8"
   },
   "devDependencies": {
     "grunt": "1.0.1",


### PR DESCRIPTION
no issue
- with Ghost-CLI comes the recommended system stack, which requires
MySQL by default. To avoid a number of issues installing sqlite on
various systems, it is being moved to an optional dependency, and mysql
is being moved to a required one.
- upgrade mysql to latest version