### PR TITLE
Give default Ghost user fixture a helpful bio

### DIFF
--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -438,6 +438,7 @@
                     "id": "5951f5fca366002ebd5dbef7",
                     "name": "Ghost",
                     "email": "ghost-author@example.com",
+                    "bio": "You can delete this user to remove all the welcome posts",
                     "status": "active",
                     "roles": ["Author"]
                 }

--- a/core/test/unit/migration_spec.js
+++ b/core/test/unit/migration_spec.js
@@ -20,7 +20,7 @@ var should = require('should'), // jshint ignore:line
 describe('DB version integrity', function () {
     // Only these variables should need updating
     var currentSchemaHash = '0de1eaa8bc79046a9f43927917c294c3',
-        currentFixturesHash = '7c8b21872959945c22ed5780f513db67';
+        currentFixturesHash = 'e2c71e808c3d33660c498d164639dc8c';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation


### PR DESCRIPTION
no issue

Had a couple of people ask about how to delete welcome posts easily, so adding a bio to the default user to draw a little more attention to it