### PR TITLE
📖 update all support.ghost.org links to docs/help.ghost.org

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This is a plain English summary of all of the components within Ghost which may affect your privacy in some way. Please keep in mind that if you use third party Themes or Apps with Ghost, there may be additional things not listed here.
 
-Each of the items listed in this document can be disabled via Ghost's `config.js` file. Check out the [configuration guide](http://support.ghost.org/config/) for details.
+Each of the items listed in this document can be disabled via Ghost's `config.js` file. Check out the [configuration guide](https://docs.ghost.org/v0.11.9/docs/configuring-ghost) for details.
 
 ## Official Services
 

--- a/config.example.js
+++ b/config.example.js
@@ -1,7 +1,8 @@
 // # Ghost Configuration
-// Setup your Ghost install for various [environments](http://support.ghost.org/config/#about-environments).
+// Setup your Ghost install for various [environments](https://docs.ghost.org/v0.11.9/docs/configuring-ghost#section-about-environments).
 
-// Ghost runs in `development` mode by default. Full documentation can be found at http://support.ghost.org/config/
+// Ghost runs in `development` mode by default. Full documentation can be found
+// at https://docs.ghost.org/v0.11.9/docs/configuring-ghost
 
 var path = require('path'),
     config;
@@ -39,7 +40,7 @@ config = {
         // referrerPolicy: 'origin-when-cross-origin',
 
         // Example mail config
-        // Visit http://support.ghost.org/mail for instructions
+        // Visit https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost for instructions
         // ```
         //  mail: {
         //      transport: 'SMTP',

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -440,7 +440,7 @@ authentication = {
                             i18n.t(
                                 'errors.api.authentication.unableToSendWelcomeEmail'
                             ),
-                            i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'http://support.ghost.org/mail/'})
+                            i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost'})
                         );
                     });
                 })

--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -31,7 +31,7 @@ function sendMail(object) {
                     message: [
                         i18n.t('warnings.index.unableToSendEmail'),
                         i18n.t('common.seeLinkForInstructions',
-                            {link: '<a href=\'http://support.ghost.org/mail\' target=\'_blank\'>http://support.ghost.org/mail</a>'})
+                            {link: '<a href=\'https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost\' target=\'_blank\'>https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost</a>'})
                     ].join(' ')
                 }]},
                 {context: {internal: true}}

--- a/core/server/apps/subscribers/index.js
+++ b/core/server/apps/subscribers/index.js
@@ -55,7 +55,7 @@ module.exports = {
         var errorMessages = [
             i18n.t('warnings.helpers.helperNotAvailable', {helperName: 'subscribe_form'}),
             i18n.t('warnings.helpers.apiMustBeEnabled', {helperName: 'subscribe_form', flagName: 'subscribers'}),
-            i18n.t('warnings.helpers.seeLink', {url: 'http://support.ghost.org/subscribers-beta/'})
+            i18n.t('warnings.helpers.seeLink', {url: 'https://help.ghost.org/hc/en-us/articles/224089787-Subscribers-Beta'})
         ];
 
         // Correct way to register a helper from an app

--- a/core/server/config/index.js
+++ b/core/server/config/index.js
@@ -503,7 +503,7 @@ ConfigManager.prototype.displayDeprecated = function (item, properties, address)
         }
         errorText = i18n.t('errors.config.deprecatedProperty.error', {property: chalk.bold(address.join('.'))});
         explanationText =  i18n.t('errors.config.deprecatedProperty.explanation');
-        helpText = i18n.t('errors.config.deprecatedProperty.help', {url: 'http://support.ghost.org/config'});
+        helpText = i18n.t('errors.config.deprecatedProperty.help', {url: 'https://docs.ghost.org/v0.11.9/docs/configuring-ghost'});
         errors.logWarn(errorText, explanationText, helpText);
     }
 };

--- a/core/server/controllers/admin.js
+++ b/core/server/controllers/admin.js
@@ -45,7 +45,7 @@ adminControllers = {
                 location: 'upgrade.new-version-available',
                 dismissible: false,
                 message: i18n.t('notices.controllers.newVersionAvailable',
-                                {version: updateVersion, link: '<a href="http://support.ghost.org/how-to-upgrade/" target="_blank">Click here</a>'})};
+                                {version: updateVersion, link: '<a href="https://docs.ghost.org/v0.11.9/docs/how-to-upgrade-ghost" target="_blank">Click here</a>'})};
 
             return api.notifications.browse({context: {internal: true}}).then(function then(results) {
                 if (!_.some(results.notifications, {message: notification.message})) {

--- a/core/server/data/migration/update.js
+++ b/core/server/data/migration/update.js
@@ -128,7 +128,7 @@ isDatabaseOutOfDate = function isDatabaseOutOfDate(options) {
         return {error: new errors.DatabaseVersion(
             i18n.t('errors.data.versioning.index.cannotMigrate.error'),
             i18n.t('errors.data.versioning.index.cannotMigrate.context'),
-            i18n.t('common.seeLinkForInstructions', {link: 'http://support.ghost.org/how-to-upgrade/'})
+            i18n.t('common.seeLinkForInstructions', {link: 'https://docs.ghost.org/v0.11.9/docs/how-to-upgrade-ghost'})
         )};
     }
     // CASE: the database exists but is out of date

--- a/core/server/data/slack/index.js
+++ b/core/server/data/slack/index.js
@@ -35,7 +35,7 @@ function makeRequest(reqOptions, reqPayload) {
         errors.logError(
             error,
             i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.error'),
-            i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.help', {url: 'http://support.ghost.org'})
+            i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.help', {url: 'http://docs.ghost.org/v0.11.9'})
         );
     });
 

--- a/core/server/data/xml/xmlrpc.js
+++ b/core/server/data/xml/xmlrpc.js
@@ -70,7 +70,7 @@ function ping(post) {
                 errors.logError(
                     error,
                     i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.error'),
-                    i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.help', {url: 'http://support.ghost.org'})
+                    i18n.t('errors.data.xml.xmlrpc.pingUpdateFailed.help', {url: 'http://docs.ghost.org/v0.11.9'})
                 );
             }
         );

--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -148,7 +148,7 @@ module.exports = function getWithLabs(resource, options) {
         errorMessages = [
             i18n.t('warnings.helpers.get.helperNotAvailable'),
             i18n.t('warnings.helpers.get.apiMustBeEnabled'),
-            i18n.t('warnings.helpers.get.seeLink', {url: 'http://support.ghost.org/public-api-beta'})
+            i18n.t('warnings.helpers.get.seeLink', {url: 'https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta'})
         ];
 
     if (labs.isSet('publicAPI') === true) {

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -47,7 +47,7 @@ function updateCheckError(error) {
     errors.logError(
         error,
         i18n.t('errors.update-check.checkingForUpdatesFailed.error'),
-        i18n.t('errors.update-check.checkingForUpdatesFailed.help', {url: 'http://support.ghost.org'})
+        i18n.t('errors.update-check.checkingForUpdatesFailed.help', {url: 'http://docs.ghost.org/v0.11.9'})
     );
 }
 

--- a/core/server/utils/npm/preinstall.js
+++ b/core/server/utils/npm/preinstall.js
@@ -12,7 +12,7 @@ function doError() {
     console.error('\x1B[31mERROR: Unsupported version of Node');
     console.error('\x1B[37mGhost supports LTS Node versions: ' + process.env.npm_package_engines_node);
     console.error('You are currently using version: ' + process.versions.node + '\033[0m');
-    console.error('\x1B[32mThis check can be overridden, see http://support.ghost.org/supported-node-versions/ for more info\033[0m');
+    console.error('\x1B[32mThis check can be overridden, see https://docs.ghost.org/v0.11.9/docs/supported-node-versions for more info\033[0m');
 
     process.exit(exitCodes.NODE_VERSION_UNSUPPORTED);
 }

--- a/core/server/utils/packages/parse-package-json.js
+++ b/core/server/utils/packages/parse-package-json.js
@@ -32,7 +32,7 @@ function parsePackageJson(path) {
                 if (!hasRequiredKeys) {
                     err = new Error(i18n.t('errors.utils.parsepackagejson.nameOrVersionMissing'));
                     err.context = path;
-                    err.help = i18n.t('errors.utils.parsepackagejson.willBeRequired', {url: 'http://docs.ghost.org/themes/'});
+                    err.help = i18n.t('errors.utils.parsepackagejson.willBeRequired', {url: 'http://themes.ghost.org/docs/packagejson'});
 
                     return Promise.reject(err);
                 }
@@ -41,7 +41,7 @@ function parsePackageJson(path) {
             } catch (parseError) {
                 err = new Error(i18n.t('errors.utils.parsepackagejson.themeFileIsMalformed'));
                 err.context = path;
-                err.help = i18n.t('errors.utils.parsepackagejson.willBeRequired', {url: 'http://docs.ghost.org/themes/'});
+                err.help = i18n.t('errors.utils.parsepackagejson.willBeRequired', {url: 'http://themes.ghost.org/docs/packagejson'});
 
                 return Promise.reject(err);
             }

--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -37,7 +37,7 @@ checks = {
             console.error('\x1B[31mERROR: Unsupported version of Node');
             console.error('\x1B[31mGhost needs Node version ' + packages.engines.node +
                           ' you are using version ' + process.versions.node + '\033[0m\n');
-            console.error('\x1B[32mPlease see http://support.ghost.org/supported-node-versions/ for more information\033[0m');
+            console.error('\x1B[32mPlease see https://docs.ghost.org/v0.11.9/docs/supported-node-versions for more information\033[0m');
 
             process.exit(exitCodes.NODE_VERSION_UNSUPPORTED);
         }
@@ -93,7 +93,7 @@ checks = {
 
         console.error('\x1B[31mERROR: Ghost is unable to start due to missing dependencies:\033[0m\n  ' + errors);
         console.error('\x1B[32m\nPlease run `npm install --production` and try starting Ghost again.');
-        console.error('\x1B[32mHelp and documentation can be found at http://support.ghost.org.\033[0m\n');
+        console.error('\x1B[32mHelp and documentation can be found at https://docs.ghost.org/v0.11.9.\033[0m\n');
 
         process.exit(exitCodes.DEPENDENCIES_MISSING);
     },
@@ -111,7 +111,7 @@ checks = {
             fd,
             errorHeader = '\x1B[31mERROR: Unable to access Ghost\'s content path:\033[0m',
             errorHelp = '\x1B[32mCheck that the content path exists and file system permissions are correct.' +
-                '\nHelp and documentation can be found at http://support.ghost.org.\033[0m';
+                '\nHelp and documentation can be found at https://docs.ghost.org/v0.11.9.\033[0m';
 
         // Get the content path to test.  If it's defined in config.js use that, if not use the default
         try {
@@ -207,7 +207,7 @@ checks = {
             console.error('\x1B[31mERROR: Unable to open sqlite3 database file for read/write\033[0m');
             console.error('  ' + e.message);
             console.error('\n\x1B[32mCheck that the sqlite3 database file permissions allow read and write access.');
-            console.error('Help and documentation can be found at http://support.ghost.org.\033[0m');
+            console.error('Help and documentation can be found at https://docs.ghost.org/v0.11.9.\033[0m');
 
             process.exit(exitCodes.SQLITE_DB_NOT_WRITABLE);
         }
@@ -226,7 +226,7 @@ checks = {
 
         if (!config.mail || !config.mail.transport) {
             console.error('\x1B[31mWARNING: Ghost is attempting to use a direct method to send email. \nIt is recommended that you explicitly configure an email service.\033[0m');
-            console.error('\x1B[32mHelp and documentation can be found at http://support.ghost.org/mail.\033[0m\n');
+            console.error('\x1B[32mHelp and documentation can be found at https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost.\033[0m\n');
         }
     },
 
@@ -262,7 +262,7 @@ checks = {
             } catch (e) {
                 console.error('\x1B[31mERROR: Javascript files have not been built.\033[0m');
                 console.error('\n\x1B[32mPlease read the getting started instructions at:');
-                console.error('https://github.com/TryGhost/Ghost#getting-started\033[0m');
+                console.error('https://docs.ghost.org/v0.11.9/docs/getting-started-guide\033[0m');
                 process.exit(exitCodes.BUILT_FILES_DO_NOT_EXIST);
             }
         }

--- a/core/test/unit/utils/packages_spec.js
+++ b/core/test/unit/utils/packages_spec.js
@@ -58,7 +58,7 @@ describe('Package Utils', function () {
                 .catch(function (err) {
                     err.message.should.equal('"name" or "version" is missing from theme package.json file.');
                     err.context.should.equal(tmpFile.name);
-                    err.help.should.equal('This will be required in future. Please see http://docs.ghost.org/themes/');
+                    err.help.should.equal('This will be required in future. Please see http://themes.ghost.org/docs/packagejson');
 
                     done();
                 })
@@ -83,7 +83,7 @@ describe('Package Utils', function () {
                 .catch(function (err) {
                     err.message.should.equal('"name" or "version" is missing from theme package.json file.');
                     err.context.should.equal(tmpFile.name);
-                    err.help.should.equal('This will be required in future. Please see http://docs.ghost.org/themes/');
+                    err.help.should.equal('This will be required in future. Please see http://themes.ghost.org/docs/packagejson');
 
                     done();
                 })
@@ -106,7 +106,7 @@ describe('Package Utils', function () {
                 .catch(function (err) {
                     err.message.should.equal('Theme package.json file is malformed');
                     err.context.should.equal(tmpFile.name);
-                    err.help.should.equal('This will be required in future. Please see http://docs.ghost.org/themes/');
+                    err.help.should.equal('This will be required in future. Please see http://themes.ghost.org/docs/packagejson');
 
                     done();
                 })


### PR DESCRIPTION
no issue
- support.ghost.org has gone away, we now have self-host/dev documentation on https://docs.ghost.org and user documentation at https://help.ghost.org