### PR TITLE
🔥 do not store settings in config

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -2,6 +2,7 @@
 // RESTful API for browsing the configuration
 var _                  = require('lodash'),
     config             = require('../config'),
+    settingsCache      = require('../api/settings').cache,
     ghostVersion       = require('../utils/ghost-version'),
     models             = require('../models'),
     Promise            = require('bluebird'),
@@ -29,7 +30,7 @@ function getBaseConfig() {
         useGravatar:    !config.isPrivacyDisabled('useGravatar'),
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        utils.url.urlFor('home', true),
-        blogTitle:      config.get('theme').title,
+        blogTitle:      settingsCache.get('title'),
         routeKeywords:  config.get('routeKeywords')
     };
 }

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -51,6 +51,7 @@ updateSettingsCache = function (settings, options) {
         .then(function (result) {
             // keep reference and update all keys
             _.extend(settingsCache, readSettingsResult(result.models));
+
             return settingsCache;
         });
 };
@@ -138,7 +139,7 @@ readSettingsResult = function (settingsModels) {
         apps = config.get('paths').availableApps,
         res;
 
-    // @TODO: why are availableThemes part of the settings cache?O_O
+    // @TODO: remove availableThemes from settings cache and create an endpoint to fetch themes
     if (settings.activeTheme && themes) {
         res = filterPaths(themes, settings.activeTheme.value);
 
@@ -387,10 +388,19 @@ module.exports = settings;
 
 /**
  * @TODO:
- * - move settings cache somewhere else and listen on model changes
- * - why are the settingsCache keys without type (core|blog)
- *   1. this is unreadable settingsCache.get('title') vs settingsCache.get('blog:title')
- *   2. we can't add any duplicate properties (e.g. blog:title, theme:title)
+ * - move settings cache somewhere else e.q. listen on model changes
+ *
+ * IMPORTANT:
+ * We store settings with a type and a key in the database.
+ *
+ * {
+ *   type: core
+ *   key: dbHash
+ *   value: ...
+ * }
+ *
+ * But the settings cache does not allow requesting a value by type, only by key.
+ * e.g. settings.cache.get('dbHash')
  */
 module.exports.cache = {
     get: function get(key) {

--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -5,8 +5,8 @@ var path                = require('path'),
     i18n                = require('../../../i18n'),
 
     // Dirty requires
-    config              = require('../../../config'),
     errors              = require('../../../errors'),
+    settingsCache       = require('../../../api/settings').cache,
     templates           = require('../../../controllers/frontend/templates'),
     postLookup          = require('../../../controllers/frontend/post-lookup'),
     setResponseContext  = require('../../../controllers/frontend/context');
@@ -36,6 +36,7 @@ function controller(req, res, next) {
 
 function getPostData(req, res, next) {
     req.body = req.body || {};
+
     postLookup(res.locals.relativeUrl)
         .then(function (result) {
             if (result && result.post) {
@@ -50,7 +51,7 @@ function getPostData(req, res, next) {
 }
 
 function checkIfAMPIsEnabled(req, res, next) {
-    var ampIsEnabled = config.get('theme:amp');
+    var ampIsEnabled = settingsCache.get('amp');
 
     if (ampIsEnabled) {
         return next();

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -63,9 +63,6 @@
         "cannotScheduleAPostBeforeInMinutes": 2,
         "publishAPostBySchedulerToleranceInMinutes": 2
     },
-    "theme": {
-        "timezone": "Etc/UTC"
-    },
     "maintenance": {
         "enabled": false
     }

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -4,8 +4,8 @@
  */
 var api = require('../../api'),
     _   = require('lodash'),
-    config = require('../../config'),
     Promise = require('bluebird'),
+    settingsCache = api.settings.cache,
     queryDefaults,
     defaultPostQuery = {};
 
@@ -33,7 +33,7 @@ _.extend(defaultPostQuery, queryDefaults, {
 function fetchPostsPerPage(options) {
     options = options || {};
 
-    var postsPerPage = parseInt(config.get('theme').postsPerPage);
+    var postsPerPage = parseInt(settingsCache.get('postsPerPage'));
 
     // No negative posts per page, must be number
     if (!isNaN(postsPerPage) && postsPerPage > 0) {

--- a/core/server/controllers/frontend/post-lookup.js
+++ b/core/server/controllers/frontend/post-lookup.js
@@ -3,8 +3,7 @@ var _          = require('lodash'),
     url        = require('url'),
     routeMatch = require('path-match')(),
     api        = require('../../api'),
-    config     = require('../../config'),
-
+    settingsCache = api.settings.cache,
     optionsFormat = '/:options?';
 
 function getOptionsFormat(linkStructure) {
@@ -13,7 +12,7 @@ function getOptionsFormat(linkStructure) {
 
 function postLookup(postUrl) {
     var postPath = url.parse(postUrl).path,
-        postPermalink = config.get('theme').permalinks,
+        postPermalink = settingsCache.get('permalinks'),
         pagePermalink = '/:slug/',
         isEditURL = false,
         matchFuncPost,

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,4 +1,5 @@
 var config = require('../../config'),
+    settingsCache = require('../../api/settings').cache,
     utils = require('../../utils');
 
 function getAssetUrl(path, isAdmin, minify) {
@@ -19,7 +20,11 @@ function getAssetUrl(path, isAdmin, minify) {
         if (isAdmin) {
             output = utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
         } else {
-            output = config.get('theme:icon') ? utils.url.urlJoin(utils.url.getSubdir(), utils.url.urlFor('image', {image: config.get('theme:icon')})) : utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
+            if (settingsCache.get('icon')) {
+                output = utils.url.urlJoin(utils.url.getSubdir(), utils.url.urlFor('image', {image: settingsCache.get('icon')}));
+            } else {
+                output = utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
+            }
         }
     }
     // Get rid of any leading slash on the path

--- a/core/server/data/meta/context_object.js
+++ b/core/server/data/meta/context_object.js
@@ -1,8 +1,16 @@
-var config = require('../../config'),
-    _      = require('lodash');
+var settingsCache = require('../../api/settings').cache,
+    _ = require('lodash');
 
 function getContextObject(data, context) {
-    var blog = config.get('theme'),
+    /**
+     * @TODO:
+     *   - the only valid property is cover
+     *   - there was no image property in config.get('theme')
+     *   - there was no author property in config.get('theme')
+     */
+    var blog = {
+            cover: settingsCache.get('cover')
+        },
         contextObject;
 
     context = _.includes(context, 'page') || _.includes(context, 'amp') ? 'post' : context;

--- a/core/server/data/meta/context_object.js
+++ b/core/server/data/meta/context_object.js
@@ -3,13 +3,12 @@ var settingsCache = require('../../api/settings').cache,
 
 function getContextObject(data, context) {
     /**
-     * @TODO:
-     *   - the only valid property is cover
-     *   - there was no image property in config.get('theme')
-     *   - there was no author property in config.get('theme')
+     * If the data object does not contain the requested context, we return the fallback object.
      */
     var blog = {
-            cover: settingsCache.get('cover')
+            cover: settingsCache.get('cover'),
+            twitter: settingsCache.get('twitter'),
+            facebook: settingsCache.get('facebook')
         },
         contextObject;
 

--- a/core/server/data/meta/description.js
+++ b/core/server/data/meta/description.js
@@ -1,16 +1,17 @@
 var _ = require('lodash'),
-    config = require('../../config');
+    settingsCache = require('../../api/settings').cache;
 
 function getDescription(data, root) {
     var description = '',
-        context = root ? root.context : null;
+        context = root ? root.context : null,
+        blogDescription = settingsCache.get('description');
 
     if (data.meta_description) {
         description = data.meta_description;
     } else if (_.includes(context, 'paged')) {
         description = '';
     } else if (_.includes(context, 'home')) {
-        description = config.get('theme').description;
+        description = blogDescription;
     } else if (_.includes(context, 'author') && data.author) {
         description = data.author.meta_description || data.author.bio;
     } else if (_.includes(context, 'tag') && data.tag) {

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -1,6 +1,5 @@
-var _ = require('lodash'),
-    Promise = require('bluebird'),
-    config = require('../../config'),
+var Promise = require('bluebird'),
+    settingsCache = require('../../api/settings').cache,
     utils = require('../../utils'),
     getUrl = require('./url'),
     getImageDimensions = require('./image-dimensions'),
@@ -46,12 +45,30 @@ function getMetaData(data, root) {
         publishedDate: getPublishedDate(data),
         modifiedDate: getModifiedDate(data),
         ogType: getOgType(data),
-        blog: _.cloneDeep(config.get('theme'))
+        // @TODO: pass into each meta helper - wrap each helper
+        blog: {
+            title: settingsCache.get('title'),
+            description: settingsCache.get('description'),
+            url: utils.url.urlFor('home', true),
+            facebook: settingsCache.get('facebook'),
+            twitter: settingsCache.get('twitter'),
+            timezone: settingsCache.get('activeTimezone'),
+            navigation: settingsCache.get('navigation'),
+            posts_per_page: settingsCache.get('postsPerPage'),
+            icon: settingsCache.get('icon'),
+            cover: settingsCache.get('cover'),
+            logo: settingsCache.get('logo'),
+            amp: settingsCache.get('amp')
+        }
     };
 
     metaData.blog.logo = {};
-    metaData.blog.logo.url = config.get('theme').logo ?
-        utils.url.urlFor('image', {image: config.get('theme').logo}, true) : utils.url.urlJoin(utils.url.urlFor('admin'), 'img/ghosticon.jpg');
+
+    if (settingsCache.get('logo')) {
+        metaData.blog.logo.url = utils.url.urlFor('image', {image: settingsCache.get('logo')}, true);
+    } else {
+        metaData.blog.logo.url = utils.url.urlJoin(utils.url.urlFor('admin'), 'img/ghosticon.jpg');
+    }
 
     // TODO: cleanup these if statements
     if (data.post && data.post.html) {

--- a/core/server/data/meta/title.js
+++ b/core/server/data/meta/title.js
@@ -1,28 +1,29 @@
 var _ = require('lodash'),
-    config = require('../../config');
+    settingsCache = require('../../api/settings').cache;
 
 function getTitle(data, root) {
     var title = '',
         context = root ? root.context : null,
-        blog = config.get('theme'),
+        blogTitle = settingsCache.get('title'),
         pagination = root ? root.pagination : null,
         pageString = '';
 
     if (pagination && pagination.total > 1) {
         pageString = ' - Page ' + pagination.page;
     }
+
     if (data.meta_title) {
         title = data.meta_title;
     } else if (_.includes(context, 'home')) {
-        title = blog.title;
+        title = blogTitle;
     } else if (_.includes(context, 'author') && data.author) {
-        title = data.author.name + pageString + ' - ' + blog.title;
+        title = data.author.name + pageString + ' - ' + blogTitle;
     } else if (_.includes(context, 'tag') && data.tag) {
-        title = data.tag.meta_title || data.tag.name + pageString + ' - ' + blog.title;
+        title = data.tag.meta_title || data.tag.name + pageString + ' - ' + blogTitle;
     } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
         title = data.post.meta_title || data.post.title;
     } else {
-        title = blog.title + pageString;
+        title = blogTitle + pageString;
     }
 
     return (title || '').trim();

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -7,6 +7,7 @@ var crypto      = require('crypto'),
     i18n        = require('../../../i18n'),
     filters     = require('../../../filters'),
     processUrls = require('../../../utils/make-absolute-urls'),
+    settingsCache = require('../../../api/settings').cache,
 
     // Really ugly temporary hack for location of things
     fetchData   = require('../../../controllers/frontend/fetch-data'),
@@ -41,8 +42,8 @@ function getData(channelOpts, slugParam) {
         if (result.data && result.data.tag) { titleStart = result.data.tag[0].name + ' - ' || ''; }
         if (result.data && result.data.author) { titleStart = result.data.author[0].name + ' - ' || ''; }
 
-        response.title = titleStart + config.get('theme').title;
-        response.description = config.get('theme').description;
+        response.title = titleStart + settingsCache.get('title');
+        response.description = settingsCache.get('description');
         response.results = {
             posts: result.posts,
             meta: result.meta

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -149,10 +149,10 @@ function init(options) {
         auth.init({
             authType: config.get('auth:type'),
             ghostAuthUrl: config.get('auth:url'),
-            redirectUri: utils.url.urlFor('admin', true),
-            clientUri: utils.url.urlFor('home', true),
-            clientName: api.settings.getSettingSync('title'),
-            clientDescription: api.settings.getSettingSync('description')
+            redirectUri: utils.url.urlJoin(utils.url.getBaseUrl(), 'ghost', '/'),
+            clientUri: utils.url.urlJoin(utils.url.getBaseUrl(), '/'),
+            clientName: api.settings.cache.get('title'),
+            clientDescription: api.settings.cache.get('description')
         }).then(function (response) {
             parentApp.use(response.auth);
         }).catch(function onAuthError(err) {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -149,8 +149,8 @@ function init(options) {
         auth.init({
             authType: config.get('auth:type'),
             ghostAuthUrl: config.get('auth:url'),
-            redirectUri: utils.url.urlJoin(utils.url.getBaseUrl(), 'ghost', '/'),
-            clientUri: utils.url.urlJoin(utils.url.getBaseUrl(), '/'),
+            redirectUri: utils.url.urlFor('admin', true),
+            clientUri: utils.url.urlFor('home', true),
             clientName: api.settings.cache.get('title'),
             clientDescription: api.settings.cache.get('description')
         }).then(function (response) {

--- a/core/server/mail/GhostMailer.js
+++ b/core/server/mail/GhostMailer.js
@@ -5,6 +5,7 @@ var _          = require('lodash'),
     nodemailer = require('nodemailer'),
     validator  = require('validator'),
     config     = require('../config'),
+    settingsCache = require('../api/settings').cache,
     i18n       = require('../i18n'),
     utils      = require('../utils');
 
@@ -31,8 +32,7 @@ GhostMailer.prototype.from = function () {
 
     // If we do have a from address, and it's just an email
     if (validator.isEmail(from)) {
-        defaultBlogTitle = config.get('theme').title ? config.get('theme').title : i18n.t('common.mail.title', {domain: this.getDomain()});
-
+        defaultBlogTitle = settingsCache.get('title') || i18n.t('common.mail.title', {domain: this.getDomain()});
         from = '"' + defaultBlogTitle + '" <' + from + '>';
     }
 

--- a/core/server/middleware/serve-favicon.js
+++ b/core/server/middleware/serve-favicon.js
@@ -1,7 +1,7 @@
 var fs     = require('fs'),
     path = require('path'),
     storage = require('../storage'),
-    config = require('../config'),
+    settingsCache = require('../api/settings').cache,
     utils  = require('../utils'),
     crypto = require('crypto'),
     buildContentResponse,
@@ -35,13 +35,13 @@ function serveFavicon() {
             // we are using an express route to skip /content/images and the result is a image path
             // based on config.getContentPath('images') + req.path
             // in this case we don't use path rewrite, that's why we have to make it manually
-            filePath = config.get('theme:icon').replace(/\/content\/images\//, '');
+            filePath = settingsCache.get('icon').replace(/\/content\/images\//, '');
 
             var originalExtension = path.extname(filePath).toLowerCase(),
                 requestedExtension = path.extname(req.path).toLowerCase();
 
             // CASE: custom favicon exists, load it from local file storage
-            if (config.get('theme:icon')) {
+            if (settingsCache.get('icon')) {
                 // depends on the uploaded icon extension
                 if (originalExtension !== requestedExtension) {
                     return res.redirect(302, '/favicon' + originalExtension);
@@ -52,8 +52,7 @@ function serveFavicon() {
                         return next(err);
                     }
 
-                    iconType = config.get('theme:icon').match(/\/favicon\.ico$/i) ? 'x-icon' : 'png';
-
+                    iconType = settingsCache.get('icon').match(/\/favicon\.ico$/i) ? 'x-icon' : 'png';
                     content = buildContentResponse(iconType, buf);
 
                     res.writeHead(200, content.headers);

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -1,9 +1,9 @@
-var config = require('../config'),
+var settingsCache = require('../api/settings').cache,
     flagIsSet;
 
+// @TODO: what is this lib doing?
 flagIsSet = function flagIsSet(flag) {
-    var labsConfig = config.get('labs');
-
+    var labsConfig = settingsCache.get('labs');
     return labsConfig && labsConfig[flag] && labsConfig[flag] === true;
 };
 

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -1,7 +1,6 @@
 var settingsCache = require('../api/settings').cache,
     flagIsSet;
 
-// @TODO: what is this lib doing?
 flagIsSet = function flagIsSet(flag) {
     var labsConfig = settingsCache.get('labs');
     return labsConfig && labsConfig[flag] && labsConfig[flag] === true;

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -5,6 +5,7 @@ var moment            = require('moment-timezone'),
     _                 = require('lodash'),
     url               = require('url'),
     config            = require('./../config'),
+    settingsCache     = require('./../api/settings').cache,
     // @TODO: unify this with routes.apiBaseUrl
     apiPath = '/ghost/api/v0.1';
 
@@ -146,8 +147,8 @@ function createUrl(urlPath, absolute, secure) {
  */
 function urlPathForPost(post) {
     var output = '',
-        permalinks = config.get('theme').permalinks,
-        publishedAtMoment = moment.tz(post.published_at || Date.now(), config.get('theme').timezone),
+        permalinks = settingsCache.get('permalinks'),
+        publishedAtMoment = moment.tz(post.published_at || Date.now(), settingsCache.get('activeTimezone')),
         tags = {
             year:   function () { return publishedAtMoment.format('YYYY'); },
             month:  function () { return publishedAtMoment.format('MM'); },

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -1,5 +1,6 @@
 var Promise       = require('bluebird'),
     should        = require('should'),
+    sinon         = require('sinon'),
     _             = require('lodash'),
     ObjectId      = require('bson-objectid'),
     testUtils     = require('../../utils'),
@@ -7,9 +8,13 @@ var Promise       = require('bluebird'),
     errors        = require('../../../server/errors'),
     db            = require('../../../server/data/db'),
     models        = require('../../../server/models'),
-    PostAPI       = require('../../../server/api/posts');
+    PostAPI       = require('../../../server/api/posts'),
+    settingsCache = require('../../../server/api/settings').cache,
+    sandbox       = sinon.sandbox.create();
 
 describe('Post API', function () {
+    var localSettingsCache = {};
+
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
     beforeEach(testUtils.setup('users:roles', 'perms:post', 'perms:init'));
@@ -40,11 +45,22 @@ describe('Post API', function () {
             .catch(done);
     });
 
+    beforeEach(function () {
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return localSettingsCache[key];
+        });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+        localSettingsCache = {};
+    });
+
     should.exist(PostAPI);
 
     describe('Browse', function () {
         beforeEach(function () {
-            configUtils.set('theme:permalinks', '/:slug/');
+            localSettingsCache.permalinks = '/:slug/';
         });
 
         afterEach(function () {

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -115,10 +115,10 @@ describe('Settings API', function () {
     });
 
     it('can edit', function () {
-        var testReference = SettingsAPI.getSettingsSync();
+        var testReference = SettingsAPI.cache.getAll();
 
         // see default-settings.json
-        SettingsAPI.getSettingSync('title').should.eql('Ghost');
+        SettingsAPI.cache.get('title').should.eql('Ghost');
         testReference.title.value.should.eql('Ghost');
 
         return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'title', value: 'UpdatedGhost'}]}, {})
@@ -128,7 +128,7 @@ describe('Settings API', function () {
                 response.settings.length.should.equal(1);
                 testUtils.API.checkResponse(response.settings[0], 'setting');
 
-                SettingsAPI.getSettingSync('title').should.eql('UpdatedGhost');
+                SettingsAPI.cache.get('title').should.eql('UpdatedGhost');
                 testReference.title.value.should.eql('UpdatedGhost');
             });
     });

--- a/core/test/unit/config/index_spec.js
+++ b/core/test/unit/config/index_spec.js
@@ -4,14 +4,12 @@ var should = require('should'),
     path = require('path'),
     rewire = require('rewire'),
     _ = require('lodash'),
-    i18n = require('../../../server/i18n'),
     configUtils = require('../../utils/configUtils');
 
 should.equal(true, true);
 
 describe('Config', function () {
     before(function () {
-        i18n.init();
         configUtils.restore();
     });
 
@@ -81,66 +79,6 @@ describe('Config', function () {
             customConfig.get('url').should.eql('http://localhost:2368');
             customConfig.get('logging:level').should.eql('error');
             customConfig.get('logging:transports').should.eql(['stdout']);
-        });
-    });
-
-    describe('Theme', function () {
-        beforeEach(function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                theme: {
-                    title: 'casper',
-                    description: 'casper',
-                    logo: 'casper',
-                    cover: 'casper',
-                    timezone: 'Etc/UTC',
-                    icon: 'core/shared/favicon.ico'
-                }
-            });
-        });
-
-        it('should have exactly the right keys', function () {
-            var themeConfig = configUtils.config.get('theme');
-
-            // This will fail if there are any extra keys
-            themeConfig.should.have.keys('title', 'description', 'logo', 'cover', 'timezone', 'icon');
-        });
-
-        it('should have the correct values for each key', function () {
-            var themeConfig = configUtils.config.get('theme');
-
-            // Check values are as we expect
-            themeConfig.should.have.property('title', 'casper');
-            themeConfig.should.have.property('description', 'casper');
-            themeConfig.should.have.property('logo', 'casper');
-            themeConfig.should.have.property('cover', 'casper');
-            themeConfig.should.have.property('timezone', 'Etc/UTC');
-            themeConfig.should.have.property('icon', 'core/shared/favicon.ico');
-        });
-    });
-
-    describe('Timezone default', function () {
-        it('should use timezone from settings when set', function () {
-            var themeConfig = configUtils.config.get('theme');
-
-            // Check values are as we expect
-            themeConfig.should.have.property('timezone', 'Etc/UTC');
-
-            configUtils.set({
-                theme: {
-                    timezone: 'Africa/Cairo'
-                }
-            });
-
-            configUtils.config.get('theme').should.have.property('timezone', 'Africa/Cairo');
-        });
-
-        it('should set theme object with timezone by default', function () {
-            var themeConfig = configUtils.defaultConfig;
-
-            // Check values are as we expect
-            themeConfig.should.have.property('theme');
-            themeConfig.theme.should.have.property('timezone', 'Etc/UTC');
         });
     });
 

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -15,6 +15,7 @@ describe('fetchData', function () {
     beforeEach(function () {
         apiPostsStub = sandbox.stub(api.posts, 'browse')
             .returns(new Promise.resolve({posts: [], meta: {pagination: {}}}));
+
         apiTagStub = sandbox.stub(api.tags, 'read').returns(new Promise.resolve({tags: []}));
         apiUserStub = sandbox.stub(api.users, 'read').returns(new Promise.resolve({users: []}));
     });
@@ -26,7 +27,7 @@ describe('fetchData', function () {
 
     describe('channel config', function () {
         beforeEach(function () {
-            configUtils.set({theme: {postsPerPage: 10}});
+            sandbox.stub(api.settings.cache, 'get').returns(10);
         });
 
         it('should handle no post options', function (done) {
@@ -66,7 +67,10 @@ describe('fetchData', function () {
                     featured: {
                         type: 'browse',
                         resource: 'posts',
-                        options: {filter: 'featured:true', limit: 3}
+                        options: {
+                            filter: 'featured:true',
+                            limit: 3
+                        }
                     }
                 }
             };
@@ -89,7 +93,9 @@ describe('fetchData', function () {
 
         it('should handle multiple queries with page param', function (done) {
             var channelOpts = {
-                postOptions: {page: 2},
+                postOptions: {
+                    page: 2
+                },
                 data: {
                     featured: {
                         type: 'browse',
@@ -148,7 +154,7 @@ describe('fetchData', function () {
 
     describe('valid postsPerPage', function () {
         beforeEach(function () {
-            configUtils.set({theme: {postsPerPage: 10}});
+            sandbox.stub(api.settings.cache, 'get').returns(10);
         });
 
         it('Adds limit & includes to options by default', function (done) {
@@ -164,7 +170,7 @@ describe('fetchData', function () {
 
     describe('invalid postsPerPage', function () {
         beforeEach(function () {
-            configUtils.set({theme: {postsPerPage: '-1'}});
+            sandbox.stub(api.settings.cache, 'get').returns(-1);
         });
 
         it('Will not add limit if postsPerPage is not valid', function (done) {

--- a/core/test/unit/controllers/frontend/post-lookup_spec.js
+++ b/core/test/unit/controllers/frontend/post-lookup_spec.js
@@ -2,28 +2,31 @@ var should         = require('should'),
     sinon          = require('sinon'),
     Promise        = require('bluebird'),
     configUtils    = require('../../../utils/configUtils'),
-
-    // Things we are testing
     api            = require('../../../../server/api'),
     postLookup     = require('../../../../server/controllers/frontend/post-lookup'),
-
+    settingsCache  = api.settings.cache,
     sandbox = sinon.sandbox.create();
 
 describe('postLookup', function () {
-    var postAPIStub;
+    var postAPIStub, localSettingsCache = {};
 
     afterEach(function () {
         sandbox.restore();
         configUtils.restore();
+        localSettingsCache = {};
     });
 
     beforeEach(function () {
         postAPIStub = sandbox.stub(api.posts, 'read');
+
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return localSettingsCache[key];
+        });
     });
 
     describe('Permalinks: /:slug/', function () {
         beforeEach(function () {
-            configUtils.set({theme: {permalinks: '/:slug/'}});
+            localSettingsCache.permalinks = '/:slug/';
 
             postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
                 .returns(new Promise.resolve({posts: [{
@@ -79,7 +82,7 @@ describe('postLookup', function () {
 
     describe('Permalinks: /:year/:month/:day/:slug/', function () {
         beforeEach(function () {
-            configUtils.set({theme: {permalinks: '/:year/:month/:day/:slug/'}});
+            localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
             postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
                 .returns(new Promise.resolve({posts: [{
@@ -135,7 +138,7 @@ describe('postLookup', function () {
 
     describe('Edit URLs', function () {
         beforeEach(function () {
-            configUtils.set({theme: {permalinks: '/:slug/'}});
+            localSettingsCache.permalinks = '/:slug/';
 
             postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
                 .returns(new Promise.resolve({posts: [{
@@ -192,9 +195,10 @@ describe('postLookup', function () {
             }).catch(done);
         });
     });
+
     describe('AMP URLs', function () {
         beforeEach(function () {
-            configUtils.set({theme: {permalinks: '/:slug/'}});
+            localSettingsCache.permalinks = '/:slug/';
 
             postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
                 .returns(new Promise.resolve({posts: [{

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -1,4 +1,3 @@
-/* globals describe, beforeEach, afterEach, it */
 var should = require('should'),
     ghostUrl = require('../../shared/ghost-url'),
     configUtils = require('../utils/configUtils'),

--- a/core/test/unit/metadata/author_image_spec.js
+++ b/core/test/unit/metadata/author_image_spec.js
@@ -1,10 +1,11 @@
-var getAuthorImage = require('../../../server/data/meta/author_image'),
-    should = require('should'),
-    configUtils = require('../../utils/configUtils');
+var should = require('should'),
+    sinon = require('sinon'),
+    getAuthorImage = require('../../../server/data/meta/author_image'),
+    sandbox = sinon.sandbox.create();
 
 describe('getAuthorImage', function () {
     afterEach(function () {
-        configUtils.restore();
+        sandbox.restore();
     });
 
     it('should return author image url if post and has url', function () {
@@ -16,6 +17,7 @@ describe('getAuthorImage', function () {
                 }
             }
         }, false);
+
         imageUrl.should.equal('/content/images/2016/01/myimage.jpg');
     });
 
@@ -66,6 +68,7 @@ describe('getAuthorImage', function () {
                 }
             }
         });
+
         should(imageUrl).equal(null);
     });
 
@@ -74,6 +77,7 @@ describe('getAuthorImage', function () {
             context: ['post'],
             post: {}
         });
+
         should(imageUrl).equal(null);
     });
 
@@ -81,21 +85,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['tag']
         });
+
         should(imageUrl).equal(null);
     });
-
-    it('should return config theme author image if context is a post and no post',
-        function () {
-            configUtils.set({
-                theme: {
-                    author: {
-                        image: '/content/images/2016/01/myimage.jpg'
-                    }
-                }
-            });
-            var imageUrl = getAuthorImage({
-                context: ['post']
-            });
-            imageUrl.should.match(/\/content\/images\/2016\/01\/myimage\.jpg$/);
-        });
 });

--- a/core/test/unit/metadata/context_object_spec.js
+++ b/core/test/unit/metadata/context_object_spec.js
@@ -1,6 +1,8 @@
 var should          = require('should'),
+    sinon           = require('sinon'),
     getContextObject = require('../../../server/data/meta/context_object.js'),
-    configUtils     = require('../../utils/configUtils');
+    settingsCache = require('../../../server/api/settings').cache,
+    sandbox = sinon.sandbox.create();
 
 describe('getContextObject', function () {
     var data, context, contextObject;
@@ -47,11 +49,15 @@ describe('getContextObject', function () {
 
     describe('override blog', function () {
         before(function () {
-            configUtils.set({theme: {foo: 'bar'}});
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return {
+                    cover: 'test.png'
+                }[key];
+            });
         });
 
         after(function () {
-            configUtils.restore();
+            sandbox.restore();
         });
 
         it('should return blog context object for unknown context', function () {
@@ -60,7 +66,7 @@ describe('getContextObject', function () {
             contextObject = getContextObject(data, context);
 
             should.exist(contextObject);
-            contextObject.should.have.property('foo', 'bar');
+            contextObject.should.have.property('cover', 'test.png');
         });
     });
 });

--- a/core/test/unit/metadata/title_spec.js
+++ b/core/test/unit/metadata/title_spec.js
@@ -1,9 +1,24 @@
-var getTitle = require('../../../server/data/meta/title'),
-    configUtils = require('../../utils/configUtils');
+
+var sinon = require('sinon'),
+    should = require('should'),
+    getTitle = require('../../../server/data/meta/title'),
+    settingsCache = require('../../../server/api/settings').cache,
+    sandbox = sinon.sandbox.create();
+
+should.equal(true, true);
 
 describe('getTitle', function () {
+    var localSettingsCache = {};
+
+    beforeEach(function () {
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return localSettingsCache[key];
+        });
+    });
+
     afterEach(function () {
-        configUtils.restore();
+        sandbox.restore();
+        localSettingsCache = {};
     });
 
     it('should return meta_title if on data root', function () {
@@ -15,36 +30,26 @@ describe('getTitle', function () {
     });
 
     it('should return blog title if on home', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title'
-            }
-        });
+        localSettingsCache.title = 'My blog title';
 
         var title = getTitle({}, {context: 'home'});
         title.should.equal('My blog title');
     });
 
     it('should return author name - blog title if on data author page', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title 2'
-            }
-        });
+        localSettingsCache.title = 'My blog title 2';
+
         var title = getTitle({
             author: {
                 name: 'Author Name'
             }
         }, {context: ['author']});
+
         title.should.equal('Author Name - My blog title 2');
     });
 
     it('should return author page title if on data author page with more then one page', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title 2'
-            }
-        });
+        localSettingsCache.title = 'My blog title 2';
 
         var title = getTitle({
             author: {
@@ -62,11 +67,7 @@ describe('getTitle', function () {
     });
 
     it('should return tag name - blog title if on data tag page no meta_title', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title 3'
-            }
-        });
+        localSettingsCache.title = 'My blog title 3';
 
         var title = getTitle({
             tag: {
@@ -78,11 +79,7 @@ describe('getTitle', function () {
     });
 
     it('should return tag name - page - blog title if on data tag page no meta_title', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title 3'
-            }
-        });
+        localSettingsCache.title = 'My blog title 3';
 
         var title = getTitle({
             tag: {
@@ -126,6 +123,7 @@ describe('getTitle', function () {
                 title: 'My awesome post!'
             }
         }, {context: ['amp', 'post']});
+
         title.should.equal('My awesome post!');
     });
 
@@ -135,6 +133,7 @@ describe('getTitle', function () {
                 title: 'My awesome page!'
             }
         }, {context: ['page']});
+
         title.should.equal('My awesome page!');
     });
 
@@ -144,6 +143,7 @@ describe('getTitle', function () {
                 title: 'My awesome page!'
             }
         }, {context: ['amp', 'page']});
+
         title.should.equal('My awesome page!');
     });
 
@@ -154,6 +154,7 @@ describe('getTitle', function () {
                 meta_title: 'My Tag Meta Title Post!  '
             }
         }, {context: ['post']});
+
         title.should.equal('My Tag Meta Title Post!');
     });
 
@@ -164,15 +165,12 @@ describe('getTitle', function () {
                 meta_title: 'My Tag Meta Title Post!  '
             }
         }, {context: ['amp', 'post']});
+
         title.should.equal('My Tag Meta Title Post!');
     });
 
     it('should return blog title with page if unknown type', function () {
-        configUtils.set({
-            theme: {
-                title: 'My blog title 4'
-            }
-        });
+        localSettingsCache.title = 'My blog title 4';
 
         var title = getTitle({}, {
             context: ['paged'],

--- a/core/test/unit/middleware/serve-favicon_spec.js
+++ b/core/test/unit/middleware/serve-favicon_spec.js
@@ -2,6 +2,7 @@ var sinon        = require('sinon'),
     should       = require('should'),
     express      = require('express'),
     serveFavicon = require('../../../server/middleware/serve-favicon'),
+    settingsCache = require('../../../server/api/settings').cache,
     configUtils  = require('../../utils/configUtils'),
     path         = require('path'),
     sandbox      = sinon.sandbox.create();
@@ -9,7 +10,7 @@ var sinon        = require('sinon'),
 should.equal(true, true);
 
 describe('Serve Favicon', function () {
-    var req, res, next, blogApp;
+    var req, res, next, blogApp, localSettingsCache = {};
 
     beforeEach(function () {
         req = sinon.spy();
@@ -17,11 +18,16 @@ describe('Serve Favicon', function () {
         next = sinon.spy();
         blogApp = express();
         req.app = blogApp;
+
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return localSettingsCache[key];
+        });
     });
 
     afterEach(function () {
         sandbox.restore();
         configUtils.restore();
+        localSettingsCache = {};
     });
 
     describe('serveFavicon', function () {
@@ -37,17 +43,14 @@ describe('Serve Favicon', function () {
             middleware(req, res, next);
             next.called.should.be.true();
         });
+
         describe('serves', function () {
             it('custom uploaded favicon.png', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.png';
-                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: 'favicon.png'
-                    }
-                });
+                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = 'favicon.png';
 
                 res = {
                     writeHead: function (statusCode) {
@@ -61,16 +64,13 @@ describe('Serve Favicon', function () {
 
                 middleware(req, res, next);
             });
+
             it('custom uploaded favicon.ico', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.ico';
-                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: 'favicon.ico'
-                    }
-                });
+                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = 'favicon.ico';
 
                 res = {
                     writeHead: function (statusCode) {
@@ -84,16 +84,13 @@ describe('Serve Favicon', function () {
 
                 middleware(req, res, next);
             });
+
             it('default favicon.ico', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.ico';
-                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: ''
-                    }
-                });
+                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = '';
 
                 res = {
                     writeHead: function (statusCode) {
@@ -108,17 +105,14 @@ describe('Serve Favicon', function () {
                 middleware(req, res, next);
             });
         });
+
         describe('redirects', function () {
             it('to custom favicon.ico when favicon.png is requested', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.png';
-                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: 'favicon.ico'
-                    }
-                });
+                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = 'favicon.ico';
 
                 res = {
                     redirect: function (statusCode) {
@@ -129,16 +123,13 @@ describe('Serve Favicon', function () {
 
                 middleware(req, res, next);
             });
+
             it('to custom favicon.png when favicon.ico is requested', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.ico';
-                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: 'favicon.png'
-                    }
-                });
+                configUtils.set('paths:contentPath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = 'favicon.png';
 
                 res = {
                     redirect: function (statusCode) {
@@ -153,13 +144,9 @@ describe('Serve Favicon', function () {
             it('to favicon.ico when favicon.png is requested', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.png';
-                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
 
-                configUtils.set({
-                    theme: {
-                        icon: ''
-                    }
-                });
+                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                localSettingsCache.icon = '';
 
                 res = {
                     redirect: function (statusCode) {

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -4,13 +4,9 @@ var should          = require('should'),
     _               = require('lodash'),
     Promise         = require('bluebird'),
     testUtils       = require('../utils'),
-
     channelConfig   = require('../../server/controllers/frontend/channel-config'),
-
-    // Things that get overridden
     api             = require('../../server/api'),
     rss             = rewire('../../server/data/xml/rss'),
-
     configUtils     = require('../utils/configUtils');
 
 // Helper function to prevent unit tests
@@ -281,6 +277,7 @@ describe('RSS', function () {
 
     describe('dataBuilder', function () {
         var apiBrowseStub, apiTagStub, apiUserStub;
+
         beforeEach(function () {
             apiBrowseStub = sandbox.stub(api.posts, 'browse', function () {
                 return Promise.resolve({posts: [], meta: {pagination: {pages: 3}}});
@@ -306,11 +303,19 @@ describe('RSS', function () {
                 set: sinon.stub()
             };
 
-            configUtils.set({url: 'http://my-ghost-blog.com', theme: {
-                title: 'Test',
-                description: 'Some Text',
-                permalinks: '/:slug/'
-            }});
+            sandbox.stub(api.settings.cache, 'get', function (key) {
+                var obj = {
+                    title: 'Test',
+                    description: 'Some Text',
+                    permalinks: '/:slug/'
+                };
+
+                return obj[key];
+            });
+
+            configUtils.set({
+                url: 'http://my-ghost-blog.com'
+            });
         });
 
         it('should process the data correctly for the index feed', function (done) {

--- a/core/test/unit/server_helpers/asset_spec.js
+++ b/core/test/unit/server_helpers/asset_spec.js
@@ -1,22 +1,28 @@
 var should         = require('should'),
     hbs            = require('express-hbs'),
+    sinon          = require('sinon'),
     utils          = require('./utils'),
     configUtils    = require('../../utils/configUtils'),
-
-// Stuff we are testing
-    handlebars     = hbs.handlebars,
-    helpers        = require('../../../server/helpers');
+    helpers        = require('../../../server/helpers'),
+    settingsCache  = require('../../../server/api/settings').cache,
+    sandbox        = sinon.sandbox.create(),
+    handlebars     = hbs.handlebars;
 
 describe('{{asset}} helper', function () {
-    var rendered;
+    var rendered, localSettingsCache = {};
 
     before(function () {
         utils.loadHelpers();
         configUtils.set({assetHash: 'abc'});
+
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return localSettingsCache[key];
+        });
     });
 
     after(function () {
         configUtils.restore();
+        sandbox.restore();
     });
 
     it('has loaded asset helper', function () {
@@ -37,7 +43,8 @@ describe('{{asset}} helper', function () {
         });
 
         it('handles custom favicon correctly', function () {
-            configUtils.set('theme:icon', '/content/images/favicon.png');
+            localSettingsCache.icon = '/content/images/favicon.png';
+
             // with ghost set and png
             rendered = helpers.asset('favicon.png', {hash: {ghost: 'true'}});
             should.exist(rendered);
@@ -48,7 +55,7 @@ describe('{{asset}} helper', function () {
             should.exist(rendered);
             String(rendered).should.equal('/content/images/favicon.png');
 
-            configUtils.set('theme:icon', '/content/images/favicon.ico');
+            localSettingsCache.icon = '/content/images/favicon.ico';
 
             // with ghost set and ico
             rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});
@@ -62,7 +69,8 @@ describe('{{asset}} helper', function () {
         });
 
         it('handles shared assets correctly', function () {
-            configUtils.set('theme:icon', '');
+            localSettingsCache.icon = '';
+
             // with ghost set
             rendered = helpers.asset('shared/asset.js', {hash: {ghost: 'true'}});
             should.exist(rendered);
@@ -107,7 +115,8 @@ describe('{{asset}} helper', function () {
         });
 
         it('handles custom favicon correctly', function () {
-            configUtils.set('theme:icon', '/content/images/favicon.png');
+            localSettingsCache.icon = '/content/images/favicon.png';
+
             // with ghost set and png
             rendered = helpers.asset('favicon.png', {hash: {ghost: 'true'}});
             should.exist(rendered);
@@ -118,7 +127,7 @@ describe('{{asset}} helper', function () {
             should.exist(rendered);
             String(rendered).should.equal('/blog/content/images/favicon.png');
 
-            configUtils.set('theme:icon', '/content/images/favicon.ico');
+            localSettingsCache.icon = '/content/images/favicon.ico';
 
             // with ghost set and ico
             rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -3,18 +3,15 @@ var should         = require('should'),
     _              = require('lodash'),
     Promise        = require('bluebird'),
     hbs            = require('express-hbs'),
+    moment         = require('moment'),
     utils          = require('./utils'),
     configUtils    = require('../../utils/configUtils'),
-    moment         = require('moment'),
-
-// Stuff we are testing
-    handlebars     = hbs.handlebars,
     helpers        = require('../../../server/helpers'),
     api            = require('../../../server/api'),
-
     labs           = require('../../../server/utils/labs'),
-
-    sandbox = sinon.sandbox.create();
+    settingsCache  = api.settings.cache,
+    handlebars     = hbs.handlebars,
+    sandbox        = sinon.sandbox.create();
 
 describe('{{ghost_head}} helper', function () {
     var settingsReadStub;
@@ -46,16 +43,19 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('without Code Injection', function () {
+        var localSettingsCache = {
+            title: 'Ghost',
+            description: 'blog description',
+            cover: '/content/images/blog-cover.png',
+            amp: true
+        };
+
         beforeEach(function () {
-            configUtils.set({
-                url: 'http://testurl.com/',
-                theme: {
-                    title: 'Ghost',
-                    description: 'blog description',
-                    cover: '/content/images/blog-cover.png',
-                    amp: true
-                }
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return localSettingsCache[key];
             });
+
+            configUtils.set('url', 'http://testurl.com/');
         });
 
         it('has loaded ghost_head helper', function () {
@@ -882,15 +882,10 @@ describe('{{ghost_head}} helper', function () {
 
         describe('with /blog subdirectory', function () {
             beforeEach(function () {
+                localSettingsCache.icon = '/content/images/favicon.png';
+
                 configUtils.set({
-                    url: 'http://testurl.com/blog/',
-                    theme: {
-                        title: 'Ghost',
-                        description: 'blog description',
-                        cover: '/content/images/blog-cover.png',
-                        amp: true,
-                        icon: '/content/images/favicon.png'
-                    }
+                    url: 'http://testurl.com/blog/'
                 });
             });
 
@@ -912,16 +907,21 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('with changed origin in config file', function () {
+        var localSettingsCache = {
+            title: 'Ghost',
+            description: 'blog description',
+            cover: '/content/images/blog-cover.png',
+            amp: true,
+            icon: '/content/images/favicon.png'
+        };
+
         beforeEach(function () {
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return localSettingsCache[key];
+            });
+
             configUtils.set({
                 url: 'http://testurl.com/blog/',
-                theme: {
-                    title: 'Ghost',
-                    description: 'blog description',
-                    cover: '/content/images/blog-cover.png',
-                    amp: true,
-                    icon: '/content/images/favicon.png'
-                },
                 referrerPolicy: 'origin'
             });
         });
@@ -941,16 +941,21 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('with useStructuredData is set to false in config file', function () {
+        var localSettingsCache = {
+            title: 'Ghost',
+            description: 'blog description',
+            cover: '/content/images/blog-cover.png',
+            amp: true,
+            icon: '/content/images/favicon.png'
+        };
+
         beforeEach(function () {
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return localSettingsCache[key];
+            });
+
             configUtils.set({
                 url: 'http://testurl.com/',
-                theme: {
-                    title: 'Ghost',
-                    description: 'blog description',
-                    cover: '/content/images/blog-cover.png',
-                    amp: true,
-                    icon: '/content/images/favicon.png'
-                },
                 privacy: {
                     useStructuredData: false
                 }
@@ -995,19 +1000,24 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('with Code Injection', function () {
+        var localSettingsCache = {
+            title: 'Ghost',
+            description: 'blog description',
+            cover: '/content/images/blog-cover.png',
+            icon: '/content/images/favicon.png'
+        };
+
         beforeEach(function () {
             settingsReadStub.returns(new Promise.resolve({
                 settings: [{value: '<style>body {background: red;}</style>'}]
             }));
 
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return localSettingsCache[key];
+            });
+
             configUtils.set({
-                url: 'http://testurl.com/',
-                theme: {
-                    title: 'Ghost',
-                    description: 'blog description',
-                    cover: '/content/images/blog-cover.png',
-                    icon: '/content/images/favicon.png'
-                }
+                url: 'http://testurl.com/'
             });
         });
 
@@ -1126,12 +1136,17 @@ describe('{{ghost_head}} helper', function () {
     });
 
     describe('amp is disabled', function () {
+        var localSettingsCache = {
+            amp: false
+        };
+
         beforeEach(function () {
             configUtils.set({
-                url: 'http://testurl.com/',
-                theme: {
-                    amp: false
-                }
+                url: 'http://testurl.com/'
+            });
+
+            sandbox.stub(settingsCache, 'get', function (key) {
+                return localSettingsCache[key];
             });
         });
 

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -1,24 +1,23 @@
 var should         = require('should'),
+    sinon          = require('sinon'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
     configUtils    = require('../../utils/configUtils'),
-
-// Stuff we are testing
     handlebars     = hbs.handlebars,
-    helpers        = require('../../../server/helpers');
+    sandbox        = sinon.sandbox.create(),
+    helpers        = require('../../../server/helpers'),
+    settingsCache  = require('../../../server/api/settings').cache;
 
 describe('{{meta_description}} helper', function () {
     before(function () {
         utils.loadHelpers();
-        configUtils.set({
-            theme: {
-                description: 'Just a blogging platform.'
-            }
-        });
+
+        sandbox.stub(settingsCache, 'get').returns('Just a blogging platform.');
     });
 
     after(function () {
         configUtils.restore();
+        sandbox.restore();
     });
 
     it('has loaded meta_description helper', function () {

--- a/core/test/unit/server_helpers/meta_title_spec.js
+++ b/core/test/unit/server_helpers/meta_title_spec.js
@@ -1,24 +1,27 @@
 var should         = require('should'),
+    sinon          = require('sinon'),
     hbs            = require('express-hbs'),
     utils          = require('./utils'),
     configUtils    = require('../../utils/configUtils'),
-
-// Stuff we are testing
     handlebars     = hbs.handlebars,
-    helpers        = require('../../../server/helpers');
+    sandbox        = sinon.sandbox.create(),
+    helpers        = require('../../../server/helpers'),
+    settingsCache  = require('../../../server/api/settings').cache;
 
 describe('{{meta_title}} helper', function () {
     before(function () {
         utils.loadHelpers();
-        configUtils.set({
-            theme: {
+
+        sandbox.stub(settingsCache, 'get', function (key) {
+            return {
                 title: 'Ghost'
-            }
+            }[key];
         });
     });
 
     after(function () {
         configUtils.restore();
+        sandbox.restore();
     });
 
     it('has loaded meta_title helper', function () {


### PR DESCRIPTION
refs #7488

Please look at each single commit to follow the changes.

- we remove the logic for remembering user settings in the config object
- instead we are using the settings cache directly

I did a quick browser test. 
For the next alpha release on Friday, i will do a bigger test.
