### PR TITLE
🐛 😱  We still require config before models!

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -69,13 +69,14 @@ function init(options) {
 
     // Initialize Internationalization
     i18n.init();
-    // Load models, no need to wait
-    models.init();
 
     // Load our config.js file from the local file system.
     return config.load(options.config).then(function () {
         return config.checkDeprecated();
     }).then(function () {
+        // Load models, no need to wait
+        models.init();
+
         /**
          * fresh install:
          * - getDatabaseVersion will throw an error and we will create all tables (including populating settings)


### PR DESCRIPTION
- This was dumb, all the tests pass but the branch broke locally for me!
- In 1.0 we've reorganised how config is required, so models.init() can be called before
- In LTS we need to leave it after config
- DERPITY DERP DERP
