### PR TITLE
🎨  protect invalid dates

### DIFF
--- a/core/server/data/meta/published_date.js
+++ b/core/server/data/meta/published_date.js
@@ -6,6 +6,7 @@ function getPublishedDate(data) {
     if (data[context] && data[context].published_at) {
         return new Date(data[context].published_at).toISOString();
     }
+
     return null;
 }
 

--- a/core/server/data/meta/published_date.js
+++ b/core/server/data/meta/published_date.js
@@ -6,7 +6,6 @@ function getPublishedDate(data) {
     if (data[context] && data[context].published_at) {
         return new Date(data[context].published_at).toISOString();
     }
-
     return null;
 }
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -145,7 +145,14 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             if (value !== null
                 && schema.tables[self.tableName].hasOwnProperty(key)
                 && schema.tables[self.tableName][key].type === 'dateTime') {
-                attrs[key] = moment(value).toDate();
+                attrs[key] = moment(value);
+
+                // CASE: if you are somehow able to store 00:00:0000 00:00:00
+                if (attrs[key].isValid()) {
+                    attrs[key] = attrs[key].toDate();
+                } else {
+                    attrs[key] = moment().toDate();
+                }
             }
         });
 


### PR DESCRIPTION
refs #8703

e.g. if you somehow are able to send and store `00:00:0000 00:00:00` for a date, Ghost would fetch the date and transforms it into an invalid JS date. This can cause trouble on usage.