### PR TITLE
Bump sinon to version 4.1.2

### DIFF
--- a/core/test/functional/routes/apps/subscribers/routing_spec.js
+++ b/core/test/functional/routes/apps/subscribers/routing_spec.js
@@ -29,7 +29,7 @@ describe('Subscriber: Routing', function () {
     });
 
     before(function () {
-        sandbox.stub(labs, 'isSet', function (key) {
+        sandbox.stub(labs, 'isSet').callsFake(function (key) {
             if (key === 'subscribers') {
                 return true;
             }

--- a/core/test/functional/routes/channel_spec.js
+++ b/core/test/functional/routes/channel_spec.js
@@ -34,7 +34,7 @@ describe('Channel Routes', function () {
     before(function (done) {
         // Default is always casper. We use the old compatible 1.4 casper theme for these tests. Available in the test content folder.
         var originalSettingsCacheGetFn = settingsCache.get;
-        sandbox.stub(settingsCache, 'get', function (key, options) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key, options) {
             if (key === 'active_theme') {
                 return 'casper-1.4';
             }

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -337,7 +337,7 @@ describe('Frontend Routing', function () {
                 });
 
                 it('should not render AMP, when AMP is disabled', function (done) {
-                    sandbox.stub(settingsCache, 'get', function (key, options) {
+                    sandbox.stub(settingsCache, 'get').callsFake(function (key, options) {
                         if (key === 'amp' && !options) {
                             return false;
                         }

--- a/core/test/integration/api/api_authentication_spec.js
+++ b/core/test/integration/api/api_authentication_spec.js
@@ -43,7 +43,7 @@ describe('Authentication API', function () {
 
     // Stub mail
     beforeEach(function () {
-        sandbox.stub(mail, 'send', function () {
+        sandbox.stub(mail, 'send').callsFake(function () {
             return Promise.resolve();
         });
     });

--- a/core/test/integration/api/api_invites_spec.js
+++ b/core/test/integration/api/api_invites_spec.js
@@ -16,7 +16,7 @@ describe('Invites API', function () {
     beforeEach(testUtils.setup('invites', 'settings', 'users:roles', 'perms:invite', 'perms:init'));
 
     beforeEach(function () {
-        sandbox.stub(mail, 'send', function () {
+        sandbox.stub(mail, 'send').callsFake(function () {
             return Promise.resolve();
         });
     });

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -47,7 +47,7 @@ describe('Post API', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });

--- a/core/test/integration/api/api_schedules_spec.js
+++ b/core/test/integration/api/api_schedules_spec.js
@@ -316,7 +316,7 @@ describe('Schedules API', function () {
                 }, 500);
 
                 // target post to publish was read already, simulate a client request
-                sandbox.stub(api.posts, 'edit', function () {
+                sandbox.stub(api.posts, 'edit').callsFake(function () {
                     var self = this,
                         args = arguments;
 

--- a/core/test/integration/api/api_subscribers_spec.js
+++ b/core/test/integration/api/api_subscribers_spec.js
@@ -279,12 +279,12 @@ describe('Subscribers API', function () {
             stub;
 
         beforeEach(function () {
-            sandbox.stub(fs, 'unlink', function (path, cb) {
+            sandbox.stub(fs, 'unlink').callsFake(function (path, cb) {
                 cb();
             });
             sandbox.stub(apiUtils, 'checkFileExists').returns(true);
             stub = sandbox.stub(apiUtils, 'checkFileIsValid').returns(true);
-            sandbox.stub(serverUtils, 'readCSV', function () {
+            sandbox.stub(serverUtils, 'readCSV').callsFake(function () {
                 if (scope.csvError) {
                     return Promise.reject(new Error('csv'));
                 }

--- a/core/test/integration/api/api_users_spec.js
+++ b/core/test/integration/api/api_users_spec.js
@@ -23,7 +23,7 @@ describe('Users API', function () {
     beforeEach(function () {
         eventsTriggered = {};
 
-        sandbox.stub(events, 'emit', function (eventName, eventObj) {
+        sandbox.stub(events, 'emit').callsFake(function (eventName, eventObj) {
             if (!eventsTriggered[eventName]) {
                 eventsTriggered[eventName] = [];
             }

--- a/core/test/integration/api/redirects_spec.js
+++ b/core/test/integration/api/redirects_spec.js
@@ -13,7 +13,7 @@ describe('Redirects API', function () {
     beforeEach(testUtils.setup('settings', 'users:roles', 'perms:redirect', 'perms:init'));
 
     beforeEach(function () {
-        sandbox.stub(mail, 'send', function () {
+        sandbox.stub(mail, 'send').callsFake(function () {
             return Promise.resolve();
         });
     });

--- a/core/test/integration/model/base/listeners_spec.js
+++ b/core/test/integration/model/base/listeners_spec.js
@@ -27,7 +27,7 @@ describe('Models: listeners', function () {
     beforeEach(testUtils.setup('owner', 'user-token:0'));
 
     beforeEach(function () {
-        sandbox.stub(events, 'on', function (eventName, callback) {
+        sandbox.stub(events, 'on').callsFake(function (eventName, callback) {
             eventsToRemember[eventName] = callback;
         });
 

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -90,7 +90,7 @@ describe('Post Model', function () {
 
         describe('findAll', function () {
             beforeEach(function () {
-                sandbox.stub(settingsCache, 'get', function (key) {
+                sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                     return {
                         permalinks: '/:slug/'
                     }[key];
@@ -145,7 +145,7 @@ describe('Post Model', function () {
 
         describe('findPage', function () {
             beforeEach(function () {
-                sandbox.stub(settingsCache, 'get', function (key) {
+                sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                     return {
                         permalinks: '/:slug/'
                     }[key];
@@ -334,7 +334,7 @@ describe('Post Model', function () {
 
         describe('findOne', function () {
             beforeEach(function () {
-                sandbox.stub(settingsCache, 'get', function (key) {
+                sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                     return {
                         permalinks: '/:slug/'
                     }[key];
@@ -387,7 +387,7 @@ describe('Post Model', function () {
             it('can findOne, returning a dated permalink', function (done) {
                 settingsCache.get.restore();
 
-                sandbox.stub(settingsCache, 'get', function (key) {
+                sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                     return {
                         permalinks: '/:year/:month/:day/:slug/'
                     }[key];
@@ -411,7 +411,7 @@ describe('Post Model', function () {
             beforeEach(function () {
                 eventsTriggered = {};
 
-                sandbox.stub(events, 'emit', function (eventName, eventObj) {
+                sandbox.stub(events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }
@@ -1017,7 +1017,7 @@ describe('Post Model', function () {
             beforeEach(function () {
                 eventsTriggered = {};
 
-                sandbox.stub(events, 'emit', function (eventName, eventObj) {
+                sandbox.stub(events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }
@@ -1402,7 +1402,7 @@ describe('Post Model', function () {
         describe('destroy', function () {
             beforeEach(function () {
                 eventsTriggered = {};
-                sandbox.stub(events, 'emit', function (eventName, eventObj) {
+                sandbox.stub(events, 'emit').callsFake(function (eventName, eventObj) {
                     if (!eventsTriggered[eventName]) {
                         eventsTriggered[eventName] = [];
                     }

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -90,7 +90,7 @@ describe('User Model', function run() {
         it('can find gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[4];
 
-            sandbox.stub(gravatar, 'lookup', function (userData) {
+            sandbox.stub(gravatar, 'lookup').callsFake(function (userData) {
                 userData.image = 'http://www.gravatar.com/avatar/2fab21a4c4ed88e76add10650c73bae1?d=404';
                 return Promise.resolve(userData);
             });
@@ -107,7 +107,7 @@ describe('User Model', function run() {
         it('can handle no gravatar', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[0];
 
-            sandbox.stub(gravatar, 'lookup', function (userData) {
+            sandbox.stub(gravatar, 'lookup').callsFake(function (userData) {
                 return Promise.resolve(userData);
             });
 
@@ -171,7 +171,7 @@ describe('User Model', function run() {
 
         beforeEach(function () {
             eventsTriggered = {};
-            sandbox.stub(events, 'emit', function (eventName, eventObj) {
+            sandbox.stub(events, 'emit').callsFake(function (eventName, eventObj) {
                 if (!eventsTriggered[eventName]) {
                     eventsTriggered[eventName] = [];
                 }

--- a/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
+++ b/core/test/unit/adapters/scheduling/SchedulingDefault_spec.js
@@ -68,7 +68,7 @@ describe('Scheduling Default Adapter', function () {
                 }),
                 allJobs = {};
 
-            sandbox.stub(scope.adapter, '_execute', function (nextJobs) {
+            sandbox.stub(scope.adapter, '_execute').callsFake(function (nextJobs) {
                 Object.keys(nextJobs).length.should.eql(182);
                 Object.keys(scope.adapter.allJobs).length.should.eql(1000 - 182);
                 done();
@@ -107,7 +107,7 @@ describe('Scheduling Default Adapter', function () {
                 nextJobs = {};
 
             sandbox.stub(scope.adapter, 'run');
-            sandbox.stub(scope.adapter, '_pingUrl', function () {
+            sandbox.stub(scope.adapter, '_pingUrl').callsFake(function () {
                 pinged = pinged + 1;
             });
 
@@ -132,7 +132,7 @@ describe('Scheduling Default Adapter', function () {
                 jobsToExecute = {};
 
             sandbox.stub(scope.adapter, 'run');
-            sandbox.stub(scope.adapter, '_pingUrl', function () {
+            sandbox.stub(scope.adapter, '_pingUrl').callsFake(function () {
                 pinged = pinged + 1;
             });
 

--- a/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
@@ -34,11 +34,11 @@ describe('Scheduling: Post Scheduling', function () {
 
         scope.adapter = new SchedulingDefault();
 
-        sandbox.stub(api.schedules, 'getScheduledPosts', function () {
+        sandbox.stub(api.schedules, 'getScheduledPosts').callsFake(function () {
             return Promise.resolve({posts: scope.scheduledPosts});
         });
 
-        sandbox.stub(events, 'onMany', function (events, stubDone) {
+        sandbox.stub(events, 'onMany').callsFake(function (events, stubDone) {
             events.forEach(function (event) {
                 scope.events[event] = stubDone;
             });
@@ -46,7 +46,7 @@ describe('Scheduling: Post Scheduling', function () {
 
         sandbox.stub(schedulingUtils, 'createAdapter').returns(Promise.resolve(scope.adapter));
 
-        sandbox.stub(models.Client, 'findOne', function () {
+        sandbox.stub(models.Client, 'findOne').callsFake(function () {
             return Promise.resolve(scope.client);
         });
 

--- a/core/test/unit/api/utils_spec.js
+++ b/core/test/unit/api/utils_spec.js
@@ -541,7 +541,7 @@ describe('API Utils', function () {
 
         it('should handle an unknown rejection', function (done) {
             var testStub = sandbox.stub().returns(new Promise.reject()),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -567,7 +567,7 @@ describe('API Utils', function () {
             var testStub = sandbox.stub().returns(new Promise.reject(
                     new errors.NoPermissionError()
                 )),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -593,7 +593,7 @@ describe('API Utils', function () {
 
         it('should handle success', function (done) {
             var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -620,7 +620,7 @@ describe('API Utils', function () {
 
         it('should ignore unsafe attrs if none are provided', function (done) {
             var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -647,7 +647,7 @@ describe('API Utils', function () {
 
         it('should ignore unsafe attrs if they are provided but not present', function (done) {
             var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub
@@ -674,7 +674,7 @@ describe('API Utils', function () {
 
         it('should pass through unsafe attrs if they DO exist', function (done) {
             var testStub = sandbox.stub().returns(new Promise.resolve()),
-                permsStub = sandbox.stub(permissions, 'canThis', function () {
+                permsStub = sandbox.stub(permissions, 'canThis').callsFake(function () {
                     return {
                         testing: {
                             test: testStub

--- a/core/test/unit/apps/private-blogging/middleware_spec.js
+++ b/core/test/unit/apps/private-blogging/middleware_spec.js
@@ -142,7 +142,7 @@ describe('Private Blogging', function () {
                 req.url = req.path = '/robots.txt';
                 res.writeHead = sandbox.spy();
                 res.end = sandbox.spy();
-                sandbox.stub(fs, 'readFile', function (file, cb) {
+                sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
                     cb(null, 'User-agent: * Disallow: /');
                 });
                 privateBlogging.filterPrivateRoutes(req, res, next);

--- a/core/test/unit/auth/oauth_spec.js
+++ b/core/test/unit/auth/oauth_spec.js
@@ -53,25 +53,25 @@ describe('OAuth', function () {
             req.client = {
                 id: 1
             };
-            res.setHeader = {};
-            res.end = {};
+
+            res.setHeader = function () {};
+            res.end = function () {};
 
             sandbox.stub(models.User, 'check')
-                .withArgs({email: 'username', password: 'password'}).returns(new Promise.resolve({
+                .withArgs({email: 'username', password: 'password'}).returns(Promise.resolve({
                 id: 1
             }));
 
             sandbox.stub(authUtils, 'createTokens')
-                .returns(new Promise.resolve({
+                .returns(Promise.resolve({
                     access_token: 'AT',
                     refresh_token: 'RT',
                     expires_in: Date.now() + 1000
                 }));
 
-            sandbox.stub(res, 'setHeader', function () {
-            });
+            sandbox.stub(res, 'setHeader').callsFake(function () {});
 
-            sandbox.stub(res, 'end', function (json) {
+            sandbox.stub(res, 'end').callsFake(function (json) {
                 try {
                     should.exist(json);
                     json = JSON.parse(json);
@@ -161,8 +161,8 @@ describe('OAuth', function () {
             req.connection = {remoteAddress: '127.0.0.1'};
             req.body.grant_type = 'refresh_token';
             req.body.refresh_token = 'token';
-            res.setHeader = {};
-            res.end = {};
+            res.setHeader = function () {};
+            res.end = function () {};
 
             sandbox.stub(models.Refreshtoken, 'findOne')
                 .withArgs({token: 'token'}).returns(new Promise.resolve({
@@ -180,10 +180,9 @@ describe('OAuth', function () {
                     expires_in: Date.now() + 1000
                 }));
 
-            sandbox.stub(res, 'setHeader', function () {
-            });
+            sandbox.stub(res, 'setHeader').callsFake(function () {});
 
-            sandbox.stub(res, 'end', function (json) {
+            sandbox.stub(res, 'end').callsFake(function (json) {
                 try {
                     should.exist(json);
                     json = JSON.parse(json);
@@ -269,7 +268,7 @@ describe('OAuth', function () {
                 }
             }));
 
-            sandbox.stub(authUtils, 'createTokens', function () {
+            sandbox.stub(authUtils, 'createTokens').callsFake(function () {
                 return Promise.reject(new Error('DB error'));
             });
 
@@ -318,7 +317,7 @@ describe('OAuth', function () {
                     expires_in: 10
                 }));
 
-            sandbox.stub(passport, 'authenticate', function (name, options, onSuccess) {
+            sandbox.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
                 return function () {
                     onSuccess(null, user);
                 };
@@ -339,7 +338,7 @@ describe('OAuth', function () {
             req.body.grant_type = 'authorization_code';
             req.body.authorizationCode = '1234';
 
-            sandbox.stub(passport, 'authenticate', function (name, options, onSuccess) {
+            sandbox.stub(passport, 'authenticate').callsFake(function (name, options, onSuccess) {
                 return function () {
                     onSuccess(new errors.UnauthorizedError());
                 };

--- a/core/test/unit/controllers/entry_spec.js
+++ b/core/test/unit/controllers/entry_spec.js
@@ -46,7 +46,7 @@ describe('Controllers', function () {
             hasTemplate: hasTemplateStub
         });
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     }
@@ -119,7 +119,7 @@ describe('Controllers', function () {
         }];
 
         beforeEach(function () {
-            sandbox.stub(api.posts, 'read', function (args) {
+            sandbox.stub(api.posts, 'read').callsFake(function (args) {
                 var post = _.find(mockPosts, function (mock) {
                     return mock.posts[0].slug === args.slug;
                 });

--- a/core/test/unit/controllers/frontend/post-lookup_spec.js
+++ b/core/test/unit/controllers/frontend/post-lookup_spec.js
@@ -19,7 +19,7 @@ describe('postLookup', function () {
     beforeEach(function () {
         postAPIStub = sandbox.stub(api.posts, 'read');
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });

--- a/core/test/unit/controllers/preview_spec.js
+++ b/core/test/unit/controllers/preview_spec.js
@@ -101,7 +101,7 @@ describe('Controllers', function () {
         }];
 
         beforeEach(function () {
-            sandbox.stub(api.posts, 'read', function (args) {
+            sandbox.stub(api.posts, 'read').callsFake(function (args) {
                 var post = _.find(mockPosts, function (mock) {
                     return mock.posts[0].uuid === args.uuid;
                 });

--- a/core/test/unit/controllers/rss_spec.js
+++ b/core/test/unit/controllers/rss_spec.js
@@ -41,11 +41,11 @@ describe('RSS', function () {
 
             // Overwrite getData
             fakeData = {meta: {pagination: {pages: 3}}};
-            getDataStub = sandbox.stub().returns(new Promise.resolve(fakeData));
+            getDataStub = sandbox.stub().returns(Promise.resolve(fakeData));
 
             resetGetData = rssController.__set__('getData', getDataStub);
 
-            rssServiceStub = sandbox.stub(rssService, 'render').returns(new Promise.resolve());
+            rssServiceStub = sandbox.stub(rssService, 'render').returns(Promise.resolve());
         });
 
         afterEach(function () {
@@ -160,7 +160,7 @@ describe('RSS', function () {
             resetFetchData = rssController.__set__('fetchData', fetchDataStub);
             getData = rssController.__get__('getData');
 
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 var obj = {
                     title: 'Test',
                     description: 'Some Text'

--- a/core/test/unit/data/importer/index_spec.js
+++ b/core/test/unit/data/importer/index_spec.js
@@ -239,10 +239,10 @@ describe('Importer', function () {
                 var input = {data: {posts: []}, images: []},
                     // pass a copy so that input doesn't get modified
                     inputCopy = _.cloneDeep(input),
-                    dataSpy = sandbox.stub(DataImporter, 'doImport', function (i) {
+                    dataSpy = sandbox.stub(DataImporter, 'doImport').callsFake(function (i) {
                         return Promise.resolve(i);
                     }),
-                    imageSpy = sandbox.stub(ImageImporter, 'doImport', function (i) {
+                    imageSpy = sandbox.stub(ImageImporter, 'doImport').callsFake(function (i) {
                         return Promise.resolve(i);
                     }),
 
@@ -686,7 +686,7 @@ describe('Importer', function () {
                 storageApi = {
                     save: sandbox.stub().returns(Promise.resolve())
                 },
-                storageSpy = sandbox.stub(storage, 'getStorage', function () {
+                storageSpy = sandbox.stub(storage, 'getStorage').callsFake(function () {
                     return storageApi;
                 });
 

--- a/core/test/unit/exporter_spec.js
+++ b/core/test/unit/exporter_spec.js
@@ -12,7 +12,7 @@ var should = require('should'),
     sandbox = sinon.sandbox.create();
 
 describe('Exporter', function () {
-    var tablesStub, queryMock, knexMock, knexStub;
+    var tablesStub, queryMock, knexMock;
 
     before(function () {
         models.init();
@@ -20,7 +20,6 @@ describe('Exporter', function () {
 
     afterEach(function () {
         sandbox.restore();
-        knexStub.restore();
     });
 
     describe('doExport', function () {
@@ -37,11 +36,8 @@ describe('Exporter', function () {
 
             knexMock = sandbox.stub().returns(queryMock);
 
-            // this MUST use sinon, not sandbox, see sinonjs/sinon#781
-            knexStub = sinon.stub(db, 'knex', {
-                get: function () {
-                    return knexMock;
-                }
+            sandbox.stub(db, 'knex').get(function () {
+                return knexMock;
             });
         });
 
@@ -59,8 +55,7 @@ describe('Exporter', function () {
                 exportData.meta.version.should.eql('1.0.0');
 
                 tablesStub.calledOnce.should.be.true();
-                knexStub.get.called.should.be.true();
-                knexMock.called.should.be.true();
+                db.knex.called.should.be.true();
                 queryMock.select.called.should.be.true();
 
                 knexMock.callCount.should.eql(expectedCallCount);
@@ -92,7 +87,7 @@ describe('Exporter', function () {
 
         it('should catch and log any errors', function (done) {
             // Setup for failure
-            queryMock.select.returns(new Promise.reject({}));
+            queryMock.select.returns(Promise.reject({}));
 
             // Execute
             exporter.doExport()

--- a/core/test/unit/helpers/asset_spec.js
+++ b/core/test/unit/helpers/asset_spec.js
@@ -13,7 +13,7 @@ describe('{{asset}} helper', function () {
         configUtils.set({assetHash: 'abc'});
         configUtils.set({useMinFiles: true});
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -46,7 +46,7 @@ describe('{{ghost_head}} helper', function () {
         };
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
 
@@ -1279,7 +1279,7 @@ describe('{{ghost_head}} helper', function () {
         };
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
 
@@ -1316,7 +1316,7 @@ describe('{{ghost_head}} helper', function () {
         };
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
 
@@ -1382,7 +1382,7 @@ describe('{{ghost_head}} helper', function () {
         };
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
 
@@ -1613,7 +1613,7 @@ describe('{{ghost_head}} helper', function () {
                 url: 'http://localhost:65530/'
             });
 
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
         });

--- a/core/test/unit/helpers/meta_title_spec.js
+++ b/core/test/unit/helpers/meta_title_spec.js
@@ -8,7 +8,7 @@ var should = require('should'),
 
 describe('{{meta_title}} helper', function () {
     before(function () {
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 title: 'Ghost'
             }[key];

--- a/core/test/unit/helpers/next_post_spec.js
+++ b/core/test/unit/helpers/next_post_spec.js
@@ -19,7 +19,7 @@ describe('{{next_post}} helper', function () {
 
     describe('with valid post data - ', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/next/', title: 'post 3'}]
@@ -61,7 +61,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for valid post with no next post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: []});
                 }
@@ -99,7 +99,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for invalid post data', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({});
                 }
@@ -126,7 +126,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for page', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -161,7 +161,7 @@ describe('{{next_post}} helper', function () {
 
     describe('for unpublished post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({posts: [{slug: '/next/', title: 'post 3'}]});
                 }
@@ -195,7 +195,7 @@ describe('{{next_post}} helper', function () {
 
     describe('with "in" option', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:>') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/next/', title: 'post 1'}]
@@ -334,7 +334,7 @@ describe('{{next_post}} helper', function () {
 
     describe('general error handling', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function () {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.reject(new errors.NotFoundError({message: 'Something wasn\'t found'}));
             });
         });

--- a/core/test/unit/helpers/prev_post_spec.js
+++ b/core/test/unit/helpers/prev_post_spec.js
@@ -19,7 +19,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('with valid post data - ', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/previous/', title: 'post 1'}]
@@ -61,7 +61,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for valid post with no previous post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: []});
                 }
@@ -99,7 +99,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for invalid post data', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({});
                 }
@@ -126,7 +126,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for page', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -161,7 +161,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('for unpublished post', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({posts: [{slug: '/previous/', title: 'post 1'}]});
                 }
@@ -195,7 +195,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('with "in" option', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function (options) {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function (options) {
                 if (options.filter.indexOf('published_at:<=') > -1) {
                     return Promise.resolve({
                         posts: [{slug: '/previous/', title: 'post 1'}]
@@ -334,7 +334,7 @@ describe('{{prev_post}} helper', function () {
 
     describe('general error handling', function () {
         beforeEach(function () {
-            browsePostStub = sandbox.stub(api.posts, 'browse', function () {
+            browsePostStub = sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.reject(new errors.NotFoundError({message: 'Something wasn\'t found'}));
             });
         });

--- a/core/test/unit/helpers/url_spec.js
+++ b/core/test/unit/helpers/url_spec.js
@@ -19,7 +19,7 @@ describe('{{url}} helper', function () {
 
     beforeEach(function () {
         rendered = null;
-        sandbox.stub(api.settings, 'read', function () {
+        sandbox.stub(api.settings, 'read').callsFake(function () {
             return Promise.resolve({settings: [{value: '/:slug/'}]});
         });
     });

--- a/core/test/unit/mail/utils_spec.js
+++ b/core/test/unit/mail/utils_spec.js
@@ -9,7 +9,7 @@ describe('Mail: Utils', function () {
     beforeEach(function () {
         scope.ghostMailer = new mail.GhostMailer();
 
-        sandbox.stub(scope.ghostMailer.transport, 'sendMail', function (message, sendMailDone) {
+        sandbox.stub(scope.ghostMailer.transport, 'sendMail').callsFake(function (message, sendMailDone) {
             sendMailDone(null, {
                 statusHandler: {
                     once: function (eventName, eventDone) {

--- a/core/test/unit/metadata/blog_logo_spec.js
+++ b/core/test/unit/metadata/blog_logo_spec.js
@@ -13,7 +13,7 @@ describe('getBlogLogo', function () {
     it('should return logo if uploaded', function () {
         var blogLogo;
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 logo: '/content/images/logo.png',
                 icon: null
@@ -28,7 +28,7 @@ describe('getBlogLogo', function () {
     it('should return custom uploaded png icon if no logo given', function () {
         var blogLogo;
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return {
                 logo: null,
                 icon: '/content/images/favicon.png'

--- a/core/test/unit/metadata/context_object_spec.js
+++ b/core/test/unit/metadata/context_object_spec.js
@@ -49,7 +49,7 @@ describe('getContextObject', function () {
 
     describe('override blog', function () {
         before(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return {
                     cover_image: 'test.png'
                 }[key];

--- a/core/test/unit/metadata/title_spec.js
+++ b/core/test/unit/metadata/title_spec.js
@@ -8,7 +8,7 @@ describe('getTitle', function () {
     var localSettingsCache = {};
 
     beforeEach(function () {
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
     });

--- a/core/test/unit/middleware/serve-favicon_spec.js
+++ b/core/test/unit/middleware/serve-favicon_spec.js
@@ -19,7 +19,7 @@ describe('Serve Favicon', function () {
         blogApp = express();
         req.app = blogApp;
 
-        sandbox.stub(settingsCache, 'get', function (key) {
+        sandbox.stub(settingsCache, 'get').callsFake(function (key) {
             return localSettingsCache[key];
         });
 

--- a/core/test/unit/middleware/serve-public-file_spec.js
+++ b/core/test/unit/middleware/serve-public-file_spec.js
@@ -36,7 +36,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: * Disallow: /';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile', function (file, cb) {
+        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 
@@ -62,7 +62,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: * Disallow: /';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile', function (file, cb) {
+        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 
@@ -86,7 +86,7 @@ describe('servePublicFile', function () {
             body = 'User-agent: {{blog-url}}';
         req.path = '/robots.txt';
 
-        sandbox.stub(fs, 'readFile', function (file, cb) {
+        sandbox.stub(fs, 'readFile').callsFake(function (file, cb) {
             cb(null, body);
         });
 

--- a/core/test/unit/models/base/listeners_spec.js
+++ b/core/test/unit/models/base/listeners_spec.js
@@ -10,7 +10,7 @@ describe('Models: listeners', function () {
     var eventsToRemember = {};
 
     before(function () {
-        sandbox.stub(events, 'on', function (name, callback) {
+        sandbox.stub(events, 'on').callsFake(function (name, callback) {
             eventsToRemember[name] = callback;
         });
 

--- a/core/test/unit/permissions/can-this_spec.js
+++ b/core/test/unit/permissions/can-this_spec.js
@@ -19,15 +19,15 @@ describe('Permissions', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(models.Permission, 'findAll', function () {
+        sandbox.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));
         });
 
-        findPostSpy = sandbox.stub(models.Post, 'findOne', function () {
+        findPostSpy = sandbox.stub(models.Post, 'findOne').callsFake(function () {
             return Promise.resolve(models.Post.forge(testUtils.DataGenerator.Content.posts[0]));
         });
 
-        findTagSpy = sandbox.stub(models.Tag, 'findOne', function () {
+        findTagSpy = sandbox.stub(models.Tag, 'findOne').callsFake(function () {
             return Promise.resolve({});
         });
     });
@@ -241,7 +241,7 @@ describe('Permissions', function () {
             // It can depend on bookshelf, but should NOT use hard coded model knowledge.
             // We use the tag model here because it doesn't have permissible, once that changes, these tests must also change
             it('No permissions: cannot edit tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: [],
@@ -264,7 +264,7 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -285,7 +285,7 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -306,7 +306,7 @@ describe('Permissions', function () {
             });
 
             it('Specific permissions: can edit correct specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -335,7 +335,7 @@ describe('Permissions', function () {
             });
 
             it('Specific permissions: cannot edit incorrect specific tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -367,7 +367,7 @@ describe('Permissions', function () {
 
             // @TODO fix this case - it makes no sense?!
             it('Specific permissions: CAN edit non-specific tag (no permissible function on model) @TODO fix this', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge([
@@ -396,7 +396,7 @@ describe('Permissions', function () {
             });
 
             it('With owner role: can edit tag (no permissible function on model)', function (done) {
-                var userProviderStub = sandbox.stub(providers, 'user', function () {
+                var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: [],
@@ -421,7 +421,7 @@ describe('Permissions', function () {
         describe('App-based permissions (requires user as well)', function () {
             // @TODO: revisit this - do we really need to have USER permissions AND app permissions?
             it('No permissions: cannot edit tag with app only (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app', function () {
+                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
                     // Fake the response from providers.app, which contains an empty array for this case
                     return Promise.resolve([]);
                 });
@@ -441,11 +441,11 @@ describe('Permissions', function () {
             });
 
             it('No permissions: cannot edit tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app', function () {
+                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains an empty array for this case
                         return Promise.resolve([]);
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user', function () {
+                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: [],
@@ -469,13 +469,13 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit specific tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app', function () {
+                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains permissions only
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models
                         });
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user', function () {
+                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -497,13 +497,13 @@ describe('Permissions', function () {
             });
 
             it('With permissions: can edit non-specific tag (no permissible function on model)', function (done) {
-                var appProviderStub = sandbox.stub(providers, 'app', function () {
+                var appProviderStub = sandbox.stub(providers, 'app').callsFake(function () {
                         // Fake the response from providers.app, which contains permissions only
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models
                         });
                     }),
-                    userProviderStub = sandbox.stub(providers, 'user', function () {
+                    userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                         // Fake the response from providers.user, which contains permissions and roles
                         return Promise.resolve({
                             permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
@@ -528,14 +528,14 @@ describe('Permissions', function () {
 
     describe('permissible (overridden)', function () {
         it('can use permissible function on model to forbid something (post model)', function (done) {
-            var userProviderStub = sandbox.stub(providers, 'user', function () {
+            var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
                         roles: undefined
                     });
                 }),
-                permissibleStub = sandbox.stub(models.Post, 'permissible', function () {
+                permissibleStub = sandbox.stub(models.Post, 'permissible').callsFake(function () {
                     return Promise.reject({message: 'Hello World!'});
                 });
 
@@ -565,14 +565,14 @@ describe('Permissions', function () {
         });
 
         it('can use permissible function on model to allow something (post model)', function (done) {
-            var userProviderStub = sandbox.stub(providers, 'user', function () {
+            var userProviderStub = sandbox.stub(providers, 'user').callsFake(function () {
                     // Fake the response from providers.user, which contains permissions and roles
                     return Promise.resolve({
                         permissions: models.Permissions.forge(testUtils.DataGenerator.Content.permissions).models,
                         roles: undefined
                     });
                 }),
-                permissibleStub = sandbox.stub(models.Post, 'permissible', function () {
+                permissibleStub = sandbox.stub(models.Post, 'permissible').callsFake(function () {
                     return Promise.resolve();
                 });
 

--- a/core/test/unit/permissions/index_spec.js
+++ b/core/test/unit/permissions/index_spec.js
@@ -19,15 +19,15 @@ describe('Permissions', function () {
     });
 
     beforeEach(function () {
-        sandbox.stub(models.Permission, 'findAll', function () {
+        sandbox.stub(models.Permission, 'findAll').callsFake(function () {
             return Promise.resolve(models.Permissions.forge(fakePermissions));
         });
 
-        findPostSpy = sandbox.stub(models.Post, 'findOne', function () {
+        findPostSpy = sandbox.stub(models.Post, 'findOne').callsFake(function () {
             return Promise.resolve(models.Post.forge(testUtils.DataGenerator.Content.posts[0]));
         });
 
-        findTagSpy = sandbox.stub(models.Tag, 'findOne', function () {
+        findTagSpy = sandbox.stub(models.Tag, 'findOne').callsFake(function () {
             return Promise.resolve({});
         });
     });

--- a/core/test/unit/permissions/providers_spec.js
+++ b/core/test/unit/permissions/providers_spec.js
@@ -18,7 +18,7 @@ describe('Permission Providers', function () {
 
     describe('User', function () {
         it('errors if user cannot be found', function (done) {
-            var findUserSpy = sandbox.stub(models.User, 'findOne', function () {
+            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
                 return Promise.resolve();
             });
 
@@ -35,7 +35,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne', function () {
+            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -79,7 +79,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and role.permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne', function () {
+            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -126,7 +126,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, permissions and role.permissions and deduplicate them', function (done) {
             // This test requires quite a lot of unique setup work
-            var findUserSpy = sandbox.stub(models.User, 'findOne', function () {
+            var findUserSpy = sandbox.stub(models.User, 'findOne').callsFake(function () {
                 // Create a fake model
                 var fakeUser = models.User.forge(testUtils.DataGenerator.Content.users[0]),
                     // Roles & Permissions need to be collections
@@ -178,7 +178,7 @@ describe('Permission Providers', function () {
         // Why is this an empty array, when the success is an object?
         // Also why is this an empty array when for users we error?!
         it('returns empty array if app cannot be found!', function (done) {
-            var findAppSpy = sandbox.stub(models.App, 'findOne', function () {
+            var findAppSpy = sandbox.stub(models.App, 'findOne').callsFake(function () {
                 return Promise.resolve();
             });
 
@@ -193,7 +193,7 @@ describe('Permission Providers', function () {
 
         it('can load user with role, and permissions', function (done) {
             // This test requires quite a lot of unique setup work
-            var findAppSpy = sandbox.stub(models.App, 'findOne', function () {
+            var findAppSpy = sandbox.stub(models.App, 'findOne').callsFake(function () {
                 var fakeApp = models.App.forge(testUtils.DataGenerator.Content.apps[0]),
                     fakePermissions = models.Permissions.forge(testUtils.DataGenerator.Content.permissions);
 

--- a/core/test/unit/services/apps/lifecycle_spec.js
+++ b/core/test/unit/services/apps/lifecycle_spec.js
@@ -20,10 +20,10 @@ describe('Apps', function () {
     beforeEach(function () {
         settingsCacheStub = sandbox.stub(settingsCache, 'get');
         settingsEditStub = sandbox.stub(api.settings, 'edit');
-        loaderActivateStub = sandbox.stub(AppLoader, 'activateAppByName', function (appName) {
+        loaderActivateStub = sandbox.stub(AppLoader, 'activateAppByName').callsFake(function (appName) {
             return new Promise.resolve(appName);
         });
-        loaderInstallStub = sandbox.stub(AppLoader, 'installAppByName', function (appName) {
+        loaderInstallStub = sandbox.stub(AppLoader, 'installAppByName').callsFake(function (appName) {
             return new Promise.resolve(appName);
         });
     });

--- a/core/test/unit/services/channels/parent-router_spec.js
+++ b/core/test/unit/services/channels/parent-router_spec.js
@@ -154,7 +154,7 @@ describe('Channels', function () {
 
         // Stub the posts api
         function setupPostsAPIStub() {
-            postAPIStub = sandbox.stub(api.posts, 'browse', function () {
+            postAPIStub = sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.resolve({posts: [{}], meta: {pagination: {pages: 3}}});
             });
         }
@@ -300,11 +300,11 @@ describe('Channels', function () {
 
         // Stub the posts and tags api
         function setupAPIStubs() {
-            postAPIStub = sandbox.stub(api.posts, 'browse', function () {
+            postAPIStub = sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.resolve({posts: [{}], meta: {pagination: {pages: 3}}});
             });
 
-            tagAPIStub = sandbox.stub(api.tags, 'read', function () {
+            tagAPIStub = sandbox.stub(api.tags, 'read').callsFake(function () {
                 return Promise.resolve({tags: [{}]});
             });
         }

--- a/core/test/unit/sitemap/generator_spec.js
+++ b/core/test/unit/sitemap/generator_spec.js
@@ -52,10 +52,10 @@ should.Assertion.add('ValidUrlNode', function (options) {
 
 describe('Generators', function () {
     var stubUrl = function (generator) {
-            sandbox.stub(generator, 'getUrlForDatum', function (datum) {
+            sandbox.stub(generator, 'getUrlForDatum').callsFake(function (datum) {
                 return 'http://my-ghost-blog.com/url/' + datum.id;
             });
-            sandbox.stub(generator, 'getUrlForImage', function (image) {
+            sandbox.stub(generator, 'getUrlForImage').callsFake(function (image) {
                 return 'http://my-ghost-blog.com/images/' + image;
             });
 
@@ -92,7 +92,7 @@ describe('Generators', function () {
         it('can initialize with non-empty siteMapContent', function (done) {
             stubUrl(generator);
 
-            sandbox.stub(generator, 'getData', function () {
+            sandbox.stub(generator, 'getData').callsFake(function () {
                 return Promise.resolve([
                     makeFakeDatum(100),
                     makeFakeDatum(200),
@@ -174,7 +174,7 @@ describe('Generators', function () {
         it('can initialize with non-empty siteMapContent', function (done) {
             stubUrl(generator);
 
-            sandbox.stub(generator, 'getData', function () {
+            sandbox.stub(generator, 'getData').callsFake(function () {
                 return Promise.resolve([
                     _.extend(makeFakeDatum(100), {
                         feature_image: 'post-100.jpg',
@@ -230,7 +230,7 @@ describe('Generators', function () {
 
         it('has a home item even if pages are empty', function (done) {
             // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse', function () {
+            sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.resolve({posts: []});
             });
 
@@ -247,7 +247,7 @@ describe('Generators', function () {
 
         it('has a home item when pages are not empty', function (done) {
             // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse', function () {
+            sandbox.stub(api.posts, 'browse').callsFake(function () {
                 return Promise.resolve({
                     posts: [_.extend(makeFakeDatum(100), {
                         page: true,

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -536,7 +536,7 @@ describe('Url', function () {
         };
 
         beforeEach(function () {
-            sandbox.stub(settingsCache, 'get', function (key) {
+            sandbox.stub(settingsCache, 'get').callsFake(function (key) {
                 return localSettingsCache[key];
             });
         });

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "run-sequence": "1.2.2",
     "should": "11.2.1",
     "should-http": "0.1.1",
-    "sinon": "1.17.7",
+    "sinon": "4.1.2",
     "supertest": "3.0.0",
     "tmp": "0.0.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,10 @@ diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diff@^3.1.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
 directmail@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/directmail/-/directmail-0.1.8.tgz#e4852c8a0c5519bef4904fcd96d760822f42a446"
@@ -1845,11 +1849,11 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0, formatio@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 formidable@^1.1.1:
   version "1.1.1"
@@ -3112,6 +3116,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^1.1.26:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.27.tgz#ec6e79410ff914e472652abfa0e603c03d60e905"
+
 keygrip@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.2.tgz#ad3297c557069dea8bcfe7a4fa491b75c5ddeb91"
@@ -3348,6 +3356,10 @@ lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"
@@ -3457,9 +3469,13 @@ lodash@~4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.3.0.tgz#efd9c4a6ec53f3b05412429915c3e4824e4d25a4"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.3.1.tgz#3d2319894471ea0950ef64692ead2a5318cff362"
 
 long-timeout@~0.1.1:
   version "0.1.1"
@@ -3875,6 +3891,16 @@ netjet@1.1.4:
     lru-cache "^4.0.0"
     posthtml "^0.9.0"
 
+nise@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.2.0.tgz#079d6cadbbcb12ba30e38f1c999f36ad4d6baa53"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.26"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
+    text-encoding "^0.6.4"
+
 nock@9.1.3:
   version "9.1.3"
   resolved "https://registry.yarnpkg.com/nock/-/nock-9.1.3.tgz#1ab95a973a876c9ae2a844241844e29dbb5a1d89"
@@ -4230,7 +4256,7 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.0:
+path-to-regexp@^1.0.0, path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
@@ -4984,13 +5010,9 @@ safefs@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/safefs/-/safefs-2.0.3.tgz#2db2b2de4c4161d6dba6609fee05ecab062c4de5"
 
-samsam@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
-
-samsam@~1.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+samsam@1.x:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
 sanitize-html@1.16.1:
   version "1.16.1"
@@ -5202,14 +5224,17 @@ simple-html-tokenizer@0.4.3:
     rai "~0.1.11"
     xoauth2 "~0.1.8"
 
-sinon@1.17.7:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-4.1.2.tgz#65610521d926fb53742dd84cd599f0b89a82f440"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lodash.get "^4.4.2"
+    lolex "^2.2.0"
+    nise "^1.2.0"
+    supports-color "^4.4.0"
+    type-detect "^4.0.0"
 
 slice-ansi@1.0.0:
   version "1.0.0"
@@ -5527,6 +5552,10 @@ taskgroup@~2.0.0:
     ambi "~2.0.0"
     typechecker "~2.0.1"
 
+text-encoding@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -5621,6 +5650,10 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+type-detect@^4.0.0:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.5.tgz#d70e5bc81db6de2a381bcaca0c6e0cbdc7635de2"
 
 type-is@^1.6.4, type-is@~1.6.10, type-is@~1.6.13, type-is@~1.6.15:
   version "1.6.15"
@@ -5761,12 +5794,6 @@ user-home@^1.0.0, user-home@^1.1.1:
 util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 utils-merge@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
refs #9178

- adapt major changes
- use `.callsFake`, see http://sinonjs.org/releases/v3.0.0/migrating-to-3.0/
- use inbuilt getters