### PR TITLE
Revert: Update bookshelf to version 0.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bcryptjs": "2.4.3",
     "bluebird": "3.5.0",
     "body-parser": "1.17.0",
-    "bookshelf": "0.10.3",
+    "bookshelf": "0.10.2",
     "chalk": "1.1.3",
     "cheerio": "0.22.0",
     "compression": "1.6.2",


### PR DESCRIPTION
no issue

- reverting to `0.10.2`
- i've got build errors for the bookshelf npm postinstall hook on a fresh machine
- see https://github.com/tgriesser/bookshelf/issues/1555

I won't revert bookshelf on master. Will look into a fix or wait for a fix.
Will care for the next Monday release.