### PR TITLE
🐛 Fixed internal tags being used as primary tags

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -509,8 +509,12 @@ Post = ghostBookshelf.Model.extend({
         }
         // If the current column settings allow it...
         if (!options.columns || (options.columns && options.columns.indexOf('primary_tag') > -1)) {
-            // ... attach a computed property of primary_tag which is the first tag or null
-            attrs.primary_tag = attrs.tags && attrs.tags.length > 0 ? attrs.tags[0] : null;
+            // ... attach a computed property of primary_tag which is the first tag if it is public, else null
+            if (attrs.tags && attrs.tags.length > 0 && attrs.tags[0].visibility === 'public') {
+                attrs.primary_tag = attrs.tags[0];
+            } else {
+                attrs.primary_tag = null;
+            }
         }
 
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {


### PR DESCRIPTION
Initially fixed this in #8924, however I realised that using the approach in that PR (pick the first non-internal tag) would leave us with more edge cases and much more complicated implementations down the road.

Therefore, I'm swapping it for this implementation, where posts that have a internal tag as the first tag do not have a primary tag. This logic is much simpler:

A primary tag is the first tag associated with a post, if that tag is public.

fixes #8920

- Implements logic such that internal tags cannot be primary tags
- If the first tag on a post is an internal tag, that post will not have a primary tag

