### PR TITLE
🐛 Fixed duplicate subdirs in plaintext

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -244,7 +244,6 @@ Post = ghostBookshelf.Model.extend({
             this.set('plaintext', htmlToText.fromString(this.get('html'), {
                 wordwrap: 80,
                 ignoreImage: true,
-                linkHrefBaseUrl: utils.url.urlFor('home').replace(/\/$/, ''),
                 hideLinkHrefIfSameAsText: true,
                 preserveNewlines: true,
                 returnDomByDefault: true,


### PR DESCRIPTION
We don't need to try to do anything to fix URLs from post HTML, they *must* already be correct!

fixes #8845

- We had a report of weird URLS being output in admin stories view
- This is due to plaintext being incorrectly generated
- In order for a URL to be correct, it would need to already contain the subdirectory
- This line in the post model adds it as well, causing a duplicate
- Hence removing this line is the fix