### PR TITLE
🛠 Keep the original error in registerAsyncTheme

### DIFF
--- a/core/server/helpers/register.js
+++ b/core/server/helpers/register.js
@@ -19,7 +19,10 @@ function asyncHelperWrapper(hbs, name, fn) {
         }).catch(function asyncHelperError(err) {
             var wrappedErr = err instanceof errors.GhostError ? err : new errors.IncorrectUsageError({
                     err: err,
-                    context: 'registerAsyncThemeHelper: ' + name
+                    context: 'registerAsyncThemeHelper: ' + name,
+                    errorDetails: {
+                        originalError: err
+                    }
                 }),
                 result = config.get('env') === 'development' ? wrappedErr : '';
 


### PR DESCRIPTION
refs #8945

- pass the original error as part of the errorDetails
- improves logging, so we know what really went wrong
