### PR TITLE
🐛  Theme name is floating point number

### DIFF
--- a/core/server/settings/cache.js
+++ b/core/server/settings/cache.js
@@ -50,7 +50,7 @@ module.exports = {
         // Default behaviour is to try to resolve the value and return that
         try {
             // CASE: if a string contains a number e.g. "1", JSON.parse will auto convert into integer
-            if (settingsCache[key].value.match(/^\d+$/)) {
+            if (!isNaN(Number(settingsCache[key].value))) {
                 return settingsCache[key].value;
             }
 

--- a/core/test/unit/settings/cache_spec.js
+++ b/core/test/unit/settings/cache_spec.js
@@ -10,6 +10,11 @@ describe('UNIT: settings cache', function () {
         (typeof cache.get('key1')).should.eql('string');
     });
 
+    it('does not auto convert string into number: float', function () {
+        cache.set('key1', {value: '1.4'});
+        (typeof cache.get('key1')).should.eql('string');
+    });
+
     it('stringified JSON get\'s parsed', function () {
         cache.set('key2', {value: '{"a":"1","b":"hallo","c":{"d":[]},"e":2}'});
         (typeof cache.get('key2')).should.eql('object');


### PR DESCRIPTION
closes #9182

- e.g. "1.4"
- extend settings cache to ensure we return strings for numbers and floating point numbers