### PR TITLE
🛠 Removed "archive" from reserved slugs

### DIFF
--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -31,7 +31,7 @@
         "primaryTagFallback": "all"
     },
     "slugs": {
-        "reserved": ["admin", "app", "apps", "archive", "archives", "categories",
+        "reserved": ["admin", "app", "apps", "categories",
             "category", "dashboard", "feed", "ghost-admin", "login", "logout",
             "page", "pages", "post", "posts", "public", "register", "setup",
             "signin", "signout", "signup", "user", "users", "wp-admin", "wp-login"],


### PR DESCRIPTION
No issue

Proposal to stop reserving `archive` and `archives` slugs. I think we reserved these originally when we thought we might build some sort of custom archive functionality into Ghost, but that hasn't happened in 4 years and we still have no plans of doing anything like that. So the only thing this does at the moment is prevent people from making their own custom-page FOR archives on the archives route. Which seems a bit silly. 

@ErisDS can you think of any other reason these were reserved? Cos I can't

Aside: There's an edgecase bug around this too. You can still create/publish a page with a slug of `archive` right now, but it just 404's. Took me a while to figure out what was going on. Maybe need error handling for reserved words when trying to publish a page with a reserved slug? Not overly important, just thought I'd mention.