### PR TITLE
[WIP] 🐛 Fixed allowed post creation with numeric id

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -327,6 +327,12 @@ Post = ghostBookshelf.Model.extend({
     onCreating: function onCreating(model, attr, options) {
         options = options || {};
 
+        if (this.get('id') && !ObjectId.isValid(this.get('id'))) {
+            return Promise.reject(new errors.ValidationError({
+                message: i18n.t('notices.data.validation.index.validationFailed', {validationName: 'isValidObjectId', key: 'id'})
+            }));
+        }
+
         // set any dynamic default properties
         if (!this.get('author_id')) {
             this.set('author_id', this.contextUser(options));

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1397,6 +1397,21 @@ describe('Post Model', function () {
                     done();
                 }).catch(done);
             });
+
+            it('can\'t add post with numeric id', function () {
+                var post = {
+                    id: 42,
+                    title: 'Here\'s a test post',
+                    mobiledoc: markdownToMobiledoc('Post Content')
+                };
+
+                return PostModel.add(post, context).then(function () {
+                    throw new Error('Adding should have failed');
+                }).catch(function (err) {
+                    should.exist(err);
+                    (err instanceof errors.ValidationError).should.eql(true);
+                });
+            });
         });
 
         describe('destroy', function () {


### PR DESCRIPTION
closes #9100
- we now throw a ValidationError if the post id is not a valid ObjectId when a post is created
- on post edit the validation happens elsewhere
