### PR TITLE
🎨  deny auto switch

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -504,16 +504,10 @@ authentication = {
      * @return {Promise}
      */
     isSetup: function isSetup() {
-        var tasks,
-            validStatuses = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
+        var tasks;
 
         function checkSetupStatus() {
-            return models.User
-                .where('status', 'in', validStatuses)
-                .count('id')
-                .then(function (count) {
-                    return !!count;
-                });
+            return models.User.isSetup();
         }
 
         function formatResponse(isSetup) {

--- a/core/server/auth/index.js
+++ b/core/server/auth/index.js
@@ -3,6 +3,7 @@ var passport = require('./passport'),
     authenticate = require('./authenticate'),
     sync = require('./sync'),
     oauth = require('./oauth'),
+    validation = require('./validation'),
     ghostAuth = require('./ghost-auth');
 
 exports.init = function (options) {
@@ -15,6 +16,7 @@ exports.init = function (options) {
         });
 };
 
+exports.validation = validation;
 exports.oauth = oauth;
 exports.authorize = authorize;
 exports.authenticate = authenticate;

--- a/core/server/auth/validation.js
+++ b/core/server/auth/validation.js
@@ -22,7 +22,7 @@ exports.switch = function validate(options) {
                         return Promise.reject(new errors.InternalServerError({
                             code: 'AUTH_SWITCH',
                             message: 'Switching the auth strategy is not allowed.',
-                            context: 'Please reset your database and start from stretch.',
+                            context: 'Please reset your database and start from scratch.',
                             help: 'NODE_ENV=production|development knex-migrator reset && NODE_ENV=production|development knex-migrator init\n'
                         }));
                     }

--- a/core/server/auth/validation.js
+++ b/core/server/auth/validation.js
@@ -1,0 +1,31 @@
+var Promise = require('bluebird'),
+    models = require('../models'),
+    errors = require('../errors');
+
+/**
+ * If the setup is completed and...
+ * 1. the public client does exist, deny to switch to local
+ * 2. the public client does not exist, deny to switch to remote
+ */
+exports.switch = function validate(options) {
+    var authType = options.authType;
+
+    return models.User.isSetup()
+        .then(function (isSetup) {
+            if (!isSetup) {
+                return;
+            }
+
+            return models.Client.findOne({slug: 'ghost-auth'}, {columns: 'id'})
+                .then(function (client) {
+                    if ((client && authType === 'password') || !client && authType === 'ghost') {
+                        return Promise.reject(new errors.InternalServerError({
+                            code: 'AUTH_SWITCH',
+                            message: 'Switching the auth strategy is not allowed.',
+                            context: 'Please reset your database and start from stretch.',
+                            help: 'NODE_ENV=production|development knex-migrator reset && NODE_ENV=production|development knex-migrator init\n'
+                        }));
+                    }
+                });
+        });
+};

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -72,7 +72,11 @@ function init() {
         parentApp = require('./app')();
 
         debug('Express Apps done');
-
+    }).then(function () {
+        return auth.validation.switch({
+            authType: config.get('auth:type')
+        });
+    }).then(function () {
         // runs asynchronous
         auth.init({
             authType: config.get('auth:type'),

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -487,6 +487,21 @@ User = ghostBookshelf.Model.extend({
         return self.edit.call(self, userData, options);
     },
 
+    /**
+     * Right now the setup of the blog depends on the user status.
+     * @TODO: see https://github.com/TryGhost/Ghost/issues/8003
+     */
+    isSetup: function isSetup() {
+        var validStatuses = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
+
+        return this
+            .where('status', 'in', validStatuses)
+            .count('id')
+            .then(function (count) {
+                return !!count;
+            });
+    },
+
     permissible: function permissible(userModelOrId, action, context, loadedPermissions, hasUserPermission, hasAppPermission) {
         var self = this,
             userModel = userModelOrId,

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -492,10 +492,8 @@ User = ghostBookshelf.Model.extend({
      * @TODO: see https://github.com/TryGhost/Ghost/issues/8003
      */
     isSetup: function isSetup() {
-        var validStatuses = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
-
         return this
-            .where('status', 'in', validStatuses)
+            .where('status', 'in', activeStates)
             .count('id')
             .then(function (count) {
                 return !!count;

--- a/core/test/unit/auth/passport_spec.js
+++ b/core/test/unit/auth/passport_spec.js
@@ -52,6 +52,8 @@ describe('Ghost Passport', function () {
             return Promise.resolve(client);
         });
 
+        sandbox.stub(models.Client, 'destroy').returns(Promise.resolve());
+
         sandbox.stub(models.Client, 'add', function () {
             client = new models.Client(testUtils.DataGenerator.forKnex.createClient());
             return Promise.resolve(client);
@@ -92,12 +94,36 @@ describe('Ghost Passport', function () {
                 should.exist(response.passport);
                 passport.use.callCount.should.eql(2);
 
-                models.Client.findOne.called.should.eql(false);
+                models.Client.findOne.called.should.eql(true);
+                models.Client.destroy.called.should.eql(false);
                 models.Client.add.called.should.eql(false);
                 FakeGhostOAuth2Strategy.prototype.setClient.called.should.eql(false);
                 FakeGhostOAuth2Strategy.prototype.registerClient.called.should.eql(false);
                 FakeGhostOAuth2Strategy.prototype.updateClient.called.should.eql(false);
             });
+        });
+
+        it('initialise passport with passport auth type [auth client exists]', function () {
+            return models.Client.add({slug: 'ghost-auth'})
+                .then(function () {
+                    models.Client.add.called.should.eql(true);
+                    models.Client.add.reset();
+
+                    return GhostPassport.init({
+                        authType: 'passport'
+                    });
+                })
+                .then(function (response) {
+                    should.exist(response.passport);
+                    passport.use.callCount.should.eql(2);
+
+                    models.Client.findOne.called.should.eql(true);
+                    models.Client.destroy.called.should.eql(true);
+                    models.Client.add.called.should.eql(false);
+                    FakeGhostOAuth2Strategy.prototype.setClient.called.should.eql(false);
+                    FakeGhostOAuth2Strategy.prototype.registerClient.called.should.eql(false);
+                    FakeGhostOAuth2Strategy.prototype.updateClient.called.should.eql(false);
+                });
         });
     });
 

--- a/core/test/unit/auth/validation_spec.js
+++ b/core/test/unit/auth/validation_spec.js
@@ -1,0 +1,78 @@
+var should = require('should'),
+    sinon = require('sinon'),
+    Promise = require('bluebird'),
+    auth = require('../../../server/auth'),
+    models = require('../../../server/models'),
+    sandbox = sinon.sandbox.create();
+
+describe('UNIT: auth validation', function () {
+    before(function () {
+        models.init();
+    });
+
+    beforeEach(function () {
+        sandbox.restore();
+    });
+
+    describe('ghost is enabled', function () {
+        it('[success]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(false));
+
+            return auth.validation.switch({
+                authType: 'ghost'
+            });
+        });
+
+        it('[success]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
+            sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
+
+            return auth.validation.switch({
+                authType: 'ghost'
+            });
+        });
+
+        it('[failure]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
+            sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
+
+            return auth.validation.switch({
+                authType: 'password'
+            }).catch(function (err) {
+                should.exist(err);
+                err.code.should.eql('AUTH_SWITCH');
+            });
+        });
+    });
+
+    describe('password is enabled', function () {
+        it('[success]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(false));
+
+            return auth.validation.switch({
+                authType: 'password'
+            });
+        });
+
+        it('[success]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
+            sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(false));
+
+            return auth.validation.switch({
+                authType: 'password'
+            });
+        });
+
+        it('[failure]', function () {
+            sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
+            sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
+
+            return auth.validation.switch({
+                authType: 'ghost'
+            }).catch(function (err) {
+                should.exist(err);
+                err.code.should.eql('AUTH_SWITCH');
+            });
+        });
+    });
+});


### PR DESCRIPTION
no issue

- deny auth switch after the blog was setup
- setup completed depends on the status of the user right now, see comments and issue https://github.com/TryGhost/Ghost/issues/8003

For now we deny the auth switch after blog setup.
I tested all kinds of edge cases e.g. user starts with a blog and switches auth strategies before setup has finished.