### PR TITLE
Added package-lock.json to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -41,3 +41,4 @@ bower_components/**
 .editorconfig
 gulpfile.js
 !content/themes/casper/gulpfile.js
+package-lock.json


### PR DESCRIPTION
no issue

- refs https://github.com/TryGhost/Ghost/commit/07dcbb0d5312acd15d4616441c6d800e1f026d76#diff-a084b794bc0759e7a6b77810e01874f2
- if we don't add the npm lock file, it get's added to the release zip when using v8
