### PR TITLE
🐛 Switched to 404 error in image size utility

### DIFF
--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -1,6 +1,7 @@
 var Promise = require('bluebird'),
     size = require('./image-size-from-url'),
     logging = require('../logging'),
+    errors = require('../errors'),
     getImageSizeFromUrl = size.getImageSizeFromUrl,
     imageSizeCache = {};
 
@@ -23,6 +24,9 @@ function getCachedImageSizeFromUrl(url) {
             imageSizeCache[url] = res;
 
             return Promise.resolve(imageSizeCache[url]);
+        }).catch(errors.NotFoundError, function () {
+            // in case of error we just attach the url
+            return Promise.resolve(imageSizeCache[url] = url);
         }).catch(function (err) {
             logging.error(err);
 

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -79,9 +79,16 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
                             context: imagePath
                         }));
                     }
+                } else if (res.statusCode === 404) {
+                    return reject(new errors.NotFoundError({
+                        message: 'Image not found.',
+                        code: 'IMAGE_SIZE',
+                        statusCode: res.statusCode,
+                        context: imagePath
+                    }));
                 } else {
                     return reject(new errors.InternalServerError({
-                        message: res.statusCode === 404 ? 'Image not found.' : 'Unknown Request error.',
+                        message: 'Unknown Request error.',
                         code: 'IMAGE_SIZE',
                         statusCode: res.statusCode,
                         context: imagePath


### PR DESCRIPTION
Have run Ghost today with this minor fix in place whilst debugging / developing other things. It helped a lot to reduce the output down.

refs #8850

- This reduces the amount of noise from the image size utility
