### PR TITLE
⬆️  Amperize 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": "^4.5.0 || ^6.9.0"
   },
   "dependencies": {
-    "amperize": "0.3.4",
+    "amperize": "0.3.5",
     "analytics-node": "2.4.1",
     "archiver": "1.3.0",
     "bcryptjs": "2.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,18 +61,20 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-amperize@0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/amperize/-/amperize-0.3.4.tgz#04b61d8cc0eab4dd1dd822cead14c4c2461dec87"
+amperize@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/amperize/-/amperize-0.3.5.tgz#0185eaea9ae617ca27e0c3dac5092574403a3851"
   dependencies:
-    async "2.1.4"
-    emits "3.0.0"
-    htmlparser2 "3.9.2"
+    async "^2.1.4"
+    emits "^3.0.0"
+    got "^7.1.0"
+    htmlparser2 "^3.9.2"
     image-size "0.5.1"
-    lodash.merge "4.6.0"
+    lodash "^4.17.4"
     nock "^9.0.2"
     rewire "^2.5.2"
     uuid "^3.0.0"
+    validator "^8.2.0"
 
 analytics-node@2.4.1:
   version "2.4.1"
@@ -203,9 +205,15 @@ async@1.x, async@^1.4.0, async@^1.5.0, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@2.1.4, async@^2.0.0:
+async@^2.0.0:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.4.tgz#2d2160c7788032e4dd6cbe2502f1f9a2c8f6cde4"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.1.4:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
 
@@ -1192,7 +1200,7 @@ electron-to-chromium@^1.2.7:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz#b2c8a2c79bb89fbbfd3724d9555e15095b5f5fb6"
 
-emits@3.0.0:
+emits@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emits/-/emits-3.0.0.tgz#32752bba95e1707b219562384ab9bb8b1fd62f70"
 
@@ -1883,7 +1891,7 @@ glogg@^1.0.0:
   dependencies:
     sparkles "^1.0.0"
 
-got@7.1.0:
+got@7.1.0, got@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
   dependencies:
@@ -2337,7 +2345,7 @@ htmlparser2@3.8.3, htmlparser2@3.8.x:
     entities "1.0"
     readable-stream "1.1"
 
-htmlparser2@3.9.2, htmlparser2@^3.8.3, htmlparser2@^3.9.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
+htmlparser2@^3.8.3, htmlparser2@^3.9.0, htmlparser2@^3.9.1, htmlparser2@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -3138,7 +3146,7 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.merge@4.6.0, lodash.merge@^4.4.0:
+lodash.merge@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -5461,6 +5469,10 @@ validate-npm-package-license@^3.0.1:
 validator@6.3.0, validator@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-6.3.0.tgz#47ce23ed8d4eaddfa9d4b8ef0071b6cf1078d7c8"
+
+validator@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-8.2.0.tgz#3c1237290e37092355344fef78c231249dab77b9"
 
 vary@^1, vary@~1.1.0, vary@~1.1.1:
   version "1.1.1"


### PR DESCRIPTION
no issue

- bump `amperize` to 0.3.5 which fixes issues with images-size requests not following redirects, and image-size requests that caused errors leading to stop transforming the rest of the passed HTML.