### PR TITLE
Fix sqlite module binary issues with yarn caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
 
 install:
   - yarn
+  - if [ "$DB" == "sqlite3" ]; then yarn add --force sqlite3; fi # fix sqlite caching issues
 
 after_success:
   - |


### PR DESCRIPTION
This PR attempts to fix the issues that have been occurring with sqlite binary caching (& yarn breaking it for some reason) in travis testing.
