### PR TITLE
💄 Logging for image size

### DIFF
--- a/core/server/utils/cached-image-size-from-url.js
+++ b/core/server/utils/cached-image-size-from-url.js
@@ -1,4 +1,5 @@
-var Promise = require('bluebird'),
+var debug = require('ghost-ignition').debug('utils:image-size-cache'),
+    Promise = require('bluebird'),
     imageSize = require('./image-size'),
     logging = require('../logging'),
     errors = require('../errors'),
@@ -22,6 +23,8 @@ function getCachedImageSizeFromUrl(url) {
         return imageSize.getImageSizeFromUrl(url).then(function (res) {
             imageSizeCache[url] = res;
 
+            debug('Cached image:', url);
+
             return Promise.resolve(imageSizeCache[url]);
         }).catch(errors.NotFoundError, function () {
             // in case of error we just attach the url
@@ -33,6 +36,7 @@ function getCachedImageSizeFromUrl(url) {
             return Promise.resolve(imageSizeCache[url] = url);
         });
     }
+    debug('Read image from cache:', url);
     // returns image size from cache
     return Promise.resolve(imageSizeCache[url]);
 }

--- a/core/server/utils/image-size.js
+++ b/core/server/utils/image-size.js
@@ -1,4 +1,5 @@
-var sizeOf = require('image-size'),
+var debug = require('ghost-ignition').debug('utils:image-size'),
+    sizeOf = require('image-size'),
     url = require('url'),
     Promise = require('bluebird'),
     got = require('got'),
@@ -114,6 +115,8 @@ getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
         imagePath,
         requestOptions
     ).then(function (response) {
+        debug('Image fetched (URL):', imagePath.href);
+
         return fetchDimensionsFromBuffer({
             buffer: response.body,
             imagePath: imagePath.href
@@ -170,6 +173,8 @@ getImageSizeFromFilePath = function getImageSizeFromFilePath(imagePath) {
     return storage.getStorage()
         .read({path: imagePath})
         .then(function readFile(buf) {
+            debug('Image fetched (storage):', imagePath);
+
             return fetchDimensionsFromBuffer({
                 buffer: buf,
                 imagePath: imagePath


### PR DESCRIPTION
no issue

- added debug logs to image size util and related fn:
    - when fetched via network request
    - when fetched from storage
    - when added to cache
    - when read from cache