### PR TITLE
🐛 Fix broken custom theme templates

### DIFF
--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -3,7 +3,6 @@
 var _                          = require('lodash'),
     chalk                      = require('chalk'),
     path                       = require('path'),
-    fs                         = require('fs'),
     Promise                    = require('bluebird'),
     hbs                        = require('express-hbs'),
     NotFoundError              = require('./not-found-error'),
@@ -70,9 +69,7 @@ function getStatusCode(error) {
  */
 errors = {
     updateActiveTheme: function (activeTheme) {
-        fs.stat(path.join(getConfigModule().paths.themePath, activeTheme, 'error.hbs'), function stat(err, stats) {
-            userErrorTemplateExists = !err && stats.isFile();
-        });
+        userErrorTemplateExists = getConfigModule().paths.availableThemes[activeTheme].hasOwnProperty('error.hbs');
     },
 
     throwError: function (err) {

--- a/core/server/utils/read-themes.js
+++ b/core/server/utils/read-themes.js
@@ -6,6 +6,7 @@
 var _ = require('lodash'),
     packages = require('../utils/packages'),
     Promise = require('bluebird'),
+    join = require('path').join,
     errors = require('../errors'),
     i18n = require('../i18n'),
 
@@ -20,7 +21,7 @@ function populateTemplates(themes) {
                 .then(function gotTemplates(templates) {
                     // Update the original themes object
                     _.each(templates, function (template) {
-                        themes[themeName][template] = template;
+                        themes[themeName][template] = join(themes[themeName].path, template);
                     });
                 });
         })

--- a/core/server/utils/read-themes.js
+++ b/core/server/utils/read-themes.js
@@ -3,9 +3,30 @@
  *
  * Util that wraps packages.read
  */
-var packages = require('../utils/packages'),
+var _ = require('lodash'),
+    packages = require('../utils/packages'),
+    Promise = require('bluebird'),
     errors = require('../errors'),
-    i18n = require('../i18n');
+    i18n = require('../i18n'),
+
+    glob = Promise.promisify(require('glob'));
+
+function populateTemplates(themes) {
+    return Promise
+        // Load templates for each theme in the object
+        .each(Object.keys(themes), function loadTemplates(themeName) {
+            // Load all the files which match x.hbs = top level templates
+            return glob('*.hbs', {cwd: themes[themeName].path})
+                .then(function gotTemplates(templates) {
+                    // Update the original themes object
+                    _.each(templates, function (template) {
+                        themes[themeName][template] = template;
+                    });
+                });
+        })
+        // Return the original (now updated) object, not the result of Promise.each
+        .return(themes);
+}
 
 /**
  * Read active theme
@@ -13,6 +34,7 @@ var packages = require('../utils/packages'),
 function readActiveTheme(dir, name) {
     return packages
         .read.one(dir, name)
+        .then(populateTemplates)
         .catch(function () {
             // For now we return an empty object as this is not fatal unless the frontend of the blog is requested
             errors.logWarn(i18n.t('errors.middleware.themehandler.missingTheme', {theme: name}));
@@ -24,7 +46,9 @@ function readActiveTheme(dir, name) {
  * Read themes
  */
 function readThemes(dir) {
-    return packages.read.all(dir);
+    return packages
+        .read.all(dir)
+        .then(populateTemplates);
 }
 
 /**

--- a/core/test/unit/controllers/frontend/templates_spec.js
+++ b/core/test/unit/controllers/frontend/templates_spec.js
@@ -104,7 +104,6 @@ describe('templates', function () {
 
         it('will fall back to post even if no index.hbs', function () {
             configUtils.set({paths: {availableThemes: {casper: {
-                assets: null,
                 'default.hbs': '/content/themes/casper/default.hbs'
             }}}});
 
@@ -118,7 +117,6 @@ describe('templates', function () {
         describe('without tag templates', function () {
             beforeEach(function () {
                 configUtils.set({paths: {availableThemes: {casper: {
-                    assets: null,
                     'default.hbs': '/content/themes/casper/default.hbs',
                     'index.hbs': '/content/themes/casper/index.hbs'
                 }}}});
@@ -134,7 +132,6 @@ describe('templates', function () {
         describe('with tag templates', function () {
             beforeEach(function () {
                 configUtils.set({paths: {availableThemes: {casper: {
-                    assets: null,
                     'default.hbs': '/content/themes/casper/default.hbs',
                     'index.hbs': '/content/themes/casper/index.hbs',
                     'tag.hbs': '/content/themes/casper/tag.hbs',
@@ -157,7 +154,6 @@ describe('templates', function () {
 
         it('will fall back to index even if no index.hbs', function () {
             configUtils.set({paths: {availableThemes: {casper: {
-                assets: null,
                 'default.hbs': '/content/themes/casper/default.hbs'
             }}}});
 

--- a/core/test/unit/error_handling_spec.js
+++ b/core/test/unit/error_handling_spec.js
@@ -320,7 +320,6 @@ describe('Error handling', function () {
                     themePath: '/content/themes',
                     availableThemes: {
                         casper: {
-                            assets: null,
                             'default.hbs': '/content/themes/casper/default.hbs',
                             'index.hbs': '/content/themes/casper/index.hbs',
                             'page.hbs': '/content/themes/casper/page.hbs',

--- a/core/test/unit/server_helpers/body_class_spec.js
+++ b/core/test/unit/server_helpers/body_class_spec.js
@@ -14,7 +14,6 @@ describe('{{body_class}} helper', function () {
         configUtils.set({paths: {
             availableThemes: {
                 casper: {
-                    assets: null,
                     'default.hbs': '/content/themes/casper/default.hbs',
                     'index.hbs': '/content/themes/casper/index.hbs',
                     'page.hbs': '/content/themes/casper/page.hbs',

--- a/core/test/unit/utils/packages_spec.js
+++ b/core/test/unit/utils/packages_spec.js
@@ -388,7 +388,7 @@ describe('Package Utils', function () {
         // NOTE: this probably shouldn't be here, but it makes more sense than in
         // The server utils spec.js and has its own home in 1.0/alpha already.
         describe('Read Themes', function () {
-            it('should read directory and include only folders', function (done) {
+            it('should read directory and include folders, package.json & templates', function (done) {
                 var themePath = tmp.dirSync({unsafeCleanup: true});
 
                 // create trash
@@ -407,7 +407,8 @@ describe('Package Utils', function () {
                             casper: {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
-                                'package.json': null
+                                'package.json': null,
+                                'index.hbs': 'index.hbs'
                             }
                         });
 
@@ -478,7 +479,8 @@ describe('Package Utils', function () {
                             casper: {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
-                                'package.json': {name: 'casper', version: '0.1.2'}
+                                'package.json': {name: 'casper', version: '0.1.2'},
+                                'index.hbs': 'index.hbs'
                             }
                         });
 

--- a/core/test/unit/utils/packages_spec.js
+++ b/core/test/unit/utils/packages_spec.js
@@ -408,7 +408,7 @@ describe('Package Utils', function () {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
                                 'package.json': null,
-                                'index.hbs': 'index.hbs'
+                                'index.hbs': join(themePath.name, 'casper', 'index.hbs')
                             }
                         });
 
@@ -480,7 +480,7 @@ describe('Package Utils', function () {
                                 name: 'casper',
                                 path: join(themePath.name, 'casper'),
                                 'package.json': {name: 'casper', version: '0.1.2'},
-                                'index.hbs': 'index.hbs'
+                                'index.hbs': join(themePath.name, 'casper', 'index.hbs')
                             }
                         });
 


### PR DESCRIPTION
fixes #8082 

This PR fixes a HORRENDOUS issue with 0.11.6 where we just don't use any custom template files, always falling back to index.hbs or post.hbs. This will break practically every theme.

It wasn't caught because I didn't go through enough of our tests to check for the old data structures. I still need to go through and update a bunch of tests to make sure I haven't broken anything else. For now, this code can be reviewed and tested.

2 things happen in this PR:

1. I put back the reading of template files. However now we ONLY read template files not all theme files
2. I reverted the change to error handling to use the now loaded templates

Glob is super fast and tells us what filenames we have, which is all we need, so this is a much better option than what we had before.

It's done in themes.read rather than in packages, because it's theme-specific behaviour.

The object that's returned / passed around is not as nice as it could be, but that kind of thing can be done better in alpha when we're not trying to ship an emergency fix.

----

- this fix puts back our ability to serve any custom template
- this was a major DERP.
- let's not talk about it anymore.
