### PR TITLE
Bump Amperize to version 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": "^4.5.0 || ^6.9.0"
   },
   "dependencies": {
-    "amperize": "0.3.4",
+    "amperize": "0.3.5",
     "archiver": "1.3.0",
     "bcryptjs": "2.4.3",
     "bluebird": "3.5.0",


### PR DESCRIPTION
no issue

- bump `amperize` to 0.3.5 which fixes issues with images-size requests not following redirects, and image-size requests that caused errors leading to stop transforming the rest of the passed HTML.