### PR TITLE
🐛 Ensure config is update when deleting theme

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -94,7 +94,7 @@ ConfigManager.prototype.loadThemes = function () {
 
     return readThemes(self._config.paths.themePath)
         .then(function (result) {
-            self.set({paths: {availableThemes: result}});
+            self._config.paths.availableThemes = result;
         });
 };
 

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -93,7 +93,27 @@ describe('Themes API', function () {
 
                             // ensure contains two files (zip and extracted theme)
                             fs.readdirSync(config.paths.themePath).join().match(/valid/gi).length.should.eql(1);
-                            done();
+
+                            // Check the settings API returns the correct result
+                            request.get(testUtils.API.getApiQuery('settings/'))
+                                .set('Authorization', 'Bearer ' + scope.ownerAccessToken)
+                                .expect(200)
+                                .end(function (err, res) {
+                                    if (err) {
+                                        return done(err);
+                                    }
+
+                                    var availableThemes, addedTheme;
+
+                                    availableThemes = _.find(res.body.settings, {key: 'availableThemes'}).value;
+                                    should.exist(availableThemes);
+
+                                    // The added theme should be here
+                                    addedTheme = _.find(availableThemes, {name: 'valid'});
+                                    should.exist(addedTheme);
+
+                                    done();
+                                });
                         });
                 });
         });
@@ -141,7 +161,27 @@ describe('Themes API', function () {
 
                     fs.existsSync(config.paths.themePath + '/valid').should.eql(false);
                     fs.existsSync(config.paths.themePath + '/valid.zip').should.eql(false);
-                    done();
+
+                    // Check the settings API returns the correct result
+                    request.get(testUtils.API.getApiQuery('settings/'))
+                        .set('Authorization', 'Bearer ' + scope.ownerAccessToken)
+                        .expect(200)
+                        .end(function (err, res) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            var availableThemes, deletedTheme;
+
+                            availableThemes = _.find(res.body.settings, {key: 'availableThemes'}).value;
+                            should.exist(availableThemes);
+
+                            // The deleted theme should not be here
+                            deletedTheme = _.find(availableThemes, {name: 'valid'});
+                            should.not.exist(deletedTheme);
+
+                            done();
+                        });
                 });
         });
     });


### PR DESCRIPTION
Adding an extra call to the api in the deletion route test made the tests fail. Fixing the config call back to what it was before made it pass again.

fixes #8059

- Not sure why I changed this the first time, it was obviously like this for a reason 😂
- Config.set() doesn't update the object properly, modifying this._config does
- Thank heavens this doesn't exist in alpha anymore 😁