### PR TITLE
🐝  Add image property to rss

### DIFF
--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -100,6 +100,7 @@ generateFeed = function generateFeed(data) {
         generator: 'Ghost ' + data.version,
         feed_url: data.feedUrl,
         site_url: data.siteUrl,
+        image_url: utils.url.urlFor({relativeUrl: 'favicon.png'}, true),
         ttl: '60',
         custom_namespaces: {
             content: 'http://purl.org/rss/1.0/modules/content/',

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -87,6 +87,7 @@ describe('RSS', function () {
                 xmlData.should.match(/<channel><title><!\[CDATA\[Test Title\]\]><\/title>/);
                 xmlData.should.match(/<description><!\[CDATA\[Testing Desc\]\]><\/description>/);
                 xmlData.should.match(/<link>http:\/\/my-ghost-blog.com\/<\/link>/);
+                xmlData.should.match(/<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
                 xmlData.should.match(/<generator>Ghost 0.6<\/generator>/);
                 xmlData.should.match(/<lastBuildDate>.*?<\/lastBuildDate>/);
                 xmlData.should.match(/<atom:link href="http:\/\/my-ghost-blog.com\/rss\/" rel="self"/);
@@ -118,6 +119,7 @@ describe('RSS', function () {
                 xmlData.should.match(/<item><title><!\[CDATA\[HTML Ipsum\]\]><\/title>/);
                 xmlData.should.match(/<description><!\[CDATA\[<h1>HTML Ipsum Presents<\/h1>/);
                 xmlData.should.match(/<link>http:\/\/my-ghost-blog.com\/html-ipsum\/<\/link>/);
+                xmlData.should.match(/<image><url>http:\/\/my-ghost-blog.com\/favicon.png<\/url><title>Test Title<\/title><link>http:\/\/my-ghost-blog.com\/<\/link><\/image>/);
                 xmlData.should.match(/<guid isPermaLink="false">/);
                 xmlData.should.match(/<\/guid><dc:creator><!\[CDATA\[Joe Bloggs\]\]><\/dc:creator>/);
                 xmlData.should.match(/<pubDate>Thu, 01 Jan 2015/);


### PR DESCRIPTION
refs #7688

Adds an image property to our generated rss data, which links to the favicon (has to be `.png` reg. [RSS board).](http://www.rssboard.org/rss-2-0-1#ltimagegtSubelementOfLtchannelgt)