### PR TITLE
🙈  Used `got` to handle requests for image-size

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -129,8 +129,13 @@
                 }
             },
             "request": {
-                "message": "URL empty or invalid.",
-                "context": "{url}"
+                "message": "URL empty or invalid: {url}"
+            },
+            "imageSize": {
+                "imageSizeDimensions": "Could not read image dimensions. Message: {message}",
+                "requestTimedOut": "Request timed out: {url}",
+                "imageNotFound": "Image not found: {url}",
+                "unknownRequestError": "Unknown request error: {url}"
             }
         },
         "config": {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -127,6 +127,10 @@
                     "context": "Theme name: {name}",
                     "help": "Valid package.json will be required in future. Please see {url}"
                 }
+            },
+            "request": {
+                "message": "URL empty or invalid.",
+                "context": "{url}"
             }
         },
         "config": {

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -23,9 +23,11 @@ function getCachedImageSizeFromUrl(url) {
             imageSizeCache[url] = res;
 
             return Promise.resolve(imageSizeCache[url]);
+        }).catch(errors.NotFoundError, function () {
+            // in case of error we just attach the url
+            return Promise.resolve(imageSizeCache[url] = url);
         }).catch(function (err) {
             errors.logError(err, err.context);
-
             // in case of error we just attach the url
             return Promise.resolve(imageSizeCache[url] = url);
         });

--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -1,6 +1,5 @@
 var imageSizeCache          = {},
     size                    = require('./image-size-from-url'),
-    Promise                 = require('bluebird'),
     errors                  = require('../errors'),
     getImageSizeFromUrl     = size.getImageSizeFromUrl;
 
@@ -22,18 +21,22 @@ function getCachedImageSizeFromUrl(url) {
         return getImageSizeFromUrl(url).then(function (res) {
             imageSizeCache[url] = res;
 
-            return Promise.resolve(imageSizeCache[url]);
+            return imageSizeCache[url];
         }).catch(errors.NotFoundError, function () {
             // in case of error we just attach the url
-            return Promise.resolve(imageSizeCache[url] = url);
+            imageSizeCache[url] = url;
+
+            return imageSizeCache[url];
         }).catch(function (err) {
             errors.logError(err, err.context);
             // in case of error we just attach the url
-            return Promise.resolve(imageSizeCache[url] = url);
+            imageSizeCache[url] = url;
+
+            return imageSizeCache[url];
         });
     }
     // returns image size from cache
-    return Promise.resolve(imageSizeCache[url]);
+    return imageSizeCache[url];
 }
 
 module.exports = getCachedImageSizeFromUrl;

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -15,9 +15,8 @@
 // If the request fails or image-size is not able to read the file, we reject with error.
 
 var sizeOf = require('image-size'),
-    url = require('url'),
     Promise = require('bluebird'),
-    got = require('got'),
+    request = require('../utils/request'),
     config = require('../config'),
     dimensions;
 
@@ -45,7 +44,6 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
         }
     }
 
-    imagePath = url.parse(imagePath);
     requestOptions = {
         headers: {
             'User-Agent': 'Mozilla/5.0'
@@ -54,7 +52,7 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
         encoding: null
     };
 
-    return got(
+    return request(
         imagePath,
         requestOptions
     ).then(function (response) {

--- a/core/server/utils/image-size-from-url.js
+++ b/core/server/utils/image-size-from-url.js
@@ -1,5 +1,5 @@
 // Supported formats of https://github.com/image-size/image-size:
-// BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG
+// BMP, GIF, JPEG, PNG, PSD, TIFF, WebP, SVG, ICO
 // ***
 // Takes the url of the image and an optional timeout
 // getImageSizeFromUrl returns an Object like this
@@ -16,9 +16,12 @@
 
 var sizeOf = require('image-size'),
     Promise = require('bluebird'),
+    url = require('url'),
     request = require('../utils/request'),
     config = require('../config'),
-    dimensions;
+    errors = require('../errors'),
+    i18n = require('../i18n'),
+    _ = require('lodash');
 
 /**
  * @description read image dimensions from URL
@@ -27,21 +30,29 @@ var sizeOf = require('image-size'),
  */
 module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
     var imageObject = {},
+        dimensions,
+        parsedUrl,
         requestOptions,
         timeout = config.times.getImageSizeTimeoutInMS || 10000;
 
-    imageObject.url = imagePath;
+    // CASE: relative assets path for image, e. g. `/assets/img/`
+    if (imagePath.match(/^\/assets/)) {
+        imagePath = config.urlJoin(config.urlFor('home', true), '/', imagePath);
+    }
+
+    // CASE: when imagePath can't be resolved it returns undefined. Save absolute imagePath only, when resolved
+    // successfully.
+    imagePath = config.urlFor('image', {image: imagePath}, true) ? config.urlFor('image', {image: imagePath}, true) : imagePath;
+
+    parsedUrl = url.parse(imagePath);
 
     // check if we got an url without any protocol
-    if (imagePath.indexOf('http') === -1) {
-        // our gravatar urls start with '//' in that case add 'http:'
-        if (imagePath.indexOf('//') === 0) {
-            // it's a gravatar url
-            imagePath = 'http:' + imagePath;
-        } else {
-            // get absolute url for image
-            imagePath = config.urlFor('image', {image: imagePath}, true);
-        }
+    if (!parsedUrl.protocol) {
+        // save the original URL, as this is used for structured data
+        imageObject.url = imagePath;
+        // CASE: our gravatar URLs start with '//' and we need to add 'http:'
+        // to make the request work
+        imagePath = 'http:' + imagePath;
     }
 
     requestOptions = {
@@ -56,35 +67,48 @@ module.exports.getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
         imagePath,
         requestOptions
     ).then(function (response) {
+        if (!imageObject.url) {
+            imageObject.url = imagePath;
+        }
+
         try {
-            // response.body contains the Buffer. Using the Buffer rather than an URL
-            // requires to use sizeOf synchronously. See https://github.com/image-size/image-size#asynchronous
+            // Using the Buffer rather than an URL requires to use sizeOf synchronously.
+            // See https://github.com/image-size/image-size#asynchronous
             dimensions = sizeOf(response.body);
+
+            // CASE: `.ico` files might have multiple images and therefore multiple sizes.
+            // We return the largest size found (image-size default is the first size found)
+            if (dimensions.images) {
+                dimensions.width = _.maxBy(dimensions.images, function (w) {return w.width;}).width;
+                dimensions.height = _.maxBy(dimensions.images, function (h) {return h.height;}).height;
+            }
 
             imageObject.width = dimensions.width;
             imageObject.height = dimensions.height;
 
             return Promise.resolve(imageObject);
         } catch (err) {
-            err.context = imagePath.href;
-
-            return Promise.reject(err);
+            return Promise.reject(new errors.InternalServerError(
+                i18n.t('errors.utils.imageSize.imageSizeDimensions', {message: err})
+            ));
         }
+    }).catch({code: 'URL_MISSING_INVALID'}, function (err) {
+        // CASE: request util returns correct error already, just pass it through.
+        return Promise.reject(err);
+    }).catch({code: 'ETIMEDOUT'}, {statusCode: 408}, function (err) {
+        return Promise.reject(new errors.InternalServerError(
+            i18n.t('errors.utils.imageSize.requestTimedOut', {url: err.url || imagePath})
+        ));
+    }).catch({code: 'ENOENT'}, {statusCode: 404}, function (err) {
+        return Promise.reject(new errors.NotFoundError(
+            i18n.t('errors.utils.imageSize.imageNotFound', {url: err.url || imagePath})
+        ));
     }).catch(function (err) {
-        err.context = err.url || imagePath.href || imagePath;
-
-        if (err.statusCode === 404) {
-            err.message = 'Image not found.';
-
-            return Promise.reject(err);
-        } else if (err.code === 'ETIMEDOUT') {
-            err.message = 'Request timed out.';
-
-            return Promise.reject(err);
-        } else {
-            err.message = 'Unknown Request error.';
-
+        if (err instanceof errors.NotFoundError || err instanceof errors.InternalServerError) {
             return Promise.reject(err);
         }
+        return Promise.reject(new errors.InternalServerError(
+            i18n.t('errors.utils.imageSize.unknownRequestError', {url: err.url || imagePath})
+        ));
     });
 };

--- a/core/server/utils/request.js
+++ b/core/server/utils/request.js
@@ -1,0 +1,26 @@
+var got = require('got'),
+    Promise = require('bluebird'),
+    validator = require('../data/validation').validator,
+    errors = require('../errors'),
+    i18n = require('../i18n'),
+    _  = require('lodash');
+
+module.exports = function request(url, options) {
+    if (_.isEmpty(url) || !validator.isURL(url)) {
+        return Promise.reject(new errors.InternalServerError(
+            i18n.t('errors.utils.request.message'),
+            i18n.t('errors.utils.request.context', {url: url})
+        ));
+    }
+
+    return new Promise(function (resolve, reject) {
+        return got(
+            url,
+            options
+        ).then(function (response) {
+            return resolve(response);
+        }).catch(function (err) {
+            return reject(err);
+        });
+    });
+};

--- a/core/server/utils/request.js
+++ b/core/server/utils/request.js
@@ -8,8 +8,7 @@ var got = require('got'),
 module.exports = function request(url, options) {
     if (_.isEmpty(url) || !validator.isURL(url)) {
         return Promise.reject(new errors.InternalServerError(
-            i18n.t('errors.utils.request.message'),
-            i18n.t('errors.utils.request.context', {url: url})
+            i18n.t('errors.utils.request.message', {url: url})
         ));
     }
 

--- a/core/test/unit/server_helpers/ghost_head_spec.js
+++ b/core/test/unit/server_helpers/ghost_head_spec.js
@@ -48,7 +48,7 @@ describe('{{ghost_head}} helper', function () {
     describe('without Code Injection', function () {
         beforeEach(function () {
             configUtils.set({
-                url: 'http://localhost:82832/',
+                url: 'http://localhost:65530/',
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
@@ -68,9 +68,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['paged', 'index']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/page\/2\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -84,27 +84,27 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['home', 'index']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/" \/>/);
                 rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/blog-cover.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/blog-cover.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/blog-cover.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/blog-cover.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Website"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/blog-cover.png"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/blog-cover.png"/);
                 rendered.string.should.match(/"description": "blog description"/);
 
                 done();
@@ -136,33 +136,33 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['page']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/about\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/about\/" \/>/);
                 rendered.string.should.match(/<meta name="referrer" content="no-referrer-when-downgrade" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="About" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="all about our blog" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/about\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image-about.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/about\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/test-image-about.png" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="About" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="all about our blog" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/about\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image-about.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/about\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/test-image-about.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
                 rendered.string.should.match(/"publisher": {/);
                 rendered.string.should.match(/"@type": "Organization"/);
                 rendered.string.should.match(/"name": "Ghost"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/about\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/about\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image-about.png"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image-about.png"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
                 rendered.string.should.match(/"description": "all about our blog"/);
 
                 done();
@@ -182,26 +182,26 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="tag meta title" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="tag meta description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="tag meta title" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="tag meta description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/tag\/tagtitle\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/tag-image.png"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/tag\/tagtitle\/"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
                 rendered.string.should.match(/"description": "tag meta description"/);
 
@@ -223,26 +223,26 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="tagtitle - Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="tag description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="tagtitle - Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="tag description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/tag\/tagtitle\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/tag-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/tag\/tagtitle\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/tag-image.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Series"/);
                 rendered.string.should.match(/"publisher": {\n        "@type": "Organization",\n        "name": "Ghost",/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/tag\/tagtitle\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/tag-image.png"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/tag\/tagtitle\/"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/tag-image.png"/);
                 rendered.string.should.match(/"name": "tagtitle"/);
                 rendered.string.should.match(/"description": "tag description"/);
 
@@ -284,9 +284,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['tag']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/tag\/tagtitle\/page\/2\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/tag\/tagtitle\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -311,27 +311,27 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['author']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/author\/AuthorName\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="profile" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="Author bio" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/author-cover-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/author\/AuthorName\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/author-cover-image.png" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser\" \/>/);
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Author name - Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="Author bio" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/author\/AuthorName\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/author\/AuthorName\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/author-cover-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/author-cover-image.png" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"sameAs": \[\n        "http:\/\/authorwebsite.com",\n        "https:\/\/www.facebook.com\/testuser",\n        "https:\/\/twitter.com\/testuser"\n    \]/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/AuthorName\/"/);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/author-cover-image.png"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/AuthorName\/"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/author-cover-image.png"/);
                 rendered.string.should.match(/"name": "Author name"/);
                 rendered.string.should.match(/"description": "Author bio"/);
 
@@ -356,9 +356,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['paged', 'author']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/author\/AuthorName\/page\/2\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/author\/AuthorName\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -373,7 +373,7 @@ describe('{{ghost_head}} helper', function () {
             ).then(function (rendered) {
                 should.exist(rendered);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.9" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 done();
             }).catch(done);
@@ -409,14 +409,14 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(re1);
                 rendered.string.should.match(re2);
                 rendered.string.should.match(/<meta property="article:tag" content="tag1" \/>/);
@@ -425,8 +425,8 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
@@ -436,20 +436,20 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 post.should.eql(postBk);
 
@@ -487,14 +487,14 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.not.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.not.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(re1);
                 rendered.string.should.match(re2);
                 rendered.string.should.match(/<meta property="article:tag" content="tag1" \/>/);
@@ -503,8 +503,8 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
@@ -514,20 +514,20 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"description": "Author bio"/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 post.should.eql(postBk);
 
@@ -565,14 +565,14 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost &quot;test&quot;" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog &quot;test&quot; description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.match(re1);
                 rendered.string.should.match(re2);
@@ -582,9 +582,9 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost &quot;test&quot;" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog &quot;test&quot; description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/post\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/"@type": "Article"/);
@@ -594,20 +594,20 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost &quot;test&quot;"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog &quot;test&quot; description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 done();
             }).catch(done);
@@ -641,14 +641,14 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.match(re1);
                 rendered.string.should.match(re2);
@@ -656,8 +656,8 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:card" content="summary_large_image" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:82832\/content\/images\/test-image.png" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:image" content="http:\/\/localhost:65530\/content\/images\/test-image.png" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
@@ -667,20 +667,20 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"author": {/);
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
-                rendered.string.should.match(/"image\": \"http:\/\/localhost:82832\/content\/images\/test-author-image.png\"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"image\": \"http:\/\/localhost:65530\/content\/images\/test-author-image.png\"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
-                rendered.string.should.match(/"image": "http:\/\/localhost:82832\/content\/images\/test-image.png"/);
+                rendered.string.should.match(/"image": "http:\/\/localhost:65530\/content\/images\/test-image.png"/);
                 rendered.string.should.not.match(/"keywords":/);
                 rendered.string.should.match(/"description": "blog description"/);
                 rendered.string.should.match(/"@context": "https:\/\/schema.org"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 done();
             }).catch(done);
@@ -715,13 +715,13 @@ describe('{{ghost_head}} helper', function () {
                     re4 = new RegExp('"dateModified": "' + post.updated_at);
 
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="article" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/post\/" \/>/);
                 rendered.string.should.match(/<meta property="article:author" content="https:\/\/www.facebook.com\/testuser" \/>/);
                 rendered.string.should.not.match(/<meta property="og:image"/);
                 rendered.string.should.match(re1);
@@ -732,7 +732,7 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/<meta name="twitter:card" content="summary" \/>/);
                 rendered.string.should.match(/<meta name="twitter:title" content="Welcome to Ghost" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="blog description" \/>/);
-                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:82832\/post\/" \/>/);
+                rendered.string.should.match(/<meta name="twitter:url" content="http:\/\/localhost:65530\/post\/" \/>/);
                 rendered.string.should.match(/<meta name="twitter:creator" content="@testuser" \/>/);
                 rendered.string.should.not.match(/<meta name="twitter:image"/);
                 rendered.string.should.match(/<script type=\"application\/ld\+json\">/);
@@ -745,16 +745,16 @@ describe('{{ghost_head}} helper', function () {
                 rendered.string.should.match(/"@type": "Person"/);
                 rendered.string.should.match(/"name": "Author name"/);
                 rendered.string.should.not.match(/"image\"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/author\/Author\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/author\/Author\/"/);
                 rendered.string.should.match(/"sameAs": \[\n            "http:\/\/authorwebsite.com",\n            "https:\/\/www.facebook.com\/testuser",\n            "https:\/\/twitter.com\/testuser"\n        \]/);
                 rendered.string.should.match(/"headline": "Welcome to Ghost"/);
-                rendered.string.should.match(/"url": "http:\/\/localhost:82832\/post\/"/);
+                rendered.string.should.match(/"url": "http:\/\/localhost:65530\/post\/"/);
                 rendered.string.should.match(re3);
                 rendered.string.should.match(re4);
                 rendered.string.should.match(/"keywords": "tag1, tag2, tag3"/);
                 rendered.string.should.match(/"description": "blog description"/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 done();
             }).catch(done);
@@ -766,13 +766,13 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['featured']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/featured\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/featured\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<meta property="og:site_name" content="Ghost" \/>/);
                 rendered.string.should.match(/<meta property="og:type" content="website" \/>/);
                 rendered.string.should.match(/<meta property="og:title" content="Ghost" \/>/);
-                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:82832\/featured\/" \/>/);
+                rendered.string.should.match(/<meta property="og:url" content="http:\/\/localhost:65530\/featured\/" \/>/);
 
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -794,7 +794,7 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['post']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta property="og:description" content="This is a short post" \/>/);
                 rendered.string.should.match(/<meta name="twitter:description" content="This is a short post" \/>/);
 
@@ -816,9 +816,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['page']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/about\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/about\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
 
                 done();
             }).catch(done);
@@ -830,11 +830,11 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['index', 'paged'], pagination: {total: 4, page: 3, next: 4, prev: 2}}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/page\/3\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/page\/3\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="prev" href="http:\/\/localhost:82832\/page\/2\/" \/>/);
-                rendered.string.should.match(/<link rel="next" href="http:\/\/localhost:82832\/page\/4\/" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="prev" href="http:\/\/localhost:65530\/page\/2\/" \/>/);
+                rendered.string.should.match(/<link rel="next" href="http:\/\/localhost:65530\/page\/4\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -848,11 +848,11 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['index', 'paged'], pagination: {total: 3, page: 2, next: 3, prev: 1}}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/page\/2\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/page\/2\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="prev" href="http:\/\/localhost:82832\/" \/>/);
-                rendered.string.should.match(/<link rel="next" href="http:\/\/localhost:82832\/page\/3\/" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="prev" href="http:\/\/localhost:65530\/" \/>/);
+                rendered.string.should.match(/<link rel="next" href="http:\/\/localhost:65530\/page\/3\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -863,7 +863,7 @@ describe('{{ghost_head}} helper', function () {
         describe('with /blog subdirectory', function () {
             beforeEach(function () {
                 configUtils.set({
-                    url: 'http://localhost:82832/blog/',
+                    url: 'http://localhost:65530/blog/',
                     theme: {
                         title: 'Ghost',
                         description: 'blog description',
@@ -878,9 +878,9 @@ describe('{{ghost_head}} helper', function () {
                     {data: {root: {context: []}}}
                 ).then(function (rendered) {
                     should.exist(rendered);
-                    rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/blog\/" \/>/);
+                    rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/blog\/" \/>/);
                     rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                    rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/blog\/rss\/" \/>/);
+                    rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/blog\/rss\/" \/>/);
 
                     done();
                 }).catch(done);
@@ -891,7 +891,7 @@ describe('{{ghost_head}} helper', function () {
     describe('with changed origin in config file', function () {
         beforeEach(function () {
             configUtils.set({
-                url: 'http://localhost:82832/blog/',
+                url: 'http://localhost:65530/blog/',
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
@@ -918,7 +918,7 @@ describe('{{ghost_head}} helper', function () {
     describe('with useStructuredData is set to false in config file', function () {
         beforeEach(function () {
             configUtils.set({
-                url: 'http://localhost:82832/',
+                url: 'http://localhost:65530/',
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
@@ -955,10 +955,10 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: ['post']}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/post\/" \/>/);
-                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:82832\/post\/amp\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/post\/" \/>/);
+                rendered.string.should.match(/<link rel="amphtml" href="http:\/\/localhost:65530\/post\/amp\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<meta property="og/);
                 rendered.string.should.not.match(/<script type=\"application\/ld\+json\">/);
 
@@ -974,7 +974,7 @@ describe('{{ghost_head}} helper', function () {
             }));
 
             configUtils.set({
-                url: 'http://localhost:82832/',
+                url: 'http://localhost:65530/',
                 theme: {
                     title: 'Ghost',
                     description: 'blog description',
@@ -989,9 +989,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: []}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.match(/<style>body {background: red;}<\/style>/);
 
                 done();
@@ -1021,9 +1021,9 @@ describe('{{ghost_head}} helper', function () {
                 {data: {root: {context: []}}}
             ).then(function (rendered) {
                 should.exist(rendered);
-                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:82832\/" \/>/);
+                rendered.string.should.match(/<link rel="canonical" href="http:\/\/localhost:65530\/" \/>/);
                 rendered.string.should.match(/<meta name="generator" content="Ghost 0.3" \/>/);
-                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:82832\/rss\/" \/>/);
+                rendered.string.should.match(/<link rel="alternate" type="application\/rss\+xml" title="Ghost" href="http:\/\/localhost:65530\/rss\/" \/>/);
                 rendered.string.should.not.match(/<style>body {background: red;}<\/style>/);
 
                 done();
@@ -1098,7 +1098,7 @@ describe('{{ghost_head}} helper', function () {
     describe('amp is disabled', function () {
         beforeEach(function () {
             configUtils.set({
-                url: 'http://localhost:82832/',
+                url: 'http://localhost:65530/',
                 theme: {
                     amp: false
                 }

--- a/core/test/unit/utils/cached-image-size-from-url_spec.js
+++ b/core/test/unit/utils/cached-image-size-from-url_spec.js
@@ -22,7 +22,9 @@ describe('getCachedImageSizeFromUrl', function () {
     });
 
     it('should read from cache, if dimensions for image are fetched already', function (done) {
-        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
+        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            cachedImagedSizeResult,
+            imageSizeSpy;
 
         sizeOfStub.returns(new Promise.resolve({
             width: 50,
@@ -32,7 +34,10 @@ describe('getCachedImageSizeFromUrl', function () {
 
         getCachedImageSizeFromUrl.__set__('getImageSizeFromUrl', sizeOfStub);
 
-        getCachedImageSizeFromUrl(url).then(function () {
+        imageSizeSpy = getCachedImageSizeFromUrl.__get__('getImageSizeFromUrl');
+
+        cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
+        cachedImagedSizeResult.then(function () {
             // first call to get result from `getImageSizeFromUrl`
             cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
             should.exist(cachedImagedSize);
@@ -41,9 +46,13 @@ describe('getCachedImageSizeFromUrl', function () {
             cachedImagedSize[url].width.should.be.equal(50);
             should.exist(cachedImagedSize[url].height);
             cachedImagedSize[url].height.should.be.equal(50);
+
             // second call to check if values get returned from cache
-            getCachedImageSizeFromUrl(url).then(function () {
+            cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
+            cachedImagedSizeResult.then(function () {
                 cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
+                imageSizeSpy.calledOnce.should.be.true();
+                imageSizeSpy.calledTwice.should.be.false();
                 should.exist(cachedImagedSize);
                 cachedImagedSize.should.have.property(url);
                 should.exist(cachedImagedSize[url].width);
@@ -57,21 +66,22 @@ describe('getCachedImageSizeFromUrl', function () {
     });
 
     it('can handle image-size errors', function (done) {
-        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg';
+        var url = 'http://mysite.com/content/image/mypostcoverimage.jpg',
+            cachedImagedSizeResult;
 
         sizeOfStub.returns(new Promise.reject('error'));
 
         getCachedImageSizeFromUrl.__set__('getImageSizeFromUrl', sizeOfStub);
 
-        getCachedImageSizeFromUrl(url)
-        .then(function () {
-            cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
-            should.exist(cachedImagedSize);
-            cachedImagedSize.should.have.property(url);
-            should.not.exist(cachedImagedSize[url].width);
-            should.not.exist(cachedImagedSize[url].height);
-            done();
-        }).catch(done);
+        cachedImagedSizeResult = Promise.resolve(getCachedImageSizeFromUrl(url));
+        cachedImagedSizeResult.then(function () {
+                cachedImagedSize = getCachedImageSizeFromUrl.__get__('imageSizeCache');
+                should.exist(cachedImagedSize);
+                cachedImagedSize.should.have.property(url);
+                should.not.exist(cachedImagedSize[url].width);
+                should.not.exist(cachedImagedSize[url].height);
+                done();
+            }).catch(done);
     });
 
     it('should return null if url is undefined', function (done) {

--- a/core/test/unit/utils/image-size-from-url_spec.js
+++ b/core/test/unit/utils/image-size-from-url_spec.js
@@ -6,7 +6,9 @@ var should = require('should'),
     configUtils = require('../../utils/configUtils'),
 
     // Stuff we are testing
-    imageSize = rewire('../../../server/utils/image-size-from-url');
+    imageSize = rewire('../../../server/utils/image-size-from-url'),
+
+    sandbox = sinon.sandbox.create();
 
 describe('Image Size', function () {
     var sizeOfStub,
@@ -14,21 +16,17 @@ describe('Image Size', function () {
         requestMock,
         secondRequestMock;
 
-    beforeEach(function () {
-        sizeOfStub = sinon.stub();
-    });
-
     afterEach(function () {
-        sinon.restore();
+        sandbox.restore();
         configUtils.restore();
         imageSize = rewire('../../../server/utils/image-size-from-url');
     });
 
-    it('should have an image size function', function () {
+    it('[success] should have an image size function', function () {
         should.exist(imageSize);
     });
 
-    it('should return image dimensions with http request', function (done) {
+    it('[success] should return image dimensions with http request', function (done) {
         var url = 'http://img.stockfresh.com/files/f/feedough/x/11/1540353_20925115.jpg',
             expectedImageObject =
                 {
@@ -41,6 +39,7 @@ describe('Image Size', function () {
             .get('/files/f/feedough/x/11/1540353_20925115.jpg')
             .reply(200);
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -57,7 +56,7 @@ describe('Image Size', function () {
         }).catch(done);
     });
 
-    it('should return image dimensions with https request', function (done) {
+    it('[success] should return image dimensions with https request', function (done) {
         var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256',
             expectedImageObject =
                 {
@@ -71,6 +70,7 @@ describe('Image Size', function () {
                 body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.returns({width: 256, height: 256, type: 'png'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -87,7 +87,7 @@ describe('Image Size', function () {
         }).catch(done);
     });
 
-    it('should return image dimensions for gravatar images request', function (done) {
+    it('[success] should return image dimensions for gravatar images request', function (done) {
         var url = '//www.gravatar.com/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x',
             expectedImageObject =
                 {
@@ -101,6 +101,7 @@ describe('Image Size', function () {
                 body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.returns({width: 250, height: 250, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -117,17 +118,131 @@ describe('Image Size', function () {
         }).catch(done);
     });
 
-    it('should return image dimensions relative url request', function (done) {
+    it('[success] should return image dimensions for images with subdirectory blog', function (done) {
+        var url = '/content/images/favicon_too_large.png',
+            urlForStub,
+            expectedImageObject =
+            {
+                height: 1010,
+                url: 'http://myblog.com/blog/content/images/favicon_too_large.png',
+                width: 1010
+            };
+
+        urlForStub = sandbox.stub(config, 'urlFor');
+        urlForStub.withArgs('image').returns('http://myblog.com/blog/content/images/favicon_too_large.png');
+        urlForStub.withArgs('home').returns('http://myblog.com/blog/');
+
+        requestMock = nock('http://myblog.com')
+            .get('/blog/content/images/favicon_too_large.png')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+        sizeOfStub = sandbox.stub();
+        sizeOfStub.returns({width: 1010, height: 1010, type: 'png'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('[success] should returns largest image value for .ico files', function (done) {
+        var url = 'https://super-website.com/media/icon.ico',
+            expectedImageObject =
+            {
+                height: 48,
+                url: 'https://super-website.com/media/icon.ico',
+                width: 48
+            };
+
+        requestMock = nock('https://super-website.com')
+            .get('/media/icon.ico')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+        sizeOfStub = sandbox.stub();
+        sizeOfStub.returns({
+            width: 32,
+            height: 32,
+            type: 'ico',
+            images: [
+                {width: 48, height: 48},
+                {width: 32, height: 32},
+                {width: 16, height: 16}
+            ]
+        });
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('[success] should return image dimensions asset path images', function (done) {
+        var url = '/assets/img/logo.png?v=d30c3d1e41',
+            urlForStub,
+            expectedImageObject =
+            {
+                height: 100,
+                url: 'http://myblog.com/assets/img/logo.png?v=d30c3d1e41',
+                width: 100
+            };
+
+        urlForStub = sandbox.stub(config, 'urlFor');
+        urlForStub.withArgs('home').returns('http://myblog.com/');
+
+        requestMock = nock('http://myblog.com')
+            .get('/assets/img/logo.png?v=d30c3d1e41')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+        sizeOfStub = sandbox.stub();
+        sizeOfStub.returns({width: 100, height: 100, type: 'svg'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
+    });
+
+    it('[success] should return image dimensions relative url request', function (done) {
         var url = '/content/images/cat.jpg',
             urlForStub,
             expectedImageObject =
                 {
                     height: 100,
-                    url: '/content/images/cat.jpg',
+                    url: 'http://myblog.com/content/images/cat.jpg',
                     width: 100
                 };
 
-        urlForStub = sinon.stub(config, 'urlFor');
+        urlForStub = sandbox.stub(config, 'urlFor');
         urlForStub.withArgs('image').returns('http://myblog.com/content/images/cat.jpg');
 
         requestMock = nock('http://myblog.com')
@@ -136,6 +251,7 @@ describe('Image Size', function () {
                 body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -152,22 +268,7 @@ describe('Image Size', function () {
         }).catch(done);
     });
 
-    it('can handle an error a statuscode not 200', function (done) {
-        var url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
-
-        requestMock = nock('http://noimagehere.com')
-            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
-            .reply(404);
-
-        result = imageSize.getImageSizeFromUrl(url)
-        .catch(function (err) {
-            requestMock.isDone().should.be.true();
-            should.exist(err);
-            done();
-        });
-    });
-
-    it('can handle redirect', function (done) {
+    it('[success] can handle redirect', function (done) {
         var url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg',
             expectedImageObject =
             {
@@ -191,6 +292,7 @@ describe('Image Size', function () {
                 body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -208,7 +310,34 @@ describe('Image Size', function () {
         }).catch(done);
     });
 
-    it('will timeout', function (done) {
+    it('[failure] can handle an error a statuscode not 200', function (done) {
+        var url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg';
+
+        requestMock = nock('http://noimagehere.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(404);
+
+        result = imageSize.getImageSizeFromUrl(url)
+        .catch(function (err) {
+            requestMock.isDone().should.be.true();
+            should.exist(err);
+            err.message.should.be.equal('Image not found: http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg');
+            done();
+        });
+    });
+
+    it('[failure] can handle invalid URL', function (done) {
+        var url = 'not-a-url';
+
+        result = imageSize.getImageSizeFromUrl(url)
+        .catch(function (err) {
+            should.exist(err);
+            err.message.should.be.equal('URL empty or invalid: http:not-a-url');
+            done();
+        });
+    });
+
+    it('[failure] will timeout', function (done) {
         var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256';
         requestMock = nock('https://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
@@ -225,11 +354,12 @@ describe('Image Size', function () {
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);
+            err.message.should.be.equal('Request timed out: https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256');
             done();
         });
     });
 
-    it('returns error if \`image-size`\ module throws error', function (done) {
+    it('[failure] returns error if \`image-size`\ module throws error', function (done) {
         var url = 'https://static.wixstatic.com/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256',
 
         requestMock = nock('https://static.wixstatic.com')
@@ -238,6 +368,7 @@ describe('Image Size', function () {
                 body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
+        sizeOfStub = sandbox.stub();
         sizeOfStub.throws({error: 'image-size could not find dimensions'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
@@ -249,12 +380,12 @@ describe('Image Size', function () {
         });
     });
 
-    it('returns error if request errors', function (done) {
+    it('[failure] returns error if request errors', function (done) {
         var url = 'https://notarealwebsite.com/images/notapicture.jpg',
 
         requestMock = nock('https://notarealwebsite.com')
             .get('/images/notapicture.jpg')
-            .replyWithError({message: 'something awful happened', code: 'AWFUL_ERROR'});
+            .reply(500, {message: 'something awful happened', code: 'AWFUL_ERROR'});
 
         result = imageSize.getImageSizeFromUrl(url)
         .catch(function (err) {

--- a/core/test/unit/utils/image-size-from-url_spec.js
+++ b/core/test/unit/utils/image-size-from-url_spec.js
@@ -1,5 +1,4 @@
 var should = require('should'),
-    Promise = require('bluebird'),
     rewire = require('rewire'),
     nock = require('nock'),
     sinon = require('sinon'),
@@ -12,7 +11,8 @@ var should = require('should'),
 describe('Image Size', function () {
     var sizeOfStub,
         result,
-        requestMock;
+        requestMock,
+        secondRequestMock;
 
     beforeEach(function () {
         sizeOfStub = sinon.stub();
@@ -21,6 +21,7 @@ describe('Image Size', function () {
     afterEach(function () {
         sinon.restore();
         configUtils.restore();
+        imageSize = rewire('../../../server/utils/image-size-from-url');
     });
 
     it('should have an image size function', function () {
@@ -43,7 +44,7 @@ describe('Image Size', function () {
         sizeOfStub.returns({width: 50, height: 50, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
             requestMock.isDone().should.be.true();
             should.exist(res);
             should.exist(res.width);
@@ -67,13 +68,13 @@ describe('Image Size', function () {
         requestMock = nock('https://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
         sizeOfStub.returns({width: 256, height: 256, type: 'png'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
             requestMock.isDone().should.be.true();
             should.exist(res);
             should.exist(res.width);
@@ -97,13 +98,13 @@ describe('Image Size', function () {
         requestMock = nock('http://www.gravatar.com')
             .get('/avatar/ef6dcde5c99bb8f685dd451ccc3e050a?s=250&d=mm&r=x')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
         sizeOfStub.returns({width: 250, height: 250, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
             requestMock.isDone().should.be.true();
             should.exist(res);
             should.exist(res.width);
@@ -132,13 +133,13 @@ describe('Image Size', function () {
         requestMock = nock('http://myblog.com')
             .get('/content/images/cat.jpg')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
         sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url)).then(function (res) {
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
             requestMock.isDone().should.be.true();
             should.exist(res);
             should.exist(res.width);
@@ -158,12 +159,53 @@ describe('Image Size', function () {
             .get('/files/f/feedough/x/11/1540353_20925115.jpg')
             .reply(404);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url))
+        result = imageSize.getImageSizeFromUrl(url)
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);
             done();
         });
+    });
+
+    it('can handle redirect', function (done) {
+        var url = 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg',
+            expectedImageObject =
+            {
+                height: 100,
+                url: 'http://noimagehere.com/files/f/feedough/x/11/1540353_20925115.jpg',
+                width: 100
+            };
+
+        requestMock = nock('http://noimagehere.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(301, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            },
+            {
+                location: 'http://someredirectedurl.com/files/f/feedough/x/11/1540353_20925115.jpg'
+            });
+
+        secondRequestMock = nock('http://someredirectedurl.com')
+            .get('/files/f/feedough/x/11/1540353_20925115.jpg')
+            .reply(200, {
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+            });
+
+        sizeOfStub.returns({width: 100, height: 100, type: 'jpg'});
+        imageSize.__set__('sizeOf', sizeOfStub);
+
+        result = imageSize.getImageSizeFromUrl(url).then(function (res) {
+            requestMock.isDone().should.be.true();
+            secondRequestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.width);
+            res.width.should.be.equal(expectedImageObject.width);
+            should.exist(res.height);
+            res.height.should.be.equal(expectedImageObject.height);
+            should.exist(res.url);
+            res.url.should.be.equal(expectedImageObject.url);
+            done();
+        }).catch(done);
     });
 
     it('will timeout', function (done) {
@@ -179,7 +221,7 @@ describe('Image Size', function () {
             }
         });
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url))
+        result = imageSize.getImageSizeFromUrl(url)
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);
@@ -193,13 +235,13 @@ describe('Image Size', function () {
         requestMock = nock('https://static.wixstatic.com')
             .get('/media/355241_d31358572a2542c5a44738ddcb59e7ea.jpg_256')
             .reply(200, {
-                data: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
+                body: '<Buffer 2c be a4 40 f7 87 73 1e 57 2c c1 e4 0d 79 03 95 42 f0 42 2e 41 95 27 c9 5c 35 a7 71 2c 09 5a 57 d3 04 1e 83 03 28 07 96 b0 c8 88 65 07 7a d1 d6 63 50>'
             });
 
         sizeOfStub.throws({error: 'image-size could not find dimensions'});
         imageSize.__set__('sizeOf', sizeOfStub);
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url))
+        result = imageSize.getImageSizeFromUrl(url)
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);
@@ -214,7 +256,7 @@ describe('Image Size', function () {
             .get('/images/notapicture.jpg')
             .replyWithError({message: 'something awful happened', code: 'AWFUL_ERROR'});
 
-        result = Promise.resolve(imageSize.getImageSizeFromUrl(url))
+        result = imageSize.getImageSizeFromUrl(url)
         .catch(function (err) {
             requestMock.isDone().should.be.true();
             should.exist(err);

--- a/core/test/unit/utils/request_spec.js
+++ b/core/test/unit/utils/request_spec.js
@@ -1,0 +1,186 @@
+var should = require('should'),
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+    nock = require('nock'),
+
+    // Stuff we are testing
+    request = rewire('../../../server/utils/request'),
+
+    sandbox = sinon.sandbox.create();
+
+describe('Request', function () {
+    var result,
+        requestMock,
+        secondRequestMock;
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('[success] should return response for http request', function (done) {
+        var url = 'http://some-website.com/endpoint/',
+            expectedResponse =
+            {
+                body: 'Response body',
+                url: 'http://some-website.com/endpoint/',
+                statusCode: 200
+            },
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        requestMock = nock('http://some-website.com')
+            .get('/endpoint/')
+            .reply(200, 'Response body');
+
+        result = request(url, options).then(function (res) {
+            requestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.body);
+            res.body.should.be.equal(expectedResponse.body);
+            should.exist(res.url);
+            res.statusCode.should.be.equal(expectedResponse.statusCode);
+            should.exist(res.statusCode);
+            res.url.should.be.equal(expectedResponse.url);
+            done();
+        }).catch(done);
+    });
+
+    it('[success] can handle redirect', function (done) {
+        var url = 'http://some-website.com/endpoint/',
+            expectedResponse =
+            {
+                body: 'Redirected response',
+                url: 'http://someredirectedurl.com/files/',
+                statusCode: 200
+            },
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        requestMock = nock('http://some-website.com')
+            .get('/endpoint/')
+            .reply(301, 'Oops, got redirected',
+            {
+                location: 'http://someredirectedurl.com/files/'
+            });
+
+        secondRequestMock = nock('http://someredirectedurl.com')
+            .get('/files/')
+            .reply(200, 'Redirected response');
+
+        result = request(url, options).then(function (res) {
+            requestMock.isDone().should.be.true();
+            secondRequestMock.isDone().should.be.true();
+            should.exist(res);
+            should.exist(res.body);
+            res.body.should.be.equal(expectedResponse.body);
+            should.exist(res.url);
+            res.statusCode.should.be.equal(expectedResponse.statusCode);
+            should.exist(res.statusCode);
+            res.url.should.be.equal(expectedResponse.url);
+            done();
+        }).catch(done);
+    });
+
+    it('[failure] can handle invalid url', function (done) {
+        var url = 'test',
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        result = request(url, options)
+            .catch(function (err) {
+                should.exist(err);
+                err.message.should.be.equal('URL empty or invalid.');
+                done();
+            });
+    });
+
+    it('[failure] can handle empty url', function (done) {
+        var url = '',
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        result = request(url, options)
+            .catch(function (err) {
+                should.exist(err);
+                err.message.should.be.equal('URL empty or invalid.');
+                done();
+            });
+    });
+
+    it('[failure] can handle an error with statuscode not 200', function (done) {
+        var url = 'http://nofilehere.com/files/test.txt',
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        requestMock = nock('http://nofilehere.com')
+            .get('/files/test.txt')
+            .reply(404);
+
+        result = request(url, options)
+            .catch(function (err) {
+                requestMock.isDone().should.be.true();
+                should.exist(err);
+                err.statusMessage.should.be.equal('Not Found');
+                done();
+            });
+    });
+
+    it('[failure] will timeout', function (done) {
+        var url = 'http://nofilehere.com/files/test.txt',
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                },
+                timeout: 10
+            };
+
+        requestMock = nock('http://nofilehere.com')
+            .get('/files/test.txt')
+            .socketDelay(11)
+            .reply(408);
+
+        result = request(url, options)
+            .catch(function (err) {
+                requestMock.isDone().should.be.true();
+                should.exist(err);
+                err.statusMessage.should.be.equal('Request Timeout');
+                done();
+            });
+    });
+
+    it('[failure] returns error if request errors', function (done) {
+        var url = 'http://nofilehere.com/files/test.txt',
+            options = {
+                headers: {
+                    'User-Agent': 'Mozilla/5.0'
+                }
+            };
+
+        requestMock = nock('http://nofilehere.com')
+            .get('/files/test.txt')
+            .reply(500, {message: 'something aweful happend', code: 'AWFUL_ERROR'});
+
+        result = request(url, options)
+            .catch(function (err) {
+                requestMock.isDone().should.be.true();
+                should.exist(err);
+                err.statusMessage.should.be.equal('Internal Server Error');
+                done();
+            });
+    });
+});

--- a/core/test/unit/utils/request_spec.js
+++ b/core/test/unit/utils/request_spec.js
@@ -98,7 +98,7 @@ describe('Request', function () {
         result = request(url, options)
             .catch(function (err) {
                 should.exist(err);
-                err.message.should.be.equal('URL empty or invalid.');
+                err.message.should.be.equal('URL empty or invalid: test');
                 done();
             });
     });
@@ -114,7 +114,7 @@ describe('Request', function () {
         result = request(url, options)
             .catch(function (err) {
                 should.exist(err);
-                err.message.should.be.equal('URL empty or invalid.');
+                err.message.should.be.equal('URL empty or invalid: ');
                 done();
             });
     });

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "fs-extra": "2.1.2",
     "ghost-gql": "0.0.6",
     "glob": "5.0.15",
+    "got": "7.1.0",
     "gscan": "0.2.4",
     "html-to-text": "3.2.0",
     "image-size": "0.5.1",


### PR DESCRIPTION
closes #8589
refs #8868

This PR ports most of the changes of #8892 and #8986 to improve the image-size util.

----

- Swapped `request` with `got` in `getImageSizeFromUrl` fn.
- wrapped `got` request library in its own `request.js` util that returns bluebird promises and validates URL before starting a request
- Used catch predicates instead of conditionals in `getImageSizeFromUrl`
- Returned `NotFoundError` if applicable as the caller function `cachedImageSizeFromUrl` is differentiating those between this error and others.
- The logic that checked for an existing protocol (e. g. gravatar URLs) was overly complicated. Refactored it to be more simple.
- We're always resolving the result in `getCachedImageSizeFromUrl`, so there's no need to return the values with a `Promise.resolve()`. The caller fn uses waits for the Promises to be fulfilled.
- added and improved tests