### PR TITLE
Allow to migrate initial database without active theme

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -130,7 +130,7 @@ validateSettings = function validateSettings(defaultSettings, model) {
     return Promise.resolve();
 };
 
-validateActiveTheme = function validateActiveTheme(themeName) {
+validateActiveTheme = function validateActiveTheme(themeName, options) {
     // If Ghost is running and its availableThemes collection exists
     // give it priority.
     if (config.paths.availableThemes && Object.keys(config.paths.availableThemes).length > 0) {
@@ -145,9 +145,15 @@ validateActiveTheme = function validateActiveTheme(themeName) {
     }
 
     return availableThemes.then(function then(themes) {
-        if (!themes.hasOwnProperty(themeName)) {
-            return Promise.reject(new errors.ValidationError(i18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}), 'activeTheme'));
+        if (themes.hasOwnProperty(themeName)) {
+            return;
         }
+
+        if (options && options.showWarning) {
+            errors.logWarn(i18n.t('errors.middleware.themehandler.missingTheme', {theme: themeName}));
+            return;
+        }
+        return Promise.reject(new errors.ValidationError(i18n.t('notices.data.validation.index.themeCannotBeActivated', {themeName: themeName}), 'activeTheme'));
     });
 };
 

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -85,7 +85,7 @@ Settings = ghostBookshelf.Model.extend({
                 return;
             }
 
-            return validation.validateActiveTheme(themeName);
+            return validation.validateActiveTheme(themeName, {showWarning: model.isNew()});
         });
     }
 }, {

--- a/core/test/unit/server_helpers/is_spec.js
+++ b/core/test/unit/server_helpers/is_spec.js
@@ -6,11 +6,17 @@ var should         = require('should'),
 // Stuff we are testing
     handlebars     = hbs.handlebars,
     helpers        = require('../../../server/helpers'),
-    errors         = require('../../../server/errors');
+    errors         = require('../../../server/errors'),
+
+    sandbox        = sinon.sandbox.create();
 
 describe('{{#is}} helper', function () {
     before(function () {
         utils.loadHelpers();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
     });
 
     it('has loaded is block helper', function () {
@@ -19,8 +25,8 @@ describe('{{#is}} helper', function () {
 
     // All positive tests
     it('should match single context "index"', function () {
-        var fn = sinon.spy(),
-            inverse = sinon.spy();
+        var fn = sandbox.spy(),
+            inverse = sandbox.spy();
 
         helpers.is.call(
             {},
@@ -33,8 +39,8 @@ describe('{{#is}} helper', function () {
     });
 
     it('should match OR context "index, paged"', function () {
-        var fn = sinon.spy(),
-            inverse = sinon.spy();
+        var fn = sandbox.spy(),
+            inverse = sandbox.spy();
 
         helpers.is.call(
             {},
@@ -47,8 +53,8 @@ describe('{{#is}} helper', function () {
     });
 
     it('should not match "paged"', function () {
-        var fn = sinon.spy(),
-            inverse = sinon.spy();
+        var fn = sandbox.spy(),
+            inverse = sandbox.spy();
 
         helpers.is.call(
             {},
@@ -61,9 +67,9 @@ describe('{{#is}} helper', function () {
     });
 
     it('should log warning with no args', function () {
-        var fn = sinon.spy(),
-            inverse = sinon.spy(),
-            logWarn = sinon.stub(errors, 'logWarn');
+        var fn = sandbox.spy(),
+            inverse = sandbox.spy(),
+            logWarn = sandbox.stub(errors, 'logWarn');
 
         helpers.is.call(
             {},


### PR DESCRIPTION
It is possible to use Ghost without an active theme. The front page
renders an error and we can set a new active theme with the admin panel.
However, it was impossible to migrate a fresh database without active theme folder
in place.

In this commit we introduce `showWarning` option for validation function.
When it is set to true, then validation displays warning instead of
rejecting active theme in case it is missing. Validation works as before
when that option is set to false or omitted.

It's somehow related to #4866

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [x] The build will pass (run `npm test`).

More info can be found by clicking the "guidelines for contributing" link above.
