### PR TITLE
🐛  Fixed error handling for html response

### DIFF
--- a/core/server/apps/amp/lib/helpers/amp_components.js
+++ b/core/server/apps/amp/lib/helpers/amp_components.js
@@ -13,7 +13,7 @@ var proxy = require('../../../../helpers/proxy'),
 
 function ampComponents() {
     var components = [],
-        html = this.post.html || this.html;
+        html = this.post && this.post.html || this.html;
 
     if (!html) {
         return;

--- a/core/server/controllers/frontend/templates.js
+++ b/core/server/controllers/frontend/templates.js
@@ -143,7 +143,7 @@ _private.getTemplateForError = function getTemplateForError(statusCode) {
 module.exports.setTemplate = function setTemplate(req, res, data) {
     var routeConfig = res._route || {};
 
-    if (res._template) {
+    if (res._template && !req.err) {
         return;
     }
 


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/41

- if you add invalid handlebars logic e.g. {{if condition condition}}, handlebars throws an error
- in case of having invalid hbs in an amp page, the amp component throwed another syntax error (which is fixed in this PR)
- furthermore the `setTemplate` helper function had a logic bug, which did not handle errors correctly
  - if there is an error and a template is set (e.g. amp), we have to still render the error page and not the amp page
- this fix only ensures that the error handling is correct, we still see the error of the "ugly" handlebars message
  - e.g. [amp.hbs] Cannot read property 'includeZero' of undefined
  - but no longer -> Cannot read property 'html' of undefined (which was a syntax error in Ghost)
  - this should be detected in gscan and should show a warning like "You are using a wrong handlebars syntax in template x"