### PR TITLE
🐛  escape blog title for mail header

### DIFF
--- a/core/server/mail/GhostMailer.js
+++ b/core/server/mail/GhostMailer.js
@@ -30,7 +30,7 @@ GhostMailer.prototype.from = function () {
 
     // If we do have a from address, and it's just an email
     if (validator.isEmail(from)) {
-        defaultBlogTitle = config.theme.title ? config.theme.title : i18n.t('common.mail.title', {domain: this.getDomain()});
+        defaultBlogTitle = config.theme.title ? config.theme.title.replace(/"/g, '\\"') : i18n.t('common.mail.title', {domain: this.getDomain()});
 
         from = '"' + defaultBlogTitle + '" <' + from + '>';
     }

--- a/core/test/unit/mail/GhostMailer_spec.js
+++ b/core/test/unit/mail/GhostMailer_spec.js
@@ -191,6 +191,10 @@ describe('Mail: Ghostmailer', function () {
             // Strip Port
             configUtils.set({url: 'http://default.com:2368/', mail: {from: null}, theme: {title: 'Test'}});
             mailer.from().should.equal('"Test" <ghost@default.com>');
+
+            // Escape title
+            configUtils.set({url: 'http://default.com:2368/', mail: {from: null}, theme: {title: 'Test"'}});
+            mailer.from().should.equal('"Test\\"" <ghost@default.com>');
         });
 
         it('should use mail.from if both from and fromaddress are present', function () {


### PR DESCRIPTION
closes #8436

- this is how the from field looks like "blog title \<owner@blog.com\>"
- so if you set your blog title with double quotes, it throws a syntax error from the smpt library

**We have to pull this bug fix into master**