### PR TITLE
🐛  destroy unknown user id

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -488,6 +488,10 @@ User = ghostBookshelf.Model.extend({
             origArgs = _.toArray(arguments).slice(1);
             // Get the actual user model
             return this.findOne({id: userModelOrId, status: 'all'}, {include: ['roles']}).then(function then(foundUserModel) {
+                if (!foundUserModel) {
+                    return Promise.reject(new errors.NotFoundError(i18n.t('errors.models.user.userNotFound')));
+                }
+
                 // Build up the original args but substitute with actual model
                 var newArgs = [foundUserModel].concat(origArgs);
 

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -415,6 +415,21 @@ describe('User API', function () {
                     });
             });
         });
+
+        describe('Destroy', function () {
+            it('[failure] destroy unknown user', function (done) {
+                request.delete(testUtils.API.getApiQuery('users/458'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect(404)
+                    .end(function (err) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        done();
+                    });
+            });
+        });
     });
 
     describe('As Editor', function () {


### PR DESCRIPTION
no issue

- a protection against not found users for permission checks was missing
- there is actually a bigger underlying architectual problem:
  - the permission check should rely on an existing user
  - so there should be a first api layer, which 1. validates (this code exists) and 2. ensures that requested database id's exist
  - but this requires a bigger refactoring