### PR TITLE
🐛  status filtering for users api

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -19,6 +19,7 @@ var _              = require('lodash'),
     tokenSecurity  = {},
     activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'],
     invitedStates  = ['invited', 'invited-pending'],
+    allStates      = activeStates.concat(invitedStates),
     User,
     Users;
 
@@ -202,8 +203,7 @@ User = ghostBookshelf.Model.extend({
         // This is the only place that 'options.where' is set now
         options.where = {statements: []};
 
-        var allStates = activeStates.concat(invitedStates),
-            value;
+        var value;
 
         // Filter on the status.  A status of 'all' translates to no filter since we want all statuses
         if (options.status !== 'all') {
@@ -297,7 +297,8 @@ User = ghostBookshelf.Model.extend({
         } else if (status === 'invited') {
             query.query('whereIn', 'status', invitedStates);
         } else if (status !== 'all') {
-            query.query('where', {status: options.status});
+            status = allStates.indexOf(status) !== -1 ? status : 'active';
+            query.query('where', {status: status});
         }
 
         options = this.filterOptions(options, 'findOne');

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -136,6 +136,28 @@ describe('User API', function () {
                     });
             });
 
+            it('use invalid status option', function (done) {
+                request.get(testUtils.API.getApiQuery('users/me/?status=al'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user');
+                        done();
+                    });
+            });
+
             it('can retrieve a user by id', function (done) {
                 request.get(testUtils.API.getApiQuery('users/2/'))
                     .set('Authorization', 'Bearer ' + ownerAccessToken)


### PR DESCRIPTION
no issue

- protect input for status
- fix bug with `options.status`, which was always undefined
