### PR TITLE
🐛  require overrides in MigratorConfig.js

### DIFF
--- a/MigratorConfig.js
+++ b/MigratorConfig.js
@@ -1,6 +1,12 @@
 var config = require('./core/server/config'),
     utils = require('./core/server/utils');
 
+/**
+ * knex-migrator can be used via CLI or within the application
+ * when using the CLI, we need to ensure that our global overrides are triggered
+ */
+require('./core/server/overrides');
+
 module.exports = {
     currentVersion: utils.ghostVersion.safe,
     database: config.get('database'),


### PR DESCRIPTION
no issue

- if using knex-migrator cli not the whole ghost application is required
- that's why we need to ensure the overrides file is loaded
- if not, all dates are in local dates