### PR TITLE
Add GET/DELETE /subscribers/email/:email/ endpoints

### DIFF
--- a/core/server/api/routes.js
+++ b/core/server/api/routes.js
@@ -84,9 +84,11 @@ module.exports = function apiRoutes() {
         api.http(api.subscribers.importCSV)
     );
     apiRouter.get('/subscribers/:id', labs.subscribers, mw.authenticatePrivate, api.http(api.subscribers.read));
+    apiRouter.get('/subscribers/email/:email', labs.subscribers, mw.authenticatePrivate, api.http(api.subscribers.read));
     apiRouter.post('/subscribers', labs.subscribers, mw.authenticatePublic, api.http(api.subscribers.add));
     apiRouter.put('/subscribers/:id', labs.subscribers, mw.authenticatePrivate, api.http(api.subscribers.edit));
     apiRouter.del('/subscribers/:id', labs.subscribers, mw.authenticatePrivate, api.http(api.subscribers.destroy));
+    apiRouter.del('/subscribers/email/:email', labs.subscribers, mw.authenticatePrivate, api.http(api.subscribers.destroy));
 
     // ## Roles
     apiRouter.get('/roles/', mw.authenticatePrivate, api.http(api.roles.browse));

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -224,9 +224,9 @@ subscribers = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
-            getSubscriberByEmail,
-            apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions}),
+            apiUtils.validate(docName, {opts: ['id', 'email']}),
             apiUtils.handlePermissions(docName, 'destroy'),
+            getSubscriberByEmail,
             doQuery
         ];
 

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -53,7 +53,7 @@ subscribers = {
      * @return {Promise<Subscriber>} Subscriber
      */
     read: function read(options) {
-        var attrs = ['id'],
+        var attrs = ['id', 'email'],
             tasks;
 
         /**
@@ -192,6 +192,29 @@ subscribers = {
 
         /**
          * ### Delete Subscriber
+         * If we have an email param, check the subscriber exists
+         * @type {[type]}
+         */
+        function getSubscriberByEmail(options) {
+            if (options.email) {
+                return models.Subscriber.getByEmail(options.email, options)
+                    .then(function (subscriber) {
+                        if (!subscriber) {
+                            return Promise.reject(new errors.NotFoundError({
+                                message: i18n.t('errors.api.subscribers.subscriberNotFound')
+                            }));
+                        }
+
+                        options.id = subscriber.get('id');
+                        return options;
+                    });
+            }
+
+            return options;
+        }
+
+        /**
+         * ### Delete Subscriber
          * Make the call to the Model layer
          * @param {Object} options
          */
@@ -201,6 +224,7 @@ subscribers = {
 
         // Push all of our tasks into a `tasks` array in the correct order
         tasks = [
+            getSubscriberByEmail,
             apiUtils.validate(docName, {opts: apiUtils.idDefaultOptions}),
             apiUtils.handlePermissions(docName, 'destroy'),
             doQuery

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -118,7 +118,8 @@ utils = {
                 to: {isDate: true},
                 fields: {matches: /^[\w, ]+$/},
                 order: {matches: /^[a-z0-9_,\. ]+$/i},
-                name: {}
+                name: {},
+                email: {isEmail: true}
             },
             // these values are sanitised/validated separately
             noValidation = ['data', 'context', 'include', 'filter', 'forUpdate', 'transacting', 'formats'],


### PR DESCRIPTION
no issue
- useful for managing subscribers via external systems/API calls where it's likely only the e-mail address will be known
- adds `GET /subscribers/email/:email/`
- adds `DELETE /subscribers/email/:email/`