### PR TITLE
🐛 Added error handling for ghost_head

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -17,6 +17,7 @@ var proxy = require('./proxy'),
     filters = proxy.filters,
     labs = proxy.labs,
     api = proxy.api,
+    logging = proxy.logging,
     settingsCache = proxy.settingsCache,
     config = proxy.config,
     blogIconUtils = proxy.blogIcon;
@@ -167,6 +168,11 @@ module.exports = function ghost_head(options) {
         }
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
+        return new SafeString(head.join('\n    ').trim());
+    }).catch(function handleError(err) {
+        logging.error(err);
+
+        // Return what we have so far (currently nothing)
         return new SafeString(head.join('\n    ').trim());
     });
 };


### PR DESCRIPTION
This PR is quite small but could have quite far-reaching consequences in terms of ensuring that Ghost pages render even if there are errors.

We also need to move a lot of code out of the rendering layer, but we'll get to that later.

refs #8945 

- Ensure that errors in ghost_head are logged
- Render some content despite the error!