### PR TITLE
🐛 Honour labs defaults on import

### DIFF
--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -1396,6 +1396,9 @@ describe('Import (new test structure)', function () {
                     settings[9].key.should.eql('default_locale');
                     settings[9].value.should.eql('en');
 
+                    settings[18].key.should.eql('labs');
+                    settings[18].value.should.eql('{"publicAPI":true}');
+
                     // Check post language is null
                     should(firstPost.locale).equal(null);
                     // Check user language is null


### PR DESCRIPTION
closes #8601

- This makes sure that when you do an import, you still get the LATEST
  default settings for labs. Even if you had a different value before.
- LTS -> 1.0 is an upgrade, and Public API should be on by default, even if you
  had deliberately turned it off before.
- Cheeky test added