### PR TITLE
🔥  config: remove print error stack option

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -6,7 +6,6 @@
     },
     "privacy": false,
     "useMinFiles": true,
-    "printErrorStack": false,
     "paths": {
         "contentPath": "content/"
     },

--- a/core/server/config/env/config.development.json
+++ b/core/server/config/env/config.development.json
@@ -18,7 +18,6 @@
         "useUpdateCheck": true
     },
     "useMinFiles": false,
-    "printErrorStack": true,
     "caching": {
         "theme": {
             "maxAge": 0


### PR DESCRIPTION
no issue

Stack printing was removed for now.
The config options weren't cleaned up correctly.