### PR TITLE
Remove: Knex Cli as Global Deep

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
 
 ```bash
 git clone [Ghost's repo URL or your Ghost Fork's URL]
-npm install -g knex-migrator gulp
 npm install
 git submodule update --init
 cd core/client
@@ -33,7 +32,7 @@ npm install
 bower install
 cd ../..
 gulp setup
-knex-migrator init
+npm run dbinit #or yarn dbinit
 gulp dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "./core/index",
   "scripts": {
     "start": "node index",
+    "dbinit": "knex-migrator init",
     "test": "grunt validate --verbose"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,7 +3450,7 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-knex-migrator@2.0.7:
+knex-migrator@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/knex-migrator/-/knex-migrator-2.0.7.tgz#9e58b4a9a828a4dcc16a1900eafcd6880a1da57d"
   dependencies:


### PR DESCRIPTION
I was talking with @ErisDS today, and talk about create a script for *db init* to use `knex-migrator` as local deep! Here a little solution :metal: 
