### PR TITLE
[WIP] Improved importer logic for password in users

### DIFF
--- a/core/server/data/importer/importers/data/users.js
+++ b/core/server/data/importer/importers/data/users.js
@@ -2,8 +2,7 @@
 
 const debug = require('ghost-ignition').debug('importer:users'),
     _ = require('lodash'),
-    BaseImporter = require('./base'),
-    globalUtils = require('../../../../utils');
+    BaseImporter = require('./base');
 
 class UsersImporter extends BaseImporter {
     constructor(options) {
@@ -43,7 +42,6 @@ class UsersImporter extends BaseImporter {
 
         if (importOptions.importPersistUser !== true) {
             _.each(this.dataToImport, function (model) {
-                model.password = globalUtils.uid(50);
                 if (model.status !== 'inactive') {
                     model.status = 'locked';
                 }


### PR DESCRIPTION
refs #9150

This PR changes the logic when importing users:
- don't set a default uid for every password so we're able to detect hashed passwords
- detect hashed password (hashed with Bcrypt, when used Ghost for export) and don't run into the validations. Already hashed passwords get re-hashed and stored
- run only non-hashed passwords through the password length validator. An invalid (=too short) password will cause the import to fail.
- in `importPersistUser` mode, don't run into validations and don't hash the password. Just take it exactly as provided.

Todos:
- [ ] More tests for these specific cases, especially `importPersistUser` mode (no test for this so far)