### PR TITLE
🐛  Fixed being able to store invalid date formats

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -257,7 +257,8 @@
                 "token": {
                     "noUserFound": "No user found",
                     "tokenNotFound": "Token not found"
-                }
+                },
+                "invalidDate": "Date format for `{key}` is invalid."
             },
             "plugins": {
                 "filter": {

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -963,6 +963,54 @@ describe('Post Model', function () {
                     done();
                 }).catch(done);
             });
+
+            it('send invalid published_at date', function (done) {
+                var postId = testUtils.DataGenerator.Content.posts[0].id;
+
+                PostModel
+                    .findOne({
+                        id: postId
+                    })
+                    .then(function (results) {
+                        var post;
+                        should.exist(results);
+                        post = results.toJSON();
+                        post.id.should.equal(postId);
+
+                        return PostModel.edit({published_at: '0000-00-00 00:00:00'}, _.extend({}, context, {id: postId}));
+                    })
+                    .then(function () {
+                        done(new Error('This test should fail.'));
+                    })
+                    .catch(function (err) {
+                        err.statusCode.should.eql(422);
+                        done();
+                    });
+            });
+
+            it('send empty date', function (done) {
+                var postId = testUtils.DataGenerator.Content.posts[0].id;
+
+                PostModel
+                    .findOne({
+                        id: postId
+                    })
+                    .then(function (results) {
+                        var post;
+                        should.exist(results);
+                        post = results.toJSON();
+                        post.id.should.equal(postId);
+
+                        return PostModel.edit({created_at: ''}, _.extend({}, context, {id: postId}));
+                    })
+                    .then(function () {
+                        done(new Error('This test should fail.'));
+                    })
+                    .catch(function (err) {
+                        err.statusCode.should.eql(422);
+                        done();
+                    });
+            });
         });
 
         describe('add', function () {


### PR DESCRIPTION
closes #9089

- return API error if client sends invalid date
- protect code base if db has invalid dates in the database

The alternative is to add a complex migration script which iterates over **all** resources and checks if we have any invalid dates in the database. I would like to avoid this right now, because i doubt this is a common bug.
