### PR TITLE
Update config location and docs url in PRIVACY

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This is a plain English summary of all of the components within Ghost which may affect your privacy in some way. Please keep in mind that if you use third party Themes or Apps with Ghost, there may be additional things not listed here.
 
-Each of the items listed in this document can be disabled via Ghost's `config.js` file. Check out the [configuration guide](https://docs.ghost.org/v1.0.0/docs/configuring-ghost) for details.
+Each of the items listed in this document can be disabled via Ghost's `config.[env].json` file. Check out the [configuration guide](https://docs.ghost.org/v1.0.0/docs/config) for details.
 
 ## Official Services
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,7 +2,7 @@
 
 This is a plain English summary of all of the components within Ghost which may affect your privacy in some way. Please keep in mind that if you use third party Themes or Apps with Ghost, there may be additional things not listed here.
 
-Each of the items listed in this document can be disabled via Ghost's `config.[env].json` file. Check out the [configuration guide](https://docs.ghost.org/v1.0.0/docs/config) for details.
+Each of the items listed in this document can be disabled via Ghost's `config.[env].json` file. Check out the [configuration guide](https://docs.ghost.org/docs/config#section-privacy) for details.
 
 ## Official Services
 


### PR DESCRIPTION
- config.js is no longer used by ghost, it's been moved to config.json
- Ghost config docs location changed
- Fixes #8816 