### PR TITLE
🐛  invite permissions for Editor

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -365,7 +365,8 @@
                     "user": "all",
                     "role": "all",
                     "client": "all",
-                    "subscriber": ["add"]
+                    "subscriber": ["add"],
+                    "invite": "all"
                 },
                 "Author": {
                     "post": ["browse", "read", "add"],

--- a/core/test/integration/api/api_invites_spec.js
+++ b/core/test/integration/api/api_invites_spec.js
@@ -325,6 +325,19 @@ describe('Invites API', function () {
                 }).catch(checkForErrorType('NoPermissionError', done));
             });
 
+            it('CANNOT add an Adminstrator', function (done) {
+                InvitesAPI.add({
+                    invites: [
+                        {
+                            email: 'test@example.com',
+                            role_id: testUtils.roles.ids.admin
+                        }
+                    ]
+                }, context.editor).then(function () {
+                    done(new Error('Editor should not be able to add an owner'));
+                }).catch(checkForErrorType('NoPermissionError', done));
+            });
+
             it('CANNOT add an Author', function (done) {
                 InvitesAPI.add({
                     invites: [


### PR DESCRIPTION
closes #7723

- editor role had no permissions assigned for invites

It looks like they were never configured for the editor role.