### PR TITLE
🔥 ✨ use nconf-fork

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -26,7 +26,8 @@ _private.loadNconf = function loadNconf(options) {
      * env arguments
      */
     nconf.env({
-        separator: '__'
+        separator: '__',
+        arraySeparator: ','
     });
 
     nconf.file('custom-env', path.join(customConfigPath, 'config.' + env + '.json'));

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "moment-timezone": "0.5.9",
     "multer": "1.3.0",
     "mysql": "2.13.0",
-    "nconf": "0.8.4",
+    "nconf-fork": "0.8.5",
     "netjet": "1.1.3",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4214,6 +4214,15 @@ natural-compare@~1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.2.2.tgz#1f96d60e3141cac1b6d05653ce0daeac763af6aa"
 
+nconf-fork@0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/nconf-fork/-/nconf-fork-0.8.5.tgz#746bb18d34d972386b40ffe371cef0da5e5b4621"
+  dependencies:
+    async "^1.4.0"
+    ini "^1.3.0"
+    secure-keys "^1.0.0"
+    yargs "^3.19.0"
+
 nconf@0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/nconf/-/nconf-0.8.4.tgz#9502234f7ad6238cab7f92d7c068c20434d3ff93"


### PR DESCRIPTION
no issue

- nconf support is quite dead
- i have forked nconf
- if we need any updates, i will care
- use arraySeparator for env parameter
- e.g. logging__transports=stdout,file,loggly works now