### PR TITLE
🐛 fixed `grunt dev` restarting loads during tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,7 +68,7 @@ var overrides      = require('./core/server/overrides'),
                     }
                 },
                 express: {
-                    files:  ['core/ghost-server.js', 'core/server/**/*.js', 'config.*.json'],
+                    files:  ['core/ghost-server.js', 'core/server/**/*.js', 'config.*.json', '!config.testing.json'],
                     tasks:  ['express:dev'],
                     options: {
                         nospawn: true,


### PR DESCRIPTION
closes #8599

- `grunt dev` was watching for changes to all config files
- added an ignore for config.testing.json
- now it won't restart constantly during tests

