### PR TITLE
🔥  remove fileStorage option

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -26,7 +26,6 @@ function getAboutConfig() {
 
 function getBaseConfig() {
     return {
-        fileStorage:    config.get('fileStorage') !== false,
         useGravatar:    !config.isPrivacyDisabled('useGravatar'),
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        utils.url.urlFor('home', true),

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -40,7 +40,6 @@ describe('Configuration API', function () {
                 amp: 'amp'
             });
 
-            props.fileStorage.should.eql(true);
             props.useGravatar.should.eql(false);
             props.publicAPI.should.eql(false);
             props.clientId.should.eql('ghost-admin');


### PR DESCRIPTION
refs #8032

- this was used to disable the upload image functionality in Ghost-Admin
- we no longer need this boolean, because people can add their own storage adapter

**I haven't found any other occurrences.** 
I made a project search.