### PR TITLE
🐛  fix hasDateChanged

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -225,8 +225,17 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         return this.updatedAttributes()[attr];
     },
 
-    hasDateChanged: function (attr) {
-        return moment(this.get(attr)).diff(moment(this.updated(attr))) !== 0;
+    /**
+     * There is difference between `updated` and `previous`:
+     * Depending on the hook (before or after writing into the db), both fields have a different meaning.
+     * e.g. onSaving  -> before db write (has to use previous)
+     *      onUpdated -> after db write  (has to use updated)
+     *
+     * hasDateChanged('attr', {beforeWrite: true})
+     */
+    hasDateChanged: function (attr, options) {
+        options = options || {};
+        return moment(this.get(attr)).diff(moment(options.beforeWrite ? this.previous(attr) : this.updated(attr))) !== 0;
     }
 }, {
     // ## Data Utility Functions

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -168,7 +168,7 @@ Post = ghostBookshelf.Model.extend({
             prevSlug    = this._previousAttributes.slug,
             tagsToCheck = this.get('tags'),
             publishedAt = this.get('published_at'),
-            publishedAtHasChanged = this.hasDateChanged('published_at'),
+            publishedAtHasChanged = this.hasDateChanged('published_at', {beforeWrite: true}),
             tags = [];
 
         // CASE: disallow published -> scheduled

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -473,16 +473,21 @@ describe('Post Model', function () {
             });
 
             it('draft -> scheduled without published_at update', function (done) {
-                PostModel.findOne({status: 'draft'}).then(function (results) {
-                    var post;
+                var post;
 
+                PostModel.findOne({status: 'draft'}).then(function (results) {
                     should.exist(results);
                     post = results.toJSON();
                     post.status.should.equal('draft');
 
+                    results.set('published_at', null);
+                    return results.save(null, context);
+                }).then(function () {
                     return PostModel.edit({
                         status: 'scheduled'
                     }, _.extend({}, context, {id: post.id}));
+                }).then(function () {
+                    done(new Error('expected error'));
                 }).catch(function (err) {
                     should.exist(err);
                     (err instanceof errors.ValidationError).should.eql(true);
@@ -569,7 +574,7 @@ describe('Post Model', function () {
 
                     return PostModel.edit({
                         status: 'scheduled',
-                        published_at: moment().add(20, 'days')
+                        published_at: moment().add(20, 'days').toDate()
                     }, _.extend({}, context, {id: post.id}));
                 }).then(function (edited) {
                     should.exist(edited);
@@ -596,6 +601,40 @@ describe('Post Model', function () {
                 }).then(function (edited) {
                     should.exist(edited);
                     edited.attributes.status.should.equal('scheduled');
+                    eventSpy.callCount.should.eql(1);
+                    eventSpy.firstCall.calledWith('post.edited').should.be.true();
+
+                    done();
+                }).catch(done);
+            });
+
+            it('scheduled -> scheduled with unchanged published_at (within the 2 minutes window)', function (done) {
+                var post;
+
+                PostModel.findOne({status: 'scheduled'}).then(function (results) {
+                    should.exist(results);
+                    post = results.toJSON();
+                    post.status.should.equal('scheduled');
+
+                    results.set('published_at', moment().add(2, 'minutes').add(2, 'seconds').toDate());
+                    return results.save(null, context);
+                }).then(function (edited) {
+                    edited.attributes.status.should.equal('scheduled');
+                    eventSpy.callCount.should.eql(2);
+                    eventSpy.firstCall.calledWith('post.rescheduled').should.be.true();
+                    eventSpy.secondCall.calledWith('post.edited').should.be.true();
+
+                    eventSpy.reset();
+
+                    return Promise.delay(1000 * 3);
+                }).then(function () {
+                    return PostModel.edit({
+                        status: 'scheduled'
+                    }, _.extend({}, context, {id: post.id}));
+                }).then(function (edited) {
+                    should.exist(edited);
+                    edited.attributes.status.should.equal('scheduled');
+
                     eventSpy.callCount.should.eql(1);
                     eventSpy.firstCall.calledWith('post.edited').should.be.true();
 


### PR DESCRIPTION
no issue

- i don't know if this never worked or has worked and something changed in bookshelf
- but this fixes: saving the content (no change for published_at) of a scheduled post within the 2minutes window
- add `beforeWrite` option to hasDateChanged helper, see comment
- use previous for `beforeWrite` operations
- add a test and fix some other small issues in the scheduler tests