### PR TITLE
✨ `grunt dev` admin livereload

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,6 +9,7 @@
 // jshint unused: false
 var overrides      = require('./core/server/overrides'),
     config         = require('./core/server/config'),
+    utils          = require('./core/server/utils'),
     _              = require('lodash'),
     chalk          = require('chalk'),
     fs             = require('fs-extra'),
@@ -219,7 +220,20 @@ var overrides      = require('./core/server/overrides'),
                 client: {
                     cmd: 'grunt subgrunt:watch',
                     bg: true,
-                    stdout: true,
+                    stdout: function (chunk) {
+                        // hide certain output to prevent confusion
+                        var filter = [
+                            /> ghost-admin/,
+                            /^Livereload/,
+                            /^Serving on/
+                        ].some(function (regexp) {
+                            return regexp.test(chunk);
+                        });
+
+                        if (!filter) {
+                            grunt.log.write(chunk);
+                        }
+                    },
                     stderr: true
                 }
             },
@@ -339,7 +353,9 @@ var overrides      = require('./core/server/overrides'),
                 },
 
                 watch: {
-                    'core/client': 'shell:ember:watch'
+                    projects: {
+                        'core/client': ['shell:ember:watch', '--live-reload-base-url="' + utils.url.getSubdir() + '/ghost/"']
+                    }
                 }
             }
         };

--- a/core/server/admin/app.js
+++ b/core/server/admin/app.js
@@ -36,6 +36,13 @@ module.exports = function setupAdminApp() {
     // Service Worker for offline support
     adminApp.get(/^\/(sw.js|sw-registration.js)$/, require('./serviceworker'));
 
+    // Ember CLI's live-reload script
+    if (config.get('env') === 'development') {
+        adminApp.get('/ember-cli-live-reload.js', function (req, res) {
+            res.redirect('http://localhost:4200' + utils.url.getSubdir() + '/ghost/ember-cli-live-reload.js');
+        });
+    }
+
     // Render error page in case of maintenance
     adminApp.use(maintenance);
 


### PR DESCRIPTION
refs TryGhost#8161, requires TryGhost/Ghost-Admin#590
- adds a development-only route to the admin app that redirects to ember-cli's livereload script
- updates Gruntfile `watch` task to pass the `live-reload-base-url` param with subdirectory support
- updates Gruntfile `bgShell:client` task to filter potentially confusing output from `ember serve`
  - removes `Livereload server on http://localhost:49153`
  - removes `Serving on http://localhost:4200/`

With this and the required Ghost-Admin PR, when using `grunt dev` the admin screen will refresh any time a file is changed. It will also allow client tests to be run simultaneously by visiting http://localhost:4200/tests

With this and the required Ghost-Admin PR, when using `grunt dev` the admin screen will refresh any time a file is changed. It will also allow client tests to be run simultaneously by visiting http://localhost:4200/tests

TODO:
- [x] make admin route only available in development mode
- [x] update admin route to use subdirectory
- [x] update `subgrunt:watch` task to pass configured subdirectory as `live-reload-base-url` option
- [x] see if it's possible to suppress the `ember serve` output to avoid confusion (see example below)