### PR TITLE
Fixes - #9263 - Changed the symbol to use :)

### DIFF
--- a/core/server/services/slack.js
+++ b/core/server/services/slack.js
@@ -98,7 +98,7 @@ function listener(model, options) {
 
 function testPing() {
     ping({
-        message: 'Heya! This is a test notification from your Ghost blog :simple_smile:. Seems to work fine!'
+        message: 'Heya! This is a test notification from your Ghost blog :). Seems to work fine!'
     });
 }
 

--- a/core/server/services/slack.js
+++ b/core/server/services/slack.js
@@ -98,7 +98,7 @@ function listener(model, options) {
 
 function testPing() {
     ping({
-        message: 'Heya! This is a test notification from your Ghost blog :). Seems to work fine!'
+        message: 'Heya! This is a test notification from your Ghost blog :smile:. Seems to work fine!'
     });
 }
 


### PR DESCRIPTION
Fixes #9263 

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)
