### PR TITLE
Asset amends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ config.*.json
 /core/built
 /core/server/admin/views/*
 /core/server/public/ghost-url.min.js
+/core/server/public/ghost.min.css
 
 # Coverage reports
 coverage.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -323,6 +323,17 @@ var overrides      = require('./core/server/overrides'),
                 }
             },
 
+            cssnano: {
+                prod: {
+                    options: {
+                        sourcemap: false
+                    },
+                    files: {
+                        'core/server/public/ghost.min.css': 'core/server/public/ghost.css'
+                    }
+                }
+            },
+
             // ### grunt-subgrunt
             // Run grunt tasks in submodule Gruntfiles
             subgrunt: {
@@ -662,7 +673,7 @@ var overrides      = require('./core/server/overrides'),
         //
         // It is otherwise the same as running `grunt`, but is only used when running Ghost in the `production` env.
         grunt.registerTask('prod', 'Build JS & templates for production',
-            ['subgrunt:prod', 'uglify:prod', 'master-warn']);
+            ['subgrunt:prod', 'uglify:prod', 'cssnano:prod', 'master-warn']);
 
         // ### Live reload
         // `grunt dev` - build assets on the fly whilst developing

--- a/core/server/apps/private-blogging/lib/views/private.hbs
+++ b/core/server/apps/private-blogging/lib/views/private.hbs
@@ -15,7 +15,7 @@
         <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
         <meta http-equiv="cleartype" content="on">
 
-        <link rel="stylesheet" href="{{asset "public/ghost.css"}}"/>
+        <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}"/>
     </head>
     <body>
         <div class="gh-app">

--- a/core/server/apps/subscribers/lib/views/subscribe.hbs
+++ b/core/server/apps/subscribers/lib/views/subscribe.hbs
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
     <meta http-equiv="cleartype" content="on">
 
-    <link rel="stylesheet" href="{{asset "public/ghost.css"}}"/>
+    <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}"/>
 </head>
 <body>
 <div class="gh-app">

--- a/core/server/blog/app.js
+++ b/core/server/blog/app.js
@@ -53,6 +53,7 @@ module.exports = function setupBlogApp() {
 
     // Serve stylesheets for default templates
     blogApp.use(servePublicFile('public/ghost.css', 'text/css', utils.ONE_HOUR_S));
+    blogApp.use(servePublicFile('public/ghost.min.css', 'text/css', utils.ONE_HOUR_S));
 
     // Serve images for default templates
     blogApp.use(servePublicFile('public/404-ghost@2x.png', 'png', utils.ONE_HOUR_S));

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -5,6 +5,8 @@
         "port": 2368
     },
     "privacy": false,
+    "useMinFiles": true,
+    "printErrorStack": false,
     "paths": {
         "contentPath": "content/"
     },

--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -17,7 +17,7 @@
         "useRpcPing": false,
         "useUpdateCheck": true
     },
-    "minifyAssets": false,
+    "useMinFiles": false,
     "printErrorStack": true,
     "caching": {
         "theme": {

--- a/core/server/config/env/config.testing-mysql.json
+++ b/core/server/config/env/config.testing-mysql.json
@@ -53,5 +53,5 @@
         "useTinfoil": true,
         "useStructuredData": true
     },
-    "minifyAssets": false
+    "useMinFiles": false
 }

--- a/core/server/config/env/config.testing.json
+++ b/core/server/config/env/config.testing.json
@@ -52,5 +52,5 @@
         "useTinfoil": true,
         "useStructuredData": true
     },
-    "minifyAssets": false
+    "useMinFiles": false
 }

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -2,29 +2,21 @@ var config = require('../../config'),
     settingsCache = require('../../settings/cache'),
     utils = require('../../utils');
 
-function getAssetUrl(path, isAdmin, minify) {
+function getAssetUrl(path, minify) {
     var output = '';
 
     output += utils.url.urlJoin(utils.url.getSubdir(), '/');
 
     if (!path.match(/^favicon\.(ico|png)$/) && !path.match(/^public/) && !path.match(/^asset/)) {
-        if (isAdmin) {
-            output = utils.url.urlJoin(output, 'ghost/');
-        }
-
         output = utils.url.urlJoin(output, 'assets/');
     }
     // Serve either uploaded favicon or default
     // for favicon, we don't care anymore about the `/` leading slash, as we don't support theme favicons
     if (path.match(/\/?favicon\.(ico|png)$/)) {
-        if (isAdmin) {
-            output = utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
+        if (settingsCache.get('icon')) {
+            output = utils.url.urlJoin(utils.url.getSubdir(), utils.url.urlFor('image', {image: settingsCache.get('icon')}));
         } else {
-            if (settingsCache.get('icon')) {
-                output = utils.url.urlJoin(utils.url.getSubdir(), utils.url.urlFor('image', {image: settingsCache.get('icon')}));
-            } else {
-                output = utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
-            }
+            output = utils.url.urlJoin(utils.url.getSubdir(), '/favicon.ico');
         }
     }
     // Get rid of any leading slash on the path

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -2,7 +2,7 @@ var config = require('../../config'),
     settingsCache = require('../../settings/cache'),
     utils = require('../../utils');
 
-function getAssetUrl(path, minify) {
+function getAssetUrl(path, hasMinFile) {
     var output = '';
 
     output += utils.url.urlJoin(utils.url.getSubdir(), '/');
@@ -22,8 +22,8 @@ function getAssetUrl(path, minify) {
     // Get rid of any leading slash on the path
     path = path.replace(/^\//, '');
 
-    // replace ".foo" with ".min.foo" in production
-    if (minify) {
+    // replace ".foo" with ".min.foo" if configured
+    if (hasMinFile && config.get('useMinFiles') !== false) {
         path = path.replace(/\.([^\.]*)$/, '.min.$1');
     }
 

--- a/core/server/helpers/asset.js
+++ b/core/server/helpers/asset.js
@@ -8,11 +8,9 @@ var proxy = require('./proxy'),
     SafeString = proxy.SafeString;
 
 module.exports = function asset(path, options) {
-    var isAdmin,
-        minify;
+    var minify;
 
     if (options && options.hash) {
-        isAdmin = options.hash.ghost;
         minify = options.hash.minifyInProduction;
     }
 
@@ -21,6 +19,6 @@ module.exports = function asset(path, options) {
     }
 
     return new SafeString(
-        getAssetUrl(path, isAdmin, minify)
+        getAssetUrl(path, minify)
     );
 };

--- a/core/server/helpers/asset.js
+++ b/core/server/helpers/asset.js
@@ -11,10 +11,10 @@ module.exports = function asset(path, options) {
     var minify;
 
     if (options && options.hash) {
-        minify = options.hash.minifyInProduction;
+        minify = options.hash.hasMinFile;
     }
 
-    if (config.get('minifyAssets') === false) {
+    if (config.get('useMinFiles') === false) {
         minify = false;
     }
 

--- a/core/server/helpers/asset.js
+++ b/core/server/helpers/asset.js
@@ -3,22 +3,14 @@
 //
 // Returns the path to the specified asset. The ghost flag outputs the asset path for the Ghost admin
 var proxy = require('./proxy'),
-    config = proxy.config,
+    _ = require('lodash'),
     getAssetUrl = proxy.metaData.getAssetUrl,
     SafeString = proxy.SafeString;
 
 module.exports = function asset(path, options) {
-    var minify;
-
-    if (options && options.hash) {
-        minify = options.hash.hasMinFile;
-    }
-
-    if (config.get('useMinFiles') === false) {
-        minify = false;
-    }
+    var hasMinFile = _.get(options, 'hash.hasMinFile');
 
     return new SafeString(
-        getAssetUrl(path, minify)
+        getAssetUrl(path, hasMinFile)
     );
 };

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -11,6 +11,7 @@ var proxy = require('./proxy'),
     Promise = require('bluebird'),
 
     getMetaData = proxy.metaData.get,
+    getAssetUrl = proxy.metaData.getAssetUrl,
     escapeExpression = proxy.escapeExpression,
     SafeString = proxy.SafeString,
     filters = proxy.filters,
@@ -66,12 +67,9 @@ function finaliseStructuredData(metaData) {
 }
 
 function getAjaxHelper(clientId, clientSecret) {
-    // @TODO: swap this for a direct utility, rather than using the helper? see #8221
-    // Note: this is here because the asset helper isn't registered when this file is first loaded
-    var assetHelper = proxy.hbs.handlebars.helpers.asset;
-
     return '<script type="text/javascript" src="' +
-        assetHelper('public/ghost-url.js', {hash: {hasMinFile: true}}) + '"></script>\n' +
+        getAssetUrl('public/ghost-url.js', true) +
+        '"></script>\n' +
         '<script type="text/javascript">\n' +
         'ghost.init({\n' +
         '\tclientId: "' + clientId + '",\n' +

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -71,7 +71,7 @@ function getAjaxHelper(clientId, clientSecret) {
     var assetHelper = proxy.hbs.handlebars.helpers.asset;
 
     return '<script type="text/javascript" src="' +
-        assetHelper('public/ghost-url.js', {hash: {minifyInProduction: true}}) + '"></script>\n' +
+        assetHelper('public/ghost-url.js', {hash: {hasMinFile: true}}) + '"></script>\n' +
         '<script type="text/javascript">\n' +
         'ghost.init({\n' +
         '\tclientId: "' + clientId + '",\n' +

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -33,7 +33,7 @@ module.exports = {
 
     // Config!
     // Keys used:
-    // minifyAssets in asset helper
+    // useMinFile in asset helper
     // isPrivacyDisabled & referrerPolicy used in ghost_head
     // Subscribe app uses routeKeywords
     config: {

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -33,7 +33,6 @@ module.exports = {
 
     // Config!
     // Keys used:
-    // useMinFile in asset helper
     // isPrivacyDisabled & referrerPolicy used in ghost_head
     // Subscribe app uses routeKeywords
     config: {

--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -8,9 +8,12 @@ var _ = require('lodash'),
     _private = {},
     errorHandler = {};
 
+/**
+ * This is a bare minimum setup, which allows us to render the error page
+ * It uses the {{asset}} helper, and nothing more
+ */
 _private.createHbsEngine = function createHbsEngine() {
     var engine = hbs.create();
-    // @TODO get rid of this after #8126
     engine.registerHelper('asset', require('../helpers/asset'));
 
     return engine.express4();

--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -15,7 +15,7 @@
     <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
     <meta http-equiv="cleartype" content="on">
 
-    <link rel="stylesheet" href="{{asset "public/ghost.css"}}"/>
+    <link rel="stylesheet" href="{{asset "public/ghost.css" hasMinFile="true"}}"/>
 
   </head>
   <body>

--- a/core/test/unit/metadata/asset_url_spec.js
+++ b/core/test/unit/metadata/asset_url_spec.js
@@ -1,9 +1,18 @@
 var should = require('should'), // jshint ignore:line
+    sinon = require('sinon'),
     getAssetUrl = require('../../../server/data/meta/asset_url'),
+    settingsCache = require('../../../server/settings/cache'),
     configUtils = require('../../utils/configUtils'),
-    config = configUtils.config;
+    config = configUtils.config,
+
+    sandbox = sinon.sandbox.create();
 
 describe('getAssetUrl', function () {
+    afterEach(function () {
+        configUtils.restore();
+        sandbox.restore();
+    });
+
     it('should return asset url with just context', function () {
         var testUrl = getAssetUrl('myfile.js');
         testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
@@ -12,11 +21,6 @@ describe('getAssetUrl', function () {
     it('should return asset url with just context even with leading /', function () {
         var testUrl = getAssetUrl('/myfile.js');
         testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
-    });
-
-    it('should not add asset to url if favicon.ico', function () {
-        var testUrl = getAssetUrl('favicon.ico');
-        testUrl.should.equal('/favicon.ico');
     });
 
     it('should not add asset to url if ghost.css for default templates', function () {
@@ -29,11 +33,25 @@ describe('getAssetUrl', function () {
         testUrl.should.equal('/public/myfile.js?v=' + config.get('assetHash'));
     });
 
-    describe('minify', function () {
-        afterEach(function () {
-            configUtils.restore();
+    describe('favicon', function () {
+        it('should not add asset to url if favicon.ico', function () {
+            var testUrl = getAssetUrl('favicon.ico');
+            testUrl.should.equal('/favicon.ico');
         });
 
+        it('should not add asset to url if favicon.png', function () {
+            var testUrl = getAssetUrl('favicon.png');
+            testUrl.should.equal('/favicon.ico');
+        });
+
+        it.skip('should correct favicon path for custom png', function () {
+            sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+            var testUrl = getAssetUrl('favicon.ico');
+            testUrl.should.equal('/favicon.png');
+        });
+    });
+
+    describe('minify', function () {
         it('should return asset minified url when hasMinFile & useMinFiles are both set to true', function () {
             configUtils.set('useMinFiles', true);
             var testUrl = getAssetUrl('myfile.js', true);
@@ -56,6 +74,76 @@ describe('getAssetUrl', function () {
             configUtils.set('useMinFiles', true);
             var testUrl = getAssetUrl('test.page/myfile.js', true);
             testUrl.should.equal('/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+        });
+    });
+
+    describe('with /blog subdirectory', function () {
+        beforeEach(function () {
+            configUtils.set({url: 'http://localhost:82832/blog'});
+        });
+
+        it('should return asset url with just context', function () {
+            var testUrl = getAssetUrl('myfile.js');
+            testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        it('should return asset url with just context even with leading /', function () {
+            var testUrl = getAssetUrl('/myfile.js');
+            testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        it('should not add asset to url if ghost.css for default templates', function () {
+            var testUrl = getAssetUrl('public/ghost.css');
+            testUrl.should.equal('/blog/public/ghost.css?v=' + config.get('assetHash'));
+        });
+
+        it('should not add asset to url has public in it', function () {
+            var testUrl = getAssetUrl('public/myfile.js');
+            testUrl.should.equal('/blog/public/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        describe('favicon', function () {
+            it('should not add asset to url if favicon.ico', function () {
+                var testUrl = getAssetUrl('favicon.ico');
+                testUrl.should.equal('/blog/favicon.ico');
+            });
+
+            it('should not add asset to url if favicon.png', function () {
+                var testUrl = getAssetUrl('favicon.png');
+                testUrl.should.equal('/blog/favicon.ico');
+            });
+
+            it.skip('should return correct favicon path for custom png', function () {
+                sandbox.stub(settingsCache, 'get').withArgs('icon').returns('/content/images/2017/04/my-icon.png');
+                var testUrl = getAssetUrl('favicon.ico');
+                testUrl.should.equal('/blog/favicon.png');
+            });
+        });
+
+        describe('minify', function () {
+            it('should return asset minified url when hasMinFile & useMinFiles are both set to true', function () {
+                configUtils.set('useMinFiles', true);
+                var testUrl = getAssetUrl('myfile.js', true);
+                testUrl.should.equal('/blog/assets/myfile.min.js?v=' + config.get('assetHash'));
+            });
+
+            it('should NOT return asset minified url when hasMinFile true but useMinFiles is false', function () {
+                configUtils.set('useMinFiles', false);
+                var testUrl = getAssetUrl('myfile.js', true);
+                testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+            });
+
+            it('should NOT return asset minified url when hasMinFile false but useMinFiles is true', function () {
+                configUtils.set('useMinFiles', true);
+                var testUrl = getAssetUrl('myfile.js', false);
+                testUrl.should.equal('/blog/assets/myfile.js?v=' + config.get('assetHash'));
+            });
+
+            it('should not add min to anything besides the last .', function () {
+                configUtils.set('useMinFiles', true);
+                var testUrl = getAssetUrl('test.page/myfile.js', true);
+                testUrl.should.equal('/blog/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+            });
         });
     });
 });

--- a/core/test/unit/metadata/asset_url_spec.js
+++ b/core/test/unit/metadata/asset_url_spec.js
@@ -13,38 +13,28 @@ describe('getAssetUrl', function () {
         testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
     });
 
-    it('should return ghost url if is admin', function () {
-        var testUrl = getAssetUrl('myfile.js', true);
-        testUrl.should.equal('/ghost/assets/myfile.js?v=' + config.get('assetHash'));
-    });
-
-    it('should not add ghost to url if is admin and has asset in context', function () {
-        var testUrl = getAssetUrl('asset/myfile.js', true);
-        testUrl.should.equal('/asset/myfile.js?v=' + config.get('assetHash'));
-    });
-
-    it('should not add ghost or asset to url if favicon.ico', function () {
+    it('should not add asset to url if favicon.ico', function () {
         var testUrl = getAssetUrl('favicon.ico');
         testUrl.should.equal('/favicon.ico');
     });
 
-    it('should not add ghost or asset to url if ghost.css for default templates', function () {
+    it('should not add asset to url if ghost.css for default templates', function () {
         var testUrl = getAssetUrl('public/ghost.css');
         testUrl.should.equal('/public/ghost.css?v=' + config.get('assetHash'));
     });
 
-    it('should not add ghost or asset to url has public in it', function () {
+    it('should not add asset to url has public in it', function () {
         var testUrl = getAssetUrl('public/myfile.js');
         testUrl.should.equal('/public/myfile.js?v=' + config.get('assetHash'));
     });
 
     it('should return asset minified url when minify true', function () {
-        var testUrl = getAssetUrl('myfile.js', false, true);
+        var testUrl = getAssetUrl('myfile.js', true);
         testUrl.should.equal('/assets/myfile.min.js?v=' + config.get('assetHash'));
     });
 
     it('should not add min to anything besides the last .', function () {
-        var testUrl = getAssetUrl('test.page/myfile.js', false, true);
+        var testUrl = getAssetUrl('test.page/myfile.js', true);
         testUrl.should.equal('/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
     });
 });

--- a/core/test/unit/metadata/asset_url_spec.js
+++ b/core/test/unit/metadata/asset_url_spec.js
@@ -1,6 +1,7 @@
 var should = require('should'), // jshint ignore:line
     getAssetUrl = require('../../../server/data/meta/asset_url'),
-    config = require('../../../server/config');
+    configUtils = require('../../utils/configUtils'),
+    config = configUtils.config;
 
 describe('getAssetUrl', function () {
     it('should return asset url with just context', function () {
@@ -28,13 +29,33 @@ describe('getAssetUrl', function () {
         testUrl.should.equal('/public/myfile.js?v=' + config.get('assetHash'));
     });
 
-    it('should return asset minified url when minify true', function () {
-        var testUrl = getAssetUrl('myfile.js', true);
-        testUrl.should.equal('/assets/myfile.min.js?v=' + config.get('assetHash'));
-    });
+    describe('minify', function () {
+        afterEach(function () {
+            configUtils.restore();
+        });
 
-    it('should not add min to anything besides the last .', function () {
-        var testUrl = getAssetUrl('test.page/myfile.js', true);
-        testUrl.should.equal('/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+        it('should return asset minified url when hasMinFile & useMinFiles are both set to true', function () {
+            configUtils.set('useMinFiles', true);
+            var testUrl = getAssetUrl('myfile.js', true);
+            testUrl.should.equal('/assets/myfile.min.js?v=' + config.get('assetHash'));
+        });
+
+        it('should NOT return asset minified url when hasMinFile true but useMinFiles is false', function () {
+            configUtils.set('useMinFiles', false);
+            var testUrl = getAssetUrl('myfile.js', true);
+            testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        it('should NOT return asset minified url when hasMinFile false but useMinFiles is true', function () {
+            configUtils.set('useMinFiles', true);
+            var testUrl = getAssetUrl('myfile.js', false);
+            testUrl.should.equal('/assets/myfile.js?v=' + config.get('assetHash'));
+        });
+
+        it('should not add min to anything besides the last .', function () {
+            configUtils.set('useMinFiles', true);
+            var testUrl = getAssetUrl('test.page/myfile.js', true);
+            testUrl.should.equal('/assets/test.page/myfile.min.js?v=' + config.get('assetHash'));
+        });
     });
 });

--- a/core/test/unit/server_helpers/asset_spec.js
+++ b/core/test/unit/server_helpers/asset_spec.js
@@ -11,6 +11,7 @@ describe('{{asset}} helper', function () {
 
     before(function () {
         configUtils.set({assetHash: 'abc'});
+        configUtils.set({useMinFiles: true});
 
         sandbox.stub(settingsCache, 'get', function (key) {
             return localSettingsCache[key];
@@ -51,7 +52,7 @@ describe('{{asset}} helper', function () {
             String(rendered).should.equal('/content/images/favicon.ico');
         });
 
-        it('handles shared assets correctly', function () {
+        it('handles public assets correctly', function () {
             localSettingsCache.icon = '';
 
             rendered = helpers.asset('public/asset.js');
@@ -63,6 +64,12 @@ describe('{{asset}} helper', function () {
             rendered = helpers.asset('js/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/assets/js/asset.js?v=abc');
+        });
+
+        it('handles hasMinFile assets correctly', function () {
+            rendered = helpers.asset('js/asset.js', {hash: {hasMinFile: true}});
+            should.exist(rendered);
+            String(rendered).should.equal('/assets/js/asset.min.js?v=abc');
         });
     });
 
@@ -99,7 +106,7 @@ describe('{{asset}} helper', function () {
             String(rendered).should.equal('/blog/content/images/favicon.ico');
         });
 
-        it('handles shared assets correctly', function () {
+        it('handles public assets correctly', function () {
             rendered = helpers.asset('public/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/blog/public/asset.js?v=abc');
@@ -109,6 +116,12 @@ describe('{{asset}} helper', function () {
             rendered = helpers.asset('js/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/blog/assets/js/asset.js?v=abc');
+        });
+
+        it('handles hasMinFile assets correctly', function () {
+            rendered = helpers.asset('js/asset.js', {hash: {hasMinFile: true}});
+            should.exist(rendered);
+            String(rendered).should.equal('/blog/assets/js/asset.min.js?v=abc');
         });
 
         configUtils.restore();

--- a/core/test/unit/server_helpers/asset_spec.js
+++ b/core/test/unit/server_helpers/asset_spec.js
@@ -24,24 +24,12 @@ describe('{{asset}} helper', function () {
 
     describe('no subdirectory', function () {
         it('handles favicon correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/favicon.ico');
-
-            // without ghost set
             rendered = helpers.asset('favicon.ico');
             should.exist(rendered);
             String(rendered).should.equal('/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('public/ghost.css', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/public/ghost.css?v=abc');
-
-            // without ghost set
             rendered = helpers.asset('public/ghost.css');
             should.exist(rendered);
             String(rendered).should.equal('/public/ghost.css?v=abc');
@@ -50,24 +38,14 @@ describe('{{asset}} helper', function () {
         it('handles custom favicon correctly', function () {
             localSettingsCache.icon = '/content/images/favicon.png';
 
-            // with ghost set and png
-            rendered = helpers.asset('favicon.png', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/favicon.ico');
-
-            // without ghost set and png
+            // with png
             rendered = helpers.asset('favicon.png');
             should.exist(rendered);
             String(rendered).should.equal('/content/images/favicon.png');
 
             localSettingsCache.icon = '/content/images/favicon.ico';
 
-            // with ghost set and ico
-            rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/favicon.ico');
-
-            // without ghost set and ico
+            // with ico
             rendered = helpers.asset('favicon.ico');
             should.exist(rendered);
             String(rendered).should.equal('/content/images/favicon.ico');
@@ -76,26 +54,12 @@ describe('{{asset}} helper', function () {
         it('handles shared assets correctly', function () {
             localSettingsCache.icon = '';
 
-            // with ghost set
-            rendered = helpers.asset('public/asset.js', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/public/asset.js?v=abc');
-
-            // without ghost set
             rendered = helpers.asset('public/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/public/asset.js?v=abc');
         });
 
-        it('handles admin assets correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('js/asset.js', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/ghost/assets/js/asset.js?v=abc');
-        });
-
         it('handles theme assets correctly', function () {
-            // with ghost set
             rendered = helpers.asset('js/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/assets/js/asset.js?v=abc');
@@ -108,24 +72,12 @@ describe('{{asset}} helper', function () {
         });
 
         it('handles favicon correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/favicon.ico');
-
-            // without ghost set
             rendered = helpers.asset('favicon.ico');
             should.exist(rendered);
             String(rendered).should.equal('/blog/favicon.ico');
         });
 
         it('handles ghost.css for default templates correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('public/ghost.css', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/public/ghost.css?v=abc');
-
-            // without ghost set
             rendered = helpers.asset('public/ghost.css');
             should.exist(rendered);
             String(rendered).should.equal('/blog/public/ghost.css?v=abc');
@@ -134,50 +86,26 @@ describe('{{asset}} helper', function () {
         it('handles custom favicon correctly', function () {
             localSettingsCache.icon = '/content/images/favicon.png';
 
-            // with ghost set and png
-            rendered = helpers.asset('favicon.png', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/favicon.ico');
-
-            // without ghost set and png
+            // with  png
             rendered = helpers.asset('favicon.png');
             should.exist(rendered);
             String(rendered).should.equal('/blog/content/images/favicon.png');
 
             localSettingsCache.icon = '/content/images/favicon.ico';
 
-            // with ghost set and ico
-            rendered = helpers.asset('favicon.ico', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/favicon.ico');
-
-            // without ghost set and ico
+            // with ico
             rendered = helpers.asset('favicon.ico');
             should.exist(rendered);
             String(rendered).should.equal('/blog/content/images/favicon.ico');
         });
 
         it('handles shared assets correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('public/asset.js', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/public/asset.js?v=abc');
-
-            // without ghost set
             rendered = helpers.asset('public/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/blog/public/asset.js?v=abc');
         });
 
-        it('handles admin assets correctly', function () {
-            // with ghost set
-            rendered = helpers.asset('js/asset.js', {hash: {ghost: 'true'}});
-            should.exist(rendered);
-            String(rendered).should.equal('/blog/ghost/assets/js/asset.js?v=abc');
-        });
-
         it('handles theme assets correctly', function () {
-            // with ghost set
             rendered = helpers.asset('js/asset.js');
             should.exist(rendered);
             String(rendered).should.equal('/blog/assets/js/asset.js?v=abc');

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "grunt-contrib-jshint": "1.0.0",
     "grunt-contrib-uglify": "2.0.0",
     "grunt-contrib-watch": "1.0.0",
+    "grunt-cssnano": "2.1.0",
     "grunt-docker": "0.0.11",
     "grunt-express-server": "0.5.3",
     "grunt-jscs": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,10 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
+
 ambi@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ambi/-/ambi-2.0.0.tgz#42c2bf98e8d101aa4da28a812678a5dbe36ada66"
@@ -111,7 +115,7 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.0 || ^1.1.13"
 
-argparse@^1.0.2:
+argparse@^1.0.2, argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
   dependencies:
@@ -192,6 +196,17 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+autoprefixer@^6.3.1:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
+  dependencies:
+    browserslist "^1.7.6"
+    caniuse-db "^1.0.30000634"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
 aws-sdk-apis@3.x:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/aws-sdk-apis/-/aws-sdk-apis-3.1.10.tgz#4eed97f590a16cf080fd1b8d8cfdf2472de8ab0e"
@@ -236,7 +251,7 @@ bal-util@~1.18.0:
     taskgroup "~2.0.0"
     typechecker "~2.0.1"
 
-balanced-match@^0.4.1:
+balanced-match@^0.4.1, balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
@@ -375,6 +390,13 @@ browserify-zlib@^0.1.4:
   dependencies:
     pako "~0.2.0"
 
+browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
+  dependencies:
+    caniuse-db "^1.0.30000639"
+    electron-to-chromium "^1.2.7"
+
 "brute-knex@https://github.com/cobbspur/brute-knex/tarball/37439f56965b17d29bb4ff9b3f3222b2f4bd6ce3":
   version "2.0.0"
   resolved "https://github.com/cobbspur/brute-knex/tarball/37439f56965b17d29bb4ff9b3f3222b2f4bd6ce3#1a7aff22aa22c1a9809310676d527d49ef9be47f"
@@ -458,6 +480,19 @@ camelcase@^2.0.0, camelcase@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
+caniuse-api@^1.5.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-1.6.1.tgz#b534e7c734c4f81ec5fbe8aca2ad24354b962c6c"
+  dependencies:
+    browserslist "^1.3.6"
+    caniuse-db "^1.0.30000529"
+    lodash.memoize "^4.1.2"
+    lodash.uniq "^4.5.0"
+
+caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
+  version "1.0.30000649"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000649.tgz#1ee1754a6df235450c8b7cd15e0ebf507221a86a"
+
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
@@ -481,7 +516,7 @@ center-align@^0.1.1:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@*, chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@~1.1.0, chalk@~1.1.1:
+chalk@*, chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3, chalk@~1.1.0, chalk@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -526,6 +561,12 @@ cjson@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.2.1.tgz#73cd8aad65d9e1505f9af1744d3b79c1527682a5"
 
+clap@^1.0.9:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
+  dependencies:
+    chalk "^1.1.3"
+
 cli-table@~0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -567,6 +608,12 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
+coa@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.1.tgz#7f959346cfc8719e3f7233cd6852854a7c67d8a3"
+  dependencies:
+    q "^1.1.2"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -578,6 +625,38 @@ coffee-script@~1.10.0:
 coffee-script@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.3.3.tgz#150d6b4cb522894369efed6a2101c20bc7f4a4f4"
+
+color-convert@^1.3.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.0.0, color-name@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
+
+color-string@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-0.3.0.tgz#27d46fb67025c5c2fa25993bfbf579e47841b991"
+  dependencies:
+    color-name "^1.0.0"
+
+color@^0.11.0:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
+  dependencies:
+    clone "^1.0.2"
+    color-convert "^1.3.0"
+    color-string "^0.3.0"
+
+colormin@^1.0.5:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colormin/-/colormin-1.1.2.tgz#ea2f7420a72b96881a38aae59ec124a6f7298133"
+  dependencies:
+    color "^0.11.0"
+    css-color-names "0.0.4"
+    has "^1.0.1"
 
 colors@0.5.x:
   version "0.5.1"
@@ -762,6 +841,10 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
+css-color-names@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -774,6 +857,50 @@ css-select@~1.2.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+cssnano@^3.0.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
+  dependencies:
+    autoprefixer "^6.3.1"
+    decamelize "^1.1.2"
+    defined "^1.0.0"
+    has "^1.0.1"
+    object-assign "^4.0.1"
+    postcss "^5.0.14"
+    postcss-calc "^5.2.0"
+    postcss-colormin "^2.1.8"
+    postcss-convert-values "^2.3.4"
+    postcss-discard-comments "^2.0.4"
+    postcss-discard-duplicates "^2.0.1"
+    postcss-discard-empty "^2.0.1"
+    postcss-discard-overridden "^0.1.1"
+    postcss-discard-unused "^2.2.1"
+    postcss-filter-plugins "^2.0.0"
+    postcss-merge-idents "^2.1.5"
+    postcss-merge-longhand "^2.0.1"
+    postcss-merge-rules "^2.0.3"
+    postcss-minify-font-values "^1.0.2"
+    postcss-minify-gradients "^1.0.1"
+    postcss-minify-params "^1.0.4"
+    postcss-minify-selectors "^2.0.4"
+    postcss-normalize-charset "^1.1.0"
+    postcss-normalize-url "^3.0.7"
+    postcss-ordered-values "^2.1.0"
+    postcss-reduce-idents "^2.2.2"
+    postcss-reduce-initial "^1.0.0"
+    postcss-reduce-transforms "^1.0.3"
+    postcss-svgo "^2.1.1"
+    postcss-unique-selectors "^2.0.2"
+    postcss-value-parser "^3.2.3"
+    postcss-zindex "^2.0.1"
+
+csso@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/csso/-/csso-2.3.2.tgz#ddd52c587033f49e94b71fc55569f252e8ff5f85"
+  dependencies:
+    clap "^1.0.9"
+    source-map "^0.5.3"
 
 cst@^0.4.3:
   version "0.4.9"
@@ -871,6 +998,10 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+defined@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1005,6 +1136,10 @@ editorconfig@^0.13.2:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-to-chromium@^1.2.7:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.2.tgz#b8ce5c93b308db0e92f6d0435c46ddec8f6363ab"
 
 emits@3.0.0:
   version "3.0.0"
@@ -1393,6 +1528,10 @@ flagged-respawn@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-0.3.2.tgz#ff191eddcd7088a675b2610fffc976be9b8074b5"
 
+flatten@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
 follow-redirects@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.3.tgz#6ce67a24db1fe13f226c1171a72a7ef2b17b8f65"
@@ -1498,6 +1637,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 gauge@~2.7.1:
   version "2.7.3"
@@ -1771,6 +1914,12 @@ grunt-contrib-watch@1.0.0:
     lodash "^3.10.1"
     tiny-lr "^0.2.1"
 
+grunt-cssnano@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/grunt-cssnano/-/grunt-cssnano-2.1.0.tgz#e564f7d5a88bef409e46431dacabafd5c71fbd87"
+  dependencies:
+    cssnano "^3.0.0"
+
 grunt-docker@0.0.11:
   version "0.0.11"
   resolved "https://registry.yarnpkg.com/grunt-docker/-/grunt-docker-0.0.11.tgz#99ff7094df22d793ac093f9e8b105dfe0f2aab35"
@@ -2034,6 +2183,12 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
+
 hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -2072,6 +2227,10 @@ hooker@^0.2.3, hooker@~0.2.3:
 hosted-git-info@^2.1.4:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.1.tgz#4b0445e41c004a8bd1337773a4ff790ca40318c8"
+
+html-comment-regex@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.1.tgz#668b93776eaae55ebde8f3ad464b307a4963625e"
 
 html-to-text@3.2.0:
   version "3.2.0"
@@ -2175,6 +2334,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
+
 inflection@^1.5.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.12.0.tgz#a200935656d6f5f6bc4dc7502e1aecb703228416"
@@ -2239,6 +2402,10 @@ ipaddr.js@1.3.0:
 irregular-plurals@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/irregular-plurals/-/irregular-plurals-1.2.0.tgz#38f299834ba8c00c30be9c554e137269752ff3ac"
+
+is-absolute-url@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-absolute-url/-/is-absolute-url-2.1.0.tgz#50530dfb84fcc9aa7dbe7852e83a37b93b9f2aa6"
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -2309,6 +2476,10 @@ is-number@^2.0.2, is-number@^2.1.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -2320,6 +2491,12 @@ is-primitive@^2.0.0:
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
+
+is-svg@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-2.1.0.tgz#cf61090da0d9efbcab8722deba6f032208dbb0e9"
+  dependencies:
+    html-comment-regex "^1.1.0"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2431,6 +2608,10 @@ jpeg-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
 
+js-base64@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
+
 js-beautify@1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.6.4.tgz#a9af79699742ac9a1b6fddc1fdbc78bc4d515fc3"
@@ -2470,6 +2651,13 @@ js-yaml@~3.4.0:
     argparse "^1.0.2"
     esprima "^2.6.0"
     inherit "^2.2.2"
+
+js-yaml@~3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -2852,6 +3040,10 @@ lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+
 lodash.merge@4.6.0, lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
@@ -2900,6 +3092,10 @@ lodash.templatesettings@^3.0.0:
 lodash.unescape@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
+lodash.uniq@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
 lodash@3.10.1, lodash@^3.10.1, lodash@^3.5.0, lodash@^3.7.0, lodash@~3.10.0, lodash@~3.10.1:
   version "3.10.1"
@@ -2987,6 +3183,10 @@ lru-cache@^4.0.0:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
+macaddress@^0.2.8:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/macaddress/-/macaddress-0.2.8.tgz#5904dc537c39ec6dbefeae902327135fa8511f12"
+
 mailcomposer@~0.2.10:
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/mailcomposer/-/mailcomposer-0.2.12.tgz#4d02a604616adcb45fb36d37513f4c1bd0b75681"
@@ -3009,6 +3209,10 @@ matchdep@1.0.1:
     micromatch "^2.3.7"
     resolve "~1.1.6"
     stack-trace "0.0.9"
+
+math-expression-evaluator@^1.2.14:
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz#b357fa1ca9faefb8e48d10c14ef2bcb2d9f0a7c9"
 
 maxmin@^1.1.0:
   version "1.1.0"
@@ -3400,6 +3604,19 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+
+normalize-url@^1.4.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-1.9.1.tgz#2cc0d66b31ea23036458436e3620d85954c66c3c"
+  dependencies:
+    object-assign "^4.0.1"
+    prepend-http "^1.0.0"
+    query-string "^4.1.0"
+    sort-keys "^1.0.0"
+
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
@@ -3420,6 +3637,10 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -3707,6 +3928,217 @@ pngjs@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.0.1.tgz#b15086ac1ac47298c8fd3f9cdf364fa9879c4db6"
 
+postcss-calc@^5.2.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-calc/-/postcss-calc-5.3.1.tgz#77bae7ca928ad85716e2fda42f261bf7c1d65b5e"
+  dependencies:
+    postcss "^5.0.2"
+    postcss-message-helpers "^2.0.0"
+    reduce-css-calc "^1.2.6"
+
+postcss-colormin@^2.1.8:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/postcss-colormin/-/postcss-colormin-2.2.2.tgz#6631417d5f0e909a3d7ec26b24c8a8d1e4f96e4b"
+  dependencies:
+    colormin "^1.0.5"
+    postcss "^5.0.13"
+    postcss-value-parser "^3.2.3"
+
+postcss-convert-values@^2.3.4:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz#bbd8593c5c1fd2e3d1c322bb925dcae8dae4d62d"
+  dependencies:
+    postcss "^5.0.11"
+    postcss-value-parser "^3.1.2"
+
+postcss-discard-comments@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz#befe89fafd5b3dace5ccce51b76b81514be00e3d"
+  dependencies:
+    postcss "^5.0.14"
+
+postcss-discard-duplicates@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz#b9abf27b88ac188158a5eb12abcae20263b91932"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-discard-empty@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz#d2b4bd9d5ced5ebd8dcade7640c7d7cd7f4f92b5"
+  dependencies:
+    postcss "^5.0.14"
+
+postcss-discard-overridden@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz#8b1eaf554f686fb288cd874c55667b0aa3668d58"
+  dependencies:
+    postcss "^5.0.16"
+
+postcss-discard-unused@^2.2.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz#bce30b2cc591ffc634322b5fb3464b6d934f4433"
+  dependencies:
+    postcss "^5.0.14"
+    uniqs "^2.0.0"
+
+postcss-filter-plugins@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz#6d85862534d735ac420e4a85806e1f5d4286d84c"
+  dependencies:
+    postcss "^5.0.4"
+    uniqid "^4.0.0"
+
+postcss-merge-idents@^2.1.5:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz#4c5530313c08e1d5b3bbf3d2bbc747e278eea270"
+  dependencies:
+    has "^1.0.1"
+    postcss "^5.0.10"
+    postcss-value-parser "^3.1.1"
+
+postcss-merge-longhand@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz#23d90cd127b0a77994915332739034a1a4f3d658"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-merge-rules@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz#d1df5dfaa7b1acc3be553f0e9e10e87c61b5f721"
+  dependencies:
+    browserslist "^1.5.2"
+    caniuse-api "^1.5.2"
+    postcss "^5.0.4"
+    postcss-selector-parser "^2.2.2"
+    vendors "^1.0.0"
+
+postcss-message-helpers@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz#a4f2f4fab6e4fe002f0aed000478cdf52f9ba60e"
+
+postcss-minify-font-values@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz#4b58edb56641eba7c8474ab3526cafd7bbdecb69"
+  dependencies:
+    object-assign "^4.0.1"
+    postcss "^5.0.4"
+    postcss-value-parser "^3.0.2"
+
+postcss-minify-gradients@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz#5dbda11373703f83cfb4a3ea3881d8d75ff5e6e1"
+  dependencies:
+    postcss "^5.0.12"
+    postcss-value-parser "^3.3.0"
+
+postcss-minify-params@^1.0.4:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz#ad2ce071373b943b3d930a3fa59a358c28d6f1f3"
+  dependencies:
+    alphanum-sort "^1.0.1"
+    postcss "^5.0.2"
+    postcss-value-parser "^3.0.2"
+    uniqs "^2.0.0"
+
+postcss-minify-selectors@^2.0.4:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz#b2c6a98c0072cf91b932d1a496508114311735bf"
+  dependencies:
+    alphanum-sort "^1.0.2"
+    has "^1.0.1"
+    postcss "^5.0.14"
+    postcss-selector-parser "^2.0.0"
+
+postcss-normalize-charset@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz#ef9ee71212d7fe759c78ed162f61ed62b5cb93f1"
+  dependencies:
+    postcss "^5.0.5"
+
+postcss-normalize-url@^3.0.7:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz#108f74b3f2fcdaf891a2ffa3ea4592279fc78222"
+  dependencies:
+    is-absolute-url "^2.0.0"
+    normalize-url "^1.4.0"
+    postcss "^5.0.14"
+    postcss-value-parser "^3.2.3"
+
+postcss-ordered-values@^2.1.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz#eec6c2a67b6c412a8db2042e77fe8da43f95c11d"
+  dependencies:
+    postcss "^5.0.4"
+    postcss-value-parser "^3.0.1"
+
+postcss-reduce-idents@^2.2.2:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz#c2c6d20cc958284f6abfbe63f7609bf409059ad3"
+  dependencies:
+    postcss "^5.0.4"
+    postcss-value-parser "^3.0.2"
+
+postcss-reduce-initial@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz#68f80695f045d08263a879ad240df8dd64f644ea"
+  dependencies:
+    postcss "^5.0.4"
+
+postcss-reduce-transforms@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz#ff76f4d8212437b31c298a42d2e1444025771ae1"
+  dependencies:
+    has "^1.0.1"
+    postcss "^5.0.8"
+    postcss-value-parser "^3.0.1"
+
+postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-svgo@^2.1.1:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/postcss-svgo/-/postcss-svgo-2.1.6.tgz#b6df18aa613b666e133f08adb5219c2684ac108d"
+  dependencies:
+    is-svg "^2.0.0"
+    postcss "^5.0.14"
+    postcss-value-parser "^3.2.3"
+    svgo "^0.7.0"
+
+postcss-unique-selectors@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz#981d57d29ddcb33e7b1dfe1fd43b8649f933ca1d"
+  dependencies:
+    alphanum-sort "^1.0.1"
+    postcss "^5.0.4"
+    uniqs "^2.0.0"
+
+postcss-value-parser@^3.0.1, postcss-value-parser@^3.0.2, postcss-value-parser@^3.1.1, postcss-value-parser@^3.1.2, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
+
+postcss-zindex@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-zindex/-/postcss-zindex-2.2.0.tgz#d2109ddc055b91af67fc4cb3b025946639d2af22"
+  dependencies:
+    has "^1.0.1"
+    postcss "^5.0.4"
+    uniqs "^2.0.0"
+
+postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.8, postcss@^5.2.16:
+  version "5.2.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.16.tgz#732b3100000f9ff8379a48a53839ed097376ad57"
+  dependencies:
+    chalk "^1.1.3"
+    js-base64 "^2.1.9"
+    source-map "^0.5.6"
+    supports-color "^3.2.3"
+
 posthtml-parser@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/posthtml-parser/-/posthtml-parser-0.2.1.tgz#35d530de386740c2ba24ff2eb2faf39ccdf271dd"
@@ -3728,6 +4160,10 @@ posthtml@^0.9.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prepend-http@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
 preserve@^0.2.0:
   version "0.2.0"
@@ -3811,6 +4247,10 @@ pygmentize-bundled@~2.1.0:
     readable-stream "~1.0.17"
     through2 "~0.2.1"
 
+q@^1.1.2:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
+
 qs@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be"
@@ -3830,6 +4270,13 @@ qs@~5.1.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+query-string@^4.1.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.2.tgz#ec0fd765f58a50031a3968c2431386f8947a5cdd"
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 rai@~0.1.11:
   version "0.1.12"
@@ -3958,6 +4405,20 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+reduce-css-calc@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
+  dependencies:
+    balanced-match "^0.4.2"
+    math-expression-evaluator "^1.2.14"
+    reduce-function-call "^1.0.1"
+
+reduce-function-call@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
+  dependencies:
+    balanced-match "^0.4.2"
 
 regenerator-runtime@^0.10.0:
   version "0.10.3"
@@ -4144,7 +4605,7 @@ sax@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.4.2.tgz#39f3b601733d6bec97105b242a2a40fd6978ac3c"
 
-sax@>=0.6.0:
+sax@>=0.6.0, sax@~1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
@@ -4334,13 +4795,19 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
+sort-keys@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 source-map-support@^0.4.0:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
   dependencies:
     source-map "^0.5.6"
 
-"source-map@>= 0.1.2", source-map@^0.5.6, source-map@~0.5.1:
+"source-map@>= 0.1.2", source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4442,6 +4909,10 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
 
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+
 string-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
@@ -4526,11 +4997,23 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.0:
+supports-color@^3.1.0, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+svgo@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"
+  dependencies:
+    coa "~1.0.1"
+    colors "~1.1.2"
+    csso "~2.3.1"
+    js-yaml "~3.7.0"
+    mkdirp "~0.5.1"
+    sax "~1.2.1"
+    whet.extend "~0.9.9"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -4751,6 +5234,20 @@ unidecode@0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/unidecode/-/unidecode-0.1.8.tgz#efbb301538bc45246a9ac8c559d72f015305053e"
 
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+
+uniqid@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/uniqid/-/uniqid-4.1.1.tgz#89220ddf6b751ae52b5f72484863528596bb84c1"
+  dependencies:
+    macaddress "^0.2.8"
+
+uniqs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -4823,6 +5320,10 @@ vary@^1, vary@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
+vendors@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
+
 verror@1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
@@ -4875,6 +5376,10 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+
+whet.extend@~0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"
 
 which@^1.1.1, which@^1.2.12, which@~1.2.1:
   version "1.2.14"


### PR DESCRIPTION
refs #8221 

### Task list from the issue:

- [x] 3. Co-locate assets (@AileenCGN done in #8273)
- [x] 6. get rid of ghosticon.jpg (@AileenCGN done in #8285)

In this PR:
- [x] 1. No more ghost="true" or serving admin assets except via the static middleware in 
admin/app
    - this was straight forward
- [x] Bonus: reconsider build pipeline
    - we now have a build tool for minifying css via cssnano. This just works for ghost.css at the moment, but can always be extended.
- [x] 4. Get rid of `minifyInProduction` / `minifyAsset`
    - these properties have been renamed and reworked to hopefully be simpler.
    - `minifyInProduction` -> `hasMinFile` = this means this asset should have a .min file available
    - `minifyAssets` -> `useMinFiles` = this means that in this env we want to serve .min files if available
- [x] 2. Ensure the error templates will always work
    - this is mostly a documentation task. We will still need the asset helper for rendering errors, so I've removed the TODO in the code, updated the code comments & added a note to #7421.
- [x] 8. revisit the use of the asset helper in ghost_head
    - now that the other tasks are done, it was easy to change this

TODO:

- [ ] 7. asset url utility
- [ ] 5. Reconsider asset hashing



