### PR TITLE
Implement: Helper to get (in minutes) the read time

### DIFF
--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -38,6 +38,7 @@ coreHelpers.tags = require('./tags');
 coreHelpers.title = require('./title');
 coreHelpers.twitter_url = require('./twitter_url');
 coreHelpers.url = require('./url');
+coreHelpers.read_time = require('./read_time');
 
 // Specialist helpers for certain templates
 coreHelpers.page_url = require('./page_url');
@@ -110,6 +111,7 @@ registerHelpers = function () {
     registerThemeHelper('twitter_url', coreHelpers.twitter_url);
     registerThemeHelper('facebook_url', coreHelpers.facebook_url);
     registerThemeHelper('url', coreHelpers.url);
+    registerThemeHelper('read_time', coreHelpers.read_time);
 
     // Async theme helpers
     registerAsyncThemeHelper('ghost_foot', coreHelpers.ghost_foot);

--- a/core/server/helpers/read_time.js
+++ b/core/server/helpers/read_time.js
@@ -1,0 +1,23 @@
+// # Excerpt Helper
+// Usage: `{{read_time}}`
+//
+// Attempts to return how minutes (in average) you will need to read the post
+
+var hbs = require('express-hbs'),
+    getContent = require('./content'),
+    content, wordCount, time;
+
+function readTime() {
+    content = getContent.bind(this)().toString();
+    content = content.replace(/<a href="#fn.*?rel="footnote">.*?<\/a>/gi, '');
+    content = content.replace(/<div class="footnotes"><ol>.*?<\/ol><\/div>/, '');
+    content = content.replace(/<\/?[^>]+>/gi, '');
+    content = content.replace(/(\r\n|\n|\r)+/gm, ' ');
+
+    wordCount = content.replace(/[^\w ]/g, '').split(/\s+/).length;
+    time = Math.floor(wordCount / 250) + 1;
+
+    return new hbs.handlebars.SafeString(time.toString());
+}
+
+module.exports = readTime;


### PR DESCRIPTION
Actually I was working at a migration from wordpress to ghost, our layout need things that ghost not give 2 us :) This is an attempt to help with some stuff :heart: 

Implement: Helper to get (in minutes) the read time of a post! 

workaround ref: http://devangst.com/ghost-theme-add-reading-time-to-your-blog/
from wishlist too: http://ideas.ghost.org/forums/285309-wishlist/suggestions/7182854-estimated-reading-time

Let me know if have something to change or improve! Thx!