### PR TITLE
✨  add read method to local file storage

### DIFF
--- a/core/server/storage/base.js
+++ b/core/server/storage/base.js
@@ -3,7 +3,7 @@ var moment = require('moment'),
 
 function StorageBase() {
     Object.defineProperty(this, 'requiredFns', {
-        value: ['exists', 'save', 'serve', 'delete'],
+        value: ['exists', 'save', 'serve', 'delete', 'read'],
         writable: false
     });
 }

--- a/core/server/storage/local-file-store.js
+++ b/core/server/storage/local-file-store.js
@@ -24,7 +24,7 @@ util.inherits(LocalFileStore, BaseStore);
 // Saves the image to storage (the file system)
 // - image is the express image object
 // - returns a promise which ultimately returns the full url to the uploaded image
-LocalFileStore.prototype.save = function (image, targetDir) {
+LocalFileStore.prototype.save = function save(image, targetDir) {
     targetDir = targetDir || this.getTargetDir(config.getContentPath('images'));
     var targetFilename;
 
@@ -49,7 +49,7 @@ LocalFileStore.prototype.save = function (image, targetDir) {
     });
 };
 
-LocalFileStore.prototype.exists = function (filename) {
+LocalFileStore.prototype.exists = function exists(filename) {
     return new Promise(function (resolve) {
         fs.stat(filename, function (err) {
             var exists = !err;
@@ -59,7 +59,7 @@ LocalFileStore.prototype.exists = function (filename) {
 };
 
 // middleware for serving the files
-LocalFileStore.prototype.serve = function (options) {
+LocalFileStore.prototype.serve = function serve(options) {
     options = options || {};
 
     // CASE: serve themes
@@ -117,11 +117,37 @@ LocalFileStore.prototype.serve = function (options) {
     }
 };
 
-LocalFileStore.prototype.delete = function (fileName, targetDir) {
+LocalFileStore.prototype.delete = function deleteFile(fileName, targetDir) {
     targetDir = targetDir || this.getTargetDir(config.getContentPath('images'));
 
     var pathToDelete = path.join(targetDir, fileName);
     return remove(pathToDelete);
+};
+
+/**
+ * Reads bytes from disk for a target image
+ * path: path of target image (without content path!)
+ */
+LocalFileStore.prototype.read = function read(options) {
+    options = options || {};
+
+    // remove trailing slashes
+    options.path = (options.path || '').replace(/\/$|\\$/, '');
+
+    var targetPath = path.join(config.getContentPath('images'), options.path);
+
+    return new Promise(function (resolve, reject) {
+        fs.readFile(targetPath, function (err, bytes) {
+            if (err) {
+                return reject(new errors.GhostError({
+                    err: err,
+                    message: 'Could not read image: ' + targetPath
+                }));
+            }
+
+            resolve(bytes);
+        });
+    });
 };
 
 module.exports = LocalFileStore;

--- a/core/test/unit/storage/index_spec.js
+++ b/core/test/unit/storage/index_spec.js
@@ -67,6 +67,7 @@ describe('storage: index_spec', function () {
                 'AnotherAdapter.prototype.save = function (){};' +
                 'AnotherAdapter.prototype.serve = function (){};' +
                 'AnotherAdapter.prototype.delete = function (){};' +
+                'AnotherAdapter.prototype.read = function (){};' +
                 'module.exports = AnotherAdapter', chosenStorage;
 
             fs.writeFileSync(scope.adapter, jsFile);
@@ -103,6 +104,7 @@ describe('storage: index_spec', function () {
                 'AnotherAdapter.prototype.save = function (){};' +
                 'AnotherAdapter.prototype.serve = function (){};' +
                 'AnotherAdapter.prototype.delete = function (){};' +
+                'AnotherAdapter.prototype.read = function (){};' +
                 'module.exports = AnotherAdapter', adapter;
 
             fs.writeFileSync(scope.adapter, jsFile);

--- a/core/test/unit/storage/local-file-store_spec.js
+++ b/core/test/unit/storage/local-file-store_spec.js
@@ -3,6 +3,7 @@ var fs              = require('fs-extra'),
     path            = require('path'),
     should          = require('should'),
     sinon           = require('sinon'),
+    errors          = require('../../../server/errors'),
     LocalFileStore  = require('../../../server/storage/local-file-store'),
     localFileStore,
 
@@ -146,6 +147,41 @@ describe('Local File System Storage', function () {
 
             done();
         }).catch(done);
+    });
+
+    describe('read image', function () {
+        beforeEach(function () {
+            // we have some example images in our test utils folder
+            configUtils.set('paths:contentPath', path.join(__dirname, '../../utils/fixtures'));
+        });
+
+        it('success', function (done) {
+            localFileStore.read({path: 'ghost-logo.png'})
+                .then(function (bytes) {
+                    bytes.length.should.eql(8638);
+                    done();
+                });
+        });
+
+        it('success', function (done) {
+            localFileStore.read({path: '/ghost-logo.png/'})
+                .then(function (bytes) {
+                    bytes.length.should.eql(8638);
+                    done();
+                });
+        });
+
+        it('image does not exist', function (done) {
+            localFileStore.read({path: 'does-not-exist.png'})
+                .then(function () {
+                    done(new Error('image should not exist'));
+                })
+                .catch(function (err) {
+                    (err instanceof errors.GhostError).should.eql(true);
+                    err.code.should.eql('ENOENT');
+                    done();
+                });
+        });
     });
 
     describe('validate extentions', function () {


### PR DESCRIPTION
refs #7688, refs #7687

- add a read method to our local file storage
- reads the bytes of a target image

We are adding a read method to storage adapters to be able to cache bytes in process.
With this strategy we can serve files faster, when they didn't change.

**This is a breaking change to storage adapters!**

Usage example @AileenCGN 

```
blogApp.use(function(req,res,next) {
   if (req.path.match(/favicon/)( {
       // @TODO: does custom favicon exist?check in settings!
       // @TODO: ensure we load bytes from cache! (if (faviconCached) ....)
       storage.getStorage().read({path: req.path})
           .then(function(bytes) {
                  // example code for how to write bytes can be found in existing serve shared file middleware
           })
           .catch(next);
   }
})
```