### PR TITLE
🐛  fix favicon path

### DIFF
--- a/core/server/middleware/serve-favicon.js
+++ b/core/server/middleware/serve-favicon.js
@@ -1,9 +1,10 @@
-var fs     = require('fs'),
+var fs = require('fs'),
     path = require('path'),
-    storage = require('../storage'),
-    settingsCache = require('../settings/cache'),
-    utils  = require('../utils'),
     crypto = require('crypto'),
+    config = require('../config'),
+    storage = require('../storage'),
+    utils  = require('../utils'),
+    settingsCache = require('../settings/cache'),
     buildContentResponse,
     content;
 
@@ -59,7 +60,7 @@ function serveFavicon() {
                     res.end(content.body);
                 });
             } else {
-                filePath = 'core/shared/favicon.ico';
+                filePath = path.join(config.get('paths:corePath'), 'shared', 'favicon.ico');
                 originalExtension = path.extname(filePath).toLowerCase();
 
                 // CASE: always redirect to .ico for default icon

--- a/core/test/unit/middleware/serve-favicon_spec.js
+++ b/core/test/unit/middleware/serve-favicon_spec.js
@@ -88,8 +88,6 @@ describe('Serve Favicon', function () {
             it('default favicon.ico', function (done) {
                 var middleware = serveFavicon();
                 req.path = '/favicon.ico';
-
-                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
                 localSettingsCache.icon = '';
 
                 res = {


### PR DESCRIPTION
closes #8187

- if you start Ghost via the Ghost-CLI, the path to the favicon must be absolute
- because the CLI spawns a Ghost process from the root folder of the CLI folder e.g. node current/index.js