### PR TITLE
Add `configuration/private` endpoint and settings for Unsplash

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -67,7 +67,6 @@ function apiRoutes() {
     // ## Configuration
     apiRouter.get('/configuration', api.http(api.configuration.read));
     apiRouter.get('/configuration/:key', authenticatePrivate, api.http(api.configuration.read));
-    apiRouter.get('/configuration/timezones', authenticatePrivate, api.http(api.configuration.read));
 
     // ## Posts
     apiRouter.get('/posts', authenticatePublic, api.http(api.posts.browse));

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -16,7 +16,7 @@ function fetchAvailableTimezones() {
 }
 
 function fetchPrivateConfig() {
-    var unsplashConfig = config.get('unsplash') ? config.get('unsplash').applicationId : '';
+    var unsplashConfig = config.get('unsplash') || {};
 
     return {
         unsplashAPI: unsplashConfig

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -15,6 +15,14 @@ function fetchAvailableTimezones() {
     return timezones;
 }
 
+function fetchPrivateConfig() {
+    var unsplashConfig = config.get('unsplash') ? config.get('unsplash').applicationId : '';
+
+    return {
+        unsplashAPI: unsplashConfig
+    };
+}
+
 function getAboutConfig() {
     return {
         version: ghostVersion.full,
@@ -25,15 +33,13 @@ function getAboutConfig() {
 }
 
 function getBaseConfig() {
-    var unsplashConfig = config.get('unsplash') ? config.get('unsplash').applicationId : '';
     return {
         useGravatar:    !config.isPrivacyDisabled('useGravatar'),
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        utils.url.urlFor('home', true),
         blogTitle:      settingsCache.get('title'),
         routeKeywords:  config.get('routeKeywords'),
-        clientExtensions: config.get('clientExtensions'),
-        unsplashAPI:    unsplashConfig
+        clientExtensions: config.get('clientExtensions')
     };
 }
 
@@ -88,6 +94,11 @@ configuration = {
         // Timezone endpoint
         if (options.key === 'timezones') {
             return Promise.resolve({configuration: [fetchAvailableTimezones()]});
+        }
+
+        // Private configuration config for API keys used by the client
+        if (options.key === 'private') {
+            return Promise.resolve({configuration: [fetchPrivateConfig()]});
         }
 
         return Promise.resolve({configuration: []});

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -25,13 +25,15 @@ function getAboutConfig() {
 }
 
 function getBaseConfig() {
+    var unsplashConfig = config.get('unsplash') ? config.get('unsplash').applicationId : '';
     return {
         useGravatar:    !config.isPrivacyDisabled('useGravatar'),
         publicAPI:      config.get('publicAPI') === true,
         blogUrl:        utils.url.urlFor('home', true),
         blogTitle:      settingsCache.get('title'),
         routeKeywords:  config.get('routeKeywords'),
-        clientExtensions: config.get('clientExtensions')
+        clientExtensions: config.get('clientExtensions'),
+        unsplashAPI:    unsplashConfig
     };
 }
 

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -80,6 +80,9 @@
         },
         "slack": {
             "defaultValue": "[{\"url\":\"\"}]"
+        },
+        "unsplash": {
+            "defaultValue": "[{\"applicationId\":\"\", \"isActive\": true}]"
         }
     },
     "theme": {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -82,7 +82,7 @@
             "defaultValue": "[{\"url\":\"\"}]"
         },
         "unsplash": {
-            "defaultValue": "{\"applicationId\":\"\", \"isActive\": false}"
+            "defaultValue": ""
         }
     },
     "theme": {

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -82,7 +82,7 @@
             "defaultValue": "[{\"url\":\"\"}]"
         },
         "unsplash": {
-            "defaultValue": "[{\"applicationId\":\"\", \"isActive\": true}]"
+            "defaultValue": "{\"applicationId\":\"\", \"isActive\": false}"
         }
     },
     "theme": {

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -79,4 +79,20 @@ describe('Configuration API', function () {
             done();
         }).catch(done);
     });
+
+    it('can read private config and get all expected properties', function (done) {
+        ConfigurationAPI.read({key: 'private'}).then(function (response) {
+            var props;
+
+            should.exist(response);
+            should.exist(response.configuration);
+            response.configuration.should.be.an.Array().with.lengthOf(1);
+            props = response.configuration[0];
+
+            // value not available, because settings API was not called yet
+            props.hasOwnProperty('unsplashApi').should.eql(false);
+
+            done();
+        }).catch(done);
+    });
 });

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -89,8 +89,9 @@ describe('Configuration API', function () {
             response.configuration.should.be.an.Array().with.lengthOf(1);
             props = response.configuration[0];
 
-            // value not available, because settings API was not called yet
-            props.hasOwnProperty('unsplashApi').should.eql(false);
+            // property is set, but value not available, because settings API was not called yet
+            props.should.have.property('unsplashAPI').which.is.an.Object();
+            props.unsplashAPI.should.be.empty();
 
             done();
         }).catch(done);


### PR DESCRIPTION
refs #8859
- adds new `configuration/private` endpoint for exposing config that should not be accessible without authentication
- adds `unsplashAPI` to private config
- adds empty `unsplash` config to default settings