### PR TITLE
Update amperize to version 0.3.4 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": "^4.2.0 || ^6.9.0"
   },
   "dependencies": {
-    "amperize": "1.0.0",
+    "amperize": "0.3.4",
     "archiver": "1.3.0",
     "bcryptjs": "2.3.0",
     "bluebird": "3.4.7",


### PR DESCRIPTION
closes #7864

- manual PR is needed, because LTS is on amperize 1.0.0
- but 1.0.0 was not published on purpose
- the latest release is 0.3.4