### PR TITLE
🐛  import subscribers with post_id reference

### DIFF
--- a/core/server/data/import/utils.js
+++ b/core/server/data/import/utils.js
@@ -306,7 +306,7 @@ utils = {
         }
 
         var ops = [];
-        tableData = stripProperties(['id'], tableData);
+        tableData = stripProperties(['id', 'post_id'], tableData);
 
         _.each(tableData, function (subscriber) {
             ops.push(models.Subscriber.add(subscriber, _.extend({}, internalContext, {transacting: transaction}))

--- a/core/test/utils/fixtures/export/export-000.json
+++ b/core/test/utils/fixtures/export/export-000.json
@@ -168,7 +168,8 @@
         "subscribers": [
             {
                 "id": 1,
-                "email": "subscriber1@test.com"
+                "email": "subscriber1@test.com",
+                "post_id": 888
             },
             {
                 "id": 2,


### PR DESCRIPTION
no issue

- we need to strip this property, otherwise it could throw database error on MySQL

The `import_spec` test would fail if we don't strip this property.