### PR TITLE
Redirect with the base url

### DIFF
--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -9,12 +9,13 @@
 var slashes = require('connect-slashes'),
     config = require('../config');
 
-module.exports = [
-    var baseUrl = config.get('url');
+var baseUrl = config.get('url');
 
-    if (!baseUrl) {
-        baseUrl = '/';
-    }
+if (!baseUrl) {
+    baseUrl = '/';
+}
+
+module.exports = [
 
     slashes(true, {
         base: baseUrl,

--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -12,7 +12,7 @@ var slashes = require('connect-slashes'),
 var baseUrl = config.get('url');
 
 if (!baseUrl) {
-    baseUrl = '/';
+    baseUrl = '';
 }
 
 module.exports = [

--- a/core/server/middleware/pretty-urls.js
+++ b/core/server/middleware/pretty-urls.js
@@ -10,7 +10,14 @@ var slashes = require('connect-slashes'),
     config = require('../config');
 
 module.exports = [
+    var baseUrl = config.get('url');
+
+    if (!baseUrl) {
+        baseUrl = '/';
+    }
+
     slashes(true, {
+        base: baseUrl,
         headers: {
             'Cache-Control': 'public, max-age=' + config.get('caching:301:maxAge')
         }


### PR DESCRIPTION
Pretty URLs should consider the base URL of the project or it ends up redirecting wrong.

If you host your blog under `/blog` and you navigate to `/blog/something`, it will attempt to redirect to `/something`/ instead of `/blog/something/`.

This adds support to actually pass the base url downstream to the `connect-slashes` lib.