### PR TITLE
Improved pagination misusage error and reattach error to request object

### DIFF
--- a/core/server/helpers/pagination.js
+++ b/core/server/helpers/pagination.js
@@ -12,7 +12,9 @@ var proxy = require('./proxy'),
 pagination = function (options) {
     if (!_.isObject(this.pagination) || _.isFunction(this.pagination)) {
         throw new errors.IncorrectUsageError({
-            message: i18n.t('warnings.helpers.pagination.invalidData')
+            level: 'normal',
+            message: i18n.t('warnings.helpers.pagination.invalidData'),
+            help: 'https://themes.ghost.org/docs/pagination'
         });
     }
 

--- a/core/server/middleware/error-handler.js
+++ b/core/server/middleware/error-handler.js
@@ -114,6 +114,9 @@ _private.HTMLErrorRenderer = function HTMLErrorRender(err, req, res, next) {
             return res.send(html);
         }
 
+        // re-attach new error e.g. error template has syntax error or misusage
+        req.err = err;
+
         // And then try to explain things to the user...
         // Cheat and output the error using handlebars escapeExpression
         return res.status(500).send(

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -524,7 +524,7 @@
                 "isDeprecated": "Warning: pageUrl is deprecated, please use page_url instead\nThe helper pageUrl has been replaced with page_url in Ghost 0.4.2, and will be removed entirely in Ghost 0.6\nIn your theme's pagination.hbs file, pageUrl should be renamed to page_url"
             },
             "pagination": {
-                "invalidData": "pagination data is not an object or is a function",
+                "invalidData": "The \\{\\{pagination\\}\\} helper was used outside of a paginated context. See https://themes.ghost.org/docs/pagination.",
                 "valuesMustBeDefined": "All values must be defined for page, pages, limit and total",
                 "nextPrevValuesMustBeNumeric": "Invalid value, Next/Prev must be a number",
                 "valuesMustBeNumeric": "Invalid value, check page, pages, limit and total are numbers"

--- a/core/test/unit/helpers/pagination_spec.js
+++ b/core/test/unit/helpers/pagination_spec.js
@@ -29,11 +29,11 @@ describe('{{pagination}} helper', function () {
             return function () {
                 helpers.pagination.call(data);
             };
-        };
+        }, expectedMessage = 'The {{pagination}} helper was used outside of a paginated context. See https://themes.ghost.org/docs/pagination.';
 
-        runHelper('not an object').should.throwError('pagination data is not an object or is a function');
+        runHelper('not an object').should.throwError(expectedMessage);
         runHelper(function () {
-        }).should.throwError('pagination data is not an object or is a function');
+        }).should.throwError(expectedMessage);
     });
 
     it('can render single page with no pagination necessary', function () {


### PR DESCRIPTION
Please merge both commits!
See commit descriptions.

You can reproduce an error if you add a custom error template and add the `{{pagination}}` helper on top.