### PR TITLE
[WIP] 🐛  content folder has no themes

### DIFF
--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -145,14 +145,15 @@ readSettingsResult = function (settingsModels) {
         themes = config.paths.availableThemes,
         res;
 
+    settings.availableThemes = {
+        key: 'availableThemes',
+        value: [],
+        type: 'theme'
+    };
+
     if (settings.activeTheme && !_.isEmpty(themes)) {
         res = filterPackages(themes, settings.activeTheme.value);
-
-        settings.availableThemes = {
-            key: 'availableThemes',
-            value: res,
-            type: 'theme'
-        };
+        settings.availableThemes.value = res;
     }
 
     return settings;


### PR DESCRIPTION
no issue

- if your content/themes folder has no themes, your admin panel doesn't work anymore

### TODO
- the current fix can work, but this function is used for browsing and editing settings
- in case of editing, we only return the affected settings model
- and if we keep it like this, Ghost would always return the availableThemes
- we should make a differentiation between browsing and editing
- because i think, we only need to return the availableThemes on browsing settings (because it's an additional settings key, which does not exist in the database)
