### PR TITLE
Add support for custom channel contexts

### DIFF
--- a/core/server/controllers/frontend/context.js
+++ b/core/server/controllers/frontend/context.js
@@ -54,7 +54,11 @@ function setResponseContext(req, res, data) {
 
     // Each page can only have at most one of these
     if (res.locals.channel) {
-        res.locals.context.push(res.locals.channel.name);
+        if (res.locals.channel.context) {
+            res.locals.context = res.locals.context.concat(res.locals.channel.context);
+        } else {
+            res.locals.context.push(res.locals.channel.name);
+        }
     } else if (privatePattern.test(res.locals.relativeUrl)) {
         res.locals.context.push('private');
     } else if (subscribePattern.test(res.locals.relativeUrl) && labs.isSet('subscribers') === true) {

--- a/core/test/unit/controllers/frontend/context_spec.js
+++ b/core/test/unit/controllers/frontend/context_spec.js
@@ -273,6 +273,23 @@ describe('Contexts', function () {
                 res.locals.context[0].should.eql('featured');
             });
 
+            it('will use a custom context for a custom channel', function () {
+                var channel = _.clone(featuredChannel);
+                channel.context = ['custom-context', 'test'];
+
+                // Setup test
+                setupContext('/featured/', channel);
+
+                // Execute test
+                setResponseContext(req, res, data);
+
+                // Check context
+                should.exist(res.locals.context);
+                res.locals.context.should.be.an.Array().with.lengthOf(2);
+                res.locals.context[0].should.eql('custom-context');
+                res.locals.context[1].should.eql('test');
+            });
+
             it('will not identify /page/2/ as paged without page param', function () {
                 // Setup test
                 setupContext('/featured/page/2/', featuredChannel);


### PR DESCRIPTION
Trying to make it possible for custom channels to have secondary features like metadata.

refs #5091

- This simple change allows custom contexts to use existing channel logic
- E.g. if we want to create a custom tag-based channel, it can pass "tag" as the context, and get all the same metadata logic