### PR TITLE
⬆️  bump minimum node version [4.5.0, 6.9.0]

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
   },
   "engines": {
-    "node": "^4.2.0 || ^6.5.0"
+    "node": "^4.5.0 || ^6.9.0"
   },
   "dependencies": {
     "amperize": "0.3.4",


### PR DESCRIPTION
no issue

- the new ember version requires `4.5.0`
- i've also bumped node v6, because of the latest security vulnerability report (see https://nodejs.org/en/blog/vulnerability/october-2016-security-releases/ and https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V6.md#2016-10-18-version-690-boron-lts-rvagg)
  "All of these vulnerabilities are considered low-severity for Node.js users, however, users of Node.js v6.x should upgrade at their earliest convenience."

Even if it does not affect us in theory, i personally feel that we should bump the minimum node version if there are security fixes? 

If you agree, we should also update https://github.com/TryGhost/Ghost-CLI/blob/master/package.json#L36.