### PR TITLE
Two fixes for redirects

### DIFF
--- a/core/server/api/app.js
+++ b/core/server/api/app.js
@@ -13,7 +13,6 @@ var debug = require('ghost-ignition').debug('api'),
     // Shared
     bodyParser = require('body-parser'), // global, shared
     cacheControl = require('../middleware/cache-control'), // global, shared
-    urlRedirects = require('../middleware/url-redirects'),
     maintenance = require('../middleware/maintenance'), // global, shared
     errorHandler = require('../middleware/error-handler'); // global, shared
 
@@ -36,10 +35,6 @@ module.exports = function setupApiApp() {
 
     // send 503 json response in case of maintenance
     apiApp.use(maintenance);
-
-    // Force SSL if required
-    // must happen AFTER asset loading and BEFORE routing
-    apiApp.use(urlRedirects);
 
     // Check version matches for API requests, depends on res.locals.safeVersion being set
     // Therefore must come after themeHandler.ghostLocals, for now

--- a/core/server/api/middleware.js
+++ b/core/server/api/middleware.js
@@ -1,13 +1,15 @@
 var prettyURLs = require('../middleware/pretty-urls'),
     cors = require('../middleware/api/cors'),
+    urlRedirects = require('../middleware/url-redirects'),
     auth = require('../auth');
 
 /**
  * Auth Middleware Packages
  *
  * IMPORTANT
- * - cors middleware MUST happen before pretty urls, because otherwise cors header can get lost
+ * - cors middleware MUST happen before pretty urls, because otherwise cors header can get lost on redirect
  * - cors middleware MUST happen after authenticateClient, because authenticateClient reads the trusted domains
+ * - url redirects MUST happen after cors, otherwise cors header can get lost on redirect
  */
 
 /**
@@ -19,6 +21,7 @@ module.exports.authenticatePublic = [
     // This is a labs-enabled middleware
     auth.authorize.requiresAuthorizedUserPublicAPI,
     cors,
+    urlRedirects,
     prettyURLs
 ];
 
@@ -30,6 +33,7 @@ module.exports.authenticatePrivate = [
     auth.authenticate.authenticateUser,
     auth.authorize.requiresAuthorizedUser,
     cors,
+    urlRedirects,
     prettyURLs
 ];
 
@@ -42,6 +46,7 @@ module.exports.authenticateClient = function authenticateClient(client) {
         auth.authenticate.authenticateUser,
         auth.authorize.requiresAuthorizedClient(client),
         cors,
+        urlRedirects,
         prettyURLs
     ];
 };

--- a/core/server/middleware/url-redirects.js
+++ b/core/server/middleware/url-redirects.js
@@ -95,7 +95,7 @@ urlRedirects = function urlRedirects(req, res, next) {
     var redirectFn = res.isAdmin ? _private.getAdminRedirectUrl : _private.getBlogRedirectUrl,
         redirectUrl = redirectFn({
             requestedHost: req.get('host'),
-            requestedUrl: req.originalUrl || req.url,
+            requestedUrl: url.parse(req.originalUrl || req.url).pathname,
             queryParameters: req.query,
             secure: req.secure
         });

--- a/core/test/unit/middleware/url-redirects_spec.js
+++ b/core/test/unit/middleware/url-redirects_spec.js
@@ -244,6 +244,28 @@ describe('UNIT: url redirects', function () {
         done();
     });
 
+    it('[redirect] original url has search params', function (done) {
+        configUtils.set({
+            url: 'http://default.com:2368',
+            admin: {
+                url: 'https://admin.default.com:2368'
+            }
+        });
+
+        host = 'default.com:2368';
+        res.isAdmin = true;
+
+        req.originalUrl = '/ghost/something?a=b';
+        req.query = {
+            a: 'b'
+        };
+
+        urlRedirects(req, res, next);
+        next.called.should.be.false();
+        res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/something/?a=b').should.be.true();
+        done();
+    });
+
     it('[redirect] same url and admin url, but different protocol.', function (done) {
         configUtils.set({
             url: 'http://default.com:2368',


### PR DESCRIPTION
Please merge both commits into master.

First commit fixes a case where we loose the origin header, which can trouble public api access.
Second commit fixes a case where Ghost adds doubled query params on redirect.

Please read the commit messages.