### PR TITLE
[HOLD] 🐛  https image urls if accessed over SSL

### DIFF
--- a/core/server/config/url.js
+++ b/core/server/config/url.js
@@ -188,7 +188,6 @@ function urlFor(context, data, absolute) {
             urlPath = data.image;
             imagePathRe = new RegExp('^' + ghostConfig.paths.subdir + '/' + ghostConfig.paths.imagesRelPath);
             absolute = imagePathRe.test(data.image) ? absolute : false;
-            secure = data.image.secure;
 
             if (absolute) {
                 // Remove the sub-directory from the URL because ghostConfig will add it back.

--- a/core/test/unit/config_spec.js
+++ b/core/test/unit/config_spec.js
@@ -416,6 +416,10 @@ describe('Config', function () {
                 testData = {image: '/blog/content/images/my-image4.jpg'};
                 config.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
                 config.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/content/images/my-image4.jpg');
+
+                testData = {image: '/blog/content/images/my-image4.jpg', secure: true};
+                config.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
+                config.urlFor(testContext, testData, true).should.equal('https://my-ghost-blog.com/blog/content/images/my-image4.jpg');
             });
 
             it('should return a url for a nav item when asked for it', function () {


### PR DESCRIPTION
closes #8372

- https image urls if accessed over SSL (fix secure option for images)

@AileenCGN Could you please double check tomorrow morning?
I am afraid i have overseen a usage or a special hidden behaviour.

Thanks 👋