### PR TITLE
🐛  Add `published_at` to post model fixtures

### DIFF
--- a/core/server/data/migrations/init/2-create-fixtures.js
+++ b/core/server/data/migrations/init/2-create-fixtures.js
@@ -1,7 +1,8 @@
 var Promise = require('bluebird'),
     _ = require('lodash'),
     fixtures = require('../../schema/fixtures'),
-    logging = require('../../../logging');
+    logging = require('../../../logging'),
+    moment = require('moment');
 
 module.exports = function insertFixtures(options) {
     var localOptions = _.merge({
@@ -10,6 +11,15 @@ module.exports = function insertFixtures(options) {
 
     return Promise.mapSeries(fixtures.models, function (model) {
         logging.info('Model: ' + model.name);
+
+        // The Post model fixtures need a `published_at` date, where at least the seconds
+        // are different, otherwise `prev_post` and `next_post` helpers won't workd with
+        // them.
+        if (model.name === 'Post') {
+            _.forEach(model.entries, function (post, index) {
+                post.published_at = moment().add(index, 'seconds');
+            });
+        }
         return fixtures.utils.addFixturesForModel(model, localOptions);
     }).then(function () {
         return Promise.mapSeries(fixtures.relations, function (relation) {


### PR DESCRIPTION
closes #8562

Before we create our model fixtures, we assign a `published_at` property with a difference of 1 second for each blog post, so the `prev_post` and `next_post` helper work correctly. This fixed also an issue, where the order of the fixtures wasn't correct.