### PR TITLE
Allow to set custom pool options for postgres

### DIFF
--- a/core/server/data/db/connection.js
+++ b/core/server/data/db/connection.js
@@ -1,4 +1,5 @@
 var knex = require('knex'),
+    _ = require('lodash'),
     config = require('../../config'),
     knexInstance;
 
@@ -30,13 +31,13 @@ function configure(dbConfig) {
 
         // https://github.com/tgriesser/knex/issues/97
         // this sets the timezone to UTC only for the connection!
-        dbConfig.pool = {
+        dbConfig.pool = _.defaults({
             afterCreate: function (connection, callback) {
                 connection.query('set timezone=\'UTC\'', function (err) {
                     callback(err, connection);
                 });
             }
-        };
+        }, dbConfig.pool);
     }
 
     if (client === 'sqlite3') {


### PR DESCRIPTION
Hey guys,
I'm using elephantsql database with a strict limit of number of active connections. I can not set `pool:{min/max}` for postgres because it is overwritten in the configuration with an afterHook, ignoring my settings.

This PR merges options passed by user with this default hook to support them both.

Afaik postgres is not supported on master branch, so I targeted the lts branch with this PR.

- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

More info can be found by clicking the "guidelines for contributing" link above.
