### PR TITLE
🛠 Added `npm run dev` to run grunt dev w/ DEBUG on

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "./core/index",
   "scripts": {
     "start": "node index",
+    "dev": "DEBUG=ghost:* grunt dev",
     "test": "grunt validate --verbose",
     "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
   },


### PR DESCRIPTION
no issue

- Most of our other projects have `npm run dev`
- In Ghost we use `grunt dev`, but I also want to have DEBUG turned on for development
- `npm run dev` is a shortcut for these 2 things
- Also cos I keep accidentally typing `npm run dev` anyway 😬

