### PR TITLE
🐛 Fixed meta on subscribe page if labs not enabled

### DIFF
--- a/core/server/controllers/frontend/context.js
+++ b/core/server/controllers/frontend/context.js
@@ -12,6 +12,7 @@
  */
 
 var config = require('../../config'),
+    labs = require('../../utils/labs'),
 
     // Context patterns, should eventually come from Channel configuration
     privatePattern = new RegExp('^\\/' + config.get('routeKeywords').private + '\\/'),
@@ -56,7 +57,7 @@ function setResponseContext(req, res, data) {
         res.locals.context.push(req.channelConfig.name);
     } else if (privatePattern.test(res.locals.relativeUrl)) {
         res.locals.context.push('private');
-    } else if (subscribePattern.test(res.locals.relativeUrl)) {
+    } else if (subscribePattern.test(res.locals.relativeUrl) && labs.isSet('subscribers') === true) {
         res.locals.context.push('subscribe');
     } else if (data && data.post && data.post.page) {
         res.locals.context.push('page');

--- a/core/test/unit/controllers/frontend/context_spec.js
+++ b/core/test/unit/controllers/frontend/context_spec.js
@@ -1,9 +1,13 @@
 var should = require('should'),
+    sinon = require('sinon'),
     _ = require('lodash'),
 
     // Stuff we are testing
     channelConfig = require('../../../../server/controllers/frontend/channel-config'),
-    setResponseContext = require('../../../../server/controllers/frontend/context');
+    setResponseContext = require('../../../../server/controllers/frontend/context'),
+    labs = require('../../../../server/utils/labs'),
+
+    sandbox = sinon.sandbox.create();
 
 describe('Contexts', function () {
     var req, res, data, setupContext;
@@ -17,6 +21,10 @@ describe('Contexts', function () {
             locals: {}
         };
         data = {};
+    });
+
+    afterEach(function () {
+        sandbox.restore();
     });
 
     /**
@@ -352,9 +360,13 @@ describe('Contexts', function () {
     });
 
     describe('Subscribe', function () {
-        it('should correctly identify /subscribe/ as the subscribe route', function () {
+        it('should identify /subscribe/ as the subscribe route if labs flag set', function () {
             // Setup test
+            sandbox.stub(labs, 'isSet').returns(true);
             setupContext('/subscribe/');
+            data.post = {
+                page: false
+            };
 
             // Execute test
             setResponseContext(req, res, data);
@@ -363,6 +375,23 @@ describe('Contexts', function () {
             should.exist(res.locals.context);
             res.locals.context.should.be.an.Array().with.lengthOf(1);
             res.locals.context[0].should.eql('subscribe');
+        });
+
+        it('should not identify /subscribe/ as subscribe route if labs flag NOT set', function () {
+            // Setup test
+            sandbox.stub(labs, 'isSet').returns(false);
+            setupContext('/subscribe/');
+            data.post = {
+                page: false
+            };
+
+            // Execute test
+            setResponseContext(req, res, data);
+
+            // Check context
+            should.exist(res.locals.context);
+            res.locals.context.should.be.an.Array().with.lengthOf(1);
+            res.locals.context[0].should.eql('post');
         });
     });
 


### PR DESCRIPTION
The problem here was that the subscribe context was being used even when subscribers is not enabled. This PR makes sure it depends on the labs flag. Now a `/subscribe/` page used without enabling the subscribers feature will work as expected.

closes #8597

- Only set the subscribe context if the labs flag is set


