### PR TITLE
Enable optional post rescheduling on boot

### DIFF
--- a/core/server/adapters/scheduling/SchedulingDefault.js
+++ b/core/server/adapters/scheduling/SchedulingDefault.js
@@ -17,6 +17,7 @@ function SchedulingDefault(options) {
     this.beforePingInMs = -50;
     this.retryTimeoutInMs = 1000 * 5;
 
+    this.rescheduleOnBoot = true;
     this.allJobs = {};
     this.deletedJobs = {};
     this.isRunning = false;

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -51,12 +51,13 @@ exports.init = function init(options) {
     return _private.loadClient()
         .then(function (_client) {
             client = _client;
-
             return localUtils.createAdapter(config);
         })
         .then(function (_adapter) {
             adapter = _adapter;
-
+            if (!adapter.rescheduleOnBoot) {
+                return [];
+            }
             return _private.loadScheduledPosts();
         })
         .then(function (scheduledPosts) {


### PR DESCRIPTION
No Issue
- allows custom scheduling adaptors with persistent data to not reschedule posts when Ghost is restarted
