### PR TITLE
🎨  fix tests

### DIFF
--- a/core/test/utils/fixtures/export/export-000.json
+++ b/core/test/utils/fixtures/export/export-000.json
@@ -173,10 +173,6 @@
             {
                 "id": 2,
                 "email": "subscriber2@test.com"
-            },
-            {
-                "id": 3,
-                "email": "subscriber2@test.com"
             }
         ]
     }


### PR DESCRIPTION
no issue

LTS branch is red, because of postgres.

- if an import contains duplicates for subscribers, postgres behaves different to mysql and sqlite
- it detects a duplicate and then it does not import ANYTHING
- i spend 30mins trying to fix this issue, but i was not able to
- i looked at the knex debug and the transaction get's successfully committed, but no data in the database
- as i don't want to spend more time on this, i deleted the duplicated subscriber from the test json
- so in case of postgres: if somebody imports a database with duplicated subscribers, he get's a success message but no data is imported
- i would like to wait until somebody reports this issue as a bug and see how many users affects this bug - as a workaround: everybody can remove the duplicate subscriber
- postgres was dropped in Ghost 1.0