### PR TITLE
🐛 Fixed showing "theme missing" error incorrectly

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -107,7 +107,8 @@
             "themehandler": {
                 "missingTheme": "The currently active theme \"{theme}\" is missing.",
                 "invalidTheme": "The currently active theme \"{theme}\" is invalid.",
-                "themeHasErrors": "The currently active theme \"{theme}\" has errors, but will still work."
+                "themeHasErrors": "The currently active theme \"{theme}\" has errors, but will still work.",
+                "activateFailed": "Unable to activate the theme \"{theme}\"."
             },
             "redirects": {
                 "register": "Could not register custom redirects."


### PR DESCRIPTION
closes #8222

- There are still some cases where Ghost shows "the currently active theme X is missing" when it isn't
- This is due to the error handling masking several cases
- This PR resolves that, ensuring errors from gscan and the underlying environment don't get masked
