### PR TITLE
fix version check error for minor versions >= 10; fixes #8040

### DIFF
--- a/core/server/utils/npm/preinstall.js
+++ b/core/server/utils/npm/preinstall.js
@@ -31,7 +31,7 @@ if (process.env.GHOST_NODE_VERSION_CHECK === 'false') {
                 (matchChar === '~' && currentVersion === versionString)
                 || (matchChar === '^'
                     && currentVersion.match(majorRegex)[0] === versionString.match(majorRegex)[0]
-                    && currentVersion.match(minorRegex)[0] >= versionString.match(minorRegex)[0]
+                    && parseInt(currentVersion.match(minorRegex)[0]) >= parseInt(versionString.match(minorRegex)[0])
                 )
             ) {
                 foundMatch = true;


### PR DESCRIPTION
Was hoping to use the `semver` package but realised this gets run before npm install, so instead just converted the minor versions to numbers before comparing.

I tested it on a bunch of different node versions and it now seems to create the correct output for each version (ie it now accepts 6.10.0).

cheers,

Pete