### PR TITLE
🐛  user was not imported, but the importer tries to correct the refer…

### DIFF
--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -209,6 +209,13 @@ class Base {
                     email: oldUser.email,
                     status: 'all'
                 }, options).then(function (userModel) {
+                    // CASE: user could not be imported e.g. multiple roles attached
+                    if (!userModel) {
+                        userModel = {
+                            id: models.User.ownerUser
+                        };
+                    }
+
                     dataToEdit = {};
                     dataToEdit[key] = userModel.id;
 


### PR DESCRIPTION
no issue

- this is usually an edge case, but i investigated because i thought that the importer is broken
- the importer logic is build like this:
   - it creates a transaction
   - this transactions runs through:
      - beforeImport
      - doImport
      - afterImport
   - afterImport corrects user references and if a user could not be imported, we have to protect that
       NOTE: we could create two transactions to be more correct, but building this had no priority because of edge cases only
             having two transactions would solve: you first add the data (error or success), then you correct the data
   - usually a user can be always imported (!), but there are a few edge cases (e.g. multiple roles attached)