### PR TITLE
🎨  change location of adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ Session.vim
 /content/apps/**/*
 /content/themes/**/*
 /content/images/**/*
+/content/adapters/storage/**/*
+/content/adapters/scheduling/**/*
 !/content/themes/casper/**
 !/README.md
 

--- a/content/adapters/README.md
+++ b/content/adapters/README.md
@@ -11,7 +11,7 @@ This default adapter can be found in `core/server/storage/LocalFileStorage.js`.
 
 ### SchedulingDefault
 By default Ghost will schedule your posts using a pure JavaScript solution.
-It doesn't make usage of `cron` or similar.
+It doesn't use of `cron` or similar.
 This default adapter can be found in `core/server/scheduling/SchedulingDefault.js`.
 
 ### Custom Adapter

--- a/content/adapters/README.md
+++ b/content/adapters/README.md
@@ -11,7 +11,7 @@ This default adapter can be found in `core/server/storage/LocalFileStorage.js`.
 
 ### SchedulingDefault
 By default Ghost will schedule your posts using a pure JavaScript solution.
-It doesn't use of `cron` or similar.
+It doesn't use `cron` or similar.
 This default adapter can be found in `core/server/scheduling/SchedulingDefault.js`.
 
 ### Custom Adapter

--- a/content/adapters/README.md
+++ b/content/adapters/README.md
@@ -1,0 +1,23 @@
+# Content / Adapters
+
+
+An adapter is a way to override a default behaviour in Ghost.
+The default behaviour in Ghost is as following:
+
+### LocalFileStorage
+By default Ghost will upload your images to the `content/images` folder.
+The LocalFileStorage is using the file system to read or write images.
+This default adapter can be found in `core/server/storage/LocalFileStorage.js`.
+
+### SchedulingDefault
+By default Ghost will schedule your posts using a pure JavaScript solution.
+It doesn't make usage of `cron` or similar.
+This default adapter can be found in `core/server/scheduling/SchedulingDefault.js`.
+
+### Custom Adapter
+To override any of the default adapters, you have to add a folder (`content/adapters/storage` or `content/adapters/scheduling`) and copy your adapter to it. 
+
+Please follow our detailed guides:
+https://github.com/TryGhost/Ghost/wiki/Using-a-custom-storage-module
+https://github.com/TryGhost/Ghost/wiki/Using-a-custom-scheduling-module
+

--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -49,16 +49,16 @@ exports.makePathsAbsolute = function makePathsAbsolute(obj, parent) {
  */
 exports.getContentPath = function getContentPath(type) {
     switch (type) {
-        case 'storage':
-            return path.join(this.get('paths:contentPath'), 'storage/');
         case 'images':
             return path.join(this.get('paths:contentPath'), 'images/');
         case 'apps':
             return path.join(this.get('paths:contentPath'), 'apps/');
         case 'themes':
             return path.join(this.get('paths:contentPath'), 'themes/');
+        case 'storage':
+            return path.join(this.get('paths:contentPath'), 'adapters', 'storage/');
         case 'scheduling':
-            return path.join(this.get('paths:contentPath'), 'scheduling/');
+            return path.join(this.get('paths:contentPath'), 'adapters', 'scheduling/');
         case 'logs':
             return path.join(this.get('paths:contentPath'), 'logs/');
         case 'data':


### PR DESCRIPTION
closes #7687

- change location from content/storage or content/scheduling to content/adapters/storage or content/adapters/scheduling
- i have added a @TODO to https://github.com/TryGhost/Ghost/issues/7421 to check if both adapter types needs an update in the documentation
- i have tested adding a custom storage adapter, works

**Note:** we could do way more for adapter improvements e.g. transform scheduling into classes and source out scheduling base, but scheduling is right now not a candidate for having lot's of custom adapters available. We build a good JavaScript solution, people usually use as default. Furthermore, we could group the default adapters into one folder e.g. `core/server/adapters`. But as we would like to re-group our folders anyway, we can do that after `1.0` launch. Or pre launch `1.0`?