### PR TITLE
🐛 🔗 resolve symlinks before building zip

### DIFF
--- a/core/server/utils/zip-folder.js
+++ b/core/server/utils/zip-folder.js
@@ -5,6 +5,12 @@ module.exports = function zipFolder(folderToZip, destination, callback) {
         output = fs.createWriteStream(destination),
         archive = archiver.create('zip', {});
 
+    // If folder to zip is a symlink, we want to get the target
+    // of the link and zip that instead of zipping the symlink
+    if (fs.lstatSync(folderToZip).isSymbolicLink()) {
+        folderToZip = fs.realpathSync(folderToZip);
+    }
+
     output.on('close', function () {
         callback(null, archive.pointer());
     });

--- a/core/test/unit/utils/zip-folder_spec.js
+++ b/core/test/unit/utils/zip-folder_spec.js
@@ -1,0 +1,49 @@
+var should = require('should'), // jshint ignore:line
+    path = require('path'),
+    fs = require('fs-extra'),
+    extract = require('extract-zip-fork'),
+    utils = require('../../../server/utils');
+
+describe('Utils: zip-folder', function () {
+    const symlinkPath = path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'theme-symlink'),
+        folderToSymlink = path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'casper'),
+        zipDestination = path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'theme-symlink.zip'),
+        unzipDestination = path.join(__dirname, '..', '..', 'utils', 'fixtures', 'themes', 'theme-symlink-unzipped');
+
+    before(function () {
+        fs.removeSync(symlinkPath);
+        fs.removeSync(zipDestination);
+        fs.removeSync(unzipDestination);
+    });
+
+    after(function () {
+        fs.removeSync(symlinkPath);
+        fs.removeSync(zipDestination);
+        fs.removeSync(unzipDestination);
+    });
+
+    it('ensure symlinks work', function (done) {
+        fs.symlink(folderToSymlink, symlinkPath);
+
+        utils.zipFolder(symlinkPath, zipDestination, function (err) {
+            if (err) {
+                return done(err);
+            }
+
+            extract(zipDestination, {dir: unzipDestination}, function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                fs.readdir(unzipDestination, function (err, files) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    files.length.should.eql(10);
+                    done();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
closes #8778
- if folderToZip is a symlink, find the target using fs.realpathSync so we zip the right thing
