### PR TITLE
🐛  fix hasDateChanged

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -249,8 +249,17 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return this.updatedAttributes()[attr];
     },
 
-    hasDateChanged: function (attr) {
-        return moment(this.get(attr)).diff(moment(this.updated(attr))) !== 0;
+    /**
+     * There is difference between `updated` and `previous`:
+     * Depending on the hook (before or after writing into the db), both fields have a different meaning.
+     * e.g. onSaving  -> before db write (has to use previous)
+     *      onUpdated -> after db write  (has to use updated)
+     *
+     * hasDateChanged('attr', {beforeWrite: true})
+     */
+    hasDateChanged: function (attr, options) {
+        options = options || {};
+        return moment(this.get(attr)).diff(moment(options.beforeWrite ? this.previous(attr) : this.updated(attr))) !== 0;
     },
 
     /**

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -149,7 +149,7 @@ Post = ghostBookshelf.Model.extend({
             prevSlug    = this._previousAttributes.slug,
             tagsToCheck = this.get('tags'),
             publishedAt = this.get('published_at'),
-            publishedAtHasChanged = this.hasDateChanged('published_at'),
+            publishedAtHasChanged = this.hasDateChanged('published_at', {beforeWrite: true}),
             mobiledoc   = this.get('mobiledoc'),
             tags = [];
 


### PR DESCRIPTION
no issue

- i don't know if this never worked or has worked and something changed in bookshelf
- **but this fixes: saving the content (no change for published_at) of a scheduled post within the 2minutes window**
- add `beforeWrite` option to hasDateChanged helper, see comment
- add a test and fix some other small issues in the scheduler tests

This was tested with #8249.
I need to port this fix over to `LTS` as well.