### PR TITLE
Update check module improvements for incoming errors

### DIFF
--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -167,9 +167,22 @@ function updateCheckRequest() {
                 res.on('end', function onEnd() {
                     try {
                         resData = JSON.parse(resData);
+
+                        if (res.statusCode !== 200 && res.statusCode !== 201) {
+                            // CASE: no notifications available, ignore
+                            if (res.statusCode === 404) {
+                                return resolve({
+                                    next_check: Math.round(Date.now() / 1000 + 24 * 3600),
+                                    notifications: []
+                                });
+                            }
+
+                            return reject(new errors.BadRequestError(res.statusCode + ':' + JSON.stringify(resData)));
+                        }
+
                         resolve(resData);
                     } catch (e) {
-                        reject(i18n.t('errors.update-check.unableToDecodeUpdateResponse.error'));
+                        reject(new errors.BadRequestError(i18n.t('errors.update-check.unableToDecodeUpdateResponse.error') + ':' + resData));
                     }
                 });
             });

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -39,11 +39,18 @@ var crypto   = require('crypto'),
     allowedCheckEnvironments = ['development', 'production'],
     currentVersion = config.ghostVersion;
 
+function nextCheckTimestamp() {
+    var now = Math.round(new Date().getTime() / 1000);
+    return now + (24 * 3600);
+}
+
 function updateCheckError(error) {
-    api.settings.edit(
-        {settings: [{key: 'nextUpdateCheck', value: Math.round(Date.now() / 1000 + 24 * 3600)}]},
-        internal
-    );
+    api.settings.edit({
+        settings: [{
+            key: 'nextUpdateCheck',
+            value: nextCheckTimestamp()
+        }]
+    }, internal);
 
     errors.logError(
         error,
@@ -172,7 +179,7 @@ function updateCheckRequest() {
                             // CASE: no notifications available, ignore
                             if (res.statusCode === 404) {
                                 return resolve({
-                                    next_check: Math.round(Date.now() / 1000 + 24 * 3600),
+                                    next_check: nextCheckTimestamp(),
                                     notifications: []
                                 });
                             }


### PR DESCRIPTION
refs #5071

- if Ghost received an error from the service e.g. no update notifications available
- we have to add a proper handling in Ghost
- e.g. we don't log 404, but we have to ensure we delay the next request to the service, otherwise we spam the service
- many more tests 🙏🏽