### PR TITLE
add extraneous files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -19,6 +19,7 @@ node_modules/**
 .git*
 .groc*
 .jshintrc
+.jscsrc
 *.iml
 config.js
 core/built/**/*.map
@@ -32,3 +33,4 @@ SECURITY.md
 !core/server/mail/templates/**
 bower_components/**
 .editorconfig
+gulpfile.js


### PR DESCRIPTION
no issue
- these files are unnecessarily included in `npm publish`

@ErisDS is there a reason the build files (Grunt & gulp) are included in the built zip? Not that it's a huge deal but noticed they're there and (probably) not needed as all the built files are already there.