### PR TITLE
🐛  import invalid dates

### DIFF
--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -54,8 +54,32 @@ class Base {
         });
     }
 
+    /**
+     * Clean invalid values.
+     */
+    sanitizeValues() {
+        let temporaryDate, self = this;
+
+        _.each(this.dataToImport, function (obj) {
+            _.each(_.pick(obj, ['updated_at', 'created_at', 'published_at']), function (value, key) {
+                temporaryDate = new Date(value);
+
+                if (isNaN(temporaryDate)) {
+                    self.problems.push({
+                        message: 'Date is in a wrong format and invalid. It was replaced with the current timestamp.',
+                        help: self.modelName,
+                        context: JSON.stringify(obj)
+                    });
+
+                    obj[key] = new Date().toISOString();
+                }
+            });
+        });
+    }
+
     beforeImport() {
         this.stripProperties(['id']);
+        this.sanitizeValues();
         return Promise.resolve();
     }
 

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -353,7 +353,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      * `sanitizeData` ensures that client data is in the correct format for further operations.
      *
      * Dates:
-     * - client dates are sent as ISO format (moment(..).format())
+     * - client dates are sent as ISO 8601 format (moment(..).format())
      * - server dates are in JS Date format
      *   >> when bookshelf fetches data from the database, all dates are in JS Dates
      *   >> see `parse`

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -60,7 +60,7 @@ describe('Import', function () {
             }).then(function (importResult) {
                 should.exist(importResult.data.posts);
                 importResult.data.posts.length.should.equal(1);
-                importResult.problems.length.should.eql(2);
+                importResult.problems.length.should.eql(3);
 
                 done();
             }).catch(done);
@@ -89,6 +89,26 @@ describe('Import', function () {
                 importResult.problems.length.should.equal(3);
 
                 importResult.problems[2].message.should.equal('Theme not imported, please upload in Settings - Design');
+
+                done();
+            }).catch(done);
+        });
+
+        it('cares about invalid dates', function (done) {
+            var exportData;
+
+            testUtils.fixtures.loadExportFixture('export-003',{lts:true}).then(function (exported) {
+                exportData = exported;
+                return dataImporter.doImport(exportData);
+            }).then(function (importResult) {
+                should.exist(importResult.data.posts);
+                importResult.data.posts.length.should.equal(1);
+                importResult.problems.length.should.eql(3);
+
+                moment(importResult.data.posts[0].created_at).isValid().should.eql(true);
+                moment(importResult.data.posts[0].updated_at).format().should.eql('2013-10-18T23:58:44Z');
+                moment(importResult.data.posts[0].published_at).format().should.eql('2013-12-29T11:58:30Z');
+                moment(importResult.data.tags[0].updated_at).format().should.eql('2016-07-17T12:02:54Z');
 
                 done();
             }).catch(done);

--- a/core/test/utils/fixtures/export/lts/export-003.json
+++ b/core/test/utils/fixtures/export/lts/export-003.json
@@ -20,9 +20,9 @@
                 "meta_title": null,
                 "meta_description": null,
                 "author_id": 1,
-                "created_at": 1388318310782,
+                "created_at": "00-00-0000 00:00:00",
                 "created_by": 1,
-                "updated_at": 1388318310782,
+                "updated_at": "Fri, 18 Oct 2013 23:58:44 +0000",
                 "updated_by": 1,
                 "published_at": 1388318310783,
                 "published_by": 1
@@ -47,7 +47,7 @@
                 "meta_title": null,
                 "meta_description": null,
                 "last_login": null,
-                "created_at": 1388319501897,
+                "created_at": "2017-07-17T12:02:54.000Z",
                 "created_by": 1,
                 "updated_at": null,
                 "updated_by": null
@@ -305,7 +305,7 @@
                 "meta_description": null,
                 "created_at": 1388318310790,
                 "created_by": 1,
-                "updated_at": 1388318310790,
+                "updated_at": "2016-07-17T12:02:54.000Z",
                 "updated_by": 1
             }
         ],


### PR DESCRIPTION
closes #8703, closes #8015

- add sanitize fn to importer
- check wether an imported date is a valid date
- if not, print a warning

Closing #8015 as well, as this should be fixed on master. No need to fix this on LTS, we already closed some of the LTS importer bugs. If users want a better importer, they have to switch to 1.0.