### PR TITLE
Remove wishlist links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,13 +5,13 @@ For **help**, **support** and **questions** please use **[slack](https://slack.g
 ---
 
 If you're [raising a bug](https://docs.ghost.org/v1/docs/contributing#bugs) 🐛 please be sure to [include as much info as possible](https://docs.ghost.org/v1/docs/contributing#bug-template) so that we can fix it!
- 
+
 ---
 
 If you've **got some code** ✨ you want to [pull request](https://docs.ghost.org/v1/docs/contributing#pull-requests) please use this [commit message format](https://docs.ghost.org/v1/docs/git-workflow#section-notes-on-writing-good-commit-messages) and check it passes the tests by running `grunt validate`. Thanks for helping us make Ghost better.
- 
+
 ---
- 
+
 **Our [Full Contributor Guide](https://docs.ghost.org/v1/docs/contributing)** covers everything you'll need to get started as a contributor 😁
 
 
@@ -22,7 +22,6 @@ If you've **got some code** ✨ you want to [pull request](https://docs.ghost.or
 - [api documentation](https://api.ghost.org)
 - [self-hoster guide](http://docs.ghost.org/v1/)
 - [feature roadmap](https://trello.com/b/EceUgtCL/ghost-roadmap)
-- [feature wishlist](http://ideas.ghost.org)
 - [community guidelines](https://ghost.org/conduct/)
 - [dev blog](http://dev.ghost.org)
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,12 @@
 Welcome to Ghost's GitHub repo! 👋🎉
 
-Do you need help or have a question? Please come chat in Slack: https://ghost.org/slack 👫. Got an idea for a new feature? Please add it to our wishlist: http://ideas.ghost.org 🌟. Found a bug? Please fill out the sections below... thank you 👍
+Do you need help or have a question? Please come chat in Slack: https://ghost.org/slack 👫. Found a bug? Please fill out the sections below... thank you 👍
 
 If your issue is with Ghost CLI, please report it on the CLI repo ➡️ https://github.com/TryGhost/Ghost-CLI/issues/new.
 
 ### Issue Summary
 
-A summary of the issue and the browser/OS environment in which it occurs. 
+A summary of the issue and the browser/OS environment in which it occurs.
 
 ### Steps to Reproduce
 
@@ -19,5 +19,5 @@ Any other info e.g. Why do you consider this to be a bug? What did you expect to
 
 * Ghost Version:
 * Node Version:
-* Browser/OS: 
-* Database: 
+* Browser/OS:
+* Database:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ The project is maintained by a non-profit organisation called the **Ghost Founda
 - [Theme Docs](http://themes.ghost.org/v1/)
 - [API Docs](https://api.ghost.org/)
 - [Contributing Guide](https://docs.ghost.org/v1/docs/contributing)
-- [Feature Requests](http://ideas.ghost.org/)
 - [Developer Blog](http://dev.ghost.org)
 - [Self-hoster Docs](http://docs.ghost.org/v1/)
 


### PR DESCRIPTION
No issue

The uservoice wishlist has been pretty inactive and neglected for quite a long time now. Removing links to it from Ghost is the first step toward retiring it. We're still listening to user feedback in order to determine the Ghost roadmap, but simplifying the process around it.

Matches https://github.com/TryGhost/Ghost-Admin/pull/850