### PR TITLE
🔥   Removed certain fields from public user response

### DIFF
--- a/core/server/models/plugins/access-rules.js
+++ b/core/server/models/plugins/access-rules.js
@@ -13,11 +13,14 @@ module.exports = function (Bookshelf) {
         _context: null,
 
         /**
-         * ## Is Public Context?
-         * A helper to determine if this is a public request or not
+         * A model method/helper to determine if this is a public request or not.
          * @returns {boolean}
          */
-        isPublicContext: function isPublicContext() {
+        isPublicContext: function isPublicContext(options) {
+            if (options) {
+                return Model.isPublicContext(options);
+            }
+
             return !!(this._context && this._context.public);
         },
 
@@ -27,8 +30,22 @@ module.exports = function (Bookshelf) {
     },
     {
         /**
+         * A static method to determine if this is a public request or not.
+         * @returns {boolean}
+         */
+        isPublicContext: function isPublicContext(options) {
+            if (options && options.context && options.context.public) {
+                return true;
+            }
+
+            return false;
+        },
+
+        /**
          * ## Forge
          * Ensure that context gets set as part of the forge
+         *
+         * @TODO: We almost never use `.forge(options)` - reconsider.
          *
          * @param {object} attributes
          * @param {object} options

--- a/core/server/models/plugins/access-rules.js
+++ b/core/server/models/plugins/access-rules.js
@@ -13,14 +13,11 @@ module.exports = function (Bookshelf) {
         _context: null,
 
         /**
-         * A model method/helper to determine if this is a public request or not.
+         * ## Is Public Context?
+         * A helper to determine if this is a public request or not
          * @returns {boolean}
          */
-        isPublicContext: function isPublicContext(options) {
-            if (options) {
-                return Model.isPublicContext(options);
-            }
-
+        isPublicContext: function isPublicContext() {
             return !!(this._context && this._context.public);
         },
 
@@ -30,22 +27,8 @@ module.exports = function (Bookshelf) {
     },
     {
         /**
-         * A static method to determine if this is a public request or not.
-         * @returns {boolean}
-         */
-        isPublicContext: function isPublicContext(options) {
-            if (options && options.context && options.context.public) {
-                return true;
-            }
-
-            return false;
-        },
-
-        /**
          * ## Forge
          * Ensure that context gets set as part of the forge
-         *
-         * @TODO: We almost never use `.forge(options)` - reconsider.
          *
          * @param {object} attributes
          * @param {object} options

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -192,10 +192,13 @@ User = ghostBookshelf.Model.extend({
         options = options || {};
 
         var attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
+
         // remove password hash for security reasons
         delete attrs.password;
         delete attrs.ghost_auth_access_token;
 
+        // NOTE: We don't expose the email address for for external, app and public context.
+        // @TODO: Why? External+Public is actually the same context? Was also mentioned here https://github.com/TryGhost/Ghost/issues/9043
         if (!options || !options.context || (!options.context.user && !options.context.internal)) {
             delete attrs.email;
         }

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -316,9 +316,9 @@ User = ghostBookshelf.Model.extend({
             permittedOptionsToReturn = permittedOptionsToReturn.concat(validOptions[methodName]);
         }
 
-        // CASE: The `include` paramater is allowed when using the public API, but not the `roles` value.
+        // CASE: The `include` parameter is allowed when using the public API, but not the `roles` value.
         // Otherwise we expose too much information.
-        if (options && options.context && options.context.public) {
+        if (this.isPublicContext(options)) {
             if (options.include && options.include.indexOf('roles') !== -1) {
                 options.include.splice(options.include.indexOf('roles'), 1);
             }

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -203,6 +203,17 @@ User = ghostBookshelf.Model.extend({
             delete attrs.email;
         }
 
+        // We don't expose these fields when fetching data via the public API.
+        if (this.isPublicContext(options)) {
+            delete attrs.created_at;
+            delete attrs.created_by;
+            delete attrs.updated_at;
+            delete attrs.updated_by;
+            delete attrs.last_seen;
+            delete attrs.status;
+            delete attrs.ghost_auth_id;
+        }
+
         return attrs;
     },
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -204,7 +204,7 @@ User = ghostBookshelf.Model.extend({
         }
 
         // We don't expose these fields when fetching data via the public API.
-        if (this.isPublicContext(options)) {
+        if (options && options.context && options.context.public) {
             delete attrs.created_at;
             delete attrs.created_by;
             delete attrs.updated_at;
@@ -329,7 +329,7 @@ User = ghostBookshelf.Model.extend({
 
         // CASE: The `include` parameter is allowed when using the public API, but not the `roles` value.
         // Otherwise we expose too much information.
-        if (this.isPublicContext(options)) {
+        if (options && options.context && options.context.public) {
             if (options.include && options.include.indexOf('roles') !== -1) {
                 options.include.splice(options.include.indexOf('roles'), 1);
             }

--- a/core/server/permissions/parse-context.js
+++ b/core/server/permissions/parse-context.js
@@ -15,6 +15,7 @@ module.exports = function parseContext(context) {
         public: true
     };
 
+    // NOTE: We use the `external` context for subscribers only at the moment.
     if (context && (context === 'external' || context.external)) {
         parsed.external = true;
         parsed.public = false;

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -322,7 +322,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(2);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, null, null, {public: true});
                 done();
             });
     });
@@ -345,7 +345,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(2);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, null, null, {public: true});
                 done();
             });
     });
@@ -368,7 +368,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(1);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, null, null, {public: true});
                 done();
             });
     });
@@ -391,7 +391,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(1);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], null, null, {public: true});
                 done();
             });
     });
@@ -414,7 +414,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(1);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], null, null, {public: true});
                 done();
             });
     });
@@ -453,7 +453,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(1);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, null, null, {public: true});
                 done();
             });
     });
@@ -476,7 +476,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(2);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', ['count'], null, null, {public: true});
                 done();
             });
     });
@@ -499,7 +499,7 @@ describe('Public API', function () {
                 jsonResponse.users.should.have.length(2);
 
                 // We don't expose the email address.
-                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, ['email']);
+                testUtils.API.checkResponse(jsonResponse.users[0], 'user', null, null, null, {public: true});
                 done();
             });
     });

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -1,44 +1,59 @@
-var _               = require('lodash'),
-    url             = require('url'),
-    moment          = require('moment'),
-    config          = require('../../server/config'),
-    schema          = require('../../server/data/schema').tables,
-    ApiRouteBase    = '/ghost/api/v0.1/',
-    host            = config.get('server').host,
-    port            = config.get('server').port,
-    protocol        = 'http://',
+var _ = require('lodash'),
+    url = require('url'),
+    moment = require('moment'),
+    config = require('../../server/config'),
+    schema = require('../../server/data/schema').tables,
+    ApiRouteBase = '/ghost/api/v0.1/',
+    host = config.get('server').host,
+    port = config.get('server').port,
+    protocol = 'http://',
     expectedProperties = {
         // API top level
-        posts:         ['posts', 'meta'],
-        tags:          ['tags', 'meta'],
-        users:         ['users', 'meta'],
-        settings:      ['settings', 'meta'],
-        subscribers:   ['subscribers', 'meta'],
-        roles:         ['roles'],
-        pagination:    ['page', 'limit', 'pages', 'total', 'next', 'prev'],
-        slugs:         ['slugs'],
-        slug:          ['slug'],
-        // object / model level
-        // Post API
-        post:        _(schema.posts).keys()
-            // does not return all formats by default
+        posts: ['posts', 'meta'],
+        tags: ['tags', 'meta'],
+        users: ['users', 'meta'],
+        settings: ['settings', 'meta'],
+        subscribers: ['subscribers', 'meta'],
+        roles: ['roles'],
+        pagination: ['page', 'limit', 'pages', 'total', 'next', 'prev'],
+        slugs: ['slugs'],
+        slug: ['slug'],
+        post: _(schema.posts)
+            .keys()
+            // by default we only return html
             .without('mobiledoc', 'amp', 'plaintext')
             // swaps author_id to author, and always returns computed properties: url, comment_id, primary_tag
             .without('author_id').concat('author', 'url', 'comment_id', 'primary_tag')
             .value(),
-        // User API always removes the password field
-        user:        _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),
+        user: {
+            default: _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),
+            public: _(schema.users)
+                .keys()
+                .without(
+                    'password',
+                    'email',
+                    'ghost_auth_access_token',
+                    'ghost_auth_id',
+                    'created_at',
+                    'created_by',
+                    'updated_at',
+                    'updated_by',
+                    'last_seen',
+                    'status'
+                )
+                .value()
+        },
         // Tag API swaps parent_id to parent
-        tag:         _(schema.tags).keys().without('parent_id').concat('parent').value(),
-        setting:     _.keys(schema.settings),
+        tag: _(schema.tags).keys().without('parent_id').concat('parent').value(),
+        setting: _.keys(schema.settings),
         subscriber: _.keys(schema.subscribers),
         accesstoken: _.keys(schema.accesstokens),
-        role:        _.keys(schema.roles),
-        permission:  _.keys(schema.permissions),
+        role: _.keys(schema.roles),
+        permission: _.keys(schema.permissions),
         notification: ['type', 'message', 'status', 'id', 'dismissible', 'location'],
-        theme:        ['name', 'package', 'active'],
-        themes:       ['themes'],
-        invites:      _(schema.invites).keys().without('token').value()
+        theme: ['name', 'package', 'active'],
+        themes: ['themes'],
+        invites: _(schema.invites).keys().without('token').value()
     };
 
 function getApiQuery(route) {
@@ -83,8 +98,11 @@ function checkResponseValue(jsonResponse, expectedProperties) {
     providedProperties.length.should.eql(expectedProperties.length);
 }
 
-function checkResponse(jsonResponse, objectType, additionalProperties, missingProperties, onlyProperties) {
-    var checkProperties = expectedProperties[objectType];
+// @TODO: support options pattern only, it's annoying to call checkResponse(null, null, null, something)
+function checkResponse(jsonResponse, objectType, additionalProperties, missingProperties, onlyProperties, options) {
+    options = options || {};
+
+    var checkProperties = options.public ? (expectedProperties[objectType].public || expectedProperties[objectType]) : (expectedProperties[objectType].default || expectedProperties[objectType]);
 
     checkProperties = onlyProperties ? onlyProperties : checkProperties;
     checkProperties = additionalProperties ? checkProperties.concat(additionalProperties) : checkProperties;


### PR DESCRIPTION
no issue

Do not expose `created_at`, `updated_at`, `updated_by`, `created_by`, `ghost_auth_id`, `last_seen` and `status`  via the public user api.
Our public api is a beta feature and you can expect breaking changes at any time, [see](https://api.ghost.org/docs/getting-started#section-stability-and-progress).

You can squash the commits together. Each commit contains useful information to understand the changes.