### PR TITLE
🐛  fix transfer ownership

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -302,16 +302,11 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
     /**
      * please use these static definitions when comparing id's
-     * we keep type number, because we have too many check's where we rely on
+     * we keep type Number, because we have too many check's where we rely on Number
      * context.user ? true : false (if context.user is 0 as number, this condition is false)
      */
     internalUser: 1,
-    ownerUser: 1,
     externalUser: 0,
-
-    isOwnerUser: function isOwnerUser(id) {
-        return id === ghostBookshelf.Model.ownerUser || id === ghostBookshelf.Model.ownerUser.toString();
-    },
 
     isInternalUser: function isInternalUser(id) {
         return id === ghostBookshelf.Model.internalUser || id === ghostBookshelf.Model.internalUser.toString();

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -244,6 +244,7 @@
                 "tokenLocked": "Token locked",
                 "invalidToken": "Invalid token",
                 "userNotFound": "User not found",
+                "ownerNotFound": "Owner not found",
                 "onlyOwnerCanTransferOwnerRole": "Only owners are able to transfer the owner role.",
                 "onlyAdmCanBeAssignedOwnerRole": "Only administrators can be assigned the owner role."
             },

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -75,8 +75,9 @@ describe('Authentication API', function () {
                             done(new Error('Setup ran when it should not have.'));
                         }).catch(function (err) {
                             should.exist(err);
-                            err.name.should.equal('InternalServerError');
-                            err.statusCode.should.equal(500);
+                            err.name.should.equal('NotFoundError');
+                            err.message.should.equal('Owner not found');
+                            err.statusCode.should.equal(404);
 
                             done();
                         }).catch(done);

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -1321,6 +1321,37 @@ describe('Users API', function () {
                 done(new Error('Admin is not denied transferring ownership.'));
             }).catch(checkForErrorType('NoPermissionError', done));
         });
+
+        it('Blog is still setup', function (done) {
+            // transfer ownership to admin user
+            UserAPI.transferOwnership(
+                {owner: [{id: userIdFor.admin}]},
+                context.owner
+            ).then(function (response) {
+                should.exist(response);
+                return models.User.isSetup();
+            }).then(function (isSetup) {
+                isSetup.should.eql(true);
+                done();
+            }).catch(done);
+        });
+
+        it('Blog is still setup, new owner is locked', function (done) {
+            // transfer ownership to admin user
+            UserAPI.transferOwnership(
+                {owner: [{id: userIdFor.admin}]},
+                context.owner
+            ).then(function (response) {
+                should.exist(response);
+                return models.User.edit({status: 'locked'}, {id: userIdFor.admin});
+            }).then(function (modifiedUser) {
+                modifiedUser.get('status').should.eql('locked');
+                return models.User.isSetup();
+            }).then(function (isSetup) {
+                isSetup.should.eql(true);
+                done();
+            }).catch(done);
+        });
     });
 
     describe('Change Password', function () {

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -238,7 +238,7 @@ fixtures = {
         }
 
         return db.knex('users')
-            .where('id', '=', models.User.ownerUser)
+            .where('id', '=', DataGenerator.Content.users[0].id)
             .update(user);
     },
 


### PR DESCRIPTION
closes #8781

- when the ownership get's transferred, the id of the new owner is not '1' anymore
- we previously added a database rule, which signalises if the blog is setup or not, see https://github.com/TryGhost/Ghost/commit/827aa15757bcfdcfe7cbb0a3ce9e3c3117657ce2#diff-7a2fe80302d7d6bf67f97cdccef1f71fR542
- this database rule is based on the owner id being '1', which is wrong when you transfer ownership
- we should keep in mind, that the owner id being '1' is only the default Ghost setup, but it can change

- [x] blog setup and locked users
- [x] add tests
- [x] do final manual test