### PR TITLE
😝 replace removeSync by sync

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -140,7 +140,7 @@ themes = {
                 // @TODO we should probably do this as part of saving the theme
                 // remove zip upload from multer
                 // happens in background
-                Promise.promisify(fs.removeSync)(zip.path)
+                Promise.promisify(fs.remove)(zip.path)
                     .catch(function (err) {
                         logging.error(new errors.GhostError({err: err}));
                     });
@@ -149,7 +149,7 @@ themes = {
                 // remove extracted dir from gscan
                 // happens in background
                 if (checkedTheme) {
-                    Promise.promisify(fs.removeSync)(checkedTheme.path)
+                    Promise.promisify(fs.remove)(checkedTheme.path)
                         .catch(function (err) {
                             logging.error(new errors.GhostError({err: err}));
                         });


### PR DESCRIPTION
refs #8510

- nothing to see here!

We haven't seen the error before, because `fs-extra` had no protection in previous versions.
I saw an behaviour change in the admin section followed by the none removed theme (upload theme, remove theme, upload again failed). So insta fix.

Affects: LTS!