### PR TITLE
🎨  change default auth strategy for development mode

### DIFF
--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -8,8 +8,7 @@
         "debug": false
     },
     "auth": {
-        "type": "ghost",
-        "url": "http://devauth.ghost.org:8080"
+        "type": "password"
     },
     "paths": {
         "contentPath": "content/"


### PR DESCRIPTION
no issue

- we would like to switch to password strategy when developing
- this can be overridden by a custom development configuration
- furthermore we would like to get rid of the `http://devauth.ghost.org:8080` testing server