### PR TITLE
Protected internal tags visibility

### DIFF
--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -8,6 +8,12 @@ Tag = ghostBookshelf.Model.extend({
 
     tableName: 'tags',
 
+    defaults: function defaults() {
+        return {
+            visibility: 'public'
+        };
+    },
+
     emitChange: function emitChange(event) {
         events.emit('tag' + '.' + event, this);
     },
@@ -24,11 +30,16 @@ Tag = ghostBookshelf.Model.extend({
         model.emitChange('deleted');
     },
 
-    onSaving: function onSaving(newPage, attr, options) {
+    onSaving: function onSaving(newTag, attr, options) {
         /*jshint unused:false*/
         var self = this;
 
         ghostBookshelf.Model.prototype.onSaving.apply(this, arguments);
+
+        // name: #later slug: hash-later
+        if (/^#/.test(newTag.get('name'))) {
+            this.set('visibility', 'internal');
+        }
 
         if (this.hasChanged('slug') || !this.get('slug')) {
             // Pass the new slug through the generator to strip illegal characters, detect duplicates

--- a/core/test/integration/api/api_tags_spec.js
+++ b/core/test/integration/api/api_tags_spec.js
@@ -1,6 +1,5 @@
 var should = require('should'),
     testUtils = require('../../utils'),
-    Promise = require('bluebird'),
     _ = require('lodash'),
     // Stuff we are testing
     context = testUtils.context,
@@ -28,7 +27,6 @@ describe('Tags API', function () {
 
         beforeEach(function () {
             newTag = _.clone(_.omit(testUtils.DataGenerator.forKnex.createTag(testUtils.DataGenerator.Content.tags[0]), 'id'));
-            Promise.resolve(newTag);
         });
 
         it('can add a tag (admin)', function (done) {
@@ -47,6 +45,21 @@ describe('Tags API', function () {
                     should.exist(results);
                     should.exist(results.tags);
                     results.tags.length.should.be.above(0);
+                    results.tags[0].visibility.should.eql('public');
+                    done();
+                }).catch(done);
+        });
+
+        it('add internal tag', function (done) {
+            TagAPI
+                .add({tags: [{name: '#test'}]}, testUtils.context.editor)
+                .then(function (results) {
+                    should.exist(results);
+                    should.exist(results.tags);
+                    results.tags.length.should.be.above(0);
+                    results.tags[0].visibility.should.eql('internal');
+                    results.tags[0].name.should.eql('#test');
+                    results.tags[0].slug.should.eql('hash-test');
                     done();
                 }).catch(done);
         });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8943

- if you send a tag name with a hash, it's an internal tag
- ensure that the visibility property is forced to `internal`
- add a proper test

NOTE: Slug generation for internal tags is not running on import, because we can destroy their links to tags, [see](https://github.com/TryGhost/Ghost/pull/6771/files#diff-f8d02ad12b13d44b912bbf46cf7193b6R498). But in this case here, we only change the visibility of a tag. And per definition: a tag with a hash in the beginning is internal. So no need to check if importing?

When adding tags via the posts api, the tag saving hook is triggered as well, see https://github.com/TryGhost/Ghost/blob/master/core/server/models/base/utils.js#L93