### PR TITLE
🐛 Fixed import and redirect uploads for Win10/Edge

### DIFF
--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -52,7 +52,7 @@
         },
         "db": {
             "extensions": [".json", ".zip"],
-            "contentTypes": ["application/octet-stream", "application/json", "application/zip", "application/x-zip-compressed"]
+            "contentTypes": ["text/plain", "application/octet-stream", "application/json", "application/zip", "application/x-zip-compressed"]
         },
         "themes": {
             "extensions": [".zip"],
@@ -60,7 +60,7 @@
         },
         "redirects": {
             "extensions": [".json"],
-            "contentTypes": ["application/octet-stream", "application/json"]
+            "contentTypes": ["text/plain", "application/octet-stream", "application/json"]
         }
     },
     "times": {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9236
- added `text/plain` to the allowed mime types for db and redirect uploads