### PR TITLE
🐛 Removed Casper's gulpfile from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -40,3 +40,4 @@ SECURITY.md
 bower_components/**
 .editorconfig
 gulpfile.js
+!content/themes/casper/gulpfile.js


### PR DESCRIPTION
Currently, when we package up Ghost for npm, we remove Casper's gulpfile. It is present in the Casper releases and the Ghost releases, but not on npm. This means that it isn't present on any installs made via Ghost-CLI.

I believe this is an accidental side effect of us having added Ghost's gulpfile to the `.npmignore` file, back when we tried gulp. 

Given that we bundle both the src and the built Casper code in a release, it feels odd not to also provide the build tools. Especially as this makes it very hard for people to use ghost-cli for a local theme-dev install, then copy Casper to use as a base for their own theme. Plus its a tiny file 😄

Note: once this is released, we can remove the note here: https://docs.ghost.org/docs/install-local#section-developing-themes and perhaps expand the docs to link back to the Casper Readme.md file for build instructions instead.

no issue

- Don't exclude Casper's gulpfile when packaging Ghost to npm.

