### PR TITLE
Added Ghost-CLI version range to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
   },
   "engines": {
-    "node": "^4.5.0 || ^6.9.0 || ^8.9.0"
+    "node": "^4.5.0 || ^6.9.0 || ^8.9.0",
+    "cli": "^1.3.0"
   },
   "dependencies": {
     "amperize": "0.3.5",


### PR DESCRIPTION
Ghost-CLI 1.3.0 and above will check this field to determine if the ghost version is compatible with it.

This allows for breaking changes (such as the coming knex-migrator 3.0 change) to be added without worrying about CLI breakage for older versions.