### PR TITLE
✨ Private RSS feed

### DIFF
--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -37,7 +37,7 @@ privateBlogging = {
         })(req, res, next);
     },
 
-    filterPrivateRoutes: function filterPrivateRoutes(req, res, next) {
+    filterPrivateRoutes: function excludePrivateRoutes(req, res, next) {
         if (res.isAdmin || !res.isPrivateBlog || req.url.lastIndexOf(privateRoute, 0) === 0) {
             return next();
         }
@@ -59,11 +59,12 @@ privateBlogging = {
         }
 
         // CASE: Allow private RSS feed urls.
-        if (req.path.match(new RegExp('/' + settingsCache.get('global_hash') + '/rss/')) !== -1) {
+        if (req.path.indexOf(settingsCache.get('global_hash') + '/rss') !== -1) {
             req.url = req.url.replace(settingsCache.get('global_hash') + '/', '');
             return next();
         }
 
+        // NOTE: Redirect to /private if the session does not exist.
         privateBlogging.authenticatePrivateSession(req, res, function onSessionVerified() {
             // CASE: RSS is disabled for private blogging e.g. they create overhead
             if (req.path.lastIndexOf('/rss/', 0) === 0 || req.path.lastIndexOf('/rss/') === req.url.length - 5) {

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -59,8 +59,8 @@ privateBlogging = {
         }
 
         // CASE: Allow private RSS feed urls.
-        if (req.path.indexOf(settingsCache.get('global_hash') + '/rss') !== -1) {
-            req.url = req.url.replace(settingsCache.get('global_hash') + '/', '');
+        if (req.path.indexOf(settingsCache.get('public_hash') + '/rss') !== -1) {
+            req.url = req.url.replace(settingsCache.get('public_hash') + '/', '');
             return next();
         }
 

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -37,7 +37,7 @@ privateBlogging = {
         })(req, res, next);
     },
 
-    filterPrivateRoutes: function excludePrivateRoutes(req, res, next) {
+    filterPrivateRoutes: function filterPrivateRoutes(req, res, next) {
         if (res.isAdmin || !res.isPrivateBlog || req.url.lastIndexOf(privateRoute, 0) === 0) {
             return next();
         }

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -59,7 +59,9 @@ privateBlogging = {
         }
 
         // CASE: Allow private RSS feed urls.
-        if (req.path.indexOf(settingsCache.get('public_hash') + '/rss') !== -1) {
+        // Any url which contains the hash and the postfix /rss is allowed to access a private rss feed without
+        // a session. As soon as a path matches, we rewrite the url. Even Express uses rewriting when using `app.use()`.
+        if (req.url.indexOf(settingsCache.get('public_hash') + '/rss') !== -1) {
             req.url = req.url.replace(settingsCache.get('public_hash') + '/', '');
             return next();
         }

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -57,6 +57,13 @@ privateBlogging = {
             });
         }
 
+        // CASE: any route which ends with /:hash/rss is allowed to pass without a session.
+        // e.g. useful for private RSS feed urls
+        if (req.path.match(new RegExp('/' + settingsCache.get('global_hash') + '/rss/')) !== -1) {
+            req.url = req.url.replace(settingsCache.get('global_hash') + '/', '');
+            return next();
+        }
+
         privateBlogging.authenticatePrivateSession(req, res, next);
     },
 

--- a/core/server/apps/private-blogging/tests/middleware_spec.js
+++ b/core/server/apps/private-blogging/tests/middleware_spec.js
@@ -2,8 +2,9 @@
 var should = require('should'), // jshint ignore:line
     sinon = require('sinon'),
     crypto = require('crypto'),
-    settingsCache = require('../../../settings/cache'),
     fs = require('fs'),
+    errors = require('../../../errors'),
+    settingsCache = require('../../../settings/cache'),
     privateBlogging = require('../lib/middleware'),
     sandbox = sinon.sandbox.create();
 
@@ -222,6 +223,55 @@ describe('Private Blogging', function () {
 
                     privateBlogging.authenticateProtection(req, res, next);
                     res.redirect.called.should.be.true();
+                });
+
+                it('filterPrivateRoutes should 404 for rss requests', function () {
+                    var salt = Date.now().toString();
+                    req.url = req.path = '/rss/';
+
+                    req.session = {
+                        token: hash('rightpassword', salt),
+                        salt: salt
+                    };
+
+                    res.isPrivateBlog = true;
+                    res.redirect = sandbox.spy();
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    next.called.should.be.true();
+                    (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                });
+
+                it('filterPrivateRoutes should 404 for all rss requests', function () {
+                    var salt = Date.now().toString();
+                    req.url = req.path = '/tag/welcome/rss/';
+
+                    req.session = {
+                        token: hash('rightpassword', salt),
+                        salt: salt
+                    };
+
+                    res.isPrivateBlog = true;
+                    res.redirect = sandbox.spy();
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    next.called.should.be.true();
+                    (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                });
+
+                it('filterPrivateRoutes should 404 for all rss requests', function () {
+                    settingsStub.withArgs('public_hash').returns('777aaa');
+
+                    var salt = Date.now().toString();
+                    req.url = req.originalUrl = req.path = '/777aaa/rss/';
+                    req.params = {};
+
+                    res.isPrivateBlog = true;
+                    res.render = sandbox.spy();
+                    res.locals = {};
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    res.render.called.should.be.true();
                 });
             });
         });

--- a/core/server/apps/private-blogging/tests/middleware_spec.js
+++ b/core/server/apps/private-blogging/tests/middleware_spec.js
@@ -225,7 +225,7 @@ describe('Private Blogging', function () {
                     res.redirect.called.should.be.true();
                 });
 
-                it('filterPrivateRoutes should 404 for rss requests', function () {
+                it('filterPrivateRoutes should 404 for /rss/ requests', function () {
                     var salt = Date.now().toString();
                     req.url = req.path = '/rss/';
 
@@ -242,7 +242,24 @@ describe('Private Blogging', function () {
                     (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
                 });
 
-                it('filterPrivateRoutes should 404 for all rss requests', function () {
+                it('filterPrivateRoutes should 404 for /rss requests', function () {
+                    var salt = Date.now().toString();
+                    req.url = req.path = '/rss';
+
+                    req.session = {
+                        token: hash('rightpassword', salt),
+                        salt: salt
+                    };
+
+                    res.isPrivateBlog = true;
+                    res.redirect = sandbox.spy();
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    next.called.should.be.true();
+                    (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
+                });
+
+                it('filterPrivateRoutes should 404 for tag rss requests', function () {
                     var salt = Date.now().toString();
                     req.url = req.path = '/tag/welcome/rss/';
 
@@ -259,7 +276,7 @@ describe('Private Blogging', function () {
                     (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
                 });
 
-                it('filterPrivateRoutes: allow private rss feed', function () {
+                it('filterPrivateRoutes: allow private /rss/ feed', function () {
                     settingsStub.withArgs('public_hash').returns('777aaa');
 
                     req.url = req.originalUrl = req.path = '/777aaa/rss/';
@@ -271,6 +288,20 @@ describe('Private Blogging', function () {
                     privateBlogging.filterPrivateRoutes(req, res, next);
                     next.called.should.be.true();
                     req.url.should.eql('/rss/');
+                });
+
+                it('filterPrivateRoutes: allow private /rss feed', function () {
+                    settingsStub.withArgs('public_hash').returns('777aaa');
+
+                    req.url = req.originalUrl = req.path = '/777aaa/rss';
+                    req.params = {};
+
+                    res.isPrivateBlog = true;
+                    res.locals = {};
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    next.called.should.be.true();
+                    req.url.should.eql('/rss');
                 });
 
                 it('filterPrivateRoutes: allow private rss feed e.g. tags', function () {

--- a/core/server/apps/private-blogging/tests/middleware_spec.js
+++ b/core/server/apps/private-blogging/tests/middleware_spec.js
@@ -260,7 +260,7 @@ describe('Private Blogging', function () {
                 });
 
                 it('filterPrivateRoutes: allow private rss feed', function () {
-                    settingsStub.withArgs('global_hash').returns('777aaa');
+                    settingsStub.withArgs('public_hash').returns('777aaa');
 
                     req.url = req.originalUrl = req.path = '/777aaa/rss/';
                     req.params = {};
@@ -274,7 +274,7 @@ describe('Private Blogging', function () {
                 });
 
                 it('filterPrivateRoutes: allow private rss feed e.g. tags', function () {
-                    settingsStub.withArgs('global_hash').returns('777aaa');
+                    settingsStub.withArgs('public_hash').returns('777aaa');
 
                     req.url = req.originalUrl = req.path = '/tag/getting-started/777aaa/rss/';
                     req.params = {};
@@ -288,7 +288,7 @@ describe('Private Blogging', function () {
                 });
 
                 it('[failure] filterPrivateRoutes: allow private rss feed e.g. tags', function () {
-                    settingsStub.withArgs('global_hash').returns('777aaa');
+                    settingsStub.withArgs('public_hash').returns('777aaa');
 
                     req.url = req.originalUrl = req.path = '/tag/getting-started/rss/';
                     req.params = {};

--- a/core/server/apps/private-blogging/tests/middleware_spec.js
+++ b/core/server/apps/private-blogging/tests/middleware_spec.js
@@ -259,19 +259,50 @@ describe('Private Blogging', function () {
                     (next.firstCall.args[0] instanceof errors.NotFoundError).should.eql(true);
                 });
 
-                it('filterPrivateRoutes should 404 for all rss requests', function () {
-                    settingsStub.withArgs('public_hash').returns('777aaa');
+                it('filterPrivateRoutes: allow private rss feed', function () {
+                    settingsStub.withArgs('global_hash').returns('777aaa');
 
                     var salt = Date.now().toString();
                     req.url = req.originalUrl = req.path = '/777aaa/rss/';
                     req.params = {};
 
                     res.isPrivateBlog = true;
-                    res.render = sandbox.spy();
                     res.locals = {};
 
                     privateBlogging.filterPrivateRoutes(req, res, next);
-                    res.render.called.should.be.true();
+                    next.called.should.be.true();
+                    req.url.should.eql('/rss/');
+                });
+
+                it('filterPrivateRoutes: allow private rss feed e.g. tags', function () {
+                    settingsStub.withArgs('global_hash').returns('777aaa');
+
+                    var salt = Date.now().toString();
+                    req.url = req.originalUrl = req.path = '/tag/getting-started/777aaa/rss/';
+                    req.params = {};
+
+                    res.isPrivateBlog = true;
+                    res.locals = {};
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    next.called.should.be.true();
+                    req.url.should.eql('/tag/getting-started/rss/');
+                });
+
+                it('[failure] filterPrivateRoutes: allow private rss feed e.g. tags', function () {
+                    settingsStub.withArgs('global_hash').returns('777aaa');
+
+                    var salt = Date.now().toString();
+                    req.url = req.originalUrl = req.path = '/tag/getting-started/rss/';
+                    req.params = {};
+
+                    res.isPrivateBlog = true;
+                    res.locals = {};
+
+                    res.redirect = sandbox.spy();
+
+                    privateBlogging.filterPrivateRoutes(req, res, next);
+                    res.redirect.called.should.be.true();
                 });
             });
         });

--- a/core/server/apps/private-blogging/tests/middleware_spec.js
+++ b/core/server/apps/private-blogging/tests/middleware_spec.js
@@ -262,7 +262,6 @@ describe('Private Blogging', function () {
                 it('filterPrivateRoutes: allow private rss feed', function () {
                     settingsStub.withArgs('global_hash').returns('777aaa');
 
-                    var salt = Date.now().toString();
                     req.url = req.originalUrl = req.path = '/777aaa/rss/';
                     req.params = {};
 
@@ -277,7 +276,6 @@ describe('Private Blogging', function () {
                 it('filterPrivateRoutes: allow private rss feed e.g. tags', function () {
                     settingsStub.withArgs('global_hash').returns('777aaa');
 
-                    var salt = Date.now().toString();
                     req.url = req.originalUrl = req.path = '/tag/getting-started/777aaa/rss/';
                     req.params = {};
 
@@ -292,7 +290,6 @@ describe('Private Blogging', function () {
                 it('[failure] filterPrivateRoutes: allow private rss feed e.g. tags', function () {
                     settingsStub.withArgs('global_hash').returns('777aaa');
 
-                    var salt = Date.now().toString();
                     req.url = req.originalUrl = req.path = '/tag/getting-started/rss/';
                     req.params = {};
 

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -3,9 +3,6 @@
         "db_hash": {
             "defaultValue": null
         },
-        "global_hash": {
-            "defaultValue": null
-        },
         "next_update_check": {
             "defaultValue": null
         },
@@ -107,6 +104,9 @@
         },
         "password": {
             "defaultValue": ""
+        },
+        "public_hash": {
+            "defaultValue": null
         }
     }
 }

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -3,6 +3,9 @@
         "db_hash": {
             "defaultValue": null
         },
+        "global_hash": {
+            "defaultValue": null
+        },
         "next_update_check": {
             "defaultValue": null
         },

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -7,7 +7,6 @@ var Settings,
     errors         = require('../errors'),
     events         = require('../events'),
     i18n           = require('../i18n'),
-    globalUtils    = require('../utils'),
     validation     = require('../data/validation'),
 
     internalContext = {context: {internal: true}},

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -21,7 +21,7 @@ function parseDefaultSettings() {
         defaultSettingsFlattened = {},
         dynamicDefault = {
             db_hash: uuid.v4(),
-            global_hash: crypto.randomBytes(20).toString('hex')
+            public_hash: crypto.randomBytes(15).toString('hex')
         };
 
     _.each(defaultSettingsInCategories, function each(settings, categoryName) {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -2,6 +2,7 @@ var Settings,
     Promise        = require('bluebird'),
     _              = require('lodash'),
     uuid           = require('uuid'),
+    crypto         = require('crypto'),
     ghostBookshelf = require('./base'),
     errors         = require('../errors'),
     events         = require('../events'),
@@ -21,7 +22,7 @@ function parseDefaultSettings() {
         defaultSettingsFlattened = {},
         dynamicDefault = {
             db_hash: uuid.v4(),
-            global_hash: globalUtils.uid(15, {lca: true})
+            global_hash: crypto.randomBytes(20).toString('hex')
         };
 
     _.each(defaultSettingsInCategories, function each(settings, categoryName) {

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -6,6 +6,7 @@ var Settings,
     errors         = require('../errors'),
     events         = require('../events'),
     i18n           = require('../i18n'),
+    globalUtils    = require('../utils'),
     validation     = require('../data/validation'),
 
     internalContext = {context: {internal: true}},
@@ -19,7 +20,8 @@ function parseDefaultSettings() {
     var defaultSettingsInCategories = require('../data/schema/').defaultSettings,
         defaultSettingsFlattened = {},
         dynamicDefault = {
-            db_hash: uuid.v4()
+            db_hash: uuid.v4(),
+            global_hash: globalUtils.uid(15, {lca: true})
         };
 
     _.each(defaultSettingsInCategories, function each(settings, categoryName) {

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -45,20 +45,11 @@ utils = {
      * @return {String}
      * @api private
      */
-    uid: function (len, options) {
-        options = options || {};
-
+    uid: function (len) {
         var buf = [],
             chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
-            charlen,
+            charlen = chars.length,
             i;
-
-        // lowercase alphanumeric
-        if (options.lca) {
-            chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
-        }
-
-        charlen = chars.length;
 
         for (i = 0; i < len; i = i + 1) {
             buf.push(chars[getRandomInt(0, charlen - 1)]);

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -45,11 +45,20 @@ utils = {
      * @return {String}
      * @api private
      */
-    uid: function (len) {
+    uid: function (len, options) {
+        options = options || {};
+
         var buf = [],
             chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789',
-            charlen = chars.length,
+            charlen,
             i;
+
+        // lowercase alphanumeric
+        if (options.lca) {
+            chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+        }
+
+        charlen = chars.length;
 
         for (i = 0; i < len; i = i + 1) {
             buf.push(chars[getRandomInt(0, charlen - 1)]);


### PR DESCRIPTION
refs #9001 

- [x] reconsider core settings vs private setting - where should the hash live?
- [x] add admin ui change - show the direct link for the private rss feed
- [x] test on subdir
- [x] describe how this feature works
- [x] add more tests
- [x] code quality check

### what can you expect
- if your blog is public, rss still works as before
- if your blog is private, the default rss feature is disabled
- if your blog is private, you have access to a private rss feed from outside
- this private rss feed url is displayed in the admin UI
- you can access all rss urls e.g. /:hash/rss, /:hash/rss/2, /tag/:slug/:hash/rss 
- sitemaps weren't touched at all here

Note: I had several implementation options. e.g. we could register a whole new route for the hashed url, but that is super complicated e.g. we need to outsource rss into an app/module and the hash can change. And i really like url rewriting for this case.