### PR TITLE
🐛 fix incorrect rendering of non-closing tags (eg. <br></br>)

### DIFF
--- a/core/server/utils/mobiledoc-converter.js
+++ b/core/server/utils/mobiledoc-converter.js
@@ -39,7 +39,7 @@ module.exports = {
     render: function (mobiledoc) {
         var renderer = new Renderer(options),
         rendered = renderer.render(mobiledoc),
-        serializer = new SimpleDom.HTMLSerializer([]),
+        serializer = new SimpleDom.HTMLSerializer(SimpleDom.voidMap),
         html = serializer.serializeChildren(rendered.result);
         return html;
     }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8743
- the serializer in our mobiledoc renderer didn't have the list of non-closing HTML tags passed in which meant that tags such as `<br>` in the markdown HTML output were being re-serialized to `<br></br>` which is invalid HTML which (at least Chrome) then attempts to fix by rendering it as `<br><br>` instead
- the elements with incorrect rendering that may result in unwanted "fixing" by browsers are `AREA`, `BASE`, `BR`, `COL`, `COMMAND`, `EMBED`, `HR`, `IMG`, `INPUT`, `KEYGEN`, `LINK`, `META`, `PARAM`, `SOURCE`, `TRACK`, and `WBR`