### PR TITLE
🐛 Prevents xmlrpc pings happening on import

### DIFF
--- a/core/server/data/slack/index.js
+++ b/core/server/data/slack/index.js
@@ -43,15 +43,8 @@ function makeRequest(reqOptions, reqPayload) {
     req.end();
 }
 
-function ping(post, options) {
-    options = options || {};
-
+function ping(post) {
     var message, reqOptions;
-
-    // CASE: do not ping slack if we import a database
-    if (options.importing) {
-        return Promise.resolve();
-    }
 
     // If this is a post, we want to send the link of the post
     if (schema.isPost(post)) {
@@ -107,7 +100,13 @@ function ping(post, options) {
 }
 
 function listener(model, options) {
-    ping(model.toJSON(), options);
+    // CASE: do not ping slack if we import a database
+    // TODO: refactor post.published events to never fire on importing
+    if (options && options.importing) {
+        return;
+    }
+
+    ping(model.toJSON());
 }
 
 function testPing() {

--- a/core/server/data/xml/xmlrpc.js
+++ b/core/server/data/xml/xmlrpc.js
@@ -1,12 +1,13 @@
-var _               = require('lodash'),
-    http            = require('http'),
-    xml             = require('xml'),
-    config          = require('../../config'),
-    utils           = require('../../utils'),
-    errors          = require('../../errors'),
-    logging         = require('../../logging'),
-    events          = require('../../events'),
-    i18n            = require('../../i18n'),
+var _ = require('lodash'),
+    http = require('http'),
+    xml = require('xml'),
+    config = require('../../config'),
+    utils = require('../../utils'),
+    errors = require('../../errors'),
+    logging = require('../../logging'),
+    events = require('../../events'),
+    i18n = require('../../i18n'),
+    settingsCache = require('../../settings/cache'),
     pingList;
 
 // ToDo: Make this configurable
@@ -32,7 +33,7 @@ function ping(post) {
             'themes'
         ];
 
-    if (post.page || config.isPrivacyDisabled('useRpcPing')) {
+    if (post.page || config.isPrivacyDisabled('useRpcPing') || settingsCache.get('is_private')) {
         return;
     }
 

--- a/core/server/data/xml/xmlrpc.js
+++ b/core/server/data/xml/xmlrpc.js
@@ -90,7 +90,13 @@ function ping(post) {
     });
 }
 
-function listener(model) {
+function listener(model, options) {
+    // CASE: do not rpc ping if we import a database
+    // TODO: refactor post.published events to never fire on importing
+    if (options && options.importing) {
+        return;
+    }
+
     ping(model.toJSON());
 }
 

--- a/core/test/unit/slack_spec.js
+++ b/core/test/unit/slack_spec.js
@@ -82,6 +82,25 @@ describe('Slack', function () {
         resetSlack();
     });
 
+    it('listener() does not call ping() when importing', function () {
+        var testPost = _.clone(testUtils.DataGenerator.Content.posts[2]),
+            testModel = {
+                toJSON: function () {
+                    return testPost;
+                }
+            },
+            pingStub = sandbox.stub(),
+            resetSlack = slack.__set__('ping', pingStub),
+            listener = slack.__get__('listener');
+
+        listener(testModel, {importing: true});
+
+        pingStub.calledOnce.should.be.false();
+
+        // Reset slack ping method
+        resetSlack();
+    });
+
     it('testPing() calls ping() with default message', function () {
         var pingStub = sandbox.stub(),
             resetSlack = slack.__set__('ping', pingStub),
@@ -293,16 +312,6 @@ describe('Slack', function () {
                 makeRequestSpy.called.should.be.false();
                 done();
             });
-        });
-
-        it('do not ping if content is imported', function (done) {
-            ping({}, {importing: true}).then(function () {
-                isPostStub.called.should.be.false();
-                urlForSpy.called.should.be.false();
-                settingsAPIStub.called.should.be.false();
-                makeRequestSpy.called.should.be.false();
-                done();
-            }).catch(done);
         });
     });
 });

--- a/core/test/unit/xmlrpc_spec.js
+++ b/core/test/unit/xmlrpc_spec.js
@@ -52,6 +52,25 @@ describe('XMLRPC', function () {
         resetXmlRpc();
     });
 
+    it('listener() does not call ping() when importing', function () {
+        var testPost = _.clone(testUtils.DataGenerator.Content.posts[2]),
+            testModel = {
+                toJSON: function () {
+                    return testPost;
+                }
+            },
+            pingStub = sandbox.stub(),
+            resetXmlRpc = xmlrpc.__set__('ping', pingStub),
+            listener = xmlrpc.__get__('listener');
+
+        listener(testModel, {importing: true});
+
+        pingStub.calledOnce.should.be.false();
+
+        // Reset xmlrpc ping method
+        resetXmlRpc();
+    });
+
     describe('ping()', function () {
         var ping = xmlrpc.__get__('ping');
 


### PR DESCRIPTION
closes #9164

- check options.importing on xmlrpc
- cleanup slack to work the same way
- update tests
- TODO: we need to prevent this event happening altogether
