### PR TITLE
Prevent markdown rendering duplicate heading ID attributes

### DIFF
--- a/core/server/utils/markdown-converter.js
+++ b/core/server/utils/markdown-converter.js
@@ -14,16 +14,17 @@ var MarkdownIt = require('markdown-it'),
                 if (usedHeaders[slug]) {
                     usedHeaders[slug] += 1;
                     slug += usedHeaders[slug];
+                } else {
+                    usedHeaders[slug] = 1;
                 }
                 return slug;
             };
             var originalHeadingOpen = md.renderer.rules.heading_open;
+            var usedHeaders = {};
 
             // originally from https://github.com/leff/markdown-it-named-headers
             // moved here to avoid pulling in http://stringjs.com dependency
             md.renderer.rules.heading_open = function (tokens, idx, something, somethingelse, self) {
-                var usedHeaders = {};
-
                 tokens[idx].attrs = tokens[idx].attrs || [];
 
                 var title = tokens[idx + 1].children.reduce(function (acc, t) {

--- a/core/test/unit/apps/default-cards/markdown_spec.js
+++ b/core/test/unit/apps/default-cards/markdown_spec.js
@@ -31,4 +31,18 @@ describe('Markdown card', function () {
         var serializer = new SimpleDom.HTMLSerializer([]);
         serializer.serialize(card.render(opts)).should.match('<div class="kg-card-markdown"><h1 id="heading">HEADING</h1>\n<h2>Heading 2></div>');
     });
+
+    it('Does not create duplicate IDs', function () {
+        opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                markdown: '# Foo\r\nLorem\r\n\r\n# Foo\r\nDolor'
+            }
+        };
+
+        var serializer = new SimpleDom.HTMLSerializer([]);
+        serializer.serialize(card.render(opts)).should.match('<div class="kg-card-markdown"><h1 id="foo">Foo</h1>\n<p>Lorem</p>\n<h1 id="foo2">Foo</h1>\n<p>Dolor</p>\n</div>');
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/TryGhost/Ghost/issues/9260.
**NOT COMPLETE - FEEDBACK REQUESTED**

Checklist for this right now:

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `npm test`)

This is a proposed fix for this issue. Based on the presence of the `usedHeaders` object, it looks like the original code expected to avoid this issue, but it didn't work (you can verify with the test I added). 

The reason this fails tests right now is because the `usedHeaders` object persists between document renders. So there are two separate tests which render `# HEADING` and they do so with the `id` of `heading` and `heading2` respectively. The second test therefore fails. I could have modified the tests to use different heading text, but I think it would be better to actually make the `usedHeaders` object exist per-document instead.

The only way I can see to do this from the function interface is to key to the tokens list, so something like:
```javascript
var usedHeaders = {};
[...]
usedHeaders[tokens][slug] = 1;
```
Then, the list of `usedHeaders` is unique for each list of tokens. But there's no obvious way to do this without adding a bunch of code to set up a dictionary which can be keyed by object, or generating a string hash of the tokens list, or similar. Both seem a bit heavy-handed here.

I'd love feedback. If this work is welcome and nobody can suggest better than the above, I'll go that route.