### PR TITLE
🐛  subscribers: fix delete post and delete all content

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -92,13 +92,12 @@ db = {
 
         function deleteContent() {
             var collections = [
-                models.Subscriber.findAll(queryOpts),
                 models.Post.findAll(queryOpts),
                 models.Tag.findAll(queryOpts)
             ];
 
             return Promise.each(collections, function then(Collection) {
-                return Collection.invokeThen('destroy');
+                return Collection.invokeThen('destroy', queryOpts);
             }).return({db: []})
             .catch(function (error) {
                 throw new errors.InternalServerError(error.message || error);

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -131,6 +131,20 @@ Post = ghostBookshelf.Model.extend({
                     });
                 })
                 .then(function () {
+                    // @TODO: filtering is not possible for subscribers, see https://github.com/TryGhost/GQL/issues/22
+                    return ghostBookshelf.model('Subscriber')
+                        .where({
+                            post_id: model.id
+                        })
+                        .fetchAll(options);
+                })
+                .then(function (response) {
+                    return Promise.each(response.models, function (subscriber) {
+                        subscriber.set('post_id', null);
+                        return subscriber.save(null, options);
+                    });
+                })
+                .then(function () {
                     if (model.previous('status') === 'published') {
                         model.emitChange('unpublished');
                     }

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -266,7 +266,8 @@ DataGenerator.forKnex = (function () {
         users,
         roles_users,
         clients,
-        trustedDomains;
+        trustedDomains,
+        subscribers;
 
     function createBasic(overrides) {
         var newObj = _.cloneDeep(overrides);
@@ -467,6 +468,11 @@ DataGenerator.forKnex = (function () {
         createAppField(DataGenerator.Content.app_fields[1])
     ];
 
+    subscribers = [
+        createBasic(DataGenerator.Content.subscribers[0]),
+        createBasic(DataGenerator.Content.subscribers[1])
+    ];
+
     return {
         createPost: createPost,
         createGenericPost: createGenericPost,
@@ -493,7 +499,8 @@ DataGenerator.forKnex = (function () {
         roles: roles,
         users: users,
         roles_users: roles_users,
-        clients: clients
+        clients: clients,
+        subscribers: subscribers
     };
 }());
 


### PR DESCRIPTION
refs #7875

- do not delete subscribers if deleting all the content
- ensure dropping all the content and deleteting a single post will delete the reference in the subscriber if exist

- [x] raise GQL issue regarding filtering, see https://github.com/TryGhost/GQL/issues/22
- [x] manual browser test
- [x] pull change into master