### PR TITLE
Blog and Admin redirects with trailing slash

### DIFF
--- a/core/server/middleware/url-redirects.js
+++ b/core/server/middleware/url-redirects.js
@@ -10,6 +10,12 @@ _private.redirectUrl = function redirectUrl(options) {
         query = options.query,
         parts = url.parse(redirectTo);
 
+    // CASE: ensure we always add a trailing slash to reduce the number of redirects
+    // e.g. you are redirected from example.com/ghost to admin.example.com/ghost and Ghost would detect a missing slash and redirect you to /ghost/
+    if (!path.match(/\/$/)) {
+        path += '/';
+    }
+
     return url.format({
         protocol: parts.protocol,
         hostname: parts.hostname,

--- a/core/test/unit/middleware/url-redirects_spec.js
+++ b/core/test/unit/middleware/url-redirects_spec.js
@@ -177,7 +177,7 @@ describe('UNIT: url redirects', function () {
         req.originalUrl = '/ghost';
         urlRedirects(req, res, next);
         next.called.should.be.false();
-        res.redirect.calledWith(301, 'https://default.com:2368/ghost').should.be.true();
+        res.redirect.calledWith(301, 'https://default.com:2368/ghost/').should.be.true();
         done();
     });
 
@@ -195,7 +195,7 @@ describe('UNIT: url redirects', function () {
         req.originalUrl = '/ghost';
         urlRedirects(req, res, next);
         next.called.should.be.false();
-        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost').should.be.true();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/').should.be.true();
         done();
     });
 
@@ -213,7 +213,7 @@ describe('UNIT: url redirects', function () {
         req.originalUrl = '/blog/ghost';
         urlRedirects(req, res, next);
         next.called.should.be.false();
-        res.redirect.calledWith(301, 'https://admin.default.com:2368/blog/ghost').should.be.true();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/blog/ghost/').should.be.true();
 
         req.secure = true;
         host = 'admin.default.com:2368';
@@ -240,7 +240,7 @@ describe('UNIT: url redirects', function () {
 
         urlRedirects(req, res, next);
         next.called.should.be.false();
-        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost?test=true').should.be.true();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/?test=true').should.be.true();
         done();
     });
 
@@ -258,7 +258,7 @@ describe('UNIT: url redirects', function () {
         req.originalUrl = '/ghost';
         urlRedirects(req, res, next);
         next.called.should.be.false();
-        res.redirect.calledWith(301, 'https://default.com:2368/ghost').should.be.true();
+        res.redirect.calledWith(301, 'https://default.com:2368/ghost/').should.be.true();
 
         req.secure = true;
         urlRedirects(req, res, next);


### PR DESCRIPTION
no issue

- reduce the number of redirects
- before: you are redirected from example.com/ghost to admin.example.com/ghost and Ghost would detect a missing slash and redirect you to /ghost/
- now: you are redirected from example.com/ghost to admin.example.com/ghost/
