### PR TITLE
Ensure tests exit in Travis (second attempt)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -180,7 +180,7 @@ var config         = require('./core/server/config'),
                     options: {
                         mask: '**/*_spec.js',
                         coverageFolder: 'core/test/coverage/unit',
-                        mochaOptions: ['--timeout=15000', '--require', 'core/server/overrides'],
+                        mochaOptions: ['--timeout=15000', '--require', 'core/server/overrides', '--exit'],
                         excludes: ['core/client', 'core/server/built']
                     }
                 },
@@ -193,7 +193,7 @@ var config         = require('./core/server/config'),
                     options: {
                         coverageFolder: 'core/test/coverage/all',
                         mask: '**/*_spec.js',
-                        mochaOptions: ['--timeout=15000', '--require', 'core/server/overrides'],
+                        mochaOptions: ['--timeout=15000', '--require', 'core/server/overrides', '--exit'],
                         excludes: ['core/client', 'core/server/built']
                     }
 

--- a/core/test/functional/routes/apps/subscribers/routing_spec.js
+++ b/core/test/functional/routes/apps/subscribers/routing_spec.js
@@ -24,6 +24,8 @@ describe('Subscriber: Routing', function () {
         });
     });
 
+    after(testUtils.teardown);
+
     after(function () {
         return ghostServer.stop();
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/commit/611e8b5634668ae7f908765532510cdf919d47cf

Second attempt 👻
Looks like only `grunt coverage` won't tell Travis that the tests are finished.