### PR TITLE
🐛 Fixed internal links converting to absolute URLs

### DIFF
--- a/core/server/apps/amp/tests/amp_content_spec.js
+++ b/core/server/apps/amp/tests/amp_content_spec.js
@@ -263,6 +263,29 @@ describe('{{amp_content}} helper', function () {
             }).catch(done);
         });
 
+        it('does not convert internal anchor links starting with "#"', function (done) {
+            var testData = {
+                    html: '<a href="#jumptosection">Table of Content</a>',
+                    updated_at: 'Wed Jul 27 2016 18:17:22 GMT+0200 (CEST)',
+                    id: 1
+                },
+                ampResult = ampContentHelper.call(testData),
+                sanitizedHTML,
+                ampedHTML;
+
+            ampResult.then(function (rendered) {
+                sanitizedHTML = ampContentHelper.__get__('cleanHTML');
+                ampedHTML = ampContentHelper.__get__('ampHTML');
+                should.exist(rendered);
+                rendered.string.should.equal('<a href="#jumptosection">Table of Content</a>');
+                should.exist(ampedHTML);
+                ampedHTML.should.be.equal('<a href="#jumptosection">Table of Content</a>');
+                should.exist(sanitizedHTML);
+                sanitizedHTML.should.be.equal('<a href="#jumptosection">Table of Content</a>');
+                done();
+            }).catch(done);
+        });
+
         it('sanitizes remaining and not valid tags', function (done) {
             var testData = {
                     html: '<form<input type="text" placeholder="Hi AMP tester"></form>' +

--- a/core/server/utils/make-absolute-urls.js
+++ b/core/server/utils/make-absolute-urls.js
@@ -41,6 +41,10 @@ function makeAbsoluteUrls(html, siteUrl, itemUrl) {
                 return;
             }
 
+            // CASE: don't convert internal links
+            if (attributeValue[0] === '#') {
+                return;
+            }
             // compose an absolute URL
 
             // if the relative URL begins with a '/' use the blog URL (including sub-directory)

--- a/core/test/unit/rss_spec.js
+++ b/core/test/unit/rss_spec.js
@@ -223,7 +223,7 @@ describe('RSS', function () {
                 should.exist(xmlData);
 
                 // anchor URL - <a href="#nowhere" title="Anchor URL">
-                xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/not-so-short-bit-complex\/#nowhere" title="Anchor URL">/);
+                xmlData.should.match(/<a href="#nowhere" title="Anchor URL">/);
 
                 // relative URL - <a href="/about#nowhere" title="Relative URL">
                 xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
@@ -258,7 +258,7 @@ describe('RSS', function () {
                 should.exist(xmlData);
 
                 // anchor URL - <a href="#nowhere" title="Anchor URL">
-                xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/blog\/not-so-short-bit-complex\/#nowhere" title="Anchor URL">/);
+                xmlData.should.match(/<a href="#nowhere" title="Anchor URL">/);
 
                 // relative URL - <a href="/about#nowhere" title="Relative URL">
                 xmlData.should.match(/<a href="http:\/\/my-ghost-blog.com\/blog\/about#nowhere" title="Relative URL">/);

--- a/core/test/unit/utils/make-absolute-urls_spec.js
+++ b/core/test/unit/utils/make-absolute-urls_spec.js
@@ -14,25 +14,31 @@ describe('Make absolute URLs ', function () {
         configUtils.restore();
     });
 
-    it('does not convert absolute URLs', function () {
+    it('[success] does not convert absolute URLs', function () {
         var html = '<a href="http://my-ghost-blog.com/content/images" title="Absolute URL">',
             result = makeAbsoluteUrls(html, siteUrl, itemUrl).html();
 
         result.should.match(/<a href="http:\/\/my-ghost-blog.com\/content\/images" title="Absolute URL">/);
     });
-    it('does not convert protocol relative `//` URLs', function () {
+    it('[failure] does not convert protocol relative `//` URLs', function () {
         var html = '<a href="//my-ghost-blog.com/content/images" title="Absolute URL">',
             result = makeAbsoluteUrls(html, siteUrl, itemUrl).html();
 
         result.should.match(/<a href="\/\/my-ghost-blog.com\/content\/images" title="Absolute URL">/);
     });
-    it('succesfully converts a relative URL', function () {
+    it('[failure] does not convert internal links starting with "#"', function () {
+        var html = '<a href="#jumptosection" title="Table of Content">',
+            result = makeAbsoluteUrls(html, siteUrl, itemUrl).html();
+
+        result.should.match(/<a href="#jumptosection" title="Table of Content">/);
+    });
+    it('[success] converts a relative URL', function () {
         var html = '<a href="/about#nowhere" title="Relative URL">',
             result = makeAbsoluteUrls(html, siteUrl, itemUrl).html();
 
         result.should.match(/<a href="http:\/\/my-ghost-blog.com\/about#nowhere" title="Relative URL">/);
     });
-    it('succesfully converts a relative URL including subdirectories', function () {
+    it('[success] converts a relative URL including subdirectories', function () {
         var html = '<a href="/about#nowhere" title="Relative URL">',
             result = makeAbsoluteUrls(html, 'http://my-ghost-blog.com/blog', itemUrl).html();
 


### PR DESCRIPTION
closes #9136

Changed the functionality in `make-absolute-urls.js` util to not convert the URL when starting which an `#`, as it indicates and internal link.
The util is used inside of the `{{amp_content}}` helper and to render the RSS feed. I tested the changes with the most popular RSS reader 'Feedly' and it seems like these internal links get converted to absolute URL inside of Feedly automatically.