### PR TITLE
⚡❓  Make AMP optional

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -61,7 +61,8 @@ updateConfigCache = function () {
             permalinks: (settingsCache.permalinks && settingsCache.permalinks.value) || '/:slug/',
             twitter: (settingsCache.twitter && settingsCache.twitter.value) || '',
             facebook: (settingsCache.facebook && settingsCache.facebook.value) || '',
-            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.theme.timezone
+            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.theme.timezone,
+            amp: (settingsCache.amp && settingsCache.amp.value) || true
         },
         labs: labsValue
     });

--- a/core/server/apps/amp/index.js
+++ b/core/server/apps/amp/index.js
@@ -1,8 +1,13 @@
-var router           = require('./lib/router'),
-    registerAmpHelpers  = require('./lib/helpers'),
+var router = require('./lib/router'),
+    registerAmpHelpers = require('./lib/helpers'),
+    config = require('../../config'),
+    ampIsEnabled;
 
-    // Dirty requires
-    config     = require('../../config');
+ampIsEnabled = function ampIsEnabled() {
+    var ampSettings = config.theme.amp;
+
+    return ampSettings === 'true' ? true : false;
+};
 
 module.exports = {
     activate: function activate(ghost) {
@@ -10,6 +15,12 @@ module.exports = {
     },
 
     setupRoutes: function setupRoutes(blogRouter) {
-        blogRouter.use('*/' + config.routeKeywords.amp + '/', router);
+        blogRouter.use('*/' + config.routeKeywords.amp + '/', function ampEnabled(req, res, next) {
+            if (ampIsEnabled() === true) {
+                return router.apply(this, arguments);
+            }
+
+            next();
+        });
     }
 };

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -73,6 +73,18 @@ frontendControllers = {
 
             // CASE: permalink is not valid anymore, we redirect him permanently to the correct one
             if (post.url !== req.path) {
+                // CASE: AMP request, when AMP is disabled can't fully get handled by AMP router
+                // This is ugly, but the redirect wouldn't work for static pages in AMP router
+
+                if (req.path.match(/\/amp\/?$/i)) {
+                    // CASE: it's a static page, we return a 404
+                    if (post.page) {
+                        return res.sendStatus(404);
+                    }
+                    // CASE: it's a normal post with disabled AMP, we return a temporary redirect
+                    res.set('Cache-Control', 'public, max-age=0');
+                    return res.redirect(302, (req.originalUrl || req.url).slice(0, -1 * (config.routeKeywords.amp.length + 1)));
+                }
                 return res.redirect(301, post.url);
             }
 

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -68,6 +68,9 @@
                 "notContains": "/ghost/"
             }
         },
+        "amp": {
+            "defaultValue": "true"
+        },
         "ghost_head": {
             "defaultValue" : ""
         },

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -8,8 +8,9 @@ var request    = require('supertest'),
     should     = require('should'),
     moment     = require('moment'),
     cheerio    = require('cheerio'),
-    testUtils  = require('../../utils'),
-    ghost      = require('../../../../core');
+    testUtils   = require('../../utils'),
+    configUtils = require('../../utils/configUtils'),
+    ghost       = require('../../../../core');
 
 describe('Frontend Routing', function () {
     function doEnd(done) {
@@ -239,6 +240,20 @@ describe('Frontend Routing', function () {
                     .expect('Cache-Control', testUtils.cacheRules.private)
                     .expect(404)
                     .expect(/Page not found/)
+                    .end(doEnd(done));
+            });
+
+            it('should not render AMP, when AMP flag in settings is disabled', function (done) {
+                after(function () {
+                    configUtils.restore();
+                });
+
+                configUtils.set({theme: {amp: 'false'}});
+
+                request.get('/welcome-to-ghost/amp/')
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect(302)
+                    .expect('Location', '/welcome-to-ghost/')
                     .end(doEnd(done));
             });
         });
@@ -474,6 +489,20 @@ describe('Frontend Routing', function () {
         it('/blog/tag/getting-started/ should 200', function (done) {
             request.get('/blog/tag/getting-started/')
                 .expect(200)
+                .end(doEnd(done));
+        });
+
+        it.skip('/blog/welcome-to-ghost/amp/ should 302 when AMP is disabled', function (done) {
+            after(function () {
+                configUtils.restore();
+            });
+
+            configUtils.set({theme: {amp: 'false'}});
+
+            request.get('/blog/welcome-to-ghost/amp/')
+                .expect('Cache-Control', testUtils.cacheRules.public)
+                .expect(302)
+                .expect('Location', '/blog/welcome-to-ghost/')
                 .end(doEnd(done));
         });
     });


### PR DESCRIPTION
refs #7769

Because Google AMP is bitching around and shows errors in Googles' webmaster tools for missing post images and blog icons, we decided to make AMP optional. It will be enabled by default, but can be disabled in general settings. Once disabled, the `amp` route doesn't work anymore.

This PR contains the back end changes for LTS:
- Adds `amp` to settings table incl default setting `true`
- Adds `amp` value to our settings cache
- Changes the route handling of AMP app to check for the `amp` setting first.
- Adds functional tests to frontend routing