### PR TITLE
👋🏼  Don't use ghosticon.jpg from admin assets

### DIFF
--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -66,7 +66,13 @@ function getMetaData(data, root) {
     if (settingsCache.get('logo')) {
         metaData.blog.logo.url = utils.url.urlFor('image', {image: settingsCache.get('logo')}, true);
     } else {
-        metaData.blog.logo.url = utils.url.urlJoin(utils.url.urlFor('admin'), 'img/ghosticon.jpg');
+        metaData.blog.logo.url = utils.url.urlFor({relativeUrl: 'favicon.ico'}, true);
+        // Setting image dimensions to force the default logo to be an `ImageObject` and make
+        // Google happy with it. See https://github.com/TryGhost/Ghost/issues/7558
+        metaData.blog.logo.dimensions = {
+            width: 60,
+            height: 60
+        };
     }
 
     // TODO: cleanup these if statements

--- a/core/server/data/slack/index.js
+++ b/core/server/data/slack/index.js
@@ -73,7 +73,7 @@ function ping(post) {
             slackData = {
                 text: message,
                 unfurl_links: true,
-                icon_url: utils.url.urlJoin(utils.url.urlFor('admin', true), 'img/ghosticon.jpg'),
+                icon_url: utils.url.urlFor({relativeUrl: 'favicon.ico'}, true),
                 username: 'Ghost'
             };
 

--- a/core/test/unit/slack_spec.js
+++ b/core/test/unit/slack_spec.js
@@ -200,7 +200,7 @@ describe('Slack', function () {
                 settingsAPIStub.calledOnce.should.be.true();
                 requestOptions.should.have.property('href').and.be.equal('https://hooks.slack.com/services/a-b-c-d');
                 requestData.should.have.property('text').and.be.equal('http://myblog.com/');
-                requestData.should.have.property('icon_url').and.be.equal('http://myblog.com/ghost/img/ghosticon.jpg');
+                requestData.should.have.property('icon_url').and.be.equal('http://myblog.com/favicon.ico');
                 requestData.should.have.property('username').and.be.equal('Ghost');
                 done();
             };
@@ -222,7 +222,7 @@ describe('Slack', function () {
                 settingsAPIStub.calledOnce.should.be.true();
                 requestOptions.should.have.property('href').and.be.equal('https://hooks.slack.com/services/a-b-c-d');
                 requestData.should.have.property('text').and.be.equal('Hi!');
-                requestData.should.have.property('icon_url').and.be.equal('https://myblog.com/ghost/img/ghosticon.jpg');
+                requestData.should.have.property('icon_url').and.be.equal('https://myblog.com/favicon.ico');
                 requestData.should.have.property('username').and.be.equal('Ghost');
                 done();
             };


### PR DESCRIPTION
refs #8221

Use our default `favicon.ico` instead of `ghosticon.jpg` which is served from the admins' assets.
Adds additionally fake image dimensions for our json-ld data to satisfy Google.