### PR TITLE
jshintrc: use type Number for `esversion`

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,5 +23,5 @@
     "predef": [
         "-Promise"
     ],
-    "esversion": "6"
+    "esversion": 6
 }


### PR DESCRIPTION
no issue

- refs http://jshint.com/docs/options/
- the value is a Number, not a String
- e.g. if you use template literal strings, jshint complains that you have to use `esversion: 6`

> 'template literal syntax' is only available in ES6 (use 'esversion: 6')