### PR TITLE
🎨  optimise requires for MigratorConfig

### DIFF
--- a/MigratorConfig.js
+++ b/MigratorConfig.js
@@ -1,5 +1,5 @@
 var config = require('./core/server/config'),
-    utils = require('./core/server/utils');
+    ghostVersion = require('./core/server/utils/ghost-version');
 
 /**
  * knex-migrator can be used via CLI or within the application
@@ -8,7 +8,7 @@ var config = require('./core/server/config'),
 require('./core/server/overrides');
 
 module.exports = {
-    currentVersion: utils.ghostVersion.safe,
+    currentVersion: ghostVersion.safe,
     database: config.get('database'),
     migrationPath: config.get('paths:migrationPath')
 };

--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -1,6 +1,5 @@
 var path = require('path'),
-    _ = require('lodash'),
-    errors = require('../errors');
+    _ = require('lodash');
 
 exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
     if (!this.get('privacy')) {
@@ -30,19 +29,6 @@ exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
  */
 exports.makePathsAbsolute = function makePathsAbsolute(obj, parent) {
     var self = this;
-
-    if (!obj) {
-        throw new errors.IncorrectUsageError({
-            message: 'makePathsAbsolute: Can\'t make paths absolute of non existing object.',
-            help: parent
-        });
-    }
-
-    if (!parent) {
-        throw new errors.IncorrectUsageError({
-            message: 'makePathsAbsolute: Parent is missing.'
-        });
-    }
 
     _.each(obj, function (configValue, pathsKey) {
         if (_.isObject(configValue)) {


### PR DESCRIPTION
no issue

- if knex-migrator loads the MigratorConfig too much stuff was required, which increases the memory usage
- i have deleted the IncorrectUsage errors for now, because this error should actually never appear