### PR TITLE
Add check for ssl cert in config

### DIFF
--- a/core/server/config/utils.js
+++ b/core/server/config/utils.js
@@ -25,7 +25,8 @@ exports.isPrivacyDisabled = function isPrivacyDisabled(privacyFlag) {
  * @TODO: re-write this function a little bit so we don't have to add the parent path - that is hard to understand
  *
  * Path must be string.
- * Path must match minimum one / or \
+ * Path must be valid based on character match. REGEX for valid path match came
+ *   from here: (https://github.com/jonschlinkert/is-invalid-path), MIT Licensed
  * Path can be a "." to re-present current folder
  */
 exports.makePathsAbsolute = function makePathsAbsolute(obj, parent) {
@@ -36,7 +37,7 @@ exports.makePathsAbsolute = function makePathsAbsolute(obj, parent) {
             makePathsAbsolute.bind(self)(configValue, parent + ':' + pathsKey);
         } else if (
             _.isString(configValue) &&
-            (configValue.match(/\/+|\\+/) || configValue === '.') &&
+            (!/['\"!#$%&+^<=>`]/.test(configValue) || configValue === '.') &&
             !path.isAbsolute(configValue)
         ) {
             self.set(parent + ':' + pathsKey, path.normalize(path.join(__dirname, '../../..', configValue)));

--- a/core/test/unit/config/utils_spec.js
+++ b/core/test/unit/config/utils_spec.js
@@ -77,5 +77,25 @@ describe('UNIT: Config utils', function () {
             changedKey[0][0].should.eql('database:filename');
             changedKey[0][1].should.not.eql('content\\data\\ghost.db');
         });
+
+        it('ensure it skips certificates', function () {
+            var changedKey = [],
+                obj = {
+                    database: {
+                        ssl: {
+                            ca: '-----BEGIN CERTIFICATE-----\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n-----END CERTIFICATE-----',
+                            key: '-----BEGIN RSA PRIVATE KEY-----\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n-----END RSA PRIVATE KEY-----',
+                            cert: '-----BEGIN CERTIFICATE-----\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=\n-----END CERTIFICATE-----'
+                        }
+                    }
+                };
+
+            this.set = function (key, value) {
+                changedKey.push([key, value]);
+            };
+
+            configUtils.makePathsAbsolute.bind(this)(obj.database, 'database');
+            changedKey.length.should.eql(0);
+        });
     });
 });


### PR DESCRIPTION
When connecting Ghost to MySQL over SSL the certificate needs to be added
into the ('config.' + `env` + '.json') file as a sting. Prior to this
change the installation path was being pre-pended to the `configValue`
object resulting in an error within the MySQL module.

Here's an example of the database configuration section being used.
``` json
{
  "database": {
    "client": "mysql",
    "connection": {
      "host": "0.0.0.0",
      "user": "XXX",
      "password": "XXXYYYZZZ",
      "database": "YYY",
      "ssl": {
        "rejectUnauthorized": false,
        "ca": "-----BEGIN CERTIFICATE-----\n...\n...\n-----END CERTIFICATE-----",
        "key": "-----BEGIN RSA PRIVATE KEY-----\n...\n...\n-----END RSA PRIVATE KEY-----",
        "cert": "-----BEGIN CERTIFICATE-----\n...\n...\n-----END CERTIFICATE-----"
      }
    }
  }
}
```

Passing these options into the config results in the following which
breaks the certificate parsing:
``` js
{ rejectUnauthorized: false,
  ca: '/var/www/PATH/test/versions/1.12.1/-----BEGIN CERTIFICATE-----\n./.\n-----END CERTIFICATE-----',
  key: '/var/www/PATH/test/versions/1.12.1/-----BEGIN RSA PRIVATE KEY-----\n./..\n./..\n-----END RSA PRIVATE KEY-----',
  cert: '/var/www/PATH/test/versions/1.12.1/-----BEGIN CERTIFICATE-----\n./..\n./..\n-----END CERTIFICATE-----' }
```

This change adds an additional match check looking for "-----BEGIN" or
"-----END"  within the `configValue` object which should be unique to
certificates found in config. With this correction ghost is able to
communicate to a database server using SSL.

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!
- [x] Commit message has a short title & issue references
- [x] Commits are squashed 
- [ ] The build will pass (run `npm test`).

More info can be found by clicking the "guidelines for contributing" link above.
