### PR TITLE
Refactored to save settings only if value changes

### DIFF
--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -123,6 +123,7 @@ Settings = ghostBookshelf.Model.extend({
                     if (options.importing) {
                         return setting.save(item, options);
                     } else {
+                        // If we have a value, set it.
                         if (item.hasOwnProperty('value')) {
                             setting.set('value', item.value);
                         }
@@ -131,8 +132,9 @@ Settings = ghostBookshelf.Model.extend({
                             setting.set('type', item.type);
                         }
 
+                        // If anything has changed, save the updated model
                         if (setting.hasChanged()) {
-                            return setting.save(options);
+                            return setting.save(null, options);
                         }
 
                         return setting;

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -118,22 +118,25 @@ Settings = ghostBookshelf.Model.extend({
             item = self.filterData(item);
 
             return Settings.forge({key: item.key}).fetch(options).then(function then(setting) {
-                var saveData = {};
-
                 if (setting) {
-                    if (item.hasOwnProperty('value')) {
-                        saveData.value = item.value;
-                    }
-                    // Internal context can overwrite type (for fixture migrations)
-                    if (options.context && options.context.internal && item.hasOwnProperty('type')) {
-                        saveData.type = item.type;
-                    }
                     // it's allowed to edit all attributes in case of importing/migrating
                     if (options.importing) {
-                        saveData = item;
-                    }
+                        return setting.save(item, options);
+                    } else {
+                        if (item.hasOwnProperty('value')) {
+                            setting.set('value', item.value);
+                        }
+                        // Internal context can overwrite type (for fixture migrations)
+                        if (options.context && options.context.internal && item.hasOwnProperty('type')) {
+                            setting.set('type', item.type);
+                        }
 
-                    return setting.save(saveData, options);
+                        if (setting.hasChanged()) {
+                            return setting.save(options);
+                        }
+
+                        return setting;
+                    }
                 }
 
                 return Promise.reject(new errors.NotFoundError({message: i18n.t('errors.models.settings.unableToFindSetting', {key: item.key})}));


### PR DESCRIPTION
This is quite a small change, but with potentially larger consequences. At the moment, requests from the Ghost Admin come into the settings endpoint with multiple settings to update. There's no guarantee any of them have changed.

On the server side, we blindly processed all the settings, saving each one with the "new" value regardless of whether anything changed. The updated_at value will change every time.

The code in this PR changes this to be smarter. We set relevant properties on the model and then if bookshelf's `hasChanged` method tells us any of the values are different, we save, else we just return.

The benefit is less events flying through the settingsCache system. My end goal here related to #9192 is to know when a setting is _really_ changed to check if a route like `/subscribers/`or `/amp/` should be enabled or not.

refs #9192

- Each setting is saved individually
- Update this to only happen on import, or when a value changes
- Reduces the amount of work Ghost does on every setting change
