### PR TITLE
🐛  Fixed error for password authentication with Bearer Token

### DIFF
--- a/core/server/auth/authenticate.js
+++ b/core/server/auth/authenticate.js
@@ -14,10 +14,17 @@ authenticate = {
          * See e.g. https://tools.ietf.org/html/rfc6749#page-38. Ghost has no differentiation for this at the moment.
          * See also See https://tools.ietf.org/html/rfc6749#section-2.1.
          *
-         * Ghost requires client authentication for `grant_type: password`. This is inconsistent, because you
-         * can skip client authentication to refresh your access token (`grant_type: refresh_token`).
+         * Ghost requires client authentication for `grant_type: password`, because we have to ensure that
+         * we tie a client to a new access token. That means `grant_type: refresh_token` does not require
+         * client authentication, because binding a client already happened.
          *
-         * Keep in mind: You can request data from the API with a Bearer but without client credentials e.g. GET /posts.
+         * To sum up:
+         *   - password authentication requires client authentication
+         *   - refreshing a token does not require client authentication
+         *   - public API requires client authentication
+         *      - as soon as you send an access token in the header or via query
+         *      - we deny public API access
+         *   - API access with a Bearer does not require client authentication
          */
         if (authUtils.getBearerAutorizationToken(req) && !authUtils.hasGrantType(req, 'password')) {
             return next();

--- a/core/server/auth/authenticate.js
+++ b/core/server/auth/authenticate.js
@@ -9,8 +9,17 @@ var passport = require('passport'),
 authenticate = {
     // ### Authenticate Client Middleware
     authenticateClient: function authenticateClient(req, res, next) {
-        // skip client authentication if bearer token is present
-        if (authUtils.getBearerAutorizationToken(req)) {
+        /**
+         * In theory, client authentication is not required for public clients, only for confidential clients.
+         * See e.g. https://tools.ietf.org/html/rfc6749#page-38. Ghost has no differentiation for this at the moment.
+         * See also See https://tools.ietf.org/html/rfc6749#section-2.1.
+         *
+         * Ghost requires client authentication for `grant_type: password`. This is inconsistent, because you
+         * can skip client authentication to refresh your access token (`grant_type: refresh_token`).
+         *
+         * Keep in mind: You can request data from the API with a Bearer but without client credentials e.g. GET /posts.
+         */
+        if (authUtils.getBearerAutorizationToken(req) && !authUtils.hasGrantType(req, 'password')) {
             return next();
         }
 

--- a/core/server/auth/utils.js
+++ b/core/server/auth/utils.js
@@ -115,3 +115,8 @@ module.exports.getBearerAutorizationToken = function (req) {
 
     return token;
 };
+
+module.exports.hasGrantType = function hasGrantType(req, type) {
+    return req.body && req.body.hasOwnProperty('grant_type') && req.body.grant_type === type
+        || req.query && req.query.hasOwnProperty('grant_type') && req.query.grant_type === type;
+};

--- a/core/test/unit/auth/oauth_spec.js
+++ b/core/test/unit/auth/oauth_spec.js
@@ -50,13 +50,11 @@ describe('OAuth', function () {
             req.body.grant_type = 'password';
             req.body.username = 'username';
             req.body.password = 'password';
+            req.client = {
+                id: 1
+            };
             res.setHeader = {};
             res.end = {};
-
-            sandbox.stub(models.Client, 'findOne')
-                .withArgs({slug: 'test'}).returns(new Promise.resolve({
-                id: 1
-            }));
 
             sandbox.stub(models.User, 'check')
                 .withArgs({email: 'username', password: 'password'}).returns(new Promise.resolve({
@@ -105,11 +103,8 @@ describe('OAuth', function () {
             res.setHeader = {};
             res.end = {};
 
-            sandbox.stub(models.Client, 'findOne')
-                .withArgs({slug: 'test'}).returns(new Promise.resolve());
-
             oAuth.generateAccessToken(req, res, function (err) {
-                err.errorType.should.eql('NoPermissionError');
+                err.errorType.should.eql('UnauthorizedError');
                 done();
             });
         });
@@ -124,13 +119,11 @@ describe('OAuth', function () {
             req.body.grant_type = 'password';
             req.body.username = 'username';
             req.body.password = 'password';
+            req.client = {
+                id: 1
+            };
             res.setHeader = {};
             res.end = {};
-
-            sandbox.stub(models.Client, 'findOne')
-                .withArgs({slug: 'test'}).returns(new Promise.resolve({
-                id: 1
-            }));
 
             sandbox.stub(models.User, 'check')
                 .withArgs({email: 'username', password: 'password'}).returns(new Promise.resolve({


### PR DESCRIPTION
refs #8613

### Background
- if you send a request to /authentication/token with `grant_type:password` and a Bearer token, Ghost was not able to handle this combination
- because it skipped the client authentication, see https://github.com/TryGhost/Ghost/blob/1.17.0/core/server/auth/authenticate.js#L13
- and OAuth detects the `grant_type: password` and jumps in the target implementation
- the target implementation for password authentication **again** tried to fetch the client and failed, because it relied on the previous client authentication
- see https://github.com/TryGhost/Ghost/blob/1.17.0/core/server/auth/oauth.js#L40 (client.slug is undefined if client authentication is skipped)
- ^ so this is the bug

### so when is a client authentication required?
- RFC (https://tools.ietf.org/html/rfc6749#page-38) differentiates between confidential and public clients, Ghost has no implementation for this at the moment
  - so in theory, public clients don't have to be authenticated, only if the credentials are included
- so with the current implemention
  - it is possible to skip client authentication for `grant_type: refresh_token`, because the implementation does not use the client, see https://github.com/TryGhost/Ghost/blob/1.17.0/core/server/auth/oauth.js#L11 - the refresh token generation uses the connected client it from the old refresh token
  - but the password authentication requires the client, see https://github.com/TryGhost/Ghost/blob/1.17.0/core/server/auth/oauth.js#L52, because it connects the client id with the generated token

### decision
- to not invent a breaking change here, i'll think we should just fix what we have here in Ghost at the moment - require client authentication for password authentication and all other cases can be skipped
- that means if you send a Bearer token and `grant_type: password`, client authentication is required and you will receive a new access token if user/pass is valid
- **we can change this behaviour in the next major**

## Notes
I have removed the extra client request to the database for the password authentication, this is not needed. We already do client password authentication [here](https://github.com/TryGhost/Ghost/blob/1.17.0/core/server/auth/auth-strategies.js#L19);
If a Bearer token is present and you have not send a `grant_type` (which signalises OAuth to do authentication), you can skip the client authentication.


@kevinansfield Any concerns?
@sebgie I'm pulling you in here, because you initially implemented OAuth in Ghost.


### Alternative?
Alternatively, we could require client authentication for **any**  grant type. But i don't know if this could break a client. 

Let me know if something is not clear enough.