### PR TITLE
Ensure tests exit in Travis

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,8 @@ var config         = require('./core/server/config'),
                     reporter: grunt.option('reporter') || 'spec',
                     timeout: '30000',
                     save: grunt.option('reporter-output'),
-                    require: ['core/server/overrides']
+                    require: ['core/server/overrides'],
+                    exit: true
                 },
 
                 // #### All Unit tests


### PR DESCRIPTION
refs https://github.com/mochajs/mocha/issues/3044

- there was a breaking change in mocha, which i have mentioned [here](https://github.com/TryGhost/Ghost/commit/ee7710ba68fc9a2f8a523ac2429bc3ff45a87b40), but i thought it's not required, but it is
- it can happen that with mocha 4.x, travis does not complete a test run, because the process does not exit (maybe the test env does not shutdown everything completely)
- but it's hard to figure out why that happens, so we simply add `--exit` (this reflects the mocha 3.x behaviour)
- i've tested that failed tests are still counted and the build results in a red state