### PR TITLE
✨ Pass clientExtensions to Ghost Admin

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -30,7 +30,8 @@ function getBaseConfig() {
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        utils.url.urlFor('home', true),
         blogTitle:      settingsCache.get('title'),
-        routeKeywords:  config.get('routeKeywords')
+        routeKeywords:  config.get('routeKeywords'),
+        clientExtensions: config.get('clientExtensions')
     };
 }
 


### PR DESCRIPTION
If there is a `clientExtensions` object in the config, pass this to Ghost-Admin.