### PR TITLE
🦄  Channels: make RSS & Pagination configurable

### DIFF
--- a/core/server/controllers/frontend/channels.js
+++ b/core/server/controllers/frontend/channels.js
@@ -72,9 +72,17 @@ channelRouter = function router() {
 
         // @TODO figure out how to collapse this into a single rule
         channelRouter.get(baseRoute, configChannel, renderChannel);
-        channelRouter.get(pageRoute, configChannel, renderChannel);
-        channelRouter.param('page', handlePageParam);
-        channelRouter.use(rssRouter(configChannel));
+
+        // @TODO improve config and add defaults to make this simpler
+        if (channel.paged !== false) {
+            channelRouter.param('page', handlePageParam);
+            channelRouter.get(pageRoute, configChannel, renderChannel);
+        }
+
+        // @TODO improve config and add defaults to make this simpler
+        if (channel.rss !== false) {
+            channelRouter.use(rssRouter(configChannel));
+        }
 
         if (channel.editRedirect) {
             channelRouter.get('/edit/', function redirect(req, res) {

--- a/core/test/unit/controllers/frontend/channel-config_spec.js
+++ b/core/test/unit/controllers/frontend/channel-config_spec.js
@@ -1,22 +1,22 @@
 /*jshint expr:true*/
 var should = require('should'),
-    channelConfig = require('../../../../server/controllers/frontend/channel-config').get;
+    channelConfig = require('../../../../server/controllers/frontend/channel-config');
 
 describe('Channel Config', function () {
     it('should get the index config', function () {
-        var result = channelConfig('index');
+        var result = channelConfig.get('index');
         should.exist(result);
         result.name.should.eql('index');
     });
 
     it('should get the author config', function () {
-        var result = channelConfig('author');
+        var result = channelConfig.get('author');
         should.exist(result);
         result.name.should.eql('author');
     });
 
     it('should get the tag config', function () {
-        var result = channelConfig('tag');
+        var result = channelConfig.get('tag');
         should.exist(result);
         result.name.should.eql('tag');
     });

--- a/core/test/unit/controllers/frontend/custom_channels_spec.js
+++ b/core/test/unit/controllers/frontend/custom_channels_spec.js
@@ -1,0 +1,95 @@
+var should = require('should'),  // jshint ignore:line
+    sinon = require('sinon'),
+
+    // Stuff we are testing
+    channelConfig = require('../../../../server/controllers/frontend/channel-config'),
+    channels = require('../../../../server/controllers/frontend/channels'),
+
+    sandbox = sinon.sandbox.create();
+
+/**
+ * These tests are a bit weird,
+ * need to test express private API
+ * Would be better to be testing our own internal API
+ * E.g. setupRSS.calledOnce, rather than router stack!
+ */
+describe('Custom Channels', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('allows basic custom config', function () {
+        sandbox.stub(channelConfig, 'list').returns({
+            home: {
+                name: 'home',
+                route: '/home/'
+            }
+        });
+
+        var channelRouter = channels.router(),
+            topRouter = channelRouter.stack[0],
+            routeStack = topRouter.handle.stack,
+            rssRouter = routeStack[2].handle.stack;
+
+        topRouter.regexp.toString().should.match(/\\\/home\\\//);
+        routeStack.should.have.lengthOf(3);
+
+        // Route 1 should be /
+        routeStack[0].route.path.should.eql('/');
+        // Route 2 should be pagination
+        routeStack[1].route.path.should.eql('/page/:page(\\d+)/');
+        // Route 3 should be a whole new router for RSS
+        rssRouter.should.have.lengthOf(3);
+        rssRouter[0].route.path.should.eql('/rss/');
+        rssRouter[1].route.path.should.eql('/rss/:page(\\d+)/');
+        rssRouter[2].route.path.should.eql('/feed/');
+    });
+
+    it('allows rss to be disabled', function () {
+        sandbox.stub(channelConfig, 'list').returns({
+            home: {
+                name: 'home',
+                route: '/home/',
+                rss: false
+            }
+        });
+
+        var channelRouter = channels.router(),
+            topRouter = channelRouter.stack[0],
+            routeStack = topRouter.handle.stack;
+
+        topRouter.regexp.toString().should.match(/\\\/home\\\//);
+        routeStack.should.have.lengthOf(2);
+
+        // Route 1 should be /
+        routeStack[0].route.path.should.eql('/');
+        // Route 2 should be pagination
+        routeStack[1].route.path.should.eql('/page/:page(\\d+)/');
+    });
+
+    it('allows pagination to be disabled', function () {
+        sandbox.stub(channelConfig, 'list').returns({
+            home: {
+                name: 'home',
+                route: '/home/',
+                paged: false
+            }
+        });
+
+        var channelRouter = channels.router(),
+            topRouter = channelRouter.stack[0],
+            routeStack = topRouter.handle.stack,
+            rssRouter = routeStack[1].handle.stack;
+
+        topRouter.regexp.toString().should.match(/\\\/home\\\//);
+        routeStack.should.have.lengthOf(2);
+
+        // Route 1 should be /
+        routeStack[0].route.path.should.eql('/');
+        // Route 2 should be a whole new router for RSS
+        rssRouter.should.have.lengthOf(3);
+        rssRouter[0].route.path.should.eql('/rss/');
+        rssRouter[1].route.path.should.eql('/rss/:page(\\d+)/');
+        rssRouter[2].route.path.should.eql('/feed/');
+    });
+});


### PR DESCRIPTION
refs #5091

- occurred to me whilst documenting the custom homepage config, that RSS and pagination
need to be optional
- added a very quick if statement & tests
- needs further refactoring & test improvements
- this will not disable the RSS url output in meta data yet 😔

--- 

@AileenCGN This PR might be interesting to you. I have some notes, along the lines of what we've talked about with refactoring meta data that I thought I'd leave here - nothing TODO just providing context 😬 

There is a bit of a disconnect between "channels" and meta data at the moment. Each "channel" has some configuration, which is stored in the `req` object that all the express routers & middleware have access to. However, the meta data is calculated after being called by the `ghost_head` helper, which doesn't have access to this at the moment.

I think there are 2 approaches we could use:
1. Store channel config in [res.locals](http://expressjs.com/en/4x/api.html#res.locals) instead of on `req` as express always [passes locals to the render](https://github.com/expressjs/express/blob/master/lib/response.js#L962) and so helpers can get access to these values (available as this.x or options.data.root.x inside of [a helper](https://github.com/TryGhost/Ghost/blob/2f866a99f64ee840032388a6e95645c36690018a/core/server/helpers/ghost_head.js#L91))
2. Move meta data processing into middleware. So all the data, urls, etc, are all generated up front, and then we insert the values into templates at render time.

I actually think **both** of these things are needed - config should be stored in res.locals (a me thing) aaaaand we should move towards splitting the "processing" and "rendering" of meta data into 2 phases - which is along the same lines of what we've talked about before with having different "templates" for meta data, I think.