### PR TITLE
✨ Autofill plaintext field on save

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -7,6 +7,7 @@ var _               = require('lodash'),
     errors          = require('../errors'),
     Showdown        = require('showdown-ghost'),
     legacyConverter = new Showdown.converter({extensions: ['ghostgfm', 'footnotes', 'highlight']}),
+    htmlToText      = require('html-to-text'),
     ghostBookshelf  = require('./base'),
     events          = require('../events'),
     config          = require('../config'),
@@ -205,6 +206,18 @@ Post = ghostBookshelf.Model.extend({
         } else {
             // legacy showdown mode
             this.set('html', legacyConverter.makeHtml(_.toString(this.get('markdown'))));
+        }
+
+        if (this.hasChanged('html')) {
+            this.set('plaintext', htmlToText.fromString(this.get('html'), {
+                wordwrap: 80,
+                ignoreImage: true,
+                linkHrefBaseUrl: utils.url.urlFor('home').replace(/\/$/, ''),
+                hideLinkHrefIfSameAsText: true,
+                preserveNewlines: true,
+                returnDomByDefault: true,
+                uppercaseHeadings: false
+            }));
         }
 
         // disabling sanitization until we can implement a better version

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -59,6 +59,11 @@ describe('Post Model', function () {
             firstPost.updated_by.name.should.equal(DataGenerator.Content.users[0].name);
             firstPost.published_by.name.should.equal(DataGenerator.Content.users[0].name);
             firstPost.tags[0].name.should.equal(DataGenerator.Content.tags[0].name);
+
+            // Formats
+            // @TODO change / update this for mobiledoc in
+            firstPost.markdown.should.match(/HTML Ipsum Presents/);
+            firstPost.html.should.match(/HTML Ipsum Presents/);
         }
 
         describe('findAll', function () {
@@ -421,6 +426,23 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     should.exist(edited);
                     edited.attributes.markdown.should.equal('123');
+                    done();
+                }).catch(done);
+            });
+
+            it('converts html to plaintext', function (done) {
+                var postId = testUtils.DataGenerator.Content.posts[0].id;
+
+                PostModel.findOne({id: postId}).then(function (results) {
+                    should.exist(results);
+                    results.attributes.html.should.match(/HTML Ipsum Presents/);
+                    should.not.exist(results.attributes.plaintext);
+                    return PostModel.edit({updated_at: Date.now()}, _.extend({}, context, {id: postId}));
+                }).then(function (edited) {
+                    should.exist(edited);
+
+                    edited.attributes.html.should.match(/HTML Ipsum Presents/);
+                    edited.attributes.plaintext.should.match(/HTML Ipsum Presents/);
                     done();
                 }).catch(done);
             });
@@ -905,6 +927,8 @@ describe('Post Model', function () {
                     createdPost.get('markdown').should.equal(newPost.markdown, 'markdown is correct');
                     createdPost.has('html').should.equal(true);
                     createdPost.get('html').should.equal(newPostDB.html);
+                    createdPost.has('plaintext').should.equal(true);
+                    createdPost.get('plaintext').should.match(/^testing/);
                     createdPost.get('slug').should.equal(newPostDB.slug + '-2');
                     (!!createdPost.get('featured')).should.equal(false);
                     (!!createdPost.get('page')).should.equal(false);


### PR DESCRIPTION
This ensures that the plaintext field is populated, which should allow Ghost-Admin to be updated to make use of it.

There is much work to be done to improve the tests - this just makes the feature available.

refs #8275

- If the HTML field has changed, update the plaintext field
- Use html-to-text to generate a plaintext version of the HTML which retains some structure
- Add a couple of tests - although there's much to do here!

