### PR TITLE
Koenig editor resurrection

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -30,7 +30,8 @@ function getBaseConfig() {
         blogUrl: urlService.utils.urlFor('home', true),
         blogTitle: settingsCache.get('title'),
         routeKeywords: config.get('routeKeywords'),
-        clientExtensions: config.get('clientExtensions')
+        clientExtensions: config.get('clientExtensions'),
+        enableDeveloperExperiments: config.get('enableDeveloperExperiments')
     };
 }
 

--- a/core/server/lib/mobiledoc/cards/html.js
+++ b/core/server/lib/mobiledoc/cards/html.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     name: 'card-html',
     type: 'dom',

--- a/core/server/lib/mobiledoc/cards/html.js
+++ b/core/server/lib/mobiledoc/cards/html.js
@@ -1,12 +1,13 @@
-var SimpleDom = require('simple-dom'),
-    tokenizer = require('simple-html-tokenizer').tokenize,
-    parser;
-
 module.exports = {
     name: 'card-html',
     type: 'dom',
     render(opts) {
-        parser = new SimpleDom.HTMLParser(tokenizer, opts.env.dom, SimpleDom.voidMap);
-        return parser.parse('<div class="kg-card-html">' + opts.payload.html + '</div>');
+        let html = `<div class="kg-card-html">${opts.payload.html}</div>`;
+
+        // use the SimpleDOM document to create a raw HTML section.
+        // avoids parsing/rendering of potentially broken or unsupported HTML
+        let element = opts.env.dom.createRawHTMLSection(html);
+
+        return element;
     }
 };


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost-Admin/pull/916

This is a PR to get the Koenig editor we were testing during the alphas working again. It's a long way from being considered usable as a general editor so it sits behind two layers of config/flags; "developer experiments" need to be enabled via server-side config and the koenig editor flag then needs to be checked inside Labs.

- [x] add "enableDeveloperExperiments" config flag
- [x] test full mobiledoc rendering with existing cards
- [x] update HTML card to allow any HTML through, similar to the markdown card this prevents outright errors from suspect markup due to SimpleDOM's intentionally limited dom parsing/error handling