### PR TITLE
🎨 Disable auto-linking of domain names in markdown

### DIFF
--- a/core/server/utils/markdown-converter.js
+++ b/core/server/utils/markdown-converter.js
@@ -1,4 +1,4 @@
-var MarkdownIt  = require('markdown-it'),
+var MarkdownIt = require('markdown-it'),
     converter = new MarkdownIt({
         html: true,
         breaks: true,
@@ -43,6 +43,11 @@ var MarkdownIt  = require('markdown-it'),
         };
         // jscs:enable
     });
+
+// configure linkify-it
+converter.linkify.set({
+    fuzzyLink: false
+});
 
 module.exports = {
     render: function (markdown) {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/8987
- set `linkify-it`'s `fuzzyLink` option to false so that it only auto-links URLs starting with `http(s)://` or other valid schemes

---

🚨 **Note:** This contains a potentially breaking change:
- for new posts, text which looks like a valid domain (eg. `example.com`) will no longer be auto-linked
- when editing old posts, any links on previously auto-linked domains will be removed
- if you want to link `example.com` it will be necessary to use full markdown syntax, eg. `[example.com](https://example.com)`