### PR TITLE
🔥  Removed public API endpoint to fetch users by email address

### DIFF
--- a/core/server/api/routes.js
+++ b/core/server/api/routes.js
@@ -57,7 +57,8 @@ module.exports = function apiRoutes() {
     apiRouter.get('/users', mw.authenticatePublic, api.http(api.users.browse));
     apiRouter.get('/users/:id', mw.authenticatePublic, api.http(api.users.read));
     apiRouter.get('/users/slug/:slug', mw.authenticatePublic, api.http(api.users.read));
-    apiRouter.get('/users/email/:email', mw.authenticatePublic, api.http(api.users.read));
+    // NOTE: We don't expose any email addresses via the public api.
+    apiRouter.get('/users/email/:email', mw.authenticatePrivate, api.http(api.users.read));
 
     apiRouter.put('/users/password', mw.authenticatePrivate, api.http(api.users.changePassword));
     apiRouter.put('/users/owner', mw.authenticatePrivate, api.http(api.users.transferOwnership));

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -373,6 +373,22 @@ describe('Public API', function () {
             });
     });
 
+    it('[unsupported] browse user by email', function (done) {
+        request
+            .get(testUtils.API.getApiQuery('users/email/ghost-author@ghost.org/?client_id=ghost-admin&client_secret=not_available'))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(403)
+            .end(function (err) {
+                if (err) {
+                    return done(err);
+                }
+
+                done();
+            });
+    });
+
     it('browse user by id: ignores fetching roles', function (done) {
         request.get(testUtils.API.getApiQuery('users/1/?client_id=ghost-admin&client_secret=not_available&include=roles'))
             .set('Origin', testUtils.API.getURL())


### PR DESCRIPTION
no issue

- our public API is still a beta/labs feature
- from api.ghost.org
  > The API is still under very (very) heavy development and subject to regular breaking changes.
- users should expect breaking changes in any release (independent from semver versions)
- the public user API never returns any email addresses to decrease the information we expose
- there is no need to keep the support fetching a user by email address