### PR TITLE
💄 don't include client tests in release build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -28,6 +28,7 @@ node_modules/**
 config.js
 core/built/**/*.map
 core/built/**/test-*
+core/built/**/tests-*
 core/client/**
 core/test/**
 CONTRIBUTING.md


### PR DESCRIPTION
no issue
- add `core/built/assets/test-*.js` to the npm ignore list