### PR TITLE
🐛  return seconds for expires_in

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -609,7 +609,7 @@ authentication = {
                         return {
                             access_token: newAccessToken,
                             refresh_token: refreshToken,
-                            expires_in: newAccessExpiry
+                            expires_in: globalUtils.ONE_HOUR_S
                         };
                     });
             });


### PR DESCRIPTION
no issue

- we previously added a new endpoint to exchange a one time token for a pair of auth tokens
- this endpoint should return seconds for the expires_in return value