### PR TITLE
🔥✨ remove forceAdminSSL and urlSSL, add admin url

### DIFF
--- a/core/server/admin/app.js
+++ b/core/server/admin/app.js
@@ -8,7 +8,7 @@ var debug = require('debug')('ghost:admin'),
 
     // Global/shared middleware?
     cacheControl = require('../middleware/cache-control'),
-    checkSSL = require('../middleware/check-ssl'),
+    urlRedirects = require('../middleware/url-redirects'),
     errorHandler = require('../middleware//error-handler'),
     maintenance = require('../middleware/maintenance'),
     prettyURLs = require('../middleware//pretty-urls'),
@@ -46,7 +46,7 @@ module.exports = function setupAdminApp() {
 
     // Force SSL if required
     // must happen AFTER asset loading and BEFORE routing
-    adminApp.use(checkSSL);
+    adminApp.use(urlRedirects);
 
     // Add in all trailing slashes & remove uppercase
     // must happen AFTER asset loading and BEFORE routing

--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -21,7 +21,7 @@ var debug = require('debug')('ghost:api'),
     // Shared
     bodyParser = require('body-parser'), // global, shared
     cacheControl = require('../middleware/cache-control'), // global, shared
-    checkSSL = require('../middleware/check-ssl'),
+    urlRedirects = require('../middleware/url-redirects'),
     prettyURLs = require('../middleware/pretty-urls'),
     maintenance = require('../middleware/maintenance'), // global, shared
     errorHandler = require('../middleware/error-handler'), // global, shared
@@ -235,7 +235,7 @@ module.exports = function setupApiApp() {
 
     // Force SSL if required
     // must happen AFTER asset loading and BEFORE routing
-    apiApp.use(checkSSL);
+    apiApp.use(urlRedirects);
 
     // Add in all trailing slashes & remove uppercase
     // must happen AFTER asset loading and BEFORE routing

--- a/core/server/blog/app.js
+++ b/core/server/blog/app.js
@@ -14,7 +14,7 @@ var debug = require('debug')('ghost:blog'),
 
     // local middleware
     cacheControl = require('../middleware/cache-control'),
-    checkSSL = require('../middleware/check-ssl'),
+    urlRedirects = require('../middleware/url-redirects'),
     errorHandler = require('../middleware/error-handler'),
     maintenance = require('../middleware/maintenance'),
     prettyURLs = require('../middleware/pretty-urls'),
@@ -75,7 +75,7 @@ module.exports = function setupBlogApp() {
 
     // Force SSL if required
     // must happen AFTER asset loading and BEFORE routing
-    blogApp.use(checkSSL);
+    blogApp.use(urlRedirects);
 
     // Add in all trailing slashes & remove uppercase
     // must happen AFTER asset loading and BEFORE routing

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -1,6 +1,5 @@
 {
     "url": "http://localhost:2368",
-    "urlSSL": false,
     "forceAdminSSL": false,
     "server": {
         "host": "127.0.0.1",

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -1,6 +1,5 @@
 {
     "url": "http://localhost:2368",
-    "forceAdminSSL": false,
     "server": {
         "host": "127.0.0.1",
         "port": 2368

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -170,7 +170,7 @@ function init(options) {
         return scheduling.init({
             schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
-            apiUrl: utils.url.apiUrl(),
+            apiUrl: utils.url.urlFor('api', true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         });

--- a/core/server/middleware/api/cors.js
+++ b/core/server/middleware/api/cors.js
@@ -35,9 +35,7 @@ function getIPs() {
 function getUrls() {
     var urls = [url.parse(utils.url.urlFor('home', true)).hostname];
 
-    if (config.get('urlSSL')) {
-        urls.push(url.parse(config.get('urlSSL')).hostname);
-    }
+    // @TODO: add admin.url if available
 
     return urls;
 }

--- a/core/server/middleware/api/cors.js
+++ b/core/server/middleware/api/cors.js
@@ -3,7 +3,6 @@ var cors = require('cors'),
     url = require('url'),
     os = require('os'),
     utils = require('../../utils'),
-    config = require('../../config'),
     whitelist = [],
     ENABLE_CORS = {origin: true, maxAge: 86400},
     DISABLE_CORS = {origin: false};
@@ -33,9 +32,15 @@ function getIPs() {
 }
 
 function getUrls() {
-    var urls = [url.parse(utils.url.urlFor('home', true)).hostname];
+    var blogHost = url.parse(utils.url.urlFor('home', true)).hostname,
+        adminHost = url.parse(utils.url.urlFor('admin', true)).hostname,
+        urls = [];
 
-    // @TODO: add admin.url if available
+    urls.push(blogHost);
+
+    if (adminHost !== blogHost) {
+        urls.push(adminHost);
+    }
 
     return urls;
 }

--- a/core/server/middleware/check-ssl.js
+++ b/core/server/middleware/check-ssl.js
@@ -12,11 +12,11 @@ function isSSLrequired(isAdmin, configUrl, forceAdminSSL) {
 }
 
 // The guts of checkSSL. Indicate forbidden or redirect according to configuration.
-// Required args: forceAdminSSL, url and urlSSL should be passed from config. reqURL from req.url
+// Required args: forceAdminSSL and url should be passed from config. reqURL from req.url
 function sslForbiddenOrRedirect(opt) {
     var forceAdminSSL = opt.forceAdminSSL,
         reqUrl        = url.parse(opt.reqUrl), // expected to be relative-to-root
-        baseUrl       = url.parse(opt.configUrlSSL || opt.configUrl),
+        baseUrl       = url.parse(opt.configUrl),
         response = {
         // Check if forceAdminSSL: { redirect: false } is set, which means
         // we should just deny non-SSL access rather than redirect
@@ -43,7 +43,6 @@ checkSSL = function checkSSL(req, res, next) {
         if (!req.secure) {
             var response = sslForbiddenOrRedirect({
                 forceAdminSSL: config.get('forceAdminSSL'),
-                configUrlSSL: config.get('urlSSL'),
                 configUrl: utils.url.urlFor('home', true),
                 reqUrl: req.originalUrl || req.url
             });

--- a/core/server/middleware/serve-shared-file.js
+++ b/core/server/middleware/serve-shared-file.js
@@ -28,7 +28,7 @@ function serveSharedFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, utils.url.urlFor('home', true).replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, utils.url.apiUrl({cors: true}));
+                        buf = buf.toString().replace(apiRegex, utils.url.urlFor('api', {cors: true}, true));
                     }
                     content = {
                         headers: {

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -32,10 +32,7 @@ themeHandler = {
             labsData = _.cloneDeep(settingsCache.get('labs')),
             blogApp = req.app;
 
-        if (req.secure && config.get('urlSSL')) {
-            // For secure requests override .url property with the SSL version
-            themeData.url = config.get('urlSSL').replace(/\/$/, '');
-        }
+        // @TODO: send req.secure to url: utils.url.urlFor('home'...)
 
         hbs.updateTemplateOptions({
             data: {
@@ -49,7 +46,7 @@ themeHandler = {
         }
 
         // Pass 'secure' flag to the view engine
-        // so that templates can choose 'url' vs 'urlSSL'
+        // so that templates can choose to render https or http 'url', see url utility
         res.locals.secure = req.secure;
 
         next();

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -8,6 +8,7 @@ var _      = require('lodash'),
     utils = require('../utils'),
     logging = require('../logging'),
     errors = require('../errors'),
+    utils = require('../utils'),
     i18n = require('../i18n'),
     themeHandler;
 
@@ -32,7 +33,9 @@ themeHandler = {
             labsData = _.cloneDeep(settingsCache.get('labs')),
             blogApp = req.app;
 
-        // @TODO: send req.secure to url: utils.url.urlFor('home'...)
+        // @TODO: MERGE WITH OPEN PR
+        // https://github.com/TryGhost/Ghost/pull/7924
+        themeData.url = utils.url.urlFor('home', {secure: req.secure}, true);
 
         hbs.updateTemplateOptions({
             data: {

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -19,7 +19,7 @@ themeHandler = {
         var themeData = {
                 title: settingsCache.get('title'),
                 description: settingsCache.get('description'),
-                url: utils.url.urlFor('home', true),
+                url: utils.url.urlFor('home', {secure: req.secure}, true),
                 facebook: settingsCache.get('facebook'),
                 twitter: settingsCache.get('twitter'),
                 timezone: settingsCache.get('activeTimezone'),
@@ -32,10 +32,6 @@ themeHandler = {
             },
             labsData = _.cloneDeep(settingsCache.get('labs')),
             blogApp = req.app;
-
-        // @TODO: MERGE WITH OPEN PR
-        // https://github.com/TryGhost/Ghost/pull/7924
-        themeData.url = utils.url.urlFor('home', {secure: req.secure}, true);
 
         hbs.updateTemplateOptions({
             data: {

--- a/core/server/middleware/url-redirects.js
+++ b/core/server/middleware/url-redirects.js
@@ -1,7 +1,7 @@
 var url = require('url'),
     debug = require('debug')('ghost:redirects'),
     utils = require('../utils'),
-    checkSSLAndRedirects;
+    urlRedirects;
 
 function redirectUrl(options) {
     var redirectTo = options.redirectTo,
@@ -20,9 +20,8 @@ function redirectUrl(options) {
 
 /**
  * SSL AND REDIRECTS
- * @TODO: rename file
  */
-checkSSLAndRedirects = function checkSSLAndRedirects(req, res, next) {
+urlRedirects = function urlRedirects(req, res, next) {
     var requestedUrl = req.originalUrl || req.url,
         requestedHost = req.get('host'),
         targetHostWithProtocol,
@@ -66,4 +65,4 @@ checkSSLAndRedirects = function checkSSLAndRedirects(req, res, next) {
     next();
 };
 
-module.exports = checkSSLAndRedirects;
+module.exports = urlRedirects;

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -6,7 +6,7 @@ var moment            = require('moment-timezone'),
     url               = require('url'),
     config            = require('./../config'),
     settingsCache     = require('./../api/settings').cache,
-     // @TODO: unify this with the path in server/app.js   
+    // @TODO: unify this with the path in server/app.js   
     API_PATH          = '/ghost/api/v0.1/',
     STATIC_IMAGE_URL_PREFIX = 'content/images';
 

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -6,7 +6,7 @@ var moment            = require('moment-timezone'),
     url               = require('url'),
     config            = require('./../config'),
     settingsCache     = require('./../api/settings').cache,
-    // @TODO: unify this with the path in server/app.js   
+    // @TODO: unify this with the path in server/app.js
     API_PATH          = '/ghost/api/v0.1/',
     STATIC_IMAGE_URL_PREFIX = 'content/images';
 

--- a/core/test/functional/routes/admin_spec.js
+++ b/core/test/functional/routes/admin_spec.js
@@ -1,15 +1,14 @@
-
 // # Frontend Route tests
 // As it stands, these tests depend on the database, and as such are integration tests.
 // Mocking out the models to not touch the DB would turn these into unit tests, and should probably be done in future,
 // But then again testing real code, rather than mock code, might be more useful...
 
-var request    = require('supertest'),
-    should     = require('should'),
-    testUtils  = require('../../utils'),
-    ghost      = testUtils.startGhost,
-    i18n       = require('../../../../core/server/i18n'),
-    config     = require('../../../../core/server/config');
+var request = require('supertest'),
+    should = require('should'),
+    testUtils = require('../../utils'),
+    ghost = testUtils.startGhost,
+    i18n = require('../../../../core/server/i18n'),
+    config = require('../../../../core/server/config');
 
 i18n.init();
 
@@ -42,196 +41,164 @@ describe('Admin Routing', function () {
 
     before(testUtils.teardown);
 
-    before(function (done) {
-        ghost().then(function (ghostServer) {
-            // Setup the request object with the ghost express app
-            request = request(ghostServer.rootApp);
-
-            done();
-        }).catch(function (e) {
-            console.log('Ghost Error: ', e);
-            console.log(e.stack);
-            done(e);
-        });
-    });
-
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
-    });
-
-    describe('Assets', function () {
-        it('should return 404 for unknown assets', function (done) {
-            request.get('/ghost/assets/not-found.js')
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(404)
-                .end(doEnd(done));
-        });
-
-        it('should retrieve built assets', function (done) {
-            request.get('/ghost/assets/vendor.js')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(200)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Legacy Redirects', function () {
-        it('should redirect /logout/ to /ghost/signout/', function (done) {
-            request.get('/logout/')
-                .expect('Location', '/ghost/signout/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-
-        it('should redirect /signout/ to /ghost/signout/', function (done) {
-            request.get('/signout/')
-                .expect('Location', '/ghost/signout/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-
-        it('should redirect /signup/ to /ghost/signup/', function (done) {
-            request.get('/signup/')
-                .expect('Location', '/ghost/signup/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-
-        // Admin aliases
-        it('should redirect /signin/ to /ghost/', function (done) {
-            request.get('/signin/')
-                .expect('Location', '/ghost/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-
-        it('should redirect /admin/ to /ghost/', function (done) {
-            request.get('/admin/')
-                .expect('Location', '/ghost/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-
-        it('should redirect /GHOST/ to /ghost/', function (done) {
-            request.get('/GHOST/')
-                .expect('Location', '/ghost/')
-                .expect(301)
-                .end(doEndNoAuth(done));
-        });
-    });
-
-    // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
-    describe('Require HTTPS - no redirect', function () {
-        var forkedGhost, request;
+    describe('NO FORK', function () {
+        var ghostServer;
 
         before(function (done) {
-            testUtils.fork.ghost({
-                forceAdminSSL: {redirect: false},
-                url: 'https://localhost/'
-            }, 'testhttps')
-                .then(function (child) {
-                    forkedGhost = child;
-                    request = require('supertest');
-                    request = request(config.get('url').replace(/\/$/, ''));
-                })
-                .then(done)
-                .catch(done);
+            ghost().then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                return ghostServer.start();
+            }).then(function () {
+                request = request(config.get('url'));
+                done();
+            }).catch(function (e) {
+                console.log('Ghost Error: ', e);
+                console.log(e.stack);
+                done(e);
+            });
         });
 
-        after(function (done) {
-            if (forkedGhost) {
-                forkedGhost.kill(done);
-            } else {
-                done(new Error('No forked ghost process exists, test setup must have failed.'));
-            }
+        after(function () {
+            return testUtils.clearData()
+                .then(function () {
+                    return ghostServer.stop();
+                });
         });
 
-        it('should block admin access over non-HTTPS', function (done) {
-            request.get('/ghost/')
-                .expect(403)
-                .end(doEnd(done));
+        describe('Assets', function () {
+            it('should return 404 for unknown assets', function (done) {
+                request.get('/ghost/assets/not-found.js')
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+
+            it('should retrieve built assets', function (done) {
+                request.get('/ghost/assets/vendor.js')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(200)
+                    .end(doEnd(done));
+            });
         });
 
-        it('should allow admin access over HTTPS', function (done) {
-            request.get('/ghost/setup/')
-                .set('X-Forwarded-Proto', 'https')
-                .expect(200)
-                .end(doEnd(done));
+        describe('Legacy Redirects', function () {
+            it('should redirect /logout/ to /ghost/signout/', function (done) {
+                request.get('/logout/')
+                    .expect('Location', '/ghost/signout/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+
+            it('should redirect /signout/ to /ghost/signout/', function (done) {
+                request.get('/signout/')
+                    .expect('Location', '/ghost/signout/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+
+            it('should redirect /signup/ to /ghost/signup/', function (done) {
+                request.get('/signup/')
+                    .expect('Location', '/ghost/signup/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+
+            // Admin aliases
+            it('should redirect /signin/ to /ghost/', function (done) {
+                request.get('/signin/')
+                    .expect('Location', '/ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+
+            it('should redirect /admin/ to /ghost/', function (done) {
+                request.get('/admin/')
+                    .expect('Location', '/ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+
+            it('should redirect /GHOST/ to /ghost/', function (done) {
+                request.get('/GHOST/')
+                    .expect('Location', '/ghost/')
+                    .expect(301)
+                    .end(doEndNoAuth(done));
+            });
+        });
+
+        describe('Ghost Admin Setup', function () {
+            it('should redirect from /ghost/ to /ghost/setup/ when no user/not installed yet', function (done) {
+                request.get('/ghost/')
+                    .expect('Location', /ghost\/setup/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(302)
+                    .end(doEnd(done));
+            });
+
+            it('should redirect from /ghost/signin/ to /ghost/setup/ when no user', function (done) {
+                request.get('/ghost/signin/')
+                    .expect('Location', /ghost\/setup/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(302)
+                    .end(doEnd(done));
+            });
+
+            it('should respond with html for /ghost/setup/', function (done) {
+                request.get('/ghost/setup/')
+                    .expect('Content-Type', /html/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(doEnd(done));
+            });
         });
     });
 
-    describe('Require HTTPS - redirect', function () {
-        var forkedGhost, request;
+    describe('FORK', function () {
+        // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
+        describe('Require HTTPS - redirect', function () {
+            var forkedGhost, request;
 
-        before(function (done) {
-            testUtils.fork.ghost({
-                forceAdminSSL: {redirect: true},
-                url: 'https://localhost/',
-                server: {
-                    port: 2390
+            before(function (done) {
+                testUtils.fork.ghost({
+                    url: 'https://localhost/',
+                    server: {
+                        port: 2390
+                    }
+                }, 'testhttps')
+                    .then(function (child) {
+                        forkedGhost = child;
+                        request = require('supertest');
+                        request = request('http://localhost:2390');
+                    }).then(done)
+                    .catch(done);
+            });
+
+            after(function (done) {
+                if (forkedGhost) {
+                    forkedGhost.kill(done);
+                } else {
+                    done(new Error('No forked ghost process exists, test setup must have failed.'));
                 }
-            }, 'testhttps')
-                .then(function (child) {
-                    forkedGhost = child;
-                    request = require('supertest');
-                    request = request('http://localhost:2390');
-                }).then(done)
-                .catch(done);
-        });
+            });
 
-        after(function (done) {
-            if (forkedGhost) {
-                forkedGhost.kill(done);
-            } else {
-                done(new Error('No forked ghost process exists, test setup must have failed.'));
-            }
-        });
+            it('should redirect admin access over non-HTTPS', function (done) {
+                request.get('/ghost/')
+                    .expect('Location', /^https:\/\/localhost:2390\/ghost\//)
+                    .expect(301)
+                    .end(doEnd(done));
+            });
 
-        it('should redirect admin access over non-HTTPS', function (done) {
-            request.get('/ghost/')
-                .expect('Location', /^https:\/\/localhost:2390\/ghost\//)
-                .expect(301)
-                .end(doEnd(done));
-        });
-
-        it('should allow admin access over HTTPS', function (done) {
-            request.get('/ghost/setup/')
-                .set('X-Forwarded-Proto', 'https')
-                .expect(200)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Ghost Admin Setup', function () {
-        it('should redirect from /ghost/ to /ghost/setup/ when no user/not installed yet', function (done) {
-            request.get('/ghost/')
-                .expect('Location', /ghost\/setup/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(302)
-                .end(doEnd(done));
-        });
-
-        it('should redirect from /ghost/signin/ to /ghost/setup/ when no user', function (done) {
-            request.get('/ghost/signin/')
-                .expect('Location', /ghost\/setup/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(302)
-                .end(doEnd(done));
-        });
-
-        it('should respond with html for /ghost/setup/', function (done) {
-            request.get('/ghost/setup/')
-                .expect('Content-Type', /html/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(doEnd(done));
+            it('should allow admin access over HTTPS', function (done) {
+                request.get('/ghost/setup/')
+                    .set('X-Forwarded-Proto', 'https')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
         });
     });
 });

--- a/core/test/functional/routes/admin_spec.js
+++ b/core/test/functional/routes/admin_spec.js
@@ -134,7 +134,7 @@ describe('Admin Routing', function () {
         before(function (done) {
             testUtils.fork.ghost({
                 forceAdminSSL: {redirect: false},
-                urlSSL: 'https://localhost/'
+                url: 'https://localhost/'
             }, 'testhttps')
                 .then(function (child) {
                     forkedGhost = child;
@@ -169,15 +169,19 @@ describe('Admin Routing', function () {
 
     describe('Require HTTPS - redirect', function () {
         var forkedGhost, request;
+
         before(function (done) {
             testUtils.fork.ghost({
                 forceAdminSSL: {redirect: true},
-                urlSSL: 'https://localhost/'
+                url: 'https://localhost/',
+                server: {
+                    port: 2390
+                }
             }, 'testhttps')
                 .then(function (child) {
                     forkedGhost = child;
                     request = require('supertest');
-                    request = request(config.get('url').replace(/\/$/, ''));
+                    request = request('http://localhost:2390');
                 }).then(done)
                 .catch(done);
         });
@@ -192,7 +196,7 @@ describe('Admin Routing', function () {
 
         it('should redirect admin access over non-HTTPS', function (done) {
             request.get('/ghost/')
-                .expect('Location', /^https:\/\/localhost\/ghost\//)
+                .expect('Location', /^https:\/\/localhost:2390\/ghost\//)
                 .expect(301)
                 .end(doEnd(done));
         });

--- a/core/test/functional/routes/api/authentication_spec.js
+++ b/core/test/functional/routes/api/authentication_spec.js
@@ -10,13 +10,16 @@ var supertest     = require('supertest'),
     request;
 
 describe('Authentication API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -31,10 +34,11 @@ describe('Authentication API', function () {
         });
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     it('can authenticate', function (done) {

--- a/core/test/functional/routes/api/configuration_spec.js
+++ b/core/test/functional/routes/api/configuration_spec.js
@@ -1,29 +1,34 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('Configuration API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
         }).then(function () {
-            return testUtils.doAuth(request, 'posts');
+            request = supertest.agent(config.get('url'));
+        }).then(function () {
+            return testUtils.doAuth(request);
         }).then(function (token) {
             accesstoken = token;
             done();
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     describe('success', function () {

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -2,17 +2,21 @@ var supertest     = require('supertest'),
     should        = require('should'),
     path          = require('path'),
     testUtils     = require('../../../utils'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('DB API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -21,10 +25,11 @@ describe('DB API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     it('attaches the Content-Disposition header on export', function (done) {

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -1,17 +1,21 @@
 var testUtils     = require('../../../utils'),
     supertest     = require('supertest'),
     should        = require('should'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('Notifications API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -20,10 +24,11 @@ describe('Notifications API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     describe('Add', function () {

--- a/core/test/functional/routes/api/settings_spec.js
+++ b/core/test/functional/routes/api/settings_spec.js
@@ -1,17 +1,21 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('Settings API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -20,10 +24,11 @@ describe('Settings API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     // TODO: currently includes values of type=core

--- a/core/test/functional/routes/api/slugs_spec.js
+++ b/core/test/functional/routes/api/slugs_spec.js
@@ -1,17 +1,21 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('Slug API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -20,10 +24,11 @@ describe('Slug API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     it('should be able to get a post slug', function (done) {

--- a/core/test/functional/routes/api/tags_spec.js
+++ b/core/test/functional/routes/api/tags_spec.js
@@ -1,17 +1,21 @@
 var testUtils     = require('../../../utils'),
     should        = require('should'),
     supertest     = require('supertest'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
 describe('Tag API', function () {
-    var accesstoken = '';
+    var accesstoken = '', ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request, 'posts');
         }).then(function (token) {
@@ -20,10 +24,11 @@ describe('Tag API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     it('can retrieve all tags', function (done) {

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -22,11 +22,14 @@ describe('Themes API', function () {
                 .attach(fieldName, themePath);
         },
         editor: null
-    };
+    }, ghostServer;
 
     before(function (done) {
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request);
         }).then(function (token) {
@@ -47,7 +50,7 @@ describe('Themes API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
+    after(function () {
         // clean successful uploaded themes
         fs.removeSync(config.getContentPath('themes') + '/valid');
         fs.removeSync(config.getContentPath('themes') + '/casper.zip');
@@ -55,10 +58,10 @@ describe('Themes API', function () {
         // gscan creates /test/tmp in test mode
         fs.removeSync(config.get('paths').appRoot + '/test');
 
-        testUtils.clearData()
+        return testUtils.clearData()
             .then(function () {
-                done();
-            }).catch(done);
+                return ghostServer.stop();
+            });
     });
 
     describe('success cases', function () {

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -2,6 +2,7 @@ var testUtils = require('../../../utils'),
     should = require('should'),
     supertest = require('supertest'),
     ObjectId = require('bson-objectid'),
+    config        = require('../../../../../core/server/config'),
     ghost         = testUtils.startGhost,
     request;
 
@@ -9,13 +10,16 @@ describe('User API', function () {
     var ownerAccessToken = '',
         editorAccessToken = '',
         authorAccessToken = '',
-        editor, author;
+        editor, author, ghostServer;
 
     before(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (ghostServer) {
-            request = supertest.agent(ghostServer.rootApp);
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = supertest.agent(config.get('url'));
         }).then(function () {
             // create editor
             return testUtils.createUser({
@@ -51,10 +55,11 @@ describe('User API', function () {
         }).catch(done);
     });
 
-    after(function (done) {
-        testUtils.clearData().then(function () {
-            done();
-        }).catch(done);
+    after(function () {
+        return testUtils.clearData()
+            .then(function () {
+                return ghostServer.stop();
+            });
     });
 
     describe('As Owner', function () {

--- a/core/test/functional/routes/channel_spec.js
+++ b/core/test/functional/routes/channel_spec.js
@@ -7,9 +7,12 @@ var request    = require('supertest'),
     should     = require('should'),
     cheerio    = require('cheerio'),
     testUtils  = require('../../utils'),
+    config     = require('../../../../core/server/config'),
     ghost      = testUtils.startGhost;
 
 describe('Channel Routes', function () {
+    var ghostServer;
+
     function doEnd(done) {
         return function (err, res) {
             if (err) {
@@ -26,10 +29,11 @@ describe('Channel Routes', function () {
     }
 
     before(function (done) {
-        ghost().then(function (ghostServer) {
-            // Setup the request object with the ghost express app
-            request = request(ghostServer.rootApp);
-
+        ghost().then(function (_ghostServer) {
+            ghostServer = _ghostServer;
+            return ghostServer.start();
+        }).then(function () {
+            request = request(config.get('url'));
             done();
         }).catch(function (e) {
             console.log('Ghost Error: ', e);
@@ -39,6 +43,10 @@ describe('Channel Routes', function () {
     });
 
     after(testUtils.teardown);
+
+    after(function () {
+        return ghostServer.stop();
+    });
 
     describe('Index', function () {
         it('should respond with html', function (done) {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -14,6 +14,8 @@ var request = require('supertest'),
     ghost   = testUtils.startGhost;
 
 describe('Frontend Routing', function () {
+    var ghostServer;
+
     function doEnd(done) {
         return function (err, res) {
             if (err) {
@@ -37,252 +39,403 @@ describe('Frontend Routing', function () {
         });
     }
 
-    before(function (done) {
-        ghost().then(function (ghostServer) {
-            // Setup the request object with the ghost express app
-            request = request(ghostServer.rootApp);
-
-            done();
-        }).catch(function (e) {
-            console.log('Ghost Error: ', e);
-            console.log(e.stack);
-            done(e);
-        });
-    });
-
-    afterEach(function () {
-        sandbox.restore();
-    });
-
-    describe('Date permalinks', function () {
+    describe('NO FORK', function () {
         before(function (done) {
-            // Only way to swap permalinks setting is to login and visit the URL because
-            // poking the database doesn't work as settings are cached
-            testUtils.togglePermalinks(request, 'date')
-                .then(function () {
-                    done();
-                })
-                .catch(done);
-        });
-
-        after(function (done) {
-            testUtils.togglePermalinks(request)
-                .then(function () {
-                    done();
-                })
-                .catch(done);
-        });
-
-        it('should load a post with date permalink', function (done) {
-            var date = moment().format('YYYY/MM/DD');
-
-            request.get('/' + date + '/welcome-to-ghost/')
-                .expect(200)
-                .expect('Content-Type', /html/)
-                .end(doEnd(done));
-        });
-
-        it('expect redirect because of wrong/old permalink prefix', function (done) {
-            var date = moment().format('YYYY/MM/DD');
-
-            request.get('/2016/04/01/welcome-to-ghost/')
-                .expect('Content-Type', /html/)
-                .end(function (err, res) {
-                    res.status.should.eql(301);
-                    request.get('/' + date + '/welcome-to-ghost/')
-                        .expect(200)
-                        .expect('Content-Type', /html/)
-                        .end(doEnd(done));
-                });
-        });
-
-        it('should serve RSS with date permalink', function (done) {
-            request.get('/rss/')
-                .expect('Content-Type', 'text/xml; charset=utf-8')
-                .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
-                    }
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    should.not.exist(res.headers['X-CSRF-Token']);
-                    should.not.exist(res.headers['set-cookie']);
-                    should.exist(res.headers.date);
-
-                    var content = res.text,
-                        todayMoment = moment(),
-                        dd = todayMoment.format('DD'),
-                        mm = todayMoment.format('MM'),
-                        yyyy = todayMoment.format('YYYY'),
-                        postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
-
-                    content.indexOf(postLink).should.be.above(0);
-                    done();
-                });
-        });
-    });
-
-    describe('Test with Initial Fixtures', function () {
-        after(testUtils.teardown);
-
-        describe('Error', function () {
-            it('should 404 for unknown post', function (done) {
-                request.get('/spectacular/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-
-            it('should 404 for unknown post with invalid characters', function (done) {
-                request.get('/$pec+acular~/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-
-            it('should 404 for unknown frontend route', function (done) {
-                request.get('/spectacular/marvellous/')
-                    .set('Accept', 'application/json')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-
-            it('should 404 for encoded char not 301 from uncapitalise', function (done) {
-                request.get('/|/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-
-            it('should 404 for unknown file', function (done) {
-                request.get('/content/images/some/file/that/doesnt-exist.jpg')
-                    .expect('Cache-Control', testUtils.cacheRules['private'])
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+            ghost().then(function (_ghostServer) {
+                ghostServer = _ghostServer;
+                return ghostServer.start();
+            }).then(function () {
+                request = request(configUtils.config.get('url'));
+                done();
+            }).catch(function (e) {
+                console.log('Ghost Error: ', e);
+                console.log(e.stack);
+                done(e);
             });
         });
 
-        describe('Single post', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/welcome-to-ghost')
-                    .expect('Location', '/welcome-to-ghost/')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
-            });
+        after(function () {
+            return ghostServer.stop();
+        });
 
-            it('should redirect uppercase', function (done) {
-                request.get('/Welcome-To-Ghost/')
-                    .expect('Location', '/welcome-to-ghost/')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
-            });
-
-            it('should sanitize double slashes when redirecting uppercase', function (done) {
-                request.get('///Google.com/')
-                    .expect('Location', '/google.com/')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
-            });
-
-            it('should respond with html for valid url', function (done) {
-                request.get('/welcome-to-ghost/')
-                    .expect('Content-Type', /html/)
-                    .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(200)
-                    .end(function (err, res) {
-                        if (err) {
-                            return done(err);
-                        }
-
-                        var $ = cheerio.load(res.text);
-
-                        should.not.exist(res.headers['x-cache-invalidate']);
-                        should.not.exist(res.headers['X-CSRF-Token']);
-                        should.not.exist(res.headers['set-cookie']);
-                        should.exist(res.headers.date);
-
-                        $('title').text().should.equal('Welcome to Ghost');
-                        $('.content .post').length.should.equal(1);
-                        $('.poweredby').text().should.equal('Proudly published with Ghost');
-                        $('body.post-template').length.should.equal(1);
-                        $('body.tag-getting-started').length.should.equal(1);
-                        $('article.post').length.should.equal(1);
-                        $('article.tag-getting-started').length.should.equal(1);
-
+        describe('Date permalinks', function () {
+            before(function (done) {
+                // Only way to swap permalinks setting is to login and visit the URL because
+                // poking the database doesn't work as settings are cached
+                testUtils.togglePermalinks(request, 'date')
+                    .then(function () {
                         done();
-                    });
+                    })
+                    .catch(done);
             });
 
-            it('should not work with date permalinks', function (done) {
-                // get today's date
+            after(function (done) {
+                testUtils.togglePermalinks(request)
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
+            it('should load a post with date permalink', function (done) {
                 var date = moment().format('YYYY/MM/DD');
 
                 request.get('/' + date + '/welcome-to-ghost/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-        });
-
-        describe('Post edit', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/welcome-to-ghost/edit')
-                    .expect('Location', '/welcome-to-ghost/edit/')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
+                    .expect(200)
+                    .expect('Content-Type', /html/)
                     .end(doEnd(done));
             });
 
-            it('should redirect to editor', function (done) {
-                request.get('/welcome-to-ghost/edit/')
-                    .expect('Location', /ghost\/editor\/\w+/)
+            it('expect redirect because of wrong/old permalink prefix', function (done) {
+                var date = moment().format('YYYY/MM/DD');
+
+                request.get('/2016/04/01/welcome-to-ghost/')
+                    .expect('Content-Type', /html/)
+                    .end(function (err, res) {
+                        res.status.should.eql(301);
+                        request.get('/' + date + '/welcome-to-ghost/')
+                            .expect(200)
+                            .expect('Content-Type', /html/)
+                            .end(doEnd(done));
+                    });
+            });
+
+            it('should serve RSS with date permalink', function (done) {
+                request.get('/rss/')
+                    .expect('Content-Type', 'text/xml; charset=utf-8')
                     .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(302)
-                    .end(doEnd(done));
-            });
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
 
-            it('should 404 for non-edit parameter', function (done) {
-                request.get('/welcome-to-ghost/notedit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        should.not.exist(res.headers['X-CSRF-Token']);
+                        should.not.exist(res.headers['set-cookie']);
+                        should.exist(res.headers.date);
+
+                        var content = res.text,
+                            todayMoment = moment(),
+                            dd = todayMoment.format('DD'),
+                            mm = todayMoment.format('MM'),
+                            yyyy = todayMoment.format('YYYY'),
+                            postLink = '/' + yyyy + '/' + mm + '/' + dd + '/welcome-to-ghost/';
+
+                        content.indexOf(postLink).should.be.above(0);
+                        done();
+                    });
             });
         });
 
-        describe('AMP post', function () {
+        describe('Test with Initial Fixtures', function () {
+            after(testUtils.teardown);
+
+            describe('Error', function () {
+                it('should 404 for unknown post', function (done) {
+                    request.get('/spectacular/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for unknown post with invalid characters', function (done) {
+                    request.get('/$pec+acular~/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for unknown frontend route', function (done) {
+                    request.get('/spectacular/marvellous/')
+                        .set('Accept', 'application/json')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for encoded char not 301 from uncapitalise', function (done) {
+                    request.get('/|/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for unknown file', function (done) {
+                    request.get('/content/images/some/file/that/doesnt-exist.jpg')
+                        .expect('Cache-Control', testUtils.cacheRules['private'])
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+
+            describe('Single post', function () {
+                it('should redirect without slash', function (done) {
+                    request.get('/welcome-to-ghost')
+                        .expect('Location', '/welcome-to-ghost/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should redirect uppercase', function (done) {
+                    request.get('/Welcome-To-Ghost/')
+                        .expect('Location', '/welcome-to-ghost/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should sanitize double slashes when redirecting uppercase', function (done) {
+                    request.get('///Google.com/')
+                        .expect('Location', '/google.com/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should respond with html for valid url', function (done) {
+                    request.get('/welcome-to-ghost/')
+                        .expect('Content-Type', /html/)
+                        .expect('Cache-Control', testUtils.cacheRules.public)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            var $ = cheerio.load(res.text);
+
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.not.exist(res.headers['X-CSRF-Token']);
+                            should.not.exist(res.headers['set-cookie']);
+                            should.exist(res.headers.date);
+
+                            $('title').text().should.equal('Welcome to Ghost');
+                            $('.content .post').length.should.equal(1);
+                            $('.poweredby').text().should.equal('Proudly published with Ghost');
+                            $('body.post-template').length.should.equal(1);
+                            $('body.tag-getting-started').length.should.equal(1);
+                            $('article.post').length.should.equal(1);
+                            $('article.tag-getting-started').length.should.equal(1);
+
+                            done();
+                        });
+                });
+
+                it('should not work with date permalinks', function (done) {
+                    // get today's date
+                    var date = moment().format('YYYY/MM/DD');
+
+                    request.get('/' + date + '/welcome-to-ghost/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+
+            describe('Post edit', function () {
+                it('should redirect without slash', function (done) {
+                    request.get('/welcome-to-ghost/edit')
+                        .expect('Location', '/welcome-to-ghost/edit/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should redirect to editor', function (done) {
+                    request.get('/welcome-to-ghost/edit/')
+                        .expect('Location', /ghost\/editor\/\w+/)
+                        .expect('Cache-Control', testUtils.cacheRules.public)
+                        .expect(302)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for non-edit parameter', function (done) {
+                    request.get('/welcome-to-ghost/notedit/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+
+            describe('AMP post', function () {
+                it('should redirect without slash', function (done) {
+                    request.get('/welcome-to-ghost/amp')
+                        .expect('Location', '/welcome-to-ghost/amp/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should redirect uppercase', function (done) {
+                    request.get('/Welcome-To-Ghost/AMP/')
+                        .expect('Location', '/welcome-to-ghost/amp/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should respond with html for valid url', function (done) {
+                    request.get('/welcome-to-ghost/amp/')
+                        .expect('Content-Type', /html/)
+                        .expect('Cache-Control', testUtils.cacheRules.public)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            var $ = cheerio.load(res.text);
+
+                            should.not.exist(res.headers['x-cache-invalidate']);
+                            should.not.exist(res.headers['X-CSRF-Token']);
+                            should.not.exist(res.headers['set-cookie']);
+                            should.exist(res.headers.date);
+
+                            $('title').text().should.equal('Welcome to Ghost');
+                            $('.content .post').length.should.equal(1);
+                            $('.poweredby').text().should.equal('Proudly published with Ghost');
+                            $('body.amp-template').length.should.equal(1);
+                            $('article.post').length.should.equal(1);
+
+                            done();
+                        });
+                });
+
+                it('should not work with date permalinks', function (done) {
+                    // get today's date
+                    var date = moment().format('YYYY/MM/DD');
+
+                    request.get('/' + date + '/welcome-to-ghost/amp/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+
+                it('should not render AMP, when AMP is disabled', function (done) {
+                    var originalFn = settingsCache.get;
+
+                    sandbox.stub(settingsCache, 'get', function (key) {
+                        if (key !== 'amp') {
+                            return originalFn(key);
+                        }
+
+                        return false;
+                    });
+
+                    request.get('/welcome-to-ghost/amp/')
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+
+            describe('Static assets', function () {
+                it('should retrieve theme assets', function (done) {
+                    request.get('/assets/css/screen.css')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(200)
+                        .end(doEnd(done));
+                });
+
+                it('should retrieve default robots.txt', function (done) {
+                    request.get('/robots.txt')
+                        .expect('Cache-Control', testUtils.cacheRules.hour)
+                        .expect('ETag', /[0-9a-f]{32}/i)
+                        .expect(200)
+                        .end(doEnd(done));
+                });
+
+                it('should retrieve default favicon.ico', function (done) {
+                    request.get('/favicon.ico')
+                        .expect('Cache-Control', testUtils.cacheRules.day)
+                        .expect('ETag', /[0-9a-f]{32}/i)
+                        .expect(200)
+                        .end(doEnd(done));
+                });
+
+                // at the moment there is no image fixture to test
+                // it('should retrieve image assets', function (done) {
+                // request.get('/content/images/some.jpg')
+                //    .expect('Cache-Control', testUtils.cacheRules.year)
+                //    .end(doEnd(done));
+                // });
+            });
+        });
+
+        describe('Static page', function () {
+            before(addPosts);
+            after(testUtils.teardown);
+
             it('should redirect without slash', function (done) {
-                request.get('/welcome-to-ghost/amp')
-                    .expect('Location', '/welcome-to-ghost/amp/')
+                request.get('/static-page-test')
+                    .expect('Location', '/static-page-test/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
                     .end(doEnd(done));
             });
 
-            it('should redirect uppercase', function (done) {
-                request.get('/Welcome-To-Ghost/AMP/')
-                    .expect('Location', '/welcome-to-ghost/amp/')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
-                    .expect(301)
-                    .end(doEnd(done));
-            });
-
-            it('should respond with html for valid url', function (done) {
-                request.get('/welcome-to-ghost/amp/')
+            it('should respond with xml', function (done) {
+                request.get('/static-page-test/')
                     .expect('Content-Type', /html/)
                     .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            describe('edit', function () {
+                it('should redirect without slash', function (done) {
+                    request.get('/static-page-test/edit')
+                        .expect('Location', '/static-page-test/edit/')
+                        .expect('Cache-Control', testUtils.cacheRules.year)
+                        .expect(301)
+                        .end(doEnd(done));
+                });
+
+                it('should redirect to editor', function (done) {
+                    request.get('/static-page-test/edit/')
+                        .expect('Location', /ghost\/editor\/\w+/)
+                        .expect('Cache-Control', testUtils.cacheRules.public)
+                        .expect(302)
+                        .end(doEnd(done));
+                });
+
+                it('should 404 for non-edit parameter', function (done) {
+                    request.get('/static-page-test/notedit/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+
+            describe('amp', function () {
+                it('should 404 for amp parameter', function (done) {
+                    request.get('/static-page-test/amp/')
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(404)
+                        .expect(/Page not found/)
+                        .end(doEnd(done));
+                });
+            });
+        });
+
+        describe('Post preview', function () {
+            before(addPosts);
+            after(testUtils.teardown);
+
+            it('should display draft posts accessed via uuid', function (done) {
+                request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c903/')
+                    .expect('Content-Type', /html/)
                     .expect(200)
                     .end(function (err, res) {
                         if (err) {
@@ -296,28 +449,170 @@ describe('Frontend Routing', function () {
                         should.not.exist(res.headers['set-cookie']);
                         should.exist(res.headers.date);
 
-                        $('title').text().should.equal('Welcome to Ghost');
+                        $('title').text().should.equal('Not finished yet');
                         $('.content .post').length.should.equal(1);
                         $('.poweredby').text().should.equal('Proudly published with Ghost');
-                        $('body.amp-template').length.should.equal(1);
+                        $('body.post-template').length.should.equal(1);
                         $('article.post').length.should.equal(1);
 
                         done();
                     });
             });
 
-            it('should not work with date permalinks', function (done) {
-                // get today's date
-                var date = moment().format('YYYY/MM/DD');
-
-                request.get('/' + date + '/welcome-to-ghost/amp/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
+            it('should redirect published posts to their live url', function (done) {
+                request.get('/p/2ac6b4f6-e1f3-406c-9247-c94a0496d39d/')
+                    .expect(301)
+                    .expect('Location', '/short-and-sweet/')
+                    .expect('Cache-Control', testUtils.cacheRules.public)
                     .end(doEnd(done));
             });
 
-            it('should not render AMP, when AMP is disabled', function (done) {
+            it('404s unknown uuids', function (done) {
+                request.get('/p/aac6b4f6-e1f3-406c-9247-c94a0496d39f/')
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+        });
+
+        describe('Post with Ghost in the url', function () {
+            before(addPosts);
+            after(testUtils.teardown);
+
+            // All of Ghost's admin depends on the /ghost/ in the url to work properly
+            // Badly formed regexs can cause breakage if a post slug starts with the 5 letters ghost
+            it('should retrieve a blog post with ghost at the start of the url', function (done) {
+                request.get('/ghostly-kitchen-sink/')
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+        });
+
+        describe('Site Map', function () {
+            before(testUtils.teardown);
+
+            before(function (done) {
+                testUtils.initData().then(function () {
+                    return testUtils.fixtures.insertPostsAndTags();
+                }).then(function () {
+                    done();
+                }).catch(done);
+            });
+
+            it('should serve sitemap.xml', function (done) {
+                request.get('/sitemap.xml')
+                    .expect(200)
+                    .expect('Cache-Control', testUtils.cacheRules.hour)
+                    .expect('Content-Type', 'text/xml; charset=utf-8')
+                    .end(function (err, res) {
+                        res.text.should.match(/sitemapindex/);
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('should serve sitemap-posts.xml', function (done) {
+                request.get('/sitemap-posts.xml')
+                    .expect(200)
+                    .expect('Cache-Control', testUtils.cacheRules.hour)
+                    .expect('Content-Type', 'text/xml; charset=utf-8')
+                    .end(function (err, res) {
+                        res.text.should.match(/urlset/);
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('should serve sitemap-pages.xml', function (done) {
+                request.get('/sitemap-posts.xml')
+                    .expect(200)
+                    .expect('Cache-Control', testUtils.cacheRules.hour)
+                    .expect('Content-Type', 'text/xml; charset=utf-8')
+                    .end(function (err, res) {
+                        res.text.should.match(/urlset/);
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            // TODO: Other pages and verify content
+        });
+    });
+
+    describe('FORK', function () {
+        describe('Subdirectory (no slash)', function () {
+            var forkedGhost, request;
+
+            before(function (done) {
+                testUtils.fork.ghost({
+                    url: 'http://localhost/blog'
+                }, 'testsubdir')
+                    .then(function (child) {
+                        forkedGhost = child;
+                        request = require('supertest');
+                        request = request('http://localhost:' + child.port);
+                    }).then(done).catch(done);
+            });
+
+            after(function (done) {
+                if (forkedGhost) {
+                    forkedGhost.kill(done);
+                } else {
+                    done(new Error('No forked ghost process exists, test setup must have failed.'));
+                }
+            });
+
+            it('http://localhost should 404', function (done) {
+                request.get('/')
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/ should 404', function (done) {
+                request.get('/')
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/blog should 301 to  http://localhost/blog/', function (done) {
+                request.get('/blog')
+                    .expect(301)
+                    .expect('Location', '/blog/')
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/blog/ should 200', function (done) {
+                request.get('/blog/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/blog/welcome-to-ghost should 301 to http://localhost/blog/welcome-to-ghost/', function (done) {
+                request.get('/blog/welcome-to-ghost')
+                    .expect(301)
+                    .expect('Location', '/blog/welcome-to-ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/blog/welcome-to-ghost/ should 200', function (done) {
+                request.get('/blog/welcome-to-ghost/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
+                request.get('/blog/tag/getting-started')
+                    .expect(301)
+                    .expect('Location', '/blog/tag/getting-started/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/tag/getting-started/ should 200', function (done) {
+                request.get('/blog/tag/getting-started/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/welcome-to-ghost/amp/ should 200', function (done) {
                 var originalFn = settingsCache.get;
 
                 sandbox.stub(settingsCache, 'get', function (key) {
@@ -325,447 +620,156 @@ describe('Frontend Routing', function () {
                         return originalFn(key);
                     }
 
-                    return false;
+                    return true;
+                });
+                request.get('/blog/welcome-to-ghost/amp/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+        });
+
+        describe('Subdirectory (with slash)', function () {
+            var forkedGhost, request;
+
+            before(function (done) {
+                testUtils.fork.ghost({
+                    url: 'http://localhost/blog/'
+                }, 'testsubdir')
+                    .then(function (child) {
+                        forkedGhost = child;
+                        request = require('supertest');
+                        request = request('http://localhost:' + child.port);
+                    }).then(done).catch(done);
+            });
+
+            after(function (done) {
+                if (forkedGhost) {
+                    forkedGhost.kill(done);
+                } else {
+                    done(new Error('No forked ghost process exists, test setup must have failed.'));
+                }
+            });
+
+            it('http://localhost should 404', function (done) {
+                request.get('/')
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+
+            it('http://localhost/ should 404', function (done) {
+                request.get('/')
+                    .expect(404)
+                    .end(doEnd(done));
+            });
+
+            it('/blog should 301 to /blog/', function (done) {
+                request.get('/blog')
+                    .expect(301)
+                    .expect('Location', '/blog/')
+                    .end(doEnd(done));
+            });
+
+            it('/blog/ should 200', function (done) {
+                request.get('/blog/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/welcome-to-ghost should 301 to /blog/welcome-to-ghost/', function (done) {
+                request.get('/blog/welcome-to-ghost')
+                    .expect(301)
+                    .expect('Location', '/blog/welcome-to-ghost/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/welcome-to-ghost/ should 200', function (done) {
+                request.get('/blog/welcome-to-ghost/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
+                request.get('/blog/tag/getting-started')
+                    .expect(301)
+                    .expect('Location', '/blog/tag/getting-started/')
+                    .expect('Cache-Control', testUtils.cacheRules.year)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/tag/getting-started/ should 200', function (done) {
+                request.get('/blog/tag/getting-started/')
+                    .expect(200)
+                    .end(doEnd(done));
+            });
+
+            it('/blog/welcome-to-ghost/amp/ should 200', function (done) {
+                var originalFn = settingsCache.get;
+
+                sandbox.stub(settingsCache, 'get', function (key) {
+                    if (key !== 'amp') {
+                        return originalFn(key);
+                    }
+
+                    return true;
                 });
 
-                request.get('/welcome-to-ghost/amp/')
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-        });
-
-        describe('Static assets', function () {
-            it('should retrieve theme assets', function (done) {
-                request.get('/assets/css/screen.css')
-                    .expect('Cache-Control', testUtils.cacheRules.year)
+                request.get('/blog/welcome-to-ghost/amp/')
                     .expect(200)
                     .end(doEnd(done));
             });
 
-            it('should retrieve default robots.txt', function (done) {
-                request.get('/robots.txt')
-                    .expect('Cache-Control', testUtils.cacheRules.hour)
-                    .expect('ETag', /[0-9a-f]{32}/i)
-                    .expect(200)
-                    .end(doEnd(done));
-            });
-
-            it('should retrieve default favicon.ico', function (done) {
-                request.get('/favicon.ico')
-                    .expect('Cache-Control', testUtils.cacheRules.day)
-                    .expect('ETag', /[0-9a-f]{32}/i)
-                    .expect(200)
-                    .end(doEnd(done));
-            });
-
-            // at the moment there is no image fixture to test
-            // it('should retrieve image assets', function (done) {
-            // request.get('/content/images/some.jpg')
-            //    .expect('Cache-Control', testUtils.cacheRules.year)
-            //    .end(doEnd(done));
-            // });
-        });
-    });
-
-    describe('Static page', function () {
-        before(addPosts);
-        after(testUtils.teardown);
-
-        it('should redirect without slash', function (done) {
-            request.get('/static-page-test')
-                .expect('Location', '/static-page-test/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEnd(done));
-        });
-
-        it('should respond with xml', function (done) {
-            request.get('/static-page-test/')
-                .expect('Content-Type', /html/)
-                .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        describe('edit', function () {
-            it('should redirect without slash', function (done) {
-                request.get('/static-page-test/edit')
-                    .expect('Location', '/static-page-test/edit/')
+            it('should uncapitalise correctly with 301 to subdir', function (done) {
+                request.get('/blog/AAA/')
+                    .expect('Location', '/blog/aaa/')
                     .expect('Cache-Control', testUtils.cacheRules.year)
                     .expect(301)
                     .end(doEnd(done));
             });
-
-            it('should redirect to editor', function (done) {
-                request.get('/static-page-test/edit/')
-                    .expect('Location', /ghost\/editor\/\w+/)
-                    .expect('Cache-Control', testUtils.cacheRules.public)
-                    .expect(302)
-                    .end(doEnd(done));
-            });
-
-            it('should 404 for non-edit parameter', function (done) {
-                request.get('/static-page-test/notedit/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
         });
 
-        describe('amp', function () {
-            it('should 404 for amp parameter', function (done) {
-                request.get('/static-page-test/amp/')
-                    .expect('Cache-Control', testUtils.cacheRules.private)
-                    .expect(404)
-                    .expect(/Page not found/)
-                    .end(doEnd(done));
-            });
-        });
-    });
+        // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
+        describe('HTTPS', function () {
+            var forkedGhost, request;
 
-    describe('Post preview', function () {
-        before(addPosts);
-        after(testUtils.teardown);
-
-        it('should display draft posts accessed via uuid', function (done) {
-            request.get('/p/d52c42ae-2755-455c-80ec-70b2ec55c903/')
-                .expect('Content-Type', /html/)
-                .expect(200)
-                .end(function (err, res) {
-                    if (err) {
-                        return done(err);
+            before(function (done) {
+                testUtils.fork.ghost({
+                    url: 'http://localhost:2370/',
+                    server: {
+                        port: 2370
                     }
-
-                    var $ = cheerio.load(res.text);
-
-                    should.not.exist(res.headers['x-cache-invalidate']);
-                    should.not.exist(res.headers['X-CSRF-Token']);
-                    should.not.exist(res.headers['set-cookie']);
-                    should.exist(res.headers.date);
-
-                    $('title').text().should.equal('Not finished yet');
-                    $('.content .post').length.should.equal(1);
-                    $('.poweredby').text().should.equal('Proudly published with Ghost');
-                    $('body.post-template').length.should.equal(1);
-                    $('article.post').length.should.equal(1);
-
-                    done();
-                });
-        });
-
-        it('should redirect published posts to their live url', function (done) {
-            request.get('/p/2ac6b4f6-e1f3-406c-9247-c94a0496d39d/')
-                .expect(301)
-                .expect('Location', '/short-and-sweet/')
-                .expect('Cache-Control', testUtils.cacheRules.public)
-                .end(doEnd(done));
-        });
-
-        it('404s unknown uuids', function (done) {
-            request.get('/p/aac6b4f6-e1f3-406c-9247-c94a0496d39f/')
-                .expect(404)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Post with Ghost in the url', function () {
-        before(addPosts);
-        after(testUtils.teardown);
-
-        // All of Ghost's admin depends on the /ghost/ in the url to work properly
-        // Badly formed regexs can cause breakage if a post slug starts with the 5 letters ghost
-        it('should retrieve a blog post with ghost at the start of the url', function (done) {
-            request.get('/ghostly-kitchen-sink/')
-                .expect('Cache-Control', testUtils.cacheRules.public)
-                .expect(200)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Subdirectory (no slash)', function () {
-        var forkedGhost, request;
-
-        before(function (done) {
-            testUtils.fork.ghost({
-                url: 'http://localhost/blog'
-            }, 'testsubdir')
-                .then(function (child) {
-                    forkedGhost = child;
-                    request = require('supertest');
-                    request = request('http://localhost:' + child.port);
-                }).then(done).catch(done);
-        });
-
-        after(function (done) {
-            if (forkedGhost) {
-                forkedGhost.kill(done);
-            } else {
-                done(new Error('No forked ghost process exists, test setup must have failed.'));
-            }
-        });
-
-        it('http://localhost should 404', function (done) {
-            request.get('/')
-                .expect(404)
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/ should 404', function (done) {
-            request.get('/')
-                .expect(404)
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/blog should 301 to  http://localhost/blog/', function (done) {
-            request.get('/blog')
-                .expect(301)
-                .expect('Location', '/blog/')
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/blog/ should 200', function (done) {
-            request.get('/blog/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/blog/welcome-to-ghost should 301 to http://localhost/blog/welcome-to-ghost/', function (done) {
-            request.get('/blog/welcome-to-ghost')
-                .expect(301)
-                .expect('Location', '/blog/welcome-to-ghost/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/blog/welcome-to-ghost/ should 200', function (done) {
-            request.get('/blog/welcome-to-ghost/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
-            request.get('/blog/tag/getting-started')
-                .expect(301)
-                .expect('Location', '/blog/tag/getting-started/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .end(doEnd(done));
-        });
-
-        it('/blog/tag/getting-started/ should 200', function (done) {
-            request.get('/blog/tag/getting-started/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('/blog/welcome-to-ghost/amp/ should 200', function (done) {
-            var originalFn = settingsCache.get;
-
-            sandbox.stub(settingsCache, 'get', function (key) {
-                if (key !== 'amp') {
-                    return originalFn(key);
-                }
-
-                return true;
+                }, 'testhttps')
+                    .then(function (child) {
+                        forkedGhost = child;
+                        request = require('supertest');
+                        request = request('http://localhost:2370');
+                    }).then(done).catch(done);
             });
 
-            request.get('/blog/welcome-to-ghost/amp/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Subdirectory (with slash)', function () {
-        var forkedGhost, request;
-
-        before(function (done) {
-            testUtils.fork.ghost({
-                url: 'http://localhost/blog/'
-            }, 'testsubdir')
-                .then(function (child) {
-                    forkedGhost = child;
-                    request = require('supertest');
-                    request = request('http://localhost:' + child.port);
-                }).then(done).catch(done);
-        });
-
-        after(function (done) {
-            if (forkedGhost) {
-                forkedGhost.kill(done);
-            } else {
-                done(new Error('No forked ghost process exists, test setup must have failed.'));
-            }
-        });
-
-        it('http://localhost should 404', function (done) {
-            request.get('/')
-                .expect(404)
-                .end(doEnd(done));
-        });
-
-        it('http://localhost/ should 404', function (done) {
-            request.get('/')
-                .expect(404)
-                .end(doEnd(done));
-        });
-
-        it('/blog should 301 to /blog/', function (done) {
-            request.get('/blog')
-                .expect(301)
-                .expect('Location', '/blog/')
-                .end(doEnd(done));
-        });
-
-        it('/blog/ should 200', function (done) {
-            request.get('/blog/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('/blog/welcome-to-ghost should 301 to /blog/welcome-to-ghost/', function (done) {
-            request.get('/blog/welcome-to-ghost')
-                .expect(301)
-                .expect('Location', '/blog/welcome-to-ghost/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .end(doEnd(done));
-        });
-
-        it('/blog/welcome-to-ghost/ should 200', function (done) {
-            request.get('/blog/welcome-to-ghost/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('/blog/tag/getting-started should 301 to /blog/tag/getting-started/', function (done) {
-            request.get('/blog/tag/getting-started')
-                .expect(301)
-                .expect('Location', '/blog/tag/getting-started/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .end(doEnd(done));
-        });
-
-        it('/blog/tag/getting-started/ should 200', function (done) {
-            request.get('/blog/tag/getting-started/')
-                .expect(200)
-                .end(doEnd(done));
-        });
-
-        it('/blog/welcome-to-ghost/amp/ should 200', function (done) {
-            var originalFn = settingsCache.get;
-
-            sandbox.stub(settingsCache, 'get', function (key) {
-                if (key !== 'amp') {
-                    return originalFn(key);
+            after(function (done) {
+                if (forkedGhost) {
+                    forkedGhost.kill(done);
+                } else {
+                    done(new Error('No forked ghost process exists, test setup must have failed.'));
                 }
-
-                return true;
             });
 
-            request.get('/blog/welcome-to-ghost/amp/')
-                .expect(200)
-                .end(doEnd(done));
+            it('should set links to url over non-HTTPS', function (done) {
+                request.get('/')
+                    .expect(200)
+                    .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
+                    .expect(/<a href="http:\/\/localhost:2370\/">Ghost<\/a\>/)
+                    .end(doEnd(done));
+            });
+
+            it('should set links over HTTPS besides canonical', function (done) {
+                request.get('/')
+                    .set('X-Forwarded-Proto', 'https')
+                    .expect(200)
+                    .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
+                    .expect(/<a href="https:\/\/localhost:2370\/">Ghost<\/a\>/)
+                    .end(doEnd(done));
+            });
         });
-
-        it('should uncapitalise correctly with 301 to subdir', function (done) {
-            request.get('/blog/AAA/')
-                .expect('Location', '/blog/aaa/')
-                .expect('Cache-Control', testUtils.cacheRules.year)
-                .expect(301)
-                .end(doEnd(done));
-        });
-    });
-
-    // we'll use X-Forwarded-Proto: https to simulate an 'https://' request behind a proxy
-    describe('HTTPS', function () {
-        var forkedGhost, request;
-
-        before(function (done) {
-            testUtils.fork.ghost({
-                forceAdminSSL: {redirect: false},
-                url: 'http://localhost:2370/',
-                server: {
-                    port: 2370
-                }
-            }, 'testhttps')
-                .then(function (child) {
-                    forkedGhost = child;
-                    request = require('supertest');
-                    request = request('http://localhost:2370');
-                }).then(done).catch(done);
-        });
-
-        after(function (done) {
-            if (forkedGhost) {
-                forkedGhost.kill(done);
-            } else {
-                done(new Error('No forked ghost process exists, test setup must have failed.'));
-            }
-        });
-
-        it('should set links to url over non-HTTPS', function (done) {
-            request.get('/')
-                .expect(200)
-                .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
-                .expect(/<a href="http:\/\/localhost:2370\/">Ghost<\/a\>/)
-                .end(doEnd(done));
-        });
-
-        // @TODO: does not work because of the theme-handler missing secure option right now
-        it.skip('should set links over HTTPS besides canonical', function (done) {
-            request.get('/')
-                .set('X-Forwarded-Proto', 'https')
-                .expect(200)
-                .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
-                .expect(/<a href="https:\/\/localhost:2370">Ghost<\/a\>/)
-                .end(doEnd(done));
-        });
-    });
-
-    describe('Site Map', function () {
-        before(testUtils.teardown);
-
-        before(function (done) {
-            testUtils.initData().then(function () {
-                return testUtils.fixtures.insertPostsAndTags();
-            }).then(function () {
-                done();
-            }).catch(done);
-        });
-
-        it('should serve sitemap.xml', function (done) {
-            request.get('/sitemap.xml')
-                .expect(200)
-                .expect('Cache-Control', testUtils.cacheRules.hour)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(function (err, res) {
-                    res.text.should.match(/sitemapindex/);
-                    doEnd(done)(err, res);
-                });
-        });
-
-        it('should serve sitemap-posts.xml', function (done) {
-            request.get('/sitemap-posts.xml')
-                .expect(200)
-                .expect('Cache-Control', testUtils.cacheRules.hour)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(function (err, res) {
-                    res.text.should.match(/urlset/);
-                    doEnd(done)(err, res);
-                });
-        });
-
-        it('should serve sitemap-pages.xml', function (done) {
-            request.get('/sitemap-posts.xml')
-                .expect(200)
-                .expect('Cache-Control', testUtils.cacheRules.hour)
-                .expect('Content-Type', 'text/xml; charset=utf-8')
-                .end(function (err, res) {
-                    res.text.should.match(/urlset/);
-                    doEnd(done)(err, res);
-                });
-        });
-
-        // TODO: Other pages and verify content
     });
 });

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -683,7 +683,7 @@ describe('Frontend Routing', function () {
         before(function (done) {
             testUtils.fork.ghost({
                 forceAdminSSL: {redirect: false},
-                urlSSL: 'https://localhost/',
+                url: 'http://localhost:2370/',
                 server: {
                     port: 2370
                 }
@@ -691,7 +691,7 @@ describe('Frontend Routing', function () {
                 .then(function (child) {
                     forkedGhost = child;
                     request = require('supertest');
-                    request = request('http://127.0.0.1:2370');
+                    request = request('http://localhost:2370');
                 }).then(done).catch(done);
         });
 
@@ -706,17 +706,18 @@ describe('Frontend Routing', function () {
         it('should set links to url over non-HTTPS', function (done) {
             request.get('/')
                 .expect(200)
-                .expect(/<link rel="canonical" href="http:\/\/127.0.0.1:2370\/" \/\>/)
-                .expect(/<a href="http:\/\/127.0.0.1:2370\/">Ghost<\/a\>/)
+                .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
+                .expect(/<a href="http:\/\/localhost:2370\/">Ghost<\/a\>/)
                 .end(doEnd(done));
         });
 
-        it('should set links to urlSSL over HTTPS besides canonical', function (done) {
+        // @TODO: does not work because of the theme-handler missing secure option right now
+        it.skip('should set links over HTTPS besides canonical', function (done) {
             request.get('/')
                 .set('X-Forwarded-Proto', 'https')
                 .expect(200)
-                .expect(/<link rel="canonical" href="http:\/\/127.0.0.1:2370\/" \/\>/)
-                .expect(/<a href="https:\/\/localhost">Ghost<\/a\>/)
+                .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
+                .expect(/<a href="https:\/\/localhost:2370">Ghost<\/a\>/)
                 .end(doEnd(done));
         });
     });

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -9,6 +9,7 @@ var request = require('supertest'),
     sinon = require('sinon'),
     cheerio = require('cheerio'),
     testUtils = require('../../utils'),
+    config = require('../../../server/config'),
     settingsCache = require('../../../server/api/settings').cache,
     sandbox = sinon.sandbox.create(),
     ghost   = testUtils.startGhost;
@@ -39,13 +40,17 @@ describe('Frontend Routing', function () {
         });
     }
 
+    afterEach(function () {
+        sandbox.restore();
+    });
+
     describe('NO FORK', function () {
         before(function (done) {
             ghost().then(function (_ghostServer) {
                 ghostServer = _ghostServer;
                 return ghostServer.start();
             }).then(function () {
-                request = request(configUtils.config.get('url'));
+                request = request(config.get('url'));
                 done();
             }).catch(function (e) {
                 console.log('Ghost Error: ', e);

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -114,10 +114,11 @@ describe('Ghost Ajax Helper', function () {
         configUtils.set({
             url: 'https://testblog.com/'
         });
+
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: utils.url.urlFor('api', true)
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -136,7 +137,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: utils.url.urlFor('api', true)
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});

--- a/core/test/unit/ghost_url_spec.js
+++ b/core/test/unit/ghost_url_spec.js
@@ -30,7 +30,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -40,7 +40,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         ghostUrl.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -50,7 +50,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         ghostUrl.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -60,7 +60,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostUrl.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -98,7 +98,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -117,7 +117,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -136,7 +136,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostUrl.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -156,7 +156,7 @@ describe('Ghost Ajax Helper', function () {
         ghostUrl.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.apiUrl({cors: true})
+            url: utils.url.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostUrl.url.api('posts', {limit: 3}),

--- a/core/test/unit/middleware/api/cors_spec.js
+++ b/core/test/unit/middleware/api/cors_spec.js
@@ -159,5 +159,25 @@ describe('cors', function () {
         done();
     });
 
-    //@TODO: add test for admin.url
+    it('should be enabled if the origin matches config.url', function (done) {
+        var origin = 'http://admin:2222';
+
+        configUtils.set({
+            url: 'https://blog',
+            admin: {
+                url: origin
+            }
+        });
+
+        req.get = sinon.stub().withArgs('origin').returns(origin);
+        res.get = sinon.stub().withArgs('origin').returns(origin);
+        req.headers.origin = origin;
+
+        cors(req, res, next);
+
+        next.called.should.be.true();
+        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
+
+        done();
+    });
 });

--- a/core/test/unit/middleware/api/cors_spec.js
+++ b/core/test/unit/middleware/api/cors_spec.js
@@ -159,22 +159,5 @@ describe('cors', function () {
         done();
     });
 
-    it('should be enabled if the origin matches config.urlSSL', function (done) {
-        var origin = 'https://secure.blog';
-        configUtils.set({
-            url: 'http://my.blog',
-            urlSSL:  origin
-        });
-
-        req.get = sinon.stub().withArgs('origin').returns(origin);
-        res.get = sinon.stub().withArgs('origin').returns(origin);
-        req.headers.origin = origin;
-
-        cors(req, res, next);
-
-        next.called.should.be.true();
-        res.headers['Access-Control-Allow-Origin'].should.equal(origin);
-
-        done();
-    });
+    //@TODO: add test for admin.url
 });

--- a/core/test/unit/middleware/check-ssl_spec.js
+++ b/core/test/unit/middleware/check-ssl_spec.js
@@ -1,201 +1,196 @@
-var sinon    = require('sinon'),
-    should   = require('should'),
+var sinon = require('sinon'),
+    should = require('should'),
     configUtils = require('../../utils/configUtils'),
-    checkSSL = require('../../../server/middleware/check-ssl');
+    checkSSL = require('../../../server/middleware/check-ssl'),
+    sandbox = sinon.sandbox.create();
 
 should.equal(true, true);
 
 describe('checkSSL', function () {
-    var res, req, next, sandbox;
+    var res, req, next, host;
 
     beforeEach(function () {
-        sandbox = sinon.sandbox.create();
-        req = {};
-        res = {};
-        next = sandbox.spy();
+        req = {
+            get: function get() {
+                return host;
+            }
+        };
+        res = {
+            redirect: sandbox.spy()
+        };
 
-        configUtils.set({
-            url: 'http://default.com:2368/'
-        });
+        next = sandbox.spy();
     });
 
     afterEach(function () {
         sandbox.restore();
         configUtils.restore();
+        host = null;
     });
 
-    it('should not require SSL (frontend)', function (done) {
+    it('blog is http, requester uses http', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368/'
+        });
+
+        host = 'default.com:2368';
+
         req.originalUrl = '/';
         checkSSL(req, res, next);
         next.called.should.be.true();
+        res.redirect.called.should.be.false();
         next.calledWith().should.be.true();
         done();
     });
 
-    it('should require SSL (frontend)', function (done) {
+    it('blog is https, requester uses https', function (done) {
+        configUtils.set({
+            url: 'https://default.com:2368/'
+        });
+
+        host = 'default.com:2368';
+
         req.originalUrl = '/';
         req.secure = true;
         checkSSL(req, res, next);
         next.called.should.be.true();
+        res.redirect.called.should.be.false();
         next.calledWith().should.be.true();
         done();
     });
 
-    it('should not require SSL (admin)', function (done) {
-        req.originalUrl = '/ghost';
-        res.isAdmin = true;
-        checkSSL(req, res, next);
-        next.called.should.be.true();
-        next.calledWith().should.be.true();
-        done();
-    });
-
-    it('should not redirect with SSL (admin)', function (done) {
-        req.originalUrl = '/ghost';
-        res.isAdmin = true;
-        res.secure = true;
-
-        checkSSL(req, res, next);
-        next.called.should.be.true();
-        next.calledWith().should.be.true();
-        done();
-    });
-
-    it('should not redirect with force admin SSL (admin)', function (done) {
-        req.originalUrl = '/ghost';
-        res.isAdmin = true;
-        req.secure = true;
+    it('blog is https, requester uses http [redirect]', function (done) {
         configUtils.set({
-            url: 'http://default.com:2368/',
-            forceAdminSSL: true
-        });
-        checkSSL(req, res, next);
-        next.called.should.be.true();
-        next.calledWith().should.be.true();
-        done();
-    });
-
-    it('should redirect with force admin SSL (admin)', function (done) {
-        req.originalUrl = '/ghost/';
-        res.isAdmin = true;
-        res.redirect = {};
-        req.secure = false;
-        configUtils.set({
-            url: 'http://default.com:2368/',
-            forceAdminSSL: true
+            url: 'https://default.com:2368/'
         });
 
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://default.com:2368/ghost/');
-            return;
-        });
-        checkSSL(req, res, next);
-        next.called.should.be.false();
-        done();
-    });
+        host = 'default.com:2368';
 
-    it('should redirect to subdirectory with force admin SSL (admin)', function (done) {
-        req.originalUrl = '/blog/ghost/';
-        res.isAdmin = true;
-        res.redirect = {};
-        req.secure = false;
-        configUtils.set({
-            url: 'http://default.com:2368/blog/',
-            forceAdminSSL: true
-        });
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://default.com:2368/blog/ghost/');
-            return;
-        });
-        checkSSL(req, res, next);
-        next.called.should.be.false();
-        done();
-    });
-
-    it('should redirect and keep query with force admin SSL (admin)', function (done) {
-        req.originalUrl = '/ghost/';
-        req.query = {
-            test: 'true'
-        };
-        res.isAdmin = true;
-        res.redirect = {};
-        req.secure = false;
-        configUtils.set({
-            url: 'http://default.com:2368/',
-            forceAdminSSL: true
-        });
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://default.com:2368/ghost/?test=true');
-            return;
-        });
-        checkSSL(req, res, next);
-        next.called.should.be.false();
-        done();
-    });
-
-    it('should redirect with with config.url being SSL (frontend)', function (done) {
         req.originalUrl = '/';
-        req.secure = false;
-        res.redirect = {};
-        configUtils.set({
-            url: 'https://default.com:2368',
-            forceAdminSSL: true
-        });
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://default.com:2368/');
-            return;
-        });
         checkSSL(req, res, next);
         next.called.should.be.false();
+        res.redirect.called.should.be.true();
         done();
     });
 
-    it('should not redirect if redirect:false (admin)', function (done) {
-        req.originalUrl = '/ghost/';
-        res.isAdmin = true;
-        res.sendStatus = {};
-        req.secure = false;
+    it('blog is http, requester uses https', function (done) {
         configUtils.set({
-            url: 'http://default.com:2368/',
-            forceAdminSSL: {
-                redirect: false
+            url: 'http://default.com:2368/'
+        });
+
+        host = 'default.com:2368';
+
+        req.originalUrl = '/';
+        req.secure = true;
+        checkSSL(req, res, next);
+        next.called.should.be.true();
+        res.redirect.called.should.be.false();
+        done();
+    });
+
+    it('blog is http, requester uses https', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368/'
+        });
+
+        host = 'default.com:2368/';
+
+        req.originalUrl = '/';
+        req.secure = true;
+        checkSSL(req, res, next);
+        next.called.should.be.true();
+        res.redirect.called.should.be.false();
+        done();
+    });
+
+    it('admin is blog url and http, requester is http', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368'
+        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/ghost';
+        checkSSL(req, res, next);
+        next.called.should.be.true();
+        res.redirect.called.should.be.false();
+        done();
+    });
+
+    it('admin is custom url and https, requester is http [redirect]', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368',
+            admin: {
+                url: 'https://default.com:2368'
             }
         });
-        sandbox.stub(res, 'sendStatus', function (statusCode) {
-            statusCode.should.eql(403);
-            return;
-        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/ghost';
         checkSSL(req, res, next);
         next.called.should.be.false();
+        res.redirect.calledWith(301, 'https://default.com:2368/ghost').should.be.true();
         done();
     });
 
-    it('should redirect to correct path with force admin SSL (admin as subapp)', function (done) {
-        req.url = '/';
-        req.originalUrl = '/ghost/';
-        res.isAdmin = true;
-        res.redirect = {};
-        req.secure = false;
+    it('admin is custom url and https, requester is http [redirect]', function (done) {
         configUtils.set({
-            url: 'http://default.com:2368/',
-            forceAdminSSL: true
+            url: 'http://default.com:2368',
+            admin: {
+                url: 'https://admin.default.com:2368'
+            }
         });
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://default.com:2368/ghost/');
-            return;
-        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/ghost';
         checkSSL(req, res, next);
         next.called.should.be.false();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost').should.be.true();
+        done();
+    });
+
+    it('subdirectory [redirect]', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368/blog',
+            admin: {
+                url: 'https://admin.default.com:2368'
+            }
+        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/blog/ghost';
+        checkSSL(req, res, next);
+        next.called.should.be.false();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/blog/ghost').should.be.true();
+        done();
+    });
+
+    it('keeps query [redirect]', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368',
+            admin: {
+                url: 'https://admin.default.com:2368'
+            }
+        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/ghost';
+        req.query = {
+            test: true
+        };
+
+        checkSSL(req, res, next);
+        next.called.should.be.false();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost?test=true').should.be.true();
         done();
     });
 });

--- a/core/test/unit/middleware/check-ssl_spec.js
+++ b/core/test/unit/middleware/check-ssl_spec.js
@@ -82,9 +82,9 @@ describe('checkSSL', function () {
         req.secure = false;
         configUtils.set({
             url: 'http://default.com:2368/',
-            urlSSL: '',
             forceAdminSSL: true
         });
+
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
             url.should.not.be.empty();
@@ -103,7 +103,6 @@ describe('checkSSL', function () {
         req.secure = false;
         configUtils.set({
             url: 'http://default.com:2368/blog/',
-            urlSSL: '',
             forceAdminSSL: true
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
@@ -127,7 +126,6 @@ describe('checkSSL', function () {
         req.secure = false;
         configUtils.set({
             url: 'http://default.com:2368/',
-            urlSSL: '',
             forceAdminSSL: true
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
@@ -147,34 +145,12 @@ describe('checkSSL', function () {
         res.redirect = {};
         configUtils.set({
             url: 'https://default.com:2368',
-            urlSSL: '',
             forceAdminSSL: true
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {
             statusCode.should.eql(301);
             url.should.not.be.empty();
             url.should.eql('https://default.com:2368/');
-            return;
-        });
-        checkSSL(req, res, next);
-        next.called.should.be.false();
-        done();
-    });
-
-    it('should redirect to urlSSL (admin)', function (done) {
-        req.originalUrl = '/ghost/';
-        res.isAdmin = true;
-        res.redirect = {};
-        req.secure = false;
-        configUtils.set({
-            url: 'http://default.com:2368/',
-            urlSSL: 'https://ssl-domain.com:2368/',
-            forceAdminSSL: true
-        });
-        sandbox.stub(res, 'redirect', function (statusCode, url) {
-            statusCode.should.eql(301);
-            url.should.not.be.empty();
-            url.should.eql('https://ssl-domain.com:2368/ghost/');
             return;
         });
         checkSSL(req, res, next);
@@ -210,7 +186,6 @@ describe('checkSSL', function () {
         req.secure = false;
         configUtils.set({
             url: 'http://default.com:2368/',
-            urlSSL: '',
             forceAdminSSL: true
         });
         sandbox.stub(res, 'redirect', function (statusCode, url) {

--- a/core/test/unit/middleware/theme-handler_spec.js
+++ b/core/test/unit/middleware/theme-handler_spec.js
@@ -67,23 +67,6 @@ describe('Theme Handler', function () {
             next.called.should.be.true();
         });
 
-        it('handles secure context', function () {
-            var themeOptSpy = sandbox.stub(hbs, 'updateTemplateOptions');
-            req.secure = true;
-            res.locals = {};
-            configUtils.set({urlSSL: 'https://secure.blog'});
-
-            themeHandler.configHbsForContext(req, res, next);
-
-            themeOptSpy.calledOnce.should.be.true();
-            themeOptSpy.firstCall.args[0].should.be.an.Object().and.have.property('data');
-            themeOptSpy.firstCall.args[0].data.should.be.an.Object().and.have.property('blog');
-            themeOptSpy.firstCall.args[0].data.blog.should.be.an.Object().and.have.property('url');
-            themeOptSpy.firstCall.args[0].data.blog.url.should.eql('https://secure.blog');
-            res.locals.secure.should.equal(true);
-            next.called.should.be.true();
-        });
-
         it('sets view path', function () {
             req.secure = true;
             res.locals = {};

--- a/core/test/unit/middleware/url-redirects_spec.js
+++ b/core/test/unit/middleware/url-redirects_spec.js
@@ -1,7 +1,7 @@
 var sinon = require('sinon'),
     should = require('should'),
     configUtils = require('../../utils/configUtils'),
-    checkSSL = require('../../../server/middleware/check-ssl'),
+    urlRedirects = require('../../../server/middleware/url-redirects'),
     sandbox = sinon.sandbox.create();
 
 should.equal(true, true);
@@ -36,7 +36,7 @@ describe('checkSSL', function () {
         host = 'default.com:2368';
 
         req.originalUrl = '/';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
         next.calledWith().should.be.true();
@@ -52,7 +52,7 @@ describe('checkSSL', function () {
 
         req.originalUrl = '/';
         req.secure = true;
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
         next.calledWith().should.be.true();
@@ -67,7 +67,7 @@ describe('checkSSL', function () {
         host = 'default.com:2368';
 
         req.originalUrl = '/';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.called.should.be.true();
         done();
@@ -82,7 +82,7 @@ describe('checkSSL', function () {
 
         req.originalUrl = '/';
         req.secure = true;
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
         done();
@@ -97,7 +97,7 @@ describe('checkSSL', function () {
 
         req.originalUrl = '/';
         req.secure = true;
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
         done();
@@ -112,7 +112,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
 
         req.originalUrl = '/ghost';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
         done();
@@ -130,7 +130,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
 
         req.originalUrl = '/ghost';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://default.com:2368/ghost').should.be.true();
         done();
@@ -148,7 +148,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
 
         req.originalUrl = '/ghost';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost').should.be.true();
         done();
@@ -166,7 +166,7 @@ describe('checkSSL', function () {
         res.isAdmin = true;
 
         req.originalUrl = '/blog/ghost';
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/blog/ghost').should.be.true();
         done();
@@ -188,7 +188,7 @@ describe('checkSSL', function () {
             test: true
         };
 
-        checkSSL(req, res, next);
+        urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost?test=true').should.be.true();
         done();

--- a/core/test/unit/slack_spec.js
+++ b/core/test/unit/slack_spec.js
@@ -195,7 +195,7 @@ describe('Slack', function () {
             isPostStub.returns(false);
             settingsObj.settings[0] = slackObjWithUrl;
 
-            configUtils.set('forceAdminSSL', true);
+            configUtils.set('url', 'https://myblog.com');
 
             // assertions
             makeRequestAssertions = function (requestOptions, requestData) {

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -291,8 +291,8 @@ describe('Url', function () {
             utils.url.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
             utils.url.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
 
-            utils.url.urlFor('api').should.equal('/ghost/api/v0.1');
-            utils.url.urlFor('api', true).should.equal('http://my-ghost-blog.com/ghost/api/v0.1');
+            utils.url.urlFor('api').should.equal('/ghost/api/v0.1/');
+            utils.url.urlFor('api', true).should.equal('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('admin: relative', function () {
@@ -343,6 +343,77 @@ describe('Url', function () {
             });
 
             utils.url.urlFor('admin').should.equal('/blog/ghost/');
+        });
+
+        it('should return https config.url if forceAdminSSL set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                forceAdminSSL: true
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return https config.urlSSL if forceAdminSSL set and urlSSL is misconfigured', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                urlSSL: 'http://other-ghost-blog.com',
+                forceAdminSSL: true
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return https config.urlSSL if forceAdminSSL set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                urlSSL: 'https://other-ghost-blog.com',
+                forceAdminSSL: true
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return https config.urlSSL if set and misconfigured & forceAdminSSL is NOT set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                urlSSL: 'http://other-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return https config.urlSSL if set & forceAdminSSL is NOT set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                urlSSL: 'https://other-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return https config.url if config.url is https & forceAdminSSL is NOT set', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('CORS: should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('should return protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
     });
 
@@ -430,79 +501,6 @@ describe('Url', function () {
             postLink = postLink.replace('DD', nowMoment.format('DD'));
 
             utils.url.urlPathForPost(testData).should.equal(postLink);
-        });
-    });
-
-    describe('apiUrl', function () {
-        it('should return https config.url if forceAdminSSL set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                forceAdminSSL: true
-            });
-
-            utils.url.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if forceAdminSSL set and urlSSL is misconfigured', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'http://other-ghost-blog.com',
-                forceAdminSSL: true
-            });
-
-            utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if forceAdminSSL set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'https://other-ghost-blog.com',
-                forceAdminSSL: true
-            });
-
-            utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if set and misconfigured & forceAdminSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'http://other-ghost-blog.com'
-            });
-
-            utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if set & forceAdminSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'https://other-ghost-blog.com'
-            });
-
-            utils.url.apiUrl().should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.url if config.url is https & forceAdminSSL is NOT set', function () {
-            configUtils.set({
-                url: 'https://my-ghost-blog.com'
-            });
-
-            utils.url.apiUrl().should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('CORS: should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com'
-            });
-
-            utils.url.apiUrl({cors: true}).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com'
-            });
-
-            utils.url.apiUrl().should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
     });
 });

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -286,13 +286,10 @@ describe('Url', function () {
             utils.url.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
         });
 
-        it('should return other known paths when requested', function () {
+        it('sitemap: should return other known paths when requested', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
             utils.url.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
             utils.url.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
-
-            utils.url.urlFor('api').should.equal('/ghost/api/v0.1/');
-            utils.url.urlFor('api', true).should.equal('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('admin: relative', function () {
@@ -303,7 +300,7 @@ describe('Url', function () {
             utils.url.urlFor('admin').should.equal('/ghost/');
         });
 
-        it('admin: forceAdminSSL is false', function () {
+        it('admin: url is http', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com'
             });
@@ -311,27 +308,28 @@ describe('Url', function () {
             utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/ghost/');
         });
 
-        it('admin: forceAdminSSL is true', function () {
+        it('admin: custom admin url is set', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com',
-                forceAdminSSL: true
+                admin: {
+                    url: 'https://admin.my-ghost-blog.com'
+                }
             });
 
-            utils.url.urlFor('admin', true).should.equal('https://my-ghost-blog.com/ghost/');
-        });
-
-        it('admin: forceAdminSSL is true', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                forceAdminSSL: true
-            });
-
-            utils.url.urlFor('admin', true).should.equal('https://my-ghost-blog.com/ghost/');
+            utils.url.urlFor('admin', true).should.equal('https://admin.my-ghost-blog.com/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com/blog'
+            });
+
+            utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
+        });
+
+        it('admin: blog is on subdir', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com/blog/'
             });
 
             utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
@@ -345,16 +343,70 @@ describe('Url', function () {
             utils.url.urlFor('admin').should.equal('/blog/ghost/');
         });
 
-        it('should return https config.url if forceAdminSSL set', function () {
+        it('admin: blog is on subdir', function () {
             configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                forceAdminSSL: true
+                url: 'http://my-ghost-blog.com/blog',
+                admin: {
+                    url: 'http://something.com'
+                }
             });
 
-            utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
-        it('should return http if config.url is http & forceAdminSSL is NOT set', function () {
+        it('admin: blog is on subdir', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com/blog',
+                admin: {
+                    url: 'http://something.com/blog'
+                }
+            });
+
+            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+        });
+
+        it('admin: blog is on subdir', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com/blog',
+                admin: {
+                    url: 'http://something.com/blog/'
+                }
+            });
+
+            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+        });
+
+        it('admin: blog is on subdir', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com/blog/',
+                admin: {
+                    url: 'http://something.com/blog'
+                }
+            });
+
+            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+        });
+
+        it('api: should return admin url is set', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                admin: {
+                    url: 'https://something.de'
+                }
+            });
+
+            utils.url.urlFor('api', true).should.eql('https://something.de/ghost/api/v0.1/');
+        });
+
+        it('api: url has subdir', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com/blog'
+            });
+
+            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
+        });
+
+        it('api: should return http if config.url is http', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com'
             });
@@ -362,7 +414,7 @@ describe('Url', function () {
             utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('should return https if config.url is https & forceAdminSSL is NOT set', function () {
+        it('api: should return https if config.url is https', function () {
             configUtils.set({
                 url: 'https://my-ghost-blog.com'
             });
@@ -370,7 +422,7 @@ describe('Url', function () {
             utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('CORS: should return no protocol', function () {
+        it('api: cors should return no protocol', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com'
             });

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -104,22 +104,22 @@ describe('Url', function () {
         it('should return home url when asked for', function () {
             var testContext = 'home';
 
-            configUtils.set({url: 'http://my-ghost-blog.com', urlSSL: 'https://my-ghost-blog.com'});
+            configUtils.set({url: 'http://my-ghost-blog.com'});
             utils.url.urlFor(testContext).should.equal('/');
             utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
             utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
 
-            configUtils.set({url: 'http://my-ghost-blog.com/', urlSSL: 'https://my-ghost-blog.com/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/'});
             utils.url.urlFor(testContext).should.equal('/');
             utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
             utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
 
-            configUtils.set({url: 'http://my-ghost-blog.com/blog', urlSSL: 'https://my-ghost-blog.com/blog'});
+            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
             utils.url.urlFor(testContext).should.equal('/blog/');
             utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
             utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
 
-            configUtils.set({url: 'http://my-ghost-blog.com/blog/', urlSSL: 'https://my-ghost-blog.com/blog/'});
+            configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
             utils.url.urlFor(testContext).should.equal('/blog/');
             utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
             utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
@@ -245,7 +245,7 @@ describe('Url', function () {
             var testContext = 'nav',
                 testData;
 
-            configUtils.set({url: 'http://my-ghost-blog.com', urlSSL: 'https://my-ghost-blog.com'});
+            configUtils.set({url: 'http://my-ghost-blog.com'});
 
             testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}};
             utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
@@ -354,45 +354,15 @@ describe('Url', function () {
             utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('should return https config.urlSSL if forceAdminSSL set and urlSSL is misconfigured', function () {
+        it('should return http if config.url is http & forceAdminSSL is NOT set', function () {
             configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'http://other-ghost-blog.com',
-                forceAdminSSL: true
+                url: 'http://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
+            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('should return https config.urlSSL if forceAdminSSL set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'https://other-ghost-blog.com',
-                forceAdminSSL: true
-            });
-
-            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if set and misconfigured & forceAdminSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'http://other-ghost-blog.com'
-            });
-
-            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.urlSSL if set & forceAdminSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com',
-                urlSSL: 'https://other-ghost-blog.com'
-            });
-
-            utils.url.urlFor('api', true).should.eql('https://other-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return https config.url if config.url is https & forceAdminSSL is NOT set', function () {
+        it('should return https if config.url is https & forceAdminSSL is NOT set', function () {
             configUtils.set({
                 url: 'https://my-ghost-blog.com'
             });
@@ -400,20 +370,12 @@ describe('Url', function () {
             utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('CORS: should return no protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
+        it('CORS: should return no protocol', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com'
             });
 
             utils.url.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
-        });
-
-        it('should return protocol config.url if config.url is NOT https & forceAdminSSL/urlSSL is NOT set', function () {
-            configUtils.set({
-                url: 'http://my-ghost-blog.com'
-            });
-
-            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
     });
 

--- a/core/test/utils/configUtils.js
+++ b/core/test/utils/configUtils.js
@@ -27,6 +27,12 @@ configUtils.set = function () {
  * nconf keeps this as a reference and then it can happen that the defaultConfig get's overridden by new values
  */
 configUtils.restore = function () {
+    /**
+     * we have to reset the whole config object
+     * config keys, which get set via a test and do not exist in the config files, won't get reseted
+     */
+    config.reset();
+
     _.each(configUtils.defaultConfig, function (value, key) {
         config.set(key, _.cloneDeep(value));
     });


### PR DESCRIPTION
refs #7488 

We would like to remove the following config options:

- `forceAdminSSL`
- `urlSSL`

### forceAdminSSL

This option was added to be able to force users to serve the admin area via HTTPS.

### urlSSL

This option was originally added because of Heroku. It required a different domain/url for SSL to non-SSL.

---

Both config options were always confusing and as we are now going to release `1.0.0`, we would like to change this by adding an optional admin config.

```
url: 'http://your-blog.com',
admin: {
   url: 'https://admin.your-blog.com'
}
```

```
url: 'https://your-blog.com'
```

```
url: 'http://your-blog.com',
admin: {
   url: 'https://your-blog.com'
}
```

More information will be available when we release `1.0.0` and it's documenation.

- [x] add description
- [x] extend commit messages (tests === might solve some random failures in travis!)
- [x] rename check-ssl to redirects-and-ssl or similar - if time
- [x] add comments on the most important code changes
- [x] code audit
- [x] browser test
- [x] wait for config merges
- [x] req.host behind proxy