### PR TITLE
[WIP] 🎨 ✨  sitemap: authors and tags with connected posts

### DIFF
--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -1,6 +1,9 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    utils  = require('../../../utils'),
+var _ = require('lodash'),
+    Promise = require('bluebird'),
+    api = require('../../../api'),
+    models = require('../../../models'),
+    utils = require('../../../utils'),
+    logging = require('../../../logging'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -15,10 +18,83 @@ _.extend(TagsMapGenerator.prototype, BaseMapGenerator.prototype);
 
 _.extend(TagsMapGenerator.prototype, {
     bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('tag.added', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.deleted', self.removeUrl.bind(self));
+        var self = this,
+            addOrRemoveTagUrl = function fetchTag(tagName) {
+                return models.Tag
+                    .findOne({name: tagName}, {
+                        include: 'count.posts',
+                        context: {
+                            public: true
+                        }
+                    })
+                    .then(function (tagModelWithPostsCount) {
+                        // CASE: tag is public, connected to a post and get's changed to internal
+                        // we don't use filter: 'visibility:public' to detect these changes.
+                        if (tagModelWithPostsCount.get('visibility') !== 'public') {
+                            self.removeUrl(tagModelWithPostsCount);
+                        } else {
+                            if (tagModelWithPostsCount.get('count__posts') > 0) {
+                                self.addOrUpdateUrl(tagModelWithPostsCount);
+                            } else {
+                                self.removeUrl(tagModelWithPostsCount);
+                            }
+                        }
+                    })
+                    .catch(function (err) {
+                        logging.error(err);
+                    });
+            };
+
+        /**
+         * Interesting event to update information like tag name.
+         * Tag properties can only be changed in the tag management.
+         * We have to ensure a tag, which get's updated is connected to minimum one post.
+         */
+        this.dataEvents.on('tag.edited', function (tagModel) {
+            return addOrRemoveTagUrl(tagModel.get('name'));
+        });
+
+        /**
+         * Event is **only** triggered when the tag get's physically deleted.
+         * This is only possible from the tag management area.
+         * This is important to detect, because an auto detach from all posts happens.
+         * We have to remove the url in any case!
+         */
+        this.dataEvents.on('tag.deleted', function (tagModel) {
+            self.removeUrl(tagModel);
+        });
+
+        /**
+         * We have to listen for `tags-updated` event, here are some example cases:
+         * e.g. if a tag get's detached, it's covered by `removedTags`
+         * e.g. a post is already published and a user attaches an existing tag to it.
+         *
+         * `removedTags`, `existingTags` and `createdTags` are JSON objects!
+         */
+        this.dataEvents.on('post.tags-updated', function (postModel) {
+            var removedTags = postModel.tagsToRemove || [],
+                existingTags = postModel.tagsThatExisted || [],
+                createdTags = postModel.tagsToCreate || [];
+
+            return Promise.each(removedTags.concat(existingTags).concat(createdTags), function (tag) {
+                return addOrRemoveTagUrl(tag.name);
+            });
+        });
+
+        /**
+         * We have to listen for the `post.unpublished` event, to verify that all
+         * tags attached to this post are checked if they have minimum one published post attached.
+         * We have to listen for `post.published`, because if you attach tags on a draft, save and later publish
+         * the post, no tag urls are added/updated/removed.
+         */
+        this.dataEvents.onMany(['post.published', 'post.unpublished'], function (postModel) {
+            postModel.load('tags')
+                .then(function (postModelWithTags) {
+                    return Promise.each(postModelWithTags.related('tags').models, function (tagModel) {
+                        return addOrRemoveTagUrl(tagModel.get('name'));
+                    });
+                });
+        });
     },
 
     getData: function () {

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -24,12 +24,15 @@ _.extend(TagsMapGenerator.prototype, {
     getData: function () {
         return api.tags.browse({
             context: {
-                internal: true
+                public: true
             },
             filter: 'visibility:public',
-            limit: 'all'
+            limit: 'all',
+            include: 'count.posts'
         }).then(function (resp) {
-            return resp.tags;
+            return _.filter(resp.tags, function (tag) {
+                return tag.count.posts > 0;
+            });
         });
     },
 

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -27,13 +27,16 @@ _.extend(UserMapGenerator.prototype, {
     getData: function () {
         return api.users.browse({
             context: {
-                internal: true
+                public: true
             },
             filter: 'visibility:public',
             status: 'active',
-            limit: 'all'
+            limit: 'all',
+            include: 'count.posts'
         }).then(function (resp) {
-            return resp.users;
+            return _.filter(resp.users, function (user) {
+                return user.count.posts > 0;
+            });
         });
     },
 

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,6 +1,7 @@
 var _ = require('lodash'),
     validator = require('validator'),
     api = require('../../../api'),
+    errors = require('../../../errors'),
     logging = require('../../../logging'),
     models = require('../../../models'),
     utils = require('../../../utils'),
@@ -18,10 +19,80 @@ _.extend(UserMapGenerator.prototype, BaseMapGenerator.prototype);
 
 _.extend(UserMapGenerator.prototype, {
     bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('user.activated', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.activated.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.deactivated', self.removeUrl.bind(self));
+        var self = this,
+            addOrRemoveAuthorUrl = function fetchAuthor(authorId) {
+                return models.User
+                    .findOne({id: authorId}, {status: 'all', include: 'count.posts', context: {public: true}})
+                    .then(function (authorModelWithPostsCount) {
+                        if (!authorModelWithPostsCount) {
+                            throw new errors.NotFoundError({
+                                message: 'Sitemap: UserGenerator could not found author',
+                                context: authorId
+                            });
+                        }
+
+                        return authorModelWithPostsCount;
+                    })
+                    .then(function (authorModelWithPostsCount) {
+                        if (authorModelWithPostsCount.get('count__posts') === 0) {
+                            self.removeUrl(authorModelWithPostsCount);
+                        } else {
+                            self.addOrUpdateUrl(authorModelWithPostsCount);
+                        }
+                    })
+                    .catch(function (err) {
+                        logging.error(err);
+                    });
+            };
+
+        /**
+         * Definitely remove url if user is deactivated (e.g. suspended).
+         * No need to fetch the author.
+         */
+        this.dataEvents.on('user.deactivated', function (model) {
+            self.removeUrl(model);
+        });
+
+        /**
+         * We have to listen for the activated user event, because if a user get's deactivated and
+         * has > 0 posts connected and get's activated again, we have to take care of this case.
+         */
+        this.dataEvents.on('user.activated', function (model) {
+            addOrRemoveAuthorUrl(model.id);
+        });
+
+        /**
+         * Only care about the edit event, if specific fields changed.
+         * Otherwise:
+         *   - e.g. if a user get's activated, another `user.edited` event is triggered
+         *   - we only care about specific things here
+         *
+         * Edit event helps to keep the author url up-to-date.
+         */
+        this.dataEvents.on('user.edited', function (model) {
+            var slugChanged = model.get('slug') !== model.updated('slug');
+
+            if (slugChanged) {
+                addOrRemoveAuthorUrl(model.id);
+            }
+        });
+
+        /**
+         * If a post get's deleted or the whole content get's deleted, we have to check if
+         * the author has minimum one post connected. We have to use `previous`, because if a post get's deleted,
+         * the current properties are nulled.
+         */
+        this.dataEvents.on('post.deleted', function (model) {
+            addOrRemoveAuthorUrl(model.previous('author_id'));
+        });
+
+        /**
+         * We check if an author is still connected to minimum 1 post.
+         * We have to fetch the related author object.
+         */
+        this.dataEvents.onMany(['post.published', 'post.unpublished'], function (model) {
+            addOrRemoveAuthorUrl(model.get('author_id'));
+        });
     },
 
     getData: function () {

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,10 +1,10 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    utils  = require('../../../utils'),
-    validator        = require('validator'),
-    BaseMapGenerator = require('./base-generator'),
-    // @TODO: figure out a way to get rid of this
-    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
+var _ = require('lodash'),
+    validator = require('validator'),
+    api = require('../../../api'),
+    logging = require('../../../logging'),
+    models = require('../../../models'),
+    utils = require('../../../utils'),
+    BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
 function UserMapGenerator(opts) {
@@ -41,7 +41,7 @@ _.extend(UserMapGenerator.prototype, {
     },
 
     validateDatum: function (datum) {
-        return datum.visibility === 'public' && _.includes(activeStates, datum.status);
+        return datum.visibility === 'public' && _.includes(models.User.activeStates, datum.status);
     },
 
     getUrlForDatum: function (user) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -352,6 +352,12 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         itemCollection.applyDefaultAndCustomFilters(options);
 
+        // we always have to fetch a minimum set of attributes, otherwise connected logic won't work e.g. events
+        if (options.columns) {
+            options.columns = _.intersection(options.columns, this.prototype.permittedAttributes());
+            options.columns = _.union(options.columns, this.prototype.defaultColumnsToFetch());
+        }
+
         return itemCollection.fetchAll(options).then(function then(result) {
             if (options.include) {
                 _.each(result.models, function each(item) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -128,9 +128,6 @@ Post = ghostBookshelf.Model.extend({
 
     /**
      * Will detach all tags.
-     * @param model
-     * @param options
-     * @returns {*}
      */
     onDestroying: function onDestroying(model, options) {
         this.tagsToSave = [];
@@ -358,8 +355,7 @@ Post = ghostBookshelf.Model.extend({
 
                 /**
                  * These are ALL JSON objects.
-                 * e.g. created tags don't have a slug yet, because `tagsToCreate` is just a list of tags to create.
-                 * 
+                 * e.g. created tags don't have a slug yet, because `tagsToCreate` is just a list of tags to create
                  * @TODO:
                  *   - we could attach these arrays after the query and have tag models available
                  *   - but right now it's not needed

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -124,10 +124,6 @@ Post = ghostBookshelf.Model.extend({
 
     onDestroyed: function onDestroyed(savedModel) {
         savedModel.emitChange('deleted', {usePreviousResourceType: true});
-
-        if (savedModel.previous('status') === 'published') {
-            savedModel.emitChange('unpublished', {usePreviousResourceType: true});
-        }
     },
 
     /**

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -20,10 +20,17 @@ Post = ghostBookshelf.Model.extend({
 
     tableName: 'posts',
 
-    emitChange: function emitChange(event, usePreviousResourceType) {
+    emitChange: function emitChange(event, options) {
+        options = options || {};
+
         var resourceType = this.get('page') ? 'page' : 'post';
-        if (usePreviousResourceType) {
+
+        if (options.useUpdatedResourceType) {
             resourceType = this.updated('page') ? 'page' : 'post';
+        }
+
+        if (options.usePreviousResourceType) {
+            resourceType = this.previous('page') ? 'page' : 'post';
         }
 
         events.emit(resourceType + '.' + event, this);
@@ -62,14 +69,14 @@ Post = ghostBookshelf.Model.extend({
         // Handle added and deleted for post -> page or page -> post
         if (model.resourceTypeChanging) {
             if (model.wasPublished) {
-                model.emitChange('unpublished', true);
+                model.emitChange('unpublished', {useUpdatedResourceType: true});
             }
 
             if (model.wasScheduled) {
-                model.emitChange('unscheduled', true);
+                model.emitChange('unscheduled', {useUpdatedResourceType: true});
             }
 
-            model.emitChange('deleted', true);
+            model.emitChange('deleted', {useUpdatedResourceType: true});
             model.emitChange('added');
 
             if (model.isPublished) {

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -94,7 +94,7 @@ Tag = ghostBookshelf.Model.extend({
         options = this.filterOptions(options, 'findOne');
         data = this.filterData(data, 'findOne');
 
-        var tag = this.forge(data);
+        var tag = this.forge(data, options);
 
         // Add related objects
         options.withRelated = _.union(options.withRelated, options.include);

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -771,7 +771,8 @@ User = ghostBookshelf.Model.extend({
             }
         });
     },
-    inactiveStates: inactiveStates
+    inactiveStates: inactiveStates,
+    activeStates: activeStates
 });
 
 Users = ghostBookshelf.Collection.extend({

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -339,14 +339,14 @@ User = ghostBookshelf.Model.extend({
             options.withRelated = _.union(options.withRelated, ['roles']);
             options.include = _.union(options.include, ['roles']);
 
-            query = this.forge(data, {include: options.include});
+            query = this.forge(data, {include: options.include, context: options.context});
 
             query.query('join', 'roles_users', 'users.id', '=', 'roles_users.user_id');
             query.query('join', 'roles', 'roles_users.role_id', '=', 'roles.id');
             query.query('where', 'roles.name', '=', lookupRole);
         } else {
             // We pass include to forge so that toJSON has access
-            query = this.forge(data, {include: options.include});
+            query = this.forge(data, {include: options.include, context: options.context});
         }
 
         if (status === 'active') {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -5,11 +5,12 @@
 var should = require('should'),
     sinon = require('sinon'),
     supertest = require('supertest'),
-    testUtils = require('../../utils'),
     moment = require('moment'),
     cheerio = require('cheerio'),
     _ = require('lodash'),
+    testUtils = require('../../utils'),
     config = require('../../../server/config'),
+    events = require('../../../server/events'),
     settingsCache = require('../../../server/settings/cache'),
     origCache = _.cloneDeep(settingsCache),
     ghost = testUtils.startGhost,
@@ -555,6 +556,10 @@ describe('Frontend Routing', function () {
         }
 
         describe('Subdirectory (no slash)', function () {
+            before(function () {
+                events.removeAllListeners();
+            });
+
             before(function (done) {
                 testUtils.fork.ghost({
                     url: 'http://localhost/blog'

--- a/core/test/integration/api/api_schedules_spec.js
+++ b/core/test/integration/api/api_schedules_spec.js
@@ -102,7 +102,7 @@ describe('Schedules API', function () {
                 api.schedules.getScheduledPosts()
                     .then(function (result) {
                         result.posts.length.should.eql(5);
-                        Object.keys(result.posts[0].toJSON()).should.eql(['id', 'published_at', 'created_at', 'author', 'url']);
+                        Object.keys(result.posts[0].toJSON()).should.eql(['id', 'published_at', 'created_at', 'slug', 'author', 'url']);
                         done();
                     })
                     .catch(done);

--- a/core/test/integration/data/xml/sitemap/tag-generator_spec.js
+++ b/core/test/integration/data/xml/sitemap/tag-generator_spec.js
@@ -269,14 +269,14 @@ describe('Integration: Tag Generator', function () {
                 (function retry() {
                     clearTimeout(timeout);
 
-                    if (sitemap.tags.removeUrl.calledOnce) {
+                    if (sitemap.tags.removeUrl.called) {
                         sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length - 1);
                         (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) === null).should.eql(true);
 
                         return done();
                     }
 
-                    timeout = setTimeout(retry, 100);
+                    timeout = setTimeout(retry, 200);
                 }());
             })
             .catch(done);

--- a/core/test/integration/data/xml/sitemap/tag-generator_spec.js
+++ b/core/test/integration/data/xml/sitemap/tag-generator_spec.js
@@ -1,0 +1,372 @@
+var should = require('should'),
+    sinon = require('sinon'),
+    _ = require('lodash'),
+    Promise = require('bluebird'),
+    testUtils = require('../../../../utils'),
+    events = require('../../../../../server/events'),
+    models = require('../../../../../server/models'),
+    SiteMapGenerator = require('../../../../../server/data/xml/sitemap/manager'),
+    sandbox = sinon.sandbox.create(),
+    sitemap;
+
+should.equal(true, true);
+
+describe('Integration: Tag Generator', function () {
+    var publishedPostsWithTags = [],
+        publicTagsWithConnectedPosts = {};
+
+    afterEach(testUtils.teardown);
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    before(testUtils.teardown);
+    beforeEach(testUtils.setup('default', 'perms:init', 'posts', 'users'));
+
+    beforeEach(function () {
+        sitemap = new SiteMapGenerator();
+
+        // do not initialise the other generators
+        sandbox.stub(sitemap.authors, 'init').returns(Promise.resolve());
+        sandbox.stub(sitemap.pages, 'init').returns(Promise.resolve());
+        sandbox.stub(sitemap.posts, 'init').returns(Promise.resolve());
+
+        return sitemap.init();
+    });
+
+    beforeEach(function () {
+        publicTagsWithConnectedPosts = {};
+        publishedPostsWithTags = [];
+
+        return models.Post.findAll({status: 'published', include: ['tags']})
+            .then(function (postModels) {
+                // there are four posts, which have posts connected
+                var publishedPostsWithTagsExpected = 4;
+
+                _.each(postModels.models, function (postModel) {
+                    if (postModel.related('tags').length) {
+                        publishedPostsWithTags.push(postModel);
+                        _.each(postModel.related('tags').models, function (tagModel) {
+                            if (tagModel.get('visibility') === 'public') {
+                                publicTagsWithConnectedPosts[tagModel.id] = tagModel;
+                            }
+                        });
+                    }
+                });
+
+                publishedPostsWithTagsExpected.should.eql(publishedPostsWithTags.length);
+            });
+    });
+
+    afterEach(function () {
+        events.removeAllListeners();
+    });
+
+    it('initial tag state', function () {
+        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length);
+    });
+
+    it('unpublish a post: expect removal of tag url', function (done) {
+        var timeout;
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        models.Post.edit({status: 'draft'}, {id: publishedPostsWithTags[3].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length - 1);
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('publish a new post with existing tag, which is already visible', function (done) {
+        var timeout;
+        sandbox.spy(sitemap.tags, 'addOrUpdateUrl');
+
+        models.Post.add({status: 'draft'}, testUtils.context.internal)
+            .then(function (postModel) {
+                return models.Post.edit({
+                    status: 'published',
+                    tags: [{name: testUtils.DataGenerator.forKnex.tags[0].name}]
+                }, {id: postModel.id});
+            })
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.addOrUpdateUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length);
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('tag get\'s deleted from tag management', function (done) {
+        var timeout;
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        models.Tag.destroy({id: testUtils.DataGenerator.forKnex.tags[0].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length - 1);
+
+                        _.each(publishedPostsWithTags, function (postModel) {
+                            _.each(postModel.related('tags').models, function (tagModel) {
+                                // should not appear in the sitemap anymore
+                                if (tagModel.get('slug') === testUtils.DataGenerator.forKnex.tags[0].slug) {
+                                    (sitemap.getSiteMapXml('tags').match(new RegExp(tagModel.get('slug'))) === null).should.eql(true);
+                                } else {
+                                    (sitemap.getSiteMapXml('tags').match(new RegExp(tagModel.get('slug'))) !== null).should.eql(true);
+                                }
+                            });
+                        });
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('Tag name get\'s updated and has > 0 posts connected', function (done) {
+        var timeout,
+            newTagSlug = 'tag-slug-change',
+            oldTagSlug = testUtils.DataGenerator.forKnex.tags[0].slug;
+
+        (sitemap.getSiteMapXml('tags').match(new RegExp(oldTagSlug)) !== null).should.eql(true);
+
+        sandbox.spy(sitemap.tags, 'addOrUpdateUrl');
+
+        models.Tag.edit({slug: newTagSlug}, {id: testUtils.DataGenerator.forKnex.tags[0].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.addOrUpdateUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(oldTagSlug)) === null).should.eql(true);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(newTagSlug)) !== null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('Tag name get\'s updated and has 0 posts connected', function (done) {
+        var timeout,
+            newTagSlug = 'tag-slug-change',
+            oldTagSlug = testUtils.DataGenerator.forKnex.tags[3].slug;
+
+        // not present in sitemap, correct
+        (sitemap.getSiteMapXml('tags').match(new RegExp(oldTagSlug)) === null).should.eql(true);
+
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        models.Tag.edit({slug: newTagSlug}, {id: testUtils.DataGenerator.forKnex.tags[3].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(oldTagSlug)) === null).should.eql(true);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(newTagSlug)) === null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('Tag was public and is now internal, has 1 post connected', function (done) {
+        var timeout,
+            affectedTagSlug = testUtils.DataGenerator.forKnex.tags[2].slug,
+            connectedPosts = 0;
+
+        // tag is public and present in sitemap, correct
+        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) !== null).should.eql(true);
+
+        _.each(publishedPostsWithTags, function (postModel) {
+            _.each(postModel.related('tags').models, function (tagModel) {
+                // should not appear in the sitemap anymore
+                if (tagModel.get('slug') === affectedTagSlug) {
+                    connectedPosts = connectedPosts + 1;
+                }
+            });
+        });
+
+        // has 1 post connected, correct
+        connectedPosts.should.eql(1);
+
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        models.Tag.edit({visibility: 'internal'}, {id: testUtils.DataGenerator.forKnex.tags[2].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length - 1);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) === null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('public tag get\'s detached from published post', function (done) {
+        var timeout,
+            affectedTagSlug = testUtils.DataGenerator.forKnex.tags[2].slug,
+            connectedPosts = [];
+
+        // tag is public and present in sitemap, correct
+        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) !== null).should.eql(true);
+
+        _.each(publishedPostsWithTags, function (postModel) {
+            _.each(postModel.related('tags').models, function (tagModel) {
+                // should not appear in the sitemap anymore
+                if (tagModel.get('slug') === affectedTagSlug) {
+                    connectedPosts.push(postModel);
+                }
+            });
+        });
+
+        // has 1 post connected, correct
+        connectedPosts.length.should.eql(1);
+
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        // detach all tags
+        models.Post.edit({tags: []}, {id: connectedPosts[0].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length - 1);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) === null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('public tag get\'s detached from published post, but has another post connection', function (done) {
+        var timeout,
+            affectedTagSlug = testUtils.DataGenerator.forKnex.tags[0].slug,
+            connectedPosts = [];
+
+        // tag is public and present in sitemap, correct
+        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) !== null).should.eql(true);
+
+        _.each(publishedPostsWithTags, function (postModel) {
+            _.each(postModel.related('tags').models, function (tagModel) {
+                // should not appear in the sitemap anymore
+                if (tagModel.get('slug') === affectedTagSlug) {
+                    connectedPosts.push(postModel);
+                }
+            });
+        });
+
+        // has 2 post connected, correct
+        connectedPosts.length.should.eql(2);
+
+        sandbox.spy(sitemap.tags, 'addOrUpdateUrl');
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        // detach all tags from first post
+        models.Post.edit({tags: []}, {id: connectedPosts[0].id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.tags.addOrUpdateUrl.calledOnce) {
+                        sitemap.tags.removeUrl.called.should.eql(false);
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(affectedTagSlug)) !== null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('public tag get\'s attached to published post, expect new tag url', function (done) {
+        var timeout,
+            newTag = {slug: 'hello-ghost', name: 'hello ghost'},
+            connectedPosts = 0,
+            addToPublishedPost = publishedPostsWithTags[0],
+            existingTags = addToPublishedPost.related('tags').toJSON();
+
+        // not present, as it's a new tag
+        (sitemap.getSiteMapXml('tags').match(new RegExp(newTag.slug)) === null).should.eql(true);
+
+        _.each(publishedPostsWithTags, function (postModel) {
+            _.each(postModel.related('tags').models, function (tagModel) {
+                if (tagModel.get('slug') === newTag.slug) {
+                    connectedPosts.push(postModel);
+                }
+            });
+        });
+
+        // has 0 post connected, correct
+        connectedPosts.should.eql(0);
+
+        sandbox.spy(sitemap.tags, 'addOrUpdateUrl');
+        sandbox.spy(sitemap.tags, 'removeUrl');
+
+        // attach new post
+        models.Post.edit({tags: [newTag].concat(existingTags)}, {id: addToPublishedPost.id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    // right now the sitemap generator does not compare existing tag url! see @TODO in base-generator
+                    if (sitemap.tags.addOrUpdateUrl.callCount === existingTags.length + 1) {
+                        sitemap.tags.removeUrl.called.should.eql(false);
+                        sitemap.getSiteMapXml('tags').match(/<url>/gi).length.should.eql(Object.keys(publicTagsWithConnectedPosts).length + 1);
+                        (sitemap.getSiteMapXml('tags').match(new RegExp(newTag.slug)) !== null).should.eql(true);
+
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+});

--- a/core/test/integration/data/xml/sitemap/user-generator_spec.js
+++ b/core/test/integration/data/xml/sitemap/user-generator_spec.js
@@ -1,0 +1,249 @@
+var should = require('should'),
+    sinon = require('sinon'),
+    _ = require('lodash'),
+    Promise = require('bluebird'),
+    testUtils = require('../../../../utils'),
+    events = require('../../../../../server/events'),
+    models = require('../../../../../server/models'),
+    SiteMapGenerator = require('../../../../../server/data/xml/sitemap/manager'),
+    sandbox = sinon.sandbox.create(),
+    sitemap;
+
+should.equal(true, true);
+
+describe('Integration: User Generator', function () {
+    var activeUsers = {};
+
+    afterEach(testUtils.teardown);
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    before(testUtils.teardown);
+    beforeEach(testUtils.setup('perms:init', 'posts', 'users', 'users-posts:1', 'users-posts:2'));
+
+    beforeEach(function () {
+        sitemap = new SiteMapGenerator();
+
+        // do not initialise the other generators
+        sandbox.stub(sitemap.tags, 'init').returns(Promise.resolve());
+        sandbox.stub(sitemap.pages, 'init').returns(Promise.resolve());
+        sandbox.stub(sitemap.posts, 'init').returns(Promise.resolve());
+
+        return sitemap.init();
+    });
+
+    beforeEach(function () {
+        activeUsers = [];
+
+        return models.User.findAll(_.merge({include: 'count.posts', status: 'active'}, testUtils.context.public))
+            .then(function (userModels) {
+                _.each(userModels.models, function (userModel) {
+                    activeUsers[userModel.get('email')] = userModel;
+                });
+
+                Object.keys(activeUsers).length.should.eql(3);
+
+                // only two users have posts connected
+                activeUsers[testUtils.DataGenerator.Content.extraUsers[0].email].get('count__posts').should.eql(0);
+                activeUsers[testUtils.DataGenerator.Content.extraUsers[1].email].get('count__posts').should.eql(2);
+                activeUsers[testUtils.DataGenerator.Content.extraUsers[2].email].get('count__posts').should.eql(2);
+            });
+    });
+
+    afterEach(function () {
+        events.removeAllListeners();
+    });
+
+    it('initial tag state', function () {
+        sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 1);
+    });
+
+    it('user get\'s suspended', function (done) {
+        var timeout,
+            userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[1].email];
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+
+        models.User.edit({status: 'inactive'}, {id: userToChange.id})
+            .then(function () {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.authors.removeUrl.calledOnce) {
+                        sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 2);
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('user get\'s suspended and activated right after', function (done) {
+        var timeout,
+            userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[1].email];
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+        sandbox.spy(sitemap.authors, 'addOrUpdateUrl');
+
+        models.User.edit({status: 'inactive'}, {id: userToChange.id})
+            .then(function () {
+                return new Promise(function (resolve) {
+                    (function retry() {
+                        clearTimeout(timeout);
+
+                        if (sitemap.authors.removeUrl.calledOnce) {
+                            sitemap.authors.addOrUpdateUrl.called.should.eql(false);
+                            sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 2);
+                            return resolve();
+                        }
+
+                        timeout = setTimeout(retry, 100);
+                    }());
+                });
+            })
+            .then(function () {
+                return models.User.edit({status: 'active'}, {id: userToChange.id});
+            })
+            .then(function () {
+                // reset, because deactivating a user triggers another `user.edited` event
+                sitemap.authors.addOrUpdateUrl.reset();
+
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.authors.addOrUpdateUrl.calledOnce) {
+                        sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 1);
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('slug changes', function (done) {
+        var timeout,
+            userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[1].email],
+            currentSlug = userToChange.get('slug'),
+            newSlug = 'this-is-my-slug-now';
+
+        // current slug exists, new slug doesn't
+        (sitemap.getSiteMapXml('authors').match(new RegExp(currentSlug)) !== null).should.eql(true);
+        (sitemap.getSiteMapXml('authors').match(new RegExp(newSlug)) === null).should.eql(true);
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+        sandbox.spy(sitemap.authors, 'addOrUpdateUrl');
+
+        models.User.edit({slug: newSlug}, {id: userToChange.id})
+            .then(function (userModel) {
+                userModel.get('slug').should.eql(newSlug);
+
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (sitemap.authors.addOrUpdateUrl.calledOnce) {
+                        sitemap.authors.removeUrl.called.should.eql(false);
+                        sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 1);
+
+                        (sitemap.getSiteMapXml('authors').match(new RegExp(currentSlug)) === null).should.eql(true);
+                        (sitemap.getSiteMapXml('authors').match(new RegExp(newSlug)) !== null).should.eql(true);
+                        return done();
+                    }
+
+                    timeout = setTimeout(retry, 100);
+                }());
+            })
+            .catch(done);
+    });
+
+    it('delete 1 post, user has 2 posts', function (done) {
+        var userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[2].email];
+
+        // has 2 posts
+        userToChange.get('count__posts').should.eql(2);
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+        sandbox.spy(sitemap.authors, 'addOrUpdateUrl');
+
+        models.Post.findOne({author_id: userToChange.id})
+            .then(function (postModel) {
+                return postModel.destroy();
+            })
+            .then(function () {
+                return models.User.findOne({id: userToChange.id}, {include: 'count.posts'});
+            })
+            .then(function (userModel) {
+                userModel.get('count__posts').should.eql(1);
+            })
+            .then(function () {
+                sitemap.authors.addOrUpdateUrl.calledOnce.should.eql(true);
+                sitemap.authors.removeUrl.called.should.eql(false);
+
+                // author url is still present
+                sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 1);
+                done();
+            })
+            .catch(done);
+    });
+
+    it('delete 2 posts, user has 2 posts', function (done) {
+        var userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[2].email];
+
+        // has 2 posts
+        userToChange.get('count__posts').should.eql(2);
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+        sandbox.spy(sitemap.authors, 'addOrUpdateUrl');
+
+        models.Post.findAll({filter: 'author_id:' + userToChange.id})
+            .then(function (postModels) {
+                return postModels.invokeThen('destroy');
+            })
+            .then(function () {
+                return models.User.findOne({id: userToChange.id}, {include: 'count.posts'});
+            })
+            .then(function (userModel) {
+                userModel.get('count__posts').should.eql(0);
+            })
+            .then(function () {
+                sitemap.authors.addOrUpdateUrl.called.should.eql(false);
+                sitemap.authors.removeUrl.calledTwice.should.eql(true);
+
+                // author url was removed, author has 0 posts connected
+                sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length - 2);
+                done();
+            })
+            .catch(done);
+    });
+
+    it('publish post, user has 0 posts', function (done) {
+        var userToChange = activeUsers[testUtils.DataGenerator.Content.extraUsers[0].email];
+
+        // has 0 posts
+        userToChange.get('count__posts').should.eql(0);
+
+        sandbox.spy(sitemap.authors, 'removeUrl');
+        sandbox.spy(sitemap.authors, 'addOrUpdateUrl');
+
+        models.Post.add({author_id: userToChange.id, status: 'published'})
+            .then(function () {
+                return models.User.findOne({id: userToChange.id}, {include: 'count.posts'});
+            })
+            .then(function (userModel) {
+                userModel.get('count__posts').should.eql(1);
+            })
+            .then(function () {
+                sitemap.authors.addOrUpdateUrl.calledOnce.should.eql(true);
+                sitemap.authors.removeUrl.called.should.eql(false);
+
+                // another author url was added :)
+                sitemap.getSiteMapXml('authors').match(/<url>/gi).length.should.eql(Object.keys(activeUsers).length);
+                done();
+            })
+            .catch(done);
+    });
+});

--- a/core/test/integration/data/xml/sitemap/user-generator_spec.js
+++ b/core/test/integration/data/xml/sitemap/user-generator_spec.js
@@ -178,6 +178,7 @@ describe('Integration: User Generator', function () {
             })
             .then(function (userModel) {
                 userModel.get('count__posts').should.eql(1);
+                return Promise.delay(200);
             })
             .then(function () {
                 sitemap.authors.addOrUpdateUrl.calledOnce.should.eql(true);

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1304,8 +1304,8 @@ describe('Post Model', function () {
                     should.equal(deleted.author, undefined);
 
                     Object.keys(eventsTriggered).length.should.eql(2);
-                    should.exist(eventsTriggered['post.unpublished']);
                     should.exist(eventsTriggered['post.deleted']);
+                    should.exist(eventsTriggered['post.tags-updated']);
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -1341,8 +1341,9 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(1);
+                    Object.keys(eventsTriggered).length.should.eql(2);
                     should.exist(eventsTriggered['post.deleted']);
+                    should.exist(eventsTriggered['post.tags-updated']);
 
                     // Double check we can't find the post again
                     return PostModel.findOne(firstItemData);
@@ -1378,8 +1379,7 @@ describe('Post Model', function () {
 
                     should.equal(deleted.author, undefined);
 
-                    Object.keys(eventsTriggered).length.should.eql(2);
-                    should.exist(eventsTriggered['page.unpublished']);
+                    Object.keys(eventsTriggered).length.should.eql(1);
                     should.exist(eventsTriggered['page.deleted']);
 
                     // Double check we can't find the post again

--- a/core/test/unit/sitemap/generator_spec.js
+++ b/core/test/unit/sitemap/generator_spec.js
@@ -6,6 +6,7 @@ var should = require('should'),
 
     // Stuff we are testing
     api = require('../../../server/api'),
+    models = require('../../../server/models'),
     utils = require('../../../server/utils'),
     BaseGenerator = require('../../../server/data/xml/sitemap/base-generator'),
     PostGenerator = require('../../../server/data/xml/sitemap/post-generator'),
@@ -69,6 +70,10 @@ describe('Generators', function () {
             };
         },
         generator;
+
+    before(function () {
+        models.init();
+    });
 
     afterEach(function () {
         sandbox.restore();
@@ -340,7 +345,7 @@ describe('Generators', function () {
         it('does not create a node for invited users', function () {
             var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
                 cover: 'user-100.jpg',
-                status: 'invited'
+                status: 'inactive'
             }));
 
             urlNode.should.be.false();

--- a/core/test/unit/sitemap/manager_spec.js
+++ b/core/test/unit/sitemap/manager_spec.js
@@ -203,38 +203,5 @@ describe('Sitemap', function () {
                 done();
             }).catch(done);
         });
-
-        it('updates authors site map', function (done) {
-            manager.init().then(function () {
-                events.on('user.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // user added is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                events.on('user.edited', function () {
-                    // user edited is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                events.on('user.activated', function () {
-                    // user activated is the point we know the user can be added
-                    manager.authors.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                events.on('user.activated.edited', function () {
-                    // user activated.edited means we can be sure the user is active
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                events.on('user.deleted', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-
-                events.emit('post.unpublished', post);
-            }).catch(done);
-        });
     });
 });

--- a/core/test/unit/sitemap/manager_spec.js
+++ b/core/test/unit/sitemap/manager_spec.js
@@ -232,44 +232,8 @@ describe('Sitemap', function () {
                     manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
                     manager.authors.removeUrl.called.should.equal(false);
                 });
-                events.on('user.deactivated', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.calledOnce.should.equal(true);
-                });
 
-                events.emit('user.added', fake);
-                events.emit('user.edited', fake);
-                events.emit('user.activated', fake);
-                events.emit('user.activated.edited', fake);
-                events.emit('user.deleted', fake);
-                events.emit('user.deactivated', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('updates tags site map', function (done) {
-            manager.init().then(function () {
-                events.on('tag.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    manager.tags.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                events.on('tag.edited', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                events.on('tag.deleted', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.calledOnce.should.equal(true);
-                });
-
-                events.emit('tag.added', fake);
-                events.emit('tag.edited', fake);
-                events.emit('tag.deleted', fake);
-
-                done();
+                events.emit('post.unpublished', post);
             }).catch(done);
         });
     });

--- a/core/test/unit/sitemap/manager_spec.js
+++ b/core/test/unit/sitemap/manager_spec.js
@@ -4,6 +4,7 @@ var should = require('should'),
 
     // Stuff we are testing
     events = require('../../../server/events'),
+    models = require('../../../server/models'),
     SiteMapManager = require('../../../server/data/xml/sitemap/manager'),
     PostGenerator = require('../../../server/data/xml/sitemap/post-generator'),
     PageGenerator = require('../../../server/data/xml/sitemap/page-generator'),
@@ -15,6 +16,7 @@ var should = require('should'),
 describe('Sitemap', function () {
     var makeStubManager = function () {
         var posts, pages, tags, authors;
+
         sandbox.stub(PostGenerator.prototype, 'refreshAll').returns(Promise.resolve());
         sandbox.stub(PageGenerator.prototype, 'refreshAll').returns(Promise.resolve());
         sandbox.stub(TagGenerator.prototype, 'refreshAll').returns(Promise.resolve());
@@ -43,6 +45,10 @@ describe('Sitemap', function () {
         return new SiteMapManager({posts: posts, pages: pages, tags: tags, authors: authors});
     };
 
+    before(function () {
+        models.init();
+    });
+
     afterEach(function () {
         sandbox.restore();
         events.removeAllListeners();
@@ -64,6 +70,7 @@ describe('Sitemap', function () {
 
         it('can initialize', function (done) {
             manager.initialized.should.equal(false);
+
             manager.init().then(function () {
                 manager.posts.init.called.should.equal(true);
                 manager.pages.init.called.should.equal(true);
@@ -76,7 +83,15 @@ describe('Sitemap', function () {
             }).catch(done);
         });
 
-        it('updates page site map correctly', function (done) {
+        it('page-generator: updates site map correctly', function (done) {
+            manager.posts.init.restore();
+            manager.authors.init.restore();
+            manager.tags.init.restore();
+
+            sandbox.stub(manager.posts, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.authors, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.tags, 'init').returns(Promise.resolve());
+
             manager.init().then(function () {
                 events.on('page.added', function (fakeModel) {
                     fakeModel.should.eql(fake);
@@ -121,7 +136,15 @@ describe('Sitemap', function () {
             }).catch(done);
         });
 
-        it('updates post site map', function (done) {
+        it('post-generator: updates site map', function (done) {
+            manager.pages.init.restore();
+            manager.authors.init.restore();
+            manager.tags.init.restore();
+
+            sandbox.stub(manager.pages, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.authors, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.tags, 'init').returns(Promise.resolve());
+
             manager.init().then(function () {
                 events.on('post.added', function (fakeModel) {
                     fakeModel.should.eql(fake);
@@ -166,7 +189,15 @@ describe('Sitemap', function () {
             }).catch(done);
         });
 
-        it('doesn\'t add posts until they are published', function (done) {
+        it('post-generator: doesn\'t add posts until they are published', function (done) {
+            manager.pages.init.restore();
+            manager.authors.init.restore();
+            manager.tags.init.restore();
+
+            sandbox.stub(manager.pages, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.authors, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.tags, 'init').returns(Promise.resolve());
+
             manager.init().then(function () {
                 events.on('post.added', function () {
                     manager.posts.addOrUpdateUrl.called.should.equal(false);
@@ -191,7 +222,15 @@ describe('Sitemap', function () {
             }).catch(done);
         });
 
-        it('deletes posts that were unpublished', function (done) {
+        it('post-generator: deletes posts that were unpublished', function (done) {
+            manager.pages.init.restore();
+            manager.authors.init.restore();
+            manager.tags.init.restore();
+
+            sandbox.stub(manager.pages, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.authors, 'init').returns(Promise.resolve());
+            sandbox.stub(manager.tags, 'init').returns(Promise.resolve());
+
             manager.init().then(function () {
                 events.on('post.unpublished', function () {
                     manager.posts.addOrUpdateUrl.called.should.equal(false);

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -340,6 +340,19 @@ DataGenerator.forKnex = (function () {
         });
     }
 
+    function createTag(overrides) {
+        var newObj = _.cloneDeep(overrides);
+
+        return _.defaults(newObj, {
+            id: ObjectId.generate(),
+            created_by: DataGenerator.Content.users[0].id,
+            created_at: new Date(),
+            updated_by: DataGenerator.Content.users[0].id,
+            updated_at: new Date(),
+            visibility: 'public'
+        });
+    }
+
     function createPost(overrides) {
         var newObj = _.cloneDeep(overrides);
 
@@ -503,11 +516,11 @@ DataGenerator.forKnex = (function () {
     ];
 
     tags = [
-        createBasic(DataGenerator.Content.tags[0]),
-        createBasic(DataGenerator.Content.tags[1]),
-        createBasic(DataGenerator.Content.tags[2]),
-        createBasic(DataGenerator.Content.tags[3]),
-        createBasic(DataGenerator.Content.tags[4])
+        createTag(DataGenerator.Content.tags[0]),
+        createTag(DataGenerator.Content.tags[1]),
+        createTag(DataGenerator.Content.tags[2]),
+        createTag(DataGenerator.Content.tags[3]),
+        createTag(DataGenerator.Content.tags[4])
     ];
 
     roles = [

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -359,6 +359,7 @@ DataGenerator.forKnex = (function () {
         return _.defaults(newObj, {
             id: ObjectId.generate(),
             uuid: uuid.v4(),
+            slug: 'slug-' + globalUtils.uid(5),
             title: 'title',
             status: 'published',
             html: overrides.markdown,

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -285,6 +285,15 @@ fixtures = {
         });
     },
 
+    // Creates posts for extra users
+    createExtraUsersPosts: function (index) {
+        var user = DataGenerator.Content.extraUsers[index || 0];
+        return fixtures.insertPosts([
+            DataGenerator.forKnex.createPost({author_id: user.id}),
+            DataGenerator.forKnex.createPost({author_id: user.id})
+        ]);
+    },
+
     // Creates a client, and access and refresh tokens for user with index or 2 by default
     createTokensForUser: function createTokensForUser(index) {
         return db.knex('clients').insert(DataGenerator.forKnex.clients).then(function () {
@@ -484,6 +493,9 @@ toDoList = {
     users: function createExtraUsers() {
         return fixtures.createExtraUsers();
     },
+    'users-posts': function (index) {
+        return fixtures.createExtraUsersPosts(index);
+    },
     'user-token': function createTokensForUser(index) {
         return fixtures.createTokensForUser(index);
     },
@@ -555,7 +567,9 @@ getFixtureOps = function getFixtureOps(toDos) {
     _.each(toDos, function (value, toDo) {
         var tmp;
 
-        if ((toDo !== 'perms:init' && toDo.indexOf('perms:') !== -1) || toDo.indexOf('user-token:') !== -1) {
+        if ((toDo !== 'perms:init' && toDo.indexOf('perms:') !== -1) ||
+            toDo.indexOf('users-posts:') !== -1 ||
+            toDo.indexOf('user-token:') !== -1) {
             tmp = toDo.split(':');
 
             fixtureOps.push(function addCustomFixture() {
@@ -834,6 +848,7 @@ module.exports = {
     context: {
         internal: {context: {internal: true}},
         external: {context: {external: true}},
+        public: {context: {public: true}},
         owner: {context: {user: DataGenerator.Content.users[0].id}},
         admin: {context: {user: DataGenerator.Content.users[1].id}},
         editor: {context: {user: DataGenerator.Content.users[2].id}},


### PR DESCRIPTION
closes #4588

This feature was bigger then expected 🙀

The functionality to get the count of a post related to an author or tag was already present as a bookshelf plugin. e.g. `include: 'count.post'`. 
I struggled a bit, because it was hard to support all kinds of cases for showing/hiding tags/authors related to posts. Especially because i had to choose which events i will use, and which aren't helpful. I've started with a different solution (which i preferred), which triggered attached/detached tag events for posts from our base utility. But i ran into a trap, because the update of tags happens in a transaction. This means that the event was always triggered to early and the result was always "false".

So, i decided to add an `post.tags-updated` event. You can see everything in the commits and comments.

I did lot's of small adaptions, which were required to support all kinds of edge cases.

Furthermore, i have moved our tags- and user generator sitemap tests from unit to integration tests. The unit tests are not really helpful, they simply expect to much and changing any connected logic, won't get covered. 

- [x] final browser test
- [x] final code review + more commit squashes?
- [x] move unit sitemap tests ot integration sitemap tests (tags/authors only)