### PR TITLE
 ✨ Support filtering based on primary_tag

### DIFF
--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -154,11 +154,11 @@ describe('Advanced Browse', function () {
             });
         });
 
-        describe('4. Posts - filter="author:[leslie,pat]+(tag:audio,image:-null)"', function () {
+        describe('4. Posts - filter="author:[leslie,pat]+(tag:hash-audio,image:-null)"', function () {
             // Note that `pat` doesn't exist (it's `pat-smith`)
-            it('Will fetch posts by the author `leslie` or `pat` which are either have tag `audio` or an image.', function (done) {
+            it('Will fetch posts by the author `leslie` or `pat` which are either have tag `hash-audio` or an image.', function (done) {
                 PostAPI.browse({
-                    filter: 'author:[leslie,pat]+(tag:audio,feature_image:-null)',
+                    filter: 'author:[leslie,pat]+(tag:hash-audio,feature_image:-null)',
                     include: 'author,tags'
                 }).then(function (result) {
                     var ids, authors;
@@ -177,7 +177,7 @@ describe('Advanced Browse', function () {
                     });
                     authors.should.matchAny(/leslie|pat/);
 
-                    // Each post must either be featured or have the tag 'audio'
+                    // Each post must either be featured or have the tag 'hash-audio'
                     _.each(result.posts, function (post) {
                         var tags = _.map(post.tags, 'slug');
                         // This construct ensures we get an assertion or a failure
@@ -185,7 +185,7 @@ describe('Advanced Browse', function () {
                             post.feature_image.should.not.be.empty();
                         } else {
                             tags = _.map(post.tags, 'slug');
-                            tags.should.containEql('audio');
+                            tags.should.containEql('hash-audio');
                         }
                     });
 
@@ -391,7 +391,7 @@ describe('Advanced Browse', function () {
                 }).count.posts.should.eql(5);
 
                 _.find(result.tags, function (tag) {
-                    return tag.name === 'Audio';
+                    return tag.name === '#Audio';
                 }).count.posts.should.eql(6);
 
                 _.find(result.tags, function (tag) {
@@ -443,7 +443,7 @@ describe('Advanced Browse', function () {
                 }).count.posts.should.eql(5);
 
                 _.find(result.tags, function (tag) {
-                    return tag.name === 'Audio';
+                    return tag.name === '#Audio';
                 }).count.posts.should.eql(6);
 
                 _.find(result.tags, function (tag) {

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -365,6 +365,107 @@ describe('Advanced Browse', function () {
         });
     });
 
+    describe('Primary Tags', function () {
+        it('Will fetch posts which have a primary tag of photo', function (done) {
+            PostAPI.browse({
+                filter: 'primary_tag:photo',
+                include: 'tags'
+            }).then(function (result) {
+                var ids;
+
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                // 2. The data part of the response should be correct
+                // We should have 5 matching items
+                result.posts.should.be.an.Array().with.lengthOf(4);
+
+                ids = _.map(result.posts, 'id');
+                ids.should.eql([
+                    testUtils.filterData.data.posts[10].id,
+                    testUtils.filterData.data.posts[8].id,
+                    testUtils.filterData.data.posts[2].id,
+                    testUtils.filterData.data.posts[1].id
+                ]);
+
+                _.each(result.posts, function (post) {
+                    post.page.should.be.false();
+                    post.status.should.eql('published');
+                });
+
+                // 3. The meta object should contain the right details
+                result.meta.should.have.property('pagination');
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.page.should.eql(1);
+                result.meta.pagination.limit.should.eql(15);
+                result.meta.pagination.pages.should.eql(1);
+                result.meta.pagination.total.should.eql(4);
+                should.equal(result.meta.pagination.next, null);
+                should.equal(result.meta.pagination.prev, null);
+
+                done();
+            }).catch(done);
+        });
+
+        it('Will fetch empty list if no post has matching primary-tag', function (done) {
+            PostAPI.browse({
+                filter: 'primary_tag:no-posts',
+                include: 'tags'
+            }).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                // 2. The data part of the response should be correct
+                // We should have 5 matching items
+                result.posts.should.be.an.Array().with.lengthOf(0);
+
+                // 3. The meta object should contain the right details
+                result.meta.should.have.property('pagination');
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.page.should.eql(1);
+                result.meta.pagination.limit.should.eql(15);
+                result.meta.pagination.pages.should.eql(1);
+                result.meta.pagination.total.should.eql(0);
+                should.equal(result.meta.pagination.next, null);
+                should.equal(result.meta.pagination.prev, null);
+
+                done();
+            }).catch(done);
+        });
+
+        it('Will fetch empty list if primary_tag is internal', function (done) {
+            PostAPI.browse({
+                filter: 'primary_tag:no-posts',
+                include: 'tags'
+            }).then(function (result) {
+                // 1. Result should have the correct base structure
+                should.exist(result);
+                result.should.have.property('posts');
+                result.should.have.property('meta');
+
+                // 2. The data part of the response should be correct
+                // We should have 5 matching items
+                result.posts.should.be.an.Array().with.lengthOf(0);
+
+                // 3. The meta object should contain the right details
+                result.meta.should.have.property('pagination');
+                result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                result.meta.pagination.page.should.eql(1);
+                result.meta.pagination.limit.should.eql(15);
+                result.meta.pagination.pages.should.eql(1);
+                result.meta.pagination.total.should.eql(0);
+                should.equal(result.meta.pagination.next, null);
+                should.equal(result.meta.pagination.prev, null);
+
+                done();
+            }).catch(done);
+        });
+    });
+
     describe('Count capabilities', function () {
         it('can fetch `count.posts` for tags (public data only)', function (done) {
             TagAPI.browse({include: 'count.posts'}).then(function (result) {

--- a/core/test/unit/models_plugins/filter_spec.js
+++ b/core/test/unit/models_plugins/filter_spec.js
@@ -167,7 +167,8 @@ describe('Filter', function () {
                 fetchSpy = sandbox.stub(ghostBookshelf.Model.prototype, 'fetchAndCombineFilters');
                 filterGQL.knexify = sandbox.stub();
                 filterGQL.json = {
-                    printStatements: sandbox.stub()
+                    printStatements: sandbox.stub(),
+                    replaceStatements: sandbox.stub().returnsArg(0)
                 };
 
                 restoreGQL = filter.__set__('gql', filterGQL);
@@ -226,8 +227,12 @@ describe('Filter', function () {
             });
         });
 
+        describe('Pre Process Filters', function () {
+            it('should not have tests yet, as this needs to be removed');
+        });
+
         describe('Post Process Filters', function () {
-            it('should not have tests yet, as this is about to be removed');
+            it('should not have tests yet, as this needs to be removed');
         });
     });
 

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -358,6 +358,19 @@ DataGenerator.forKnex = (function () {
         });
     }
 
+    function createTag(overrides) {
+        var newObj = _.cloneDeep(overrides);
+
+        return _.defaults(newObj, {
+            id: ObjectId.generate(),
+            visibility: 'public',
+            created_by: DataGenerator.Content.users[0].id,
+            created_at: new Date(),
+            updated_by: DataGenerator.Content.users[0].id,
+            updated_at: new Date()
+        });
+    }
+
     function createPost(overrides) {
         var newObj = _.cloneDeep(overrides),
             mobiledoc = JSON.parse(overrides.mobiledoc || '{}');
@@ -521,11 +534,11 @@ DataGenerator.forKnex = (function () {
     ];
 
     tags = [
-        createBasic(DataGenerator.Content.tags[0]),
-        createBasic(DataGenerator.Content.tags[1]),
-        createBasic(DataGenerator.Content.tags[2]),
-        createBasic(DataGenerator.Content.tags[3]),
-        createBasic(DataGenerator.Content.tags[4])
+        createTag(DataGenerator.Content.tags[0]),
+        createTag(DataGenerator.Content.tags[1]),
+        createTag(DataGenerator.Content.tags[2]),
+        createTag(DataGenerator.Content.tags[3]),
+        createTag(DataGenerator.Content.tags[4])
     ];
 
     roles = [
@@ -616,7 +629,7 @@ DataGenerator.forKnex = (function () {
     return {
         createPost: createPost,
         createGenericPost: createGenericPost,
-        createTag: createBasic,
+        createTag: createTag,
         createUser: createUser,
         createClient: createClient,
         createGenericUser: createGenericUser,

--- a/core/test/utils/fixtures/filter-param/index.js
+++ b/core/test/utils/fixtures/filter-param/index.js
@@ -59,10 +59,11 @@ data.tags = [
     },
     {
         id: ObjectId.generate(),
-        name: 'Audio',
-        slug: 'audio',
+        name: '#Audio',
+        slug: 'hash-audio',
         feature_image: 'some/image/path.jpg',
         description: 'Audio posts',
+        visibility: 'internal',
         created_by: data.users[0].id
     },
     {
@@ -308,7 +309,7 @@ function createUsers(knex, DataGenerator) {
 
 function createTags(knex, DataGenerator) {
     data.tags = _.map(data.tags, function (tag) {
-        return DataGenerator.forKnex.createBasic(tag);
+        return DataGenerator.forKnex.createTag(tag);
     });
 
     // Next, insert it into the database & return the correctly indexed data

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "express-hbs": "1.0.4",
     "extract-zip-fork": "1.5.1",
     "fs-extra": "3.0.1",
-    "ghost-gql": "0.0.6",
+    "ghost-gql": "0.0.8",
     "ghost-ignition": "2.8.14",
     "ghost-storage-base": "0.0.1",
     "glob": "5.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,9 +1745,9 @@ getsetdeep@~2.0.0:
   dependencies:
     typechecker "~2.0.1"
 
-ghost-gql@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/ghost-gql/-/ghost-gql-0.0.6.tgz#be811bc95f8f72671009c33100fc85d2d02758ee"
+ghost-gql@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ghost-gql/-/ghost-gql-0.0.8.tgz#630410cf1f71ccffbdab3d9d01419981c794b0ce"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
closes #8668, refs #8920
Requires: https://github.com/TryGhost/GQL/pull/33

Before this is merged, we need to merge the change to GQL and release a new version, then update this in Ghost.

-----

## What's going on here?

In Ghost, we now have a concept of `primary_tag`. For the time being at least, this is a computed, not stored property, computed in the `toJSON()` function of the post model. 

Logically, the primary tag is the first tag in the list, IF that tag is public. If the tag is an internal tag, then the post does not have a primary tag.

Ghost's API filtering allows us to do things like `filter="tag:{{primary_tag.slug}}`, which will return all posts that have the same tag as the current post's primary tag. This is very useful but we want to go one step farther and be able to do `filter="primary_tag:{{primary_tag.slug}}` in order to build lists of posts which all have the same primary tag.

However, because filtering translates to SQL statements, this won't work, as there is no field called `primary_tag` on the post table. 

Therefore, in order to be able to filter based on `primary_tag` we need to translate `primary_tag` into logic that can be performed in SQL before we run the statement against the database.

The current filtering logic has a `postProcessFilters` function, which is used to handle similar logic for joins, however it is very tricky to do field aliasing after the fact when the statements have already been translated into a knex querybuilder object.

Instead, I've added `preProcessFilters` which allows us to run the query through a lodash-esque replace function, which replaces `primary_tag` with the grouped logic for "first tag if that tag is public".

There's no doubt about it, this is ugly. 

It introduces an automatic limitation in the filtering logic, whereby you can ONLY filter based on the primary tag, and not also based on other tags. For now, this limitation is acceptable. 

## In future

It may be that in future we need to add a `primary_tag_id` to the post table in order to truly simplify this.

Long term we _already_ know that our first implementation of GQL was not quite right, and there is an overhaul on the cards that will help to reduce these complexities.

Short term, this achieves `filter="primary_tag:{{primary_tag.slug}}` which can be combined with any non-tag based filters, to allow some pretty fun stuff.
