### PR TITLE
HTML page error: correct templateData

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -84,6 +84,7 @@ function getAjaxHelper(clientId, clientSecret) {
 
 module.exports = function ghost_head(options) {
     debug('begin');
+
     // if server error page do nothing
     if (this.statusCode >= 500) {
         return;

--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -81,11 +81,13 @@ _private.HTMLErrorRenderer = function HTMLErrorRender(err, req, res, next) {
     }
 
     var templateData = {
-        message: err.message,
-        code: err.statusCode,
-        errorDetails: err.errorDetails || []
-    },
-    template = templates.error(err.statusCode);
+            message: err.message,
+            // @deprecated
+            code: err.statusCode,
+            statusCode: err.statusCode,
+            errorDetails: err.errorDetails || []
+        },
+        template = templates.error(err.statusCode);
 
     // It can be that something went wrong with the theme or otherwise loading handlebars
     // This ensures that no matter what res.render will work here


### PR DESCRIPTION
no issue

- `this.statusCode` was always undefined
- see HTML error handler
- it's hard to add a test for this case
- manual test only

Added `deprecated`, because error templates probably use `code`.