### PR TITLE
🎨  optimise error handling

### DIFF
--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -80,6 +80,7 @@ _private.prepareError = function prepareError(err, req, res, next) {
         } else {
             err = new errors.GhostError({
                 err: err,
+                message: err.message,
                 statusCode: err.statusCode
             });
         }

--- a/core/server/themes/index.js
+++ b/core/server/themes/index.js
@@ -39,9 +39,12 @@ module.exports = {
                         debug('Activating theme (method A on boot)', activeThemeName);
                         self.activate(theme, checkedTheme);
                     })
-                    .catch(function () {
+                    .catch(function (err) {
                         // Active theme is not valid, we don't want to exit because the admin panel will still work
-                        logging.warn(i18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}));
+                        logging.error(new errors.InternalServerError({
+                            message: i18n.t('errors.middleware.themehandler.invalidTheme', {theme: activeThemeName}),
+                            err: err
+                        }));
                     });
             })
             .catch(function () {


### PR DESCRIPTION
no issue

- if you start Ghost and your theme is invalid, you only get a warning, but no reason -> i had several cases where this wasn't very useful
- furthermore, if any error is thrown in Ghost, which is not a custom Ignition error, we take care that the error message to inherit from shows up -> e.g. you add an unknown handlebars helper in your theme -> the error comes from handlebars --> the message must show up in the frontend

With #8377 even error details are displayed pretty.
