### PR TITLE
✨  make AMP optional

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -61,7 +61,8 @@ updateConfigCache = function () {
             permalinks: (settingsCache.permalinks && settingsCache.permalinks.value) || '/:slug/',
             twitter: (settingsCache.twitter && settingsCache.twitter.value) || '',
             facebook: (settingsCache.facebook && settingsCache.facebook.value) || '',
-            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.theme.timezone
+            timezone: (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.theme.timezone,
+            amp: (settingsCache.amp && settingsCache.amp.value === 'true')
         },
         labs: labsValue
     });

--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -60,14 +60,15 @@ function checkIfAMPIsEnabled(req, res, next) {
     }
 
     /**
-     * CASE: amp is disabled, we redirect the user to the requested post
+     * CASE: amp is disabled, we serve 404
+     *
+     * Alternatively we could redirect to the original post, as the user can enable/disable AMP every time.
      *
      * If we would call `next()`, express jumps to the frontend controller (server/controllers/frontend/index.js fn single)
      * and tries to lookup the post (again) and checks whether the post url equals the requested url (post.url !== req.path).
      * This check would fail if the blog is setup on a subdirectory.
      */
-    res.set('Cache-Control', 'public, max-age=0');
-    return res.redirect(302, (req.originalUrl || req.url).slice(0, -1 * (config.routeKeywords.amp.length + 1)));
+    errors.error404(req, res, next);
 }
 
 // AMP frontend route

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -66,6 +66,11 @@ frontendControllers = {
                 return next();
             }
 
+            // CASE: postlookup can detect options for example /edit, unknown options get ignored and end in 404
+            if (lookup.isUnknownOption) {
+                return next();
+            }
+
             // CASE: last param is of url is /edit, redirect to admin
             if (lookup.isEditURL) {
                 return res.redirect(config.paths.subdir + '/ghost/editor/' + post.id + '/');

--- a/core/server/controllers/frontend/post-lookup.js
+++ b/core/server/controllers/frontend/post-lookup.js
@@ -16,7 +16,6 @@ function postLookup(postUrl) {
         postPermalink = config.theme.permalinks,
         pagePermalink = '/:slug/',
         isEditURL = false,
-        isAmpURL = false,
         matchFuncPost,
         matchFuncPage,
         postParams,
@@ -38,23 +37,12 @@ function postLookup(postUrl) {
     }
 
     // If params contains options, and it is equal to 'edit', this is an edit URL
-    // If params contains options, and it is equal to 'amp', this is an amp URL
     if (params.options && params.options.toLowerCase() === 'edit') {
         isEditURL = true;
-    } else if (params.options && params.options.toLowerCase() === 'amp') {
-        isAmpURL = true;
-    } else if (params.options !== undefined) {
-        // Unknown string in URL, return empty
-        return Promise.resolve();
     }
 
-    // Sanitize params we're going to use to lookup the post.
-    params = _.pick(params, 'slug', 'id');
-    // Add author & tag
-    params.include = 'author,tags';
-
     // Query database to find post
-    return api.posts.read(params).then(function then(result) {
+    return api.posts.read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,tags'})).then(function then(result) {
         var post = result.posts[0];
 
         if (!post) {
@@ -71,15 +59,10 @@ function postLookup(postUrl) {
             return Promise.resolve();
         }
 
-        // We don't support AMP for static pages yet
-        if (post.page && isAmpURL) {
-            return Promise.resolve();
-        }
-
         return {
             post: post,
             isEditURL: isEditURL,
-            isAmpURL: isAmpURL
+            isUnknownOption: isEditURL ? false : params.options ? true : false
         };
     });
 }

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -68,6 +68,9 @@
                 "notContains": "/ghost/"
             }
         },
+        "amp": {
+            "defaultValue": "true"
+        },
         "ghost_head": {
             "defaultValue" : ""
         },

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -98,7 +98,8 @@ function ghost_head(options) {
                 escapeExpression(metaData.canonicalUrl) + '" />');
             head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
 
-            if (_.includes(context, 'post') && !_.includes(context, 'amp')) {
+            // show amp link in post when 1. we are not on the amp page and 2. amp is enabled
+            if (_.includes(context, 'post') && !_.includes(context, 'amp') && config.theme.amp) {
                 head.push('<link rel="amphtml" href="' +
                     escapeExpression(metaData.ampUrl) + '" />');
             }

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -243,7 +243,7 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
 
-            it('should not render AMP, when AMP flag in settings is disabled', function (done) {
+            it('should serve 404, when AMP is disabled', function (done) {
                 after(function () {
                     configUtils.restore();
                 });
@@ -251,9 +251,7 @@ describe('Frontend Routing', function () {
                 configUtils.set({theme: {amp: false}});
 
                 request.get('/welcome-to-ghost/amp/')
-                    .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(302)
-                    .expect('Location', '/welcome-to-ghost/')
+                    .expect(404)
                     .end(doEnd(done));
             });
         });

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -9,6 +9,7 @@ var request    = require('supertest'),
     moment     = require('moment'),
     cheerio    = require('cheerio'),
     testUtils  = require('../../utils'),
+    configUtils = require('../../utils/configUtils'),
     ghost      = require('../../../../core');
 
 describe('Frontend Routing', function () {
@@ -241,6 +242,20 @@ describe('Frontend Routing', function () {
                     .expect(/Page not found/)
                     .end(doEnd(done));
             });
+
+            it('should not render AMP, when AMP flag in settings is disabled', function (done) {
+                after(function () {
+                    configUtils.restore();
+                });
+
+                configUtils.set({theme: {amp: false}});
+
+                request.get('/welcome-to-ghost/amp/')
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect(302)
+                    .expect('Location', '/welcome-to-ghost/')
+                    .end(doEnd(done));
+            });
         });
 
         describe('Static assets', function () {
@@ -404,6 +419,7 @@ describe('Frontend Routing', function () {
 
     describe('Subdirectory (no slash)', function () {
         var forkedGhost, request;
+
         before(function (done) {
             var configTest = testUtils.fork.config();
             configTest.url = 'http://localhost/blog';

--- a/core/test/unit/apps/amp/lib/router_spec.js
+++ b/core/test/unit/apps/amp/lib/router_spec.js
@@ -1,0 +1,39 @@
+var sinon = require('sinon'),
+    router = require('../../../../../server/apps/amp/lib/router'),
+    configUtils = require('../../../../utils/configUtils'),
+    testUtils = require('../../../../utils'),
+    sandbox = sinon.sandbox.create();
+
+describe('UNIT: Apps Amp Router', function () {
+    afterEach(function () {
+        configUtils.restore();
+        sandbox.restore();
+    });
+
+    it('blog has subdirectory and amp is disabled', function (done) {
+        configUtils.set({
+            theme: {
+                amp: false
+            }
+        });
+
+        var req = {
+            originalUrl: '/blog/welcome-ghost/amp',
+            body: {
+                post: {
+                    title: testUtils.DataGenerator.forModel.posts[0]
+                }
+            }
+        }, res = {
+            set: sandbox.stub(),
+            redirect: function (statusCode, url) {
+                res.set.calledOnce.should.eql(true);
+                statusCode.should.eql(302);
+                url.should.eql('/blog/welcome-ghost');
+                done();
+            }
+        };
+
+        router.checkIfAMPIsEnabled(req, res);
+    });
+});

--- a/core/test/unit/apps/amp/lib/router_spec.js
+++ b/core/test/unit/apps/amp/lib/router_spec.js
@@ -25,12 +25,15 @@ describe('UNIT: Apps Amp Router', function () {
                 }
             }
         }, res = {
-            set: sandbox.stub(),
-            redirect: function (statusCode, url) {
-                res.set.calledOnce.should.eql(true);
-                statusCode.should.eql(302);
-                url.should.eql('/blog/welcome-ghost');
+            send: function (message) {
+                message.should.eql('Page not found');
                 done();
+            },
+            set: sandbox.stub(),
+            status: function (statusCode) {
+                res.set.calledOnce.should.eql(true);
+                statusCode.should.eql(404);
+                return {send: res.send};
             }
         };
 

--- a/core/test/unit/controllers/frontend/post-lookup_spec.js
+++ b/core/test/unit/controllers/frontend/post-lookup_spec.js
@@ -40,7 +40,6 @@ describe('postLookup', function () {
                 should.exist(lookup.post);
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
                 lookup.isEditURL.should.be.false();
-                lookup.isAmpURL.should.be.false();
 
                 done();
             }).catch(done);
@@ -54,7 +53,6 @@ describe('postLookup', function () {
                 should.exist(lookup.post);
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
                 lookup.isEditURL.should.be.false();
-                lookup.isAmpURL.should.be.false();
 
                 done();
             }).catch(done);
@@ -116,7 +114,6 @@ describe('postLookup', function () {
                 should.exist(lookup.post);
                 lookup.post.should.have.property('url', '/2016/01/01/welcome-to-ghost/');
                 lookup.isEditURL.should.be.false();
-                lookup.isAmpURL.should.be.false();
 
                 done();
             }).catch(done);
@@ -130,7 +127,6 @@ describe('postLookup', function () {
                 should.exist(lookup.post);
                 lookup.post.should.have.property('url', '/2016/01/01/welcome-to-ghost/');
                 lookup.isEditURL.should.be.false();
-                lookup.isAmpURL.should.be.false();
 
                 done();
             }).catch(done);
@@ -154,7 +150,6 @@ describe('postLookup', function () {
             postLookup(testUrl).then(function (lookup) {
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
                 lookup.isEditURL.should.be.true();
-                lookup.isAmpURL.should.be.false();
                 done();
             }).catch(done);
         });
@@ -165,7 +160,6 @@ describe('postLookup', function () {
             postLookup(testUrl).then(function (lookup) {
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
                 lookup.isEditURL.should.be.true();
-                lookup.isAmpURL.should.be.false();
                 done();
             }).catch(done);
         });
@@ -192,7 +186,8 @@ describe('postLookup', function () {
             var testUrl = '/welcome-to-ghost/notedit/';
 
             postLookup(testUrl).then(function (lookup) {
-                should.not.exist(lookup);
+                lookup.post.should.have.property('url', '/welcome-to-ghost/');
+                lookup.isUnknownOption.should.eql(true);
                 done();
             }).catch(done);
         });
@@ -213,7 +208,6 @@ describe('postLookup', function () {
 
             postLookup(testUrl).then(function (lookup) {
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
-                lookup.isAmpURL.should.be.true();
                 lookup.isEditURL.should.be.false();
                 done();
             }).catch(done);
@@ -224,7 +218,6 @@ describe('postLookup', function () {
 
             postLookup(testUrl).then(function (lookup) {
                 lookup.post.should.have.property('url', '/welcome-to-ghost/');
-                lookup.isAmpURL.should.be.true();
                 lookup.isEditURL.should.be.false();
                 done();
             }).catch(done);
@@ -241,15 +234,6 @@ describe('postLookup', function () {
 
         it('cannot lookup relative url: /:year/:month/:day/:slug/amp/', function (done) {
             var testUrl = '/2016/01/01/welcome-to-ghost/amp/';
-
-            postLookup(testUrl).then(function (lookup) {
-                should.not.exist(lookup);
-                done();
-            }).catch(done);
-        });
-
-        it('cannot lookup relative url: /:slug/notamp/', function (done) {
-            var testUrl = '/welcome-to-ghost/notamp/';
 
             postLookup(testUrl).then(function (lookup) {
                 should.not.exist(lookup);

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -52,7 +52,8 @@ describe('{{ghost_head}} helper', function () {
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
-                    cover: '/content/images/blog-cover.png'
+                    cover: '/content/images/blog-cover.png',
+                    amp: true
                 }
             });
         });
@@ -894,7 +895,8 @@ describe('{{ghost_head}} helper', function () {
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
-                    cover: '/content/images/blog-cover.png'
+                    cover: '/content/images/blog-cover.png',
+                    amp: true
                 },
                 referrerPolicy: 'origin'
             });
@@ -920,7 +922,8 @@ describe('{{ghost_head}} helper', function () {
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
-                    cover: '/content/images/blog-cover.png'
+                    cover: '/content/images/blog-cover.png',
+                    amp: true
                 },
                 privacy: {
                     useStructuredData: false
@@ -1089,6 +1092,46 @@ describe('{{ghost_head}} helper', function () {
 
                 done();
             });
+        });
+    });
+
+    describe('amp is disabled', function () {
+        beforeEach(function () {
+            configUtils.set({
+                url: 'http://testurl.com/',
+                theme: {
+                    amp: false
+                }
+            });
+        });
+
+        it('does not contain amphtml link', function (done) {
+            var post = {
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at:  moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                author: {
+                    name: 'Author name',
+                    url: 'http//:testauthorurl.com',
+                    slug: 'Author',
+                    image: 'content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            };
+
+            helpers.ghost_head.call(
+                {relativeUrl: '/post/', safeVersion: '0.3', context: ['post'], post: post},
+                {data: {root: {context: ['post']}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.not.match(/<link rel="amphtml"/);
+                done();
+            }).catch(done);
         });
     });
 });


### PR DESCRIPTION
closes #7769

Because Google AMP is bitching around and shows errors in Googles' webmaster tools for missing post images and blog icons, we decided to make AMP optional. It will be enabled by default, but can be disabled in general settings. Once disabled, the `amp` route doesn't work anymore.

This PR contains the back end changes for LTS:
- Adds `amp` to settings table incl default setting `true`
- Adds `amp` value to our settings cache
- Changes the route handling of AMP app to check for the `amp` setting first.
- Adds functional tests to frontend routing

### postlookup && amp
We have too many places for checking amp logic. I had the refactor the post-lookup.js unit a little. 
Refactoring and clean code is helpful for Ghost 1.0 as well.

Thanks to @AileenCGN for pre-work 👍 