### PR TITLE
⬆️  bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ghost-ignition": "2.8.11",
     "ghost-storage-base": "0.0.1",
     "glob": "5.0.15",
-    "gscan": "1.1.4",
+    "gscan": "1.1.5",
     "html-to-text": "3.3.0",
     "icojs": "0.7.2",
     "image-size": "0.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2127,9 +2127,9 @@ grunt@~0.4.0:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-gscan@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.1.4.tgz#0658159ef54736b8f6fe8bd56958a44cb79c0578"
+gscan@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.1.5.tgz#76d524339c70c9cdcd71049b4da1b89140888670"
   dependencies:
     bluebird "3.4.6"
     chalk "1.1.1"


### PR DESCRIPTION
no issue

- gscan@1.1.5