### PR TITLE
📖 shorten mail config docs links

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This is a plain English summary of all of the components within Ghost which may affect your privacy in some way. Please keep in mind that if you use third party Themes or Apps with Ghost, there may be additional things not listed here.
 
-Each of the items listed in this document can be disabled via Ghost's `config.js` file. Check out the [configuration guide](http://support.ghost.org/config/) for details.
+Each of the items listed in this document can be disabled via Ghost's `config.js` file. Check out the [configuration guide](https://docs.ghost.org/v1.0.0/docs/configuring-ghost) for details.
 
 ## Official Services
 

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -536,7 +536,7 @@ authentication = {
                         logging.error(new errors.EmailError({
                             err: error,
                             context: i18n.t('errors.api.authentication.unableToSendWelcomeEmail'),
-                            help: i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'http://docs.ghost.org/v1.0.0/docs/mail-configuration-on-self-hosted-version-of-ghost'})
+                            help: i18n.t('errors.api.authentication.checkEmailConfigInstructions', {url: 'http://docs.ghost.org/v1.0.0/docs/mail-config'})
                         }));
                     });
                 })

--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -29,7 +29,7 @@ function sendMail(object) {
                     message: [
                         i18n.t('warnings.index.unableToSendEmail'),
                         i18n.t('common.seeLinkForInstructions',
-                            {link: '<a href=\'https://docs.ghost.org/v1.0.0/docs/mail-configuration-on-self-hosted-version-of-ghost\' target=\'_blank\'>Checkout our mail configuration docs!</a>'})
+                            {link: '<a href=\'https://docs.ghost.org/v1.0.0/docs/mail-config\' target=\'_blank\'>Checkout our mail configuration docs!</a>'})
                     ].join(' ')
                 }]},
                 {context: {internal: true}}


### PR DESCRIPTION
no issue
- URL on docs.ghost.org has been shortened for more readable display in errors
- fix broken support.ghost.org link in PRIVACY.md