### PR TITLE
✨  public client registration: remember auth url

### DIFF
--- a/core/server/auth/passport.js
+++ b/core/server/auth/passport.js
@@ -77,7 +77,8 @@ _private.updateClient = function updateClient(options) {
                         uuid: credentials.client_id,
                         secret: credentials.client_secret,
                         redirection_uri: credentials.redirect_uri,
-                        client_uri: credentials.blog_uri
+                        client_uri: credentials.blog_uri,
+                        auth_uri: ghostOAuth2Strategy.url
                     }, {context: {internal: true}});
                 }).then(function addedLocalClient(client) {
                     debug('Added local client: ' + JSON.stringify(client.toJSON()));
@@ -93,6 +94,7 @@ _private.updateClient = function updateClient(options) {
             if (client.get('redirection_uri') === redirectUri &&
                 client.get('name') === clientName &&
                 client.get('description') === clientDescription &&
+                client.get('auth_uri') === ghostOAuth2Strategy.url &&
                 client.get('client_uri') === clientUri) {
                 debug('Client did not change');
 
@@ -113,6 +115,7 @@ _private.updateClient = function updateClient(options) {
             }, _.isUndefined)).then(function updatedRemoteClient(updatedRemoteClient) {
                 debug('Update remote client: ' + JSON.stringify(updatedRemoteClient));
 
+                client.set('auth_uri', ghostOAuth2Strategy.url);
                 client.set('redirection_uri', updatedRemoteClient.redirect_uri);
                 client.set('client_uri', updatedRemoteClient.blog_uri);
                 client.set('name', updatedRemoteClient.name);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -165,6 +165,7 @@ module.exports = {
         secret: {type: 'string', maxlength: 150, nullable: false},
         redirection_uri: {type: 'string', maxlength: 2000, nullable: true},
         client_uri: {type: 'string', maxlength: 2000, nullable: true},
+        auth_uri: {type: 'string', maxlength: 2000, nullable: true},
         logo: {type: 'string', maxlength: 2000, nullable: true},
         status: {type: 'string', maxlength: 150, nullable: false, defaultTo: 'development'},
         type: {type: 'string', maxlength: 150, nullable: false, defaultTo: 'ua', validations: {isIn: [['ua', 'web', 'native']]}},

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -1,6 +1,7 @@
 var sinon = require('sinon'),
     rewire = require('rewire'),
     _ = require('lodash'),
+    should = require('should'),
     Promise = require('bluebird'),
     crypto = require('crypto'),
     fs = require('fs'),
@@ -11,13 +12,15 @@ var sinon = require('sinon'),
     fixtures = require('../../server/data/schema/fixtures'),
     sandbox = sinon.sandbox.create();
 
+should.equal(true, true);
+
 // Check version integrity
 // These tests exist to ensure that developers are not able to modify the database schema, or permissions fixtures
 // without knowing that they also need to update the default database version,
 // both of which are required for migrations to work properly.
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    var currentSchemaHash = '71d6b843f798352f804db09e5478eef5',
+    var currentSchemaHash = 'fa72ab0ca7ce8ee20bafb6e73b61a324',
         currentFixturesHash = 'b9e684a87353c592df9b23948e364c05';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
no issue

- we have to remember the auth url in Ghost
- if Ghost starts for the first time, it registers a public client in the defined auth service
- if you change the auth service, Ghost won't recognize
- if Ghost doesn't recognize, you will see a client does not exist error in Ghost Admin