### PR TITLE
🛠 switch to using yarn in our Grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -236,22 +236,6 @@ var overrides      = require('./core/server/overrides'),
                 }
             },
 
-            // ### grunt-shell
-            // Command line tools where it's easier to run a command directly than configure a grunt plugin
-            shell: {
-                shrinkwrap: {
-                    command: 'npm shrinkwrap'
-                },
-
-                prune: {
-                    command: 'npm prune'
-                },
-
-                dedupe: {
-                    command: 'npm dedupe'
-                }
-            },
-
             // ### grunt-docker
             // Generate documentation from code
             docker: {
@@ -273,9 +257,7 @@ var overrides      = require('./core/server/overrides'),
                 built: {
                     src: [
                         'core/built/**',
-                        'core/client/dist/**',
-                        'core/client/public/assets/img/contributors/**',
-                        'core/client/app/templates/-contributors.hbs'
+                        'core/client/dist/**'
                     ]
                 },
                 release: {
@@ -330,7 +312,8 @@ var overrides      = require('./core/server/overrides'),
             // Run grunt tasks in submodule Gruntfiles
             subgrunt: {
                 options: {
-                    npmInstall: false
+                    npmInstall: false,
+                    npmPath: 'yarn'
                 },
 
                 init: {
@@ -624,7 +607,7 @@ var overrides      = require('./core/server/overrides'),
         // the Ghost assets in order to make them work.
         //
         // There are a number of grunt tasks available to help with this. Firstly after fetching an updated version of
-        // the Ghost codebase, after running `npm install`, you will need to run [grunt init](#init%20assets).
+        // the Ghost codebase, after running `yarn install`, you will need to run [grunt init](#init%20assets).
         //
         // For production blogs you will need to run [grunt prod](#production%20assets).
         //
@@ -634,11 +617,11 @@ var overrides      = require('./core/server/overrides'),
         // ### Init assets
         // `grunt init` - will run an initial asset build for you
         //
-        // Grunt init runs `npm install && bower install` inside `core/client` as well as the standard asset build
+        // Grunt init runs `yarn install && bower install` inside `core/client` as well as the standard asset build
         // tasks which occur when you run just `grunt`. This fetches the latest client-side dependencies.
         //
         // This task is very important, and should always be run when fetching down an updated code base just after
-        // running `npm install`.
+        // running `yarn install`.
         //
         // `bower` does have some quirks, such as not running as root. If you have problems please try running
         // `grunt init --verbose` to see if there are any errors.
@@ -665,10 +648,6 @@ var overrides      = require('./core/server/overrides'),
         // It is otherwise the same as running `grunt`, but is only used when running Ghost in the `production` env.
         grunt.registerTask('prod', 'Build JS & templates for production',
             ['subgrunt:prod', 'uglify:prod', 'master-warn']);
-
-        grunt.registerTask('deps', 'Prepare dependencies',
-            ['shell:dedupe', 'shell:prune', 'shell:shrinkwrap']
-        );
 
         // ### Live reload
         // `grunt dev` - build assets on the fly whilst developing
@@ -715,7 +694,7 @@ var overrides      = require('./core/server/overrides'),
                     dest: '<%= paths.releaseBuild %>/'
                 });
 
-                grunt.task.run(['init', 'prod', 'clean:release', 'deps', 'copy:release', 'compress:release']);
+                grunt.task.run(['init', 'prod', 'clean:release', 'copy:release', 'compress:release']);
             }
         );
     };

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 
 **Please note:** These are the install instructions for Ghost 1.0-alpha, which is **not** stable. If you're looking for the latest release of Ghost, check out the [stable branch](https://github.com/TryGhost/Ghost/tree/stable) or the [latest release](https://github.com/TryGhost/Ghost/releases). If you get stuck, come say hi over [on slack](https://slack.ghost.org)!
 
+**Important**: Ghost uses [`yarn`](https://yarnpkg.com) rather than `npm` to manage it's dependencies. Ensure that you have it installed and you have configured your `PATH` environment variable for it to work correctly. We recommend the ["Installation Script" instructions](https://yarnpkg.com/en/docs/install#alternatives-tab) because it works better with `nvm` but choose the best option for your development setup.
+
 Install and run Ghost.
 <pre>
 <b>git clone git@github.com:TryGhost/Ghost.git ghost</b>
     Download the Ghost code base
 <b>npm run init</b>
-    Short command for: npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init
+    Short command for: yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt init
 <b>knex-migrator init</b>
-    Creates and initialises your database 
+    Creates and initialises your database
 <b>grunt dev</b>
-    Starts the express server and ember build 
+    Starts the express server and ember build
 </pre>
 
 Run server tests
@@ -54,7 +56,7 @@ Read more about the [development workflows](https://github.com/TryGhost/Ghost/wi
 
 The easiest way to deploy Ghost is with our official **[Ghost(Pro)](https://ghost.org/pricing/)** managed service. You can have a fresh instance up and running in a couple of clicks with a worldwide CDN, backups, security and maintenance all done for you.
 
-Not only will it save you [many hours per month](https://ghost.org/ghost-pro-vs-self-hosting/), but all revenue goes to the Ghost Foundation, which funds the maintenance and further development of Ghost itself. So you’ll be supporting open source software *and* getting a great service **at the same time**! Talk about win/win. :trophy: 
+Not only will it save you [many hours per month](https://ghost.org/ghost-pro-vs-self-hosting/), but all revenue goes to the Ghost Foundation, which funds the maintenance and further development of Ghost itself. So you’ll be supporting open source software *and* getting a great service **at the same time**! Talk about win/win. :trophy:
 
 [Other options](http://support.ghost.org/deploying-ghost/) are also available if you prefer playing around with servers by yourself, of course. The freedom of choice is in your hands.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node index",
     "test": "grunt validate --verbose",
-    "init": "npm install -g knex-migrator ember-cli grunt-cli && npm install && grunt init || true"
+    "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt init || true"
   },
   "engines": {
     "node": "^4.2.0 || ^6.5.0"


### PR DESCRIPTION
requires https://github.com/TryGhost/Ghost-Admin/pull/613
- use `yarn install` instead of `npm install` in grunt tasks
- remove `grunt deps` and `grunt shell:{shrinkwrap/prune/dedupe}` tasks as they are not needed when using `yarn`
- set `options.npmPath` to `yarn` for subgrunt so it doesn't use `npm install` automatically
- don't remove client contributors files in `grunt clean` - those files are now manually created and should be kept