### PR TITLE
add content/logs to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,8 @@ content/apps/**
 !content/apps/README.md
 content/data/**
 !content/data/README.md
+content/logs/**
+!content/logs/README.md
 node_modules/**
 **/*.db*
 *.db*


### PR DESCRIPTION
refs TryGhost/Ghost-CLI#362
- ensures logs don't get published to npm

In Ghost 1.0-RC.1, some stray logs were accidentally published to NPM. This change makes sure that doesn't happen again 😉 