### PR TITLE
🐛  re-run init migrations protection

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -398,7 +398,7 @@
         {
             "from": {
                 "model": "User",
-                "match": "name",
+                "match": "id",
                 "relation": "roles"
             },
             "to": {
@@ -406,7 +406,7 @@
                 "match": "name"
             },
             "entries": {
-                "Ghost Owner": ["Owner"]
+                "1": ["Owner"]
             }
         }
     ]

--- a/core/server/data/schema/fixtures/utils.js
+++ b/core/server/data/schema/fixtures/utils.js
@@ -96,7 +96,8 @@ fetchRelationData = function fetchRelationData(relation, options) {
  */
 addFixturesForModel = function addFixturesForModel(modelFixture, options) {
     return Promise.mapSeries(modelFixture.entries, function (entry) {
-        return models[modelFixture.name].findOne(entry, options).then(function (found) {
+        // CASE: if id is specified, only query by id
+        return models[modelFixture.name].findOne(entry.id ? {id: entry.id} : entry, options).then(function (found) {
             if (!found) {
                 return models[modelFixture.name].add(entry, options);
             }

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ var should = require('should'),
 describe('DB version integrity', function () {
     // Only these variables should need updating
     var currentSchemaHash = '71d6b843f798352f804db09e5478eef5',
-        currentFixturesHash = 'c08c23c38a3732452a48915952861fc7';
+        currentFixturesHash = 'b9e684a87353c592df9b23948e364c05';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
no issue

- if re-running the init scripts (for example: you lost the init rows in the migrations table), then it was throwing errors

1. the owner slug and email can change -> no match and it tried to reinsert the user with id 1, which failed
2. querying an inactive user is not allowed, because the user model protects against it