### PR TITLE
🐛  protect setup

### DIFF
--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -115,7 +115,7 @@ strategies = {
         };
 
         handleSetup = function handleSetup() {
-            return models.User.findOne({slug: 'ghost-owner', status: 'all'}, options)
+            return models.User.findOne({slug: 'ghost-owner', status: 'inactive'}, options)
                 .then(function fetchedOwner(owner) {
                     if (!owner) {
                         throw new errors.NotFoundError({message: i18n.t('errors.models.user.userNotFound')});


### PR DESCRIPTION
refs #7452

- we have to query the owner user by `inactive` status
- otherwise it is possible to override the owner's email address, because we queried by status `all`
- if the owner user set's up the blog successfully, the slug does not change, it stays `ghost-owner`
- this is because we don't forward the name of the user from ghost auth server - @ErisDS is this a bug?