### PR TITLE
update default post to use a single markdown card

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -6,7 +6,7 @@
                 {
                     "title": "Welcome to Ghost",
                     "slug": "welcome-to-ghost",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"atoms\":[],\"cards\":[],\"markups\":[],\"sections\":[[1,\"p\",[[0,[],0,\"Click here to learn more about our all-new editor and improved admin panel 📖 ➡️\"]]],[1,\"p\",[[0,[],0,\"This post is a placeholder for brand new content that is coming soon...\"]]]]}",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Click here to learn more about our all-new editor and improved admin panel 📖 ➡️\\n\\nThis post is a placeholder for brand new content that is coming soon...\"}]],\"sections\":[[10,0]]}",
                     "image": null,
                     "featured": false,
                     "page": false,

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ var should = require('should'), // jshint ignore:line
 describe('DB version integrity', function () {
     // Only these variables should need updating
     var currentSchemaHash = '0d3a45d3db7f7ae6effb654621ca8ab5',
-        currentFixturesHash = 'ad12de59b939b13dc198611a6438ab51';
+        currentFixturesHash = '164fb8790b01943caa73846a5fdf8644';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
no issue
- now that we've switched to using a SimpleMDE based editor in Ghost-Admin the default post needs to match the expected single-markdown-card format