### PR TITLE
[i18n] Better support for bad translation requests

### DIFF
--- a/core/server/i18n.js
+++ b/core/server/i18n.js
@@ -71,7 +71,7 @@ I18n = {
         if (_.isEqual(matchingString, {})) {
             console.error('Unable to find matching path [' + msgPath + '] in locale file.\n');
             matchingString = 'i18n error: path "' + msgPath + '" was not found.';
-        } else if(_.isObject(matchingString)) {
+        } else if (_.isObject(matchingString)) {
             console.error('Path [' + msgPath + '] is too broad.\n');
             matchingString = 'i18n error: path "' + msgPath + '" is too broad.';
         }

--- a/core/server/i18n.js
+++ b/core/server/i18n.js
@@ -65,12 +65,15 @@ I18n = {
         path = msgPath.split('.');
         path.forEach(function (key) {
             // reassign matching object, or set to an empty string if there is no match
-            matchingString = matchingString[key] || null;
+            matchingString = matchingString[key] || {};
         });
 
-        if (_.isNull(matchingString)) {
+        if (_.isEqual(matchingString, {})) {
             console.error('Unable to find matching path [' + msgPath + '] in locale file.\n');
             matchingString = 'i18n error: path "' + msgPath + '" was not found.';
+        } else if(_.isObject(matchingString)) {
+            console.error('Path [' + msgPath + '] is too broad.\n');
+            matchingString = 'i18n error: path "' + msgPath + '" is too broad.';
         }
 
         return matchingString;

--- a/core/server/i18n.js
+++ b/core/server/i18n.js
@@ -5,6 +5,8 @@ var supportedLocales    = ['en'],
     fs                  = require('fs'),
     chalk               = require('chalk'),
     MessageFormat       = require('intl-messageformat'),
+    logging             = require('./logging'),
+    errors              = require('./errors'),
 
     // TODO: fetch this dynamically based on overall blog settings (`key = "default_locale"`) in the `settings` table
     currentLocale       = 'en',
@@ -68,12 +70,11 @@ I18n = {
             matchingString = matchingString[key] || {};
         });
 
-        if (_.isEqual(matchingString, {})) {
-            console.error('Unable to find matching path [' + msgPath + '] in locale file.\n');
-            matchingString = 'i18n error: path "' + msgPath + '" was not found.';
-        } else if (_.isObject(matchingString)) {
-            console.error('Path [' + msgPath + '] is too broad.\n');
-            matchingString = 'i18n error: path "' + msgPath + '" is too broad.';
+        if (_.isObject(matchingString) || _.isEqual(matchingString, {})) {
+            logging.error(new errors.IncorrectUsageError({
+                message: `i18n error: path "${msgPath}" was not found`
+            }));
+            matchingString = blos.errors.errors.anErrorOccurred;
         }
 
         return matchingString;


### PR DESCRIPTION
Closes #9079 

- Add support for multiple subpaths not existing (i.e. `foo.bar.baz` - none of foo, foo.bar & foo.bar.baz exist in the translations)
- Add support for too broad translation requests (i.e. `errors` - an error is thrown when you try to format a non-string (object) and errors has quite a bit of data which would be sent to the client)