### PR TITLE
✨ Enable Public API by default

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -73,7 +73,7 @@
             "defaultValue" : ""
         },
         "labs": {
-            "defaultValue": "{}"
+            "defaultValue": "{\"publicAPI\": true}"
         },
         "navigation": {
             "defaultValue": "[{\"label\":\"Home\", \"url\":\"/\"}]"

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -7,37 +7,19 @@ var should = require('should'),
     request;
 
 describe('Public API', function () {
-    var publicAPIaccessSetting = {
-        settings: [
-            {key: 'labs', value: {publicAPI: true}}
-        ]
-    }, ghostServer;
+    var ghostServer;
 
-    before(function (done) {
+    before(function () {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
-        ghost().then(function (_ghostServer) {
+        return ghost().then(function (_ghostServer) {
             ghostServer = _ghostServer;
             return ghostServer.start();
         }).then(function () {
             request = supertest.agent(config.get('url'));
         }).then(function () {
             return testUtils.doAuth(request, 'posts', 'tags', 'client:trusted-domain');
-        }).then(function (token) {
-            // enable public API
-            request.put(testUtils.API.getApiQuery('settings/'))
-                .set('Authorization', 'Bearer ' + token)
-                .send(publicAPIaccessSetting)
-                .expect('Content-Type', /json/)
-                .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
-                .end(function (err) {
-                    if (err) {
-                        return done(err);
-                    }
-                    done();
-                });
-        }).catch(done);
+        });
     });
 
     after(function () {


### PR DESCRIPTION
closes #8601 

For 1.0, there is some minor changes needed to public API:

- enable it by default (it's still beta, it's just enabled by default)

Background: the new casper 2.0 theme is using the {{get}} helper.

- [x] test with fresh db

