### PR TITLE
🐷  Rename 'favicon' to 'icon'

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -67,9 +67,9 @@ updateConfigCache = function () {
     config.set('theme:timezone', (settingsCache.activeTimezone && settingsCache.activeTimezone.value) || config.get('theme').timezone);
     config.set('theme:url', globalUtils.url.urlFor('home', true));
     config.set('theme:amp', (settingsCache.amp && settingsCache.amp.value === 'true'));
-    config.set('theme:favicon', (settingsCache.favicon && settingsCache.favicon.value) ?
-                                {type: 'upload', url: (settingsCache.favicon && settingsCache.favicon.value)} :
-                                {type: 'default', url: config.get('theme:favicon')});
+    config.set('theme:icon', (settingsCache.icon && settingsCache.icon.value) ?
+                                {type: 'upload', url: (settingsCache.icon && settingsCache.icon.value)} :
+                                {type: 'default', url: config.get('theme:icon')});
 
     _.each(labsValue, function (value, key) {
         config.set('labs:' + key, value);

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -61,7 +61,7 @@
     },
     "theme": {
         "timezone": "Etc/UTC",
-        "favicon": {
+        "icon": {
             "type": "default",
             "url": "core/shared/favicon.ico"
         }

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -29,7 +29,7 @@
         "cover": {
             "defaultValue": ""
         },
-        "favicon": {
+        "icon": {
             "defaultValue": ""
         },
         "defaultLang": {

--- a/core/test/unit/config/index_spec.js
+++ b/core/test/unit/config/index_spec.js
@@ -37,7 +37,7 @@ describe('Config', function () {
                     logo: 'casper',
                     cover: 'casper',
                     timezone: 'Etc/UTC',
-                    favicon: {
+                    icon: {
                         type: 'default',
                         url: 'core/shared/favicon.ico'
                     }
@@ -49,7 +49,7 @@ describe('Config', function () {
             var themeConfig = config.get('theme');
 
             // This will fail if there are any extra keys
-            themeConfig.should.have.keys('title', 'description', 'logo', 'cover', 'timezone', 'favicon');
+            themeConfig.should.have.keys('title', 'description', 'logo', 'cover', 'timezone', 'icon');
         });
 
         it('should have the correct values for each key', function () {
@@ -61,7 +61,7 @@ describe('Config', function () {
             themeConfig.should.have.property('logo', 'casper');
             themeConfig.should.have.property('cover', 'casper');
             themeConfig.should.have.property('timezone', 'Etc/UTC');
-            themeConfig.should.have.property('favicon', {
+            themeConfig.should.have.property('icon', {
                 type: 'default',
                 url: 'core/shared/favicon.ico'
             });
@@ -94,25 +94,25 @@ describe('Config', function () {
     });
 
     describe('Favicon default', function () {
-        it('should use uploaded favicon', function () {
+        it('should use uploaded blog icon', function () {
             var themeConfig = config.get('theme');
 
             // Check values are as we expect
-            themeConfig.should.have.property('favicon', {
+            themeConfig.should.have.property('icon', {
                 type: 'default',
                 url: 'core/shared/favicon.ico'
             });
 
             configUtils.set({
                 theme: {
-                    favicon: {
+                    icon: {
                         type: 'upload',
                         url: 'content/images/favicon.ico'
                     }
                 }
             });
 
-            config.get('theme').should.have.property('favicon', {
+            config.get('theme').should.have.property('icon', {
                 type: 'upload',
                 url: 'content/images/favicon.ico'
             });
@@ -123,7 +123,7 @@ describe('Config', function () {
 
             // Check values are as we expect
             themeConfig.should.have.property('theme');
-            themeConfig.theme.should.have.property('favicon', {
+            themeConfig.theme.should.have.property('icon', {
                 type: 'default',
                 url: 'core/shared/favicon.ico'
             });


### PR DESCRIPTION
refs TryGhost/Ghost#7688

Just renames `favicon` to `icon` as our usage for it will not be for favicon purposes only.