### PR TITLE
Destroy unknown user id and permissible protection against null users

### DIFF
--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -20,9 +20,14 @@ events.on('token.added', function (tokenModel) {
 /**
  * WHEN user get's suspended (status=inactive), we delete his tokens to ensure
  * he can't login anymore
+ *
+ * NOTE:
+ *   - this event get's triggered either on user update (suspended) or if an **active** user get's deleted.
+ *   - if an active user get's deleted, we have to access the previous attributes, because this is how bookshelf works
+ *     if you delete a user.
  */
 events.on('user.deactivated', function (userModel) {
-    var options = {id: userModel.id};
+    var options = {id: userModel.id || userModel.previousAttributes().id};
 
     models.Accesstoken.destroyByUser(options)
         .then(function () {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -562,6 +562,12 @@ User = ghostBookshelf.Model.extend({
 
             // Get the actual user model
             return this.findOne({id: userModelOrId, status: 'all'}, {include: ['roles']}).then(function then(foundUserModel) {
+                if (!foundUserModel) {
+                    throw new errors.NotFoundError({
+                        message: i18n.t('errors.models.user.userNotFound')
+                    });
+                }
+
                 // Build up the original args but substitute with actual model
                 var newArgs = [foundUserModel].concat(origArgs);
 

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -12,7 +12,7 @@ describe('User API', function () {
         authorAccessToken = '',
         editor, author, ghostServer, inactiveUser;
 
-    before(function (done) {
+    beforeEach(function (done) {
         // starting ghost automatically populates the db
         // TODO: prevent db init, and manage bringing up the DB with fixtures ourselves
         ghost().then(function (_ghostServer) {
@@ -63,7 +63,7 @@ describe('User API', function () {
         }).catch(done);
     });
 
-    after(function () {
+    afterEach(function () {
         return testUtils.clearData()
             .then(function () {
                 return ghostServer.stop();
@@ -430,6 +430,34 @@ describe('User API', function () {
 
                                 done();
                             });
+                    });
+            });
+        });
+
+        describe('Destroy', function () {
+            it('[success] Destroy active user', function (done) {
+                request.delete(testUtils.API.getApiQuery('users/' + editor.id))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect(204)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+
+            it('[failure] Destroy unknown user id', function (done) {
+                request.delete(testUtils.API.getApiQuery('users/' + ObjectId.generate()))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect(403)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
                     });
             });
         });


### PR DESCRIPTION
**Please merge both commits.**

no issue

I've discovering two bugs while destroying users.

1. If a user get's destroyed, an event is triggered to remove tokens. This token handling was added when we have implemented suspending a user. There was a bug that a destroyed user has only access to previous attributes -> bookshelf behaviour.

2. I've played with destroying users and discovered a missing piece of logic: if you delete an unknown user id, the permission layer fails, because of a logic bug. It continues with a null user and crashes. (behaviour is equivalent to LTS, PR is coming, a pretty old bug). See commit messages, it explains that the actual fix for it is caused by a bigger architectural problem.