### PR TITLE
🐛  export database read settings from database

### DIFF
--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -25,7 +25,7 @@ exportFileName = function exportFileName() {
 
     return models.Settings.findOne(_.merge({key: 'title'}, modelOptions)).then(function (result) {
         if (result) {
-            title = serverUtils.safeString(result.attributes.value) + '.';
+            title = serverUtils.safeString(result.get('value')) + '.';
         }
 
         return title + 'ghost.' + datetime + '.json';

--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -6,7 +6,7 @@ var _ = require('lodash'),
     ghostVersion = require('../../utils/ghost-version'),
     errors      = require('../../errors'),
     logging     = require('../../logging'),
-    settings    = require('../../api/settings'),
+    models      = require('../../models'),
     i18n        = require('../../i18n'),
     excludedTables = ['accesstokens', 'refreshtokens', 'clients', 'client_trusted_domains'],
     modelOptions = {context: {internal: true}},
@@ -23,10 +23,11 @@ exportFileName = function exportFileName() {
     var datetime = (new Date()).toJSON().substring(0, 10),
         title = '';
 
-    return settings.read(_.extend({}, {key: 'title'}, modelOptions)).then(function (result) {
+    return models.Settings.findOne(_.merge({key: 'title'}, modelOptions)).then(function (result) {
         if (result) {
-            title = serverUtils.safeString(result.settings[0].value) + '.';
+            title = serverUtils.safeString(result.attributes.value) + '.';
         }
+
         return title + 'ghost.' + datetime + '.json';
     }).catch(function (err) {
         logging.error(new errors.GhostError({err: err}));

--- a/core/test/unit/exporter_spec.js
+++ b/core/test/unit/exporter_spec.js
@@ -1,17 +1,21 @@
-var should    = require('should'),
-    sinon     = require('sinon'),
-    rewire    = require('rewire'),
-    Promise   = require('bluebird'),
-    db        = require('../../server/data/db'),
-    errors    = require('../../server/errors'),
-    exporter  = rewire('../../server/data/export'),
-    schema    = require('../../server/data/schema'),
-    models    = require('../../server/models'),
+var should = require('should'),
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+    Promise = require('bluebird'),
+    db = require('../../server/data/db'),
+    errors = require('../../server/errors'),
+    exporter = rewire('../../server/data/export'),
+    schema = require('../../server/data/schema'),
+    models = require('../../server/models'),
     schemaTables = Object.keys(schema.tables),
     sandbox = sinon.sandbox.create();
 
 describe('Exporter', function () {
     var tablesStub, queryMock, knexMock, knexStub;
+
+    before(function () {
+        models.init();
+    });
 
     afterEach(function () {
         sandbox.restore();
@@ -33,7 +37,11 @@ describe('Exporter', function () {
             knexMock = sandbox.stub().returns(queryMock);
 
             // this MUST use sinon, not sandbox, see sinonjs/sinon#781
-            knexStub = sinon.stub(db, 'knex', {get: function () { return knexMock; }});
+            knexStub = sinon.stub(db, 'knex', {
+                get: function () {
+                    return knexMock;
+                }
+            });
         });
 
         it('should try to export all the correct tables', function (done) {
@@ -100,7 +108,11 @@ describe('Exporter', function () {
     describe('exportFileName', function () {
         it('should return a correctly structured filename', function (done) {
             var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
-                new Promise.resolve({attributes: {value: 'testblog'}})
+                new Promise.resolve({
+                    get: function () {
+                        return 'testblog';
+                    }
+                })
             );
 
             exporter.fileName().then(function (result) {

--- a/core/test/unit/exporter_spec.js
+++ b/core/test/unit/exporter_spec.js
@@ -6,7 +6,7 @@ var should    = require('should'),
     errors    = require('../../server/errors'),
     exporter  = rewire('../../server/data/export'),
     schema    = require('../../server/data/schema'),
-    settings  = require('../../server/api/settings'),
+    models    = require('../../server/models'),
     schemaTables = Object.keys(schema.tables),
     sandbox = sinon.sandbox.create();
 
@@ -99,8 +99,8 @@ describe('Exporter', function () {
 
     describe('exportFileName', function () {
         it('should return a correctly structured filename', function (done) {
-            var settingsStub = sandbox.stub(settings, 'read').returns(
-                new Promise.resolve({settings: [{value: 'testblog'}]})
+            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
+                new Promise.resolve({attributes: {value: 'testblog'}})
             );
 
             exporter.fileName().then(function (result) {
@@ -113,7 +113,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings is empty', function (done) {
-            var settingsStub = sandbox.stub(settings, 'read').returns(
+            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
                 new Promise.resolve()
             );
 
@@ -127,7 +127,7 @@ describe('Exporter', function () {
         });
 
         it('should return a correctly structured filename if settings errors', function (done) {
-            var settingsStub = sandbox.stub(settings, 'read').returns(
+            var settingsStub = sandbox.stub(models.Settings, 'findOne').returns(
                 new Promise.reject()
             );
 


### PR DESCRIPTION
no issue

- the backup script uses the export database lib and is broken if knex-migrator is called via shell, the settings cache is not loaded
- i have changed the export database lib to read the settings key directly from the db