### PR TITLE
✨ Added pre-commit hook to handle submodules

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Modified from https://github.com/chaitanyagupta/gitutils
+
+green='\033[0;32m'
+no_color='\033[0m'
+grey='\033[0;90m'
+
+
+ROOT_DIR=$(git rev-parse --show-cdup)
+SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //')
+MOD_SUBMODULES=$(git diff --cached --name-only | grep -F "$SUBMODULES")
+
+echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
+
+# If no modified submodules, exit with status code 0, else prompt the
+# user and exit accordingly
+if [[ -n "$MOD_SUBMODULES" ]]; then
+    echo "Submodules to be committed:"
+    echo "  (use \"git reset HEAD <file>...\" to unstage)"
+    echo
+
+    for SUB in $MOD_SUBMODULES
+    do
+        echo -e "\t${green}modified:\t$SUB${no_color}"
+    done
+    echo
+    echo -n -e "Continue with commit? ${grey}(N|y)${no_color} "
+    read -n 1 reply </dev/tty
+    echo
+    if [[ "$reply" == "y" || "$reply" == "Y" ]]; then
+        echo "Permitting submodules to be committed..."
+        exit 0
+    else
+        echo "Aborting commit due to submodule update."
+        exit 1
+    fi
+else
+    echo "No submodules in commit, continuing..."
+    exit 0
+fi

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -364,6 +364,22 @@ var overrides      = require('./core/server/overrides'),
                         'core/client': ['shell:ember:watch', '--live-reload-base-url="' + utils.url.getSubdir() + '/ghost/"']
                     }
                 }
+            },
+
+            // ### grunt-contrib-symlink
+            // Create symlink for git hooks
+            symlink: {
+                githooks: {
+                    // Enable overwrite to delete symlinks before recreating them
+                    overwrite: false,
+                    // Enable force to overwrite symlinks outside the current working directory
+                    force: false,
+                    // Expand to all files in /hooks
+                    expand: true,
+                    cwd: '.github/hooks',
+                    src: ['*'],
+                    dest: '.git/hooks'
+                }
             }
         };
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install and run Ghost.
 <b>git clone git@github.com:TryGhost/Ghost.git ghost</b>
     Download the Ghost code base
 <b>npm run init</b>
-    Short command for: yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt init
+    Short command for: yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init
 <b>knex-migrator init</b>
     Creates and initialises your database
 <b>grunt dev</b>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "node index",
     "test": "grunt validate --verbose",
-    "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt init || true"
+    "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
   },
   "engines": {
     "node": "^4.2.0 || ^6.5.0"
@@ -99,6 +99,7 @@
     "grunt-contrib-compress": "1.3.0",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-symlink": "^1.0.0",
     "grunt-contrib-uglify": "2.0.0",
     "grunt-contrib-watch": "1.0.0",
     "grunt-cssnano": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,10 @@ grunt-contrib-jshint@1.0.0:
     hooker "^0.2.3"
     jshint "~2.9.1"
 
+grunt-contrib-symlink@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/grunt-contrib-symlink/-/grunt-contrib-symlink-1.0.0.tgz#c83616c035711a6c0062a2810cf1c77ffc6bed2b"
+
 grunt-contrib-uglify@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/grunt-contrib-uglify/-/grunt-contrib-uglify-2.0.0.tgz#8c9970d690936cde6d25aa1193549bd929016930"


### PR DESCRIPTION
This PR adds a pre-commit hook that developers can install to remind them NOT to commit submodules. It is borrowed very heavily from https://github.com/chaitanyagupta/gitutils/blob/master/submodule-hooks/pre-commit, but I modified the output to closely resemble `git status`.

At the moment, this would have to be installed manually:

`cp .github/hooks/pre-commit ./git/hooks/pre-commit`
`chmod ugo+x .git/hooks/pre-commit`

We could use the `npm postinstall` hook to automatically install this using a symlink. There is a [node module](https://github.com/kilianc/shared-git-hooks)  that would do this for us, but it makes certain assumptions.

Not sure how everyone feels - should we be building up a library of hooks & auto-linking them to make everyone's life easier, or does this feel too intrusive?

-----

refs #8235

Usage:

In the root of your repo run

`cp .github/hooks/pre-commit ./git/hooks/pre-commit`
`chmod ugo+x .git/hooks/pre-commit`

- Checks to see if there are any submodules about to be committed
- Output matches closely to `git st` to make it easy to read
- Requires interaction from the committer to accept that this really should be committed
