### PR TITLE
🔑  Expand subscriber email validation

### DIFF
--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -78,6 +78,8 @@ function storeSubscriber(req, res, next) {
 
     if (_.isEmpty(req.body.email)) {
         return next(new errors.ValidationError({message: 'Email cannot be blank.'}));
+    } else if (!validator.isEmail(req.body.email)) {
+        return next(new errors.ValidationError({message: 'Invalid email.'}));
     }
 
     return api.subscribers.add({subscribers: [req.body]}, {context: {external: true}})


### PR DESCRIPTION
no issue

Expand the existing validation for subscriber email to not only check for the existence, but also if it's a valid email address. If it's not a valid email address, it will throw an error.