### PR TITLE
🐛  Correct usage of `urlJoin` for scheduling API URL

### DIFF
--- a/core/server/scheduling/post-scheduling/index.js
+++ b/core/server/scheduling/post-scheduling/index.js
@@ -15,7 +15,7 @@ _private.normalize = function normalize(options) {
 
     return {
         time: moment(object.get('published_at')).valueOf(),
-        url: config.urlJoin(apiUrl, '/schedules/posts/', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
+        url: config.urlJoin(apiUrl, 'schedules', 'posts', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
         extra: {
             httpMethod: 'PUT',
             oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null

--- a/core/test/unit/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/scheduling/post-scheduling/index_spec.js
@@ -73,7 +73,7 @@ describe('Scheduling: Post Scheduling', function () {
 
                     scope.adapter.schedule.calledWith({
                         time: moment(scope.post.get('published_at')).valueOf(),
-                        url: config.urlJoin(scope.apiUrl, '/schedules/posts/', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
+                        url: config.urlJoin(scope.apiUrl, 'schedules', 'posts', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
                         extra: {
                             httpMethod: 'PUT',
                             oldTime: null


### PR DESCRIPTION
refs #8568
follow-up of #8578

Removes the `/` inside of the `urlJoin` util, as it works best with `,` separated values.