### PR TITLE
Add bower and ember-cli install as global:

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
 
 ```bash
 git clone [Ghost's repo URL or your Ghost Fork's URL]
-npm install -g knex-migrator gulp
+npm install -g knex-migrator gulp bower ember-cli
 npm install
 git submodule update --init
 cd core/client


### PR DESCRIPTION
Update README instructions for section Developer Install
Added bower to install as global because after is used  like that in
instructions.