### PR TITLE
Revert "🎨  grunt release .knex-migrator"

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -280,7 +280,7 @@ var overrides      = require('./core/server/overrides'),
                     },
                     expand: true,
                     cwd: '<%= paths.releaseBuild %>/',
-                    src: ['**', '.knex-migrator']
+                    src: ['**']
                 }
             },
 
@@ -719,9 +719,9 @@ var overrides      = require('./core/server/overrides'),
                     // A list of files and patterns to include when creating a release zip.
                     // This is read from the `.npmignore` file and all patterns are inverted as the `.npmignore`
                     // file defines what to ignore, whereas we want to define what to include.
-                    src: ['.knex-migrator'].concat(fs.readFileSync('.npmignore', 'utf8').split('\n').filter(Boolean).map(function (pattern) {
+                    src: fs.readFileSync('.npmignore', 'utf8').split('\n').filter(Boolean).map(function (pattern) {
                         return pattern[0] === '!' ? pattern.substr(1) : '!' + pattern;
-                    })),
+                    }),
                     dest: '<%= paths.releaseBuild %>/'
                 });
 


### PR DESCRIPTION
Reverts TryGhost/Ghost#7591

refs #7489 

Now that we have renamed the knex-migrator config file, we can revert this change 👍 
See #7873 