### PR TITLE
🐛 Fixed error in error template hiding errors

### DIFF
--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
     hbs = require('express-hbs'),
+    config = require('../config'),
     errors = require('../errors'),
     i18n = require('../i18n'),
     templates = require('../controllers/frontend/templates'),
@@ -81,6 +82,8 @@ _private.HTMLErrorRenderer = function HTMLErrorRender(err, req, res, /*jshint un
     // This ensures that no matter what res.render will work here
     if (_.isEmpty(req.app.engines)) {
         req.app.engine('hbs', _private.createHbsEngine());
+        req.app.set('view engine', 'hbs');
+        req.app.set('views', config.get('paths').defaultViews);
     }
 
     res.render(templates.error(err.statusCode), templateData, function renderResponse(err, html) {


### PR DESCRIPTION
closes #8808

Problem:
- In certain cases, particularly in production mode, errors would be hidden
- E.g. fatal theme errors could not be seen, users instead saw "Failed to lookup view 'error' in views directory"
- This is extremely unhelpful, particularly for people upgrading from 1.0.0 or 1.0.1 where the disqus rule was added
afterwards and modified casper would error
Solution:
- Ensure that we properly setup handlebars when we throw an error
- If engines is not set, set all the view engine related properties

