### PR TITLE
[WIP] One-Click Update Support - Ghost component

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -208,6 +208,9 @@ function apiRoutes() {
     apiRouter.post('/invites', authenticatePrivate, api.http(api.invites.add));
     apiRouter.del('/invites/:id', authenticatePrivate, api.http(api.invites.destroy));
 
+    // ## Updates
+    apiRouter.post('/update', authenticatePrivate, api.http(api.update))
+
     return apiRouter;
 }
 

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -28,6 +28,7 @@ var _              = require('lodash'),
     uploads        = require('./upload'),
     exporter       = require('../data/export'),
     slack          = require('./slack'),
+    update         = require('./update'),
 
     http,
     addHeaders,
@@ -286,7 +287,8 @@ module.exports = {
     uploads: uploads,
     slack: slack,
     themes: themes,
-    invites: invites
+    invites: invites,
+    update: update
 };
 
 /**

--- a/core/server/api/update.js
+++ b/core/server/api/update.js
@@ -1,0 +1,57 @@
+var some = require('lodash/some'),
+    Promise = require('bluebird'),
+
+    i18n   = require('../i18n'),
+    config = require('../config'),
+    errors = require('../errors'),
+    pipeline = require('../utils/pipeline'),
+    dataProvider = require('../models');
+
+module.exports = function update(options) {
+    function handlePermissions() {
+        return dataProvider.User.findOne({id: options.context.user}, {include: ['roles']}).then(function then(user) {
+            if (!user) {
+                return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.users.userNotFound')}));
+            }
+
+            return user;
+        }).then(function afterLoad(user) {
+            if (user.related('roles').models[0].get('name') !== 'Owner') {
+                return Promise.reject(new errors.NoPermissionError({
+                    message: i18n.t('errors.api.update.notAllowedToUpdate')
+                }));
+            }
+        });
+    }
+
+    function checkForUpdate() {
+        var updateCheck = require('../update-check');
+
+        return updateCheck().then(function then() {
+            return updateCheck.showUpdateNotification();
+        }).then(function then(updateVersion) {
+            if (!updateVersion) {
+                return Promise.reject(new errors.UpdateError({message: i18n.t('errors.api.update.noUpdateAvailable')}));
+            }
+        });
+    }
+
+    function doUpdate() {
+        if (!config.get('update') || !process.send) {
+            return Promise.reject(new errors.UpdateError({
+                message: i18n.t('errors.api.update.cantUpdate'),
+                statusCode: 501
+            }));
+        }
+
+        process.send({update: true});
+    }
+
+    var tasks = [
+        handlePermissions,
+        checkForUpdate,
+        doUpdate
+    ];
+
+    return pipeline(tasks);
+};

--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -54,6 +54,13 @@ var ghostErrors = {
             errorType: 'ThemeValidationError',
             errorDetails: {}
         }, options));
+    },
+    UpdateError: function UpdateError(options) {
+        GhostError.call(this, _.merge({
+            statusCode: 400,
+            errorType: 'UpdateError',
+            errorDetails: {}
+        }, options));
     }
 };
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -411,6 +411,11 @@
                 },
                 "notAllowedToInviteOwner": "Not allowed to invite an owner user.",
                 "notAllowedToInvite": "Not allowed to invite this role."
+            },
+            "update": {
+                "notAllowedToUpdate": "Not allowed to update Ghost",
+                "noUpdateAvailable": "No update available",
+                "cantUpdate": "Ghost cannot automatically update"
             }
         },
         "data": {


### PR DESCRIPTION
Refs #8005 

This PR enables (the server side of) one-click updates of Ghost when running with the CLI. 

To get this to work, you must:
- Put `"update": true` in your config.development in a CLI setup
- change [this function](https://github.com/TryGhost/Ghost/blob/master/core/server/update-check.js#L242-L248) to not return false
- Run with the CLI

_Note: this is just a first attempt - and the final solution may look much different._

TODO:
- [ ] test all the things
- [ ] error handling