### PR TITLE
🙈  Remove `url` from default production config

### DIFF
--- a/core/server/config/env/config.production.json
+++ b/core/server/config/env/config.production.json
@@ -1,5 +1,4 @@
 {
-    "url": "http://my-ghost-blog.com",
     "database": {
         "client": "mysql",
         "connection": {


### PR DESCRIPTION
closes #8619

Removes the `url` property from `config.production.json` as it's not needed and causes confusing errors.