### PR TITLE
Allow ServiceWorker /ghost/ scope

### DIFF
--- a/core/server/admin/app.js
+++ b/core/server/admin/app.js
@@ -41,6 +41,9 @@ module.exports = function setupAdminApp() {
         {maxAge: utils.ONE_YEAR_MS, fallthrough: false}
     ));
 
+    // Service Worker for offline support
+    adminApp.get(/^\/(sw.js|sw-registration.js)$/, require('./serviceworker'));
+
     // Render error page in case of maintenance
     adminApp.use(maintenance);
 

--- a/core/server/admin/serviceworker.js
+++ b/core/server/admin/serviceworker.js
@@ -1,0 +1,16 @@
+var debug = require('debug')('ghost:admin:serviceworker'),
+    path  = require('path');
+
+// Route: index
+// Path: /ghost/sw.js|sw-registration.js
+// Method: GET
+module.exports = function adminController(req, res) {
+    /*jslint unparam:true*/
+    debug('serviceworker called');
+
+    var sw = path.join(__dirname, '..', '..', 'built', 'assets', 'sw.js'),
+        swr = path.join(__dirname, '..', '..', 'built', 'assets', 'sw-registration.js'),
+        fileToSend = req.url === '/sw.js' ? sw : swr;
+
+    res.sendFile(fileToSend);
+};


### PR DESCRIPTION
ServiceWorkers can only control the scope from which they have been served. Our service workers live, like all other files, in an `asset` folder - and could in theory only work on other files in there.

This commit fake-serves our service workers from `/ghost/`, thus allowing them to give everything offline powers. This PR works only in conjunction with https://github.com/TryGhost/Ghost-Admin/pull/523.