### PR TITLE
🐛  fix owner user slug

### DIFF
--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -115,12 +115,11 @@ strategies = {
 
                     return models.User.add({
                         email: profile.email,
-                        name: profile.email,
+                        name: profile.name,
                         password: utils.uid(50),
                         roles: [invite.toJSON().role_id],
                         ghost_auth_id: profile.id,
                         ghost_auth_access_token: ghostAuthAccessToken
-
                     }, options);
                 })
                 .then(function destroyInvite(_user) {
@@ -141,8 +140,11 @@ strategies = {
                         });
                     }
 
+                    // CASE: slug null forces regenerating the slug (ghost-owner is default and needs to be overridden)
                     return models.User.edit({
                         email: profile.email,
+                        name: profile.name,
+                        slug: null,
                         status: 'active',
                         ghost_auth_id: profile.id,
                         ghost_auth_access_token: ghostAuthAccessToken
@@ -169,6 +171,7 @@ strategies = {
 
                     return models.User.edit({
                         email: profile.email,
+                        name: profile.name,
                         ghost_auth_id: profile.id,
                         ghost_auth_access_token: ghostAuthAccessToken
                     }, _.merge({id: user.id}, options));


### PR DESCRIPTION
closes #8067

- this is only a bug present for remote authentication
- right now the remote service does not return the name of the user
- depends on an internal PR
- force regenerating the slug on setup
- override name for signin or invite if needed

- [x] do final testing if internal PR was merged and deployed