### PR TITLE
Make config available before creating a ghost instance

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -1,6 +1,7 @@
 // ## Server Loader
 // Passes options through the boot process to get a server instance back
-var server = require('./server');
+var server = require('./server'),
+    config = require('./server/config');
 
 // Set the default environment to be `development`
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
@@ -12,3 +13,4 @@ function makeGhost(options) {
 }
 
 module.exports = makeGhost;
+module.exports.config = config;

--- a/core/test/functional/module/module_spec.js
+++ b/core/test/functional/module/module_spec.js
@@ -3,12 +3,19 @@
 var should = require('should'),
     testUtils = require('../../utils'),
     ghost = testUtils.startGhost,
+    core = require('../../../../core'),
     i18n = require('../../../../core/server/i18n');
 
 i18n.init();
 
 describe('Module', function () {
     before(testUtils.teardown);
+
+    it.only('should expose configuration values', function () {
+        should.exist(core.config);
+        should.exist(core.config.get('server'));
+        should.exist(core.config.get('paths'));
+    });
 
     describe('Setup', function () {
         it('should resolve with a ghost-server instance', function (done) {


### PR DESCRIPTION
From 1.x it's not possible to configure Ghost with passing a `config` object.
Exposing `nconf` could be a solution for this.

It would also provide a way to deal with https://github.com/TryGhost/Ghost/issues/8795 and any other configuration related issues when you want to use ghost as an npm package.

```js
const path = require('path')
const ghost = require('ghost')

ghost.config.set('paths:contentPath', path.join(__dirname, 'content'))

ghost()
  .then(function (ghostServer) {
    ghostServer.start()
  })
```