### PR TITLE
💄  Clean up ghost_head test

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -90,7 +90,7 @@ function ghost_head(options) {
         },
         // CASE: blog icon is not set in config, we serve the default
         iconType = !config.get('theme:icon') ? 'x-icon' : config.get('theme:icon').match(/\/favicon\.ico$/i) ? 'x-icon' : 'png',
-        favicon = !config.get('theme:icon') ? '/favicon.ico' : utils.url.urlFor('image', {image: config.get('theme:icon')}, true);
+        favicon = !config.get('theme:icon') ? '/favicon.ico' : utils.url.urlFor('image', {image: config.get('theme:icon')});
 
     return Promise.props(fetch).then(function (response) {
         client = response.client;

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -53,8 +53,7 @@ describe('{{ghost_head}} helper', function () {
                     title: 'Ghost',
                     description: 'blog description',
                     cover: '/content/images/blog-cover.png',
-                    amp: true,
-                    icon: 'core/shared/favicon.ico'
+                    amp: true
                 }
             });
         });
@@ -69,7 +68,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['paged', 'index']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -86,7 +85,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['home', 'index']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
                 rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -139,7 +138,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['page']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/about\/" \/>/);
                 rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -186,7 +185,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
@@ -228,7 +227,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
@@ -269,7 +268,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.not.match(/<meta property="og:description" \/>/);
                 rendered.string.should.not.match(/<meta name="twitter:description"\/>/);
                 rendered.string.should.not.match(/"description":/);
@@ -291,7 +290,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/tag\/tagtitle\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -319,7 +318,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['author']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/author\/AuthorName\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="profile" \/>/);
@@ -365,7 +364,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['paged', 'author']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/author\/AuthorName\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -382,7 +381,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: []}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.9" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
 
@@ -420,7 +419,7 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -499,7 +498,7 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.not.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -578,7 +577,7 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -655,7 +654,7 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -730,7 +729,7 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
@@ -782,7 +781,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['featured']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/featured\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -811,7 +810,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['post']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="This is a short post" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="This is a short post" \/>/);
@@ -834,7 +833,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['page']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/about\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -849,7 +848,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['index', 'paged'], pagination: {total: 4, page: 3, next: 4, prev: 2}}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/page\/3\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="prev" href="http:\/\/testurl.com\/page\/2\/" \/>/);
@@ -868,7 +867,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['index', 'paged'], pagination: {total: 3, page: 2, next: 3, prev: 1}}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="core\/shared\/favicon.ico" type="x-icon" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="prev" href="http:\/\/testurl.com\/" \/>/);
@@ -982,7 +981,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['post']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="http:\/\/testurl.com\/content\/images\/favicon.png" type="png" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/content\/images\/favicon.png" type="png" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/post\/" \/>/);
                 rendered.string.should.match(/<link rel="amphtml" href="http:\/\/testurl.com\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
@@ -1018,7 +1017,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: []}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="http:\/\/testurl.com\/content\/images\/favicon.png" type="png" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/content\/images\/favicon.png" type="png" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);
@@ -1051,7 +1050,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: []}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="shortcut icon" href="http:\/\/testurl.com\/content\/images\/favicon.png" type="png" \/>/);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/content\/images\/favicon.png" type="png" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/testurl.com\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/testurl.com\/rss\/" \/>/);


### PR DESCRIPTION
refs #7688

Update the `ghost_head_spec` to reflect the current changes (we're not having a default `icon` setting in our config anymore). Render the link to the default favicon to be relative.