### PR TITLE
🐛  Fix double slash in scheduling API URL

### DIFF
--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -5,6 +5,7 @@ var Promise = require('bluebird'),
     errors = require(__dirname + '/../../../errors'),
     models = require(__dirname + '/../../../models'),
     schedules = require(__dirname + '/../../../api/schedules'),
+    utils = require(__dirname + '/../../../utils'),
     _private = {};
 
 _private.normalize = function normalize(options) {
@@ -14,7 +15,7 @@ _private.normalize = function normalize(options) {
 
     return {
         time: moment(object.get('published_at')).valueOf(),
-        url: apiUrl + '/schedules/posts/' + object.get('id') + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
+        url: utils.url.urlJoin(apiUrl, 'schedules', 'posts', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
         extra: {
             httpMethod: 'PUT',
             oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null

--- a/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
@@ -11,6 +11,7 @@ var should = require('should'),
     schedulingUtils = require(config.get('paths').corePath + '/server/adapters/scheduling/utils'),
     SchedulingDefault = require(config.get('paths').corePath + '/server/adapters/scheduling/SchedulingDefault'),
     postScheduling = require(config.get('paths').corePath + '/server/adapters/scheduling/post-scheduling'),
+    generalUtils = require(__dirname + '/../../../../../server/utils'),
 
     sandbox = sinon.sandbox.create();
 
@@ -69,7 +70,7 @@ describe('Scheduling: Post Scheduling', function () {
 
                     scope.adapter.schedule.calledWith({
                         time: moment(scope.post.get('published_at')).valueOf(),
-                        url: scope.apiUrl + '/schedules/posts/' + scope.post.get('id') + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
+                        url: generalUtils.url.urlJoin(scope.apiUrl, 'schedules', 'posts', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
                         extra: {
                             httpMethod: 'PUT',
                             oldTime: null


### PR DESCRIPTION
closes #8568

Use our `urlJoin` util to concatenate the URL (not the query part of it, as this is not supported in `urlJoin`) and to prevent possible missing or double slashes, as `config.apiUrl` could be with or without trailing slash.