### PR TITLE
⬆️ bump minimum node version [4.5.0]

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "grunt validate --verbose"
   },
   "engines": {
-    "node": "^4.2.0 || ^6.9.0"
+    "node": "^4.5.0 || ^6.9.0"
   },
   "dependencies": {
     "amperize": "0.3.4",


### PR DESCRIPTION
no issue
- ember-cli requires minimum 4.5.0
- brings inline with 1.0.0 minimum node versions