### PR TITLE
Brute store error is an internal server error

### DIFF
--- a/core/server/middleware/api/spam-prevention.js
+++ b/core/server/middleware/api/spam-prevention.js
@@ -26,7 +26,7 @@ var moment = require('moment'),
     spamConfigKeys = ['freeRetries', 'minWait', 'maxWait', 'lifetime'];
 
 handleStoreError = function handleStoreError(err) {
-    var customError = new errors.NoPermissionError({
+    var customError = new errors.InternalServerError({
         message: 'Unknown error',
         err: err.parent ? err.parent : err
     });
@@ -36,7 +36,6 @@ handleStoreError = function handleStoreError(err) {
     // we are using reset as synchronous call, so we have to log the error if it occurs
     // there is no way to try/catch, because the reset operation happens asynchronous
     if (!err.next) {
-        err.level = 'critical';
         logging.error(err);
         return;
     }


### PR DESCRIPTION
no issue

If the brute store throws an error and the `handleStoreError` is called, then the storage is unable to get/set values.
This is not a PermissionError. The result is that the user has no access, because the brute store has problems reading/writing to the storage.