### PR TITLE
🐛 Fix the config for compression

### DIFF
--- a/core/server/app.js
+++ b/core/server/app.js
@@ -36,7 +36,7 @@ module.exports = function setupParentApp() {
     }
 
     // enabled gzip compression by default
-    if (config.get('server').compress !== false) {
+    if (config.get('compress') !== false) {
         parentApp.use(compress());
     }
 


### PR DESCRIPTION
refs #7488

- This has always been documented as top-level "compress", and yet the code references server.compress
- Should be top level, I think?