### PR TITLE
🐛  Fixed `grunt release` for development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -752,12 +752,13 @@ var overrides      = require('./core/server/overrides'),
 
                 grunt.config.set('copy.admin_html', {
                     files: [{
-                        src: '<%= paths.releaseBuild %>/core/server/admin/views/default-prod.html',
-                        dest: '<%= paths.releaseBuild %>/core/server/admin/views/default.html'
+                        cwd: '.',
+                        src: 'core/server/admin/views/default-prod.html',
+                        dest: 'core/server/admin/views/default.html'
                     }]
                 });
 
-                grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'clean:tmp', 'prod', 'clean:release', 'copy:release', 'copy:admin_html', 'compress:release']);
+                grunt.task.run(['update_submodules:pinned', 'subgrunt:init', 'clean:tmp', 'prod', 'clean:release', 'copy:admin_html', 'copy:release', 'compress:release']);
             }
         );
     };


### PR DESCRIPTION
closes #8829

- `grunt release` build the admin assets in the folder you execute the command
- the admin build generates the admin views
- we copy the production view for development to avoid another ember build
- the copy command has to happen before we prepare the build zip, otherwise the release tree is incomplete
- this will prevent missing the development view for npm