### PR TITLE
🐛 serve default ghost icon

### DIFF
--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -66,7 +66,7 @@ function getMetaData(data, root) {
     if (settingsCache.get('logo')) {
         metaData.blog.logo.url = utils.url.urlFor('image', {image: settingsCache.get('logo')}, true);
     } else {
-        metaData.blog.logo.url = utils.url.urlJoin(utils.url.urlFor('admin'), 'img/ghosticon.jpg');
+        metaData.blog.logo.url = utils.url.urlJoin(utils.url.urlFor('admin'), 'assets/img/ghosticon.jpg');
     }
 
     // TODO: cleanup these if statements

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -221,7 +221,7 @@ function urlPathForPost(post) {
 // @TODO: rewrite, very hard to read, create private functions!
 function urlFor(context, data, absolute) {
     var urlPath = '/',
-        secure, imagePathRe,
+        secure, contentImageRe, assetImageRe,
         knownObjects = ['post', 'tag', 'author', 'image', 'nav'], baseUrl,
         hostname,
 
@@ -257,8 +257,9 @@ function urlFor(context, data, absolute) {
             secure = data.author.secure;
         } else if (context === 'image' && data.image) {
             urlPath = data.image;
-            imagePathRe = new RegExp('^' + getSubdir() + '/' + STATIC_IMAGE_URL_PREFIX);
-            absolute = imagePathRe.test(data.image) ? absolute : false;
+            contentImageRe = new RegExp('^' + getSubdir() + '/' + STATIC_IMAGE_URL_PREFIX);
+            assetImageRe = new RegExp('^/ghost/assets/(img|icons)');
+            absolute = contentImageRe.test(data.image) || assetImageRe.test(data.image) ? absolute : false;
             secure = data.image.secure;
 
             if (absolute) {


### PR DESCRIPTION
closes #8215

- two problems existed:
  - default icon path was wrong, asset path was missing
  - url helper does not recognise asset images as image

Note: the whole asset url generation should happen in a centralised place.
In the future we should merge our meta asset helper and these manual usages together in a url helper function.