### PR TITLE
🐛  fix admin redirect

### DIFF
--- a/core/server/middleware/check-ssl.js
+++ b/core/server/middleware/check-ssl.js
@@ -44,7 +44,7 @@ checkSSL = function checkSSL(req, res, next) {
                 forceAdminSSL: config.forceAdminSSL,
                 configUrlSSL: config.urlSSL,
                 configUrl: config.url,
-                reqUrl: req.url
+                reqUrl: req.originalUrl || req.url
             });
 
             if (response.isForbidden) {


### PR DESCRIPTION
closes #7467

We need to prefer the `req.originalUrl` as `req.url` can be rewritten by express routers.
This fix is already present in the master branch - not much to review here. 
See https://github.com/TryGhost/Ghost/blob/master/core/server/middleware/check-ssl.js#L47

Tested manually. 