### PR TITLE
Properly return a bluebird promise

### DIFF
--- a/core/server/utils/request.js
+++ b/core/server/utils/request.js
@@ -13,12 +13,14 @@ module.exports = function request(url, options) {
         }));
     }
 
-    return got(
-        url,
-        options
-    ).then(function (response) {
-        return Promise.resolve(response);
-    }).catch(function (err) {
-        return Promise.reject(err);
+    return new Promise(function (resolve, reject) {
+        return got(
+            url,
+            options
+        ).then(function (response) {
+            return resolve(response);
+        }).catch(function (err) {
+            return reject(err);
+        });
     });
 };


### PR DESCRIPTION
This really didn't make sense to me at first - but the problem is that got() itself returns the wrong kind of promise. We have to instead wrap it. Really annoying because it makes for ugly code, but this is the only way to make sure we can use function predicates everywhere.

FYI I have this wrong in other code 🙈 😞 

refs #8980

- ☹️  apparently this is actually the only way

