### PR TITLE
🎨  do not run model listeners on import

### DIFF
--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -57,23 +57,23 @@ Settings = ghostBookshelf.Model.extend({
         };
     },
 
-    emitChange: function emitChange(event) {
-        events.emit('settings' + '.' + event, this);
+    emitChange: function emitChange(event, options) {
+        events.emit('settings' + '.' + event, this, options);
     },
 
-    onDestroyed: function onDestroyed(model) {
+    onDestroyed: function onDestroyed(model, response, options) {
         model.emitChange('deleted');
-        model.emitChange(model.attributes.key + '.' + 'deleted');
+        model.emitChange(model.attributes.key + '.' + 'deleted', options);
     },
 
-    onCreated: function onCreated(model) {
+    onCreated: function onCreated(model, response, options) {
         model.emitChange('added');
-        model.emitChange(model.attributes.key + '.' + 'added');
+        model.emitChange(model.attributes.key + '.' + 'added', options);
     },
 
-    onUpdated: function onUpdated(model) {
+    onUpdated: function onUpdated(model, response, options) {
         model.emitChange('edited');
-        model.emitChange(model.attributes.key + '.' + 'edited');
+        model.emitChange(model.attributes.key + '.' + 'edited', options);
     },
 
     onValidate: function onValidate() {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -52,13 +52,13 @@ User = ghostBookshelf.Model.extend({
         }, baseDefaults);
     },
 
-    emitChange: function emitChange(event) {
-        events.emit('user' + '.' + event, this);
+    emitChange: function emitChange(event, options) {
+        events.emit('user' + '.' + event, this, options);
     },
 
-    onDestroyed: function onDestroyed(model) {
+    onDestroyed: function onDestroyed(model, response, options) {
         if (_.includes(activeStates, model.previous('status'))) {
-            model.emitChange('deactivated');
+            model.emitChange('deactivated', options);
         }
 
         model.emitChange('deleted');
@@ -73,12 +73,12 @@ User = ghostBookshelf.Model.extend({
         }
     },
 
-    onUpdated: function onUpdated(model) {
+    onUpdated: function onUpdated(model, response, options) {
         model.statusChanging = model.get('status') !== model.updated('status');
         model.isActive = _.includes(activeStates, model.get('status'));
 
         if (model.statusChanging) {
-            model.emitChange(model.isActive ? 'activated' : 'deactivated');
+            model.emitChange(model.isActive ? 'activated' : 'deactivated', options);
         } else {
             if (model.isActive) {
                 model.emitChange('activated.edited');


### PR DESCRIPTION
no issue

- if you upload a huge import file, parallel operations can throw errors e.g. lock wait exceeds
- this can happen if multiple transactions run in parallel (because the database query load is heavy)
- there is no need to run:
  1. the removal of active tokens on import, because imported users have no active session
  2. rescheduling logic on timezone change, because importing scheduled posts works out of the box via the model layer (if a published date is detected and it's in the future, the post get's scheduled)

Note: this does not prevent the import of being successful, but it's super confusing and both listener operations should not run on import.