### PR TITLE
if config.cacheControl.maxAge is set use it

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -173,7 +173,7 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // site map
     sitemapHandler(blogApp);
 
-    var maxAge = (config.cacheControl && config.cacheControl.maxAge) ? config.cacheControl.maxAge : utils.ONE_YEAR_S;
+    var maxAge = (config.cacheControl && typeof config.cacheControl.maxAge !== "undefined") ? config.cacheControl.maxAge : utils.ONE_YEAR_S;
 
     // Add in all trailing slashes
     blogApp.use(slashes(true, {

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -173,7 +173,7 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // site map
     sitemapHandler(blogApp);
 
-    var maxAge = (config.cacheControl && typeof config.cacheControl.maxAge !== "undefined") ? config.cacheControl.maxAge : utils.ONE_YEAR_S;
+    var maxAge = (config.cacheControl && typeof config.cacheControl.maxAge !== 'undefined') ? config.cacheControl.maxAge : utils.ONE_YEAR_S;
 
     // Add in all trailing slashes
     blogApp.use(slashes(true, {

--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -173,10 +173,12 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // site map
     sitemapHandler(blogApp);
 
+    var maxAge = (config.cacheControl && config.cacheControl.maxAge) ? config.cacheControl.maxAge : utils.ONE_YEAR_S;
+
     // Add in all trailing slashes
     blogApp.use(slashes(true, {
         headers: {
-            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
+            'Cache-Control': 'public, max-age=' + maxAge
         }
     }));
     blogApp.use(uncapitalise);


### PR DESCRIPTION
This adds the ability to override the cache-control header for static content and define the value in `config.js`. Useful if you wish to completely disable caching of static assets (set to `0`), or change from the default of one year.

Example configuration:

````
// in config.js
cacheControl: {
    maxAge: 3600
}
````

I noticed that the master branch does not even seem to have this file `core/server/middleware/index.js` any longer, so I'm not sure where this change belongs in master.