### PR TITLE
🐛  Get correct icon filePath with subdirectory

### DIFF
--- a/core/server/middleware/serve-favicon.js
+++ b/core/server/middleware/serve-favicon.js
@@ -36,7 +36,7 @@ function serveFavicon() {
             // we are using an express route to skip /content/images and the result is a image path
             // based on config.getContentPath('images') + req.path
             // in this case we don't use path rewrite, that's why we have to make it manually
-            filePath = settingsCache.get('icon').replace(new RegExp(utils.url.STATIC_IMAGE_URL_PREFIX), '');
+            filePath = settingsCache.get('icon').replace(new RegExp('^' + utils.url.getSubdir() + '/' + utils.url.STATIC_IMAGE_URL_PREFIX), '');
 
             var originalExtension = path.extname(filePath).toLowerCase(),
                 requestedExtension = path.extname(req.path).toLowerCase();

--- a/core/server/middleware/serve-favicon.js
+++ b/core/server/middleware/serve-favicon.js
@@ -36,7 +36,7 @@ function serveFavicon() {
             // we are using an express route to skip /content/images and the result is a image path
             // based on config.getContentPath('images') + req.path
             // in this case we don't use path rewrite, that's why we have to make it manually
-            filePath = settingsCache.get('icon').replace(new RegExp('^' + utils.url.getSubdir() + '/' + utils.url.STATIC_IMAGE_URL_PREFIX), '');
+            filePath = settingsCache.get('icon').replace(new RegExp('^' + utils.url.urlJoin(utils.url.getSubdir(), utils.url.STATIC_IMAGE_URL_PREFIX)), '');
 
             var originalExtension = path.extname(filePath).toLowerCase(),
                 requestedExtension = path.extname(req.path).toLowerCase();

--- a/core/test/unit/middleware/serve-favicon_spec.js
+++ b/core/test/unit/middleware/serve-favicon_spec.js
@@ -127,6 +127,93 @@ describe('Serve Favicon', function () {
             });
         });
 
+        describe.skip('serves with subdirectory setup', function () {
+            beforeEach(function () {
+                sandbox
+                    .stub(storage.getStorage(), 'read')
+                    .returns(new Promise.resolve('<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'));
+            });
+
+            it('custom uploaded favicon.png', function (done) {
+                var middleware = serveFavicon();
+                req.path = '/favicon.png';
+
+                configUtils.set('url', 'https://my-blog.com/blog/');
+
+                localSettingsCache.icon = 'favicon.png';
+
+                res = {
+                    writeHead: function (statusCode) {
+                        statusCode.should.eql(200);
+                    },
+                    end: function (body) {
+                        body.length.should.eql(6792);
+                        done();
+                    }
+                };
+
+                middleware(req, res, next);
+            });
+
+            it('custom uploaded favicon.ico', function (done) {
+                var middleware = serveFavicon();
+                req.path = '/favicon.ico';
+
+                storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
+                localSettingsCache.icon = 'favicon.ico';
+
+                res = {
+                    writeHead: function (statusCode) {
+                        statusCode.should.eql(200);
+                    },
+                    end: function (body) {
+                        body.length.should.eql(15086);
+                        done();
+                    }
+                };
+
+                middleware(req, res, next);
+            });
+
+            it('custom uploaded myicon.ico', function (done) {
+                var middleware = serveFavicon();
+                req.path = '/favicon.ico';
+
+                storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
+                localSettingsCache.icon = 'myicon.ico';
+
+                res = {
+                    writeHead: function (statusCode) {
+                        statusCode.should.eql(200);
+                    },
+                    end: function (body) {
+                        body.length.should.eql(15086);
+                        done();
+                    }
+                };
+
+                middleware(req, res, next);
+            });
+
+            it('default favicon.ico', function (done) {
+                var middleware = serveFavicon();
+                req.path = '/favicon.ico';
+                localSettingsCache.icon = '';
+
+                res = {
+                    writeHead: function (statusCode) {
+                        statusCode.should.eql(200);
+                    },
+                    end: function (body) {
+                        body.length.should.eql(15086);
+                        done();
+                    }
+                };
+
+                middleware(req, res, next);
+            });
+        });
+
         describe('redirects', function () {
             it('to custom favicon.ico when favicon.png is requested', function (done) {
                 var middleware = serveFavicon();

--- a/core/test/unit/middleware/serve-favicon_spec.js
+++ b/core/test/unit/middleware/serve-favicon_spec.js
@@ -166,7 +166,7 @@ describe('Serve Favicon', function () {
                 var middleware = serveFavicon();
                 req.path = '/favicon.png';
 
-                configUtils.set('paths:corePath', path.join(__dirname, '../../../test/utils/fixtures/'));
+                configUtils.set('paths:publicFilePath', path.join(__dirname, '../../../test/utils/fixtures/'));
                 localSettingsCache.icon = '';
 
                 res = {


### PR DESCRIPTION
refs #7688

Fixes a bug when the blog is set up with a subdirectory, `STATIC_IMAGE_URL_PREFIX` would only replace the `content/image` part, leading to having a `filePath` like `/blog/myicon.png`.