### PR TITLE
Remove markdown-it-named-headers and unused string.js dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "markdown-it-footnote": "3.0.1",
     "markdown-it-lazy-headers": "0.1.3",
     "markdown-it-mark": "2.0.0",
-    "markdown-it-named-headers": "0.0.4",
     "mobiledoc-dom-renderer": "0.6.5",
     "moment": "2.18.1",
     "moment-timezone": "0.5.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3311,12 +3311,6 @@ markdown-it-mark@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz#46a1aa947105aed8188978e0a016179e404f42c7"
 
-markdown-it-named-headers@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz#82efc28324240a6b1e77b9aae501771d5f351c1f"
-  dependencies:
-    string "^3.0.1"
-
 markdown-it@8.4.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.0.tgz#e2400881bf171f7018ed1bd9da441dac8af6306d"
@@ -5039,10 +5033,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-string@^3.0.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
 
 string_decoder@~0.10.x:
   version "0.10.31"


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-Admin/pull/856
- moves `markdown-it-named-headers` functionality into our own app code without requiring the [`string.js`](http://stringjs.com) sub-dependency
- matches Ghost-Admin markdown-it code