### PR TITLE
Unsplash Improvements

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -14,14 +14,6 @@ function fetchAvailableTimezones() {
     return timezones;
 }
 
-function fetchPrivateConfig() {
-    var unsplashConfig = config.get('unsplash') || {};
-
-    return {
-        unsplashAPI: unsplashConfig
-    };
-}
-
 function getAboutConfig() {
     return {
         version: ghostVersion.full,
@@ -79,11 +71,6 @@ configuration = {
         // Timezone endpoint
         if (options.key === 'timezones') {
             return Promise.resolve({configuration: [fetchAvailableTimezones()]});
-        }
-
-        // Private configuration config for API keys used by the client
-        if (options.key === 'private') {
-            return Promise.resolve({configuration: [fetchPrivateConfig()]});
         }
 
         return Promise.resolve({configuration: []});

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -82,7 +82,7 @@
             "defaultValue": "[{\"url\":\"\"}]"
         },
         "unsplash": {
-            "defaultValue": ""
+            "defaultValue": "{\"isActive\": true}"
         }
     },
     "theme": {

--- a/core/test/functional/routes/api/settings_spec.js
+++ b/core/test/functional/routes/api/settings_spec.js
@@ -1,4 +1,5 @@
 var should = require('should'),
+    _ = require('lodash'),
     supertest = require('supertest'),
     testUtils = require('../../../utils'),
     config = require('../../../../../core/server/config'),
@@ -48,6 +49,10 @@ describe('Settings API', function () {
                 should.exist(jsonResponse);
 
                 testUtils.API.checkResponse(jsonResponse, 'settings');
+
+                JSON.parse(_.find(jsonResponse.settings, {key: 'unsplash'}).value).isActive.should.eql(true);
+                JSON.parse(_.find(jsonResponse.settings, {key: 'amp'}).value).should.eql(true);
+
                 done();
             });
     });

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -71,21 +71,4 @@ describe('Configuration API', function () {
             done();
         }).catch(done);
     });
-
-    it('can read private config and get all expected properties', function (done) {
-        ConfigurationAPI.read({key: 'private'}).then(function (response) {
-            var props;
-
-            should.exist(response);
-            should.exist(response.configuration);
-            response.configuration.should.be.an.Array().with.lengthOf(1);
-            props = response.configuration[0];
-
-            // property is set, but value not available, because settings API was not called yet
-            props.should.have.property('unsplashAPI').which.is.an.Object();
-            props.unsplashAPI.should.be.empty();
-
-            done();
-        }).catch(done);
-    });
 });


### PR DESCRIPTION
refs #8859

Contains two commits:

1. Remove the private configuration endpoint. We no longer need offering unsplash as config option.
2. Enable Unsplash by default. (Admin can handle an empty unsplash settings value and enables the app by default, but it's easier to understand that Unsplash is on by default for new blogs).
