### PR TITLE
✨  Add new fixture Ghost Author

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -12,7 +12,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Advanced Markdown tips",
@@ -23,7 +26,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Making your site private",
@@ -34,7 +40,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Managing Ghost users",
@@ -45,7 +54,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Organising your content with tags",
@@ -56,7 +68,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Using the Ghost editor",
@@ -67,7 +82,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 },
                 {
                     "title": "Welcome to Ghost",
@@ -78,7 +96,10 @@
                     "page": false,
                     "status": "published",
                     "meta_title": null,
-                    "meta_description": null
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
                 }
             ]
         },
@@ -396,6 +417,13 @@
                     "email": "ghost@example.com",
                     "status": "inactive",
                     "roles": []
+                },
+                {
+                    "id": "5951f5fca366002ebd5dbef7",
+                    "name": "Ghost",
+                    "email": "ghost-author@example.com",
+                    "status": "active",
+                    "roles": ["Author"]
                 }
             ]
         }

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -539,6 +539,7 @@ User = ghostBookshelf.Model.extend({
     isSetup: function isSetup() {
         return this
             .where('status', 'in', activeStates)
+            .where('id', this.ownerUser)
             .count('id')
             .then(function (count) {
                 return !!count;

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -87,9 +87,9 @@ describe('User API', function () {
                         should.exist(jsonResponse.users);
                         testUtils.API.checkResponse(jsonResponse, 'users');
 
-                        // owner use when Ghost starts
+                        // owner use + ghost-author user when Ghost starts
                         // and two extra users, see createUser in before
-                        jsonResponse.users.should.have.length(4);
+                        jsonResponse.users.should.have.length(5);
 
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user');
                         testUtils.API.isISO8601(jsonResponse.users[0].last_seen).should.be.true();
@@ -120,9 +120,9 @@ describe('User API', function () {
                         should.exist(jsonResponse.users);
                         testUtils.API.checkResponse(jsonResponse, 'users');
 
-                        jsonResponse.users.should.have.length(4);
+                        jsonResponse.users.should.have.length(5);
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user');
-                        jsonResponse.users[3].status.should.eql(inactiveUser.status);
+                        jsonResponse.users[4].status.should.eql(inactiveUser.status);
                         done();
                     });
             });
@@ -143,7 +143,7 @@ describe('User API', function () {
                         should.exist(jsonResponse.users);
                         testUtils.API.checkResponse(jsonResponse, 'users');
 
-                        jsonResponse.users.should.have.length(4);
+                        jsonResponse.users.should.have.length(5);
                         testUtils.API.checkResponse(jsonResponse.users[0], 'user', 'roles');
                         done();
                     });

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ var should = require('should'), // jshint ignore:line
 describe('DB version integrity', function () {
     // Only these variables should need updating
     var currentSchemaHash = 'b613bca0f20e02360487a3c17a9ffcc1',
-        currentFixturesHash = 'bc9ba1689043b5abd7f7b2d046ac6ff1';
+        currentFixturesHash = '1c9d28a1fc1320d2f711345458165a7c';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
refs #8620

Adds a new Ghost Author user, which is the author of the new welcome blog posts. The user is set to active, so the author slug works (otherwise it would render a 404, when user is suspended). Furthermore, there's one little fix in the user model, which was checking only for `active` user to decide the signup or setup process for the UI. Adding one more conditional to check if the found active user is also the owner, prevents to get redirected to signin.
