### PR TITLE
🛠  Moved 404 requests from error log to access log

### DIFF
--- a/core/server/middleware/log-request.js
+++ b/core/server/middleware/log-request.js
@@ -14,7 +14,7 @@ module.exports = function logRequest(req, res, next) {
         req.requestId = requestId;
         req.userId = req.user ? (req.user.id ? req.user.id : req.user) : null;
 
-        if (req.err) {
+        if (req.err && req.err.statusCode !== 404) {
             logging.error({req: req, res: res, err: req.err});
         } else {
             logging.info({req: req, res: res});


### PR DESCRIPTION
When debugging and developing on Ghost 1.0 I'm finding it very hard to see debug statements and what's going on, due to stdout being cluttered.

I realised one of the reasons for this is that 404s for images result in large amounts of output. In LTS, a 404 would be a single line:

![](https://puu.sh/x2plu.png)

However in 1.0, we output an error + stack trace:

![](https://puu.sh/x2poD.png)

I don't think this is necessary. This tiny change makes the output look like this instead:

![](https://puu.sh/x2pDB.png)

It also means that 404s will go to the access log and not the error log, which is the same as how nginx works :)

Note: we should consider splitting the request id & log request middleware, then moving this middleware into ignition and unifying it across the several apps where it gets used 😁 

no issue

- 404 errors clutter up the log files and stdout when developing
- We don't really need these as more than a single line, like other requests
- This is how it worked in LTS
- This is also more consistent with other software (e.g. nginx)
