### PR TITLE
Always use redirect301 for 301 redirects

### DIFF
--- a/core/server/blog/routes.js
+++ b/core/server/blog/routes.js
@@ -10,10 +10,10 @@ module.exports = function frontendRoutes() {
         routeKeywords = config.get('routeKeywords');
 
     // ### Admin routes
-    router.get(/^\/(logout|signout)\/$/, function (req, res) { return utils.url.adminRedirect(res, '#/signout/', true); });
-    router.get(/^\/signup\/$/, function (req, res) { return utils.url.adminRedirect(res, '#/signup/', true); });
+    router.get(/^\/(logout|signout)\/$/, function (req, res) { return utils.url.redirectToAdmin(res, '#/signout/', true); });
+    router.get(/^\/signup\/$/, function (req, res) { return utils.url.redirectToAdmin(res, '#/signup/', true); });
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
-    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) { return utils.url.adminRedirect(res, '/', true); });
+    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) { return utils.url.redirectToAdmin(res, '/', true); });
 
     // Post Live Preview
     router.get(utils.url.urlJoin('/', routeKeywords.preview, ':uuid', ':options?'), controllers.preview);

--- a/core/server/blog/routes.js
+++ b/core/server/blog/routes.js
@@ -10,10 +10,10 @@ module.exports = function frontendRoutes() {
         routeKeywords = config.get('routeKeywords');
 
     // ### Admin routes
-    router.get(/^\/(logout|signout)\/$/, function (req, res) { return utils.url.redirectToAdmin(res, '#/signout/', true); });
-    router.get(/^\/signup\/$/, function (req, res) { return utils.url.redirectToAdmin(res, '#/signup/', true); });
+    router.get(/^\/(logout|signout)\/$/, function (req, res) { return utils.url.redirectToAdmin(301, res, '#/signout/'); });
+    router.get(/^\/signup\/$/, function (req, res) { return utils.url.redirectToAdmin(301, res, '#/signup/'); });
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
-    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) { return utils.url.redirectToAdmin(res, '/', true); });
+    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) { return utils.url.redirectToAdmin(301, res, '/'); });
 
     // Post Live Preview
     router.get(utils.url.urlJoin('/', routeKeywords.preview, ':uuid', ':options?'), controllers.preview);

--- a/core/server/blog/routes.js
+++ b/core/server/blog/routes.js
@@ -10,17 +10,10 @@ module.exports = function frontendRoutes() {
         routeKeywords = config.get('routeKeywords');
 
     // ### Admin routes
-    router.get(/^\/(logout|signout)\/$/, function redirectToSignout(req, res) {
-        utils.redirect301(res, utils.url.urlJoin(utils.url.urlFor('admin'), '#/signout/'));
-    });
-    router.get(/^\/signup\/$/, function redirectToSignup(req, res) {
-        utils.redirect301(res, utils.url.urlJoin(utils.url.urlFor('admin'), '#/signup/'));
-    });
-
+    router.get(/^\/(logout|signout)\/$/, function (req, res) { return utils.url.adminRedirect(res, '#/signout/', true); });
+    router.get(/^\/signup\/$/, function (req, res) { return utils.url.adminRedirect(res, '#/signup/', true); });
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
-    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function redirectToAdmin(req, res) {
-        utils.redirect301(res, utils.url.urlFor('admin'));
-    });
+    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, function (req, res) { return utils.url.adminRedirect(res, '/', true); });
 
     // Post Live Preview
     router.get(utils.url.urlJoin('/', routeKeywords.preview, ':uuid', ':options?'), controllers.preview);

--- a/core/server/controllers/frontend/channel-config.js
+++ b/core/server/controllers/frontend/channel-config.js
@@ -24,7 +24,7 @@ channelConfig = function channelConfig() {
                 }
             },
             slugTemplate: true,
-            editRedirect: utils.url.urlJoin(utils.url.urlFor('admin'), '#/settings/tags/:slug/')
+            editRedirect: '#/settings/tags/:slug/'
         },
         author: {
             name: 'author',
@@ -40,7 +40,7 @@ channelConfig = function channelConfig() {
                 }
             },
             slugTemplate: true,
-            editRedirect: utils.url.urlJoin(utils.url.urlFor('admin'), '#/team/:slug/')
+            editRedirect: '#/team/:slug/'
         }
     };
 

--- a/core/server/controllers/frontend/channels.js
+++ b/core/server/controllers/frontend/channels.js
@@ -86,7 +86,7 @@ channelRouter = function router() {
 
         if (channel.editRedirect) {
             channelRouter.get('/edit/', function redirect(req, res) {
-                res.redirect(utils.url.urlJoin(utils.url.getSubdir(), channel.editRedirect.replace(':slug', req.params.slug)));
+                utils.url.redirectToAdmin(302, res, channel.editRedirect.replace(':slug', req.params.slug));
             });
         }
 

--- a/core/server/controllers/frontend/channels.js
+++ b/core/server/controllers/frontend/channels.js
@@ -19,9 +19,9 @@ function handlePageParam(req, res, next, page) {
     if (page === 1) {
         // Page 1 is an alias, do a permanent 301 redirect
         if (rssRegex.test(req.url)) {
-            return utils.redirect301(res, req.originalUrl.replace(rssRegex, '/rss/'));
+            return utils.url.redirect301(res, req.originalUrl.replace(rssRegex, '/rss/'));
         } else {
-            return utils.redirect301(res, req.originalUrl.replace(pageRegex, '/'));
+            return utils.url.redirect301(res, req.originalUrl.replace(pageRegex, '/'));
         }
     } else if (page < 1 || isNaN(page)) {
         // Nothing less than 1 is a valid page number, go straight to a 404
@@ -47,7 +47,7 @@ rssRouter = function rssRouter(channelConfig) {
     router.get(baseRoute, stack);
     router.get(utils.url.urlJoin(baseRoute, ':page(\\d+)/'), stack);
     router.get('/feed/', function redirectToRSS(req, res) {
-        return utils.redirect301(res, utils.url.urlJoin(utils.url.getSubdir(), req.baseUrl, baseRoute));
+        return utils.url.redirect301(res, utils.url.urlJoin(utils.url.getSubdir(), req.baseUrl, baseRoute));
     });
 
     router.param('page', handlePageParam);

--- a/core/server/controllers/preview.js
+++ b/core/server/controllers/preview.js
@@ -21,7 +21,7 @@ module.exports = function preview(req, res, next) {
 
         if (req.params.options && req.params.options.toLowerCase() === 'edit') {
             // CASE: last param is of url is /edit, redirect to admin
-            return utils.url.redirectToAdmin(res, '#/editor/' + post.id);
+            return utils.url.redirectToAdmin(302, res, '#/editor/' + post.id);
         } else if (req.params.options) {
             // CASE: unknown options param detected. Ignore and end in 404.
             return next();

--- a/core/server/controllers/preview.js
+++ b/core/server/controllers/preview.js
@@ -21,7 +21,7 @@ module.exports = function preview(req, res, next) {
 
         if (req.params.options && req.params.options.toLowerCase() === 'edit') {
             // CASE: last param is of url is /edit, redirect to admin
-            return utils.url.adminRedirect(res, '#/editor/' + post.id);
+            return utils.url.redirectToAdmin(res, '#/editor/' + post.id);
         } else if (req.params.options) {
             // CASE: unknown options param detected. Ignore and end in 404.
             return next();

--- a/core/server/controllers/preview.js
+++ b/core/server/controllers/preview.js
@@ -21,14 +21,14 @@ module.exports = function preview(req, res, next) {
 
         if (req.params.options && req.params.options.toLowerCase() === 'edit') {
             // CASE: last param is of url is /edit, redirect to admin
-            return res.redirect(utils.url.urlJoin(utils.url.urlFor('admin'), 'editor', post.id, '/'));
+            return utils.url.adminRedirect(res, '#/editor/' + post.id);
         } else if (req.params.options) {
             // CASE: unknown options param detected. Ignore and end in 404.
             return next();
         }
 
         if (post.status === 'published') {
-            return res.redirect(301, utils.url.urlFor('post', {post: post}));
+            return utils.url.redirect301(res, utils.url.urlFor('post', {post: post}));
         }
 
         setRequestIsSecure(req, post);

--- a/core/server/controllers/single.js
+++ b/core/server/controllers/single.js
@@ -21,7 +21,7 @@ module.exports = function single(req, res, next) {
 
         // CASE: last param is of url is /edit, redirect to admin
         if (lookup.isEditURL) {
-            return utils.url.adminRedirect(res, '#/editor/' + post.id);
+            return utils.url.redirectToAdmin(res, '#/editor/' + post.id);
         }
 
         // CASE: permalink is not valid anymore, we redirect him permanently to the correct one

--- a/core/server/controllers/single.js
+++ b/core/server/controllers/single.js
@@ -21,7 +21,7 @@ module.exports = function single(req, res, next) {
 
         // CASE: last param is of url is /edit, redirect to admin
         if (lookup.isEditURL) {
-            return utils.url.redirectToAdmin(res, '#/editor/' + post.id);
+            return utils.url.redirectToAdmin(302, res, '#/editor/' + post.id);
         }
 
         // CASE: permalink is not valid anymore, we redirect him permanently to the correct one

--- a/core/server/controllers/single.js
+++ b/core/server/controllers/single.js
@@ -21,12 +21,12 @@ module.exports = function single(req, res, next) {
 
         // CASE: last param is of url is /edit, redirect to admin
         if (lookup.isEditURL) {
-            return res.redirect(utils.url.urlJoin(utils.url.urlFor('admin'), 'editor', post.id, '/'));
+            return utils.url.adminRedirect(res, '#/editor/' + post.id);
         }
 
         // CASE: permalink is not valid anymore, we redirect him permanently to the correct one
         if (post.url !== req.path) {
-            return res.redirect(301, post.url);
+            return utils.url.redirect301(res, post.url);
         }
 
         setRequestIsSecure(req, post);

--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -7,12 +7,12 @@
 // @TODO optimise this to reduce the number of redirects required to get to a pretty URL
 // @TODO move this to being used by routers?
 var slashes = require('connect-slashes'),
-    utils = require('../utils');
+    config = require('../config');
 
 module.exports = [
     slashes(true, {
         headers: {
-            'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S
+            'Cache-Control': 'public, max-age=' + config.get('caching:301:maxAge')
         }
     }),
     require('./uncapitalise')

--- a/core/server/middleware/uncapitalise.js
+++ b/core/server/middleware/uncapitalise.js
@@ -39,8 +39,7 @@ uncapitalise = function uncapitalise(req, res, next) {
           utils.removeOpenRedirectFromUrl((req.originalUrl || req.url).replace(pathToTest, pathToTest.toLowerCase()))
         );
 
-        res.set('Cache-Control', 'public, max-age=' + utils.ONE_YEAR_S);
-        res.redirect(301, redirectPath);
+        return utils.url.redirect301(res, redirectPath);
     } else {
         next();
     }

--- a/core/server/middleware/url-redirects.js
+++ b/core/server/middleware/url-redirects.js
@@ -102,7 +102,7 @@ urlRedirects = function urlRedirects(req, res, next) {
 
     if (redirectUrl) {
         debug('url redirect to: ' + redirectUrl);
-        return res.redirect(301, redirectUrl);
+        return utils.url.redirect301(res, redirectUrl);
     }
 
     debug('no url redirect');

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -1,6 +1,5 @@
 var unidecode  = require('unidecode'),
     _          = require('lodash'),
-    config = require('../config'),
     errors = require('../errors'),
     i18n = require('../i18n'),
     utils,
@@ -107,12 +106,6 @@ utils = {
             base64String += '=';
         }
         return base64String;
-    },
-
-    redirect301: function redirect301(res, path) {
-        /*jslint unparam:true*/
-        res.set({'Cache-Control': 'public, max-age=' + config.get('caching:301:maxAge')});
-        res.redirect(301, path);
     },
 
     /**

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -354,10 +354,10 @@ function redirect301(res, redirectUrl) {
     return res.redirect(301, redirectUrl);
 }
 
-function redirectToAdmin(res, adminPath, permanent) {
+function redirectToAdmin(status, res, adminPath) {
     var redirectUrl = urlJoin(urlFor('admin'), adminPath, '/');
 
-    if (permanent) {
+    if (status === 301) {
         return redirect301(res, redirectUrl);
     }
     return res.redirect(redirectUrl);

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -349,12 +349,28 @@ function isSSL(urlToParse) {
     return protocol === 'https:';
 }
 
+function redirect301(res, redirectUrl) {
+    res.set({'Cache-Control': 'public, max-age=' + config.get('caching:301:maxAge')});
+    return res.redirect(301, redirectUrl);
+}
+
+function adminRedirect(res, adminPath, permanent) {
+    var redirectUrl = urlJoin(urlFor('admin'), adminPath, '/');
+
+    if (permanent) {
+        return redirect301(res, redirectUrl);
+    }
+    return res.redirect(redirectUrl);
+}
+
 module.exports.getProtectedSlugs = getProtectedSlugs;
 module.exports.getSubdir = getSubdir;
 module.exports.urlJoin = urlJoin;
 module.exports.urlFor = urlFor;
 module.exports.isSSL = isSSL;
 module.exports.urlPathForPost = urlPathForPost;
+module.exports.adminRedirect = adminRedirect;
+module.exports.redirect301 = redirect301;
 
 /**
  * If you request **any** image in Ghost, it get's served via

--- a/core/server/utils/url.js
+++ b/core/server/utils/url.js
@@ -354,7 +354,7 @@ function redirect301(res, redirectUrl) {
     return res.redirect(301, redirectUrl);
 }
 
-function adminRedirect(res, adminPath, permanent) {
+function redirectToAdmin(res, adminPath, permanent) {
     var redirectUrl = urlJoin(urlFor('admin'), adminPath, '/');
 
     if (permanent) {
@@ -369,7 +369,7 @@ module.exports.urlJoin = urlJoin;
 module.exports.urlFor = urlFor;
 module.exports.isSSL = isSSL;
 module.exports.urlPathForPost = urlPathForPost;
-module.exports.adminRedirect = adminRedirect;
+module.exports.redirectToAdmin = redirectToAdmin;
 module.exports.redirect301 = redirect301;
 
 /**

--- a/core/test/functional/routes/api/public_api_spec.js
+++ b/core/test/functional/routes/api/public_api_spec.js
@@ -94,7 +94,8 @@ describe('Public API', function () {
 
         request.get(testUtils.API.getApiQuery('posts?client_id=ghost-test&client_secret=not_available'))
             .set('Origin', 'https://example.com')
-            .expect('Cache-Control', testUtils.cacheRules.private)
+            // 301 Redirects _should_ be cached
+            .expect('Cache-Control', testUtils.cacheRules.year)
             .expect(301)
             .end(function (err, res) {
                 if (err) {

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -263,7 +263,7 @@ describe('Frontend Routing', function () {
 
                 it('should redirect to editor', function (done) {
                     request.get('/welcome/edit/')
-                        .expect('Location', /ghost\/editor\/\w+/)
+                        .expect('Location', /ghost\/#\/editor\/\w+/)
                         .expect('Cache-Control', testUtils.cacheRules.public)
                         .expect(302)
                         .end(doEnd(done));
@@ -412,7 +412,7 @@ describe('Frontend Routing', function () {
 
                 it('should redirect to editor', function (done) {
                     request.get('/static-page-test/edit/')
-                        .expect('Location', /ghost\/editor\/\w+/)
+                        .expect('Location', /ghost\/#\/editor\/\w+/)
                         .expect('Cache-Control', testUtils.cacheRules.public)
                         .expect(302)
                         .end(doEnd(done));
@@ -473,7 +473,7 @@ describe('Frontend Routing', function () {
                 request.get('/p/2ac6b4f6-e1f3-406c-9247-c94a0496d39d/')
                     .expect(301)
                     .expect('Location', '/short-and-sweet/')
-                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .expect('Cache-Control', testUtils.cacheRules.year)
                     .end(doEnd(done));
             });
 

--- a/core/test/unit/controllers/preview_spec.js
+++ b/core/test/unit/controllers/preview_spec.js
@@ -115,7 +115,8 @@ describe('Controllers', function () {
             res = {
                 locals: {},
                 render: sinon.spy(),
-                redirect: sinon.spy()
+                redirect: sinon.spy(),
+                set: sinon.spy()
             };
         });
 
@@ -152,6 +153,7 @@ describe('Controllers', function () {
                 should.not.exist(err);
                 res.render.called.should.be.false();
                 res.redirect.called.should.be.false();
+                res.set.called.should.be.false();
 
                 done();
             });
@@ -161,6 +163,7 @@ describe('Controllers', function () {
             req.params = {uuid: 'abc-1234-03'};
             res.redirect = function (status, url) {
                 res.render.called.should.be.false();
+                res.set.called.should.be.true();
                 status.should.eql(301);
                 url.should.eql('/getting-started/');
 
@@ -174,7 +177,8 @@ describe('Controllers', function () {
             req.params = {uuid: 'abc-1234-01', options: 'edit'};
             res.redirect = function (url) {
                 res.render.called.should.be.false();
-                url.should.eql('/ghost/editor/1/');
+                res.set.called.should.be.false();
+                url.should.eql('/ghost/#/editor/1/');
 
                 done();
             };
@@ -189,6 +193,7 @@ describe('Controllers', function () {
                 should.not.exist(err);
                 res.render.called.should.be.false();
                 res.redirect.called.should.be.false();
+                res.set.called.should.be.false();
 
                 done();
             });

--- a/core/test/unit/controllers/single_spec.js
+++ b/core/test/unit/controllers/single_spec.js
@@ -17,7 +17,7 @@ var should = require('should'),
     sandbox = sinon.sandbox.create();
 
 describe('Controllers', function () {
-    var adminEditPagePath = '/ghost/editor/',
+    var adminEditPagePath = '/ghost/#/editor/',
         localSettingsCache = {},
         hasTemplateStub;
 

--- a/core/test/unit/middleware/url-redirects_spec.js
+++ b/core/test/unit/middleware/url-redirects_spec.js
@@ -15,7 +15,8 @@ describe('UNIT: url redirects', function () {
             }
         };
         res = {
-            redirect: sandbox.spy()
+            redirect: sandbox.spy(),
+            set: sandbox.spy()
         };
 
         next = sandbox.spy();
@@ -38,6 +39,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         next.calledWith().should.be.true();
         done();
     });
@@ -54,6 +56,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         next.calledWith().should.be.true();
         done();
     });
@@ -70,6 +73,7 @@ describe('UNIT: url redirects', function () {
         next.called.should.be.false();
         res.redirect.called.should.be.true();
         res.redirect.calledWith(301, 'https://default.com:2368/').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -85,6 +89,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         done();
     });
 
@@ -100,6 +105,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         done();
     });
 
@@ -115,6 +121,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         done();
     });
 
@@ -130,6 +137,7 @@ describe('UNIT: url redirects', function () {
         next.called.should.be.false();
         res.redirect.called.should.be.true();
         res.redirect.calledWith(301, 'https://localhost:2368/').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -145,6 +153,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         done();
     });
 
@@ -160,6 +169,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.true();
         res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         done();
     });
 
@@ -178,6 +188,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://default.com:2368/ghost/').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -196,6 +207,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -214,11 +226,14 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/blog/ghost/').should.be.true();
+        res.set.called.should.be.true();
 
         req.secure = true;
         host = 'admin.default.com:2368';
         urlRedirects(req, res, next);
         next.called.should.be.true();
+        res.redirect.calledOnce.should.be.true();
+        res.set.calledOnce.should.be.true();
         done();
     });
 
@@ -241,6 +256,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/?test=true').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -263,6 +279,7 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://admin.default.com:2368/ghost/something/?a=b').should.be.true();
+        res.set.called.should.be.true();
         done();
     });
 
@@ -281,9 +298,12 @@ describe('UNIT: url redirects', function () {
         urlRedirects(req, res, next);
         next.called.should.be.false();
         res.redirect.calledWith(301, 'https://default.com:2368/ghost/').should.be.true();
+        res.set.called.should.be.true();
 
         req.secure = true;
         urlRedirects(req, res, next);
+        res.redirect.calledOnce.should.be.true();
+        res.set.calledOnce.should.be.true();
         next.called.should.be.true();
         done();
     });
@@ -302,6 +322,8 @@ describe('UNIT: url redirects', function () {
 
         req.originalUrl = '/ghost';
         urlRedirects(req, res, next);
+        res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         next.called.should.be.true();
         done();
     });
@@ -320,6 +342,9 @@ describe('UNIT: url redirects', function () {
 
         req.originalUrl = '/ghost';
         urlRedirects(req, res, next);
+
+        res.redirect.called.should.be.false();
+        res.set.called.should.be.false();
         next.called.should.be.true();
         done();
     });

--- a/core/test/unit/server_utils_spec.js
+++ b/core/test/unit/server_utils_spec.js
@@ -1,5 +1,4 @@
 var should = require('should'), // jshint ignore:line
-    sinon = require('sinon'),
     nock = require('nock'),
     configUtils = require('../utils/configUtils'),
     gravatar = require('../../server/utils/gravatar'),
@@ -143,24 +142,6 @@ describe('Server Utilities', function () {
                 should.not.exist(result);
                 done();
             }).catch(done);
-        });
-    });
-
-    describe('redirect301', function () {
-        it('performs a 301 correctly', function (done) {
-            var res = {};
-
-            res.set = sinon.spy();
-
-            res.redirect = function (code, path) {
-                code.should.equal(301);
-                path.should.eql('my/awesome/path');
-                res.set.calledWith({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}).should.be.true();
-
-                done();
-            };
-
-            utils.redirect301(res, 'my/awesome/path');
         });
     });
 });

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -576,4 +576,53 @@ describe('Url', function () {
             utils.url.urlPathForPost(testData).should.equal(postLink);
         });
     });
+
+    describe('redirects', function () {
+        it('performs 301 redirect correctly', function (done) {
+            var res = {};
+
+            res.set = sinon.spy();
+
+            res.redirect = function (code, path) {
+                code.should.equal(301);
+                path.should.eql('my/awesome/path');
+                res.set.calledWith({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}).should.be.true();
+
+                done();
+            };
+
+            utils.url.redirect301(res, 'my/awesome/path');
+        });
+
+        it('performs an admin 301 redirect correctly', function (done) {
+            var res = {};
+
+            res.set = sinon.spy();
+
+            res.redirect = function (code, path) {
+                code.should.equal(301);
+                path.should.eql('/ghost/#/my/awesome/path/');
+                res.set.calledWith({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}).should.be.true();
+
+                done();
+            };
+
+            utils.url.adminRedirect(res, '#/my/awesome/path', true);
+        });
+
+        it('performs an admin 302 redirect correctly', function (done) {
+            var res = {};
+
+            res.set = sinon.spy();
+
+            res.redirect = function (path) {
+                path.should.eql('/ghost/#/my/awesome/path/');
+                res.set.called.should.be.false();
+
+                done();
+            };
+
+            utils.url.adminRedirect(res, '#/my/awesome/path');
+        });
+    });
 });

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -607,7 +607,7 @@ describe('Url', function () {
                 done();
             };
 
-            utils.url.redirectToAdmin(res, '#/my/awesome/path', true);
+            utils.url.redirectToAdmin(301, res, '#/my/awesome/path');
         });
 
         it('performs an admin 302 redirect correctly', function (done) {
@@ -622,7 +622,7 @@ describe('Url', function () {
                 done();
             };
 
-            utils.url.redirectToAdmin(res, '#/my/awesome/path');
+            utils.url.redirectToAdmin(302, res, '#/my/awesome/path');
         });
     });
 });

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -607,7 +607,7 @@ describe('Url', function () {
                 done();
             };
 
-            utils.url.adminRedirect(res, '#/my/awesome/path', true);
+            utils.url.redirectToAdmin(res, '#/my/awesome/path', true);
         });
 
         it('performs an admin 302 redirect correctly', function (done) {
@@ -622,7 +622,7 @@ describe('Url', function () {
                 done();
             };
 
-            utils.url.adminRedirect(res, '#/my/awesome/path');
+            utils.url.redirectToAdmin(res, '#/my/awesome/path');
         });
     });
 });


### PR DESCRIPTION
This PR started out as me trying to simplify the code in `/blog/routes.js`. As I did that, I realised that `utils.redirect301` wasn't always being used.

Therefore, the core concern in this PR is now changing our codebase to _always_ use that util, and moving it into utils.url as it is very strongly related to URL generation.

The only exception now is the custom redirects handler, which has it's own max-age setting & it's own redirect handling.

This PR irons out a few weirdnesses with the following rule:

> All 301 requests should be cached with the configured 301 max-age config

This includes preview redirects and redirects in the API layer. It's only the 301 that gets cached, not the result of the API request. Tests that were set incorrectly had to be fixed.

Secondarily, this PR adds a new `adminRedirect` util that saves us from needing to do the same line of `urlJoin` and `urlFor` every time we want to redirect to the admin panel.

-----

no issue

- This started as an attempt to simplify the admin redirect code
- I realised we were sometimes using utils.redirect301 and sometimes not
- Decided to move this into utils.url as it's more relevant to URL generation
- Unified usage of redirects in the codebase
- Updated tests & ensured we have basic coverage

