### PR TITLE
convert value of title to string

### DIFF
--- a/core/server/data/meta/title.js
+++ b/core/server/data/meta/title.js
@@ -38,7 +38,7 @@ function getTitle(data, root) {
         title = blogTitle + pageString;
     }
 
-    return (title || '').trim();
+    return (title || '').toString().trim();
 }
 
 module.exports = getTitle;


### PR DESCRIPTION
Page title is trimmed before being output, but if page title value is set to float, an error is thrown because it does not have the trim method.