### PR TITLE
🛠  ✨  grunt master

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -242,7 +242,7 @@ var overrides      = require('./core/server/overrides'),
                 master: {
                     command: function () {
                         var upstream = grunt.option('upstream') || 'origin';
-                        return 'git checkout master; git pull ' + upstream +' master; npm install;';
+                        return 'git checkout master; git pull ' + upstream + ' master; npm install;';
                     }
                 },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,6 +236,21 @@ var overrides      = require('./core/server/overrides'),
                 }
             },
 
+            // ### grunt-shell
+            // Command line tools where it's easier to run a command directly than configure a grunt plugin
+            shell: {
+                master: {
+                    command: function () {
+                        var upstream = grunt.option('upstream') || 'origin';
+                        return 'git checkout master; git pull ' + upstream +' master; npm install;';
+                    }
+                },
+
+                dbhealth: {
+                    command: 'knex-migrator health'
+                }
+            },
+
             // ### grunt-docker
             // Generate documentation from code
             docker: {
@@ -669,6 +684,18 @@ var overrides      = require('./core/server/overrides'),
                 grunt.task.run(['bgShell:client', 'express:dev', 'watch']);
             }
         });
+
+        /**
+         * This command helps you to bring your working directory back to current master.
+         * It will also update your dependencies and shows you if your database is health.
+         * It won't build the client!
+         *
+         * grunt dev-master [origin is the default upstream to pull from]
+         * grunt dev-master --upstream=parent
+         */
+        grunt.registerTask('dev-master', 'Update your current working folder to latest master.',
+            ['shell:master', 'update_submodules', 'subgrunt:init', 'shell:dbhealth']
+        );
 
         // ### Release
         // Run `grunt release` to create a Ghost release zip file.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -690,10 +690,10 @@ var overrides      = require('./core/server/overrides'),
          * It will also update your dependencies and shows you if your database is health.
          * It won't build the client!
          *
-         * grunt dev-master [origin is the default upstream to pull from]
-         * grunt dev-master --upstream=parent
+         * grunt master [origin is the default upstream to pull from]
+         * grunt master --upstream=parent
          */
-        grunt.registerTask('dev-master', 'Update your current working folder to latest master.',
+        grunt.registerTask('master', 'Update your current working folder to latest master.',
             ['shell:master', 'update_submodules', 'subgrunt:init', 'shell:dbhealth']
         );
 


### PR DESCRIPTION
refs #8235

- add a new grunt command `dev-master`
- this command will bring back your working directory to latest master
- plus it will update your dependencies and checks your database health
- it won't build the client (!)

`grunt dev-master` or `grunt dev-master --upstream=your-upstream-to-pull-from`

**I have tested several scenarios.**
e.g. you are on a specific branch and you have uncommitted changes - it will keep your changes and switches to master
e.g. your client is out of date
e.g. your dependencies are out of date

