### PR TITLE
✨ 🎨 Allow foreach else inside of get helper

### DIFF
--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -120,11 +120,6 @@ get = function get(resource, options) {
     return apiMethod(apiOptions).then(function success(result) {
         var blockParams;
 
-        // If no result is found, call the inverse or `{{else}}` function
-        if (_.isEmpty(result[resource])) {
-            return options.inverse(self, {data: data});
-        }
-
         // block params allows the theme developer to name the data using something like
         // `{{#get "posts" as |result pageInfo|}}`
         blockParams = [result[resource]];

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -218,10 +218,10 @@ describe('{{#get}} helper', function () {
                 'posts',
                 {hash: {filter: 'tags:none'}, fn: fn, inverse: inverse}
             ).then(function () {
-                fn.called.should.be.false();
-                inverse.calledOnce.should.be.true();
-                inverse.firstCall.args[1].should.be.an.Object().and.have.property('data');
-                inverse.firstCall.args[1].data.should.be.an.Object().and.not.have.property('error');
+                fn.calledOnce.should.be.true();
+                fn.firstCall.args[0].should.be.an.Object().with.property('posts');
+                fn.firstCall.args[0].posts.should.have.lengthOf(0);
+                inverse.called.should.be.false();
 
                 done();
             }).catch(done);


### PR DESCRIPTION
closes #7242

- before this, the get helper's else was used for empty resultsets
- the argument was made that we should fall through to a foreach or with helper's else instead
- I agree that this is the more natural, consistent approach, and so would like to change it for Ghost 1.0

E.g. as of this PR we now have:

```
{{#get "posts" filter="tag:doesnt-exist"}}
  {{#foreach posts}}
  {{else}}
    this gets executed because there are no results
  {{/foreach}}
{{/get}}
```

instead of

```
{{#get "posts" filter="tag:doesnt-exist"}}
  {{#foreach posts}}
  {{else}}
  {{/foreach}}
{{each}}
    this gets executed because there are no results
{{/get}}
```