### PR TITLE
🎨  Improved reading images from file storage which don't exist anymore

### DIFF
--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -134,9 +134,16 @@ class LocalFileStore extends StorageBase {
         return new Promise(function (resolve, reject) {
             fs.readFile(targetPath, function (err, bytes) {
                 if (err) {
+                    if (err.code === 'ENOENT') {
+                        return reject(new errors.NotFoundError({
+                            err: err,
+                            message: i18n.t('errors.errors.imageNotFoundWithRef', {img: options.path})
+                        }));
+                    }
+
                     return reject(new errors.GhostError({
                         err: err,
-                        message: 'Could not read image: ' + targetPath
+                        message: i18n.t('errors.errors.cannotReadImage', {img: options.path})
                     }));
                 }
 

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -486,6 +486,8 @@
             "renderingErrorPage": "Rendering Error Page",
             "caughtProcessingError": "Ghost caught a processing error in the middleware layer.",
             "imageNotFound": "Image not found",
+            "imageNotFoundWithRef": "Image not found: {img}",
+            "cannotReadImage": "Could not read image: {img}",
             "pageNotFound": "Page not found",
             "resourceNotFound": "Resource not found"
         }

--- a/core/server/utils/image-size.js
+++ b/core/server/utils/image-size.js
@@ -202,9 +202,10 @@ getImageSizeFromFilePath = function getImageSizeFromFilePath(imagePath) {
                 }
             }));
         }).catch(function (err) {
-            if (err instanceof errors.GhostError) {
+            if (errors.utils.isIgnitionError(err)) {
                 return Promise.reject(err);
             }
+
             return Promise.reject(new errors.InternalServerError({
                 message: err.message,
                 code: 'IMAGE_SIZE_STORAGE',

--- a/core/test/unit/adapters/storage/LocalFileStorage_spec.js
+++ b/core/test/unit/adapters/storage/LocalFileStorage_spec.js
@@ -175,7 +175,7 @@ describe('Local File System Storage', function () {
                     done(new Error('image should not exist'));
                 })
                 .catch(function (err) {
-                    (err instanceof errors.GhostError).should.eql(true);
+                    (err instanceof errors.NotFoundError).should.eql(true);
                     err.code.should.eql('ENOENT');
                     done();
                 });

--- a/core/test/unit/utils/image-size_spec.js
+++ b/core/test/unit/utils/image-size_spec.js
@@ -4,6 +4,7 @@ var should = require('should'),
     nock = require('nock'),
     configUtils = require('../../utils/configUtils'),
     utils = require('../../../server/utils'),
+    errors = require('../../../server/errors'),
     storage = require('../../../server/adapters/storage'),
     path = require('path'),
 
@@ -463,7 +464,7 @@ describe('Image Size', function () {
             result = imageSize.getImageSizeFromFilePath(url)
                 .catch(function (err) {
                     should.exist(err);
-                    err.message.should.match(/Could not read image:/);
+                    (err instanceof errors.NotFoundError).should.eql(true);
                     done();
                 });
         });


### PR DESCRIPTION
refs https://github.com/TryGhost/Team/issues/41

- differentiate error codes
- return 404 if image was not found
- else return a 500
- reuse and use i18n keys

You can reproduce by uploading a favicon and remove it from the disk.