### PR TITLE
🐛 Fixed error handling in async helpers

### DIFF
--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -103,7 +103,7 @@ get = function get(resource, options) {
         apiMethod;
 
     if (!options.fn) {
-        data.error = i18n.t('warnings.helpers.get.mustBeCalledAsBlock');
+        data.error = i18n.t('warnings.helpers.get.mustBeCalledAsBlock', {helperName: 'get'});
         logging.warn(data.error);
         return Promise.resolve();
     }
@@ -136,6 +136,7 @@ get = function get(resource, options) {
             blockParams: blockParams
         });
     }).catch(function error(err) {
+        logging.error(err);
         data.error = err.message;
         return options.inverse(self, {data: data});
     });

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -1,39 +1,39 @@
 
 // Usage:
-// `{{img_url}}` - does not work, argument is required
 // `{{img_url feature_image}}`
 // `{{img_url profile_image absolute="true"}}`
+// Note:
+// `{{img_url}}` - does not work, argument is required
 //
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 
 var proxy = require('./proxy'),
-    errors = require('../errors'),
+    logging = require('../logging'),
     i18n = require('../i18n'),
     url = proxy.url;
 
 module.exports = function imgUrl(attr, options) {
-    var absolute;
-
-    // CASE: if you pass e.g. cover_image, but it is not set, then attr is null!
-    //       in this case we don't throw an error
-    if (!options) {
-        attr = undefined;
-        options = attr;
-    }
-
-    absolute = options && options.hash && options.hash.absolute;
-
-    if (attr === undefined) {
-        throw new errors.IncorrectUsageError({
-            message: i18n.t('warnings.helpers.img_url.attrIsRequired')
-        });
-    }
-
-    // CASE: property is not set in the model e.g. cover_image
-    if (attr === null) {
+    // CASE: if no attribute is passed, e.g. `{{img_url}}` we show a warning
+    if (arguments.length < 2) {
+        logging.warn(i18n.t('warnings.helpers.img_url.attrIsRequired'));
         return;
     }
 
-    return url.urlFor('image', {image: attr}, absolute);
+    var absolute = options && options.hash && options.hash.absolute;
+
+    // CASE: if attribute is passed, but it is undefined, then the attribute was
+    // an unknown value, e.g. {{img_url feature_img}} and we also show a warning
+    if (attr === undefined) {
+        logging.warn(i18n.t('warnings.helpers.img_url.attrIsRequired'));
+        return;
+    }
+
+    if (attr) {
+        return url.urlFor('image', {image: attr}, absolute);
+    } else {
+        // CASE: if you pass e.g. cover_image, but it is not set, then attr is null!
+        // in this case we don't show a warning
+        return;
+    }
 };

--- a/core/server/helpers/prev_next.js
+++ b/core/server/helpers/prev_next.js
@@ -6,23 +6,36 @@
 var proxy = require('./proxy'),
     Promise = require('bluebird'),
 
+    logging = proxy.logging,
+    i18n = proxy.i18n,
+    createFrame = proxy.hbs.handlebars.createFrame,
+
     api = proxy.api,
     isPost = proxy.checks.isPost,
 
     fetch;
 
-fetch = function fetch(apiOptions, options) {
-    return api.posts.read(apiOptions).then(function (result) {
-        var related = result.posts[0];
+fetch = function fetch(apiOptions, options, data) {
+    var self = this;
 
-        if (related.previous) {
-            return options.fn(related.previous);
-        } else if (related.next) {
-            return options.fn(related.next);
-        } else {
-            return options.inverse(this);
-        }
-    });
+    return api.posts
+        .read(apiOptions)
+        .then(function handleSuccess(result) {
+            var related = result.posts[0];
+
+            if (related.previous) {
+                return options.fn(related.previous, {data: data});
+            } else if (related.next) {
+                return options.fn(related.next, {data: data});
+            } else {
+                return options.inverse(self, {data: data});
+            }
+        })
+        .catch(function handleError(err) {
+            logging.error(err);
+            data.error = err.message;
+            return options.inverse(self, {data: data});
+        });
 };
 
 // If prevNext method is called without valid post data then we must return a promise, if there is valid post data
@@ -31,14 +44,21 @@ fetch = function fetch(apiOptions, options) {
 module.exports = function prevNext(options) {
     options = options || {};
 
-    var apiOptions = {
-        include: options.name === 'prev_post' ? 'previous,previous.author,previous.tags' : 'next,next.author,next.tags'
-    };
+    var data = createFrame(options.data),
+        apiOptions = {
+            include: options.name === 'prev_post' ? 'previous,previous.author,previous.tags' : 'next,next.author,next.tags'
+        };
+
+    if (!options.fn) {
+        data.error = i18n.t('warnings.helpers.mustBeCalledAsBlock', {helperName: options.name});
+        logging.warn(data.error);
+        return Promise.resolve();
+    }
 
     if (isPost(this) && this.status === 'published') {
         apiOptions.slug = this.slug;
-        return fetch(apiOptions, options);
+        return fetch(apiOptions, options, data);
     } else {
-        return Promise.resolve(options.inverse(this));
+        return Promise.resolve(options.inverse(this, {data: data}));
     }
 };

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -487,11 +487,11 @@
             "helperNotAvailable": "The \\{\\{{helperName}\\}\\} helper is not available.",
             "flagMustBeEnabled": "The {flagName} flag must be enabled in labs if you wish to use the \\{\\{{helperName}\\}\\} helper.",
             "seeLink": "See {url}",
+            "mustBeCalledAsBlock": "The \\{\\{{helperName}\\}\\} helper must be called as a block. E.g.  \\{\\{#{helperName}\\}\\} \\{\\{/{helperName}\\}\\}",
             "foreach": {
                 "iteratorNeeded": "Need to pass an iterator to #foreach"
             },
             "get": {
-                "mustBeCalledAsBlock": "Get helper must be called as a block",
                 "invalidResource": "Invalid resource given to get helper"
             },
             "has": {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -521,7 +521,8 @@
                 "valuesMustBeDefined": "All values must be defined for empty, singular and plural"
             },
             "img_url": {
-                "attrIsRequired": "Attribute is required e.g. \\{\\{img_url feature_image\\}\\}"
+                "attrIsRequired": "Attribute is required e.g. \\{\\{img_url feature_image\\}\\}",
+                "attrIsUnknown": "Attribute passed to \\{\\{img_url\\}\\} is unknown"
             },
             "template": {
                 "templateNotFound": "Template {name} not found."

--- a/core/test/unit/server_helpers/img_url_spec.js
+++ b/core/test/unit/server_helpers/img_url_spec.js
@@ -4,13 +4,19 @@ var should = require('should'), // jshint ignore:line
 
     // Stuff we are testing
     helpers = require('../../../server/helpers'),
-    errors = require('../../../server/errors'),
+    logging = require('../../../server/logging'),
 
     sandbox = sinon.sandbox.create();
 
 describe('{{image}} helper', function () {
+    var logWarnStub;
+
     before(function () {
         configUtils.set({url: 'http://localhost:82832/'});
+    });
+
+    beforeEach(function () {
+        logWarnStub = sandbox.stub(logging, 'warn');
     });
 
     afterEach(function () {
@@ -25,33 +31,39 @@ describe('{{image}} helper', function () {
         var rendered = helpers.img_url('/content/images/image-relative-url.png', {});
         should.exist(rendered);
         rendered.should.equal('/content/images/image-relative-url.png');
+        logWarnStub.called.should.be.false();
     });
 
     it('should output absolute url of image if the option is present ', function () {
         var rendered = helpers.img_url('/content/images/image-relative-url.png', {hash: {absolute: 'true'}});
         should.exist(rendered);
         rendered.should.equal('http://localhost:82832/content/images/image-relative-url.png');
+        logWarnStub.called.should.be.false();
     });
 
     it('should output author url', function () {
         var rendered = helpers.img_url('/content/images/author-image-relative-url.png', {});
         should.exist(rendered);
         rendered.should.equal('/content/images/author-image-relative-url.png');
+        logWarnStub.called.should.be.false();
     });
 
-    it('should have no output if there is no image ', function (done) {
-        try {
-            helpers.img_url(undefined, {hash: {absolute: 'true'}});
-            done(new Error('we expect an error from img_url'));
-        } catch (err) {
-            (err instanceof errors.IncorrectUsageError).should.eql(true);
-            done();
-        }
+    it('should have no output if the image attributeis not provided (with warning)', function () {
+        var rendered = helpers.img_url({hash: {absolute: 'true'}});
+        should.not.exist(rendered);
+        logWarnStub.calledOnce.should.be.true();
     });
 
-    it('should have no output if there is no image ', function () {
+    it('should have no output if the image attribute evaluates to undefined (with warning)', function () {
+        var rendered = helpers.img_url(undefined, {hash: {absolute: 'true'}});
+        should.not.exist(rendered);
+        logWarnStub.calledOnce.should.be.true();
+    });
+
+    it('should have no output if the image attribute evaluates to null (no waring)', function () {
         var rendered = helpers.img_url(null, {hash: {absolute: 'true'}});
         should.not.exist(rendered);
+        logWarnStub.calledOnce.should.be.false();
     });
 
     describe('with sub-directory', function () {


### PR DESCRIPTION
This is a 3 part fix:

**Commit 1** is a global fix that should ensure any error thrown inside of any async helper will always be properly handled.

When this fix is applied, an error will be logged and an async helper like {{prev_post}} will render an error in development mode, or nothing in production mode.

**Commit 2** adds error handling to the prev/next helper, and unifies the way prev_next is treated so it behaves much more closely to the get helper.

When this fix is applied, an error will be logged and an async helper like {{prev_post}} will not render if there is an error, regardless of mode.

**Commit 3** downgrades the errors thrown by img_url to a logged warning.

When this fix is applied, a **warning** will be logged and async helpers like {{prev_post}} are unaffected.

closes #8703
