### PR TITLE
🔥  remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
     "bookshelf": "0.10.3",
     "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/0cb28fa8e3230dcbf6bca8b991dbb340b9fff6cc",
     "bson-objectid": "1.1.5",
-    "bunyan": "1.8.1",
     "chalk": "1.1.3",
     "cheerio": "0.22.0",
-    "commander": "2.9.0",
     "compression": "1.6.2",
     "connect-slashes": "1.3.1",
     "cookie-session": "1.2.0",
@@ -77,7 +75,6 @@
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",
     "path-match": "1.2.4",
-    "prettyjson": "1.2.1",
     "rss": "1.2.2",
     "sanitize-html": "1.14.1",
     "semver": "5.3.0",
@@ -135,7 +132,6 @@
   },
   "greenkeeper": {
     "ignore": [
-      "bunyan",
       "glob",
       "nodemailer",
       "showdown-ghost",


### PR DESCRIPTION
no issue

These dependencies are not used.

bunyan && prettyjson were removed by adding ghost-ignition.
commander is a package to easily add a command line program - i found no usage.