### PR TITLE
[WIP] 🐛 Fix timeout for image requests

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -286,7 +286,8 @@ ConfigManager.prototype.set = function (config) {
         preloadHeaders: this._config.preloadHeaders || false,
         times: {
             cannotScheduleAPostBeforeInMinutes: 2,
-            publishAPostBySchedulerToleranceInMinutes: 2
+            publishAPostBySchedulerToleranceInMinutes: 2,
+            imageSizeLookupTimeout: 5000
         }
     });
 

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -19,7 +19,7 @@ function getCachedImageSizeFromUrl(url) {
 
     // image size is not in cache
     if (!imageSizeCache[url]) {
-        return getImageSizeFromUrl(url, 6000).then(function (res) {
+        return getImageSizeFromUrl(url).then(function (res) {
             imageSizeCache[url] = res;
 
             return Promise.resolve(imageSizeCache[url]);
@@ -27,7 +27,7 @@ function getCachedImageSizeFromUrl(url) {
             errors.logError(err, err.context);
 
             // in case of error we just attach the url
-            return Promise.resolve(imageSizeCache[url] = url);
+            return Promise.resolve();
         });
     }
     // returns image size from cache


### PR DESCRIPTION
This is a proposal for a fix for issue #8041. 

I have a very simple reproduction case where this doesn't work.

1. Find an image URL that doesn't respond. Not 404 or host error, but hangs. I have this if you need one.
2. Put this url in a post image field.
3. Publish the post & try to visit it.

With an http url, on node v4.4.7, the timeout is still 2mins. It may be different on https or on a different node version.

The fix here is the same timeout pattern I used in the gravatar util after researching timeouts and finding them to be inconsistent.

I have only tested that this case is fixed.

@kirrg001 please can you take this over and make sure there is a well tested fix in place for 0.11.8 / alpha? Feel free to ignore this proposal and use a different approach.

Either way, it needs fixing for this case and for the AMP case which uses the same code RE: https://github.com/jbhannah/amperize/issues/95? Note: I think we will need to supply the fix ourselves.

