### PR TITLE
🐛 reclassify warnings.index.unableToSendEmail notification from warning to info level

### DIFF
--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -25,7 +25,7 @@ function sendMail(object) {
         if (mailer.state.usingDirect) {
             notifications.add(
                 {notifications: [{
-                    type: 'warn',
+                    type: 'info',
                     message: [
                         i18n.t('warnings.index.unableToSendEmail'),
                         i18n.t('common.seeLinkForInstructions',


### PR DESCRIPTION
closes TryGhost/Ghost#8680

switch notifications.type to info from warn to avoid the gh-alert-yellow screen on nightshift
