### PR TITLE
🐛 Added 409 UpdateCollisionError for the editor

### DIFF
--- a/core/server/errors.js
+++ b/core/server/errors.js
@@ -60,6 +60,12 @@ var ghostErrors = {
             statusCode: 409,
             errorType: 'DisabledFeatureError',
         }, options));
+    },
+    UpdateCollisionError: function UpdateCollisionError(options) {
+        GhostError.call(this, _.merge({
+            statusCode: 409,
+            errorType: 'UpdateCollisionError',
+        }, options));
     }
 };
 

--- a/core/server/models/plugins/collision.js
+++ b/core/server/models/plugins/collision.js
@@ -55,7 +55,7 @@ module.exports = function (Bookshelf) {
 
                 if (Object.keys(changed).length) {
                     if (clientUpdatedAt.diff(serverUpdatedAt) !== 0) {
-                        return Promise.reject(new errors.InternalServerError({
+                        return Promise.reject(new errors.UpdateCollisionError({
                             message: 'Saving failed! Someone else is editing this post.',
                             code: 'UPDATE_COLLISION'
                         }));


### PR DESCRIPTION
fixes #8898

- This is a user error, not a system error
- Downgrading to a 4xx status code means it doesn't appear in logs where it shouldn't
- We didn't have a suitable error available so I added UpdateCollisionError with 409 status