### PR TITLE
🐛 Wait for active theme to load

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -25,6 +25,7 @@ var _              = require('lodash'),
     uploads        = require('./upload'),
     exporter       = require('../data/export'),
     slack          = require('./slack'),
+    readThemes     = require('../utils/read-themes'),
 
     http,
     addHeaders,
@@ -40,7 +41,15 @@ var _              = require('lodash'),
  * @return {Promise(Settings)} Resolves to Settings Collection
  */
 init = function init() {
-    return settings.updateSettingsCache();
+    return settings.read({context: {internal: true}, key: 'activeTheme'})
+        .then(function initActiveTheme(response) {
+            var activeTheme = response.settings[0].value;
+            return readThemes.active(config.paths.themePath, activeTheme);
+        })
+        .then(function (result) {
+            config.set({paths: {availableThemes: result}});
+            return settings.updateSettingsCache();
+        });
 };
 
 function isActiveThemeOverride(method, endpoint, result) {

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -9,7 +9,6 @@ var _            = require('lodash'),
     events       = require('../events'),
     utils        = require('./utils'),
     i18n         = require('../i18n'),
-    readThemes   = require('../utils/read-themes'),
 
     docName      = 'settings',
     settings,
@@ -31,13 +30,6 @@ var _            = require('lodash'),
      * @type {{}}
      */
     settingsCache = {};
-
-// @TODO figure out a better way to do this in the alpha
-function initActiveTheme(theme) {
-    return readThemes.active(config.paths.themePath, theme).then(function (result) {
-        config.set({paths: {availableThemes: result}});
-    });
-}
 
 // @TODO figure out a better way to do this in the alpha
 events.on('server:start', function () {
@@ -206,8 +198,6 @@ readSettingsResult = function (settingsModels) {
             value: res,
             type: 'theme'
         };
-    } else if (settings.activeTheme) {
-        initActiveTheme(settings.activeTheme.value);
     }
 
     if (settings.activeApps && apps) {

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -162,14 +162,14 @@ function init(options) {
             return Promise.reject(response.error);
         }
     }).then(function () {
+        // Initialize the permissions actions and objects
+        // NOTE: Must be done before initDbHashAndFirstRun calls
+        return permissions.init();
+    }).then(function () {
         // Initialize the settings cache now,
         // This is an optimisation, so that further reads from settings are fast.
         // We do also do this after boot
         return api.init();
-    }).then(function () {
-        // Initialize the permissions actions and objects
-        // NOTE: Must be done before initDbHashAndFirstRun calls
-        return permissions.init();
     }).then(function () {
         return Promise.join(
             // Check for or initialise a dbHash.


### PR DESCRIPTION
This is a first fix for the issue outlined in #8056. It's a quick fix that just ensures we wait for the theme to load. It does not address the speed issue.

I've marked this as refs rather than closes, because I have a second fix that will also address the fact that we do a lot of unnecessary work and result in a speed up.

If we have to ship the LTS asap, this fix will be enough, the 2nd one can come later / be alpha only.

refs #8056

- Move init theme into api.init() (already gone in alpha)
- Ensures that we wait for the theme to load before the server starts

