### PR TITLE
🐛  Fixed `author.url` not returning slug

### DIFF
--- a/core/server/data/schema/checks.js
+++ b/core/server/data/schema/checks.js
@@ -10,7 +10,7 @@ function isTag(jsonData) {
 
 function isUser(jsonData) {
     return jsonData.hasOwnProperty('bio') && jsonData.hasOwnProperty('website') &&
-        jsonData.hasOwnProperty('status') && jsonData.hasOwnProperty('location');
+        jsonData.hasOwnProperty('profile_image') && jsonData.hasOwnProperty('location');
 }
 
 function isNav(jsonData) {

--- a/core/test/unit/metadata/canonical_url_spec.js
+++ b/core/test/unit/metadata/canonical_url_spec.js
@@ -49,7 +49,7 @@ describe('getCanonicalUrl', function () {
             name: 'Test User',
             bio: 'This is all about testing',
             website: 'http://my-testing-site.com',
-            status: 'testing',
+            profile_image: null,
             location: 'Wounderland',
             slug: 'test-user',
             secure: true

--- a/core/test/unit/metadata/url_spec.js
+++ b/core/test/unit/metadata/url_spec.js
@@ -77,7 +77,7 @@ describe('getUrl', function () {
             name: 'Author Name',
             bio: 'I am fun bio!',
             website: 'http://myoksite.com',
-            status: 'active',
+            profile_image: null,
             location: 'London',
             slug: 'author-name'
         });
@@ -89,7 +89,7 @@ describe('getUrl', function () {
             name: 'Author Name',
             bio: 'I am fun bio!',
             website: 'http://myoksite.com',
-            status: 'active',
+            profile_image: null,
             location: 'London',
             slug: 'author-name',
             secure: true

--- a/core/test/unit/server_helpers/url_spec.js
+++ b/core/test/unit/server_helpers/url_spec.js
@@ -94,6 +94,19 @@ describe('{{url}} helper', function () {
         rendered.string.should.equal('/tag/the-tag/');
     });
 
+    it('should return the slug with a prefixed /author/ if the context is author', function () {
+        rendered = helpers.url.call({
+            bio: null,
+            website: null,
+            profile_image: null,
+            location: null,
+            slug: 'some-author'
+        });
+
+        should.exist(rendered);
+        rendered.string.should.equal('/author/some-author/');
+    });
+
     it('should return / if not a post or tag', function () {
         rendered = helpers.url.call({mobiledoc: markdownToMobiledoc('ff'), title: 'title', slug: 'slug'});
         should.exist(rendered);


### PR DESCRIPTION
closes #9101

With https://github.com/TryGhost/Ghost/commit/506a0c3e9e51ff4a2ae5bfe0afe84cc5d0bcee18 we don't expose the `status` field for author context anymore, which is used to determine the correct URL for the `{{url}}` helper in https://github.com/TryGhost/Ghost/blob/master/core/server/data/schema/checks.js#L13

This fix uses the field `profile_image` instead and adds a missing test for author context to the `{{url}}` helper test.