### PR TITLE
🐛 fix "unbalanced tag" errors on save/import

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -178,7 +178,7 @@ Post = ghostBookshelf.Model.extend({
             publishedAt = this.get('published_at'),
             publishedAtHasChanged = this.hasDateChanged('published_at', {beforeWrite: true}),
             mobiledoc   = this.get('mobiledoc'),
-            tags = [], ops = [];
+            tags = [], ops = [], markdown, html;
 
         // CASE: disallow published -> scheduled
         // @TODO: remove when we have versioning based on updated_at
@@ -233,7 +233,11 @@ Post = ghostBookshelf.Model.extend({
         ghostBookshelf.Model.prototype.onSaving.call(this, model, attr, options);
 
         if (mobiledoc) {
-            this.set('html', utils.mobiledocConverter.render(JSON.parse(mobiledoc)));
+            // NOTE: using direct markdown parsing through markdown-it for now,
+            // mobiledoc's use of SimpleDom is very fragile with certain HTML
+            markdown = JSON.parse(mobiledoc).cards[0][1].markdown;
+            html = utils.markdownConverter.render(markdown);
+            this.set('html', '<div class="kg-card-markdown">' + html + '</div>');
         }
 
         if (this.hasChanged('html') || !this.get('plaintext')) {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/8757
- remove mobiledoc parsing, it's reliance on SimpleDom makes it too fragile when dealing with the unconstrained user-entered HTML that is allowed in markdown
- we'll need to fix the mobiledoc rendering issues before re-enabling it