### PR TITLE
🔥  Remove deprecated GHOST_NODE_VERSION_CHECK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
 env:
   global:
     - GITHUB_OAUTH_KEY=003a44d58f12089d0c0261338298af3813330949
-    - GHOST_NODE_VERSION_CHECK=false
   matrix:
     - DB=sqlite3 NODE_ENV=testing
     - DB=mysql NODE_ENV=testing-mysql


### PR DESCRIPTION
no issue

Removes the deprected `GHOST_NODE_VERSION_CHECK` from `travis.yml`