### PR TITLE
✨ Theme Browse API endpoint

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -125,6 +125,8 @@ function apiRoutes() {
     apiRouter.get('/slugs/:type/:name', authenticatePrivate, api.http(api.slugs.generate));
 
     // ## Themes
+    apiRouter.get('/themes/', authenticatePrivate, api.http(api.themes.browse));
+
     apiRouter.get('/themes/:name/download',
         authenticatePrivate,
         api.http(api.themes.download)

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -28,6 +28,10 @@ themes = {
             });
     },
 
+    browse: function browse() {
+        return Promise.resolve({themes: settings.cache.get('availableThemes')});
+    },
+
     upload: function upload(options) {
         options = options || {};
 


### PR DESCRIPTION
Haven't written tests for this yet (will do), but it otherwise works.

Thought I'd raise it as a PR to show the format that would be returned for `/GET/ themes`. Note the "activeTheme" indicator is still provided by `GET /settings/activeTheme` at the moment.

This could potentially be changed, and we can also layer on other info if needed (like the default theme, or display name for a theme). So I'm looking for a bit of direction on what the Admin needs & how hard it's going to be to swap the admin panel over so that it doesn't use settings anymore.

cc @kevinansfield or @acburdine 

