### PR TITLE
Update fixtures

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -327,8 +327,8 @@
             "entries": [
                 {
                     "id": 1,
-                    "name": "Ghost Owner",
-                    "email": "ghost@ghost.org",
+                    "name": "Ghost",
+                    "email": "ghost@example.com",
                     "status": "inactive",
                     "roles": []
                 }

--- a/core/test/integration/migration_spec.js
+++ b/core/test/integration/migration_spec.js
@@ -203,7 +203,7 @@ describe('Database Migration (special functions)', function () {
                     // User (Owner)
                     should.exist(result.users);
                     result.users.length.should.eql(1);
-                    result.users.at(0).get('name').should.eql('Ghost Owner');
+                    result.users.at(0).get('name').should.eql('Ghost');
                     result.users.at(0).get('status').should.eql('inactive');
                     result.users.at(0).related('roles').length.should.eql(1);
                     result.users.at(0).related('roles').at(0).get('name').should.eql('Owner');

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ var should = require('should'), // jshint ignore:line
 describe('DB version integrity', function () {
     // Only these variables should need updating
     var currentSchemaHash = '0d3a45d3db7f7ae6effb654621ca8ab5',
-        currentFixturesHash = '164fb8790b01943caa73846a5fdf8644';
+        currentFixturesHash = 'ec48af84f206fa377214ed4311ba6dfd';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
- Use a better name for default user pre-setup
- Make it clear that this email address is an example, not real