### PR TITLE
🎨 Improve accessibility markup in default navigation.hbs partial

### DIFF
--- a/core/server/helpers/tpl/navigation.hbs
+++ b/core/server/helpers/tpl/navigation.hbs
@@ -1,5 +1,5 @@
-<ul class="nav">
+<ul class="nav" role="menu">
     {{#foreach navigation}}
-    <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}" role="presentation"><a href="{{url absolute="true"}}">{{label}}</a></li>
+    <li class="nav-{{slug}}{{#if current}} nav-current{{/if}}" role="menuitem"><a href="{{url absolute="true"}}">{{label}}</a></li>
     {{/foreach}}
 </ul>


### PR DESCRIPTION
refs #9135
- remove `role="presentation"` attribute from list items
- add explicit `menu` and `menuitem` roles to improve screen ready accessibility

Ideally this would also have a `<nav role="navigation">` wrapper around it but I think that would be too much of a breaking change and wouldn't fit with all themes.

The accessibility markup here is intentionally minimal as the `{{navigation}}` helper can be used anywhere in a theme, it will be up to theme developers to override it where appropriate to better fit their page structure and use case.