### PR TITLE
🐛  fix brute

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -236,9 +236,9 @@ module.exports = {
     },
     brute: {
         key: {type: 'string'},
-        firstRequest: {type: 'timestamp'},
-        lastRequest: {type: 'timestamp'},
-        lifetime: {type: 'bigInteger'},
+        firstRequest: {type: 'dateTime'},
+        lastRequest: {type: 'dateTime'},
+        lifetime: {type: 'dateTime'},
         count: {type: 'integer'}
     }
 };

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -236,9 +236,9 @@ module.exports = {
     },
     brute: {
         key: {type: 'string'},
-        firstRequest: {type: 'dateTime'},
-        lastRequest: {type: 'dateTime'},
-        lifetime: {type: 'dateTime'},
+        firstRequest: {type: 'bigInteger'},
+        lastRequest: {type: 'bigInteger'},
+        lifetime: {type: 'bigInteger'},
         count: {type: 'integer'}
     }
 };

--- a/core/server/middleware/api/spam-prevention.js
+++ b/core/server/middleware/api/spam-prevention.js
@@ -23,12 +23,23 @@ var ExpressBrute = require('express-brute'),
     logging = require('../../logging'),
     spamConfigKeys = ['freeRetries', 'minWait', 'maxWait', 'lifetime'];
 
-// weird, but true
 handleStoreError = function handleStoreError(err) {
-    err.next(new errors.NoPermissionError({
+    var customError = new errors.NoPermissionError({
         message: 'Unknown error',
         err: err.parent ? err.parent : err
-    }));
+    });
+
+    // see https://github.com/AdamPflug/express-brute/issues/45
+    // express-brute does not always forward a callback
+    // we are using reset as synchronous call, so we have to log the error if it occurs
+    // there is no way to try/catch, because the reset operation happens asynchronous
+    if (!err.next) {
+        err.level = 'critical';
+        logging.error(err);
+        return;
+    }
+
+    err.next(customError);
 };
 
 // This is a global endpoint protection mechanism that will lock an endpoint if there are so many

--- a/core/server/middleware/api/spam-prevention.js
+++ b/core/server/middleware/api/spam-prevention.js
@@ -23,8 +23,12 @@ var ExpressBrute = require('express-brute'),
     logging = require('../../logging'),
     spamConfigKeys = ['freeRetries', 'minWait', 'maxWait', 'lifetime'];
 
+// weird, but true
 handleStoreError = function handleStoreError(err) {
-    return new errors.NoPermissionError({message: 'DB error', err: err});
+    err.next(new errors.NoPermissionError({
+        message: 'Unknown error',
+        err: err.parent ? err.parent : err
+    }));
 };
 
 // This is a global endpoint protection mechanism that will lock an endpoint if there are so many

--- a/core/test/unit/auth/oauth_spec.js
+++ b/core/test/unit/auth/oauth_spec.js
@@ -4,6 +4,7 @@ var sinon = require('sinon'),
     passport = require('passport'),
     testUtils = require('../../utils'),
     oAuth = require('../../../server/auth/oauth'),
+    spamPrevention = require('../../../server/middleware/api/spam-prevention'),
     api = require('../../../server/api'),
     errors = require('../../../server/errors'),
     models = require('../../../server/models');
@@ -20,6 +21,8 @@ describe('OAuth', function () {
         req = {};
         res = {};
         next = sandbox.spy();
+
+        sandbox.stub(spamPrevention.userLogin, 'reset');
     });
 
     afterEach(function () {
@@ -32,7 +35,6 @@ describe('OAuth', function () {
                 .returns(new Promise.resolve());
             sandbox.stub(models.Refreshtoken, 'destroyAllExpired')
                 .returns(new Promise.resolve());
-
             oAuth.init();
         });
 
@@ -77,6 +79,7 @@ describe('OAuth', function () {
                     json.should.have.property('expires_in');
                     json.should.have.property('token_type', 'Bearer');
                     next.called.should.eql(false);
+                    spamPrevention.userLogin.reset.called.should.eql(true);
                     done();
                 } catch (err) {
                     done(err);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bluebird": "3.4.6",
     "body-parser": "1.15.2",
     "bookshelf": "0.10.2",
-    "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0985c50b22f51d5745e6b54ed629edceb4e37c38",
+    "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0a7cf6265506e2be8151740d00518b53a53e6081",
     "bunyan": "1.8.1",
     "chalk": "1.1.3",
     "cheerio": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bluebird": "3.4.6",
     "body-parser": "1.15.2",
     "bookshelf": "0.10.2",
-    "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0a7cf6265506e2be8151740d00518b53a53e6081",
+    "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0cb28fa8e3230dcbf6bca8b991dbb340b9fff6cc",
     "bunyan": "1.8.1",
     "chalk": "1.1.3",
     "cheerio": "0.22.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bluebird": "3.4.6",
     "body-parser": "1.15.2",
     "bookshelf": "0.10.2",
-    "brute-knex": "git://github.com/cobbspur/brute-knex.git#0985c50",
+    "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0985c50b22f51d5745e6b54ed629edceb4e37c38",
     "bunyan": "1.8.1",
     "chalk": "1.1.3",
     "cheerio": "0.22.0",


### PR DESCRIPTION
no issue

- brute-knex uses timestamp type, see https://github.com/llambda/brute-knex/blob/master/index.js
- so we also defined timestamp type
- but see http://stackoverflow.com/questions/9192027/invalid-default-value-for-create-date-timestamp-field
- and see http://stackoverflow.com/questions/35237278/mysql-invalid-default-value-for-timestamp-when-no-default-value-is-given
- **mysql does not allow a second timestamp without default value, that's why initialising mysql does not work right now - it crashed because it complains that it needs a default value for the timestamp field**
- we have two options: define a default value or allow null or use dateTime
- let's use dateTime, as 1. we are using it for all our dates in Ghost and 2. it's recommended
- read here http://www.sqlteam.com/article/timestamps-vs-datetime-data-types
- there are some difference between these two types, i think the most important difference is that timestamp type changes the date if the tz changes in your database
- another fix: lifetime is timestamp not a bigInteger, this was a mistake i think (see https://github.com/llambda/brute-knex/blob/master/index.js#L115)