### PR TITLE
🎨  make settings cache avaialble

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -33,17 +33,7 @@ var _              = require('lodash'),
     cacheInvalidationHeader,
     locationHeader,
     contentDispositionHeaderExport,
-    contentDispositionHeaderSubscribers,
-    init;
-
-/**
- * ### Init
- * Initialise the API - populate the settings cache
- * @return {Promise(Settings)} Resolves to Settings Collection
- */
-init = function init() {
-    return settings.updateSettingsCache();
-};
+    contentDispositionHeaderSubscribers;
 
 function isActiveThemeOverride(method, endpoint, result) {
     return method === 'POST' && endpoint === 'themes' && result.themes && result.themes[0] && result.themes[0].active === true;
@@ -274,8 +264,6 @@ http = function http(apiMethod) {
  * ## Public API
  */
 module.exports = {
-    // Extras
-    init: init,
     http: http,
     // API Endpoints
     configuration: configuration,

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -26,7 +26,6 @@ var _            = require('lodash'),
     /**
      * ## Cache
      * Holds cached settings
-     * @private
      * @type {{}}
      */
     settingsCache = {};
@@ -52,6 +51,9 @@ updateConfigCache = function () {
         }
     }
 
+    // @TODO: why are we putting the settings cache values into config?we could access the cache directly
+    // @TODO: plus: why do we assign the values to the prefix "theme"?
+    // @TODO: might be related to https://github.com/TryGhost/Ghost/issues/7488
     config.set('theme:title', (settingsCache.title && settingsCache.title.value) || '');
     config.set('theme:description', (settingsCache.description && settingsCache.description.value) || '');
     config.set('theme:logo', (settingsCache.logo && settingsCache.logo.value) || '');
@@ -92,10 +94,9 @@ updateSettingsCache = function (settings, options) {
 
     return dataProvider.Settings.findAll(options)
         .then(function (result) {
-            settingsCache = readSettingsResult(result.models);
-
+            // keep reference and update all keys
+            _.extend(settingsCache, readSettingsResult(result.models));
             updateConfigCache();
-
             return settingsCache;
         });
 };
@@ -428,4 +429,21 @@ settings = {
 };
 
 module.exports = settings;
+
+/**
+ * synchronous function to get cached settings value
+ * returns the value of the settings entry
+ */
+module.exports.getSettingSync = function getSettingSync(key) {
+    return settingsCache[key] && settingsCache[key].value;
+};
+
+/**
+ * synchronous function to get all cached settings values
+ * returns everything for now
+ */
+module.exports.getSettingsSync = function getSettingsSync() {
+    return settingsCache;
+};
+
 module.exports.updateSettingsCache = updateSettingsCache;

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -88,10 +88,10 @@ function init(options) {
         return models.Settings.populateDefaults();
     }).then(function () {
         debug('Models & database done');
-        // Initialize the settings cache
-        return api.init();
+
+        return api.settings.updateSettingsCache();
     }).then(function () {
-        debug('API done');
+        debug('Update settings cache done');
         // Initialize the permissions actions and objects
         // NOTE: Must be done before initDbHashAndFirstRun calls
         return permissions.init();

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -115,12 +115,21 @@ describe('Settings API', function () {
     });
 
     it('can edit', function () {
+        var testReference = SettingsAPI.getSettingsSync();
+
+        // see default-settings.json
+        SettingsAPI.getSettingSync('title').should.eql('Ghost');
+        testReference.title.value.should.eql('Ghost');
+
         return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'title', value: 'UpdatedGhost'}]}, {})
             .then(function (response) {
                 should.exist(response);
                 testUtils.API.checkResponse(response, 'settings');
                 response.settings.length.should.equal(1);
                 testUtils.API.checkResponse(response.settings[0], 'setting');
+
+                SettingsAPI.getSettingSync('title').should.eql('UpdatedGhost');
+                testReference.title.value.should.eql('UpdatedGhost');
             });
     });
 

--- a/core/test/unit/server_spec.js
+++ b/core/test/unit/server_spec.js
@@ -33,7 +33,7 @@ describe('server bootstrap', function () {
         populateStub = sandbox.stub(migration, 'populate').returns(Promise.resolve());
         sandbox.stub(models.Settings, 'populateDefaults').returns(Promise.resolve());
         sandbox.stub(permissions, 'init').returns(Promise.resolve());
-        sandbox.stub(api, 'init').returns(Promise.resolve());
+        sandbox.stub(api.settings, 'updateSettingsCache').returns(Promise.resolve());
         sandbox.stub(apps, 'init').returns(Promise.resolve());
         sandbox.stub(slack, 'listen').returns(Promise.resolve());
         sandbox.stub(xmlrpc, 'listen').returns(Promise.resolve());


### PR DESCRIPTION
no issue

This PR makes it possible to access the settings-cache .
So everywhere in Ghost you can do:

`api.settings.getSettingsSync()`
`api.settings.getSettingSync(key)`

Requirement: We ensure that we never destroy the object id reference.
It's not allowed to set values from outside.

This PR also removes `api.init`. This function just wrapped another function, which was: update settings cache. We can re-add it when having more then one task for api initialisation. This has improved readability.

**The background of this change is the following:**
When trying to read the blog title and blog description to register a public client for Ghost Auth, then i would like to avoid doing: `config.get('theme:title')`. I would rather access the settings cache.
Because in my opinion: we should remove all the theme config values, see TODO:

https://github.com/TryGhost/Ghost/compare/master...kirrg001:1.0.0-dev/settings-cache?expand=1#diff-12a8dbd78d369667d9a6160c856477dfR54


- [x] this change was tested in interactive shell, add a test to remember how this works and that it works