### PR TITLE
✨ New fully-loaded & validated activeTheme concept

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -112,7 +112,7 @@ themes = {
                 return themeUtils.loadOne(zip.shortName);
             })
             .then(function (loadedTheme) {
-                // If this is the active theme, we are overridding
+                // If this is the active theme, we are overriding
                 // This is a special case of activation
                 if (zip.shortName === settingsCache.get('activeTheme')) {
                     // Activate! (sort of)

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -1,6 +1,7 @@
 // # Themes API
 // RESTful API for Themes
-var Promise = require('bluebird'),
+var debug = require('debug')('ghost:api:themes'),
+    Promise = require('bluebird'),
     fs = require('fs-extra'),
     config = require('../config'),
     errors = require('../errors'),
@@ -56,6 +57,7 @@ themes = {
             })
             .then(function hasEditedSetting() {
                 // @TODO actually do things to activate the theme, other than just the setting?
+                debug('Activating theme (method B on API "activate")', themeName);
                 return themeUtils.toJSON(themeName, checkedTheme);
             });
     },
@@ -108,6 +110,12 @@ themes = {
                 return themeUtils.loadOne(zip.shortName);
             })
             .then(function () {
+                // If this is the active theme, we are overridding
+                // This is a special case of activation
+                if (zip.shortName === settingsCache.get('activeTheme')) {
+                    debug('Activating theme (method C, on API "override")', zip.shortName);
+                }
+
                 // @TODO: unify the name across gscan and Ghost!
                 return themeUtils.toJSON(zip.shortName, checkedTheme);
             })

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -56,8 +56,10 @@ themes = {
                 return settingsModel.edit(newSettings, options);
             })
             .then(function hasEditedSetting() {
-                // @TODO actually do things to activate the theme, other than just the setting?
+                // Activate! (sort of)
                 debug('Activating theme (method B on API "activate")', themeName);
+                themeUtils.activate(loadedTheme, checkedTheme);
+
                 return themeUtils.toJSON(themeName, checkedTheme);
             });
     },
@@ -109,11 +111,13 @@ themes = {
                 // Sets the theme on the themeList
                 return themeUtils.loadOne(zip.shortName);
             })
-            .then(function () {
+            .then(function (loadedTheme) {
                 // If this is the active theme, we are overridding
                 // This is a special case of activation
                 if (zip.shortName === settingsCache.get('activeTheme')) {
+                    // Activate! (sort of)
                     debug('Activating theme (method C, on API "override")', zip.shortName);
+                    themeUtils.activate(loadedTheme, checkedTheme);
                 }
 
                 // @TODO: unify the name across gscan and Ghost!

--- a/core/server/middleware/static-theme.js
+++ b/core/server/middleware/static-theme.js
@@ -2,6 +2,7 @@ var _       = require('lodash'),
     express = require('express'),
     path    = require('path'),
     config  = require('../config'),
+    themeUtils = require('../themes'),
     utils   = require('../utils');
 
 function isBlackListedFileType(file) {
@@ -17,12 +18,12 @@ function isWhiteListedFile(file) {
 }
 
 function forwardToExpressStatic(req, res, next) {
-    if (!req.app.get('activeTheme')) {
+    if (!themeUtils.getActive()) {
         next();
     } else {
         var configMaxAge = config.get('caching:theme:maxAge');
 
-        express.static(path.join(config.getContentPath('themes'), req.app.get('activeTheme')),
+        express.static(themeUtils.getActive().path,
             {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : utils.ONE_YEAR_MS}
         )(req, res, next);
     }

--- a/core/server/middleware/theme-handler.js
+++ b/core/server/middleware/theme-handler.js
@@ -1,13 +1,11 @@
 var _      = require('lodash'),
-    fs     = require('fs'),
-    path   = require('path'),
     hbs    = require('express-hbs'),
     config = require('../config'),
     utils = require('../utils'),
     errors = require('../errors'),
     i18n = require('../i18n'),
     settingsCache = require('../settings/cache'),
-    themeList = require('../themes').list,
+    themeUtils = require('../themes'),
     themeHandler;
 
 themeHandler = {
@@ -52,33 +50,29 @@ themeHandler = {
 
     // ### Activate Theme
     // Helper for updateActiveTheme
-    activateTheme: function activateTheme(blogApp, activeThemeName) {
-        var themePartialsPath = path.join(config.getContentPath('themes'), activeThemeName, 'partials'),
-            hbsOptions = {
+    activateTheme: function activateTheme(blogApp) {
+        var hbsOptions = {
                 partialsDir: [config.get('paths').helperTemplates],
                 onCompile: function onCompile(exhbs, source) {
                     return exhbs.handlebars.compile(source, {preventIndent: true});
                 }
             };
 
-        fs.stat(themePartialsPath, function stat(err, stats) {
-            // Check that the theme has a partials directory before trying to use it
-            if (!err && stats && stats.isDirectory()) {
-                hbsOptions.partialsDir.push(themePartialsPath);
-            }
-        });
+        if (themeUtils.getActive().hasPartials()) {
+            hbsOptions.partialsDir.push(themeUtils.getActive().partialsPath);
+        }
 
         // reset the asset hash
         config.set('assetHash', null);
         // clear the view cache
         blogApp.cache = {};
         // Set the views and engine
-        blogApp.set('views', path.join(config.getContentPath('themes'), activeThemeName));
+        blogApp.set('views', themeUtils.getActive().path);
         blogApp.engine('hbs', hbs.express3(hbsOptions));
 
         // Set active theme variable on the express server
         // Note: this is effectively the "mounted" theme, which has been loaded into the express app
-        blogApp.set('activeTheme', activeThemeName);
+        blogApp.set('activeTheme', themeUtils.getActive().name);
     },
 
     // ### updateActiveTheme
@@ -87,11 +81,13 @@ themeHandler = {
     // is not yet activated.
     updateActiveTheme: function updateActiveTheme(req, res, next) {
         var blogApp = req.app,
+            // We use the settingsCache here, because the setting will be set, even if the theme itself is
+            // not usable because it is invalid or missing.
             activeThemeName = settingsCache.get('activeTheme'),
             mountedThemeName = blogApp.get('activeTheme');
 
         // This means that the theme hasn't been loaded yet i.e. there is no active theme
-        if (!themeList.get(activeThemeName)) {
+        if (!themeUtils.getActive()) {
             // This is the one place we ACTUALLY throw an error for a missing theme
             // As it's a request we cannot serve
             return next(new errors.InternalServerError({
@@ -101,7 +97,7 @@ themeHandler = {
             // If there is an active theme AND it has changed, call activate
         } else if (activeThemeName !== mountedThemeName) {
             // This is effectively "mounting" a theme into express, the theme is already "active"
-            themeHandler.activateTheme(blogApp, activeThemeName);
+            themeHandler.activateTheme(blogApp);
         }
 
         next();

--- a/core/server/themes/active.js
+++ b/core/server/themes/active.js
@@ -17,6 +17,7 @@
  *
  */
 var _ = require('lodash'),
+    join = require('path').join,
     // Current instance of ActiveTheme
     currentActiveTheme;
 
@@ -50,6 +51,10 @@ class ActiveTheme {
 
     get path() {
         return this._path;
+    }
+
+    get partialsPath() {
+        return join(this.path, 'partials');
     }
 
     hasPartials() {

--- a/core/server/themes/active.js
+++ b/core/server/themes/active.js
@@ -1,0 +1,83 @@
+'use strict';
+
+/**
+ * # Active Theme
+ *
+ * This file defines a class of active theme, and also controls the getting and setting a single instance, as there
+ * can only ever be one active theme. Unlike a singleton, the active theme can change, however only in a controlled way.
+ *
+ * I've made use of the new class & constructor syntax here, as we are now only supporting Node v4 and above, which has
+ * full support for these features.
+ *
+ * There are several different patterns available for keeping data private. Elsewhere in Ghost we use the
+ * naming convention of the _ prefix. Even though this has the downside of not being truly private, it is still one
+ * of the preferred options for keeping data private with the new class syntax, therefore I have kept it.
+ *
+ * No properties marked with an _ should be used directly.
+ *
+ */
+var _ = require('lodash'),
+    // Current instance of ActiveTheme
+    currentActiveTheme;
+
+class ActiveTheme {
+    /**
+     * @TODO this API needs to be simpler, but for now should work!
+     * @param {object} loadedTheme - the loaded theme object from the theme list
+     * @param {object} checkedTheme - the result of gscan.format for the theme we're activating
+     */
+    constructor(loadedTheme, checkedTheme) {
+        // Assign some data, mark it all as pseudo-private
+        this._name = loadedTheme.name;
+        this._path = loadedTheme.path;
+
+        // @TODO: get gscan to return validated, useful package.json fields for us!
+        this._packageInfo = loadedTheme['package.json'];
+        this._partials = checkedTheme.partials;
+        // @TODO: get gscan to return a template collection for us
+        this._templates = _.reduce(checkedTheme.files, function (templates, entry) {
+            var tplMatch = entry.file.match(/(^[^\/]+).hbs$/);
+            if (tplMatch) {
+                templates.push(tplMatch[1]);
+            }
+            return templates;
+        }, []);
+    }
+
+    get name() {
+        return this._name;
+    }
+
+    get path() {
+        return this._path;
+    }
+
+    hasPartials() {
+        return this._partials.length > 0;
+    }
+
+    hasTemplate(templateName) {
+        return this._templates.indexOf(templateName) > -1;
+    }
+}
+
+module.exports = {
+    get() {
+        return currentActiveTheme;
+    },
+    /**
+     * Set theme
+     *
+     * At this point we trust that the theme has been validated.
+     * Any handling for invalid themes should happen before we get here
+     *
+     * @TODO this API needs to be simpler, but for now should work!
+     * @param {object} loadedTheme - the loaded theme object from the theme list
+     * @param {object} checkedTheme - the result of gscan.format for the theme we're activating
+     * @return {ActiveTheme}
+     */
+    set(loadedTheme, checkedTheme) {
+        currentActiveTheme = new ActiveTheme(loadedTheme, checkedTheme);
+        return currentActiveTheme;
+    }
+};

--- a/core/server/themes/index.js
+++ b/core/server/themes/index.js
@@ -22,6 +22,9 @@ module.exports = {
         // Just read the active theme for now
         return themeLoader
             .loadOneTheme(activeThemeName)
+            .then(function activeThemeHasLoaded() {
+                debug('Activating theme (method A on boot)', activeThemeName);
+            })
             .catch(function () {
                 // Active theme is missing, we don't want to exit because the admin panel will still work
                 logging.warn(i18n.t('errors.middleware.themehandler.missingTheme', {theme: activeThemeName}));

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -25,7 +25,6 @@ describe('staticTheme', function () {
         sandbox.restore();
     });
 
-
     it('should skip for .hbs file', function (done) {
         req.path = 'mytemplate.hbs';
 
@@ -35,7 +34,6 @@ describe('staticTheme', function () {
 
             done();
         });
-
     });
 
     it('should skip for .md file', function (done) {

--- a/core/test/unit/middleware/static-theme_spec.js
+++ b/core/test/unit/middleware/static-theme_spec.js
@@ -1,104 +1,126 @@
-var sinon        = require('sinon'),
-    should       = require('should'),
+var sinon = require('sinon'),
+    should = require('should'),
 
-    express      = require('express'),
-    staticTheme  = require('../../../server/middleware/static-theme');
+    express = require('express'),
+    themeUtils = require('../../../server/themes'),
+    staticTheme = require('../../../server/middleware/static-theme'),
+
+    sandbox = sinon.sandbox.create();
 
 describe('staticTheme', function () {
-    var next;
+    var expressStaticStub, activeThemeStub, req, res;
 
     beforeEach(function () {
-        next = sinon.spy();
+        req = {};
+        res = {};
+
+        activeThemeStub = sandbox.stub(themeUtils, 'getActive').returns({
+            path: 'my/fake/path'
+        });
+
+        expressStaticStub = sandbox.spy(express, 'static');
     });
 
-    it('should call next if hbs file type', function () {
-        var req = {
-            path: 'mytemplate.hbs'
-        };
-
-        staticTheme(null)(req, null, next);
-        next.called.should.be.true();
+    afterEach(function () {
+        sandbox.restore();
     });
 
-    it('should call next if md file type', function () {
-        var req = {
-            path: 'README.md'
-        };
 
-        staticTheme(null)(req, null, next);
-        next.called.should.be.true();
+    it('should skip for .hbs file', function (done) {
+        req.path = 'mytemplate.hbs';
+
+        staticTheme()(req, res, function next() {
+            activeThemeStub.called.should.be.false();
+            expressStaticStub.called.should.be.false();
+
+            done();
+        });
+
     });
 
-    it('should call next if json file type', function () {
-        var req = {
-            path: 'sample.json'
-        };
+    it('should skip for .md file', function (done) {
+        req.path = 'README.md';
 
-        staticTheme(null)(req, null, next);
-        next.called.should.be.true();
+        staticTheme()(req, res, function next() {
+            activeThemeStub.called.should.be.false();
+            expressStaticStub.called.should.be.false();
+
+            done();
+        });
     });
 
-    it('should call express.static if valid file type', function (done) {
-        var req = {
-                path: 'myvalidfile.css',
-                app: {
-                    get: function () { return 'casper'; }
-                }
-            },
-            activeThemeStub,
-            sandbox = sinon.sandbox.create(),
-            expressStatic = sinon.spy(express, 'static');
+    it('should skip for .json file', function (done) {
+        req.path = 'sample.json';
 
-        activeThemeStub = sandbox.spy(req.app, 'get');
+        staticTheme()(req, res, function next() {
+            activeThemeStub.called.should.be.false();
+            expressStaticStub.called.should.be.false();
 
-        staticTheme(null)(req, null, function (reqArg, res, next2) {
-            /*jshint unused:false */
-            sandbox.restore();
-            next.called.should.be.false();
-            activeThemeStub.called.should.be.true();
-            expressStatic.called.should.be.true();
-            should.exist(expressStatic.args[0][1].maxAge);
+            done();
+        });
+    });
+
+    it('should call express.static for .css file', function (done) {
+        req.path = 'myvalidfile.css';
+
+        staticTheme()(req, res, function next() {
+            // Specifically gets called twice
+            activeThemeStub.calledTwice.should.be.true();
+            expressStaticStub.called.should.be.true();
+
+            // Check that express static gets called with the theme path + maxAge
+            should.exist(expressStaticStub.firstCall.args);
+            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+
+            done();
+        });
+    });
+
+    it('should call express.static for .js file', function (done) {
+        req.path = 'myvalidfile.js';
+
+        staticTheme()(req, res, function next() {
+            // Specifically gets called twice
+            activeThemeStub.calledTwice.should.be.true();
+            expressStaticStub.called.should.be.true();
+
+            // Check that express static gets called with the theme path + maxAge
+            should.exist(expressStaticStub.firstCall.args);
+            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+
             done();
         });
     });
 
     it('should not error if active theme is missing', function (done) {
-        var req = {
-                path: 'myvalidfile.css',
-                app: {
-                    get: function () { return undefined; }
-                }
-            },
-            activeThemeStub,
-            sandbox = sinon.sandbox.create();
+        req.path = 'myvalidfile.css';
 
-        activeThemeStub = sandbox.spy(req.app, 'get');
+        // make the active theme not exist
+        activeThemeStub.returns(undefined);
 
-        staticTheme(null)(req, null, function (reqArg, res, next2) {
-            /*jshint unused:false */
-            sandbox.restore();
-            next.called.should.be.false();
+        staticTheme()(req, res, function next() {
+            activeThemeStub.calledOnce.should.be.true();
+            expressStaticStub.called.should.be.false();
+
             done();
         });
     });
 
-    it('should not call next if file is on whitelist', function (done) {
-        var req = {
-                path: 'manifest.json',
-                app: {
-                    get: function () { return 'casper'; }
-                }
-            },
-            activeThemeStub,
-            sandbox = sinon.sandbox.create();
+    it('should NOT skip if file is on whitelist', function (done) {
+        req.path = 'manifest.json';
 
-        activeThemeStub = sandbox.spy(req.app, 'get');
+        staticTheme()(req, res, function next() {
+            // Specifically gets called twice
+            activeThemeStub.calledTwice.should.be.true();
+            expressStaticStub.called.should.be.true();
 
-        staticTheme(null)(req, null, function (reqArg, res, next2) {
-            /*jshint unused:false */
-            sandbox.restore();
-            next.called.should.be.false();
-            activeThemeStub.called.should.be.true();
+            // Check that express static gets called with the theme path + maxAge
+            should.exist(expressStaticStub.firstCall.args);
+            expressStaticStub.firstCall.args[0].should.eql('my/fake/path');
+            expressStaticStub.firstCall.args[1].should.be.an.Object().with.property('maxAge');
+
             done();
         });
     });


### PR DESCRIPTION
There are 3 different ways that a theme can be activated in Ghost:

A. On boot: we load the active theme from the file system, according to the `activeTheme` setting
B. On API "activate": when an /activate/ request is triggered for a theme, we validate & change the `activeTheme` setting
C. On API "override": if uploading a theme with the same name, we override. Using a dirty hack to make this work.

A: setting is done, should load & validate + next request does mounting
B: load is done, should validate & change setting + next request does mounting
C: load, validate & setting are all done + a hack is needed to ensure the next request does mounting

This PR starts by adding a debug statement to all of them, so that we can more easily keep track of when themes are activated.

It also adds validation to when we activate a theme on boot, such that all 3 methods of activation have 2 pieces of info available to them: 

1. the "loaded" theme from the theme list
2. the "checked" theme result from `gscan.format()`

I've added a new ActiveTheme class, using some of the newer ES syntax - all of this syntax is available on Node v4+, and this seemed like a good place to start playing with it to see how well it works for us. If we want, I can revert this to older syntax - it's not a lot different.

Finally I've started to roll out this new ActiveTheme concept across the application & updated a bunch of tests.

At this point, I've _almost_ gotten rid of the concept of using `req.app.get('activeTheme')` - that is setting the name of the active theme as a property on the express app. The only place it is still used is in template logic. The next PR both fixes this, and re-introduces the concept of custom theme templates in one small nice change set.

After that I will pursue with getting rid of setting the theme on express entirely, and getting rid of all of our dirty theme hacks in a separate PR.