### PR TITLE
🔥 🎨 No more updateSettingsCache

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -8,11 +8,8 @@ var Promise          = require('bluebird'),
     errors           = require('../errors'),
     utils            = require('./utils'),
     pipeline         = require('../utils/pipeline'),
-    api              = {},
-    docName      = 'db',
+    docName          = 'db',
     db;
-
-api.settings         = require('./settings');
 
 /**
  * ## DB API Methods
@@ -28,8 +25,8 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Ghost Export JSON format
      */
-    exportContent: function (options) {
-        var tasks = [];
+    exportContent: function exportContent(options) {
+        var tasks;
 
         options = options || {};
 
@@ -57,8 +54,8 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    importContent: function (options) {
-        var tasks = [];
+    importContent: function importContent(options) {
+        var tasks;
         options = options || {};
 
         function importContent(options) {
@@ -81,7 +78,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    deleteAllContent: function (options) {
+    deleteAllContent: function deleteAllContent(options) {
         var tasks,
             queryOpts = {columns: 'id', context: {internal: true}};
 

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -70,14 +70,14 @@ settingsFilter = function (settings, filter) {
  * @param {Array} settingsModels
  * @returns {Settings}
  */
-readSettingsResult = function (settingsModels) {
-    var settings = _.reduce(settingsModels, function (memo, member) {
-            if (!memo.hasOwnProperty(member.attributes.key)) {
-                memo[member.attributes.key] = member.attributes;
-            }
+readSettingsResult = function readSettingsResult(settingsModels) {
+    var settings;
 
-            return memo;
-        }, {});
+    if (Array.isArray(settingsModels)) {
+        settings = _.keyBy(_.invokeMap(settingsModels, 'toJSON'), 'key');
+    } else {
+        settings = _.keyBy(settingsModels.toJSON(), 'key');
+    }
 
     return settings;
 };

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -19,19 +19,16 @@ var _            = require('lodash'),
     canEditAllSettings,
 
 // @TODO simplify this!
-updateSettingsCache = function updateSettingsCache() {
-    return dataProvider.Settings.findAll()
-        .then(function (settingsCollection) {
-            // FindAll returns us a bookshelf Collection of Settings Models.
-            // We want to iterate over the models, and for each model:
-            // Get the key, and the JSON version of the model, and call settingsCache.set()
-            // This is identical to the updateSettingFromModel code inside of settings/cache.init()
-            _.each(settingsCollection.models, function updateSettingFromModel(settingModel) {
-                settingsCache.set(settingModel.get('key'), settingModel.toJSON());
-            });
-
-            return settingsCache.getAll();
+updateSettingsCache = function updateSettingsCache(settingsCollection) {
+        // FindAll returns us a bookshelf Collection of Settings Models.
+        // We want to iterate over the models, and for each model:
+        // Get the key, and the JSON version of the model, and call settingsCache.set()
+        // This is identical to the updateSettingFromModel code inside of settings/cache.init()
+        _.each(settingsCollection.models, function updateSettingFromModel(settingModel) {
+            settingsCache.set(settingModel.get('key'), settingModel.toJSON());
         });
+
+        return settingsCache.getAll();
 };
 
 // ## Helpers

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -13,23 +13,9 @@ var _            = require('lodash'),
 
     settingsCache = require('../settings/cache'),
 
-    updateSettingsCache,
     settingsFilter,
     settingsResult,
     canEditAllSettings,
-
-// @TODO simplify this!
-updateSettingsCache = function updateSettingsCache(settingsCollection) {
-        // FindAll returns us a bookshelf Collection of Settings Models.
-        // We want to iterate over the models, and for each model:
-        // Get the key, and the JSON version of the model, and call settingsCache.set()
-        // This is identical to the updateSettingFromModel code inside of settings/cache.init()
-        _.each(settingsCollection.models, function updateSettingFromModel(settingModel) {
-            settingsCache.set(settingModel.get('key'), settingModel.toJSON());
-        });
-
-        return settingsCache.getAll();
-};
 
 // ## Helpers
 
@@ -243,5 +229,3 @@ settings = {
 };
 
 module.exports = settings;
-
-module.exports.updateSettingsCache = updateSettingsCache;

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -20,19 +20,8 @@ var _            = require('lodash'),
     canEditAllSettings,
 
 // @TODO simplify this!
-updateSettingsCache = function updateSettingsCache(settings, options) {
-    options = options || {};
-    settings = settings || {};
-
-    if (!_.isEmpty(settings)) {
-        _.map(settings, function (setting, key) {
-            settingsCache.set(key, setting);
-        });
-
-        return Promise.resolve(settingsCache.getAll());
-    }
-
-    return dataProvider.Settings.findAll(options)
+updateSettingsCache = function updateSettingsCache() {
+    return dataProvider.Settings.findAll()
         .then(function (result) {
             // keep reference and update all keys
             _.each(readSettingsResult(result.models), function (setting, key) {

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -259,11 +259,7 @@ settings = {
                 options.user = self.user;
                 return dataProvider.Settings.edit(checkedData.settings, options);
             }).then(function (result) {
-                var readResult = readSettingsResult(result);
-
-                return updateSettingsCache(readResult).then(function () {
-                    return settingsResult(readResult, type);
-                });
+                return settingsResult(readSettingsResult(result), type);
             });
         });
     }

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -22,10 +22,13 @@ var _            = require('lodash'),
 // @TODO simplify this!
 updateSettingsCache = function updateSettingsCache() {
     return dataProvider.Settings.findAll()
-        .then(function (result) {
-            // keep reference and update all keys
-            _.each(readSettingsResult(result.models), function (setting, key) {
-                settingsCache.set(key, setting);
+        .then(function (settingsCollection) {
+            // FindAll returns us a bookshelf Collection of Settings Models.
+            // We want to iterate over the models, and for each model:
+            // Get the key, and the JSON version of the model, and call settingsCache.set()
+            // This is identical to the updateSettingFromModel code inside of settings/cache.init()
+            _.each(settingsCollection.models, function updateSettingFromModel(settingModel) {
+                settingsCache.set(settingModel.get('key'), settingModel.toJSON());
             });
 
             return settingsCache.getAll();

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -15,7 +15,6 @@ var _            = require('lodash'),
 
     updateSettingsCache,
     settingsFilter,
-    readSettingsResult,
     settingsResult,
     canEditAllSettings,
 
@@ -54,35 +53,6 @@ settingsFilter = function (settings, filter) {
         }
         return true;
     }));
-};
-
-/**
- * ### Read Settings Result
- *
- * Converts the models to keyed JSON
- * E.g.
- * dbHash: {
- *   id: '123abc',
- *   key: 'dbash',
- *   value: 'xxxx',
- *   type: 'core',
- *   timestamps
- *  }
- *
- * @private
- * @param {Array} settingsModels
- * @returns {Settings}
- */
-readSettingsResult = function readSettingsResult(settingsModels) {
-    var settings;
-
-    if (Array.isArray(settingsModels)) {
-        settings = _.keyBy(_.invokeMap(settingsModels, 'toJSON'), 'key');
-    } else {
-        settings = _.keyBy(settingsModels.toJSON(), 'key');
-    }
-
-    return settings;
 };
 
 /**

--- a/core/server/data/migrations/init/3-insert-settings.js
+++ b/core/server/data/migrations/init/3-insert-settings.js
@@ -1,7 +1,0 @@
-var _ = require('lodash'),
-    models = require('../../../models');
-
-module.exports = function insertSettings(options) {
-    var localOptions = _.merge({context: {internal: true}}, options);
-    return models.Settings.populateDefaults(localOptions);
-};

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -149,9 +149,9 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     populateDefaults: function populateDefaults(options) {
-        options = options || {};
+        var self = this;
 
-        options = _.merge({}, options, internalContext);
+        options = _.merge({}, options || {}, internalContext);
 
         return this
             .findAll(options)
@@ -167,9 +167,9 @@ Settings = ghostBookshelf.Model.extend({
                     }
                 });
 
-                if (insertOperations > 0) {
+                if (insertOperations.length > 0) {
                     return Promise.all(insertOperations).then(function fetchAllToReturn() {
-                        return this.findAll(options);
+                        return self.findAll(options);
                     });
                 }
 

--- a/core/server/settings/index.js
+++ b/core/server/settings/index.js
@@ -3,27 +3,17 @@
  * A collection of utilities for handling settings including a cache
  */
 
-var _ = require('lodash'),
-    SettingsModel = require('../models/settings').Settings,
+var SettingsModel = require('../models/settings').Settings,
     SettingsCache = require('./cache');
 
 module.exports = {
     init: function init() {
         // Bind to events
-        SettingsCache.init();
+
         // Update the defaults
         return SettingsModel.populateDefaults()
             .then(function (settingsCollection) {
-                // Reset the cache
-                // PopulateDefaults returns us a bookshelf Collection of Settings Models.
-                // We want to iterate over the models, and for each model:
-                // Get the key, and the JSON version of the model, and call settingsCache.set()
-                // This is identical to the updateSettingFromModel code inside of settings/cache.init()
-                _.each(settingsCollection.models, function updateSettingFromModel(settingModel) {
-                    SettingsCache.set(settingModel.get('key'), settingModel.toJSON());
-                });
-
-                return SettingsCache.getAll();
+                SettingsCache.init(settingsCollection);
             });
     }
 };

--- a/core/server/settings/index.js
+++ b/core/server/settings/index.js
@@ -15,9 +15,9 @@ module.exports = {
         SettingsCache.init();
         // Update the defaults
         return SettingsModel.populateDefaults()
-            .then(function () {
+            .then(function (allSettings) {
                 // Reset the cache
-                return SettingsAPI.updateSettingsCache();
+                return SettingsAPI.updateSettingsCache(allSettings);
             });
     }
 };

--- a/core/server/settings/index.js
+++ b/core/server/settings/index.js
@@ -8,11 +8,11 @@ var SettingsModel = require('../models/settings').Settings,
 
 module.exports = {
     init: function init() {
-        // Bind to events
-
         // Update the defaults
         return SettingsModel.populateDefaults()
             .then(function (settingsCollection) {
+                // Initialise the cache with the result
+                // This will bind to events for further updates
                 SettingsCache.init(settingsCollection);
             });
     }

--- a/core/test/integration/api/api_settings_spec.js
+++ b/core/test/integration/api/api_settings_spec.js
@@ -116,11 +116,8 @@ describe('Settings API', function () {
     });
 
     it('can edit', function () {
-        var testReference = settingsCache.getAll();
-
         // see default-settings.json
         settingsCache.get('title').should.eql('Ghost');
-        testReference.title.value.should.eql('Ghost');
 
         return callApiWithContext(defaultContext, 'edit', {settings: [{key: 'title', value: 'UpdatedGhost'}]}, {})
             .then(function (response) {
@@ -130,7 +127,6 @@ describe('Settings API', function () {
                 testUtils.API.checkResponse(response.settings[0], 'setting');
 
                 settingsCache.get('title').should.eql('UpdatedGhost');
-                testReference.title.value.should.eql('UpdatedGhost');
             });
     });
 


### PR DESCRIPTION
Don't be fooled by the ridiculous number of commits, this is me very slowly but surely and carefully removing the concept of updateSettingsCache and making sure I didn't break anything.

I also removed readSettingsResult - this was converting from an array of models to a keyed JSON response & is now done inline in settings.edit with lots of docs.

I also did a bit of a last hurrah at the end, and updated the settingsCache to have a tonne of documentation.

There is one functional change in there - the addition of _.cloneDeep() to `set` and `getAll` so that we don't allow for modifying objects outside of the settingsCache API.

