### PR TITLE
🐛  Fixed api url for the ghost sdk

### DIFF
--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -316,10 +316,13 @@ function urlFor(context, data, absolute) {
     } else if (context === 'api') {
         urlPath = getAdminUrl() || getBlogUrl();
 
-        // CASE: with or without protocol?
+        // CASE: with or without protocol? If your blog url (or admin url) is configured to http, it's still possible that e.g. nginx allows both https+http.
+        // So it depends how you serve your blog. The main focus here is to avoid cors problems.
         // @TODO: rename cors
         if (data && data.cors) {
-            urlPath = urlPath.replace(/^.*?:\/\//g, '//');
+            if (!urlPath.match(/^https:/)) {
+                urlPath = urlPath.replace(/^.*?:\/\//g, '//');
+            }
         }
 
         if (absolute) {

--- a/core/test/unit/ghost_sdk_spec.js
+++ b/core/test/unit/ghost_sdk_spec.js
@@ -33,6 +33,37 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
     });
 
+    it('blog url is https', function () {
+        configUtils.set({
+            url: 'https://testblog.com/'
+        });
+
+        ghostSdk.init({
+            clientId: '',
+            clientSecret: '',
+            url: utils.url.urlFor('api', {cors: true}, true)
+        });
+
+        ghostSdk.url.api().should.equal('https://testblog.com/ghost/api/v0.1/');
+    });
+
+    it('admin url is https', function () {
+        configUtils.set({
+            url: 'http://testblog.com/',
+            admin: {
+                url: 'https://admin.testblog.com'
+            }
+        });
+
+        ghostSdk.init({
+            clientId: '',
+            clientSecret: '',
+            url: utils.url.urlFor('api', {cors: true}, true)
+        });
+
+        ghostSdk.url.api().should.equal('https://admin.testblog.com/ghost/api/v0.1/');
+    });
+
     it('strips arguments of forward and trailing slashes correctly', function () {
         ghostSdk.init({
             clientId: '',

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -450,12 +450,42 @@ describe('Url', function () {
             utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('api: cors should return no protocol', function () {
+        it('[api url] blog url is http: cors should return no protocol', function () {
             configUtils.set({
                 url: 'http://my-ghost-blog.com'
             });
 
             utils.url.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('[api url] admin url is http: cors should return no protocol', function () {
+            configUtils.set({
+                url: 'http://my-ghost-blog.com',
+                admin: {
+                    url: 'http://admin.ghost.example'
+                }
+            });
+
+            utils.url.urlFor('api', {cors: true}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
+        });
+
+        it('[api url] admin url is https: should return with protocol', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com',
+                admin: {
+                    url: 'https://admin.ghost.example'
+                }
+            });
+
+            utils.url.urlFor('api', {cors: true}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
+        });
+
+        it('[api url] blog url is https: should return with protocol', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            utils.url.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
     });
 


### PR DESCRIPTION
no issue

- **mirror LTS behaviour to master**
- if your blog or admin url is configured to http, it's still possible that e.g. nginx allows both https/http
- that's why we should generate the api url without protocol in this case
- so it depends how you serve your blog, example:
  - blog url is http://example.com
  - generated api url for the sdk is //example.com (dynamic protocol allowed)
  - you serve your blog via https://example.com, protocol is https
  - you serve your blog via http://example.com, protocol is http
- i am  not 100% confident that this is correct, but it reflects how this has worked in LTS (so we port this over for now)