### PR TITLE
ghost_head cleanup & debug statements

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -9,6 +9,7 @@
 var proxy = require('./proxy'),
     _ = require('lodash'),
     Promise = require('bluebird'),
+    debug = require('ghost-ignition').debug('ghost_head'),
 
     getMetaData = proxy.metaData.get,
     getAssetUrl = proxy.metaData.getAssetUrl,
@@ -80,6 +81,7 @@ function getAjaxHelper(clientId, clientSecret) {
 }
 
 module.exports = function ghost_head(options) {
+    debug('begin');
     // if server error page do nothing
     if (this.statusCode >= 500) {
         return;
@@ -101,7 +103,9 @@ module.exports = function ghost_head(options) {
         favicon = blogIconUtils.getIconUrl(),
         iconType = blogIconUtils.getIconType(favicon);
 
+    debug('preparation complete, begin fetch');
     return Promise.props(fetch).then(function (response) {
+        debug('end fetch');
         client = response.client;
         metaData = response.metaData;
 
@@ -168,6 +172,7 @@ module.exports = function ghost_head(options) {
         }
         return filters.doFilter('ghost_head', head);
     }).then(function (head) {
+        debug('end');
         return new SafeString(head.join('\n    ').trim());
     }).catch(function handleError(err) {
         logging.error(err);

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -25,18 +25,20 @@ var proxy = require('./proxy'),
 
 function getClient() {
     if (labs.isSet('publicAPI') === true) {
-        return api.clients.read({slug: 'ghost-frontend'}).then(function (client) {
-            client = client.clients[0];
+        return api.clients
+            .read({slug: 'ghost-frontend'})
+            .then(function handleClient(client) {
+                client = client.clients[0];
 
-            if (client.status === 'enabled') {
-                return {
-                    id: client.slug,
-                    secret: client.secret
-                };
-            }
+                if (client.status === 'enabled') {
+                    return {
+                        id: client.slug,
+                        secret: client.secret
+                    };
+                }
 
-            return {};
-        });
+                return {};
+            });
     }
     return Promise.resolve({});
 }
@@ -104,80 +106,84 @@ module.exports = function ghost_head(options) {
         iconType = blogIconUtils.getIconType(favicon);
 
     debug('preparation complete, begin fetch');
-    return Promise.props(fetch).then(function (response) {
-        debug('end fetch');
-        client = response.client;
-        metaData = response.metaData;
+    return Promise
+        .props(fetch)
+        .then(function handleData(response) {
+            debug('end fetch');
+            client = response.client;
+            metaData = response.metaData;
 
-        if (context) {
-            // head is our main array that holds our meta data
-            if (metaData.metaDescription && metaData.metaDescription.length > 0) {
-                head.push('<meta name="description" content="' + escapeExpression(metaData.metaDescription) + '" />');
-            }
+            if (context) {
+                // head is our main array that holds our meta data
+                if (metaData.metaDescription && metaData.metaDescription.length > 0) {
+                    head.push('<meta name="description" content="' + escapeExpression(metaData.metaDescription) + '" />');
+                }
 
-            head.push('<link rel="shortcut icon" href="' + favicon + '" type="image/' + iconType + '" />');
-            head.push('<link rel="canonical" href="' +
-                escapeExpression(metaData.canonicalUrl) + '" />');
-            head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
+                head.push('<link rel="shortcut icon" href="' + favicon + '" type="image/' + iconType + '" />');
+                head.push('<link rel="canonical" href="' +
+                    escapeExpression(metaData.canonicalUrl) + '" />');
+                head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
 
-            // show amp link in post when 1. we are not on the amp page and 2. amp is enabled
-            if (_.includes(context, 'post') && !_.includes(context, 'amp') && settingsCache.get('amp')) {
-                head.push('<link rel="amphtml" href="' +
-                    escapeExpression(metaData.ampUrl) + '" />');
-            }
+                // show amp link in post when 1. we are not on the amp page and 2. amp is enabled
+                if (_.includes(context, 'post') && !_.includes(context, 'amp') && settingsCache.get('amp')) {
+                    head.push('<link rel="amphtml" href="' +
+                        escapeExpression(metaData.ampUrl) + '" />');
+                }
 
-            if (metaData.previousUrl) {
-                head.push('<link rel="prev" href="' +
-                    escapeExpression(metaData.previousUrl) + '" />');
-            }
+                if (metaData.previousUrl) {
+                    head.push('<link rel="prev" href="' +
+                        escapeExpression(metaData.previousUrl) + '" />');
+                }
 
-            if (metaData.nextUrl) {
-                head.push('<link rel="next" href="' +
-                    escapeExpression(metaData.nextUrl) + '" />');
-            }
+                if (metaData.nextUrl) {
+                    head.push('<link rel="next" href="' +
+                        escapeExpression(metaData.nextUrl) + '" />');
+                }
 
-            if (!_.includes(context, 'paged') && useStructuredData) {
-                head.push('');
-                head.push.apply(head, finaliseStructuredData(metaData));
-                head.push('');
+                if (!_.includes(context, 'paged') && useStructuredData) {
+                    head.push('');
+                    head.push.apply(head, finaliseStructuredData(metaData));
+                    head.push('');
 
-                if (metaData.schema) {
-                    head.push('<script type="application/ld+json">\n' +
-                        JSON.stringify(metaData.schema, null, '    ') +
-                        '\n    </script>\n');
+                    if (metaData.schema) {
+                        head.push('<script type="application/ld+json">\n' +
+                            JSON.stringify(metaData.schema, null, '    ') +
+                            '\n    </script>\n');
+                    }
+                }
+
+                if (client && client.id && client.secret && !_.includes(context, 'amp')) {
+                    head.push(getAjaxHelper(client.id, client.secret));
                 }
             }
 
-            if (client && client.id && client.secret && !_.includes(context, 'amp')) {
-                head.push(getAjaxHelper(client.id, client.secret));
+            head.push('<meta name="generator" content="Ghost ' +
+                escapeExpression(safeVersion) + '" />');
+
+            head.push('<link rel="alternate" type="application/rss+xml" title="' +
+                escapeExpression(metaData.blog.title)  + '" href="' +
+                escapeExpression(metaData.rssUrl) + '" />');
+
+            // no code injection for amp context!!!
+            if (!_.includes(context, 'amp')) {
+                if (!_.isEmpty(globalCodeinjection)) {
+                    head.push(globalCodeinjection);
+                }
+
+                if (!_.isEmpty(postCodeInjection)) {
+                    head.push(postCodeInjection);
+                }
             }
-        }
+            return filters.doFilter('ghost_head', head);
+        })
+        .then(function afterFilters(head) {
+            debug('end');
+            return new SafeString(head.join('\n    ').trim());
+        })
+        .catch(function handleError(err) {
+            logging.error(err);
 
-        head.push('<meta name="generator" content="Ghost ' +
-            escapeExpression(safeVersion) + '" />');
-
-        head.push('<link rel="alternate" type="application/rss+xml" title="' +
-            escapeExpression(metaData.blog.title)  + '" href="' +
-            escapeExpression(metaData.rssUrl) + '" />');
-
-        // no code injection for amp context!!!
-        if (!_.includes(context, 'amp')) {
-            if (!_.isEmpty(globalCodeinjection)) {
-                head.push(globalCodeinjection);
-            }
-
-            if (!_.isEmpty(postCodeInjection)) {
-                head.push(postCodeInjection);
-            }
-        }
-        return filters.doFilter('ghost_head', head);
-    }).then(function (head) {
-        debug('end');
-        return new SafeString(head.join('\n    ').trim());
-    }).catch(function handleError(err) {
-        logging.error(err);
-
-        // Return what we have so far (currently nothing)
-        return new SafeString(head.join('\n    ').trim());
-    });
+            // Return what we have so far (currently nothing)
+            return new SafeString(head.join('\n    ').trim());
+        });
 };

--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -89,29 +89,20 @@ module.exports = function ghost_head(options) {
         return;
     }
 
-    var metaData,
-        client,
-        head = [],
+    var head = [],
         globalCodeinjection = settingsCache.get('ghost_head'),
         postCodeInjection = options.data.root && options.data.root.post ? options.data.root.post.codeinjection_head : null,
         context = this.context ? this.context : null,
         useStructuredData = !config.isPrivacyDisabled('useStructuredData'),
         safeVersion = this.safeVersion,
         referrerPolicy = config.get('referrerPolicy') ? config.get('referrerPolicy') : 'no-referrer-when-downgrade',
-        fetch = {
-            metaData: getMetaData(this, options.data.root),
-            client: getClient()
-        },
         favicon = blogIconUtils.getIconUrl(),
         iconType = blogIconUtils.getIconType(favicon);
 
     debug('preparation complete, begin fetch');
     return Promise
-        .props(fetch)
-        .then(function handleData(response) {
+        .join(getMetaData(this, options.data.root), getClient(), function handleData(metaData, client) {
             debug('end fetch');
-            client = response.client;
-            metaData = response.metaData;
 
             if (context) {
                 // head is our main array that holds our meta data


### PR DESCRIPTION
This adds 3 cleanup / minor change commits on top of the error handling PR #8982.

- Adds a handful of debug statements, so it's easier to see where time is spent after rendering when in DEBUG mode.
- Changes the layout of promises to always have the . on a newline, which makes it easier to read
- Changes from using Promise.props to Promise.join, which allows us to remove a few lines of code that otherwise don't do much

It would be possible to squash and merge this instead of #8982, setting the commit message back to the error handling one.