### PR TITLE
🔥  remove knex-migrator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,6 @@ Install grunt
 npm install -g grunt-cli
 ```
 
-Install knex-migrator
-
-```bash
-npm install -g knex-migrator
-```
-
 Install Ghost
 
 ```bash


### PR DESCRIPTION
no issue

- we will update the instructions for 1.0 before we release 1.0

I have updated the README 3 month ago by accident. 
The current README should only contain instructions for the stable/LTS branch.

Will self-merge.