### PR TITLE
⚡️  Throw clear error message when `config.url` has no protocol

### DIFF
--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -51,8 +51,8 @@ _private.loadNconf = function loadNconf(options) {
     /**
      * Check if the URL in config has a protocol
      */
-    nconf.sanitiseUrlProtocol = localUtils.sanitiseUrlProtocol.bind(nconf);
-    nconf.sanitiseUrlProtocol();
+    nconf.checkUrlProtocol = localUtils.checkUrlProtocol.bind(nconf);
+    nconf.checkUrlProtocol();
 
     /**
      * values we have to set manual

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -49,6 +49,12 @@ _private.loadNconf = function loadNconf(options) {
     nconf.makePathsAbsolute(nconf.get('database:connection'), 'database:connection');
 
     /**
+     * Check if the URL in config has a protocol
+     */
+    nconf.sanitiseUrlProtocol = localUtils.sanitiseUrlProtocol.bind(nconf);
+    nconf.sanitiseUrlProtocol();
+
+    /**
      * values we have to set manual
      */
     nconf.set('env', env);

--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -1,6 +1,5 @@
 var path = require('path'),
-    _ = require('lodash'),
-    chalk = require('chalk');
+    _ = require('lodash');
 
 exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
     if (!this.get('privacy')) {
@@ -72,15 +71,11 @@ exports.getContentPath = function getContentPath(type) {
 /**
 * Check if the URL in config has a protocol and sanitise it if not including a warning that it should be changed
 */
-exports.sanitiseUrlProtocol = function sanitiseUrlProtocol() {
+exports.checkUrlProtocol = function checkUrlProtocol() {
     var url = this.get('url');
 
-    if (url.match(/^https?:\/\//i)) {
-        return;
-    } else {
-        this.set('url', 'http://' + url);
-        console.log(chalk.red('Watch out! Your URL in the config should have a protocol! E.g. "http://my-ghost-blog.com"'));
-        console.log(chalk.white('Current URL: ') + chalk.cyan(url));
+    if (!url.match(/^https?:\/\//i)) {
+        throw new Error('URL in config must be provided with protocol, eg. "http://my-ghost-blog.com"');
     }
 };
 

--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -1,5 +1,6 @@
 var path = require('path'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    chalk = require('chalk');
 
 exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
     if (!this.get('privacy')) {
@@ -65,6 +66,21 @@ exports.getContentPath = function getContentPath(type) {
             return path.join(this.get('paths:contentPath'), 'data/');
         default:
             throw new Error('getContentPath was called with: ' + type);
+    }
+};
+
+/**
+* Check if the URL in config has a protocol and sanitise it if not including a warning that it should be changed
+*/
+exports.sanitiseUrlProtocol = function sanitiseUrlProtocol() {
+    var url = this.get('url');
+
+    if (url.match(/^https?:\/\//i)) {
+        return;
+    } else {
+        this.set('url', 'http://' + url);
+        console.log(chalk.red('Watch out! Your URL in the config should have a protocol! E.g. "http://my-ghost-blog.com"'));
+        console.log(chalk.white('Current URL: ') + chalk.cyan(url));
     }
 };
 


### PR DESCRIPTION
closes #8449

Fixes an issue where Ghost would crash when the URL in `config` is set up without a protocol.
This PR checks the URL on startup within config utils and outputs a warning for the user, but also sanitises the URL to prevent crashes.

Not sure, if this is the wanted behaviour in this case.  We could also prevent Ghost from starting and output a more clear error message instead... Let me know, what you'd prefer @kirrg001 