### PR TITLE
🐛 fix image size timeout

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -202,6 +202,12 @@ ConfigManager.prototype.set = function (config) {
         schedulingPath = path.join(contentPath, '/scheduling/');
     }
 
+    this._config.times = _.merge({
+        cannotScheduleAPostBeforeInMinutes: 2,
+        publishAPostBySchedulerToleranceInMinutes: 2,
+        getImageSizeTimeoutInMS: 5000
+    }, this._config.times || {});
+
     _.merge(this._config, {
         ghostVersion: packageInfo.version,
         paths: {
@@ -283,11 +289,7 @@ ConfigManager.prototype.set = function (config) {
         deprecatedItems: ['updateCheck', 'mail.fromaddress'],
         // create a hash for cache busting assets
         assetHash: assetHash,
-        preloadHeaders: this._config.preloadHeaders || false,
-        times: {
-            cannotScheduleAPostBeforeInMinutes: 2,
-            publishAPostBySchedulerToleranceInMinutes: 2
-        }
+        preloadHeaders: this._config.preloadHeaders || false
     });
 
     // Also pass config object to

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -19,7 +19,7 @@ function getCachedImageSizeFromUrl(url) {
 
     // image size is not in cache
     if (!imageSizeCache[url]) {
-        return getImageSizeFromUrl(url, 5000).then(function (res) {
+        return getImageSizeFromUrl(url).then(function (res) {
             imageSizeCache[url] = res;
 
             return Promise.resolve(imageSizeCache[url]);

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -19,7 +19,7 @@ function getCachedImageSizeFromUrl(url) {
 
     // image size is not in cache
     if (!imageSizeCache[url]) {
-        return getImageSizeFromUrl(url, 6000).then(function (res) {
+        return getImageSizeFromUrl(url, 5000).then(function (res) {
             imageSizeCache[url] = res;
 
             return Promise.resolve(imageSizeCache[url]);

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -80,6 +80,13 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, tim
                     }
                 } else {
                     var err = new Error();
+
+                    if (res.statusCode === 404) {
+                        err.message = 'Image not found.';
+                    } else {
+                        err.message = 'Unknown Request error.'
+                    }
+
                     err.context = imagePath;
                     err.statusCode = res.statusCode;
 
@@ -89,8 +96,16 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, tim
         }).on('socket', function (socket) {
             if (timeout) {
                 socket.setTimeout(timeout);
+
+                /**
+                 * https://nodejs.org/api/http.html
+                 * "...if a callback is assigned to the Server's 'timeout' event, timeouts must be handled explicitly"
+                 *
+                 * socket.destroy will jump to the error listener
+                 */
                 socket.on('timeout', function () {
                     request.abort();
+                    socket.destroy(new Error('Request timed out.'));
                 });
             }
         }).on('error', function (err) {

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -27,16 +27,13 @@ var sizeOf       = require('image-size'),
 /**
  * @description read image dimensions from URL
  * @param {String} imagePath
- * @param {Number} timeout (optional)
  * @returns {Promise<Object>} imageObject or error
  */
-module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, timeout) {
+module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
     return new Promise(function imageSizeRequest(resolve, reject) {
         var imageObject = {},
-            options;
-
-        // set default timeout if called without option. Otherwise node will use default timeout of 120 sec.
-        timeout = timeout ? timeout : 10000;
+            options,
+            timeout = config.times.getImageSizeTimeoutInMS || 10000;
 
         imageObject.url = imagePath;
 

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -84,7 +84,7 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath, tim
                     if (res.statusCode === 404) {
                         err.message = 'Image not found.';
                     } else {
-                        err.message = 'Unknown Request error.'
+                        err.message = 'Unknown Request error.';
                     }
 
                     err.context = imagePath;

--- a/core/test/unit/utils/image-size-from-url_spec.js
+++ b/core/test/unit/utils/image-size-from-url_spec.js
@@ -4,6 +4,7 @@ var should = require('should'),
     nock = require('nock'),
     sinon = require('sinon'),
     config = require('../../../server/config'),
+    configUtils = require('../../utils/configUtils'),
 
     // Stuff we are testing
     imageSize = rewire('../../../server/utils/image-size-from-url');
@@ -19,6 +20,7 @@ describe('Image Size', function () {
 
     afterEach(function () {
         sinon.restore();
+        configUtils.restore();
     });
 
     it('should have an image size function', function () {
@@ -171,7 +173,13 @@ describe('Image Size', function () {
             .socketDelay(11)
             .reply(408);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url, 10))
+        configUtils.set({
+            times: {
+                getImageSizeTimeoutInMS: 10
+            }
+        });
+
+        result = Promise.resolve(imageSize.getImageSizeFromUrl(url))
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);


### PR DESCRIPTION
refs #8041

- destroy **remote** socket is required, see https://nodejs.org/api/http.html#http_server_settimeout_msecs_callback
- optimise error messages in general

I have tested a couple of cases manually.
e.g. image not found, image times out with different node versions.
It's hard to add a test case for that. 

I have also pushed a PR to amperize to solve a similar issue https://github.com/jbhannah/amperize/pull/96

@ErisDS Thanks for your PR #8204! I wanted to figure out why we have to use a custom timeout, because there is already a built-in socket timeout feature we can use. I have debugged why the implementation was wrong and read the HTTP docs. 

From the docs:
**By default, the Server's timeout value is 2 minutes, and sockets are destroyed automatically if they time out**. However, if a callback is assigned to the Server's 'timeout' event, timeouts must be handled explicitly.

`request.abort` destroys the client socket. But the remote socket must be destroyed as well, in case we want to handle the time manually. 

I saw that you have reduced the timeout to 5s, did that as well 👍 

For master, i would like to add a request utils. So we won't fall into the same trap again. All utils e.g. gravatar, image size can then use the same request util.