### PR TITLE
Full JSON support for admin redirects; Add translations - Closes #9036

### DIFF
--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -60,7 +60,7 @@
         },
         "redirects": {
             "extensions": [".json"],
-            "contentTypes": ["application/json"]
+            "contentTypes": ["application/octet-stream", "application/json"]
         }
     },
     "times": {

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -335,6 +335,10 @@
                 "notFound": "Job not found.",
                 "publishInThePast": "Use the force flag to publish a post in the past."
             },
+            "redirects": {
+                "missingFile": "Please select a JSON file.",
+                "invalidFile": "Please select a valid JSON file to import."
+            },
             "settings": {
                 "problemFindingSetting": "Problem finding setting: {key}",
                 "accessCoreSettingFromExtReq": "Attempted to access core setting from external request",


### PR DESCRIPTION
- Add `application/octet-stream` as a supported JSON file type for the redirects upload
- Add error translations for redirects uploads that aren't JSON
