### PR TITLE
🐛  be able to serve locked users

### DIFF
--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -137,7 +137,9 @@ users = {
             return canThis(options.context).edit.user(options.id).then(function () {
                 // CASE: can't edit my own status to inactive or locked
                 if (options.id === options.context.user) {
-                    if (dataProvider.User.inactiveStates.indexOf(options.data.users[0].status) !== -1) {
+                    if (dataProvider.User.inactiveStates.indexOf(options.data.users[0].status) !== -1 ||
+                        dataProvider.User.restrictedStates.indexOf(options.data.users[0].status) !== -1
+                    ) {
                         return Promise.reject(new errors.NoPermissionError({
                             message: i18n.t('errors.api.users.cannotChangeStatus')
                         }));

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -137,9 +137,7 @@ users = {
             return canThis(options.context).edit.user(options.id).then(function () {
                 // CASE: can't edit my own status to inactive or locked
                 if (options.id === options.context.user) {
-                    if (dataProvider.User.inactiveStates.indexOf(options.data.users[0].status) !== -1 ||
-                        dataProvider.User.restrictedStates.indexOf(options.data.users[0].status) !== -1
-                    ) {
+                    if (dataProvider.User.inactiveStates.indexOf(options.data.users[0].status) !== -1) {
                         return Promise.reject(new errors.NoPermissionError({
                             message: i18n.t('errors.api.users.cannotChangeStatus')
                         }));

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -17,18 +17,13 @@ var _              = require('lodash'),
     bcryptGenSalt  = Promise.promisify(bcrypt.genSalt),
     bcryptHash     = Promise.promisify(bcrypt.hash),
     bcryptCompare  = Promise.promisify(bcrypt.compare),
-    /**
-     * There are three user states:
-     * 1. active users: everything is allowed
-     * 2. restricted users: imported users, we reset their passport, they are "locked out from the admin panel"
-     * 3. inactivate users: e.g. owner user, suspended users, you can' serve their author page
-     *
-     * NOTE: warn level is not used right now!
-     */
     activeStates     = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'],
-    restrictedStates = ['locked'],
-    inactiveStates   = ['inactive'],
-    allStates        = activeStates.concat(inactiveStates).concat(restrictedStates),
+    /**
+     * inactive: owner user before blog setup, suspended users
+     * locked user: imported users, they get a random passport
+     */
+    inactiveStates   = ['inactive', 'locked'],
+    allStates        = activeStates.concat(inactiveStates),
     User,
     Users;
 
@@ -359,7 +354,7 @@ User = ghostBookshelf.Model.extend({
         }
 
         if (status === 'active') {
-            query.query('whereIn', 'status', activeStates.concat(restrictedStates));
+            query.query('whereIn', 'status', activeStates);
         } else if (status !== 'all') {
             query.query('where', {status: status});
         }
@@ -367,6 +362,7 @@ User = ghostBookshelf.Model.extend({
         options = this.filterOptions(options, 'findOne');
         delete options.include;
         options.include = optInc;
+
         return query.fetch(options);
     },
 
@@ -793,8 +789,7 @@ User = ghostBookshelf.Model.extend({
             }
         });
     },
-    inactiveStates: inactiveStates,
-    restrictedStates: restrictedStates
+    inactiveStates: inactiveStates
 });
 
 Users = ghostBookshelf.Collection.extend({

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -627,27 +627,6 @@ User = ghostBookshelf.Model.extend({
         return Promise.reject(new errors.NoPermissionError({message: i18n.t('errors.models.user.notEnoughPermission')}));
     },
 
-    setWarning: function setWarning(user, options) {
-        var status = user.get('status'),
-            regexp = /warn-(\d+)/i,
-            level;
-
-        if (status === 'active') {
-            user.set('status', 'warn-1');
-            level = 1;
-        } else {
-            level = parseInt(status.match(regexp)[1], 10) + 1;
-            if (level > 4) {
-                user.set('status', 'locked');
-            } else {
-                user.set('status', 'warn-' + level);
-            }
-        }
-        return Promise.resolve(user.save(options)).then(function then() {
-            return 5 - level;
-        });
-    },
-
     // Finds the user by email, and checks the password
     // @TODO: shorten this function and rename...
     check: function check(object) {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -20,7 +20,7 @@ var _              = require('lodash'),
     /**
      * There are three user states:
      * 1. active users: everything is allowed
-     * 2. restricted users: imported users, we reset their passport, their are just "locked out from the admin panel"
+     * 2. restricted users: imported users, we reset their passport, they are "locked out from the admin panel"
      * 3. inactivate users: e.g. owner user, suspended users, you can' serve their author page
      *
      * NOTE: warn level is not used right now!

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -17,10 +17,18 @@ var _              = require('lodash'),
     bcryptGenSalt  = Promise.promisify(bcrypt.genSalt),
     bcryptHash     = Promise.promisify(bcrypt.hash),
     bcryptCompare  = Promise.promisify(bcrypt.compare),
-
-    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'],
-    inactiveStates = ['inactive', 'locked'],
-    allStates      = activeStates.concat(inactiveStates),
+    /**
+     * There are three user states:
+     * 1. active users: everything is allowed
+     * 2. restricted users: imported users, we reset their passport, their are just "locked out from the admin panel"
+     * 3. inactivate users: e.g. owner user, suspended users, you can' serve their author page
+     *
+     * NOTE: warn level is not used right now!
+     */
+    activeStates     = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4'],
+    restrictedStates = ['locked'],
+    inactiveStates   = ['inactive'],
+    allStates        = activeStates.concat(inactiveStates).concat(restrictedStates),
     User,
     Users;
 
@@ -351,7 +359,7 @@ User = ghostBookshelf.Model.extend({
         }
 
         if (status === 'active') {
-            query.query('whereIn', 'status', activeStates);
+            query.query('whereIn', 'status', activeStates.concat(restrictedStates));
         } else if (status !== 'all') {
             query.query('where', {status: status});
         }
@@ -806,7 +814,8 @@ User = ghostBookshelf.Model.extend({
             }
         });
     },
-    inactiveStates: inactiveStates
+    inactiveStates: inactiveStates,
+    restrictedStates: restrictedStates
 });
 
 Users = ghostBookshelf.Collection.extend({

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -94,7 +94,7 @@ User = ghostBookshelf.Model.extend({
     },
 
     isActive: function isActive() {
-        return inactiveStates.indexOf(this.get('status')) === -1;
+        return activeStates.indexOf(this.get('status')) !== -1;
     },
 
     isLocked: function isLocked() {

--- a/core/server/permissions/index.js
+++ b/core/server/permissions/index.js
@@ -61,9 +61,7 @@ function applyStatusRules(docName, method, opts) {
     // Enforce status 'active' for users
     if (docName === 'users') {
         if (!opts.status) {
-            return 'active';
-        } else if (opts.status !== 'active') {
-            throw err;
+            return 'all';
         }
     }
 

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -568,6 +568,22 @@ describe('Users API', function () {
                         (err instanceof errors.NoPermissionError).should.eql(true);
                     });
                 });
+
+                it('[failure] can\' change my own status to locked', function () {
+                    return UserAPI.edit(
+                        {
+                            users: [
+                                {
+                                    status: 'locked'
+                                }
+                            ]
+                        }, _.extend({}, context.owner, {id: userIdFor.owner})
+                    ).then(function () {
+                        throw new Error('this is not allowed');
+                    }).catch(function (err) {
+                        (err instanceof errors.NoPermissionError).should.eql(true);
+                    });
+                });
             });
 
             describe('as admin', function () {

--- a/core/test/unit/permissions_spec.js
+++ b/core/test/unit/permissions_spec.js
@@ -253,7 +253,7 @@ describe('Permissions', function () {
                 result.should.not.eql(publicContext);
                 result.should.eql({
                     context: {},
-                    status: 'active'
+                    status: 'all'
                 });
 
                 return permissions.applyPublicRules('users', 'browse', _.extend({}, _.cloneDeep(publicContext), {status: 'active'}));
@@ -265,17 +265,6 @@ describe('Permissions', function () {
 
                 done();
             }).catch(done);
-        });
-
-        it('should throw an error for an inactive user', function (done) {
-            var inactive = {context: {}, status: 'inactive'};
-
-            permissions.applyPublicRules('users', 'browse', _.cloneDeep(inactive)).then(function () {
-                done('Did not throw an error for inactive');
-            }).catch(function (err) {
-                (err instanceof errors.NoPermissionError).should.eql(true);
-                done();
-            });
         });
     });
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -285,6 +285,16 @@ fixtures = {
         });
     },
 
+    insertOneUser: function insertOneUser(options) {
+        options = options || {};
+
+        return db.knex('users').insert(DataGenerator.forKnex.createUser({
+            email: options.email,
+            slug: options.slug,
+            status: options.status
+        }));
+    },
+
     // Creates a client, and access and refresh tokens for user with index or 2 by default
     createTokensForUser: function createTokensForUser(index) {
         return db.knex('clients').insert(DataGenerator.forKnex.clients).then(function () {

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -242,6 +242,14 @@ fixtures = {
             .update(user);
     },
 
+    changeOwnerUserStatus: function changeOwnerUserStatus(options) {
+        return db.knex('users')
+            .where('slug', '=', options.slug)
+            .update({
+                status: options.status
+            });
+    },
+
     createUsersWithRoles: function createUsersWithRoles() {
         return db.knex('roles').insert(DataGenerator.forKnex.roles).then(function () {
             return db.knex('users').insert(DataGenerator.forKnex.users);


### PR DESCRIPTION
closes #8645, closes #8710

- locked users were once part of the category "active users", but were moved to the inactive category, locked users are right now imported users only
  -> we have added a protection of not being able to edit yourself when you are either suspended or locked
- but they are not really active users, they are restricted, because they have no access to the admin panel
- support three categories: active, inactive, restricted