### PR TITLE
🐛  ensure import of scheduled posts works

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -212,7 +212,11 @@ Post = ghostBookshelf.Model.extend({
                     i18n.t('errors.models.post.valueCannotBeBlank', {key: 'published_at'})
                 ));
             // CASE: to schedule/reschedule a post, a minimum diff of x minutes is needed (default configured is 2minutes)
-            } else if (publishedAtHasChanged && moment(publishedAt).isBefore(moment().add(config.times.cannotScheduleAPostBeforeInMinutes, 'minutes'))) {
+            } else if (
+                publishedAtHasChanged &&
+                moment(publishedAt).isBefore(moment().add(config.times.cannotScheduleAPostBeforeInMinutes, 'minutes')) &&
+                !options.importing
+            ) {
                 return Promise.reject(new errors.ValidationError(
                     i18n.t('errors.models.post.expectedPublishedAtInFuture', {
                         cannotScheduleAPostBeforeInMinutes: config.times.cannotScheduleAPostBeforeInMinutes

--- a/core/test/integration/import_spec.js
+++ b/core/test/integration/import_spec.js
@@ -145,8 +145,11 @@ describe('Import', function () {
 
                 // we always have 1 user, the owner user we added
                 users.length.should.equal(1, 'There should only be one user');
+
                 // import no longer requires all data to be dropped, and adds posts
                 posts.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
+                posts[0].status.should.eql('published');
+                posts[1].status.should.eql('scheduled');
 
                 // test settings
                 settings.length.should.be.above(0, 'Wrong number of settings');

--- a/core/test/utils/fixtures/export/export-000.json
+++ b/core/test/utils/fixtures/export/export-000.json
@@ -26,6 +26,28 @@
                 "updated_by": 1,
                 "published_at": 1388318310783,
                 "published_by": 1
+            },
+            {
+                "id": 2,
+                "uuid": "8492fbba-1102-4b53-8e3e-abe207952f0c",
+                "title": "schedule-me",
+                "slug": "schedule-me",
+                "markdown": "You're live! Nice.",
+                "html": "<p>You're live! Nice.</p>",
+                "image": null,
+                "featured": 0,
+                "page": 0,
+                "status": "scheduled",
+                "language": "en_US",
+                "meta_title": null,
+                "meta_description": null,
+                "author_id": 1,
+                "created_at": 1388318310782,
+                "created_by": 1,
+                "updated_at": 1388318310782,
+                "updated_by": 1,
+                "published_at": 1388318310783,
+                "published_by": 1
             }
         ],
         "users": [],


### PR DESCRIPTION
closes #8354

- i thought about transforming scheduled posts into drafts on export, but this has two disadvantages:
  1. existing exports with scheduled posts won't import
  2. if you schedule a post for next week and you export/import earlier, the post is back to draft
- by this we ensure that we can simply import the post back to a scheduled post
- if the published_at is already in the past, the scheduler will care and instantly publish the post