### PR TITLE
Return dates from the database without milliseconds

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -172,12 +172,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     /**
-     * all supported databases (pg, sqlite, mysql) return different values
+     * all supported databases (sqlite, mysql) return different values
      *
      * sqlite:
      *   - knex returns a UTC String
-     * pg:
-     *   - has an active UTC session through knex and returns UTC Date
      * mysql:
      *   - knex wraps the UTC value into a local JS Date
      */
@@ -188,7 +186,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             if (value !== null
                 && schema.tables[self.tableName].hasOwnProperty(key)
                 && schema.tables[self.tableName][key].type === 'dateTime') {
-                attrs[key] = moment(value).toDate();
+                attrs[key] = moment(value).startOf('seconds').toDate();
             }
         });
 


### PR DESCRIPTION
no issue

- we store dates without milliseconds in the database
- our test environment does not use our model layer to insert data, this is related to  #7196
- so it can happen that the test env inserts unix timestamps instead of a formatted string
- e.g. adding data via the model layer (e.g. via the API) the format is always normalised to `YYYY-MM-DD HH:mm:ss`
- if we fetch the date from the database, we have a hook which sorts out knex returning different formats for dates
- this hook wraps the returned date into a UTC moment date, but adds the current milliseconds on top
- which can collide in tests when you have specific assertions
- use `startOf` to ignore milliseconds
- furthermore: remove the mentionings of `pg` (postgres)


**Example MySQL**
- knex returns 1506354477790
- `moment(1506354477790).toDate()` => `2017-09-25T15:47:57.790Z`