### PR TITLE
🐛 Fixed link that appears in update notification

### DIFF
--- a/core/server/admin/controller.js
+++ b/core/server/admin/controller.js
@@ -27,7 +27,7 @@ module.exports = function adminController(req, res) {
             location: 'upgrade.new-version-available',
             dismissible: false,
             message: i18n.t('notices.controllers.newVersionAvailable',
-                            {version: updateVersion, link: '<a href="https://docs.ghost.org/v1.0.0/docs/installing-ghost-via-the-cli" target="_blank">Click here</a>'})};
+                            {version: updateVersion, link: '<a href="https://docs.ghost.org/docs/upgrade" target="_blank">Click here</a>'})};
 
         return api.notifications.browse({context: {internal: true}}).then(function then(results) {
             if (!_.some(results.notifications, {message: notification.message})) {


### PR DESCRIPTION
PRing this for visibility, @kirrg001 think it makes sense to at least update this link now as it can go out with the next release :)

refs #8825

- The link was pointing to an install page, which had also moved
- Updated to point to the upgrade page