### PR TITLE
Improved debug logs for auth utils

### DIFF
--- a/core/server/auth/utils.js
+++ b/core/server/auth/utils.js
@@ -13,7 +13,7 @@ var Promise = require('bluebird'),
  * This access token auto expires and get's cleaned up on bootstrap (see oauth.js).
  */
 _private.decreaseOldAccessTokenExpiry = function decreaseOldAccessTokenExpiry(data, options) {
-    debug('decreaseOldAccessTokenExpiry', data, options);
+    debug('decreaseOldAccessTokenExpiry', data);
 
     if (!data.token) {
         return Promise.resolve();
@@ -32,7 +32,7 @@ _private.decreaseOldAccessTokenExpiry = function decreaseOldAccessTokenExpiry(da
 };
 
 _private.destroyOldRefreshToken = function destroyOldRefreshToken(options) {
-    debug('destroyOldRefreshToken', options);
+    debug('destroyOldRefreshToken', options.token);
 
     if (!options.token) {
         return Promise.resolve();


### PR DESCRIPTION
no issue

- reduce the debug logs

Note: It's okay to log the old token to delete, because this token is getting removed anyway.