### PR TITLE
Don't include Ghost-Admin development assets in release builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -729,8 +729,8 @@ var overrides      = require('./core/server/overrides'),
         // ### Release
         // Run `grunt release` to create a Ghost release zip file.
         // Uses the files specified by `.npmignore` to know what should and should not be included.
-        // Runs the asset generation tasks for both development and production so that the release can be used in
-        // either environment, and packages all the files up into a zip.
+        // Runs the asset generation tasks for production and duplicates default-prod.html to default.html
+        // so it can be run in either production or development, and packages all the files up into a zip.
         grunt.registerTask('release',
             'Release task - creates a final built zip\n' +
             ' - Do our standard build steps \n' +
@@ -750,7 +750,14 @@ var overrides      = require('./core/server/overrides'),
                     dest: '<%= paths.releaseBuild %>/'
                 });
 
-                grunt.task.run(['init', 'prod', 'clean:release', 'copy:release', 'compress:release']);
+                grunt.config.set('copy.admin_html', {
+                    files: [{
+                        src: '<%= paths.releaseBuild %>/core/server/admin/views/default-prod.html',
+                        dest: '<%= paths.releaseBuild %>/core/server/admin/views/default.html'
+                    }]
+                });
+
+                grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'clean:tmp', 'prod', 'clean:release', 'copy:release', 'copy:admin_html', 'compress:release']);
             }
         );
     };


### PR DESCRIPTION
no issue
- speeds up creation and reduces size of releases by not building and including the development versions of Ghost-Admin
- ensures the server can still be run in both production and development by copying the admin  `default-prod.html` file to `default.html` as part of the release task
- development builds aren't useful in release zips (especially when the sourcemaps are stripped from releases) - if deep debugging or changes are to be made in Ghost-Admin then it should be checked out from git (see https://docs.ghost.org/docs/working-with-the-admin-client)