### PR TITLE
Re-work existing email validation to incorporate previous PR feedback

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -238,6 +238,7 @@
                 "userIsInactive": "The user with that email address is inactive.",
                 "incorrectPasswordAttempts": "Your password is incorrect. <br /> {remaining} attempt{s} remaining!",
                 "userUpdateError": {
+                    "emailIsAlreadyInUse": "Email is already in use",
                     "context": "Error thrown from user update during login",
                     "help": "Visit and save your profile after logging in to check for problems."
                 },

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -262,18 +262,7 @@ describe('Users API', function () {
     });
 
     describe('Edit', function () {
-        var newName = 'Jo McBlogger',
-            newUser;
-
-        beforeEach(function () {
-            newUser = _.clone(testUtils.DataGenerator.forKnex.createUser(testUtils.DataGenerator.Content.users[4]));
-            sandbox.stub(mail, 'send', function () {
-                return Promise.resolve();
-            });
-        });
-        afterEach(function () {
-            sandbox.restore();
-        });
+        var newName = 'Jo McBlogger';
 
         function checkEditResponse(response) {
             should.exist(response);
@@ -437,23 +426,6 @@ describe('Users API', function () {
                 checkEditResponse(response);
                 done();
             }).catch(done);
-        });
-
-        it('Author can not set an email that already exists', function (done) {
-            newUser.roles = [roleIdFor.author];
-            newUser.email = 'test@example.com';
-
-            UserAPI.add({users: [newUser]}, _.extend({}, context.owner, {include: 'roles'}))
-                .then(function () {
-                    UserAPI.edit(
-                        {users: [{email: 'test@example.com', id: userIdFor.author}]}, _.extend({}, context.author, {id: userIdFor.author})
-                    ).then(function () {
-                        done(new Error('Author should not be able to set and existing email address'));
-                    }).catch(function (error) {
-                        error.errorType.should.eql('ValidationError');
-                        done();
-                    });
-                }).catch(done);
         });
 
         it('Author can edit self with role set', function (done) {

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -262,7 +262,18 @@ describe('Users API', function () {
     });
 
     describe('Edit', function () {
-        var newName = 'Jo McBlogger';
+        var newName = 'Jo McBlogger',
+            newUser;
+
+        beforeEach(function () {
+            newUser = _.clone(testUtils.DataGenerator.forKnex.createUser(testUtils.DataGenerator.Content.users[4]));
+            sandbox.stub(mail, 'send', function () {
+                return Promise.resolve();
+            });
+        });
+        afterEach(function () {
+            sandbox.restore();
+        });
 
         function checkEditResponse(response) {
             should.exist(response);
@@ -426,6 +437,23 @@ describe('Users API', function () {
                 checkEditResponse(response);
                 done();
             }).catch(done);
+        });
+
+        it('Author can not set an email that already exists', function (done) {
+            newUser.roles = [roleIdFor.author];
+            newUser.email = 'test@example.com';
+
+            UserAPI.add({users: [newUser]}, _.extend({}, context.owner, {include: 'roles'}))
+                .then(function () {
+                    UserAPI.edit(
+                        {users: [{email: 'test@example.com', id: userIdFor.author}]}, _.extend({}, context.author, {id: userIdFor.author})
+                    ).then(function () {
+                        done(new Error('Author should not be able to set and existing email address'));
+                    }).catch(function (error) {
+                        error.errorType.should.eql('ValidationError');
+                        done();
+                    });
+                }).catch(done);
         });
 
         it('Author can edit self with role set', function (done) {

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -415,6 +415,19 @@ describe('User Model', function run() {
             });
         });
 
+        it('can NOT set an already existing email address', function (done) {
+            var firstUser = testUtils.DataGenerator.Content.users[0].id,
+                secondEmail = testUtils.DataGenerator.Content.users[1].email;
+
+            UserModel.findOne({id: firstUser}).then(function (user) {
+                return user.edit({email: secondEmail});
+            }).then(function () {
+                done(new Error('Already existing email address was accepted'));
+            }).catch(function () {
+                done();
+            });
+        });
+
         it('can edit invited user', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4],
                 userId;


### PR DESCRIPTION
closes #7256
- original code changes made by @golya in #7304
- refactored edit method in user model, pulled update method from public API to prevent confusion
- added test coverage for existing email update in user model spec
- removed API test, as the current API does not allow adding new users, so not possible to test updating existing one

- [x] Commit message has a short title & issue references
- [x] Commits are squashed (left original commit from @golya, squashed my changes)
- [x] The build will pass (run `npm test`).