### PR TITLE
🐛 Ensure that admin templates are on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -30,6 +30,7 @@ CONTRIBUTING.md
 SECURITY.md
 .travis.yml
 *.html
+!core/server/admin/views/**
 !core/server/mail/templates/**
 bower_components/**
 .editorconfig


### PR DESCRIPTION
Tested using `npm pack` - includes the files now.

fixes #8216

- Admin templates are now html files, we need to not ignore them