### PR TITLE
Removed unused API endpoint: POST /users

### DIFF
--- a/core/server/api/routes.js
+++ b/core/server/api/routes.js
@@ -62,8 +62,6 @@ module.exports = function apiRoutes() {
     apiRouter.put('/users/password', mw.authenticatePrivate, api.http(api.users.changePassword));
     apiRouter.put('/users/owner', mw.authenticatePrivate, api.http(api.users.transferOwnership));
     apiRouter.put('/users/:id', mw.authenticatePrivate, api.http(api.users.edit));
-
-    apiRouter.post('/users', mw.authenticatePrivate, api.http(api.users.add));
     apiRouter.del('/users/:id', mw.authenticatePrivate, api.http(api.users.destroy));
 
     // ## Tags


### PR DESCRIPTION
no issue

- this endpoint does not exist anymore
- if you want to add a new user, you have to invite him via the invites API
- on invite accept, the user is inserted

Note: The implementation of `users.add` didn't even exist anymore. This is a leftover when we've worked on the invites overhaul  😀

Note: Nothing to update in our docs, because we don't have any documentation about our "private" authenticated api.