### PR TITLE
add `--server/client` options to `grunt dev`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,9 +61,7 @@ var overrides      = require('./core/server/overrides'),
                 livereload: {
                     files: [
                         'content/themes/casper/assets/css/*.css',
-                        'content/themes/casper/assets/js/*.js',
-                        'core/built/assets/*.js',
-                        'core/client/dist/index.html'
+                        'content/themes/casper/assets/js/*.js'
                     ],
                     options: {
                         livereload: true
@@ -219,10 +217,10 @@ var overrides      = require('./core/server/overrides'),
             bgShell: {
                 client: {
                     cmd: 'grunt subgrunt:watch',
-                    bg: true,
+                    bg: grunt.option('client') ? false : true,
                     stdout: function (chunk) {
-                        // hide certain output to prevent confusion
-                        var filter = [
+                        // hide certain output to prevent confusion when running alongside server
+                        var filter = grunt.option('client') ? false : [
                             /> ghost-admin/,
                             /^Livereload/,
                             /^Serving on/
@@ -683,8 +681,15 @@ var overrides      = require('./core/server/overrides'),
         // frontend code changes.
         //
         // Note that the current implementation of watch only works with casper, not other themes.
-        grunt.registerTask('dev', 'Dev Mode; watch files and restart server on changes',
-           ['bgShell:client', 'express:dev', 'watch']);
+        grunt.registerTask('dev', 'Dev Mode; watch files and restart server on changes', function () {
+            if (grunt.option('client')) {
+                grunt.task.run(['bgShell:client']);
+            } else if (grunt.option('server')) {
+                grunt.task.run(['express:dev', 'watch']);
+            } else {
+                grunt.task.run(['bgShell:client', 'express:dev', 'watch']);
+            }
+        });
 
         // ### Release
         // Run `grunt release` to create a Ghost release zip file.


### PR DESCRIPTION
refs #8235
- adds `grunt dev --server` which will start the express server and restart on server changes but will not rebuild or watch any client files (if client files are missing or out of date you can run `grunt build` first)
- adds `grunt dev --client` which will only start the client server and rebuilding/livereload - useful if you are experiencing issues with one or the other crashing because you can run server/client in separate tabs