### PR TITLE
API layer refactoring && avoid bypassing filtering options in User model

### DIFF
--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -103,7 +103,9 @@ notifications = {
                 }
             });
 
-            return addedNotifications;
+            return {
+                notifications: addedNotifications
+            };
         }
 
         tasks = [
@@ -112,9 +114,7 @@ notifications = {
             saveNotifications
         ];
 
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            return {notifications: result};
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**

--- a/core/server/api/slugs.js
+++ b/core/server/api/slugs.js
@@ -57,7 +57,18 @@ slugs = {
          * @returns {Object} options
          */
         function modelQuery(options) {
-            return models.Base.Model.generateSlug(allowedTypes[options.type], options.data.name, {status: 'all'});
+            return models.Base.Model.generateSlug(allowedTypes[options.type], options.data.name, {status: 'all'})
+                .then(function onModelResponse(slug) {
+                    if (!slug) {
+                        return Promise.reject(new errors.GhostError({
+                            message: i18n.t('errors.api.slugs.couldNotGenerateSlug')
+                        }));
+                    }
+
+                    return {
+                        slugs: [{slug: slug}]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -69,13 +80,7 @@ slugs = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, options).then(function (slug) {
-            if (!slug) {
-                return Promise.reject(new errors.GhostError({message: i18n.t('errors.api.slugs.couldNotGenerateSlug')}));
-            }
-
-            return {slugs: [{slug: slug}]};
-        });
+        return pipeline(tasks, options);
     }
 };
 

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -63,7 +63,18 @@ subscribers = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.Subscriber.findOne(options.data, _.omit(options, ['data']));
+            return models.Subscriber.findOne(options.data, _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.subscribers.subscriberNotFound')
+                        }));
+                    }
+
+                    return {
+                        subscribers: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -74,13 +85,7 @@ subscribers = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, options).then(function formatResponse(result) {
-            if (result) {
-                return {subscribers: [result.toJSON(options)]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.subscribers.subscriberNotFound')}));
-        });
+        return pipeline(tasks, options);
     },
 
     /**
@@ -114,6 +119,11 @@ subscribers = {
 
                         return Promise.reject(error);
                     });
+                })
+                .then(function onModelResponse(model) {
+                    return {
+                        subscribers: [model.toJSON(options)]
+                    };
                 });
         }
 
@@ -125,10 +135,7 @@ subscribers = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            var subscriber = result.toJSON(options);
-            return {subscribers: [subscriber]};
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**
@@ -148,7 +155,18 @@ subscribers = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.Subscriber.edit(options.data.subscribers[0], _.omit(options, ['data']));
+            return models.Subscriber.edit(options.data.subscribers[0], _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.subscribers.subscriberNotFound')
+                        }));
+                    }
+
+                    return {
+                        subscribers: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -159,15 +177,7 @@ subscribers = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            if (result) {
-                var subscriber = result.toJSON(options);
-
-                return {subscribers: [subscriber]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.subscribers.subscriberNotFound')}));
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -63,7 +63,18 @@ tags = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.Tag.findOne(options.data, _.omit(options, ['data']));
+            return models.Tag.findOne(options.data, _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
+                        }));
+                    }
+
+                    return {
+                        tags: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -75,13 +86,7 @@ tags = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, options).then(function formatResponse(result) {
-            if (result) {
-                return {tags: [result.toJSON(options)]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.tags.tagNotFound')}));
-        });
+        return pipeline(tasks, options);
     },
 
     /**
@@ -99,7 +104,12 @@ tags = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.Tag.add(options.data.tags[0], _.omit(options, ['data']));
+            return models.Tag.add(options.data.tags[0], _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    return {
+                        tags: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -111,11 +121,7 @@ tags = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            var tag = result.toJSON(options);
-
-            return {tags: [tag]};
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**
@@ -135,7 +141,18 @@ tags = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.Tag.edit(options.data.tags[0], _.omit(options, ['data']));
+            return models.Tag.edit(options.data.tags[0], _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.tags.tagNotFound')
+                        }));
+                    }
+
+                    return {
+                        tags: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -147,15 +164,7 @@ tags = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            if (result) {
-                var tag = result.toJSON(options);
-
-                return {tags: [tag]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.tags.tagNotFound')}));
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -73,7 +73,18 @@ users = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.User.findOne(options.data, _.omit(options, ['data']));
+            return models.User.findOne(options.data, _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
+                        }));
+                    }
+
+                    return {
+                        users: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -85,13 +96,7 @@ users = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, options).then(function formatResponse(result) {
-            if (result) {
-                return {users: [result.toJSON(options)]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.users.userNotFound')}));
-        });
+        return pipeline(tasks, options);
     },
 
     /**
@@ -192,7 +197,18 @@ users = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.User.edit(options.data.users[0], _.omit(options, ['data']));
+            return models.User.edit(options.data.users[0], _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    if (!model) {
+                        return Promise.reject(new errors.NotFoundError({
+                            message: i18n.t('errors.api.users.userNotFound')
+                        }));
+                    }
+
+                    return {
+                        users: [model.toJSON(options)]
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -203,13 +219,7 @@ users = {
             doQuery
         ];
 
-        return pipeline(tasks, object, options).then(function formatResponse(result) {
-            if (result) {
-                return {users: [result.toJSON(options)]};
-            }
-
-            return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.api.users.userNotFound')}));
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**
@@ -324,7 +334,11 @@ users = {
             return models.User.changePassword(
                 options.data.password[0],
                 _.omit(options, ['data'])
-            );
+            ).then(function onModelResponse() {
+                return Promise.resolve({
+                    password: [{message: i18n.t('notices.api.users.pwdChangedSuccessfully')}]
+                });
+            });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -336,9 +350,7 @@ users = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResponse() {
-            return Promise.resolve({password: [{message: i18n.t('notices.api.users.pwdChangedSuccessfully')}]});
-        });
+        return pipeline(tasks, object, options);
     },
 
     /**
@@ -371,7 +383,14 @@ users = {
          * @returns {Object} options
          */
         function doQuery(options) {
-            return models.User.transferOwnership(options.data.owner[0], _.omit(options, ['data']));
+            return models.User.transferOwnership(options.data.owner[0], _.omit(options, ['data']))
+                .then(function onModelResponse(model) {
+                    // NOTE: model returns json object already
+                    // @TODO: why?
+                    return {
+                        users: model
+                    };
+                });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order
@@ -383,9 +402,7 @@ users = {
         ];
 
         // Pipeline calls each task passing the result of one to be the arguments for the next
-        return pipeline(tasks, object, options).then(function formatResult(result) {
-            return Promise.resolve({users: result});
-        });
+        return pipeline(tasks, object, options);
     }
 };
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -336,7 +336,6 @@ User = ghostBookshelf.Model.extend({
     findOne: function findOne(dataToClone, options) {
         var query,
             status,
-            optInc,
             data = _.cloneDeep(dataToClone),
             lookupRole = data.role;
 
@@ -348,14 +347,9 @@ User = ghostBookshelf.Model.extend({
         status = data.status;
         delete data.status;
 
-        options = _.cloneDeep(options || {});
-        optInc = options.include;
-        options.withRelated = _.union(options.withRelated, options.include);
-
         data = this.filterData(data);
         options = this.filterOptions(options, 'findOne');
-        delete options.include;
-        options.include = optInc;
+        options.withRelated = _.union(options.withRelated, options.include);
 
         // Support finding by role
         if (lookupRole) {

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -373,6 +373,52 @@ describe('Public API', function () {
             });
     });
 
+    it('browse user by slug: count.posts', function (done) {
+        request.get(testUtils.API.getApiQuery('users/slug/ghost/?client_id=ghost-admin&client_secret=not_available&include=count.posts'))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                var jsonResponse = res.body;
+
+                should.exist(jsonResponse.users);
+                jsonResponse.users.should.have.length(1);
+
+                // We don't expose the email address.
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], ['email']);
+                done();
+            });
+    });
+
+    it('browse user by id: count.posts', function (done) {
+        request.get(testUtils.API.getApiQuery('users/1/?client_id=ghost-admin&client_secret=not_available&include=count.posts'))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.not.exist(res.headers['x-cache-invalidate']);
+                var jsonResponse = res.body;
+
+                should.exist(jsonResponse.users);
+                jsonResponse.users.should.have.length(1);
+
+                // We don't expose the email address.
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], ['email']);
+                done();
+            });
+    });
+
     it('[unsupported] browse user by email', function (done) {
         request
             .get(testUtils.API.getApiQuery('users/email/ghost-author@ghost.org/?client_id=ghost-admin&client_secret=not_available'))

--- a/core/test/functional/routes/api/users_spec.js
+++ b/core/test/functional/routes/api/users_spec.js
@@ -312,6 +312,52 @@ describe('User API', function () {
                     });
             });
 
+            it('can retrieve a user by slug with count.posts', function (done) {
+                request.get(testUtils.API.getApiQuery('users/slug/joe-bloggs/?include=count.posts'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count']);
+
+                        done();
+                    });
+            });
+
+            it('can retrieve a user by id with count.posts', function (done) {
+                request.get(testUtils.API.getApiQuery('users/1/?include=count.posts'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.users);
+                        should.not.exist(jsonResponse.meta);
+
+                        jsonResponse.users.should.have.length(1);
+                        testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count']);
+
+                        done();
+                    });
+            });
+
             it('can\'t retrieve non existent user by id', function (done) {
                 request.get(testUtils.API.getApiQuery('users/' + ObjectId.generate() + '/'))
                     .set('Authorization', 'Bearer ' + ownerAccessToken)


### PR DESCRIPTION
**Please merge both commits separate.**

### First commit: Refactored the API layer: do not handle API response after pipelining

- this has a big underlying problem
- each task in the pipeline can modify the options
- e.g. add a proper permission context
- if we chain after the pipeline, we don't have access to the modified options object
- and then we pass the wrong options into the `toJSON` function of a model
- the toJSON function decides what to return based on options
- this is the easiest solution for now, but i am going to write a spec if we can solve this problem differently
- if we want to use the `toJSON` function to determine which model fields to return, we cannot do that without this change!

**NOTE: I thought about a util for the response format, but i decided against at the moment, because i am not sure if we have to change a fundamental concept of how the API works (who returns what, who returns JSON, how do we guarantee that the options object is everywhere accessible, how are headers generated etc.)**. See for example [this here](https://github.com/TryGhost/Ghost/blob/master/core/server/api/posts.js#L149) - it only happens because [the outer API level wants to add headers based on the state of a model](https://github.com/TryGhost/Ghost/blob/master/core/server/api/index.js#L99).

### Second commit: Removed bypassing option filtering in User model

- the tests were red on the first and i investigated why
- i had to create a PR with both commits, because the second commit is a result of the correctness of the first commit
- the logic in the User model bypasses filtering options!
- that is wrong, because if we filter out certain options e.g. include
- the tests from the previous commit fail because of this
- if we don't fix this logic, the tests won't pass, because as said, you can bypass certain logic e.g. remove roles from include
- this has worked before, because we passed the wrong options via the API layer
- was introduced here 014e2c8, because of #6122
- add proper tests to proof that these queries work!!