### PR TITLE
Ghost Auth: register client with blog_uri

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -115,10 +115,16 @@ function init(options) {
 
         debug('Express Apps done');
 
-        return auth.init(config.get('auth'))
-            .then(function (response) {
-                parentApp.use(response.auth);
-            });
+        return auth.init({
+            authType: config.get('auth:type'),
+            ghostAuthUrl: config.get('auth:url'),
+            redirectUri: utils.url.urlJoin(utils.url.getBaseUrl(), 'ghost', '/'),
+            blogUri: utils.url.urlJoin(utils.url.getBaseUrl(), '/'),
+            // @TODO: set blog title
+            clientName: utils.url.getBaseUrl()
+        }).then(function (response) {
+            parentApp.use(response.auth);
+        });
     }).then(function () {
         debug('Auth done');
         return new GhostServer(parentApp);

--- a/core/test/unit/auth/passport_spec.js
+++ b/core/test/unit/auth/passport_spec.js
@@ -15,8 +15,13 @@ should.equal(true, true);
 describe('Ghost Passport', function () {
     var client;
 
-    function FakeGhostOAuth2Strategy() {
+    function FakeGhostOAuth2Strategy(options) {
         this.name = 'FakeGhostOAuth2Strategy';
+
+        should.exist(options.blogUri);
+        should.exist(options.url);
+        should.exist(options.callbackURL);
+        options.passReqToCallback.should.eql(true);
     }
 
     before(function () {
@@ -46,7 +51,7 @@ describe('Ghost Passport', function () {
     describe('auth_type: password', function () {
         it('initialise passport with passport auth type', function () {
             return GhostPassport.init({
-                type: 'passport'
+                authType: 'passport'
             }).then(function (response) {
                 should.exist(response.passport);
                 passport.use.callCount.should.eql(2);
@@ -67,7 +72,10 @@ describe('Ghost Passport', function () {
             }));
 
             return GhostPassport.init({
-                type: 'ghost'
+                authType: 'ghost',
+                blogUri: 'http://my-blog.com',
+                ghostAuthUrl: 'http://devauth.ghost.org',
+                redirectUri: utils.url.getBaseUrl()
             }).then(function (response) {
                 should.exist(response.passport);
                 passport.use.callCount.should.eql(3);
@@ -86,7 +94,10 @@ describe('Ghost Passport', function () {
             }));
 
             return GhostPassport.init({
-                type: 'ghost'
+                authType: 'ghost',
+                blogUri: 'http://my-blog.com',
+                ghostAuthUrl: 'http://devauth.ghost.org',
+                redirectUri: utils.url.getBaseUrl()
             }).then(function (response) {
                 should.exist(response.passport);
                 passport.use.callCount.should.eql(3);
@@ -103,7 +114,10 @@ describe('Ghost Passport', function () {
             client = null;
 
             return GhostPassport.init({
-                type: 'ghost'
+                authType: 'ghost',
+                blogUri: 'http://my-blog.com',
+                ghostAuthUrl: 'http://devauth.ghost.org',
+                redirectUri: utils.url.getBaseUrl()
             }).then(function (response) {
                 should.exist(response.passport);
                 passport.use.callCount.should.eql(3);
@@ -121,7 +135,10 @@ describe('Ghost Passport', function () {
             FakeGhostOAuth2Strategy.prototype.registerClient.returns(Promise.reject(new Error('cannot connect to ghost.org')));
 
             return GhostPassport.init({
-                type: 'ghost'
+                authType: 'ghost',
+                blogUri: 'http://my-blog.com',
+                ghostAuthUrl: 'http://devauth.ghost.org',
+                redirectUri: utils.url.getBaseUrl()
             }).catch(function (err) {
                 (err instanceof errors.IncorrectUsageError).should.eql(true);
                 FakeGhostOAuth2Strategy.prototype.registerClient.callCount.should.eql(12);

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "nodemailer": "0.7.1",
     "oauth2orize": "1.5.1",
     "passport": "0.3.2",
-    "passport-ghost": "1.0.3",
+    "passport-ghost": "1.1.0",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.4",


### PR DESCRIPTION
refs #7654 

- passport-ghost 1.1.0
- change auth.init params to improve readablity
- register client with `blog_uri`
- i will add the `blog_uri` to the client instance when adding the feature to change the `blog_uri`

- [x] code quality
- [x] tests
- [x] manual browser test

`blog_uri` and `redirect_uri` are basically the same, except of the path `/ghost`.
But on Ghost(Pro) `redirect_uri` is the admin url (ghost.io) and `blog_uri` can be anything you would like to define/use. But this is handled by Ghost(Pro).