### PR TITLE
fix uid method in core/server/utils/index.js 

### DIFF
--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -47,7 +47,7 @@ utils = {
             charlen = chars.length,
             i;
 
-        for (i = 1; i < len; i = i + 1) {
+        for (i = 0; i < len; i = i + 1) {
             buf.push(chars[getRandomInt(0, charlen - 1)]);
         }
 


### PR DESCRIPTION

- closes #7998

for loop must start with initial value of 0 not 1. 