### PR TITLE
🐛 Use isIgnitionError to detect unhandled errors

### DIFF
--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -58,7 +58,7 @@ _private.prepareError = function prepareError(err, req, res, next) {
         err = err[0];
     }
 
-    if (!(err instanceof errors.GhostError)) {
+    if (!errors.utils.isIgnitionError(err)) {
         // We need a special case for 404 errors
         // @TODO look at adding this to the GhostError class
         if (err.statusCode && err.statusCode === 404) {

--- a/core/test/functional/routes/api/themes_spec.js
+++ b/core/test/functional/routes/api/themes_spec.js
@@ -255,6 +255,12 @@ describe('Themes API', function () {
                     }
 
                     res.statusCode.should.eql(403);
+
+                    should.exist(res.body.errors);
+                    res.body.errors.should.be.an.Array().with.lengthOf(1);
+                    res.body.errors[0].errorType.should.eql('NoPermissionError');
+                    res.body.errors[0].message.should.eql('You do not have permission to add themes');
+
                     done();
                 });
             });
@@ -263,10 +269,15 @@ describe('Themes API', function () {
                 request.del(testUtils.API.getApiQuery('themes/test'))
                     .set('Authorization', 'Bearer ' + scope.editorAccessToken)
                     .expect(403)
-                    .end(function (err) {
+                    .end(function (err, res) {
                         if (err) {
                             return done(err);
                         }
+
+                        should.exist(res.body.errors);
+                        res.body.errors.should.be.an.Array().with.lengthOf(1);
+                        res.body.errors[0].errorType.should.eql('NoPermissionError');
+                        res.body.errors[0].message.should.eql('You do not have permission to destroy themes');
 
                         done();
                     });
@@ -276,10 +287,15 @@ describe('Themes API', function () {
                 request.get(testUtils.API.getApiQuery('themes/casper/download/'))
                     .set('Authorization', 'Bearer ' + scope.editorAccessToken)
                     .expect(403)
-                    .end(function (err) {
+                    .end(function (err, res) {
                         if (err) {
                             return done(err);
                         }
+
+                        should.exist(res.body.errors);
+                        res.body.errors.should.be.an.Array().with.lengthOf(1);
+                        res.body.errors[0].errorType.should.eql('NoPermissionError');
+                        res.body.errors[0].message.should.eql('You do not have permission to read themes');
 
                         done();
                     });


### PR DESCRIPTION
closes #8099
refs https://github.com/TryGhost/Ignition/issues/28

- use new utility to detect if an error has not yet been handled & convert it to a generic Ghost error
- update theme_spec tests to include checking error messages, which catches this issue
