### PR TITLE
🐛  re-order api middlewares: cors middleware before connect-slashes

### DIFF
--- a/core/server/middleware/index.js
+++ b/core/server/middleware/index.js
@@ -8,7 +8,6 @@ var bodyParser      = require('body-parser'),
     path            = require('path'),
     routes          = require('../routes'),
     serveStatic     = require('express').static,
-    slashes         = require('connect-slashes'),
     storage         = require('../storage'),
     passport        = require('passport'),
     utils           = require('../utils'),
@@ -24,9 +23,9 @@ var bodyParser      = require('body-parser'),
     redirectToSetup  = require('./redirect-to-setup'),
     serveSharedFile  = require('./serve-shared-file'),
     spamPrevention   = require('./spam-prevention'),
+    prettyUrls       = require('./pretty-urls'),
     staticTheme      = require('./static-theme'),
     themeHandler     = require('./theme-handler'),
-    uncapitalise     = require('./uncapitalise'),
     maintenance      = require('./maintenance'),
     versionMatch     = require('./api/version-match'),
     cors             = require('./cors'),
@@ -55,6 +54,7 @@ middleware = {
         requiresAuthorizedUserPublicAPI: auth.requiresAuthorizedUserPublicAPI,
         errorHandler: errors.handleAPIError,
         cors: cors,
+        prettyUrls: prettyUrls,
         labs: labs,
         versionMatch: versionMatch,
         maintenance: maintenance
@@ -173,14 +173,6 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // site map
     sitemapHandler(blogApp);
 
-    // Add in all trailing slashes
-    blogApp.use(slashes(true, {
-        headers: {
-            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
-        }
-    }));
-    blogApp.use(uncapitalise);
-
     // Body parsing
     blogApp.use(bodyParser.json({limit: '1mb'}));
     blogApp.use(bodyParser.urlencoded({extended: true, limit: '1mb'}));
@@ -201,6 +193,8 @@ setupMiddleware = function setupMiddleware(blogApp) {
     // ### Routing
     // Set up API routes
     blogApp.use(routes.apiBaseUri, routes.api(middleware));
+
+    blogApp.use(prettyUrls);
 
     // Mount admin express app to /ghost and set up routes
     adminApp.use(redirectToSetup);

--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -1,0 +1,11 @@
+var slashes = require('connect-slashes'),
+    utils = require('../utils');
+
+module.exports = [
+    slashes(true, {
+        headers: {
+            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
+        }
+    }),
+    require('./uncapitalise')
+];

--- a/core/server/routes/api.js
+++ b/core/server/routes/api.js
@@ -9,19 +9,24 @@ apiRoutes = function apiRoutes(middleware) {
         authenticatePublic = [
             middleware.api.authenticateClient,
             middleware.api.authenticateUser,
-            middleware.api.requiresAuthorizedUserPublicAPI,
-            middleware.api.cors
+            middleware.api.requiresAuthorizedUserPublicAPI
         ],
         // Require user for private endpoints
         authenticatePrivate = [
             middleware.api.authenticateClient,
             middleware.api.authenticateUser,
-            middleware.api.requiresAuthorizedUser,
-            middleware.api.cors
+            middleware.api.requiresAuthorizedUser
         ];
 
     // alias delete with del
     router.del = router.delete;
+
+    /**
+     * cors middleware need's to be registered before pretty urls
+     * otherwise the cors header information get's lost when a redirect happens
+     */
+    router.use(middleware.api.cors);
+    router.use(middleware.api.prettyUrls);
 
     // send 503 json response in case of maintenance
     router.use(middleware.api.maintenance);


### PR DESCRIPTION
closes #7839

- when a browser sends a request to the API without a trailing slash, we are using connect-slashes to redirect permanently
- but because the CORS middleware was registered after the redirect, the CORS headers got lost

This fix was already merged into master, see #7861.
But master and LTS middleware handling is very different - that's why raising a manual PR.