### PR TITLE
🐛  Fix double slash in scheduling API URL

### DIFF
--- a/core/server/scheduling/post-scheduling/index.js
+++ b/core/server/scheduling/post-scheduling/index.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird'),
     events = require(__dirname + '/../../events'),
     errors = require(__dirname + '/../../errors'),
     models = require(__dirname + '/../../models'),
+    config = require(__dirname + '/../../config'),
     schedules = require(__dirname + '/../../api/schedules'),
     _private = {};
 
@@ -14,7 +15,7 @@ _private.normalize = function normalize(options) {
 
     return {
         time: moment(object.get('published_at')).valueOf(),
-        url: apiUrl + '/schedules/posts/' + object.get('id') + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
+        url: config.urlJoin(apiUrl, '/schedules/posts/', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
         extra: {
             httpMethod: 'PUT',
             oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null

--- a/core/test/unit/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/scheduling/post-scheduling/index_spec.js
@@ -73,7 +73,7 @@ describe('Scheduling: Post Scheduling', function () {
 
                     scope.adapter.schedule.calledWith({
                         time: moment(scope.post.get('published_at')).valueOf(),
-                        url: scope.apiUrl + '/schedules/posts/' + scope.post.get('id') + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
+                        url: config.urlJoin(scope.apiUrl, '/schedules/posts/', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
                         extra: {
                             httpMethod: 'PUT',
                             oldTime: null


### PR DESCRIPTION
refs #8568

Fixes a bug, where our scheduling API URL had a double slash, due to `config.apiUrl` being returned with a trailing slash. The usage of `config.urlJoin` removes any possible double slashes.