### PR TITLE
✨ Improved importer logic for passwords

### DIFF
--- a/core/server/data/importer/importers/data/users.js
+++ b/core/server/data/importer/importers/data/users.js
@@ -2,8 +2,7 @@
 
 const debug = require('ghost-ignition').debug('importer:users'),
     _ = require('lodash'),
-    BaseImporter = require('./base'),
-    globalUtils = require('../../../../utils');
+    BaseImporter = require('./base');
 
 class UsersImporter extends BaseImporter {
     constructor(options) {
@@ -29,7 +28,7 @@ class UsersImporter extends BaseImporter {
      *
      *   If importOptions object is supplied with a property of importPersistUser then the user status is not locked
      */
-    beforeImport(importOptions) {
+    beforeImport() {
         debug('beforeImport');
 
         let self = this, role, lookup = {};
@@ -40,15 +39,6 @@ class UsersImporter extends BaseImporter {
         });
 
         this.dataToImport = this.dataToImport.map(self.legacyMapper);
-
-        if (importOptions.importPersistUser !== true) {
-            _.each(this.dataToImport, function (model) {
-                model.password = globalUtils.uid(50);
-                if (model.status !== 'inactive') {
-                    model.status = 'locked';
-                }
-            });
-        }
 
         // NOTE: sort out duplicated roles based on incremental id
         _.each(this.roles_users, function (attachedRole) {


### PR DESCRIPTION
refs #9150

- move data manipulation for importing users from `importers/data/users` to `model/user` for more consistency (see behaviour of post imports)
- changed importing logic in `onSaving` fn for user model:
   - when importing, we set the password to a random uid and don't validate, just hash it and lock the user
   - when importing with `importPersistUser` we check if the password is a bcrypt hash already and fall back to normal behaviour if not (set random password, lock user, and hash password)
   - don't run validations when importing