### PR TITLE
🎨 Split request logging & request id middleware

### DIFF
--- a/core/server/app.js
+++ b/core/server/app.js
@@ -10,7 +10,8 @@ var debug = require('debug')('ghost:app'),
 
     // local middleware
     ghostLocals     = require('./middleware/ghost-locals'),
-    logRequest      = require('./middleware/log-request');
+    logRequest      = require('./middleware/log-request'),
+    requestId       = require('./middleware/request-id');
 
 module.exports = function setupParentApp() {
     debug('ParentApp setup start');
@@ -22,6 +23,7 @@ module.exports = function setupParentApp() {
     // (X-Forwarded-Proto header will be checked, if present)
     parentApp.enable('trust proxy');
 
+    parentApp.use(requestId);
     parentApp.use(logRequest);
 
     if (debug.enabled) {

--- a/core/server/middleware/log-request.js
+++ b/core/server/middleware/log-request.js
@@ -1,18 +1,14 @@
-var uuid = require('uuid'),
-    logging = require('../logging');
+var logging = require('../logging');
 
 /**
  * @TODO:
  * - move middleware to ignition?
  */
 module.exports = function logRequest(req, res, next) {
-    var startTime = Date.now(),
-        requestId = uuid.v1();
+    var startTime = Date.now();
 
     function logResponse() {
         res.responseTime = (Date.now() - startTime) + 'ms';
-        req.requestId = requestId;
-        req.userId = req.user ? (req.user.id ? req.user.id : req.user) : null;
 
         if (req.err && req.err.statusCode !== 404) {
             logging.error({req: req, res: res, err: req.err});

--- a/core/server/middleware/request-id.js
+++ b/core/server/middleware/request-id.js
@@ -1,0 +1,13 @@
+var uuid = require('uuid'),
+    _ = require('lodash'),
+    headerName = 'X-Request-Id',
+    idAttribute = 'requestId';
+
+module.exports = function requestId(req, res, next) {
+    req.userId = _.get(req, 'user.id', null);
+
+    req[idAttribute] = req.header(headerName) || uuid.v1();
+    res.setHeader(headerName, req[idAttribute]);
+
+    next();
+};


### PR DESCRIPTION
I did this to match other projects whilst looking at the 404 thing over the weekend. Maybe we could move log-request.js into Ghost Ignition now?

There's also 1 custom line in request-id:  

`req.userId = _.get(req, 'user.id', null);`

But I think this line may be redundant as it wouldn't appear in the logs?

no issue

- preparation for moving part or all of this into ignition

