### PR TITLE
🎨  handle case: sync email after logout

### DIFF
--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -128,7 +128,7 @@ strategies = {
                 });
         };
 
-        models.User.getByEmail(profile.email, options)
+        models.User.findOne({ghost_auth_id: profile.id}, options)
             .then(function fetchedUser(user) {
                 if (user) {
                     return user;
@@ -142,7 +142,12 @@ strategies = {
             })
             .then(function updateGhostAuthToken(user) {
                 options.id = user.id;
-                return models.User.edit({ghost_auth_access_token: ghostAuthAccessToken}, options);
+
+                return models.User.edit({
+                    email: profile.email,
+                    ghost_auth_id: profile.id,
+                    ghost_auth_access_token: ghostAuthAccessToken
+                }, options);
             })
             .then(function returnResponse(user) {
                 done(null, user, profile);

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -29,6 +29,7 @@ module.exports = {
         name: {type: 'string', maxlength: 191, nullable: false},
         slug: {type: 'string', maxlength: 191, nullable: false, unique: true},
         ghost_auth_access_token: {type: 'string', maxlength: 32, nullable: true},
+        ghost_auth_id: {type: 'string', maxlength: 24, nullable: true},
         password: {type: 'string', maxlength: 60, nullable: false},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
         image: {type: 'string', maxlength: 2000, nullable: true},

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ should.equal(true, true);
 // both of which are required for migrations to work properly.
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    var currentSchemaHash = 'e648a7d1f9b9c5eb19512999756cd4db',
+    var currentSchemaHash = 'ae4ada98be2691b4d6e323eebcdb875f',
         currentFixturesHash = 'b9e684a87353c592df9b23948e364c05';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
no issue

If the user changes the email in the remote auth service and executes a logout directly afterwards, the user would lock himself out of his blog, because the email sync happens once per hour right now. For that case, we have to store the ghost auth id, which i think not bad at all.