### PR TITLE
Bump Node v8 minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0 || ^8.8.0"
+    "node": "^4.5.0 || ^6.9.0 || ^8.9.0"
   },
   "dependencies": {
     "amperize": "0.3.5",


### PR DESCRIPTION
no issue

- the official V8 LTS release version is 8.9.0, see https://github.com/nodejs/Release/issues/263
- came out on the 31th of 10/17 (this is where the official LTS for V8 has started)
- requires an update on docs.ghost.org!!