### PR TITLE
Added default logging rotation config

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -18,7 +18,9 @@
     "logging": {
         "level": "info",
         "rotation": {
-            "enabled": false
+            "enabled": false,
+            "period": "1w",
+            "count": 100
         },
         "transports": ["stdout"]
     },

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -19,8 +19,8 @@
         "level": "info",
         "rotation": {
             "enabled": false,
-            "period": "1w",
-            "count": 100
+            "period": "1d",
+            "count": 10
         },
         "transports": ["stdout"]
     },


### PR DESCRIPTION
no issue

- define `period` and `count` in our defaults.json config
- advantage: easier access and better overview how logging is configured by default

NOTE: by default rotation is disabled in development and enabled in production. The values for logging are getting merged. 

So if you start Ghost in production, the logging config looks like:
```
{ 
  level: 'info',
  rotation: { enabled: true, period: '1d', count: 10 },
  transports: [ 'file', 'stdout' ] 
}
```