### PR TITLE
🐛 Use FS.stat to detect error template

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -3,6 +3,7 @@
 var _                          = require('lodash'),
     chalk                      = require('chalk'),
     path                       = require('path'),
+    fs                         = require('fs'),
     Promise                    = require('bluebird'),
     hbs                        = require('express-hbs'),
     NotFoundError              = require('./not-found-error'),
@@ -69,7 +70,9 @@ function getStatusCode(error) {
  */
 errors = {
     updateActiveTheme: function (activeTheme) {
-        userErrorTemplateExists = getConfigModule().paths.availableThemes[activeTheme].hasOwnProperty('error.hbs');
+        fs.stat(path.join(getConfigModule().paths.themePath, activeTheme, 'error.hbs'), function stat(err, stats) {
+            userErrorTemplateExists = !err && stats.isFile();
+        });
     },
 
     throwError: function (err) {

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -5,6 +5,7 @@ var should     = require('should'),
     rewire     = require('rewire'),
 
     // Stuff we are testing
+    fs         = require('fs'),
     chalk      = require('chalk'),
     errors     = rewire('../../server/errors'),
     configUtils = require('../utils/configUtils'),
@@ -492,6 +493,11 @@ describe('Error handling', function () {
                     }
                 },
                 next = null;
+
+            sandbox.stub(fs, 'stat', function (path, cb) {
+                cb(null, {isFile: function () { return true; }});
+            });
+
             errors.updateActiveTheme('theme-with-error');
             errors.renderErrorPage(statusCode, error, req, res, next);
         });


### PR DESCRIPTION
This is a fix for the issue I noticed just after #8064 was merged (I meant to check and forgot, sorrrrrry!) whereby we were no longer using custom error.hbs templates.

#8064 stops us from reading all files of all themes, and should reduce both load time and memory footprints for blogs with lots of themes or particularly large themes.

Now we only read package.json, but this means we need to also read other parts of the theme as and when we need them. 

This PR uses fs.stat to check if there is a custom error template. This is the same approach used for partials here: https://github.com/TryGhost/Ghost/blob/bca3e1f950e296bd7ebeb5d57ea31a11504d3eaa/core/server/middleware/theme-handler.js#L74
(This has been in place and working for a very long time, despite it being async!)

In the alpha, we'll come up with a better approach, using gscan to validate the active theme on activation, and then getting any information we need and keeping it in an active theme concept that doesn't depend on settings & config etc.

----

- As of #8064 we no longer read EVERY SINGLE file of EVERY SINGLE theme.
- Instead, we need to read the files at the points we need them
- Yes, this is async, but fast enough to not matter
- Will come up with a better solution (using Gscan?) for alpha
