### PR TITLE
Moved `published_at` creation to fixtures/utils

### DIFF
--- a/core/server/data/migrations/init/2-create-fixtures.js
+++ b/core/server/data/migrations/init/2-create-fixtures.js
@@ -1,8 +1,7 @@
 var Promise = require('bluebird'),
     _ = require('lodash'),
     fixtures = require('../../schema/fixtures'),
-    logging = require('../../../logging'),
-    moment = require('moment');
+    logging = require('../../../logging');
 
 module.exports = function insertFixtures(options) {
     var localOptions = _.merge({
@@ -12,14 +11,6 @@ module.exports = function insertFixtures(options) {
     return Promise.mapSeries(fixtures.models, function (model) {
         logging.info('Model: ' + model.name);
 
-        // The Post model fixtures need a `published_at` date, where at least the seconds
-        // are different, otherwise `prev_post` and `next_post` helpers won't workd with
-        // them.
-        if (model.name === 'Post') {
-            _.forEach(model.entries, function (post, index) {
-                post.published_at = moment().add(index, 'seconds');
-            });
-        }
         return fixtures.utils.addFixturesForModel(model, localOptions);
     }).then(function () {
         return Promise.mapSeries(fixtures.relations, function (relation) {


### PR DESCRIPTION
no issue
follow-up from #8573

Move the hack that creates `published_at` values from the migration fn to our fixture util.