### PR TITLE
suspend a user

### DIFF
--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -49,7 +49,7 @@ strategies = {
                                     return done(null, false);
                                 }
 
-                                if (model.get('status') === 'inactive') {
+                                if (!model.isActive()) {
                                     throw new errors.NoPermissionError({
                                         message: 'You were suspended from this blog.'
                                     });
@@ -161,7 +161,7 @@ strategies = {
                         throw new errors.NotFoundError();
                     }
 
-                    if (user.get('status') === 'inactive') {
+                    if (!user.isActive()) {
                         throw new errors.NoPermissionError({
                             message: 'You were suspended from this blog.'
                         });

--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -1,5 +1,4 @@
 var _ = require('lodash'),
-    Promise = require('bluebird'),
     models = require('../models'),
     utils = require('../utils'),
     i18n = require('../i18n'),
@@ -154,7 +153,7 @@ strategies = {
         handleSignIn = function handleSignIn() {
             var user;
 
-            return models.User.findOne({ghost_auth_id: profile.id, status: 'all'}, options)
+            return models.User.findOne({ghost_auth_id: profile.id}, options)
                 .then(function (_user) {
                     user = _user;
 

--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -51,7 +51,7 @@ strategies = {
 
                                 if (!model.isActive()) {
                                     throw new errors.NoPermissionError({
-                                        message: 'You were suspended from this blog.'
+                                        message: i18n.t('errors.models.user.accountSuspended')
                                     });
                                 }
 
@@ -163,7 +163,7 @@ strategies = {
 
                     if (!user.isActive()) {
                         throw new errors.NoPermissionError({
-                            message: 'You were suspended from this blog.'
+                            message: i18n.t('errors.models.user.accountSuspended')
                         });
                     }
 

--- a/core/server/auth/oauth.js
+++ b/core/server/auth/oauth.js
@@ -74,9 +74,7 @@ function exchangeAuthorizationCode(req, res, next) {
 
     passport.authenticate('ghost', {session: false, failWithError: false}, function authenticate(err, user) {
         if (err) {
-            return next(new errors.UnauthorizedError({
-                err: err
-            }));
+            return next(err);
         }
 
         if (!user) {

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -17,6 +17,25 @@ events.on('token.added', function (tokenModel) {
 });
 
 /**
+ * WHEN user get's suspended (status=inactive), we delete his tokens to ensure
+ * he can't login anymore
+ */
+events.on('user.deactivated', function (userModel) {
+    var options = {id: userModel.id};
+
+    models.Accesstoken.destroyByUser(options)
+        .then(function () {
+            return models.Refreshtoken.destroyByUser(options);
+        })
+        .catch(function (err) {
+            logging.error(new errors.GhostError({
+                err: err,
+                level: 'critical'
+            }));
+        });
+});
+
+/**
  * WHEN timezone changes, we will:
  * - reschedule all scheduled posts
  * - draft scheduled posts, when the published_at would be in the past

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -770,7 +770,8 @@ User = ghostBookshelf.Model.extend({
                 return userWithEmail;
             }
         });
-    }
+    },
+    inactiveStates: inactiveStates
 });
 
 Users = ghostBookshelf.Collection.extend({

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -18,6 +18,7 @@ var _              = require('lodash'),
     bcryptCompare  = Promise.promisify(bcrypt.compare),
 
     activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'],
+    allStates      = activeStates.concat(['inactive']),
     User,
     Users;
 
@@ -214,7 +215,7 @@ User = ghostBookshelf.Model.extend({
             return null;
         }
 
-        return this.isPublicContext() ? 'status:[' + activeStates.join(',') + ']' : null;
+        return this.isPublicContext() ? 'status:[' + allStates.join(',') + ']' : null;
     },
 
     defaultFilters: function defaultFilters() {
@@ -222,7 +223,7 @@ User = ghostBookshelf.Model.extend({
             return null;
         }
 
-        return this.isPublicContext() ? null : 'status:[' + activeStates.join(',') + ']';
+        return this.isPublicContext() ? null : 'status:[' + allStates.join(',') + ']';
     }
 }, {
     orderDefaultOptions: function orderDefaultOptions() {
@@ -244,7 +245,7 @@ User = ghostBookshelf.Model.extend({
         // This is the only place that 'options.where' is set now
         options.where = {statements: []};
 
-        var allStates = activeStates, value;
+        var value;
 
         // Filter on the status.  A status of 'all' translates to no filter since we want all statuses
         if (options.status !== 'all') {
@@ -309,7 +310,7 @@ User = ghostBookshelf.Model.extend({
 
         delete data.role;
         data = _.defaults(data || {}, {
-            status: 'active'
+            status: 'all'
         });
 
         status = data.status;

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -17,8 +17,9 @@ var _              = require('lodash'),
     bcryptHash     = Promise.promisify(bcrypt.hash),
     bcryptCompare  = Promise.promisify(bcrypt.compare),
 
-    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'],
-    allStates      = activeStates.concat(['inactive']),
+    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'],
+    inactiveStates = ['inactive', 'locked'],
+    allStates      = activeStates.concat(inactiveStates),
     User,
     Users;
 
@@ -81,6 +82,10 @@ User = ghostBookshelf.Model.extend({
         }
 
         model.emitChange('edited');
+    },
+
+    isActive: function isActive() {
+        return inactiveStates.indexOf(this.get('status')) === -1;
     },
 
     /**

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -387,6 +387,7 @@
             "users": {
                 "userNotFound": "User not found.",
                 "cannotChangeOwnRole": "You cannot change your own role.",
+                "cannotChangeStatus": "You cannot change your own status.",
                 "cannotChangeOwnersRole": "Cannot change Owner's role",
                 "noPermissionToEditUser": "You do not have permission to edit this user",
                 "noPermissionToAddUser": "You do not have permission to add this user",

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -244,6 +244,7 @@
                 },
                 "incorrectPassword": "Your password is incorrect.",
                 "accountLocked": "Your account is locked. Please reset your password to log in again by clicking the \"Forgotten password?\" link!",
+                "accountSuspended": "Your account was suspended.",
                 "newPasswordsDoNotMatch": "Your new passwords do not match",
                 "passwordRequiredForOperation": "Password is required for this operation",
                 "expiredToken": "Expired token",

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -10,7 +10,7 @@ describe('User API', function () {
     var ownerAccessToken = '',
         editorAccessToken = '',
         authorAccessToken = '',
-        editor, author, ghostServer;
+        editor, author, ghostServer, inactiveUser;
 
     before(function (done) {
         // starting ghost automatically populates the db
@@ -36,6 +36,14 @@ describe('User API', function () {
             });
         }).then(function (_user2) {
             author = _user2;
+
+            // create inactive user
+            return testUtils.createUser({
+                user: testUtils.DataGenerator.forKnex.createUser({email: 'test+3@ghost.org', status: 'inactive'}),
+                role: testUtils.DataGenerator.Content.roles[2]
+            });
+        }).then(function (_user3) {
+            inactiveUser = _user3;
 
             // by default we login with the owner
             return testUtils.doAuth(request);
@@ -81,7 +89,7 @@ describe('User API', function () {
 
                         // owner use when Ghost starts
                         // and two extra users, see createUser in before
-                        jsonResponse.users.should.have.length(3);
+                        jsonResponse.users.should.have.length(4);
 
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                         testUtils.API.isISO8601(jsonResponse.users[0].last_login).should.be.true();
@@ -112,8 +120,9 @@ describe('User API', function () {
                         should.exist(jsonResponse.users);
                         testUtils.API.checkResponse(jsonResponse, 'users');
 
-                        jsonResponse.users.should.have.length(3);
+                        jsonResponse.users.should.have.length(4);
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        jsonResponse.users[3].status.should.eql(inactiveUser.status);
                         done();
                     });
             });
@@ -134,7 +143,7 @@ describe('User API', function () {
                         should.exist(jsonResponse.users);
                         testUtils.API.checkResponse(jsonResponse, 'users');
 
-                        jsonResponse.users.should.have.length(3);
+                        jsonResponse.users.should.have.length(4);
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user', 'roles');
                         done();
                     });

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -32,7 +32,7 @@ describe('Users API', function () {
     });
 
     beforeEach(testUtils.setup(
-        'users:roles', 'users', 'user:token', 'perms:user', 'perms:role', 'perms:setting', 'perms:init', 'posts'
+        'users:roles', 'users', 'user-token', 'perms:user', 'perms:role', 'perms:setting', 'perms:init', 'posts'
     ));
 
     afterEach(function () {

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -3,6 +3,7 @@ var testUtils       = require('../../utils'),
     Promise         = require('bluebird'),
     _               = require('lodash'),
     models          = require('../../../server/models'),
+    errors          = require('../../../server/errors'),
     UserAPI         = require('../../../server/api/users'),
     db              = require('../../../server/data/db'),
     context         = testUtils.context,
@@ -458,6 +459,240 @@ describe('Users API', function () {
                     done();
                 });
             }).catch(done);
+        });
+
+        describe('Change status', function () {
+            describe('as owner', function () {
+                it('[success] can change status to inactive for admin', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.owner, {id: userIdFor.admin})
+                    ).then(function () {
+                        return models.User.findOne({id: userIdFor.admin, status: 'all'}).then(function (response) {
+                            response.get('status').should.eql('inactive');
+                        });
+                    });
+                });
+
+                it('[success] can change status to inactive for editor', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.owner, {id: userIdFor.editor})
+                    ).then(function () {
+                        return models.User.findOne({id: userIdFor.editor, status: 'all'}).then(function (response) {
+                            response.get('status').should.eql('inactive');
+                        });
+                    });
+                });
+            });
+
+            describe('as admin', function () {
+                it('[failure] can\'t change status to inactive for owner', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.admin, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\'t change status to inactive for admin', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.admin, {id: userIdFor.admin2})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[success] can change status to inactive for editor', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.admin, {id: userIdFor.editor})
+                    ).then(function () {
+                        return models.User.findOne({id: userIdFor.editor, status: 'all'}).then(function (response) {
+                            response.get('status').should.eql('inactive');
+                        });
+                    });
+                });
+            });
+
+            describe('as editor', function () {
+                it('[failure] can\'t change status to inactive for owner', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.editor, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\'t change status to inactive for admin', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.editor, {id: userIdFor.admin})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\'t change status to inactive for editor', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.editor, {id: userIdFor.editor2})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[success] can change status to inactive for author', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.editor, {id: userIdFor.author})
+                    ).then(function () {
+                        return models.User.findOne({id: userIdFor.author, status: 'all'}).then(function (response) {
+                            response.get('status').should.eql('inactive');
+                        });
+                    });
+                });
+            });
+
+            describe('as author', function () {
+                it('[failure] can\'t change status to inactive for owner', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.author, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\' change my own status to inactive', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.author, {id: userIdFor.author})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\'t change status to inactive for admin', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.author, {id: userIdFor.admin})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\'t change status to inactive for editor', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.author, {id: userIdFor.editor})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can change status to inactive for author', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.author, {id: userIdFor.author2})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+            });
         });
     });
 

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -518,6 +518,22 @@ describe('Users API', function () {
                         });
                     });
                 });
+
+                it('[failure] can\' change my own status to inactive', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.owner, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
             });
 
             describe('as admin', function () {
@@ -553,6 +569,22 @@ describe('Users API', function () {
                     });
                 });
 
+                it('[failure] can\' change my own status to inactive', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.admin, {id: userIdFor.admin})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
                 it('[success] can change status to inactive for editor', function () {
                     return UserAPI.edit(
                         {
@@ -580,6 +612,22 @@ describe('Users API', function () {
                                 }
                             ]
                         }, _.extend({}, context.editor, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
+
+                it('[failure] can\' change my own status to inactive', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'inactive'
+                                }
+                            ]
+                        }, _.extend({}, context.editor, {id: userIdFor.editor})
                     ).then(function () {
                         throw new Error('this is not allowed');
                     }).catch(function (err) {

--- a/core/test/integration/model/base/listeners_spec.js
+++ b/core/test/integration/model/base/listeners_spec.js
@@ -25,7 +25,7 @@ describe('Models: listeners', function () {
         };
 
     before(testUtils.teardown);
-    beforeEach(testUtils.setup());
+    beforeEach(testUtils.setup('user-token:0'));
 
     beforeEach(function () {
         sinon.stub(events, 'on', function (eventName, callback) {
@@ -174,6 +174,39 @@ describe('Models: listeners', function () {
                     })
                     .catch(done);
             });
+        });
+    });
+
+    describe('on user is deactived', function () {
+        it('ensure tokens get deleted', function (done) {
+            var userId = testUtils.DataGenerator.Content.users[0].id,
+                timeout,
+                retries = 0;
+
+            (function retry() {
+                Promise.props({
+                    accesstokens: models.Accesstoken.findAll({context: {internal: true}, id: userId}),
+                    refreshtokens: models.Refreshtoken.findAll({context: {internal: true}, id: userId})
+                }).then(function (result) {
+                    if (retries === 0) {
+                        // trigger event after first check how many tokens the user has
+                        eventsToRemember['user.deactivated']({
+                            id: userId
+                        });
+
+                        result.accesstokens.length.should.eql(1);
+                        result.refreshtokens.length.should.eql(1);
+                    }
+
+                    if (!result.accesstokens.length && !result.refreshtokens.length) {
+                        return done();
+                    }
+
+                    retries = retries + 1;
+                    clearTimeout(timeout);
+                    timeout = setTimeout(retry, 500);
+                }).catch(done);
+            })();
         });
     });
 });

--- a/core/test/integration/model/base/listeners_spec.js
+++ b/core/test/integration/model/base/listeners_spec.js
@@ -25,7 +25,7 @@ describe('Models: listeners', function () {
         };
 
     before(testUtils.teardown);
-    beforeEach(testUtils.setup('user-token:0'));
+    beforeEach(testUtils.setup('owner', 'user-token:0'));
 
     beforeEach(function () {
         sinon.stub(events, 'on', function (eventName, callback) {

--- a/core/test/unit/auth/auth-strategies_spec.js
+++ b/core/test/unit/auth/auth-strategies_spec.js
@@ -175,7 +175,7 @@ describe('Auth Strategies', function () {
                 next.calledOnce.should.be.true();
                 next.firstCall.args.length.should.eql(1);
                 (next.firstCall.args[0] instanceof errors.NoPermissionError).should.eql(true);
-                next.firstCall.args[0].message.should.eql('You were suspended from this blog.');
+                next.firstCall.args[0].message.should.eql('Your account was suspended.');
                 done();
             }).catch(done);
         });
@@ -399,7 +399,7 @@ describe('Auth Strategies', function () {
 
             authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, ownerProfile, function (err, user, profile) {
                 should.exist(err);
-                err.message.should.eql('You were suspended from this blog.');
+                err.message.should.eql('Your account was suspended.');
 
                 userFindOneStub.calledOnce.should.be.true();
                 userEditStub.calledOnce.should.be.false();

--- a/core/test/unit/auth/auth-strategies_spec.js
+++ b/core/test/unit/auth/auth-strategies_spec.js
@@ -114,7 +114,7 @@ describe('Auth Strategies', function () {
     });
 
     describe('Bearer Strategy', function () {
-        var tokenStub, userStub;
+        var tokenStub, userStub, userStatus;
 
         beforeEach(function () {
             tokenStub = sandbox.stub(Models.Accesstoken, 'findOne');
@@ -124,6 +124,7 @@ describe('Auth Strategies', function () {
                     return fakeValidToken;
                 }
             }));
+
             tokenStub.withArgs({token: fakeInvalidToken.token}).returns(new Promise.resolve({
                 toJSON: function () {
                     return fakeInvalidToken;
@@ -135,6 +136,9 @@ describe('Auth Strategies', function () {
             userStub.withArgs({id: 3}).returns(new Promise.resolve({
                 toJSON: function () {
                     return {id: 3};
+                },
+                get: function () {
+                    return userStatus;
                 }
             }));
         });
@@ -142,6 +146,8 @@ describe('Auth Strategies', function () {
         it('should find user with valid token', function (done) {
             var accessToken = 'valid-token',
                 userId = 3;
+
+            userStatus = 'active';
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
                 tokenStub.calledOnce.should.be.true();
@@ -151,6 +157,25 @@ describe('Auth Strategies', function () {
                 next.calledOnce.should.be.true();
                 next.firstCall.args.length.should.eql(3);
                 next.calledWith(null, {id: userId}, {scope: '*'}).should.be.true();
+                done();
+            }).catch(done);
+        });
+
+        it('should find user with valid token, but user is suspended', function (done) {
+            var accessToken = 'valid-token',
+                userId = 3;
+
+            userStatus = 'inactive';
+
+            authStrategies.bearerStrategy(accessToken, next).then(function () {
+                tokenStub.calledOnce.should.be.true();
+                tokenStub.calledWith({token: accessToken}).should.be.true();
+                userStub.calledOnce.should.be.true();
+                userStub.calledWith({id: userId}).should.be.true();
+                next.calledOnce.should.be.true();
+                next.firstCall.args.length.should.eql(1);
+                (next.firstCall.args[0] instanceof errors.NoPermissionError).should.eql(true);
+                next.firstCall.args[0].message.should.eql('You were suspended from this blog.');
                 done();
             }).catch(done);
         });
@@ -221,7 +246,7 @@ describe('Auth Strategies', function () {
             authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, profile, function (err) {
                 should.exist(err);
                 (err instanceof errors.NotFoundError).should.eql(true);
-                userFindOneStub.calledOnce.should.be.true();
+                userFindOneStub.calledOnce.should.be.false();
                 inviteStub.calledOnce.should.be.true();
                 done();
             });
@@ -242,7 +267,7 @@ describe('Auth Strategies', function () {
             authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, profile, function (err) {
                 should.exist(err);
                 (err instanceof errors.NotFoundError).should.eql(true);
-                userFindOneStub.calledOnce.should.be.true();
+                userFindOneStub.calledOnce.should.be.false();
                 inviteStub.calledOnce.should.be.true();
                 done();
             });
@@ -272,7 +297,7 @@ describe('Auth Strategies', function () {
                 user.should.eql(invitedUser);
                 profile.should.eql(invitedProfile);
 
-                userFindOneStub.calledOnce.should.be.true();
+                userFindOneStub.calledOnce.should.be.false();
                 inviteStub.calledOnce.should.be.true();
                 done();
             });
@@ -290,7 +315,12 @@ describe('Auth Strategies', function () {
             userFindOneStub.withArgs({slug: 'ghost-owner', status: 'inactive'})
                 .returns(Promise.resolve(_.merge({}, {status: 'inactive'}, owner)));
 
-            userEditStub.withArgs({status: 'active', email: 'test@example.com'}, {
+            userEditStub.withArgs({
+                status: 'active',
+                email: 'test@example.com',
+                ghost_auth_id: ownerProfile.id,
+                ghost_auth_access_token: ghostAuthAccessToken
+            }, {
                 context: {internal: true},
                 id: owner.id
             }).returns(Promise.resolve(owner));
@@ -317,11 +347,13 @@ describe('Auth Strategies', function () {
             });
         });
 
-        it('auth', function (done) {
+        it('sign in', function (done) {
             var ghostAuthAccessToken = '12345',
                 req = {body: {}},
                 ownerProfile = {email: 'test@example.com', id: '12345'},
-                owner = {id: 2};
+                owner = {id: 2, get: function () {
+                    return 'active'
+                }};
 
             userFindOneStub.returns(Promise.resolve(owner));
             userEditStub.withArgs({
@@ -343,6 +375,38 @@ describe('Auth Strategies', function () {
                 should.exist(profile);
                 user.should.eql(owner);
                 profile.should.eql(ownerProfile);
+                done();
+            });
+        });
+
+        it('sign in, but user is suspended', function (done) {
+            var ghostAuthAccessToken = '12345',
+                req = {body: {}},
+                ownerProfile = {email: 'test@example.com', id: '12345'},
+                owner = {id: 2, get: function () {
+                    return 'inactive'
+                }};
+
+            userFindOneStub.returns(Promise.resolve(owner));
+            userEditStub.withArgs({
+                ghost_auth_access_token: ghostAuthAccessToken,
+                ghost_auth_id: ownerProfile.id,
+                email: ownerProfile.email
+            }, {
+                context: {internal: true},
+                id: owner.id
+            }).returns(Promise.resolve(owner));
+
+            authStrategies.ghostStrategy(req, ghostAuthAccessToken, null, ownerProfile, function (err, user, profile) {
+                should.exist(err);
+                err.message.should.eql('You were suspended from this blog.');
+
+                userFindOneStub.calledOnce.should.be.true();
+                userEditStub.calledOnce.should.be.false();
+                inviteStub.calledOnce.should.be.false();
+
+                should.not.exist(user);
+                should.not.exist(profile);
                 done();
             });
         });

--- a/core/test/unit/auth/auth-strategies_spec.js
+++ b/core/test/unit/auth/auth-strategies_spec.js
@@ -114,7 +114,7 @@ describe('Auth Strategies', function () {
     });
 
     describe('Bearer Strategy', function () {
-        var tokenStub, userStub, userStatus;
+        var tokenStub, userStub, userIsActive;
 
         beforeEach(function () {
             tokenStub = sandbox.stub(Models.Accesstoken, 'findOne');
@@ -137,8 +137,8 @@ describe('Auth Strategies', function () {
                 toJSON: function () {
                     return {id: 3};
                 },
-                get: function () {
-                    return userStatus;
+                isActive: function () {
+                    return userIsActive;
                 }
             }));
         });
@@ -147,7 +147,7 @@ describe('Auth Strategies', function () {
             var accessToken = 'valid-token',
                 userId = 3;
 
-            userStatus = 'active';
+            userIsActive = true;
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
                 tokenStub.calledOnce.should.be.true();
@@ -165,7 +165,7 @@ describe('Auth Strategies', function () {
             var accessToken = 'valid-token',
                 userId = 3;
 
-            userStatus = 'inactive';
+            userIsActive = false;
 
             authStrategies.bearerStrategy(accessToken, next).then(function () {
                 tokenStub.calledOnce.should.be.true();
@@ -351,8 +351,8 @@ describe('Auth Strategies', function () {
             var ghostAuthAccessToken = '12345',
                 req = {body: {}},
                 ownerProfile = {email: 'test@example.com', id: '12345'},
-                owner = {id: 2, get: function () {
-                    return 'active'
+                owner = {id: 2, isActive: function () {
+                    return true;
                 }};
 
             userFindOneStub.returns(Promise.resolve(owner));
@@ -383,8 +383,8 @@ describe('Auth Strategies', function () {
             var ghostAuthAccessToken = '12345',
                 req = {body: {}},
                 ownerProfile = {email: 'test@example.com', id: '12345'},
-                owner = {id: 2, get: function () {
-                    return 'inactive'
+                owner = {id: 2, isActive: function () {
+                    return false;
                 }};
 
             userFindOneStub.returns(Promise.resolve(owner));

--- a/core/test/unit/auth/oauth_spec.js
+++ b/core/test/unit/auth/oauth_spec.js
@@ -346,7 +346,7 @@ describe('OAuth', function () {
 
             sandbox.stub(passport, 'authenticate', function (name, options, onSuccess) {
                 return function () {
-                    onSuccess(new Error('validation error'));
+                    onSuccess(new errors.UnauthorizedError());
                 };
             });
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -500,9 +500,7 @@ toDoList = {
         return permissions.init();
     },
     perms: function permissionsFor(obj) {
-        return function permissionsForObj() {
-            return fixtures.permissionsFor(obj);
-        };
+        return fixtures.permissionsFor(obj);
     },
     clients: function insertClients() {
         return fixtures.insertClients();

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -839,7 +839,10 @@ module.exports = {
             owner: DataGenerator.Content.users[0].id,
             admin: DataGenerator.Content.users[1].id,
             editor: DataGenerator.Content.users[2].id,
-            author: DataGenerator.Content.users[3].id
+            author: DataGenerator.Content.users[3].id,
+            admin2: DataGenerator.Content.users[6].id,
+            editor2: DataGenerator.Content.users[4].id,
+            author2: DataGenerator.Content.users[5].id
         }
     },
     roles: {

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -285,12 +285,16 @@ fixtures = {
         });
     },
 
-    // Creates a client, and access and refresh tokens for user 3 (author)
-    createTokensForUser: function createTokensForUser() {
+    // Creates a client, and access and refresh tokens for user with index or 2 by default
+    createTokensForUser: function createTokensForUser(index) {
         return db.knex('clients').insert(DataGenerator.forKnex.clients).then(function () {
-            return db.knex('accesstokens').insert(DataGenerator.forKnex.createToken({user_id: DataGenerator.Content.users[2].id}));
+            return db.knex('accesstokens').insert(DataGenerator.forKnex.createToken({
+                user_id: DataGenerator.Content.users[index || 2].id
+            }));
         }).then(function () {
-            return db.knex('refreshtokens').insert(DataGenerator.forKnex.createToken({user_id: DataGenerator.Content.users[2].id}));
+            return db.knex('refreshtokens').insert(DataGenerator.forKnex.createToken({
+                user_id: DataGenerator.Content.users[index || 2].id
+            }));
         });
     },
 
@@ -480,8 +484,8 @@ toDoList = {
     users: function createExtraUsers() {
         return fixtures.createExtraUsers();
     },
-    'user:token': function createTokensForUser() {
-        return fixtures.createTokensForUser();
+    'user-token': function createTokensForUser(index) {
+        return fixtures.createTokensForUser(index);
     },
     owner: function insertOwnerUser() {
         return fixtures.insertOwnerUser();
@@ -553,9 +557,12 @@ getFixtureOps = function getFixtureOps(toDos) {
     _.each(toDos, function (value, toDo) {
         var tmp;
 
-        if (toDo !== 'perms:init' && toDo.indexOf('perms:') !== -1) {
+        if ((toDo !== 'perms:init' && toDo.indexOf('perms:') !== -1) || toDo.indexOf('user-token:') !== -1) {
             tmp = toDo.split(':');
-            fixtureOps.push(toDoList[tmp[0]](tmp[1]));
+
+            fixtureOps.push(function addCustomFixture() {
+                return toDoList[tmp[0]](tmp[1]);
+            });
         } else {
             if (!toDoList[toDo]) {
                 throw new Error('setup todo does not exist - spell mistake?');


### PR DESCRIPTION
refs #8111 

This PR contains a new feature: suspending/un-suspending a user.
This branch was already tested with the Ghost-Admin PR.
Works as expected with ghost and password auth.

#### The key changes are
- Ghost returns now all (active+none active) users by default
- protect login with suspended status
- test permissions and add extra protection for suspending myself
- if a user is suspended and tries to activate himself, he won't be able to proceed the login to get a new token


#### TODO'S
- [x] wait for a ghost-admin branch to test the basics
- [x] add a test for the event listener
- [x] re-confirm that the permissions are OK
- [x] test permissions
- [x] optimise error message
- [x] add model fn: isActive isInactive
- [x] can't suspend myself
- [x] check status handling again e.g. user changes status to locked and then to active to trick the system
- [x] extend PR description
- [x] fix tests
- [x] test pwd mode 