### PR TITLE
📖 shorten mail config docs links

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -40,7 +40,7 @@ config = {
         // referrerPolicy: 'origin-when-cross-origin',
 
         // Example mail config
-        // Visit https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost for instructions
+        // Visit https://docs.ghost.org/v0.11.9/docs/mail-config for instructions
         // ```
         //  mail: {
         //      transport: 'SMTP',

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -440,7 +440,7 @@ authentication = {
                             i18n.t(
                                 'errors.api.authentication.unableToSendWelcomeEmail'
                             ),
-                            i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost'})
+                            i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'https://docs.ghost.org/v0.11.9/docs/mail-config'})
                         );
                     });
                 })

--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -31,7 +31,7 @@ function sendMail(object) {
                     message: [
                         i18n.t('warnings.index.unableToSendEmail'),
                         i18n.t('common.seeLinkForInstructions',
-                            {link: '<a href=\'https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost\' target=\'_blank\'>https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost</a>'})
+                            {link: '<a href=\'https://docs.ghost.org/v0.11.9/docs/mail-config\' target=\'_blank\'>https://docs.ghost.org/v0.11.9/docs/mail-config</a>'})
                     ].join(' ')
                 }]},
                 {context: {internal: true}}

--- a/core/server/utils/startup-check.js
+++ b/core/server/utils/startup-check.js
@@ -226,7 +226,7 @@ checks = {
 
         if (!config.mail || !config.mail.transport) {
             console.error('\x1B[31mWARNING: Ghost is attempting to use a direct method to send email. \nIt is recommended that you explicitly configure an email service.\033[0m');
-            console.error('\x1B[32mHelp and documentation can be found at https://docs.ghost.org/v0.11.9/docs/mail-configuration-on-self-hosted-version-of-ghost.\033[0m\n');
+            console.error('\x1B[32mHelp and documentation can be found at https://docs.ghost.org/v0.11.9/docs/mail-config.\033[0m\n');
         }
     },
 


### PR DESCRIPTION
no issue
- URL on docs.ghost.org has been shortened for more readable display in errors