### PR TITLE
✨  Extended {{excerpt}} to use custom excerpt & updated structured data behaviour

### DIFF
--- a/core/server/data/meta/description.js
+++ b/core/server/data/meta/description.js
@@ -6,6 +6,8 @@ function getDescription(data, root) {
         context = root ? root.context : null,
         blogDescription = settingsCache.get('description');
 
+    // We only return meta_description if provided. Only exception is the Blog
+    // description, which doesn't rely on meta_description.
     if (data.meta_description) {
         description = data.meta_description;
     } else if (_.includes(context, 'paged')) {
@@ -13,11 +15,14 @@ function getDescription(data, root) {
     } else if (_.includes(context, 'home')) {
         description = blogDescription;
     } else if (_.includes(context, 'author') && data.author) {
-        description = data.author.meta_description || data.author.bio;
+        // The usage of meta data fields for author is currently not implemented.
+        // We do have meta_description and meta_title fields
+        // in the users table, but there's no UI to populate those.
+        description = data.author.meta_description || '';
     } else if (_.includes(context, 'tag') && data.tag) {
-        description = data.tag.meta_description || data.tag.description;
+        description = data.tag.meta_description || '';
     } else if ((_.includes(context, 'post') || _.includes(context, 'page')) && data.post) {
-        description = data.post.meta_description;
+        description = data.post.meta_description || '';
     }
 
     return (description || '').trim();

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -34,7 +34,7 @@ function getMetaData(data, root) {
         authorUrl: getAuthorUrl(data, true),
         rssUrl: getRssUrl(data, true),
         metaTitle: getTitle(data, root),
-        metaDescription: getDescription(data, root),
+        metaDescription: getDescription(data, root) || null,
         coverImage: {
             url: getCoverImage(data, true)
         },
@@ -67,8 +67,17 @@ function getMetaData(data, root) {
         metaData.blog.logo = result;
 
         // TODO: cleanup these if statements
-        if (data.post && data.post.html) {
-            metaData.excerpt = getExcerpt(data.post.html, {words: 50});
+        if (data.post) {
+            // There's a specific order for description fields (not <meta name="description" /> !!) in structured data
+            // and schema.org which is used the description fields (see https://github.com/TryGhost/Ghost/issues/8793):
+            // 1. CASE: custom_excerpt is populated via the UI
+            // 2. CASE: no custom_excerpt, but meta_description is poplated via the UI
+            // 3. CASE: fall back to automated excerpt of 50 words if neither custom_excerpt nor meta_description is provided
+            var customExcerpt = data.post.custom_excerpt,
+                metaDescription = data.post.meta_description,
+                fallbackExcerpt = data.post.html ? getExcerpt(data.post.html, {words: 50}) : '';
+
+            metaData.excerpt = customExcerpt ? customExcerpt : metaDescription ? metaDescription : fallbackExcerpt;
         }
 
         if (data.post && data.post.author && data.post.author.name) {

--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -64,8 +64,9 @@ function trimSameAs(data, context) {
 }
 
 function getPostSchema(metaData, data) {
-    var description = metaData.metaDescription ? escapeExpression(metaData.metaDescription) :
-        (metaData.excerpt ? escapeExpression(metaData.excerpt) : null),
+    // CASE: metaData.excerpt for post context is populated by either the custom excerpt, the meta description,
+    // or the automated excerpt of 50 words. It is empty for any other context.
+    var description = metaData.excerpt ? escapeExpression(metaData.excerpt) : null,
         schema;
 
     schema = {
@@ -82,8 +83,8 @@ function getPostSchema(metaData, data) {
             image: schemaImageObject(metaData.authorImage),
             url: metaData.authorUrl,
             sameAs: trimSameAs(data, 'post'),
-            description: data.post.author.bio ?
-            escapeExpression(data.post.author.bio) :
+            description: data.post.author.metaDescription ?
+            escapeExpression(data.post.author.metaDescription) :
             null
         },
         headline: escapeExpression(metaData.metaTitle),

--- a/core/server/data/meta/structured_data.js
+++ b/core/server/data/meta/structured_data.js
@@ -12,7 +12,10 @@ function getStructuredData(metaData) {
         'og:site_name': metaData.blog.title,
         'og:type': metaData.ogType,
         'og:title': metaData.metaTitle,
-        'og:description': metaData.metaDescription || metaData.excerpt,
+        // CASE: metaData.excerpt for post context is populated by either the custom excerpt,
+        // the meta description, or the automated excerpt of 50 words. It is empty for any
+        // other context and *always* uses the provided meta description fields.
+        'og:description': metaData.excerpt || metaData.metaDescription,
         'og:url': metaData.canonicalUrl,
         'og:image': metaData.coverImage.url,
         'article:published_time': metaData.publishedDate,
@@ -22,7 +25,7 @@ function getStructuredData(metaData) {
         'article:author': metaData.authorFacebook ? socialUrls.facebookUrl(metaData.authorFacebook) : undefined,
         'twitter:card': card,
         'twitter:title': metaData.metaTitle,
-        'twitter:description': metaData.metaDescription || metaData.excerpt,
+        'twitter:description': metaData.excerpt || metaData.metaDescription,
         'twitter:url': metaData.canonicalUrl,
         'twitter:image': metaData.coverImage.url,
         'twitter:label1': metaData.authorName ? 'Written by' : undefined,

--- a/core/server/helpers/excerpt.js
+++ b/core/server/helpers/excerpt.js
@@ -11,7 +11,8 @@ var proxy = require('./proxy'),
     getMetaDataExcerpt = proxy.metaData.getMetaDataExcerpt;
 
 module.exports = function excerpt(options) {
-    var truncateOptions = (options || {}).hash || {};
+    var truncateOptions = (options || {}).hash || {},
+        excerptText = this.custom_excerpt ? String(this.custom_excerpt) : String(this.html);
 
     truncateOptions = _.pick(truncateOptions, ['words', 'characters']);
     _.keys(truncateOptions).map(function (key) {
@@ -19,6 +20,6 @@ module.exports = function excerpt(options) {
     });
 
     return new SafeString(
-        getMetaDataExcerpt(String(this.html), truncateOptions)
+        getMetaDataExcerpt(excerptText, truncateOptions)
     );
 };

--- a/core/test/unit/metadata/description_spec.js
+++ b/core/test/unit/metadata/description_spec.js
@@ -16,7 +16,7 @@ describe('getMetaDescription', function () {
         description.should.equal('');
     });
 
-    it('should return data author bio if on root context contains author', function () {
+    it('should not return meta description for author if on root context contains author and no meta description provided', function () {
         var description = getMetaDescription({
             author: {
                 bio: 'Just some hack building code to make the world better.'
@@ -24,7 +24,19 @@ describe('getMetaDescription', function () {
         }, {
             context: ['author']
         });
-        description.should.equal('Just some hack building code to make the world better.');
+        description.should.equal('');
+    });
+
+    it('should return meta description for author if on root context contains author and meta description provided', function () {
+        var description = getMetaDescription({
+            author: {
+                bio: 'Just some hack building code to make the world better.',
+                meta_description: 'Author meta description.'
+            }
+        }, {
+            context: ['author']
+        });
+        description.should.equal('Author meta description.');
     });
 
     it('should return data tag meta description if on root context contains tag', function () {
@@ -38,7 +50,7 @@ describe('getMetaDescription', function () {
         description.should.equal('Best tag ever!');
     });
 
-    it('should return data tag description if no meta description for tag', function () {
+    it('should not return data tag description if no meta description for tag', function () {
         var description = getMetaDescription({
             tag: {
                 meta_description: '',
@@ -47,7 +59,7 @@ describe('getMetaDescription', function () {
         }, {
             context: ['tag']
         });
-        description.should.equal('The normal description');
+        description.should.equal('');
     });
 
     it('should return data post meta description if on root context contains post', function () {

--- a/core/test/unit/metadata/schema_spec.js
+++ b/core/test/unit/metadata/schema_spec.js
@@ -38,7 +38,8 @@ describe('getSchema', function () {
                 }
             },
             keywords: ['one', 'two', 'tag'],
-            metaDescription: 'Post meta description'
+            metaDescription: 'Post meta description',
+            excerpt: 'Custom excerpt for description'
         },  data = {
             context: ['post'],
             post: {
@@ -57,7 +58,6 @@ describe('getSchema', function () {
             '@type': 'Article',
             author: {
                 '@type': 'Person',
-                description: 'My author bio.',
                 image: {
                     '@type': 'ImageObject',
                     url: 'http://mysite.com/author/image/url/me.jpg',
@@ -74,7 +74,7 @@ describe('getSchema', function () {
             },
             dateModified: '2016-01-21T22:13:05.412Z',
             datePublished: '2015-12-25T05:35:01.234Z',
-            description: 'Post meta description',
+            description: 'Custom excerpt for description',
             headline: 'Post Title',
             image: {
                 '@type': 'ImageObject',
@@ -137,7 +137,8 @@ describe('getSchema', function () {
                 }
             },
             keywords: ['one', 'two', 'tag'],
-            metaDescription: 'Post meta description'
+            metaDescription: 'Post meta description',
+            excerpt: 'Post meta description'
         },  data = {
             context: ['amp', 'post'],
             post: {
@@ -160,7 +161,6 @@ describe('getSchema', function () {
             '@type': 'Article',
             author: {
                 '@type': 'Person',
-                description: 'My author bio.',
                 image: {
                     '@type': 'ImageObject',
                     url: 'http://mysite.com/author/image/url/me.jpg',
@@ -220,7 +220,8 @@ describe('getSchema', function () {
             modifiedDate: '2016-01-21T22:13:05.412Z',
             coverImage: undefined,
             keywords: [],
-            metaDescription: 'Post meta description'
+            metaDescription: '',
+            excerpt: 'Post meta description'
         },  data = {
             context: ['post'],
             post: {
@@ -284,7 +285,8 @@ describe('getSchema', function () {
                 url: 'http://mysite.com/content/image/mypostcoverimage.jpg'
             },
             keywords: ['one', 'two', 'tag'],
-            metaDescription: 'Post meta description'
+            metaDescription: 'Post meta description',
+            excerpt: 'Post meta description'
         },  data = {
             context: ['post'],
             post: {
@@ -293,7 +295,8 @@ describe('getSchema', function () {
                     website: 'http://myblogsite.com/',
                     bio: 'My author bio.',
                     facebook: 'testuser',
-                    twitter: '@testuser'
+                    twitter: '@testuser',
+                    metaDescription: 'My author bio.'
                 }
             }
         }, schema = getSchema(metadata, data);

--- a/core/test/unit/server_helpers/excerpt_spec.js
+++ b/core/test/unit/server_helpers/excerpt_spec.js
@@ -85,4 +85,22 @@ describe('{{excerpt}} Helper', function () {
         should.exist(rendered);
         rendered.string.should.equal(expected);
     });
+
+    it('uses custom excerpt if provided instead of truncating html', function () {
+        var html = '<p>Hello <strong>World! It\'s me!</strong></p>',
+            customExcerpt = 'My Custom Excerpt wins!',
+            expected = 'My Custo',
+            rendered = (
+                helpers.excerpt.call(
+                    {
+                        html: html,
+                        custom_excerpt: customExcerpt
+                    },
+                    {hash: {characters: '8'}}
+                )
+            );
+
+        should.exist(rendered);
+        rendered.string.should.equal(expected);
+    });
 });

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -200,7 +200,7 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
 
-        it('tag first page without meta description uses tag description, and title if no meta title', function (done) {
+        it('tag first page without meta data if no meta title and meta description, but model description provided', function (done) {
             var tag = {
                 meta_description: '',
                 description: 'tag description',
@@ -216,16 +216,16 @@ describe('{{ghost_head}} helper', function () {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
-                rendered.string.should.match(/<meta name="description" content="tag description" \/>/);
+                rendered.string.should.not.match(/<meta name="description"/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="tagtitle - Ghost" \/>/);
-                rendered.string.should.match(/<meta property="og:description" content="tag description" \/>/);
+                rendered.string.should.not.match(/<meta property="og:description"/);
                 rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="tagtitle - Ghost" \/>/);
-                rendered.string.should.match(/<meta name="twitter:description" content="tag description" \/>/);
+                rendered.string.should.not.match(/<meta name="twitter:description"/);
                 rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
@@ -237,13 +237,13 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/tag\/tagtitle\/"/);
                 rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
-                rendered.string.should.match(/"description": "tag description"/);
+                rendered.string.should.not.match(/"description":/);
 
                 done();
             }).catch(done);
         });
 
-        it('tag first page with meta and model description returns no description fields', function (done) {
+        it('tag first page without meta and model description returns no description fields', function (done) {
             var tag = {
                 meta_description: '',
                 name: 'tagtitle',
@@ -310,16 +310,16 @@ describe('{{ghost_head}} helper', function () {
                 should.exist(rendered);
                 rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
                 rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
-                rendered.string.should.match(/<meta name="description" content="Author bio" \/>/);
+                rendered.string.should.not.match(/<meta name="description"/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="profile" \/>/);
-                rendered.string.should.match(/<meta property="og:description" content="Author bio" \/>/);
+                rendered.string.should.not.match(/<meta property="og:description"/);
                 rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
                 rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/author-cover-image.png" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser\" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Author name - Ghost" \/>/);
-                rendered.string.should.match(/<meta name="twitter:description" content="Author bio" \/>/);
+                rendered.string.should.not.match(/<meta name="twitter:description"/);
                 rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/author-cover-image.png" \/>/);
@@ -332,7 +332,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/AuthorName\/"/);
                 rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/author-cover-image.png"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"description": "Author bio"/);
+                rendered.string.should.not.match(/"description":/);
 
                 author.should.eql(authorBk);
 
@@ -448,7 +448,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
-                rendered.string.should.match(/"description": "Author bio"/);
+                rendered.string.should.not.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
                 rendered.string.should.match(re3);
@@ -456,6 +456,140 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog description"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
+                rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+
+                post.should.eql(postBk);
+
+                done();
+            }).catch(done);
+        });
+
+        it('returns structured data on post page with custom excerpt for description and meta description', function (done) {
+            var post = {
+                meta_description: 'blog description',
+                custom_excerpt: 'post custom excerpt',
+                title: 'Welcome to Ghost',
+                feature_image: '/content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                author: {
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    bio: 'Author bio',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            }, postBk = _.cloneDeep(post);
+
+            helpers.ghost_head.call(
+                {relativeUrl: '/post/', safeVersion: '0.3', context: ['post'], post: post},
+                {data: {root: {context: ['post']}}}
+            ).then(function (rendered) {
+                var re1 = new RegExp('<meta property="article:published_time" content="' + post.published_at),
+                    re2 = new RegExp('<meta property="article:modified_time" content="' + post.updated_at),
+                    re3 = new RegExp('"datePublished": "' + post.published_at),
+                    re4 = new RegExp('"dateModified": "' + post.updated_at);
+
+                should.exist(rendered);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<meta name="description" content="blog description" \/>/);
+                rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
+                rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:description" content="post custom excerpt" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(re1);
+                rendered.string.should.match(re2);
+                rendered.string.should.match(/<meta property="article:tag" content="tag1" \/>/);
+                rendered.string.should.match(/<meta property="article:tag" content="tag2" \/>/);
+                rendered.string.should.match(/<meta property="article:tag" content="tag3" \/>/);
+                rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
+                rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
+                rendered.string.should.match(/<meta name="twitter:description" content="post custom excerpt" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
+                rendered.string.should.match(/"@type": "Article"/);
+                rendered.string.should.match(/"publisher": {/);
+                rendered.string.should.match(/"@type": "Organization"/);
+                rendered.string.should.match(/"name": "Ghost"/);
+                rendered.string.should.match(/"author": {/);
+                rendered.string.should.match(/"@type": "Person"/);
+                rendered.string.should.match(/"name": "Author name"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
+                rendered.string.should.not.match(/"description": "Author bio"/);
+                rendered.string.should.match(/"headline": "Welcome to Ghost"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(re3);
+                rendered.string.should.match(re4);
+                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
+                rendered.string.should.match(/"description": "post custom excerpt"/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
+                rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+
+                post.should.eql(postBk);
+
+                done();
+            }).catch(done);
+        });
+
+        it('returns structured data on post page with fall back excerpt if no meta description provided', function (done) {
+            var post = {
+                meta_description: '',
+                custom_excerpt: '',
+                title: 'Welcome to Ghost',
+                html: '<p>This is a short post</p>',
+                author: {
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author'
+                }
+            }, postBk = _.cloneDeep(post);
+
+            helpers.ghost_head.call(
+                {relativeUrl: '/post/', safeVersion: '0.3', context: ['post'], post: post},
+                {data: {root: {context: ['post']}}}
+            ).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<link rel="shortcut icon" href="\/favicon.ico" type="image\/x-icon" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.not.match(/<meta name="description" content="blog description" \/>/);
+                rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
+                rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
+                rendered.string.should.match(/<meta property="og:description" content="This is a short post" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
+                rendered.string.should.match(/<meta name="twitter:description" content="This is a short post" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
+                rendered.string.should.match(/"@type": "Article"/);
+                rendered.string.should.match(/"publisher": {/);
+                rendered.string.should.match(/"@type": "Organization"/);
+                rendered.string.should.match(/"name": "Ghost"/);
+                rendered.string.should.match(/"author": {/);
+                rendered.string.should.match(/"@type": "Person"/);
+                rendered.string.should.match(/"name": "Author name"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.not.match(/"description": "Author bio"/);
+                rendered.string.should.match(/"headline": "Welcome to Ghost"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"description": "This is a short post"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
                 rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
@@ -528,7 +662,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
-                rendered.string.should.match(/"description": "Author bio"/);
+                rendered.string.should.not.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
                 rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
                 rendered.string.should.match(re3);

--- a/core/test/unit/server_helpers/meta_description_spec.js
+++ b/core/test/unit/server_helpers/meta_description_spec.js
@@ -76,14 +76,14 @@ describe('{{meta_description}} helper', function () {
         String(rendered).should.equal('');
     });
 
-    it('returns correct description for an author page', function () {
+    it('returns empty description for an author page', function () {
         var rendered = helpers.meta_description.call(
             {author: {bio: 'I am a Duck.'}},
             {data: {root: {context: ['author']}}}
         );
 
         should.exist(rendered);
-        String(rendered).should.equal('I am a Duck.');
+        String(rendered).should.equal('');
     });
 
     it('returns empty description for a paginated author page', function () {


### PR DESCRIPTION
refs #8793

- when a `custom_excerpt` field exists, the `{{excerpt}}` helper will output this and fall back to autogenerated excerpt if not.

- html tag `<meta name="description" />` for posts, tags and author doesn't get rendered if not provided.
    - fallback for `author.bio` removed
    - fallback for `tag.description` removed
- structured data and schema.org for `post` context takes the following order to render description fields:
1. custom excerpt
2. meta description
3. automated excerpt (50 words)
- updated and added tests to reflect the changes