### PR TITLE
🔥 Remove handlebars from serving admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,7 @@ config.*.json
 
 # Built asset files
 /core/built
-/core/server/admin/views/default*.hbs
+/core/server/admin/views/*
 /core/shared/ghost-url.min.js
 
 # Coverage reports

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ var overrides      = require('./core/server/overrides'),
             pkg: grunt.file.readJSON('package.json'),
 
             clientFiles: [
-                'server/admin/views/default.hbs',
+                'server/admin/views/default.html',
                 'built/assets/ghost.js',
                 'built/assets/ghost.css',
                 'built/assets/vendor.js',

--- a/core/server/admin/app.js
+++ b/core/server/admin/app.js
@@ -1,8 +1,6 @@
 var debug = require('debug')('ghost:admin'),
     config = require('../config'),
     express = require('express'),
-    adminHbs = require('express-hbs').create(),
-
     // Admin only middleware
     adminMiddleware = require('./middleware'),
 
@@ -26,14 +24,6 @@ module.exports = function setupAdminApp() {
         res.isAdmin = true;
         next();
     });
-
-    // @TODO replace all this with serving ember's index.html
-    // Create a hbs instance for admin and init view engine
-    adminApp.set('view engine', 'hbs');
-    adminApp.set('views', config.get('paths').adminViews);
-    adminApp.engine('hbs', adminHbs.express3({}));
-    // Register our `asset` helper
-    adminHbs.registerHelper('asset', require('../helpers/asset'));
 
     // Admin assets
     // @TODO ensure this gets a local 404 error handler

--- a/core/server/admin/controller.js
+++ b/core/server/admin/controller.js
@@ -1,10 +1,11 @@
-var debug         = require('debug')('ghost:admin:controller'),
-    _             = require('lodash'),
-    config        = require('../config'),
-    api           = require('../api'),
-    updateCheck   = require('../update-check'),
-    logging       = require('../logging'),
-    i18n          = require('../i18n');
+var debug = require('debug')('ghost:admin:controller'),
+    _ = require('lodash'),
+    path = require('path'),
+    config = require('../config'),
+    api = require('../api'),
+    updateCheck = require('../update-check'),
+    logging = require('../logging'),
+    i18n = require('../i18n');
 
 // Route: index
 // Path: /ghost/
@@ -34,9 +35,10 @@ module.exports = function adminController(req, res) {
             }
         });
     }).finally(function noMatterWhat() {
-        var defaultTemplate = config.get('env') === 'production' ? 'default-prod' : 'default';
+        var defaultTemplate = config.get('env') === 'production' ? 'default-prod.html' : 'default.html',
+            templatePath = path.resolve(config.get('paths').adminViews, defaultTemplate);
 
-        res.render(defaultTemplate);
+        res.sendFile(templatePath);
     }).catch(function (err) {
         logging.error(err);
     });


### PR DESCRIPTION
This requires TryGhost/Ghost-Admin#593

refs TryGhost/Ghost#8140

- now that the admin index page is just html, we don't need handlebars anymore
- as we can use res.sendFile to send the static HTML file, don't need to "render" it anymore
- remove the view engine, hbs and the use of helpers - it's all unneeded
- change the filenames to .html to reflect this
