### PR TITLE
✨ post update collision detection

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -94,7 +94,7 @@ posts = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            utils.validate(docName, {attrs: attrs}),
+            utils.validate(docName, {attrs: attrs, opts: options.opts || []}),
             utils.handlePublicPermissions(docName, 'read'),
             utils.convertOptions(allowedIncludes),
             modelQuery
@@ -135,7 +135,7 @@ posts = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            utils.validate(docName, {opts: utils.idDefaultOptions}),
+            utils.validate(docName, {opts: utils.idDefaultOptions.concat(options.opts || [])}),
             utils.handlePermissions(docName, 'edit'),
             utils.convertOptions(allowedIncludes),
             modelQuery

--- a/core/server/api/schedules.js
+++ b/core/server/api/schedules.js
@@ -10,7 +10,11 @@ var _ = require('lodash'),
     utils = require('./utils');
 
 /**
- * publish a scheduled post
+ * Publish a scheduled post
+ *
+ * `apiPosts.read` and `apiPosts.edit` must happen in one transaction.
+ * We lock the target row on fetch by using the `forUpdate` option.
+ * Read more in models/post.js - `onFetching`
  *
  * object.force: you can force publishing a post in the past (for example if your service was down)
  */
@@ -37,8 +41,6 @@ exports.publishPost = function publishPost(object, options) {
 
             return dataProvider.Base.transaction(function (transacting) {
                 cleanOptions.transacting = transacting;
-
-                // CASE: apiPosts.read and apiPosts.edit happen in a transaction, signalise `forUpdate` to knex
                 cleanOptions.forUpdate = true;
 
                 // CASE: extend allowed options, see api/utils.js

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -122,7 +122,7 @@ utils = {
                 name: {}
             },
             // these values are sanitised/validated separately
-            noValidation = ['data', 'context', 'include', 'filter'],
+            noValidation = ['data', 'context', 'include', 'filter', 'forUpdate', 'transacting'],
             errors = [];
 
         _.each(options, function (value, key) {
@@ -262,6 +262,7 @@ utils = {
                 options.columns = utils.prepareFields(options.fields);
                 delete options.fields;
             }
+
             return options;
         };
     },

--- a/core/server/errors/index.js
+++ b/core/server/errors/index.js
@@ -245,7 +245,12 @@ errors = {
 
             errorContent.message = _.isString(errorItem) ? errorItem :
                 (_.isObject(errorItem) ? errorItem.message : i18n.t('errors.errors.unknownApiError'));
+
             errorContent.errorType = errorItem.errorType || 'InternalServerError';
+
+            if (errorItem.code) {
+                errorContent.code = errorItem.code;
+            }
 
             if (errorItem.errorType === 'ThemeValidationError' && errorItem.errorDetails) {
                 errorContent.errorDetails = errorItem.errorDetails;

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -43,6 +43,9 @@ ghostBookshelf.plugin(plugins.includeCount);
 // Load the Ghost pagination plugin, which gives us the `fetchPage` method on Models
 ghostBookshelf.plugin(plugins.pagination);
 
+// Update collision plugin
+ghostBookshelf.plugin(plugins.collision);
+
 // Cache an instance of the base model prototype
 proto = ghostBookshelf.Model.prototype;
 
@@ -459,7 +462,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         return model.fetch(options).then(function then(object) {
             if (object) {
-                return object.save(data, options);
+                return object.save(data, _.merge({method: 'update'}, options));
             }
         });
     },

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -444,6 +444,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     /**
      * ### Edit
      * Naive edit
+     *
+     * We always forward the `method` option to Bookshelf, see http://bookshelfjs.org/#Model-instance-save.
+     * Based on the `method` option Bookshelf and Ghost can determine if a query is an insert or an update.
+     *
      * @param {Object} data
      * @param {Object} options (optional)
      * @return {Promise(ghostBookshelf.Model)} Edited Model

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -32,10 +32,14 @@ events.on('settings.activeTimezone.edited', function (settingModel) {
         return;
     }
 
+    /**
+     * CASE:
+     * `Post.findAll` and the Post.edit` must run in one single transaction.
+     * We lock the target row on fetch by using the `forUpdate` option.
+     * Read more in models/post.js - `onFetching`
+     */
     return models.Base.transaction(function (transacting) {
         options.transacting = transacting;
-
-        // CASE: signalise that two operations will happen (fetch for update)
         options.forUpdate = true;
 
         return models.Post.findAll(_.merge({filter: 'status:scheduled'}, options))

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -3,7 +3,8 @@ var config = require('../../config'),
     models = require(config.paths.corePath + '/server/models'),
     errors = require(config.paths.corePath + '/server/errors'),
     sequence = require(config.paths.corePath + '/server/utils/sequence'),
-    moment = require('moment-timezone');
+    moment = require('moment-timezone'),
+    _ = require('lodash');
 
 /**
  * WHEN access token is created we will update last_login for user.
@@ -23,49 +24,57 @@ events.on('token.added', function (tokenModel) {
 events.on('settings.activeTimezone.edited', function (settingModel) {
     var newTimezone = settingModel.attributes.value,
         previousTimezone = settingModel._updatedAttributes.value,
-        timezoneOffsetDiff = moment.tz(newTimezone).utcOffset() - moment.tz(previousTimezone).utcOffset();
+        timezoneOffsetDiff = moment.tz(newTimezone).utcOffset() - moment.tz(previousTimezone).utcOffset(),
+        options = {context: {internal: true}};
 
     // CASE: TZ was updated, but did not change
     if (previousTimezone === newTimezone) {
         return;
     }
 
-    models.Post.findAll({filter: 'status:scheduled', context: {internal: true}})
-        .then(function (results) {
-            if (!results.length) {
-                return;
-            }
+    return models.Base.transaction(function (transacting) {
+        options.transacting = transacting;
 
-            return sequence(results.map(function (post) {
-                return function reschedulePostIfPossible() {
-                    var newPublishedAtMoment = moment(post.get('published_at')).add(timezoneOffsetDiff, 'minutes');
+        // CASE: signalise that two operations will happen (fetch for update)
+        options.forUpdate = true;
 
-                    /**
-                     * CASE:
-                     *   - your configured TZ is GMT+01:00
-                     *   - now is 10AM +01:00 (9AM UTC)
-                     *   - your post should be published 8PM +01:00 (7PM UTC)
-                     *   - you reconfigure your blog TZ to GMT+08:00
-                     *   - now is 5PM +08:00 (9AM UTC)
-                     *   - if we don't change the published_at, 7PM + 8 hours === next day 5AM
-                     *   - so we update published_at to 7PM - 480minutes === 11AM UTC
-                     *   - 11AM UTC === 7PM +08:00
-                     */
-                    if (newPublishedAtMoment.isBefore(moment().add(5, 'minutes'))) {
-                        post.set('status', 'draft');
-                    } else {
-                        post.set('published_at', newPublishedAtMoment.toDate());
-                    }
-
-                    return models.Post.edit(post.toJSON(), {id: post.id, context: {internal: true}}).reflect();
-                };
-            })).each(function (result) {
-                if (!result.isFulfilled()) {
-                    errors.logError(result.reason());
+        return models.Post.findAll(_.merge({filter: 'status:scheduled'}, options))
+            .then(function (results) {
+                if (!results.length) {
+                    return;
                 }
+
+                return sequence(results.map(function (post) {
+                    return function reschedulePostIfPossible() {
+                        var newPublishedAtMoment = moment(post.get('published_at')).add(timezoneOffsetDiff, 'minutes');
+
+                        /**
+                         * CASE:
+                         *   - your configured TZ is GMT+01:00
+                         *   - now is 10AM +01:00 (9AM UTC)
+                         *   - your post should be published 8PM +01:00 (7PM UTC)
+                         *   - you reconfigure your blog TZ to GMT+08:00
+                         *   - now is 5PM +08:00 (9AM UTC)
+                         *   - if we don't change the published_at, 7PM + 8 hours === next day 5AM
+                         *   - so we update published_at to 7PM - 480minutes === 11AM UTC
+                         *   - 11AM UTC === 7PM +08:00
+                         */
+                        if (newPublishedAtMoment.isBefore(moment().add(5, 'minutes'))) {
+                            post.set('status', 'draft');
+                        } else {
+                            post.set('published_at', newPublishedAtMoment.toDate());
+                        }
+
+                        return models.Post.edit(post.toJSON(), _.merge({id: post.id}, options)).reflect();
+                    };
+                })).each(function (result) {
+                    if (!result.isFulfilled()) {
+                        errors.logError(result.reason());
+                    }
+                });
+            })
+            .catch(function (err) {
+                errors.logError(err);
             });
-        })
-        .catch(function (err) {
-            errors.logError(err);
-        });
+    });
 });

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -9,15 +9,19 @@ module.exports = function (Bookshelf) {
 
     Model = Bookshelf.Model.extend({
         /**
-         * Collision protection.
+         * Update collision protection.
          *
-         * NOTE: The `sync` method is called for any query e.g. update, add, delete, fetch
+         * IMPORTANT NOTES:
+         * The `sync` method is called for any query e.g. update, add, delete, fetch
          *
-         * NOTE: We had the option to override Bookshelf's `save` method, but hooking into the `sync` method gives us
-         *       the ability to access the `changed` object. Bookshelf already knows which attributes has changed.
+         * We had the option to override Bookshelf's `save` method, but hooking into the `sync` method gives us
+         * the ability to access the `changed` object. Bookshelf already knows which attributes has changed.
          *
-         * NOTE: Bookshelf's timestamp function can't be overridden, as it's synchronous, there is no way to return an Error.
+         * Bookshelf's timestamp function can't be overridden, as it's synchronous, there is no way to return an Error.
          *
+         * If we want to enable the collision plugin for other tables, the queries might need to run in a transaction.
+         * This depends on if we fetch the model before editing. Imagine two concurrent requests come in, both would fetch
+         * the same current database values and both would succeed to update and override each other.
          */
         sync: function timestamp(options) {
             var parentSync = ParentModel.prototype.sync.apply(this, arguments),
@@ -39,11 +43,10 @@ module.exports = function (Bookshelf) {
              * Because you can't change the `id` of an existing post.
              *
              * HTML is always auto generated, ignore.
-             * @TODO: how to detect TAGS?
              */
             parentSync.update = function update(attrs) {
                 var changed = _.omit(self.changed, [
-                        'created_at', 'updated_at', 'author_id', 'id', 'tags',
+                        'created_at', 'updated_at', 'author_id', 'id',
                         'published_by', 'updated_by', 'html'
                     ]),
                     clientUpdatedAt = moment(self.clientData.updated_at || self.serverData.updated_at),

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -28,6 +28,7 @@ module.exports = function (Bookshelf) {
                 originalUpdateSync = parentSync.update,
                 self = this, err;
 
+            // CASE: only enabled for posts table
             if (this.tableName !== 'posts' ||
                 !self.serverData ||
                 ((options.method !== 'update' && options.method !== 'patch') || !options.method)
@@ -69,7 +70,8 @@ module.exports = function (Bookshelf) {
         /**
          * We have to remember current server data and client data.
          * The `sync` method has no access to it.
-         * `updated_at` is already set to "Date.now" when sync.update is called.
+         * `updated_at` is already set to "Date.now" when the overridden `sync.update` is called.
+         * See https://github.com/tgriesser/bookshelf/blob/79c526870e618748caf94e7476a0bc796ee090a6/src/model.js#L955
          */
         save: function save(data) {
             this.clientData = _.cloneDeep(data) || {};

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -54,8 +54,7 @@ module.exports = function (Bookshelf) {
 
                 if (Object.keys(changed).length) {
                     if (clientUpdatedAt.diff(serverUpdatedAt) !== 0) {
-                        err = new errors.InternalServerError('Uh-oh. We already have a newer version of this post saved.' +
-                            'To prevent losing your text, please copy your changes somewhere else and then refresh this page.');
+                        err = new errors.InternalServerError('Saving failed! Someone else is editing this post.');
                         err.code = 'UPDATE_COLLISION';
                         return Promise.reject(err);
                     }

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -44,7 +44,7 @@ module.exports = function (Bookshelf) {
              *
              * HTML is always auto generated, ignore.
              */
-            parentSync.update = function update(attrs) {
+            parentSync.update = function update() {
                 var changed = _.omit(self.changed, [
                         'created_at', 'updated_at', 'author_id', 'id',
                         'published_by', 'updated_by', 'html'
@@ -67,13 +67,12 @@ module.exports = function (Bookshelf) {
             return parentSync;
         },
 
-
         /**
          * We have to remember current server data and client data.
          * The `sync` method has no access to it.
          * `updated_at` is already set to "Date.now" when sync.update is called.
          */
-        save: function save(data, options) {
+        save: function save(data) {
             this.clientData = _.cloneDeep(data) || {};
             this.serverData = _.cloneDeep(this.attributes);
 

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -1,0 +1,82 @@
+var moment = require('moment-timezone'),
+    Promise = require('bluebird'),
+    _ = require('lodash'),
+    errors = require('../../errors');
+
+module.exports = function (Bookshelf) {
+    var ParentModel = Bookshelf.Model,
+        Model;
+
+    Model = Bookshelf.Model.extend({
+        /**
+         * Collision protection.
+         *
+         * NOTE: The `sync` method is called for any query e.g. update, add, delete, fetch
+         *
+         * NOTE: We had the option to override Bookshelf's `save` method, but hooking into the `sync` method gives us
+         *       the ability to access the `changed` object. Bookshelf already knows which attributes has changed.
+         *
+         * NOTE: Bookshelf's timestamp function can't be overridden, as it's synchronous, there is no way to return an Error.
+         *
+         */
+        sync: function timestamp(options) {
+            var parentSync = ParentModel.prototype.sync.apply(this, arguments),
+                originalUpdateSync = parentSync.update,
+                self = this, err;
+
+            if (this.tableName !== 'posts' ||
+                !self.serverData ||
+                ((options.method !== 'update' && options.method !== 'patch') || !options.method)
+            ) {
+                return parentSync;
+            }
+
+            /**
+             * Only hook into the update sync
+             *
+             * IMPORTANT NOTES:
+             * Even if the client sends a different `id` property, it get's ignored by bookshelf.
+             * Because you can't change the `id` of an existing post.
+             *
+             * HTML is always auto generated, ignore.
+             * @TODO: how to detect TAGS?
+             */
+            parentSync.update = function update(attrs) {
+                var changed = _.omit(self.changed, [
+                        'created_at', 'updated_at', 'author_id', 'id', 'tags',
+                        'published_by', 'updated_by', 'html'
+                    ]),
+                    clientUpdatedAt = moment(self.clientData.updated_at || self.serverData.updated_at),
+                    serverUpdatedAt = moment(self.serverData.updated_at);
+
+                if (Object.keys(changed).length) {
+                    if (clientUpdatedAt.diff(serverUpdatedAt) !== 0) {
+                        err = new errors.InternalServerError('Uh-oh. We already have a newer version of this post saved.' +
+                            'To prevent losing your text, please copy your changes somewhere else and then refresh this page.');
+                        err.code = 'UPDATE_COLLISION';
+                        return Promise.reject(err);
+                    }
+                }
+
+                return originalUpdateSync.apply(this, arguments);
+            };
+
+            return parentSync;
+        },
+
+
+        /**
+         * We have to remember current server data and client data.
+         * The `sync` method has no access to it.
+         * `updated_at` is already set to "Date.now" when sync.update is called.
+         */
+        save: function save(data, options) {
+            this.clientData = _.cloneDeep(data) || {};
+            this.serverData = _.cloneDeep(this.attributes);
+
+            return ParentModel.prototype.save.apply(this, arguments);
+        }
+    });
+
+    Bookshelf.Model = Model;
+};

--- a/core/server/models/plugins/index.js
+++ b/core/server/models/plugins/index.js
@@ -2,5 +2,6 @@ module.exports = {
     accessRules: require('./access-rules'),
     filter: require('./filter'),
     includeCount: require('./include-count'),
-    pagination: require('./pagination')
+    pagination: require('./pagination'),
+    collision: require('./collision')
 };

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -35,8 +35,6 @@ Post = ghostBookshelf.Model.extend({
     },
 
     initialize: function initialize() {
-        var self = this;
-
         ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
 
         /**
@@ -170,7 +168,7 @@ Post = ghostBookshelf.Model.extend({
             tagsToCheck = this.get('tags'),
             publishedAt = this.get('published_at'),
             publishedAtHasChanged = this.hasDateChanged('published_at', {beforeWrite: true}),
-            tags = [];
+            tags = [], ops = [];
 
         // CASE: disallow published -> scheduled
         // @TODO: remove when we have versioning based on updated_at
@@ -244,8 +242,6 @@ Post = ghostBookshelf.Model.extend({
                 this.set('published_by', this.previous('published_by'));
             }
         }
-
-        var ops = [];
 
         /**
          * - updateTags happens before the post is saved to the database

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -39,14 +39,10 @@ Post = ghostBookshelf.Model.extend({
 
         ghostBookshelf.Model.prototype.initialize.apply(this, arguments);
 
-        this.on('saved', function onSaved(model, response, options) {
-            return self.updateTags(model, response, options);
-        });
-
         /**
          * - is called before onSaved
          */
-        this.on('created', function onCreated(model) {
+        this.on('created', function onCreated(model, response, options) {
             var status = model.get('status');
 
             model.emitChange('added');
@@ -54,6 +50,8 @@ Post = ghostBookshelf.Model.extend({
             if (['published', 'scheduled'].indexOf(status) !== -1) {
                 model.emitChange(status);
             }
+
+            return this.updateTags(model, response, options);
         });
 
         this.on('updated', function onUpdated(model) {
@@ -216,6 +214,7 @@ Post = ghostBookshelf.Model.extend({
             });
 
             // keep tags for 'saved' event
+            // get('tags') will be removed after saving, because it's not a direct attribute of posts (it's a relation)
             this.tagsToSave = tags;
         }
 
@@ -246,34 +245,57 @@ Post = ghostBookshelf.Model.extend({
             }
         }
 
+        var ops = [];
+
+        /**
+         * - updateTags happens before the post is saved to the database
+         * - when editing a post, it's running in a transaction, see Post.edit
+         * - we are using a update collision detection, we have to know if tags were updated in the client
+         *
+         * NOTE: For adding a post, updateTags happens after the post insert
+         */
+        if (options.method === 'update' || options.method === 'patch') {
+            ops.push(function updateTags() {
+                return self.updateTags(model, attr, options);
+            });
+        }
+
         // If a title is set, not the same as the old title, a draft post, and has never been published
         if (prevTitle !== undefined && newTitle !== prevTitle && newStatus === 'draft' && !publishedAt) {
-            // Pass the new slug through the generator to strip illegal characters, detect duplicates
-            return ghostBookshelf.Model.generateSlug(Post, this.get('title'),
-                    {status: 'all', transacting: options.transacting, importing: options.importing})
-                .then(function then(slug) {
-                    // After the new slug is found, do another generate for the old title to compare it to the old slug
-                    return ghostBookshelf.Model.generateSlug(Post, prevTitle,
-                        {status: 'all', transacting: options.transacting, importing: options.importing}
-                    ).then(function then(prevTitleSlug) {
-                        // If the old slug is the same as the slug that was generated from the old title
-                        // then set a new slug. If it is not the same, means was set by the user
-                        if (prevTitleSlug === prevSlug) {
-                            self.set({slug: slug});
-                        }
-                    });
-                });
-        } else {
-            // If any of the attributes above were false, set initial slug and check to see if slug was changed by the user
-            if (this.hasChanged('slug') || !this.get('slug')) {
+            ops.push(function updateSlug() {
                 // Pass the new slug through the generator to strip illegal characters, detect duplicates
-                return ghostBookshelf.Model.generateSlug(Post, this.get('slug') || this.get('title'),
-                        {status: 'all', transacting: options.transacting, importing: options.importing})
+                return ghostBookshelf.Model.generateSlug(Post, self.get('title'),
+                    {status: 'all', transacting: options.transacting, importing: options.importing})
                     .then(function then(slug) {
-                        self.set({slug: slug});
+                        // After the new slug is found, do another generate for the old title to compare it to the old slug
+                        return ghostBookshelf.Model.generateSlug(Post, prevTitle,
+                            {status: 'all', transacting: options.transacting, importing: options.importing}
+                        ).then(function then(prevTitleSlug) {
+                            // If the old slug is the same as the slug that was generated from the old title
+                            // then set a new slug. If it is not the same, means was set by the user
+                            if (prevTitleSlug === prevSlug) {
+                                self.set({slug: slug});
+                            }
+                        });
                     });
-            }
+            });
+        } else {
+            ops.push(function updateSlug() {
+                // If any of the attributes above were false, set initial slug and check to see if slug was changed by the user
+                if (self.hasChanged('slug') || !self.get('slug')) {
+                    // Pass the new slug through the generator to strip illegal characters, detect duplicates
+                    return ghostBookshelf.Model.generateSlug(Post, self.get('slug') || self.get('title'),
+                        {status: 'all', transacting: options.transacting, importing: options.importing})
+                        .then(function then(slug) {
+                            self.set({slug: slug});
+                        });
+                }
+
+                return Promise.resolve();
+            });
         }
+
+        return sequence(ops);
     },
 
     creating: function creating(model, attr, options) {
@@ -317,7 +339,9 @@ Post = ghostBookshelf.Model.extend({
                     tagsToRemove,
                     tagsToCreate;
 
+                // CASE: if nothing has changed, unset `tags`.
                 if (baseUtils.tagUpdate.tagSetsAreEqual(newTags, currentTags)) {
+                    savedModel.unset('tags');
                     return;
                 }
 

--- a/core/test/integration/api/api_schedules_spec.js
+++ b/core/test/integration/api/api_schedules_spec.js
@@ -2,12 +2,14 @@
 var should = require('should'),
     moment = require('moment'),
     Promise = require('bluebird'),
+    sinon = require('sinon'),
     testUtils = require('../../utils'),
     config = require(__dirname + '/../../../server/config'),
     sequence = require(config.paths.corePath + '/server/utils/sequence'),
     errors = require(config.paths.corePath + '/server/errors'),
     api = require(config.paths.corePath + '/server/api'),
-    models = require(config.paths.corePath + '/server/models');
+    models = require(config.paths.corePath + '/server/models'),
+    sandbox = sinon.sandbox.create();
 
 describe('Schedules API', function () {
     var scope = {posts: []};
@@ -192,6 +194,10 @@ describe('Schedules API', function () {
             config.times.cannotScheduleAPostBeforeInMinutes = originalCannotScheduleAPostBeforeInMinutes;
         });
 
+        afterEach(function () {
+            sandbox.restore();
+        });
+
         describe('success', function () {
             beforeEach(function (done) {
                 scope.posts.push(testUtils.DataGenerator.forKnex.createPost({
@@ -200,6 +206,7 @@ describe('Schedules API', function () {
                     published_by: testUtils.users.ids.author,
                     published_at: moment().toDate(),
                     status: 'scheduled',
+                    title: 'title',
                     slug: 'first'
                 }));
 
@@ -278,6 +285,50 @@ describe('Schedules API', function () {
                         result.posts[0].id.should.eql(4);
                         result.posts[0].status.should.eql('published');
                         done();
+                    })
+                    .catch(done);
+            });
+
+            it('collision protection', function (done) {
+                var originalPostApi = api.posts.edit,
+                    postId = 1, // postId 1 is status=scheduled!
+                    requestCanComeIn = false,
+                    interval;
+
+                // this request get's blocked
+                interval = setInterval(function () {
+                    if (requestCanComeIn) {
+                        clearInterval(interval);
+
+                        // happens in a transaction, request has to wait until the scheduler api finished
+                        return models.Post.edit({title: 'Berlin'}, {id: postId, context: {internal: true}})
+                            .then(function (post) {
+                                post.id.should.eql(postId);
+                                post.get('status').should.eql('published');
+                                post.get('title').should.eql('Berlin');
+                                done();
+                            })
+                            .catch(done);
+                    }
+                }, 500);
+
+                // target post to publish was read already, simulate a client request
+                sandbox.stub(api.posts, 'edit', function () {
+                    var self = this,
+                        args = arguments;
+
+                    requestCanComeIn = true;
+                    return Promise.delay(2000)
+                        .then(function () {
+                            return originalPostApi.apply(self, args);
+                        });
+                });
+
+                api.schedules.publishPost({id: postId, context: {client: 'ghost-scheduler'}})
+                    .then(function (result) {
+                        result.posts[0].id.should.eql(postId);
+                        result.posts[0].status.should.eql('published');
+                        result.posts[0].title.should.eql('title');
                     })
                     .catch(done);
             });

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1405,6 +1405,46 @@ describe('Post Model', function () {
                     });
             });
 
+            it('update post tags and updated_at is out of sync', function (done) {
+                var postToUpdate = {id: 2};
+
+                PostModel.findOne({id: postToUpdate.id, status: 'all'})
+                    .then(function () {
+                        return Promise.delay(1000);
+                    })
+                    .then(function () {
+                        return PostModel.edit({
+                            tags: [{name: 'new-tag-1'}],
+                            updated_at: moment().subtract(1, 'day').format()
+                        }, _.extend({}, context, {id: postToUpdate.id}));
+                    })
+                    .then(function () {
+                        done(new Error('expected no success'));
+                    })
+                    .catch(function (err) {
+                        err.code.should.eql('UPDATE_COLLISION');
+                        done();
+                    });
+            });
+
+            it('update post tags and updated_at is not out of sync', function (done) {
+                var postToUpdate = {id: 2};
+
+                PostModel.findOne({id: postToUpdate.id, status: 'all'})
+                    .then(function () {
+                        return Promise.delay(1000);
+                    })
+                    .then(function () {
+                        return PostModel.edit({
+                            tags: [{name: 'new-tag-1'}]
+                        }, _.extend({}, context, {id: postToUpdate.id}));
+                    })
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
             it('update post with no changes, but updated_at is out of sync', function (done) {
                 var postToUpdate = {id: 2};
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1381,6 +1381,67 @@ describe('Post Model', function () {
                 }).catch(done);
             });
         });
+
+        describe('Collision Protection', function () {
+            it('update post title, but updated_at is out of sync', function (done) {
+                var postToUpdate = {id: 2};
+
+                PostModel.findOne({id: postToUpdate.id, status: 'all'})
+                    .then(function () {
+                        return Promise.delay(1000);
+                    })
+                    .then(function () {
+                        return PostModel.edit({
+                            title: 'New Post Title',
+                            updated_at: moment().subtract(1, 'day').format()
+                        }, _.extend({}, context, {id: postToUpdate.id}));
+                    })
+                    .then(function () {
+                        done(new Error('expected no success'));
+                    })
+                    .catch(function (err) {
+                        err.code.should.eql('UPDATE_COLLISION');
+                        done();
+                    });
+            });
+
+            it('update post with no changes, but updated_at is out of sync', function (done) {
+                var postToUpdate = {id: 2};
+
+                PostModel.findOne({id: postToUpdate.id, status: 'all'})
+                    .then(function () {
+                        return Promise.delay(1000);
+                    })
+                    .then(function () {
+                        return PostModel.edit({
+                            updated_at: moment().subtract(1, 'day').format()
+                        }, _.extend({}, context, {id: postToUpdate.id}));
+                    })
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
+            it('update post with old post title, but updated_at is out of sync', function (done) {
+                var postToUpdate = {id: 2, title: testUtils.DataGenerator.forModel.posts[1].title};
+
+                PostModel.findOne({id: postToUpdate.id, status: 'all'})
+                    .then(function () {
+                        return Promise.delay(1000);
+                    })
+                    .then(function () {
+                        return PostModel.edit({
+                            title: postToUpdate.title,
+                            updated_at: moment().subtract(1, 'day').format()
+                        }, _.extend({}, context, {id: postToUpdate.id}));
+                    })
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+        });
     });
 
     describe('Multiauthor Posts', function () {


### PR DESCRIPTION
closes #5599

If two users edit the same post, it can happen that they override each others content or post settings. With this PR this won't happen anymore.
This PR can detect post changes and tag changes and if a collision is detected, the user will receive an error back. Each commit should be clear and has enough context to understand the required changes. Some tests i have added are quite complex because they simulate collision cases we have to care about. These tests are not sooo good to read. But can't change this, because they simulate a complex use case. You will see if you go through the commits.

**What i didn't test is the rest of the functionality in Ghost. Will do before we release the new LTS version**.

- [x] test on postgres
- [x] test on node 6
- [x] more comments?
- [x] go over code pieces where we use find and edit together
- [x] add more context to the commits
- [x] ensure client receives error code
- [x] tested with `1.0` - have a branch for it as well
- [x] tested with Ghost Desktop
- [x] add more tests?
- [x] Ghost-Admin: don't auto save if user isn't actively changing anything, see #8331 
- [x] optimise 1-2 comments
- [x] make another project search for editing posts