### PR TITLE
✨ Add ?formats param to Posts API

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -37,7 +37,7 @@ posts = {
      * @returns {Promise<Posts>} Posts Collection with Meta
      */
     browse: function browse(options) {
-        var extraOptions = ['status'],
+        var extraOptions = ['status', 'formats'],
             permittedOptions,
             tasks;
 
@@ -62,7 +62,7 @@ posts = {
         tasks = [
             utils.validate(docName, {opts: permittedOptions}),
             utils.handlePublicPermissions(docName, 'browse'),
-            utils.convertOptions(allowedIncludes),
+            utils.convertOptions(allowedIncludes, dataProvider.Post.allowedFormats),
             modelQuery
         ];
 
@@ -79,7 +79,7 @@ posts = {
      * @return {Promise<Post>} Post
      */
     read: function read(options) {
-        var attrs = ['id', 'slug', 'status', 'uuid'],
+        var attrs = ['id', 'slug', 'status', 'uuid', 'formats'],
             tasks;
 
         /**
@@ -96,7 +96,7 @@ posts = {
         tasks = [
             utils.validate(docName, {attrs: attrs, opts: options.opts || []}),
             utils.handlePublicPermissions(docName, 'read'),
-            utils.convertOptions(allowedIncludes),
+            utils.convertOptions(allowedIncludes, dataProvider.Post.allowedFormats),
             modelQuery
         ];
 

--- a/core/server/data/schema/checks.js
+++ b/core/server/data/schema/checks.js
@@ -1,5 +1,5 @@
 function isPost(jsonData) {
-    return jsonData.hasOwnProperty('html') && jsonData.hasOwnProperty('markdown') &&
+    return jsonData.hasOwnProperty('html') &&
         jsonData.hasOwnProperty('title') && jsonData.hasOwnProperty('slug');
 }
 

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -54,6 +54,138 @@ describe('Post API', function () {
                     testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                     _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
                     _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
+
+                    done();
+                });
+        });
+
+        it('can retrieve a single post format', function (done) {
+            request.get(testUtils.API.getApiQuery('posts/?formats=mobiledoc'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    testUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(5);
+                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc'], ['html']);
+                    testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                    _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                    _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
+
+                    done();
+                });
+        });
+
+        it('can retrieve multiple post formats', function (done) {
+            request.get(testUtils.API.getApiQuery('posts/?formats=plaintext,mobiledoc,amp'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    testUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(5);
+                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc', 'plaintext', 'amp'], ['html']);
+                    testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                    _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                    _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
+
+                    done();
+                });
+        });
+
+        it('can handle unknown post formats', function (done) {
+            request.get(testUtils.API.getApiQuery('posts/?formats=plaintext,mobiledo'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    testUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(5);
+                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['plaintext'], ['html']);
+                    testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                    _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                    _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
+
+                    done();
+                });
+        });
+
+        it('can handle empty formats (default html is expected)', function (done) {
+            request.get(testUtils.API.getApiQuery('posts/?formats='))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    testUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(5);
+                    testUtils.API.checkResponse(jsonResponse.posts[0], 'post');
+                    testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+                    _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
+                    _.isBoolean(jsonResponse.posts[0].page).should.eql(true);
+
+                    done();
+                });
+        });
+
+        it('fields and formats', function (done) {
+            request.get(testUtils.API.getApiQuery('posts/?formats=mobiledoc,html&fields=id,title'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.not.exist(res.headers['x-cache-invalidate']);
+                    var jsonResponse = res.body;
+                    should.exist(jsonResponse.posts);
+                    testUtils.API.checkResponse(jsonResponse, 'posts');
+                    jsonResponse.posts.should.have.length(5);
+
+                    testUtils.API.checkResponse(
+                        jsonResponse.posts[0],
+                        'post',
+                        null,
+                        null,
+                        ['mobiledoc', 'id', 'title', 'html']
+                    );
+
+                    testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
                     done();
                 });
         });

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -19,8 +19,13 @@ var _               = require('lodash'),
         slugs:         ['slugs'],
         slug:          ['slug'],
         // object / model level
-        // Post API swaps author_id to author, and always returns a computed 'url' property
-        post:        _(schema.posts).keys().without('author_id').concat('author', 'url').value(),
+        // Post API
+        post:        _(schema.posts).keys()
+            // does not return all formats by default
+            .without('markdown', 'mobiledoc', 'amp', 'plaintext')
+            // swaps author_id to author, and always returns a computed 'url' property
+            .without('author_id').concat('author', 'url')
+            .value(),
         // User API always removes the password field
         user:        _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),
         // Tag API swaps parent_id to parent
@@ -78,8 +83,10 @@ function checkResponseValue(jsonResponse, expectedProperties) {
     providedProperties.length.should.eql(expectedProperties.length);
 }
 
-function checkResponse(jsonResponse, objectType, additionalProperties, missingProperties) {
+function checkResponse(jsonResponse, objectType, additionalProperties, missingProperties, onlyProperties) {
     var checkProperties = expectedProperties[objectType];
+
+    checkProperties = onlyProperties ? onlyProperties : checkProperties;
     checkProperties = additionalProperties ? checkProperties.concat(additionalProperties) : checkProperties;
     checkProperties = missingProperties ? _.xor(checkProperties, missingProperties) : checkProperties;
 


### PR DESCRIPTION
This PR is a bit weird, and very lacking in tests.

I'm not particularly happy with the implementation - there's duplication of the properties at the API and model layer. I think this is a symptom of a much larger problem with regard to separation of concerns between the model & API layer - and one that's not worth fixing right now.

Note: I've implemented this such that if you did something like:

`/posts/?formats=mobiledoc,html&fields=id,title`

You'd get all 4 fields returned, and don't have to specify the formats in both formats and fields. This is a little bit inconsistent with what happens if you did:

`/posts/?include=tags&fields=id,title`

Where you'd only get the id and title fields, despite having requested tags.

I thought about this, and came to the conclusion that the concepts are different enough that it makes sense. Having to duplicate formats in a fields request is weird because they're both column names.

However, `include=tags` represents a whole object, not just a single field, and so eventually we want to be able to support something like

`/posts/?include=tags&fields=id,title,tag.name`

or 

`/posts/?include=tags&fields=id,title,tag.*`


refs #8275

- Adds support for formats param
- Returns html by default
- Can optionally return other formats by providing a comma-separated list

TODO:
- [x] revisit implementation - can we do this without duplication? (maybe track this as a separate task)
- [x] add some tests
- [x] ensure that ?fields can't be used to override ?formats in confusing ways
- [x] add admin PR (https://github.com/TryGhost/Ghost-Admin/pull/718)
