### PR TITLE
🎨  Backup redirects file before overriding

### DIFF
--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -816,7 +816,9 @@ unmockNotExistingModule = function unmockNotExistingModule() {
  * 1. sephiroth init db
  * 2. start ghost
  */
-startGhost = function startGhost() {
+startGhost = function startGhost(options) {
+    options = options || {redirectsFile: true};
+
     var contentFolderForTests = path.join(os.tmpdir(), uuid.v1(), 'ghost-test');
 
     /**
@@ -835,7 +837,10 @@ startGhost = function startGhost() {
 
     // Copy all themes into the new test content folder. Default active theme is always casper. If you want to use a different theme, you have to set the active theme (e.g. stub)
     fs.copySync(path.join(__dirname, 'fixtures', 'themes'), path.join(contentFolderForTests, 'themes'));
-    fs.copySync(path.join(__dirname, 'fixtures', 'data'), path.join(contentFolderForTests, 'data'));
+
+    if (options.redirectsFile) {
+        fs.copySync(path.join(__dirname, 'fixtures', 'data', 'redirects.json'), path.join(contentFolderForTests, 'data', 'redirects.json'));
+    }
 
     return knexMigrator.reset()
         .then(function initialiseDatabase() {


### PR DESCRIPTION
refs #9028

- if you upload a redirects file and a redirects file exists already, we backup this file to `data/redirects-YYYY-MM-DD-HH-mm-ss.json`
- decrease chance of random test failures by not comparing date format with seconds

NOTE: We would love to use the promise support by fs-extra which was added in 3.x, but they are using native Promises and Ghost uses Bluebird. There is an [open issue](https://github.com/jprichardson/node-fs-extra/issues/425) which discusses this topic. As long as fs-extra does not support alternative Promise libaries, we have to use `promisify` for fs extra calls, otherwise e.g. the catch behaviour is different.