### PR TITLE
Optimised usage of debug

### DIFF
--- a/core/server/app.js
+++ b/core/server/app.js
@@ -24,17 +24,6 @@ module.exports = function setupParentApp() {
 
     parentApp.use(logRequest);
 
-    if (debug.enabled) {
-        // debug keeps a timer, so this is super useful
-        parentApp.use((function () {
-            var reqDebug = require('debug')('ghost:req');
-            return function debugLog(req, res, next) {
-                reqDebug('Request', req.originalUrl);
-                next();
-            };
-        })());
-    }
-
     // enabled gzip compression by default
     if (config.get('compress') !== false) {
         parentApp.use(compress());

--- a/core/server/middleware/custom-redirects.js
+++ b/core/server/middleware/custom-redirects.js
@@ -1,5 +1,6 @@
 var fs = require('fs-extra'),
     _ = require('lodash'),
+    debug = require('debug')('ghost:custom-redirects'),
     config = require('../config'),
     errors = require('../errors'),
     logging = require('../logging');
@@ -10,6 +11,7 @@ var fs = require('fs-extra'),
  * file loads synchronously, because we need to register the routes before anything else
  */
 module.exports = function redirects(blogApp) {
+    debug('redirects loading');
     try {
         var redirects = fs.readFileSync(config.getContentPath('data') + '/redirects.json', 'utf-8');
         redirects = JSON.parse(redirects);
@@ -58,4 +60,6 @@ module.exports = function redirects(blogApp) {
             }));
         }
     }
+
+    debug('redirects loaded');
 };

--- a/core/server/middleware/url-redirects.js
+++ b/core/server/middleware/url-redirects.js
@@ -27,30 +27,7 @@ _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
         queryParameters = options.queryParameters,
         secure = options.secure;
 
-    debug('getAdminRedirectUrl');
-    debug('requestedUrl', requestedUrl);
-    debug('requestedHost', requestedHost);
-    debug('adminHost', adminHostWithProtocol);
-
-    /**
-     * @TODO: add back if we enable OAuth again or find an alternative solution
-     * See https://github.com/TryGhost/Ghost/issues/8152
-     *
-     * Background:
-     * For oauth we ensure that the served admin url matches the registered oauth redirect uri.
-     * If OAuth is enabled again, Ghost registeres a public client with the admin redirect uri.
-     * So this url has to be clearly, you can only serve the admin with one single url.
-     * And this must be the configured blog url (or admin url if specified)
-        if (!admimHostWithoutProtocol.match(new RegExp(requestedHost))) {
-            debug('redirect because host does not match');
-
-            return _private.redirectUrl({
-                redirectTo: adminHostWithProtocol,
-                path: requestedUrl,
-                query: queryParameters
-            });
-        }
-     */
+    debug('getAdminRedirectUrl', requestedHost, requestedUrl, adminHostWithProtocol);
 
     // CASE: we only redirect the admin access if `admin.url` is configured
     if (adminHostWithProtocol !== utils.url.urlJoin(blogHostWithProtocol, 'ghost/')) {
@@ -82,10 +59,7 @@ _private.getBlogRedirectUrl = function getBlogRedirectUrl(options) {
         queryParameters = options.queryParameters,
         secure = options.secure;
 
-    debug('getBlogRedirectUrl');
-    debug('requestedUrl', requestedUrl);
-    debug('requestedHost', requestedHost);
-    debug('blogHost', blogHostWithProtocol);
+    debug('getBlogRedirectUrl', requestedHost, requestedUrl, blogHostWithProtocol);
 
     // CASE: configured canonical url is HTTPS, but request is HTTP, redirect to requested host + SSL
     if (utils.url.isSSL(blogHostWithProtocol) && !secure) {


### PR DESCRIPTION
Nothing really changes with this PR, except we have slightly less debug output.

Request debugging was useful when the new logging system was first added as there were no timings. Don't think it is useful anymore?

Also condensed down the multiple lines from url-redirects into 1, removed some unused code at the same time, and added a start/stop debug to custom-redirects.

no issue

- Reduced debug calls down for redirects
- Added start/end debug for custom redirect loading
- Removed duplicate request debug logs

