### PR TITLE
🎨 Updates for Gruntfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   global:
     - GITHUB_OAUTH_KEY=003a44d58f12089d0c0261338298af3813330949
     - GHOST_NODE_VERSION_CHECK=false
-    - TEST_SUITE=server
   matrix:
     - DB=sqlite3 NODE_ENV=testing
     - DB=mysql NODE_ENV=testing-mysql

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -317,6 +317,7 @@ var overrides      = require('./core/server/overrides'),
                 options: {
                     npmInstall: false
                 },
+
                 init: {
                     options: {
                         npmInstall: true
@@ -336,14 +337,6 @@ var overrides      = require('./core/server/overrides'),
 
                 watch: {
                     'core/client': ['bgShell:ember', 'watch']
-                },
-
-                lint: {
-                    'core/client': 'lint'
-                },
-
-                test: {
-                    'core/client': 'shell:test'
                 }
             }
         };
@@ -470,7 +463,7 @@ var overrides      = require('./core/server/overrides'),
         // `grunt validate` is called by `npm test` and is used by Travis.
         grunt.registerTask('validate', 'Run tests and lint code', function () {
             if (process.env.TEST_SUITE === 'server') {
-                grunt.task.run(['stubClientFiles', 'test-server']);
+                grunt.task.run(['stubClientFiles', 'test-all']);
             } else if (process.env.TEST_SUITE === 'lint') {
                 grunt.task.run(['lint']);
             } else {
@@ -486,27 +479,14 @@ var overrides      = require('./core/server/overrides'),
         //
         // `grunt test-all` will lint and test your pre-built local Ghost codebase.
         //
-        // `grunt test-all` runs all 6 test suites. See the individual sub tasks below for
-        // details of each of the test suites.
-        //
-        grunt.registerTask('test-all', 'Run tests for both server and client',
-            ['test-server', 'test-client']);
-
-        grunt.registerTask('test-server', 'Run server tests',
+        grunt.registerTask('test-all', 'Run all server tests',
             ['test-routes', 'test-module', 'test-unit', 'test-integration']);
-
-        grunt.registerTask('test-client', 'Run client tests',
-            ['subgrunt:test']);
 
         // ### Lint
         //
         // `grunt lint` will run the linter and the code style checker so you can make sure your code is pretty
         grunt.registerTask('lint', 'Run the code style checks and linter for server',
             ['jshint', 'jscs']
-        );
-
-        grunt.registerTask('lint-all', 'Run the code style checks and linter for server and client',
-            ['lint', 'subgrunt:lint']
         );
 
         // ### test-setup *(utility)(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -376,12 +376,12 @@ var overrides      = require('./core/server/overrides'),
         // Run `grunt docs` to generate annotated source code using the documentation described in the code comments.
         grunt.registerTask('docs', 'Generate Docs', ['docker']);
 
-        // Runun `grunt watch-docs` to setup livereload & watch whilst you're editing the docs
+        // Run `grunt watch-docs` to setup livereload & watch whilst you're editing the docs
         grunt.registerTask('watch-docs', function () {
             grunt.config.merge({
                 watch: {
                     docs: {
-                        files: ['core/server/**/*', 'index.js', 'Gruntfile.js', 'config.example.js'],
+                        files: ['core/server/**/*', 'index.js', 'Gruntfile.js'],
                         tasks: ['docker'],
                         options: {
                             livereload: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -455,24 +455,15 @@ var overrides      = require('./core/server/overrides'),
         // ### Validate
         // **Main testing task**
         //
-        // `grunt validate` will build, lint and test your local Ghost codebase.
-        //
-        // `grunt validate` is one of the most important and useful grunt tasks that we have available to use. It
-        // manages the build of your environment and then calls `grunt test`
-        //
+        // `grunt validate` will either run all tests or run linting
         // `grunt validate` is called by `npm test` and is used by Travis.
-        grunt.registerTask('validate', 'Run tests and lint code', function () {
-            if (process.env.TEST_SUITE === 'server') {
-                grunt.task.run(['stubClientFiles', 'test-all']);
-            } else if (process.env.TEST_SUITE === 'lint') {
-                grunt.task.run(['lint']);
-            } else {
-                grunt.task.run(['validate-all']);
+        grunt.registerTask('validate', 'Run tests or lint code', function () {
+            if (process.env.TEST_SUITE === 'lint') {
+                return grunt.task.run(['lint']);
             }
-        });
 
-        grunt.registerTask('validate-all', 'Lint code and run all tests',
-            ['init', 'lint', 'test-all']);
+            grunt.task.run(['stubClientFiles', 'test-all']);
+        });
 
         // ### Test-All
         // **Main testing task**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ var overrides      = require('./core/server/overrides'),
 
                 server: [
                     '*.js',
-                    '!config*.js', // note: i added this, do we want this linted?
+                    '!config.*.json', // note: i added this, do we want this linted?
                     'core/*.js',
                     'core/server/**/*.js',
                     'core/test/**/*.js',
@@ -123,7 +123,7 @@ var overrides      = require('./core/server/overrides'),
                     files: {
                         src: [
                             '*.js',
-                            '!config*.js', // note: i added this, do we want this linted?
+                            '!config.*.json', // note: i added this, do we want this linted?
                             'core/*.js',
                             'core/server/**/*.js',
                             'core/test/**/*.js',
@@ -508,7 +508,7 @@ var overrides      = require('./core/server/overrides'),
         // ### Integration tests *(sub task)*
         // `grunt test-integration` will run just the integration tests
         //
-        // Provided you already have a `config.js` file, you can run just the model integration tests by running:
+        // Provided you already have a `config.*.json` file, you can run just the model integration tests by running:
         //
         // `grunt test:integration/model`
         //

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,10 +69,11 @@ var overrides      = require('./core/server/overrides'),
                     }
                 },
                 express: {
-                    files:  ['core/ghost-server.js', 'core/server/**/*.js'],
+                    files:  ['core/ghost-server.js', 'core/server/**/*.js', 'config.*.json'],
                     tasks:  ['express:dev'],
                     options: {
-                        spawn: false
+                        nospawn: true,
+                        livereload: true
                     }
                 }
             },
@@ -217,7 +218,9 @@ var overrides      = require('./core/server/overrides'),
             bgShell: {
                 client: {
                     cmd: 'grunt subgrunt:watch',
-                    bg: true
+                    bg: true,
+                    stdout: true,
+                    stderr: true
                 }
             },
 
@@ -336,7 +339,7 @@ var overrides      = require('./core/server/overrides'),
                 },
 
                 watch: {
-                    'core/client': ['bgShell:ember', 'watch']
+                    'core/client': 'shell:ember:watch'
                 }
             }
         };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -246,8 +246,8 @@ var overrides      = require('./core/server/overrides'),
                     options: {
                         onlyUpdated: true,
                         exclude: 'node_modules,bower_components,content,core/client,*test,*doc*,' +
-                        '*vendor,config.js,*buil*,.dist*,.idea,.git*,.travis.yml,.bower*,.editorconfig,.js*,*.md',
-                        extras: ['fileSearch']
+                        '*vendor,config.*.json,*buil*,.dist*,.idea,.git*,.travis.yml,.bower*,.editorconfig,.js*,*.md,' +
+                        'MigratorConfig.js'
                     }
                 }
             },


### PR DESCRIPTION
refs #7427 

I went through the grunt commands and tested the commands to see if i can find problems.
Furthermore i have tried to delete or change old code (e.g. old config, client tests). The most important thing is right now, that all the commands are working as expected. Afterwards we can rollback gulp.

Please see commits. Every changed is described in the commit message.

Regarding `grunt dev`:
If you change any Ghost files, the reload works as expected.
If you change any client files, ember rebuilds as expected.
There was never a reload browser tab functionality, i have asked @kevinansfield - he said that, as soon as #8142 happened, Ghost can trigger a `ember serve` command, which will also reload the browser if a change in the client files happened.


FYI: I have added a @TODO to the commit: https://github.com/TryGhost/Ghost/pull/8158/commits/9cd673f6bfee08395e1fe123be71144066a5e251