### PR TITLE
🗜 Set soft limits for blog title and description

### DIFF
--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -15,10 +15,20 @@
     },
     "blog": {
         "title": {
-            "defaultValue": "Ghost"
+            "defaultValue": "Ghost",
+            "validations": {
+                "isLength": {
+                    "max": 150
+                }
+            }
         },
         "description": {
-            "defaultValue": "The professional publishing platform"
+            "defaultValue": "The professional publishing platform",
+            "validations": {
+                "isLength": {
+                    "max": 200
+                }
+            }
         },
         "logo": {
             "defaultValue": "https://casper.ghost.org/v1.0.0/images/ghost-logo.svg"


### PR DESCRIPTION
refs #8143

Add max length validations to settings:
- `blog.title`: 150 chars
- `blog.description`: 200 chars

The `validateSettings` fn in our validations checks for existing `validations` properties in our `default-settings.json` file, similar to other tables in our `schema.js`.

![image](https://user-images.githubusercontent.com/8037602/32873308-465b50ac-cac6-11e7-9711-2731a194c227.png)

![image](https://user-images.githubusercontent.com/8037602/32873322-532323a0-cac6-11e7-88c9-3d95cc7e3776.png)