### PR TITLE
🐛 Added 409 DisabledFeatureError for labs features

### DIFF
--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -54,6 +54,12 @@ var ghostErrors = {
             errorType: 'ThemeValidationError',
             errorDetails: {}
         }, options));
+    },
+    DisabledFeatureError: function DisabledFeatureError(options) {
+        GhostError.call(this, _.merge({
+            statusCode: 409,
+            errorType: 'DisabledFeatureError',
+        }, options));
     }
 };
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -485,7 +485,7 @@
         },
         "helpers": {
             "helperNotAvailable": "The \\{\\{{helperName}\\}\\} helper is not available.",
-            "flagMustBeEnabled": "The {flagName} labs flag must be enabled if you wish to use the \\{\\{{helperName}\\}\\} helper.",
+            "flagMustBeEnabled": "The {flagName} flag must be enabled in labs if you wish to use the \\{\\{{helperName}\\}\\} helper.",
             "seeLink": "See {url}",
             "foreach": {
                 "iteratorNeeded": "Need to pass an iterator to #foreach"

--- a/core/server/utils/labs.js
+++ b/core/server/utils/labs.js
@@ -30,7 +30,7 @@ labs.enabledHelper = function enabledHelper(options, callback) {
         help: i18n.t('warnings.helpers.seeLink', {url: options.helpUrl})
     };
 
-    logging.error(new errors.GhostError(errDetails));
+    logging.error(new errors.DisabledFeatureError(errDetails));
 
     errString = new SafeString(
         '<script>console.error("' + _.values(errDetails).join(' ') + '");</script>'

--- a/core/test/unit/server_helpers/get_spec.js
+++ b/core/test/unit/server_helpers/get_spec.js
@@ -45,7 +45,7 @@ describe('{{#get}} helper', function () {
             result().should.be.an.Object().with.property(
                 'string',
                 '<script>console.error("The {{get}} helper is not available. ' +
-                'The Public API labs flag must be enabled if you wish to use the {{get}} helper. ' +
+                'The Public API flag must be enabled in labs if you wish to use the {{get}} helper. ' +
                 'See https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta");</script>'
             );
 


### PR DESCRIPTION
This was sloppy work from me the first time around!

This fixes the issue for any "labsEnabledHelper" so fixes the problem for the subscribers related helpers as well as for the get helper.

There's a slight wording tweak to the error message as well as the new error type with status code 409. 

fixes #8889

- This is a user error, not a system error
- Downgrading to a 4xx status code means it doesn't appear in logs where it shouldn't
- We didn't have a suitable error available so I added DisabledFeatureError with 409 status
- Ref: https://stackoverflow.com/questions/36874263/expected-http-status-code-for-an-action-on-a-disabled-resource
- Also tweaked the error message slightly as it didn't read clearly to me