### PR TITLE
🎨 fix admin and theme caching issues

### DIFF
--- a/core/server/admin/app.js
+++ b/core/server/admin/app.js
@@ -17,7 +17,8 @@ var debug = require('debug')('ghost:admin'),
 
 module.exports = function setupAdminApp() {
     debug('Admin setup start');
-    var adminApp = express();
+    var adminApp = express(),
+        configMaxAge;
 
     // First determine whether we're serving admin or theme content
     // @TODO finish refactoring this away.
@@ -36,9 +37,10 @@ module.exports = function setupAdminApp() {
 
     // Admin assets
     // @TODO ensure this gets a local 404 error handler
+    configMaxAge = config.get('caching:admin:maxAge');
     adminApp.use('/assets', serveStatic(
         config.get('paths').clientAssets,
-        {maxAge: utils.ONE_YEAR_MS, fallthrough: false}
+        {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : utils.ONE_YEAR_MS, fallthrough: false}
     ));
 
     // Service Worker for offline support

--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -23,6 +23,9 @@
     "caching": {
         "theme": {
             "maxAge": 0
+        },
+        "admin": {
+            "maxAge": 0
         }
     }
 }

--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -20,8 +20,10 @@ function forwardToExpressStatic(req, res, next) {
     if (!req.app.get('activeTheme')) {
         next();
     } else {
+        var configMaxAge = config.get('caching:theme:maxAge');
+
         express.static(path.join(config.getContentPath('themes'), req.app.get('activeTheme')),
-            {maxAge: config.get('caching:theme:maxAge') || utils.ONE_YEAR_MS}
+            {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : utils.ONE_YEAR_MS}
         )(req, res, next);
     }
 }


### PR DESCRIPTION
refs #7812, closes #7958
- fixes boolean logic wrt to theme cache value from config
- disable cache for admin assets in development
- only add asset hash in production
