### PR TITLE
🐛  delete all content if subscriber is associated with a post

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -92,6 +92,7 @@ db = {
 
         function deleteContent() {
             var collections = [
+                models.Subscriber.findAll(queryOpts),
                 models.Post.findAll(queryOpts),
                 models.Tag.findAll(queryOpts)
             ];

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -9,7 +9,7 @@ describe('DB API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup('users:roles', 'settings', 'posts', 'perms:db', 'perms:init'));
+    beforeEach(testUtils.setup('users:roles', 'settings', 'posts', 'subscriber', 'perms:db', 'perms:init'));
 
     should.exist(dbAPI);
 

--- a/core/test/integration/api/api_subscription_spec.js
+++ b/core/test/integration/api/api_subscription_spec.js
@@ -15,7 +15,7 @@ describe('Subscribers API', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup('users:roles', 'perms:subscriber', 'perms:init', 'subscriber'));
+    beforeEach(testUtils.setup('users:roles', 'perms:subscriber', 'perms:init', 'posts', 'subscriber'));
 
     should.exist(SubscribersAPI);
 

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -314,6 +314,8 @@ DataGenerator.Content = {
     ]
 };
 
+DataGenerator.Content.subscribers[0].post_id = DataGenerator.Content.posts[0].id;
+
 DataGenerator.forKnex = (function () {
     var posts,
         tags,


### PR DESCRIPTION
closes #7875

- we need to delete the subscribers before deleting the posts

Same fix for #7875, just for master branch.