### PR TITLE
remove node 0.12 from travis and supported node engines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 # When changing node version also update it on lines 34, 36 and 46.
 node_js:
   - "4"
-  - "0.12"
   - "6"
 sudo: false
 cache:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "~0.12.0 || ^4.2.0 || ^6.5.0"
+    "node": "^4.2.0 || ^6.5.0"
   },
   "dependencies": {
     "amperize": "1.0.0",


### PR DESCRIPTION
no issue
- node 0.12 has reached EOL
