### PR TITLE
👓  Allow invalid HTML.

### DIFF
--- a/core/server/apps/default-cards/cards/html.js
+++ b/core/server/apps/default-cards/cards/html.js
@@ -1,16 +1,18 @@
 var SimpleDom   = require('simple-dom'),
     jsdom       = require('jsdom').jsdom,
     tokenizer   = require('simple-html-tokenizer').tokenize,
-    parser;
+    parser,
+    sanitisedHTML;
 
 module.exports = {
         name: 'card-html',
         type: 'dom',
         render(opts) {
             // two stage import, firstly we import the raw payload into JSDOM to generate correct HTML.
-            var sanitisedHTML = jsdom(opts.payload.html).body.innerHTML;
+            // unfortunately mobieldoc throws errors when passed the jsdom directly.
+            sanitisedHTML = jsdom(opts.payload.html).body.innerHTML;
 
             parser = new SimpleDom.HTMLParser(tokenizer, opts.env.dom, SimpleDom.voidMap);
-            return parser.parse('<div>' + sanitisedHTML + '</div>');
+            return parser.parse('<div class="kg-card-html">' + sanitisedHTML + '</div>');
         }
     };

--- a/core/server/apps/default-cards/cards/html.js
+++ b/core/server/apps/default-cards/cards/html.js
@@ -1,4 +1,5 @@
 var SimpleDom   = require('simple-dom'),
+    jsdom       = require('jsdom').jsdom,
     tokenizer   = require('simple-html-tokenizer').tokenize,
     parser;
 
@@ -6,7 +7,10 @@ module.exports = {
         name: 'card-html',
         type: 'dom',
         render(opts) {
+            // two stage import, firstly we import the raw payload into JSDOM to generate correct HTML.
+            var sanitisedHTML = jsdom(opts.payload.html).body.innerHTML;
+
             parser = new SimpleDom.HTMLParser(tokenizer, opts.env.dom, SimpleDom.voidMap);
-            return parser.parse('<div class="kg-card-html">' + opts.payload.html + '</div>');
+            return parser.parse('<div>' + sanitisedHTML + '</div>');
         }
     };

--- a/core/server/apps/default-cards/tests/html_spec.js
+++ b/core/server/apps/default-cards/tests/html_spec.js
@@ -30,7 +30,7 @@ describe('HTML card', function () {
         var serializer = new SimpleDom.HTMLSerializer([]);
         serializer.serialize(card.render(opts)).should.match('<div class="kg-card-html">CONTENT</div>');
     });
-    it.skip('Invalid HTML returns', function () {
+    it('Unbalanced HTML renders', function () {
         opts = {
             env: {
                 dom: new SimpleDom.Document()
@@ -41,6 +41,6 @@ describe('HTML card', function () {
         };
 
         var serializer = new SimpleDom.HTMLSerializer([]);
-        serializer.serialize(card.render(opts)).should.match('<div class="kg-card-html"><h1>HEADING<</div>');
+        serializer.serialize(card.render(opts)).should.match('<div><h1>HEADING&lt;</h1></div>');
     });
 });

--- a/core/server/apps/default-cards/tests/html_spec.js
+++ b/core/server/apps/default-cards/tests/html_spec.js
@@ -41,6 +41,6 @@ describe('HTML card', function () {
         };
 
         var serializer = new SimpleDom.HTMLSerializer([]);
-        serializer.serialize(card.render(opts)).should.match('<div><h1>HEADING&lt;</h1></div>');
+        serializer.serialize(card.render(opts)).should.match('<div class="kg-card-html"><h1>HEADING&lt;</h1></div>');
     });
 });

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "image-size": "0.5.1",
     "intl": "1.2.5",
     "intl-messageformat": "1.3.0",
+    "jsdom": "9.12.0",
     "jsonpath": "0.2.11",
     "knex": "0.12.9",
     "knex-migrator": "2.0.16",


### PR DESCRIPTION
Closes: https://github.com/TryGhost/Ghost/issues/8165

Previously Ghost would throw an error if invalid or unbalanced HTML was saved in an HTML card.

This PR adds a step in the middle that parses the HTML as written in the HTML through JSDOM before being re-serialised and parsed through `simpledom` as required by the `mobiledoc-dom` renderer.