### PR TITLE
⏱ Boot time visibility amends

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -1,11 +1,13 @@
 var Nconf = require('nconf'),
     path = require('path'),
-    debug = require('debug')('ghost:config'),
+    _debug = require('debug'),
+    debug = _debug('ghost:config'),
     localUtils = require('./utils'),
     env = process.env.NODE_ENV || 'development',
     _private = {};
 
 _private.loadNconf = function loadNconf(options) {
+    debug('config start');
     options = options || {};
 
     var baseConfigPath = options.baseConfigPath || __dirname,
@@ -49,7 +51,13 @@ _private.loadNconf = function loadNconf(options) {
      */
     nconf.set('env', env);
 
-    debug(nconf.get());
+    // Wrap this in a check, because else nconf.get() is executed unnecessarily
+    // To output this, use DEBUG=ghost:*,ghost-config
+    if (_debug.enabled('ghost-config')) {
+        debug(nconf.get());
+    }
+
+    debug('config end');
     return nconf;
 };
 

--- a/index.js
+++ b/index.js
@@ -2,13 +2,20 @@
 // Orchestrates the startup of Ghost when run from command line.
 console.time('Ghost boot');
 
-var ghost = require('./core'),
-    debug = require('debug')('ghost:boot:index'),
-    express = require('express'),
-    logging = require('./core/server/logging'),
-    errors = require('./core/server/errors'),
-    utils = require('./core/server/utils'),
-    parentApp = express();
+var debug = require('debug')('ghost:boot:index'),
+    ghost, express, logging, errors, utils, parentApp;
+
+debug('First requires...');
+
+ghost = require('./core');
+
+debug('Required ghost');
+
+express = require('express');
+logging = require('./core/server/logging');
+errors = require('./core/server/errors');
+utils = require('./core/server/utils');
+parentApp = express();
 
 debug('Initialising Ghost');
 ghost().then(function (ghostServer) {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 // # Ghost Startup
 // Orchestrates the startup of Ghost when run from command line.
+console.time('Ghost boot');
+
 var ghost = require('./core'),
     debug = require('debug')('ghost:boot:index'),
     express = require('express'),
@@ -16,6 +18,7 @@ ghost().then(function (ghostServer) {
     debug('Starting Ghost');
     // Let Ghost handle starting our server instance.
     return ghostServer.start(parentApp).then(function afterStart() {
+        console.timeEnd('Ghost boot');
         // if IPC messaging is enabled, ensure ghost sends message to parent
         // process on successful start
         if (process.send) {


### PR DESCRIPTION
I've been playing around with Ghost start times a lot recently. As I've been doing that, there are a few minor amends which I make each time. Rather than keep having to do that, I'd like to push those changes onto master.

This will improve visibility on boot time for everyone. If we don't like the boot time output, we can remove that before shipping alpha, or wrap it in a config object.

----

Note: In the process of messing around with boot times, I've mostly been focused on themes/apps and how we can make loading them more efficient. However, it has become very clear that the vast majority of time it takes to start Ghost is spent on `require`. Initial requires take 2-3 seconds, and the remainder of the boot usually only takes 1, maybe 2. The main area for optimisation, is therefore looking at the require tree.

To do that, I played with a tool called [time-require](https://github.com/jaguard/time-require). The behaviour seen is strongly related to https://github.com/TryGhost/knex-migrator/issues/53 - showing knex-migrator as being an area to focus on. I believe we may improve the startup times (not just install times) of Ghost by relaxing the version restraints on lodash, bluebird, and any other common modules, in sub-dependencies like ghost-ignition, knex-migrator, gscan, etc. 

Just some food for thought 🤔  🍫 