### PR TITLE
🎨  fetch user profile by auth id

### DIFF
--- a/core/server/auth/ghost-auth.js
+++ b/core/server/auth/ghost-auth.js
@@ -4,11 +4,11 @@ var passport = require('passport'),
 module.exports.getUser = function getUser(options) {
     options = options || {};
 
-    var token = options.token,
+    var id = options.id,
         ghostOAuth2Strategy = passport._strategies.ghost;
 
     return new Promise(function (resolve, reject) {
-        ghostOAuth2Strategy.userProfile(token, function (err, profile) {
+        ghostOAuth2Strategy.userProfileByIdentityId(id, function (err, profile) {
             if (err) {
                 return reject(err);
             }

--- a/core/server/auth/sync.js
+++ b/core/server/auth/sync.js
@@ -25,7 +25,7 @@ _private.syncUser = function syncUser(loggedInUserModel) {
     }
 
     return ghostAuth.getUser({
-        token: loggedInUserModel.get('ghost_auth_access_token')
+        id: loggedInUserModel.get('ghost_auth_id')
     }).then(function (ghostUser) {
         debug('ghost_email', ghostUser.email);
         debug('user_email', loggedInUserModel.get('email'));


### PR DESCRIPTION
no issue

- the request is secured by client credentials
- we no longer sync with ghost auth token
- you can only fetch the user info if the user is connected to your blog (invited, owner)
- passport ghost instance stores the client credentials in the passport instance, no need to pass them into the user info function
- tested with staging 