### PR TITLE
🐛  Update `amp.hbs` image helper and meta

### DIFF
--- a/core/server/apps/amp/lib/views/amp.hbs
+++ b/core/server/apps/amp/lib/views/amp.hbs
@@ -6,7 +6,6 @@
 
     {{!-- Page Meta --}}
     <title>{{meta_title}}</title>
-    <meta name="description" content="{{meta_description}}" />
 
     {{!-- Mobile Meta --}}
     <meta name="HandheldFriendly" content="True" />
@@ -810,9 +809,9 @@
                     <time class="post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY-MM-DD"}}</time>
                 </section>
             </header>
-            {{#if image}}
+            {{#if feature_image}}
             <figure class="post-image">
-                <amp-img src="{{image absolute="true"}}" width="600" height="400" layout="responsive"></amp-img>
+                <amp-img src="{{img_url feature_image absolute="true"}}" width="600" height="400" layout="responsive"></amp-img>
             </figure>
             {{/if}}
             <section class="post-content">


### PR DESCRIPTION
no issue

Seems like we forgot to update the AMP template to reflect our image helper changes.

- Replaces `{{image}}` helper with `{{img_url}}` for `feature_image`
- Removes `{{meta_description}}` helper