### PR TITLE
🐛  collision: fix updated_at is null

### DIFF
--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -50,8 +50,8 @@ module.exports = function (Bookshelf) {
                         'created_at', 'updated_at', 'author_id', 'id',
                         'published_by', 'updated_by', 'html', 'plaintext'
                     ]),
-                    clientUpdatedAt = moment(self.clientData.updated_at || self.serverData.updated_at),
-                    serverUpdatedAt = moment(self.serverData.updated_at);
+                    clientUpdatedAt = moment(self.clientData.updated_at || self.serverData.updated_at || new Date()),
+                    serverUpdatedAt = moment(self.serverData.updated_at || clientUpdatedAt);
 
                 if (Object.keys(changed).length) {
                     if (clientUpdatedAt.diff(serverUpdatedAt) !== 0) {


### PR DESCRIPTION
closes #8426

- if you import posts with updated_at=null, you are not able to save this post anymore
- i am not sure how this is even possible, but maybe there is a case where updated_at can be null
