### PR TITLE
Fixed wrong handling of formats param

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -79,7 +79,9 @@ posts = {
      * @return {Promise<Post>} Post
      */
     read: function read(options) {
-        var attrs = ['id', 'slug', 'status', 'uuid', 'formats'],
+        var attrs = ['id', 'slug', 'status', 'uuid'],
+            // NOTE: the scheduler API uses the post API and forwards custom options
+            extraAllowedOptions = options.opts || ['formats'],
             tasks;
 
         /**
@@ -105,7 +107,7 @@ posts = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            apiUtils.validate(docName, {attrs: attrs, opts: options.opts || []}),
+            apiUtils.validate(docName, {attrs: attrs, opts: extraAllowedOptions}),
             apiUtils.handlePublicPermissions(docName, 'read', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes, models.Post.allowedFormats),
             modelQuery
@@ -125,7 +127,9 @@ posts = {
      * @return {Promise(Post)} Edited Post
      */
     edit: function edit(object, options) {
-        var tasks;
+        var tasks,
+            // NOTE: the scheduler API uses the post API and forwards custom options
+            extraAllowedOptions = options.opts || [];
 
         /**
          * ### Model Query
@@ -159,7 +163,7 @@ posts = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions.concat(options.opts || [])}),
+            apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions.concat(extraAllowedOptions)}),
             apiUtils.handlePermissions(docName, 'edit', unsafeAttrs),
             apiUtils.convertOptions(allowedIncludes),
             modelQuery

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -360,6 +360,30 @@ describe('Post API', function () {
                     });
             });
 
+            it('can retrieve multiple post formats', function (done) {
+                request
+                    .get(testUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?formats=plaintext,mobiledoc,amp'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.posts);
+                        jsonResponse.posts.should.have.length(1);
+                        jsonResponse.posts[0].id.should.equal(testUtils.DataGenerator.Content.posts[0].id);
+
+                        testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['mobiledoc', 'plaintext', 'amp'], ['html']);
+
+                        done();
+                    });
+            });
+
             it('can retrieve a post by slug', function (done) {
                 request.get(testUtils.API.getApiQuery('posts/slug/welcome/'))
                     .set('Authorization', 'Bearer ' + ownerAccessToken)


### PR DESCRIPTION
closes #9077

- caused by our API layer refactoring, see https://github.com/TryGhost/Ghost/pull/9068
- we can now see that code was written wrong because of this horrible API bug
- this fixes the formats parameter for querying a single post

This allows an extra `formats` option (next to include and context).