### PR TITLE
🎨  hide npm error log if running npm run init

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node index",
     "test": "grunt validate --verbose",
-    "init": "npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init"
+    "init": "npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init || true"
   },
   "engines": {
     "node": "^4.2.0 || ^6.5.0"


### PR DESCRIPTION
refs #8235

- users share the general npm error log, which won't help
- so it's better to hide this log

If an error occurs when running a npm script (e.g. `npm run init`), npm will show a general error if and that the script command failed. Users share this error and it won't bring any clarity on why this npm command failed for this user. That's why we have talked about hiding this npm log. 

### without hiding
![npmlog2](https://cloud.githubusercontent.com/assets/1160712/24609343/c9fc7534-187a-11e7-9f25-210ccf067c14.png)

### with hiding
![npmlog1](https://cloud.githubusercontent.com/assets/1160712/24609341/c895b2f0-187a-11e7-9ee1-2dfea5895455.png)

