### PR TITLE
🐛 Fixed author role permission to change author

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -12,7 +12,7 @@ var Promise = require('bluebird'),
         'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields',
         'next', 'previous', 'next.author', 'next.tags', 'previous.author', 'previous.tags'
     ],
-    unsafeAttrs = ['author', 'author_id'],
+    unsafeAttrs = ['author_id'],
     posts;
 
 /**

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -12,6 +12,7 @@ var Promise = require('bluebird'),
         'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields',
         'next', 'previous', 'next.author', 'next.tags', 'previous.author', 'previous.tags'
     ],
+    unsafeAttrs = ['author', 'author_id'],
     posts;
 
 /**
@@ -60,7 +61,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             apiUtils.validate(docName, {opts: permittedOptions}),
-            apiUtils.handlePublicPermissions(docName, 'browse'),
+            apiUtils.handlePublicPermissions(docName, 'browse', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes, models.Post.allowedFormats),
             modelQuery
         ];
@@ -94,7 +95,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             apiUtils.validate(docName, {attrs: attrs, opts: options.opts || []}),
-            apiUtils.handlePublicPermissions(docName, 'read'),
+            apiUtils.handlePublicPermissions(docName, 'read', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes, models.Post.allowedFormats),
             modelQuery
         ];
@@ -135,7 +136,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions.concat(options.opts || [])}),
-            apiUtils.handlePermissions(docName, 'edit'),
+            apiUtils.handlePermissions(docName, 'edit', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes),
             modelQuery
         ];
@@ -182,7 +183,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             apiUtils.validate(docName),
-            apiUtils.handlePermissions(docName, 'add'),
+            apiUtils.handlePermissions(docName, 'add', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes),
             modelQuery
         ];
@@ -229,7 +230,7 @@ posts = {
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
             apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions}),
-            apiUtils.handlePermissions(docName, 'destroy'),
+            apiUtils.handlePermissions(docName, 'destroy', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes),
             deletePost
         ];

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -830,8 +830,23 @@ Post = ghostBookshelf.Model.extend({
             });
         }
 
-        if (postModel) {
-            // If this is the author of the post, allow it.
+        function isChanging(attr) {
+            return unsafeAttrs[attr] && unsafeAttrs[attr] !== postModel.get(attr);
+        }
+
+        function actorIsAuthor(loadedPermissions) {
+            return loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Author'});
+        }
+
+        function isOwner() {
+            return unsafeAttrs.author_id && unsafeAttrs.author_id === context.user;
+        }
+
+        if (actorIsAuthor(loadedPermissions) && action === 'edit' && isChanging('author_id')) {
+            hasUserPermission = false;
+        } else if (actorIsAuthor(loadedPermissions) && action === 'add') {
+            hasUserPermission = isOwner();
+        } else if (postModel) {
             hasUserPermission = hasUserPermission || context.user === postModel.get('author_id');
         }
 


### PR DESCRIPTION
Hopefully this has decent enough test coverage that it doesn't have weird edge cases.

This updates the API to reflect the UI.
Author roles can only create posts with their own author_id, and cannot edit the author_id.

no issue

- This bug affects the private / undocumented API only
- Author role users should not be allowed to change the author of a post