### PR TITLE
🔑 Update Validator to 6.2.1

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -32,13 +32,13 @@
         "defaultLang": {
             "defaultValue": "en_US",
             "validations": {
-                "isNull": false
+                "isEmpty": false
             }
         },
         "postsPerPage": {
             "defaultValue": "5",
             "validations": {
-                "isNull": false,
+                "isEmpty": false,
                 "isInt": true,
                 "isLength": [1, 1000]
             }
@@ -47,13 +47,13 @@
             "defaultValue": "Etc/UTC",
             "validations": {
                 "isTimezone": true,
-                "isNull": false
+                "isEmpty": false
             }
         },
         "forceI18n": {
             "defaultValue": "true",
             "validations": {
-                "isNull": false,
+                "isEmpty": false,
                 "isIn": [["true", "false"]]
             }
         },

--- a/core/test/unit/validation_spec.js
+++ b/core/test/unit/validation_spec.js
@@ -25,9 +25,15 @@ describe('Validation', function () {
         it('isEmptyOrUrl filters javascript urls', function () {
             /*jshint scripturl:true */
             validator.isEmptyOrURL('javascript:alert(0)').should.be.false();
+            validator.isEmptyOrURL('http://example.com/lol/<script>lalala</script>/').should.be.false();
+            validator.isEmptyOrURL('http://example.com/lol?somequery=<script>lalala</script>').should.be.false();
             /*jshint scripturl:false */
             validator.isEmptyOrURL('').should.be.true();
             validator.isEmptyOrURL('http://localhost:2368').should.be.true();
+            validator.isEmptyOrURL('http://example.com/test/').should.be.true();
+            validator.isEmptyOrURL('http://www.example.com/test/').should.be.true();
+            validator.isEmptyOrURL('http://example.com/foo?somequery=bar').should.be.true();
+            validator.isEmptyOrURL('example.com/test/').should.be.true();
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "superagent": "3.3.1",
     "unidecode": "0.1.8",
     "uuid": "3.0.0",
-    "validator": "5.7.0",
+    "validator": "6.2.1",
     "xml": "1.0.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
no issue

Uses new version of [validator](https://github.com/chriso/validator.js) which checks also for in URL embedded script tags.