### PR TITLE
🎨  jsHint: support ES6 features

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -22,5 +22,6 @@
     "indent": 4,
     "predef": [
         "-Promise"
-    ]
+    ],
+    "esversion": "6"
 }


### PR DESCRIPTION
no issue

If you for example use the new ES6 `Map` feature, jsHint will show an error, that Map is undefined.
Node 4 supports over 50% of ES6 features - Node 6 almost 100%.
We would like to allow ES6 features in general by updating our `jshintrc` file.