### PR TITLE
🚓  disqus comments

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -137,6 +137,11 @@ class PostsImporter extends BaseImporter {
                     });
                 }
             }
+
+            // NOTE: we remember the old post id for disqus
+            if (model.id) {
+                model.amp = model.id.toString();
+            }
         });
 
         // NOTE: do after, because model properties are deleted e.g. post.id

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -494,7 +494,9 @@ Post = ghostBookshelf.Model.extend({
     toJSON: function toJSON(options) {
         options = options || {};
 
-        var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
+        var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options),
+            oldPostId = attrs.amp,
+            commentId;
 
         attrs = this.formatsToJSON(attrs, options);
 
@@ -506,6 +508,21 @@ Post = ghostBookshelf.Model.extend({
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {
             attrs.url = utils.url.urlPathForPost(attrs);
         }
+
+        if (oldPostId) {
+            oldPostId = Number(oldPostId);
+
+            if (isNaN(oldPostId)) {
+                commentId = attrs.id;
+            } else {
+                commentId = oldPostId;
+            }
+        } else {
+            commentId = attrs.id;
+        }
+
+        // NOTE: we remember the old post id because of disqus
+        attrs.comment_id = commentId;
 
         return attrs;
     },

--- a/core/test/integration/api/api_schedules_spec.js
+++ b/core/test/integration/api/api_schedules_spec.js
@@ -104,7 +104,7 @@ describe('Schedules API', function () {
                 api.schedules.getScheduledPosts()
                     .then(function (result) {
                         result.posts.length.should.eql(5);
-                        Object.keys(result.posts[0].toJSON()).should.eql(['id', 'published_at', 'created_at', 'author', 'url']);
+                        Object.keys(result.posts[0].toJSON()).should.eql(['id', 'published_at', 'created_at', 'author', 'url', 'comment_id']);
                         done();
                     })
                     .catch(done);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -24,7 +24,7 @@ var _               = require('lodash'),
             // does not return all formats by default
             .without('mobiledoc', 'amp', 'plaintext')
             // swaps author_id to author, and always returns a computed 'url' property
-            .without('author_id').concat('author', 'url')
+            .without('author_id').concat('author', 'url', 'comment_id')
             .value(),
         // User API always removes the password field
         user:        _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),


### PR DESCRIPTION
closes #8760

- we have to remember the old post id's when migrating a blog from LTS to 1.0
- otherwise we would break disqus comments, because they rely on the post id
- this should fix the discovered situation
