### PR TITLE
👊🏼 no-cache for favicon

### DIFF
--- a/core/server/middleware/serve-favicon.js
+++ b/core/server/middleware/serve-favicon.js
@@ -14,7 +14,7 @@ buildContentResponse = function buildContentResponse(ext, buf) {
             'Content-Type': 'image/' + ext,
             'Content-Length': buf.length,
             ETag: '"' + crypto.createHash('md5').update(buf, 'utf8').digest('hex') + '"',
-            'Cache-Control': 'public, max-age=' + utils.ONE_DAY_S
+            'Cache-Control': 'no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0'
         },
         body: buf
     };


### PR DESCRIPTION
refs #7688

Setting `Cache-Control` to `no-cache` fixes the issue that when a new blog icon is uploaded, it doesn't change in admin. Admin still needs a refresh, but not the work-around of requesting the favicon URI first.