### PR TITLE
Modify validation to allow a minimum width of 60px for publication icon

### DIFF
--- a/core/server/middleware/validation/blog-icon.js
+++ b/core/server/middleware/validation/blog-icon.js
@@ -56,13 +56,13 @@ module.exports = function blogIcon() {
                 return next(new errors.ValidationError({message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})}));
             }
 
-            // CASE: icon needs to be bigger than 60px
+            // CASE: icon needs to be bigger than or equal to 60px
             // .ico files can contain multiple sizes, we need at least a minimum of 60px (16px is ok, as long as 60px are present as well)
-            if (req.file.dimensions.width <= 60) {
+            if (req.file.dimensions.width < 60) {
                 return next(new errors.ValidationError({message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})}));
             }
 
-            // CASE: icon needs to be smaller than 1000px
+            // CASE: icon needs to be smaller than or equal to 1000px
             if (req.file.dimensions.width > 1000) {
                 return next(new errors.ValidationError({message: i18n.t('errors.api.icons.invalidFile', {extensions: iconExtensions})}));
             }


### PR DESCRIPTION
It seems like the intention was to allow publication icons that are at least 60px wide, but the current validation requires icons be greater than 60px.

Related Issue: https://github.com/TryGhost/Ghost/issues/8797

(At the very least, the verbiage in the admin screen should probably be changed from "at least 60x60px" to "more than" or similar.)

---

I ran `npm test` but it reported 20 failed tests, mostly expecting 200 responses but getting 500, or the "Cache-Control" returning the wrong value. The tests do not seem related to the change I made, and fail for me even without my change.