### PR TITLE
🐛  importing duplicate users

### DIFF
--- a/core/server/data/import/data-importer.js
+++ b/core/server/data/import/data-importer.js
@@ -59,7 +59,9 @@ DataImporter.prototype.doUserImport = function (t, tableData, owner, users, erro
         return Promise.all(userOps).then(function (descriptors) {
             descriptors.forEach(function (d) {
                 if (!d.isFulfilled()) {
-                    errors = errors.concat(d.reason());
+                    if (!d.reason().raw || (d.reason().raw.errno !== 19 && d.reason().raw.errno !== 1062)) {
+                        errors = errors.concat(d.reason());
+                    }
                 } else {
                     imported.push(d.value().toJSON(internal));
                 }


### PR DESCRIPTION
no issue

- if you import a JSON database which contains duplicate users e.g. multiple users are using the same email
- then the whole database transaction get's rolled back and Ghost fails to import the database