### PR TITLE
🚑  Disable remote authentication

### DIFF
--- a/core/server/auth/validation.js
+++ b/core/server/auth/validation.js
@@ -6,9 +6,20 @@ var Promise = require('bluebird'),
  * If the setup is completed and...
  * 1. the public client does exist, deny to switch to local
  * 2. the public client does not exist, deny to switch to remote
+ *
+ * See https://github.com/TryGhost/Ghost/issues/8342
+ * Remote authentication is disabled right now.
  */
-exports.switch = function validate(options) {
+exports.validate = function validate(options) {
     var authType = options.authType;
+
+    if (authType === 'ghost') {
+        return Promise.reject(new errors.InternalServerError({
+            code: 'AUTH_TYPE',
+            message: 'Ghost doesn\'t support remote authentication at the moment.',
+            help: 'Set `auth.type` to "password".'
+        }));
+    }
 
     return models.User.isSetup()
         .then(function (isSetup) {

--- a/core/server/config/env/config.production.json
+++ b/core/server/config/env/config.production.json
@@ -10,8 +10,7 @@
         }
     },
     "auth": {
-        "type": "ghost",
-        "url": "https://auth.ghost.org"
+        "type": "password"
     },
     "paths": {
         "contentPath": "content/"

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -73,7 +73,7 @@ function init() {
 
         debug('Express Apps done');
     }).then(function () {
-        return auth.validation.switch({
+        return auth.validation.validate({
             authType: config.get('auth:type')
         });
     }).then(function () {

--- a/core/test/unit/auth/validation_spec.js
+++ b/core/test/unit/auth/validation_spec.js
@@ -6,6 +6,11 @@ var should = require('should'),
 
     sandbox = sinon.sandbox.create();
 
+/**
+ * See https://github.com/TryGhost/Ghost/issues/8342
+ * We have disabled Ghost authentication temporary.
+ * That's why some tests are skipped for now.
+ */
 describe('UNIT: auth validation', function () {
     before(function () {
         models.init();
@@ -16,28 +21,37 @@ describe('UNIT: auth validation', function () {
     });
 
     describe('ghost is enabled', function () {
-        it('[success]', function () {
+        it('[failure]', function () {
+            return auth.validation.validate({
+                authType: 'ghost'
+            }).catch(function (err) {
+                should.exist(err);
+                err.code.should.eql('AUTH_TYPE');
+            });
+        });
+
+        it.skip('[success]', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(false));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'ghost'
             });
         });
 
-        it('[success]', function () {
+        it.skip('[success]', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
             sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'ghost'
             });
         });
 
-        it('[failure]', function () {
+        it.skip('[failure]', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
             sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'password'
             }).catch(function (err) {
                 should.exist(err);
@@ -50,7 +64,7 @@ describe('UNIT: auth validation', function () {
         it('[success]', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(false));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'password'
             });
         });
@@ -59,16 +73,16 @@ describe('UNIT: auth validation', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
             sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(false));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'password'
             });
         });
 
-        it('[failure]', function () {
+        it.skip('[failure]', function () {
             sandbox.stub(models.User, 'isSetup').returns(Promise.resolve(true));
             sandbox.stub(models.Client, 'findOne').returns(Promise.resolve(true));
 
-            return auth.validation.switch({
+            return auth.validation.validate({
                 authType: 'ghost'
             }).catch(function (err) {
                 should.exist(err);


### PR DESCRIPTION
closes #8342

- extend auth validation to deny auth type "ghost" for now
- skip some tests
- make "password" mode default

- [x] make a functional test with password mode to ensure we won't break master heavily
- [x] go over code again and check if there are more changes required