### PR TITLE
[HOLD] 🐛 Run primary tag through visibility filter

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -11,6 +11,7 @@ var _               = require('lodash'),
     config          = require('../config'),
     utils           = require('../utils'),
     baseUtils       = require('./base/utils'),
+    visibility      = require('../utils/visibility'),
     i18n            = require('../i18n'),
     Post,
     Posts;
@@ -509,8 +510,8 @@ Post = ghostBookshelf.Model.extend({
         }
         // If the current column settings allow it...
         if (!options.columns || (options.columns && options.columns.indexOf('primary_tag') > -1)) {
-            // ... attach a computed property of primary_tag which is the first tag or null
-            attrs.primary_tag = attrs.tags && attrs.tags.length > 0 ? attrs.tags[0] : null;
+            // ... attach a computed property of primary_tag which is the first public tag or null
+            attrs.primary_tag = visibility.first(attrs.tags, ['public']) || null;
         }
 
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {

--- a/core/server/utils/visibility.js
+++ b/core/server/utils/visibility.js
@@ -28,8 +28,26 @@ module.exports.filter = function visibilityFilter(items, visibility, explicit, f
     }, memo);
 };
 
+module.exports.first = function visibilityFirstMatch(items, visibility, explicit) {
+    if (_.includes(visibility, 'all')) {
+        if (_.isArray(items)) {
+            return _.head(items);
+        } else {
+            return items[_.keys(items)[0]];
+        }
+    }
+
+    return _.find(items, function (item) {
+        if (!item.visibility && !explicit || _.includes(visibility, item.visibility)) {
+            return true;
+        }
+
+        return false;
+    });
+};
+
 module.exports.parser = function visibilityParser(options) {
-    if (!options.hash.visibility) {
+    if (!_.get(options, 'hash.visibility')) {
         return ['public'];
     }
 

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -1,5 +1,4 @@
-// jshint unused: false
-var should = require('should'),
+var should = require('should'), /* jshint ignore:line */
     sinon = require('sinon'),
     _ = require('lodash'),
     moment = require('moment-timezone'),
@@ -7,7 +6,6 @@ var should = require('should'),
     settingsCache = require('../../../server/settings/cache'),
     configUtils = require('../../utils/configUtils'),
     testUtils = require('../../utils'),
-    config = configUtils.config,
 
     sandbox = sinon.sandbox.create();
 

--- a/core/test/unit/utils/visibility_spec.js
+++ b/core/test/unit/utils/visibility_spec.js
@@ -1,0 +1,94 @@
+var should = require('should'), /* jshint ignore:line */
+
+    visibility = require('../../../server/utils/visibility');
+
+describe('Visibility', function () {
+    var arrayHash, objectHash;
+
+    beforeEach(function () {
+        arrayHash = [
+            {name: 'zeroth', visibility: 'internal'},
+            {name: 'first', visibility: 'public'},
+            {name: 'second', visibility: 'public'},
+            {name: 'third', visibility: 'internal'},
+            {name: 'fourth', visibility: 'public'},
+            {name: 'fifth'}
+        ];
+        objectHash = {
+            zeroth: {name: 'zeroth', visibility: 'internal'},
+            first: {name: 'first', visibility: 'public'},
+            second: {name: 'second', visibility: 'public'},
+            third: {name: 'third', visibility: 'internal'},
+            fourth: {name: 'fourth', visibility: 'public'},
+            fifth: {name: 'fifth'}
+        };
+    });
+
+    describe('filter', function () {
+        // TODO: add tests here, currently this is covered by server_helpers/tag_spec.js and foreach_spec.js
+    });
+
+    describe('first', function () {
+        it('Returns first matching item for object with public', function () {
+            var result = visibility.first(arrayHash, ['public']);
+
+            result.should.eql({name: 'first', visibility: 'public'});
+        });
+
+        it('Returns first matching item for array  with public', function () {
+            var result = visibility.first(objectHash, ['public']);
+
+            result.should.eql({name: 'first', visibility: 'public'});
+        });
+
+        it('Returns first matching item for array with all', function () {
+            var result = visibility.first(arrayHash, ['all']);
+
+            result.should.eql({name: 'zeroth', visibility: 'internal'});
+        });
+
+        it('Returns first matching item for object with all', function () {
+            var result = visibility.first(objectHash, ['all']);
+
+            result.should.eql({name: 'zeroth', visibility: 'internal'});
+        });
+
+        it('Returns first matching item for array requiring explicit', function () {
+            arrayHash = [{name: 'zeroth'}, {name: 'first', visibility: 'public'}];
+
+            var result = visibility.first(arrayHash, ['public'], true);
+
+            result.should.eql({name: 'first', visibility: 'public'});
+        });
+
+        it('Returns first matching item for objecr requiring explicit', function () {
+            objectHash = {zeroth: {name: 'zeroth'}, first: {name: 'first', visibility: 'public'}};
+
+            var result = visibility.first(objectHash, ['public'], true);
+
+            result.should.eql({name: 'first', visibility: 'public'});
+        });
+    });
+
+    describe('parser', function () {
+        it('Returns public array if there are no options', function () {
+            visibility.parser().should.eql(['public']);
+        });
+
+        it('Returns public array if there is no hash', function () {
+            visibility.parser({}).should.eql(['public']);
+        });
+
+        it('Returns public array if there is no visibility set', function () {
+            visibility.parser({hash: {}}).should.eql(['public']);
+        });
+
+        it('Returns correct array when visibility is set to public', function () {
+            visibility.parser({hash: {visibility: 'public'}}).should.eql(['public']);
+        });
+
+        it('Returns correct array when visibility is set to all', function () {
+            visibility.parser({hash: {visibility: 'all'}}).should.eql(['all']);
+        });
+    });
+});


### PR DESCRIPTION
Ensures that the visibility rules are applied to a primary tag

closes #8920

- Added a new, efficient first method
- Applies visibility the same way as filter in tag/foreach helpers

