### PR TITLE
🐛  Remove trailing slash for `{{@blog.url}}`

### DIFF
--- a/core/server/themes/middleware.js
+++ b/core/server/themes/middleware.js
@@ -68,7 +68,8 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
 
     // Request-specific information
     // These things are super dependent on the request, so they need to be in middleware
-    blogData.url = utils.url.urlFor('home', {secure: req.secure}, true);
+    // Serve the blog url without trailing slash
+    blogData.url = utils.url.urlFor('home', {secure: req.secure, trailingSlash: false}, true);
 
     // Pass 'secure' flag to the view engine
     // so that templates can choose to render https or http 'url', see url utility

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -297,6 +297,12 @@ function urlFor(context, data, absolute) {
         if (data && data.cors) {
             urlPath = urlPath.replace(/^.*?:\/\//g, '//');
         }
+
+        // CASE: there are cases where urlFor('home') needs to be returned without trailing
+        // slash e. g. the `{{@blog.url}}` helper. See https://github.com/TryGhost/Ghost/issues/8569
+        if (data && data.trailingSlash === false) {
+            urlPath = urlPath.replace(/\/$/, '');
+        }
     } else if (context === 'admin') {
         urlPath = getAdminUrl() || getBlogUrl();
 

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -729,7 +729,7 @@ describe('Frontend Routing', function () {
                 request.get('/')
                     .expect(200)
                     .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
-                    .expect(/<a href="http:\/\/localhost:2370\/">Ghost<\/a\>/)
+                    .expect(/<a href="http:\/\/localhost:2370">Ghost<\/a\>/)
                     .end(doEnd(done));
             });
 
@@ -738,7 +738,7 @@ describe('Frontend Routing', function () {
                     .set('X-Forwarded-Proto', 'https')
                     .expect(200)
                     .expect(/<link rel="canonical" href="http:\/\/localhost:2370\/" \/\>/)
-                    .expect(/<a href="https:\/\/localhost:2370\/">Ghost<\/a\>/)
+                    .expect(/<a href="https:\/\/localhost:2370">Ghost<\/a\>/)
                     .end(doEnd(done));
             });
         });

--- a/core/test/unit/themes/middleware_spec.js
+++ b/core/test/unit/themes/middleware_spec.js
@@ -136,7 +136,7 @@ describe('Themes', function () {
                         .with.properties(blogDataExpectedProps)
                         .and.size(blogDataExpectedProps.length);
                     // url should be correct
-                    templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369/');
+                    templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369');
                     // should get the title
                     templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 
@@ -173,7 +173,7 @@ describe('Themes', function () {
                         .with.properties(blogDataExpectedProps)
                         .and.size(blogDataExpectedProps.length);
                     // url should be correct
-                    templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369/');
+                    templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369');
                     // should get the title
                     templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 
@@ -209,7 +209,7 @@ describe('Themes', function () {
                         .with.properties(blogDataExpectedProps)
                         .and.size(blogDataExpectedProps.length);
                     // url should be correct HTTPS!
-                    templateOptions.data.blog.url.should.eql('https://127.0.0.1:2369/');
+                    templateOptions.data.blog.url.should.eql('https://127.0.0.1:2369');
                     // should get the title
                     templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -124,6 +124,27 @@ describe('Url', function () {
             utils.url.urlFor(testContext).should.equal('/blog/');
             utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
             utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
+
+            // Output blog url without trailing slash
+            configUtils.set({url: 'http://my-ghost-blog.com'});
+            utils.url.urlFor(testContext).should.equal('/');
+            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com');
+
+            configUtils.set({url: 'http://my-ghost-blog.com/'});
+            utils.url.urlFor(testContext).should.equal('/');
+            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com');
+
+            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
+            utils.url.urlFor(testContext).should.equal('/blog/');
+            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com/blog');
+
+            configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
+            utils.url.urlFor(testContext).should.equal('/blog/');
+            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com/blog');
         });
 
         it('should return rss url when asked for', function () {


### PR DESCRIPTION
closes #8569

Remove the trailing slash for `{{@blog.url}}` data in theme middleware.