### PR TITLE
✨ Reimplement custom theme templates

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -12,8 +12,8 @@ var path                = require('path'),
     setResponseContext  = require('../../../controllers/frontend/context');
 
 function controller(req, res, next) {
-    var defaultView = path.resolve(__dirname, 'views', 'amp.hbs'),
-        paths = templates.getActiveThemePaths(req.app.get('activeTheme')),
+    var templateName = 'amp',
+        defaultTemplate = path.resolve(__dirname, 'views', templateName + '.hbs'),
         data = req.body || {};
 
     if (res.error) {
@@ -24,14 +24,10 @@ function controller(req, res, next) {
 
     // we have to check the context. Our context must be ['post', 'amp'], otherwise we won't render the template
     if (_.includes(res.locals.context, 'post') && _.includes(res.locals.context, 'amp')) {
-        if (paths.hasOwnProperty('amp.hbs')) {
-            return res.render('amp', data);
-        } else {
-            return res.render(defaultView, data);
-        }
-    } else {
-        return next();
+        return res.render(templates.pickTemplate(templateName, defaultTemplate), data);
     }
+
+    return next();
 }
 
 function getPostData(req, res, next) {

--- a/core/server/apps/private-blogging/lib/router.js
+++ b/core/server/apps/private-blogging/lib/router.js
@@ -5,11 +5,12 @@ var path                = require('path'),
     templates           = require('../../../controllers/frontend/templates'),
     setResponseContext  = require('../../../controllers/frontend/context'),
     brute               = require('../../../middleware/brute'),
+
     privateRouter = express.Router();
 
 function controller(req, res) {
-    var defaultView = path.resolve(__dirname, 'views', 'private.hbs'),
-        paths = templates.getActiveThemePaths(req.app.get('activeTheme')),
+    var templateName = 'private',
+        defaultTemplate = path.resolve(__dirname, 'views', templateName + '.hbs'),
         data = {};
 
     if (res.error) {
@@ -17,11 +18,8 @@ function controller(req, res) {
     }
 
     setResponseContext(req, res);
-    if (paths.hasOwnProperty('private.hbs')) {
-        return res.render('private', data);
-    } else {
-        return res.render(defaultView, data);
-    }
+
+    return res.render(templates.pickTemplate(templateName, defaultTemplate), data);
 }
 
 // password-protected frontend route

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -13,16 +13,13 @@ var path                = require('path'),
     setResponseContext  = require('../../../controllers/frontend/context');
 
 function controller(req, res) {
-    var defaultView = path.resolve(__dirname, 'views', 'subscribe.hbs'),
-        paths = templates.getActiveThemePaths(req.app.get('activeTheme')),
+    var templateName = 'subscribe',
+        defaultTemplate = path.resolve(__dirname, 'views', templateName + '.hbs'),
         data = req.body;
 
     setResponseContext(req, res);
-    if (paths.hasOwnProperty('subscribe.hbs')) {
-        return res.render('subscribe', data);
-    } else {
-        return res.render(defaultView, data);
-    }
+
+    return res.render(templates.pickTemplate(templateName, defaultTemplate), data);
 }
 
 function errorHandler(error, req, res, next) {

--- a/core/server/controllers/frontend/index.js
+++ b/core/server/controllers/frontend/index.js
@@ -26,7 +26,7 @@ var debug = require('debug')('ghost:channels:single'),
 function renderPost(req, res) {
     debug('renderPost called');
     return function renderPost(post) {
-        var view = templates.single(req.app.get('activeTheme'), post),
+        var view = templates.single(post),
             response = formatResponse.single(post);
 
         setResponseContext(req, res, response);

--- a/core/server/controllers/frontend/render-channel.js
+++ b/core/server/controllers/frontend/render-channel.js
@@ -40,7 +40,7 @@ function renderChannel(req, res, next) {
 
         // @TODO: properly design these filters
         filters.doFilter('prePostsRender', result.posts, res.locals).then(function then(posts) {
-            var view = templates.channel(req.app.get('activeTheme'), channelOpts);
+            var view = templates.channel(channelOpts);
 
             // Do final data formatting and then render
             result.posts = posts;

--- a/core/test/unit/controllers/frontend/templates_spec.js
+++ b/core/test/unit/controllers/frontend/templates_spec.js
@@ -1,17 +1,21 @@
 var should   = require('should'),
+    sinon    = require('sinon'),
     rewire   = require('rewire'),
 
 // Stuff we are testing
     templates = rewire('../../../../server/controllers/frontend/templates'),
+    themes = require('../../../../server/themes'),
 
-    themeList = require('../../../../server/themes').list;
+    sandbox = sinon.sandbox.create();
 
 describe('templates', function () {
+    var getActiveThemeStub, hasTemplateStub;
+
     afterEach(function () {
-        themeList.init();
+        sandbox.restore();
     });
 
-    describe('utils', function () {
+    describe('[private] getChannelTemplateHierarchy', function () {
         var channelTemplateList = templates.__get__('getChannelTemplateHierarchy');
 
         it('should return just index for empty channelOpts', function () {
@@ -45,23 +49,73 @@ describe('templates', function () {
         });
     });
 
-    describe('single', function () {
+    describe('pickTemplate', function () {
+        beforeEach(function () {
+            hasTemplateStub = sandbox.stub().returns(false);
+
+            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+                hasTemplate: hasTemplateStub
+            });
+        });
+
+        it('returns fallback if there is no activeTheme', function () {
+            getActiveThemeStub.returns(undefined);
+
+            templates.pickTemplate(['tag-test', 'tag', 'index'], 'fallback').should.eql('fallback');
+            templates.pickTemplate(['page-my-post', 'page', 'post'], 'fallback').should.eql('fallback');
+        });
+
+        it('returns fallback if activeTheme has no templates', function () {
+            templates.pickTemplate(['tag-test', 'tag', 'index'], 'fallback').should.eql('fallback');
+            templates.pickTemplate(['page-about', 'page', 'post'], 'fallback').should.eql('fallback');
+        });
+
         describe('with many templates', function () {
             beforeEach(function () {
-                themeList.init({casper: {
-                    assets: null,
-                    'default.hbs': '/content/themes/casper/default.hbs',
-                    'index.hbs': '/content/themes/casper/index.hbs',
-                    'page.hbs': '/content/themes/casper/page.hbs',
-                    'page-about.hbs': '/content/themes/casper/page-about.hbs',
-                    'post.hbs': '/content/themes/casper/post.hbs',
-                    'post-welcome-to-ghost.hbs': '/content/themes/casper/post-welcome-to-ghost.hbs'
+                // Set available Templates
+                hasTemplateStub.withArgs('default').returns(true);
+                hasTemplateStub.withArgs('index').returns(true);
+                hasTemplateStub.withArgs('page').returns(true);
+                hasTemplateStub.withArgs('page-about').returns(true);
+                hasTemplateStub.withArgs('post').returns(true);
+                hasTemplateStub.withArgs('amp').returns(true);
+            });
 
-                }});
+            it('returns first matching template', function () {
+                templates.pickTemplate(['page-about', 'page', 'post'], 'fallback').should.eql('page-about');
+                templates.pickTemplate(['page-magic', 'page', 'post'], 'fallback').should.eql('page');
+                templates.pickTemplate(['page', 'post'], 'fallback').should.eql('page');
+            });
+
+            it('returns correctly if template list is a string', function () {
+                templates.pickTemplate('amp', 'fallback').should.eql('amp');
+                templates.pickTemplate('subscribe', 'fallback').should.eql('fallback');
+                templates.pickTemplate('post', 'fallback').should.eql('post');
+            });
+        });
+    });
+
+    describe('single', function () {
+        beforeEach(function () {
+            hasTemplateStub = sandbox.stub().returns(false);
+
+            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+                hasTemplate: hasTemplateStub
+            });
+        });
+
+        describe('with many templates', function () {
+            beforeEach(function () {
+                // Set available Templates
+                hasTemplateStub.withArgs('default').returns(true);
+                hasTemplateStub.withArgs('index').returns(true);
+                hasTemplateStub.withArgs('page').returns(true);
+                hasTemplateStub.withArgs('page-about').returns(true);
+                hasTemplateStub.withArgs('post').returns(true);
             });
 
             it('will return correct template for a post WITHOUT custom template', function () {
-                var view = templates.single('casper', {
+                var view = templates.single({
                     page: 0,
                     slug: 'test-post'
                 });
@@ -70,7 +124,8 @@ describe('templates', function () {
             });
 
             it('will return correct template for a post WITH custom template', function () {
-                var view = templates.single('casper', {
+                hasTemplateStub.withArgs('post-welcome-to-ghost').returns(true);
+                var view = templates.single({
                     page: 0,
                     slug: 'welcome-to-ghost'
                 });
@@ -79,7 +134,7 @@ describe('templates', function () {
             });
 
             it('will return correct template for a page WITHOUT custom template', function () {
-                var view = templates.single('casper', {
+                var view = templates.single({
                     page: 1,
                     slug: 'contact'
                 });
@@ -88,7 +143,7 @@ describe('templates', function () {
             });
 
             it('will return correct template for a page WITH custom template', function () {
-                var view = templates.single('casper', {
+                var view = templates.single({
                     page: 1,
                     slug: 'about'
                 });
@@ -98,29 +153,31 @@ describe('templates', function () {
         });
 
         it('will fall back to post even if no index.hbs', function () {
-            themeList.init({casper: {
-                assets: null,
-                'default.hbs': '/content/themes/casper/default.hbs'
-            }});
+            hasTemplateStub.returns(false);
 
-            var view = templates.single('casper', {page: 1});
+            var view = templates.single({page: 1});
             should.exist(view);
             view.should.eql('post');
         });
     });
 
     describe('channel', function () {
+        beforeEach(function () {
+            hasTemplateStub = sandbox.stub().returns(false);
+
+            getActiveThemeStub = sandbox.stub(themes, 'getActive').returns({
+                hasTemplate: hasTemplateStub
+            });
+        });
+
         describe('without tag templates', function () {
             beforeEach(function () {
-                themeList.init({casper: {
-                    assets: null,
-                    'default.hbs': '/content/themes/casper/default.hbs',
-                    'index.hbs': '/content/themes/casper/index.hbs'
-                }});
+                hasTemplateStub.withArgs('default').returns(true);
+                hasTemplateStub.withArgs('index').returns(true);
             });
 
             it('will return correct view for a tag', function () {
-                var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
+                var view = templates.channel({name: 'tag', slugParam: 'development', slugTemplate: true});
                 should.exist(view);
                 view.should.eql('index');
             });
@@ -128,35 +185,27 @@ describe('templates', function () {
 
         describe('with tag templates', function () {
             beforeEach(function () {
-                themeList.init({casper: {
-                    assets: null,
-                    'default.hbs': '/content/themes/casper/default.hbs',
-                    'index.hbs': '/content/themes/casper/index.hbs',
-                    'tag.hbs': '/content/themes/casper/tag.hbs',
-                    'tag-design.hbs': '/content/themes/casper/tag-about.hbs'
-                }});
+                hasTemplateStub.withArgs('default').returns(true);
+                hasTemplateStub.withArgs('index').returns(true);
+                hasTemplateStub.withArgs('tag').returns(true);
+                hasTemplateStub.withArgs('tag-design').returns(true);
             });
 
             it('will return correct view for a tag', function () {
-                var view = templates.channel('casper', {name: 'tag', slugParam: 'design', slugTemplate: true});
+                var view = templates.channel({name: 'tag', slugParam: 'design', slugTemplate: true});
                 should.exist(view);
                 view.should.eql('tag-design');
             });
 
             it('will return correct view for a tag', function () {
-                var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
+                var view = templates.channel({name: 'tag', slugParam: 'development', slugTemplate: true});
                 should.exist(view);
                 view.should.eql('tag');
             });
         });
 
         it('will fall back to index even if no index.hbs', function () {
-            themeList.init({casper: {
-                assets: null,
-                'default.hbs': '/content/themes/casper/default.hbs'
-            }});
-
-            var view = templates.channel('casper', {name: 'tag', slugParam: 'development', slugTemplate: true});
+            var view = templates.channel({name: 'tag', slugParam: 'development', slugTemplate: true});
             should.exist(view);
             view.should.eql('index');
         });


### PR DESCRIPTION
closes #8082

- Update the `pickTemplate` logic to
  a) rely on getActive().hasTemplate() instead of being passed a list of paths
  b) support the concept of a fallback, which is returned if there is no theme, or if the theme doesn't have a more specific template
- Update every instance of template picking, across the 3 internalApps, and render-channel, to use this new logic
- update the tests