### PR TITLE
🐛  Fixed concurrent renew of access tokens

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -126,6 +126,25 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     /**
+     * http://knexjs.org/#Builder-forUpdate
+     * https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+     *
+     * Lock target collection/model for further update operations.
+     * This avoids collisions and possible content override cases.
+     */
+    onFetching: function onFetching(model, columns, options) {
+        if (options.forUpdate && options.transacting) {
+            options.query.forUpdate();
+        }
+    },
+
+    onFetchingCollection: function onFetchingCollection(model, columns, options) {
+        if (options.forUpdate && options.transacting) {
+            options.query.forUpdate();
+        }
+    },
+
+    /**
      * Adding resources implies setting these properties on the server side
      * - set `created_by` based on the context
      * - set `updated_by` based on the context
@@ -369,7 +388,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     permittedOptions: function permittedOptions() {
         // terms to whitelist for all methods.
-        return ['context', 'include', 'transacting', 'importing'];
+        return ['context', 'include', 'transacting', 'importing', 'forUpdate'];
     },
 
     /**

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -56,27 +56,6 @@ Post = ghostBookshelf.Model.extend({
         return this.updateTags(model, response, options);
     },
 
-    /**
-     * http://knexjs.org/#Builder-forUpdate
-     * https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
-     *
-     * Lock target collection/model for further update operations.
-     * This avoids collisions and possible content override cases.
-     *
-     * `forUpdate` is only supported for posts right now
-     */
-    onFetching: function onFetching(model, columns, options) {
-        if (options.forUpdate && options.transacting) {
-            options.query.forUpdate();
-        }
-    },
-
-    onFetchingCollection: function onFetchingCollection(model, columns, options) {
-        if (options.forUpdate && options.transacting) {
-            options.query.forUpdate();
-        }
-    },
-
     onUpdated: function onUpdated(model) {
         model.statusChanging = model.get('status') !== model.updated('status');
         model.isPublished = model.get('status') === 'published';
@@ -624,10 +603,9 @@ Post = ghostBookshelf.Model.extend({
             // whitelists for the `options` hash argument on methods, by method name.
             // these are the only options that can be passed to Bookshelf / Knex.
             validOptions = {
-                findOne: ['columns', 'importing', 'withRelated', 'require', 'forUpdate'],
+                findOne: ['columns', 'importing', 'withRelated', 'require'],
                 findPage: ['page', 'limit', 'columns', 'filter', 'order', 'status', 'staticPages'],
-                findAll: ['columns', 'filter', 'forUpdate'],
-                edit: ['forUpdate']
+                findAll: ['columns', 'filter']
             };
 
         // The post model additionally supports having a formats option

--- a/core/test/functional/routes/api/authentication_spec.js
+++ b/core/test/functional/routes/api/authentication_spec.js
@@ -184,6 +184,11 @@ describe('Authentication API', function () {
                                 token: accesstoken
                             }).then(function (oldAccessToken) {
                                 moment(oldAccessToken.get('expires')).diff(moment(), 'minutes').should.be.below(6);
+                                return models.Refreshtoken.findOne({
+                                    token: refreshToken
+                                });
+                            }).then(function (refreshTokenModel) {
+                                moment(refreshTokenModel.get('expires')).diff(moment(), 'month').should.be.above(5);
                                 done();
                             });
                         });

--- a/core/test/unit/auth/oauth_spec.js
+++ b/core/test/unit/auth/oauth_spec.js
@@ -269,13 +269,12 @@ describe('OAuth', function () {
                 }
             }));
 
-            sandbox.stub(authUtils, 'createTokens')
-                .returns(new Promise.reject({
-                    message: 'DB error'
-                }));
+            sandbox.stub(authUtils, 'createTokens', function () {
+                return Promise.reject(new Error('DB error'));
+            });
 
             oAuth.generateAccessToken(req, res, function (err) {
-                err.message.should.eql('DB error');
+                err.stack.should.containEql('DB error');
                 done();
             });
         });


### PR DESCRIPTION
Two commits. See both commits for context.

1. allow `forUpdate` for any model - be able to lock rows for any model e.g. in this case refresh tokens

2. Fix concurrent requests to renew an access token (row deletion error) by using the lock.

The changes look bigger than they are. The logic was just wrapped into a early transaction to ensure we lock in the right place. Furthermore, we no longer remove and add the refresh token, we simply increase the expiry to avoid deadlocks.

@kevinansfield I did a sanity check with the admin authentication (login, logout, access token renewal etc) - if you could do it as well, that would be great. I haven't added more tests, because concurrency is hard to test.