### PR TITLE
🎹  re-work url redirects

### DIFF
--- a/core/test/unit/middleware/url-redirects_spec.js
+++ b/core/test/unit/middleware/url-redirects_spec.js
@@ -59,7 +59,7 @@ describe('checkSSL', function () {
         done();
     });
 
-    it('blog is https, requester uses http [redirect]', function (done) {
+    it('[redirect] blog is https, requester uses http', function (done) {
         configUtils.set({
             url: 'https://default.com:2368/'
         });
@@ -70,6 +70,7 @@ describe('checkSSL', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.called.should.be.true();
+        res.redirect.calledWith(301, 'https://default.com:2368/').should.be.true();
         done();
     });
 
@@ -103,6 +104,36 @@ describe('checkSSL', function () {
         done();
     });
 
+    it('blog host is !== request host', function (done) {
+        configUtils.set({
+            url: 'https://default.com'
+        });
+
+        host = 'localhost:2368';
+
+        req.originalUrl = '/';
+        req.secure = true;
+        urlRedirects(req, res, next);
+        next.called.should.be.true();
+        res.redirect.called.should.be.false();
+        done();
+    });
+
+    it('[redirect] blog host is !== request host', function (done) {
+        configUtils.set({
+            url: 'https://default.com'
+        });
+
+        host = 'localhost:2368';
+
+        req.originalUrl = '/';
+        urlRedirects(req, res, next);
+        next.called.should.be.false();
+        res.redirect.called.should.be.true();
+        res.redirect.calledWith(301, 'https://localhost:2368/').should.be.true();
+        done();
+    });
+
     it('admin is blog url and http, requester is http', function (done) {
         configUtils.set({
             url: 'http://default.com:2368'
@@ -118,7 +149,7 @@ describe('checkSSL', function () {
         done();
     });
 
-    it('admin is custom url and https, requester is http [redirect]', function (done) {
+    it('[redirect] admin is custom url and https, requester is http', function (done) {
         configUtils.set({
             url: 'http://default.com:2368',
             admin: {
@@ -136,7 +167,7 @@ describe('checkSSL', function () {
         done();
     });
 
-    it('admin is custom url and https, requester is http [redirect]', function (done) {
+    it('[redirect] admin is custom url and https, requester is http', function (done) {
         configUtils.set({
             url: 'http://default.com:2368',
             admin: {
@@ -154,7 +185,7 @@ describe('checkSSL', function () {
         done();
     });
 
-    it('subdirectory [redirect]', function (done) {
+    it('[redirect] subdirectory', function (done) {
         configUtils.set({
             url: 'http://default.com:2368/blog',
             admin: {
@@ -172,7 +203,7 @@ describe('checkSSL', function () {
         done();
     });
 
-    it('keeps query [redirect]', function (done) {
+    it('[redirect] keeps query', function (done) {
         configUtils.set({
             url: 'http://default.com:2368',
             admin: {


### PR DESCRIPTION
refs #7488

- we have recently changed our url redirects
- see https://github.com/TryGhost/Ghost/pull/7937
- the url has a canonical meaning and that's why Ghost shouldn't force a redirect to the configured blog url

### CASES
I've used 2368 as **server** port.
Configured a host alias `*.ghost.local`.

```
url: 'http://localhost:9999'
```

- ✅ http://898f4752.ngrok.io
- ✅ localhost:2368
- ✅ blog.ghost.local:2368

```
url: 'http://my-blog'
```

- ✅ http://898f4752.ngrok.io
- ✅ localhost:2368
- ✅ blog.ghost.local:2368

```
url: 'https://my-blog'
```

- ✅ http://898f4752.ngrok.io redirects to https://898f4752.ngrok.io
- ✅ https://898f4752.ngrok.io
- ✅ https://localhost:2368
- ✅ http://localhost:2368 redirects to https://localhost:2368
- ✅ blog.ghost.local:2368 redirects to https://blog.ghost.local:2368

```
url: 'http://my-blog',
admin: {
   url: 'http://admin.my-blog'
}
```

- ✅ http://898f4752.ngrok.io
- ❓ http://898f4752.ngrok.io/ghost redirects to http://admin.my-blog/ghost
- ✅ localhost:2368
- ❓ localhost:2368/ghost redirects to http://admin.my-blog/ghost
- ✅ blog.ghost.local:2368


Thanks to @ErisDS for discovering and supporting this 👍 
