### PR TITLE
🦄  Moved channel config into res.locals

### DIFF
--- a/core/server/controllers/frontend/channels.js
+++ b/core/server/controllers/frontend/channels.js
@@ -35,7 +35,7 @@ function handlePageParam(req, res, next, page) {
 
 rssRouter = function rssRouter(channelConfig) {
     function rssConfigMiddleware(req, res, next) {
-        req.channelConfig.isRSS = true;
+        res.locals.channel.isRSS = true;
         next();
     }
 
@@ -57,7 +57,7 @@ rssRouter = function rssRouter(channelConfig) {
 channelRouter = function router() {
     function channelConfigMiddleware(channel) {
         return function doChannelConfig(req, res, next) {
-            req.channelConfig = _.cloneDeep(channel);
+            res.locals.channel = _.cloneDeep(channel);
             next();
         };
     }

--- a/core/server/controllers/frontend/render-channel.js
+++ b/core/server/controllers/frontend/render-channel.js
@@ -14,7 +14,7 @@ var debug = require('debug')('ghost:channels:render'),
 function renderChannel(req, res, next) {
     debug('renderChannel called');
     // Parse the parameters we need from the URL
-    var channelOpts = req.channelConfig,
+    var channelOpts = res.locals.channel,
         pageParam = req.params.page !== undefined ? req.params.page : 1,
         slugParam = req.params.slug ? safeString(req.params.slug) : undefined;
 

--- a/core/server/data/xml/rss/index.js
+++ b/core/server/data/xml/rss/index.js
@@ -161,16 +161,17 @@ generate = function generate(req, res, next) {
     // Initialize RSS
     var pageParam = req.params.page !== undefined ? req.params.page : 1,
         slugParam = req.params.slug,
-        baseUrl   = getBaseUrl(req, slugParam);
+        baseUrl   = getBaseUrl(req, slugParam),
+        channelConfig = res.locals.channel;
 
     // Ensure we at least have an empty object for postOptions
-    req.channelConfig.postOptions = req.channelConfig.postOptions || {};
+    channelConfig.postOptions = channelConfig.postOptions || {};
     // Set page on postOptions for the query made later
-    req.channelConfig.postOptions.page = pageParam;
+    channelConfig.postOptions.page = pageParam;
 
-    req.channelConfig.slugParam = slugParam;
+    channelConfig.slugParam = slugParam;
 
-    return getData(req.channelConfig).then(function then(data) {
+    return getData(channelConfig).then(function then(data) {
         var maxPage = data.results.meta.pagination.pages;
 
         // If page is greater than number of pages we have, redirect to last page

--- a/core/test/unit/controllers/frontend/channels_spec.js
+++ b/core/test/unit/controllers/frontend/channels_spec.js
@@ -29,7 +29,8 @@ describe('Channels', function () {
     // Run a test which should result in a render
     function testChannelRender(props, assertions, done) {
         res = {
-            redirect: sandbox.spy()
+            redirect: sandbox.spy(),
+            locals: {}
         };
 
         res.render = function (view) {
@@ -47,7 +48,8 @@ describe('Channels', function () {
     function testChannelRedirect(props, assertions, done) {
         res = {
             render: sandbox.spy(),
-            set: sandbox.spy()
+            set: sandbox.spy(),
+            locals: {}
         };
 
         res.redirect = function (status, path) {
@@ -66,7 +68,8 @@ describe('Channels', function () {
         res = {
             redirect: sandbox.spy(),
             render: sandbox.spy(),
-            set: sandbox.spy()
+            set: sandbox.spy(),
+            locals: {}
         };
 
         _.extend(req, props);

--- a/core/test/unit/controllers/frontend/render-channel_spec.js
+++ b/core/test/unit/controllers/frontend/render-channel_spec.js
@@ -24,8 +24,12 @@ describe('Render Channel', function () {
 
     describe('Tag config', function () {
         var req = {
-                channelConfig: channelConfig('tag'),
                 params: {}
+            },
+            res = {
+                locals: {
+                    channel: channelConfig('tag')
+                }
             },
             promise = {
                 then: function () {
@@ -45,7 +49,7 @@ describe('Render Channel', function () {
                 return promise;
             });
 
-            renderChannel(req);
+            renderChannel(req, res);
         });
     });
 });

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -97,8 +97,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -140,8 +140,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -176,8 +176,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -204,8 +204,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -238,8 +238,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -270,8 +270,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
     });
@@ -327,8 +327,8 @@ describe('RSS', function () {
                 done();
             };
 
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
             rss(req, res, failTest(done));
         });
 
@@ -336,8 +336,8 @@ describe('RSS', function () {
             // setup
             req.originalUrl = '/tag/magic/rss/';
             req.params.slug = 'magic';
-            req.channelConfig = channelConfig.get('tag');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('tag');
+            res.locals.channel.isRSS = true;
 
             // test
             res.send = function send(xmlData) {
@@ -358,8 +358,8 @@ describe('RSS', function () {
         it('should process the data correctly for an author feed', function (done) {
             req.originalUrl = '/author/joe/rss/';
             req.params.slug = 'joe';
-            req.channelConfig = channelConfig.get('author');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('author');
+            res.locals.channel.isRSS = true;
 
             // test
             res.send = function send(xmlData) {
@@ -401,8 +401,8 @@ describe('RSS', function () {
                     results: {posts: [], meta: {pagination: {pages: 1}}}
                 });
             });
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
 
             function secondCall() {
                 res.send = function sendFirst(data) {
@@ -454,8 +454,8 @@ describe('RSS', function () {
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
 
             rss(req, res, function (err) {
                 should.exist(err);
@@ -471,8 +471,8 @@ describe('RSS', function () {
 
             req = {params: {page: 4}, route: {path: '/rss/:page/'}};
             req.originalUrl = req.route.path.replace(':page', req.params.page);
-            req.channelConfig = channelConfig.get('index');
-            req.channelConfig.isRSS = true;
+            res.locals.channel = channelConfig.get('index');
+            res.locals.channel.isRSS = true;
 
             rss(req, res, function (err) {
                 should.exist(err);


### PR DESCRIPTION
This change means that inside of the ghost_head helper `options.data.root.channel` should contain the channel config for the current channel. 

This should open the door to making our meta data processing more context aware.

refs #5091

- This tiny refactor opens the door for using channel config inside of helpers
- This means that ghost_head, and the next_post/prev_post helpers can be context aware