### PR TITLE
Possible README installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Install and run Ghost.
 <pre>
 <b>git clone git@github.com:TryGhost/Ghost.git</b> [or your Ghost Fork's URL]
 <b>npm run init</b>
-    <span style="color:grey">Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init</span>
+    Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init
 <b>knex-migrator init</b>
-    <span style="color:grey">Creates and initialises your database</span> 
+    Creates and initialises your database 
 <b>grunt dev</b>
-    <span style="color:grey">Starts the express server and ember build</span> 
+    Starts the express server and ember build 
 </pre>
 
 Run server tests
@@ -45,7 +45,7 @@ ember test
 ```
 
 
-Read more about the [development workflows](https://github.com/TryGhost/Ghost/wiki/%5BHOLD%5D-Contributing-Workflow-for-1.0.0).
+Read more about the [development workflows](https://github.com/TryGhost/Ghost/wiki/Working-with-Ghost).
 
 # Deploying Ghost
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 **Please note:** These are the install instructions for Ghost 1.0-alpha, which is **not** stable. If you're looking for the latest release of Ghost, check out the [stable branch](https://github.com/TryGhost/Ghost/tree/stable) or the [latest release](https://github.com/TryGhost/Ghost/releases). If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
 
 Install and run Ghost.
-```bash
-git clone git@github.com:TryGhost/Ghost.git [or your Ghost Fork's URL]
-npm run init
-grunt dev
-```
+<pre>
+<b>git clone git@github.com:TryGhost/Ghost.git</b> [or your Ghost Fork's URL]
+<b>npm run init</b>
+    <span style="color:grey">Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init</span>
+<b>knex-migrator init</b>
+    <span style="color:grey">Creates and initialises your database</span> 
+<b>grunt dev</b>
+    <span style="color:grey">Starts the express server and ember build</span> 
+</pre>
 
 Run server tests
 
@@ -40,6 +44,8 @@ cd core/client
 ember test
 ```
 
+
+Read more about the [development workflows](https://github.com/TryGhost/Ghost/wiki/%5BHOLD%5D-Contributing-Workflow-for-1.0.0).
 
 # Deploying Ghost
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 
 Install and run Ghost.
 <pre>
-<b>git clone git@github.com:TryGhost/Ghost.git</b> [or your Ghost Fork's URL]
+<b>git clone git@github.com:TryGhost/Ghost.git</b>
+    Alternatively you can use your Ghost Fork URL
 <b>npm run init</b>
     Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init
 <b>knex-migrator init</b>

--- a/README.md
+++ b/README.md
@@ -19,26 +19,24 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 
 # Ghost 1.0-alpha Developer Install
 
-**Please note:** These are the install instructions for Ghost 1.0-alpha, which is **not** stable. If you're looking for the latest release of Ghost, check out the [stable branch](https://github.com/TryGhost/Ghost/tree/stable) or the [latest release](https://github.com/TryGhost/Ghost/releases).
+**Please note:** These are the install instructions for Ghost 1.0-alpha, which is **not** stable. If you're looking for the latest release of Ghost, check out the [stable branch](https://github.com/TryGhost/Ghost/tree/stable) or the [latest release](https://github.com/TryGhost/Ghost/releases). If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
 
-If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
-
+Install and run Ghost.
 ```bash
-git clone [Ghost's repo URL or your Ghost Fork's URL]
-npm install -g knex-migrator grunt
-npm install
-git submodule update --init
-cd core/client
-npm install
-bower install
-cd ../..
-grunt build
-knex-migrator init
+git clone git@github.com:TryGhost/Ghost.git [or your Ghost Fork's URL]
+npm run init
 grunt dev
 ```
 
-To run tests
+Run server tests
+
 ```bash
+grunt test-all
+```
+
+Run client tests
+```bash
+cd core/client
 ember test
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 
 Install and run Ghost.
 <pre>
-<b>git clone git@github.com:TryGhost/Ghost.git</b>
-    Alternatively you can use your Ghost Fork URL
+<b>git clone git@github.com:TryGhost/Ghost.git ghost</b>
+    Download the Ghost code base
 <b>npm run init</b>
     Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init
 <b>knex-migrator init</b>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "./core/index",
   "scripts": {
     "start": "node index",
-    "test": "grunt validate --verbose"
+    "test": "grunt validate --verbose",
+    "init": "npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init"
   },
   "engines": {
     "node": "^4.2.0 || ^6.5.0"


### PR DESCRIPTION
The installation steps in the README are not optimal right now.
I went over them and found some variants.

![readme2](https://cloud.githubusercontent.com/assets/1160712/23989889/8731fa20-0a34-11e7-97c0-799773710a3c.png)
^ very short, `npm run init` wraps all necessary commands to install Ghost.

![readme](https://cloud.githubusercontent.com/assets/1160712/23989887/873108ae-0a34-11e7-882d-d3903765671b.png)
^ we show people that they have to run `knex-migrator init`

![readme1](https://cloud.githubusercontent.com/assets/1160712/23989888/8731864e-0a34-11e7-90ec-15730fe07b6a.png)
^ we describe all commands

![readme3](https://cloud.githubusercontent.com/assets/1160712/23990090/3848e65c-0a35-11e7-803a-d28fdc713e98.png)

No matter which variant we take, **i would like to create a wiki page to have some more detailed descriptions for installation, workflow, testing** (e.g. how can a user reset it's database, how can a use run a single test etc). So the README could link to a wiki page with a full guide.

**One thing to note**
To be able to run `grunt init`, we have to install the Ghost dependencies. 
This was tested with a fresh clone and zero global or local npm packages.
