### PR TITLE
Small UrlService optimisations && Moved utils/url.js to UrlService

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,22 +8,22 @@
 
 require('./core/server/overrides');
 
-var config         = require('./core/server/config'),
-    utils          = require('./core/server/utils'),
-    _              = require('lodash'),
-    chalk          = require('chalk'),
-    fs             = require('fs-extra'),
-    KnexMigrator   = require('knex-migrator'),
+var config = require('./core/server/config'),
+    urlService = require('./core/server/services/url'),
+    _ = require('lodash'),
+    chalk = require('chalk'),
+    fs = require('fs-extra'),
+    KnexMigrator = require('knex-migrator'),
     knexMigrator = new KnexMigrator({
         knexMigratorFilePath: config.get('paths:appRoot')
     }),
 
-    path           = require('path'),
+    path = require('path'),
 
-    escapeChar     = process.platform.match(/^win/) ? '^' : '\\',
-    cwd            = process.cwd().replace(/( |\(|\))/g, escapeChar + '$1'),
+    escapeChar = process.platform.match(/^win/) ? '^' : '\\',
+    cwd = process.cwd().replace(/( |\(|\))/g, escapeChar + '$1'),
     buildDirectory = path.resolve(cwd, '.build'),
-    distDirectory  = path.resolve(cwd, '.dist'),
+    distDirectory = path.resolve(cwd, '.dist'),
 
     // ## Grunt configuration
 
@@ -230,8 +230,8 @@ var config         = require('./core/server/config'),
                         var upstream = grunt.option('upstream') || process.env.GHOST_UPSTREAM || 'upstream';
                         grunt.log.writeln('Pulling down the latest master from ' + upstream);
                         return 'git checkout master; git pull ' + upstream + ' master; ' +
-                        'yarn; git submodule foreach "git checkout master && git pull ' +
-                        upstream + ' master"';
+                            'yarn; git submodule foreach "git checkout master && git pull ' +
+                            upstream + ' master"';
                     }
                 },
 
@@ -349,7 +349,7 @@ var config         = require('./core/server/config'),
 
                 watch: {
                     projects: {
-                        'core/client': ['shell:ember:watch', '--live-reload-base-url="' + utils.url.getSubdir() + '/ghost/"']
+                        'core/client': ['shell:ember:watch', '--live-reload-base-url="' + urlService.utils.getSubdir() + '/ghost/"']
                     }
                 }
             },

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -1,11 +1,11 @@
 var Promise = require('bluebird'),
     moment = require('moment'),
-    localUtils = require(__dirname + '/../utils'),
-    events = require(__dirname + '/../../../events'),
-    errors = require(__dirname + '/../../../errors'),
-    models = require(__dirname + '/../../../models'),
-    schedules = require(__dirname + '/../../../api/schedules'),
-    utils = require(__dirname + '/../../../utils'),
+    localUtils = require('../utils'),
+    events = require('../../../events'),
+    errors = require('../../../errors'),
+    models = require('../../../models'),
+    schedules = require('../../../api/schedules'),
+    urlService = require('../../../services/url'),
     _private = {};
 
 _private.normalize = function normalize(options) {
@@ -15,7 +15,7 @@ _private.normalize = function normalize(options) {
 
     return {
         time: moment(object.get('published_at')).valueOf(),
-        url: utils.url.urlJoin(apiUrl, 'schedules', 'posts', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
+        url: urlService.utils.urlJoin(apiUrl, 'schedules', 'posts', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
         extra: {
             httpMethod: 'PUT',
             oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -11,7 +11,8 @@ var serveStatic = require('express').static,
     config = require('../../config'),
     errors = require('../../errors'),
     i18n = require('../../i18n'),
-    utils = require('../../utils'),
+    globalUtils = require('../../utils'),
+    urlService = require('../../services/url'),
     logging = require('../../logging'),
     StorageBase = require('ghost-storage-base');
 
@@ -47,8 +48,8 @@ class LocalFileStore extends StorageBase {
             // The src for the image must be in URI format, not a file system path, which in Windows uses \
             // For local file system storage can use relative path so add a slash
             var fullUrl = (
-                utils.url.urlJoin('/', utils.url.getSubdir(),
-                    utils.url.STATIC_IMAGE_URL_PREFIX,
+                urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
+                    urlService.utils.STATIC_IMAGE_URL_PREFIX,
                     path.relative(self.storagePath, targetFilename))
             ).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
@@ -85,7 +86,7 @@ class LocalFileStore extends StorageBase {
             return serveStatic(
                 self.storagePath,
                 {
-                    maxAge: utils.ONE_YEAR_MS,
+                    maxAge: globalUtils.ONE_YEAR_MS,
                     fallthrough: false,
                     onEnd: function onEnd() {
                         logging.info('LocalFileStorage.serve', req.path, moment().diff(startedAtMoment, 'ms') + 'ms');

--- a/core/server/adapters/storage/utils.js
+++ b/core/server/adapters/storage/utils.js
@@ -1,4 +1,4 @@
-var globalUtils = require('../../utils');
+var urlService = require('../../services/url');
 
 /**
  * @TODO: move `index.js` to here - e.g. storageUtils.getStorage
@@ -15,8 +15,8 @@ var globalUtils = require('../../utils');
  */
 exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
     // The '/' in urlJoin is necessary to add the '/' to `content/images`, if no subdirectory is setup
-    var urlRegExp = new RegExp('^' + globalUtils.url.urlJoin(globalUtils.url.urlFor('home', true), globalUtils.url.getSubdir(), '/', globalUtils.url.STATIC_IMAGE_URL_PREFIX)),
-        filePathRegExp = new RegExp('^' + globalUtils.url.urlJoin(globalUtils.url.getSubdir(), '/', globalUtils.url.STATIC_IMAGE_URL_PREFIX));
+    var urlRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX)),
+        filePathRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX));
 
     if (imagePath.match(urlRegExp)) {
         return imagePath.replace(urlRegExp, '');

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -4,6 +4,7 @@ var Promise = require('bluebird'),
     pipeline = require('../utils/pipeline'),
     mail = require('./../mail'),
     globalUtils = require('../utils'),
+    urlService = require('../services/url'),
     apiUtils = require('./utils'),
     models = require('../models'),
     config = require('../config'),
@@ -184,8 +185,8 @@ authentication = {
         }
 
         function sendResetNotification(data) {
-            var adminUrl = globalUtils.url.urlFor('admin', true),
-                resetUrl = globalUtils.url.urlJoin(adminUrl, 'reset', globalUtils.encodeBase64URLsafe(data.resetToken), '/');
+            var adminUrl = urlService.utils.urlFor('admin', true),
+                resetUrl = urlService.utils.urlJoin(adminUrl, 'reset', globalUtils.encodeBase64URLsafe(data.resetToken), '/');
 
             return mail.utils.generateContent({
                 data: {

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -2,7 +2,7 @@
 // RESTful API for browsing the configuration
 var Promise = require('bluebird'),
     _ = require('lodash'),
-    apiUtils = require('../utils'),
+    urlService = require('../services/url'),
     models = require('../models'),
     config = require('../config'),
     settingsCache = require('../settings/cache'),
@@ -27,7 +27,7 @@ function getBaseConfig() {
     return {
         useGravatar: !config.isPrivacyDisabled('useGravatar'),
         publicAPI: config.get('publicAPI') === true,
-        blogUrl: apiUtils.url.urlFor('home', true),
+        blogUrl: urlService.utils.urlFor('home', true),
         blogTitle: settingsCache.get('title'),
         routeKeywords: config.get('routeKeywords'),
         clientExtensions: config.get('clientExtensions')

--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -11,7 +11,7 @@ var Promise = require('bluebird'),
     models = require('../models'),
     config = require('../config'),
     errors = require('../errors'),
-    utilsUrl = require('../utils/url'),
+    urlService = require('../services/url'),
     docName = 'db',
     db;
 
@@ -36,7 +36,7 @@ db = {
 
         return Promise.props(props)
             .then(function successMessage(exportResult) {
-                var filename = path.resolve(utilsUrl.urlJoin(config.get('paths').contentPath, 'data', exportResult.filename));
+                var filename = path.resolve(urlService.utils.urlJoin(config.get('paths').contentPath, 'data', exportResult.filename));
 
                 return Promise.promisify(fs.writeFile)(filename, JSON.stringify(exportResult.data))
                     .then(function () {

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -8,7 +8,7 @@ var _ = require('lodash'),
     Promise = require('bluebird'),
     config = require('../config'),
     models = require('../models'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     configuration = require('./configuration'),
     db = require('./db'),
     mail = require('./mail'),
@@ -103,7 +103,7 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
             if (hasStatusChanged || wasPublishedUpdated) {
                 return INVALIDATE_ALL;
             } else {
-                return utils.url.urlFor({relativeUrl: utils.url.urlJoin('/', config.get('routeKeywords').preview, post.uuid, '/')});
+                return urlService.utils.urlFor({relativeUrl: urlService.utils.urlJoin('/', config.get('routeKeywords').preview, post.uuid, '/')});
             }
         }
     }
@@ -121,7 +121,7 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
  * @return {String} Resolves to header string
  */
 locationHeader = function locationHeader(req, result) {
-    var apiRoot = utils.url.urlFor('api'),
+    var apiRoot = urlService.utils.urlFor('api'),
         location,
         newObject,
         statusQuery;
@@ -130,19 +130,19 @@ locationHeader = function locationHeader(req, result) {
         if (result.hasOwnProperty('posts')) {
             newObject = result.posts[0];
             statusQuery = '/?status=' + newObject.status;
-            location = utils.url.urlJoin(apiRoot, 'posts', newObject.id, statusQuery);
+            location = urlService.utils.urlJoin(apiRoot, 'posts', newObject.id, statusQuery);
         } else if (result.hasOwnProperty('notifications')) {
             newObject = result.notifications[0];
-            location = utils.url.urlJoin(apiRoot, 'notifications', newObject.id, '/');
+            location = urlService.utils.urlJoin(apiRoot, 'notifications', newObject.id, '/');
         } else if (result.hasOwnProperty('users')) {
             newObject = result.users[0];
-            location = utils.url.urlJoin(apiRoot, 'users', newObject.id, '/');
+            location = urlService.utils.urlJoin(apiRoot, 'users', newObject.id, '/');
         } else if (result.hasOwnProperty('tags')) {
             newObject = result.tags[0];
-            location = utils.url.urlJoin(apiRoot, 'tags', newObject.id, '/');
+            location = urlService.utils.urlJoin(apiRoot, 'tags', newObject.id, '/');
         } else if (result.hasOwnProperty('webhooks')) {
             newObject = result.webhooks[0];
-            location = utils.url.urlJoin(apiRoot, 'webhooks', newObject.id, '/');
+            location = urlService.utils.urlJoin(apiRoot, 'webhooks', newObject.id, '/');
         }
     }
 

--- a/core/server/api/invites.js
+++ b/core/server/api/invites.js
@@ -3,6 +3,7 @@ var Promise = require('bluebird'),
     pipeline = require('../utils/pipeline'),
     mail = require('./../mail'),
     globalUtils = require('../utils'),
+    urlService = require('../services/url'),
     apiUtils = require('./utils'),
     models = require('../models'),
     errors = require('../errors'),
@@ -101,14 +102,14 @@ invites = {
                     return settingsAPI.read({key: 'title'});
                 })
                 .then(function (response) {
-                    var adminUrl = globalUtils.url.urlFor('admin', true);
+                    var adminUrl = urlService.utils.urlFor('admin', true);
 
                     emailData = {
                         blogName: response.settings[0].value,
                         invitedByName: loggedInUser.get('name'),
                         invitedByEmail: loggedInUser.get('email'),
                         // @TODO: resetLink sounds weird
-                        resetLink: globalUtils.url.urlJoin(adminUrl, 'signup', globalUtils.encodeBase64URLsafe(invite.get('token')), '/')
+                        resetLink: urlService.utils.urlJoin(adminUrl, 'signup', globalUtils.encodeBase64URLsafe(invite.get('token')), '/')
                     };
 
                     return mail.utils.generateContent({data: emailData, template: 'invite-user'});

--- a/core/server/apps/amp/lib/helpers/amp_content.js
+++ b/core/server/apps/amp/lib/helpers/amp_content.js
@@ -16,7 +16,7 @@ var Promise = require('bluebird'),
     i18n = proxy.i18n,
     errors = proxy.errors,
     makeAbsoluteUrl = require('../../../../utils/make-absolute-urls'),
-    utils = require('../../../../utils'),
+    urlService = require('../../../../services/url'),
     amperizeCache = {},
     allowedAMPTags = [],
     allowedAMPAttributes = {},
@@ -126,7 +126,7 @@ function getAmperizeHTML(html, post) {
     amperize = amperize || new Amperize();
 
     // make relative URLs abolute
-    html = makeAbsoluteUrl(html, utils.url.urlFor('home', true), post.url).html();
+    html = makeAbsoluteUrl(html, urlService.utils.urlFor('home', true), post.url).html();
 
     if (!amperizeCache[post.id] || moment(new Date(amperizeCache[post.id].updated_at)).diff(new Date(post.updated_at)) < 0) {
         return new Promise(function (resolve) {

--- a/core/server/apps/private-blogging/index.js
+++ b/core/server/apps/private-blogging/index.js
@@ -1,18 +1,18 @@
-var config     = require('../../config'),
-    utils      = require('../../utils'),
-    errors     = require('../../errors'),
-    logging    = require('../../logging'),
-    i18n       = require('../../i18n'),
+var config = require('../../config'),
+    urlService = require('../../services/url'),
+    errors = require('../../errors'),
+    logging = require('../../logging'),
+    i18n = require('../../i18n'),
     middleware = require('./lib/middleware'),
-    router     = require('./lib/router'),
+    router = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
     checkSubdir;
 
 checkSubdir = function checkSubdir() {
     var paths;
 
-    if (utils.url.getSubdir()) {
-        paths = utils.url.getSubdir().split('/');
+    if (urlService.utils.getSubdir()) {
+        paths = urlService.utils.getSubdir().split('/');
 
         if (paths.pop() === config.get('routeKeywords').private) {
             logging.error(new errors.GhostError({

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -3,7 +3,8 @@ var fs = require('fs'),
     crypto = require('crypto'),
     path = require('path'),
     config = require('../../../config'),
-    utils = require('../../../utils'),
+    urlService = require('../../../services/url'),
+    globalUtils = require('../../../utils'),
     errors = require('../../../errors'),
     i18n = require('../../../i18n'),
     settingsCache = require('../../../settings/cache'),
@@ -32,7 +33,7 @@ privateBlogging = {
         res.isPrivateBlog = true;
 
         return session({
-            maxAge: utils.ONE_MONTH_MS,
+            maxAge: globalUtils.ONE_MONTH_MS,
             signed: false
         })(req, res, next);
     },
@@ -88,7 +89,7 @@ privateBlogging = {
         if (isVerified) {
             return next();
         } else {
-            url = utils.url.urlFor({relativeUrl: privateRoute});
+            url = urlService.utils.urlFor({relativeUrl: privateRoute});
             url += req.url === '/' ? '' : '?r=' + encodeURIComponent(req.url);
             return res.redirect(url);
         }
@@ -97,7 +98,7 @@ privateBlogging = {
     // This is here so a call to /private/ after a session is verified will redirect to home;
     isPrivateSessionAuth: function isPrivateSessionAuth(req, res, next) {
         if (!res.isPrivateBlog) {
-            return res.redirect(utils.url.urlFor('home', true));
+            return res.redirect(urlService.utils.urlFor('home', true));
         }
 
         var hash = req.session.token || '',
@@ -106,7 +107,7 @@ privateBlogging = {
 
         if (isVerified) {
             // redirect to home if user is already authenticated
-            return res.redirect(utils.url.urlFor('home', true));
+            return res.redirect(urlService.utils.urlFor('home', true));
         } else {
             return next();
         }
@@ -129,7 +130,7 @@ privateBlogging = {
             req.session.token = hasher.digest('hex');
             req.session.salt = salt;
 
-            return res.redirect(utils.url.urlFor({relativeUrl: decodeURIComponent(forward)}));
+            return res.redirect(urlService.utils.urlFor({relativeUrl: decodeURIComponent(forward)}));
         } else {
             res.error = {
                 message: i18n.t('errors.middleware.privateblogging.wrongPassword')

--- a/core/server/auth/auth-strategies.js
+++ b/core/server/auth/auth-strategies.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     models = require('../models'),
-    utils = require('../utils'),
+    globalUtils = require('../utils'),
     i18n = require('../i18n'),
     errors = require('../errors'),
     strategies;
@@ -95,7 +95,7 @@ strategies = {
 
         handleInviteToken = function handleInviteToken() {
             var user, invite;
-            inviteToken = utils.decodeBase64URLsafe(inviteToken);
+            inviteToken = globalUtils.decodeBase64URLsafe(inviteToken);
 
             return models.Invite.findOne({token: inviteToken}, options)
                 .then(function addInviteUser(_invite) {
@@ -116,7 +116,7 @@ strategies = {
                     return models.User.add({
                         email: profile.email,
                         name: profile.name,
-                        password: utils.uid(50),
+                        password: globalUtils.uid(50),
                         roles: [invite.toJSON().role_id],
                         ghost_auth_id: profile.id,
                         ghost_auth_access_token: ghostAuthAccessToken

--- a/core/server/controllers/entry.js
+++ b/core/server/controllers/entry.js
@@ -1,4 +1,4 @@
-var utils = require('../utils'),
+var urlService = require('../services/url'),
     filters = require('../filters'),
     handleError = require('./frontend/error'),
     postLookup = require('./frontend/post-lookup'),
@@ -31,12 +31,12 @@ module.exports = function entryController(req, res, next) {
 
         // CASE: last param is of url is /edit, redirect to admin
         if (lookup.isEditURL) {
-            return utils.url.redirectToAdmin(302, res, '#/editor/' + post.id);
+            return urlService.utils.redirectToAdmin(302, res, '#/editor/' + post.id);
         }
 
         // CASE: permalink is not valid anymore, we redirect him permanently to the correct one
         if (post.url !== req.path) {
-            return utils.url.redirect301(res, post.url);
+            return urlService.utils.redirect301(res, post.url);
         }
 
         setRequestIsSecure(req, post);

--- a/core/server/controllers/preview.js
+++ b/core/server/controllers/preview.js
@@ -1,5 +1,5 @@
 var api = require('../api'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     filters = require('../filters'),
     handleError = require('./frontend/error'),
     renderEntry = require('./frontend/render-entry'),
@@ -30,14 +30,14 @@ module.exports = function previewController(req, res, next) {
 
         if (req.params.options && req.params.options.toLowerCase() === 'edit') {
             // CASE: last param is of url is /edit, redirect to admin
-            return utils.url.redirectToAdmin(302, res, '#/editor/' + post.id);
+            return urlService.utils.redirectToAdmin(302, res, '#/editor/' + post.id);
         } else if (req.params.options) {
             // CASE: unknown options param detected. Ignore and end in 404.
             return next();
         }
 
         if (post.status === 'published') {
-            return utils.url.redirect301(res, utils.url.urlFor('post', {post: post}));
+            return urlService.utils.redirect301(res, urlService.utils.urlFor('post', {post: post}));
         }
 
         setRequestIsSecure(req, post);

--- a/core/server/data/db/backup.js
+++ b/core/server/data/db/backup.js
@@ -1,18 +1,18 @@
 // # Backup Database
 // Provides for backing up the database before making potentially destructive changes
-var fs       = require('fs'),
-    path     = require('path'),
-    Promise  = require('bluebird'),
-    config   = require('../../config'),
-    logging  = require('../../logging'),
-    utils    = require('../../utils'),
+var fs = require('fs'),
+    path = require('path'),
+    Promise = require('bluebird'),
+    config = require('../../config'),
+    logging = require('../../logging'),
+    urlService = require('../../services/url'),
     exporter = require('../export'),
 
     writeExportFile,
     backup;
 
 writeExportFile = function writeExportFile(exportResult) {
-    var filename = path.resolve(utils.url.urlJoin(config.get('paths').contentPath, 'data', exportResult.filename));
+    var filename = path.resolve(urlService.utils.urlJoin(config.get('paths').contentPath, 'data', exportResult.filename));
 
     return Promise.promisify(fs.writeFile)(filename, JSON.stringify(exportResult.data)).return(filename);
 };

--- a/core/server/data/export/index.js
+++ b/core/server/data/export/index.js
@@ -2,12 +2,12 @@ var _ = require('lodash'),
     Promise = require('bluebird'),
     db = require('../../data/db'),
     commands = require('../schema').commands,
-    serverUtils = require('../../utils'),
+    globalUtils = require('../../utils'),
     ghostVersion = require('../../utils/ghost-version'),
-    errors      = require('../../errors'),
-    logging     = require('../../logging'),
-    models      = require('../../models'),
-    i18n        = require('../../i18n'),
+    errors = require('../../errors'),
+    logging = require('../../logging'),
+    models = require('../../models'),
+    i18n = require('../../i18n'),
     excludedTables = ['accesstokens', 'refreshtokens', 'clients', 'client_trusted_domains'],
     modelOptions = {context: {internal: true}},
 
@@ -25,7 +25,7 @@ exportFileName = function exportFileName(options) {
 
     return models.Settings.findOne({key: 'title'}, _.merge({}, modelOptions, options)).then(function (result) {
         if (result) {
-            title = serverUtils.safeString(result.get('value')) + '.';
+            title = globalUtils.safeString(result.get('value')) + '.';
         }
 
         return title + 'ghost.' + datetime + '.json';

--- a/core/server/data/importer/handlers/image.js
+++ b/core/server/data/importer/handlers/image.js
@@ -1,8 +1,8 @@
-var _       = require('lodash'),
+var _ = require('lodash'),
     Promise = require('bluebird'),
-    path    = require('path'),
-    config  = require('../../../config'),
-    utils   = require('../../../utils'),
+    path = require('path'),
+    config = require('../../../config'),
+    urlService = require('../../../services/url'),
     storage = require('../../../adapters/storage'),
 
     ImageHandler;
@@ -16,7 +16,7 @@ ImageHandler = {
     loadFile: function (files, baseDir) {
         var store = storage.getStorage(),
             baseDirRegex = baseDir ? new RegExp('^' + baseDir + '/') : new RegExp(''),
-            imageFolderRegexes = _.map(utils.url.STATIC_IMAGE_URL_PREFIX.split('/'), function (dir) {
+            imageFolderRegexes = _.map(urlService.utils.STATIC_IMAGE_URL_PREFIX.split('/'), function (dir) {
                 return new RegExp('^' + dir + '/');
             });
 
@@ -37,7 +37,7 @@ ImageHandler = {
 
         return Promise.map(files, function (image) {
             return store.getUniqueFileName(image, image.targetDir).then(function (targetFilename) {
-                image.newPath = utils.url.urlJoin('/', utils.url.getSubdir(), utils.url.STATIC_IMAGE_URL_PREFIX,
+                image.newPath = urlService.utils.urlJoin('/', urlService.utils.getSubdir(), urlService.utils.STATIC_IMAGE_URL_PREFIX,
                     path.relative(config.getContentPath('images'), targetFilename));
 
                 return image;

--- a/core/server/data/importer/importers/data/index.js
+++ b/core/server/data/importer/importers/data/index.js
@@ -1,7 +1,7 @@
 var _ = require('lodash'),
     Promise = require('bluebird'),
     models = require('../../../../models'),
-    utils = require('../../../../utils'),
+    globalUtils = require('../../../../utils'),
     SubscribersImporter = require('./subscribers'),
     PostsImporter = require('./posts'),
     TagsImporter = require('./tags'),
@@ -65,7 +65,7 @@ DataImporter = {
                 });
             });
 
-            utils.sequence(ops)
+            globalUtils.sequence(ops)
                 .then(function () {
                     results.forEach(function (promise) {
                         if (!promise.isFulfilled()) {

--- a/core/server/data/meta/amp_url.js
+++ b/core/server/data/meta/amp_url.js
@@ -1,4 +1,4 @@
-var utils  = require('../../utils'),
+var urlService = require('../../services/url'),
     getUrl = require('./url'),
     _      = require('lodash');
 
@@ -6,7 +6,7 @@ function getAmplUrl(data) {
     var context = data.context ? data.context : null;
 
     if (_.includes(context, 'post') && !_.includes(context, 'amp')) {
-        return utils.url.urlJoin(utils.url.urlFor('home', true), getUrl(data, false), 'amp/');
+        return urlService.utils.urlJoin(urlService.utils.urlFor('home', true), getUrl(data, false), 'amp/');
     }
     return null;
 }

--- a/core/server/data/meta/asset_url.js
+++ b/core/server/data/meta/asset_url.js
@@ -1,6 +1,7 @@
 var config = require('../../config'),
     blogIconUtils = require('../../utils/blog-icon'),
-    utils = require('../../utils');
+    urlService = require('../../services/url'),
+    globalUtils = require('../../utils');
 
 /**
  * Serve either uploaded favicon or default
@@ -19,11 +20,11 @@ function getAssetUrl(path, hasMinFile) {
 
     // CASE: Build the output URL
     // Add subdirectory...
-    var output = utils.url.urlJoin(utils.url.getSubdir(), '/');
+    var output = urlService.utils.urlJoin(urlService.utils.getSubdir(), '/');
 
     // Optionally add /assets/
     if (!path.match(/^public/) && !path.match(/^asset/)) {
-        output = utils.url.urlJoin(output, 'assets/');
+        output = urlService.utils.urlJoin(output, 'assets/');
     }
 
     // replace ".foo" with ".min.foo" if configured
@@ -32,12 +33,12 @@ function getAssetUrl(path, hasMinFile) {
     }
 
     // Add the path for the requested asset
-    output = utils.url.urlJoin(output, path);
+    output = urlService.utils.urlJoin(output, path);
 
     // Ensure we have an assetHash
     // @TODO rework this!
     if (!config.get('assetHash')) {
-        config.set('assetHash', utils.generateAssetHash());
+        config.set('assetHash', globalUtils.generateAssetHash());
     }
 
     // Finally add the asset hash to the output URL

--- a/core/server/data/meta/author_image.js
+++ b/core/server/data/meta/author_image.js
@@ -1,13 +1,13 @@
-var utils            = require('../../utils'),
+var urlService = require('../../services/url'),
     getContextObject = require('./context_object.js'),
-    _                = require('lodash');
+    _ = require('lodash');
 
 function getAuthorImage(data, absolute) {
     var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
     if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.profile_image) {
-        return utils.url.urlFor('image', {image: contextObject.author.profile_image}, absolute);
+        return urlService.utils.urlFor('image', {image: contextObject.author.profile_image}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -1,4 +1,4 @@
-var utils            = require('../../utils');
+var urlService = require('../../services/url');
 
 function getAuthorUrl(data, absolute) {
     var context = data.context ? data.context[0] : null;
@@ -6,10 +6,10 @@ function getAuthorUrl(data, absolute) {
     context = context === 'amp' ? 'post' : context;
 
     if (data.author) {
-        return utils.url.urlFor('author', {author: data.author}, absolute);
+        return urlService.utils.urlFor('author', {author: data.author}, absolute);
     }
     if (data[context] && data[context].author) {
-        return utils.url.urlFor('author', {author: data[context].author}, absolute);
+        return urlService.utils.urlFor('author', {author: data[context].author}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/blog_logo.js
+++ b/core/server/data/meta/blog_logo.js
@@ -1,12 +1,12 @@
-var utils            = require('../../utils'),
-    settingsCache    = require('../../settings/cache'),
-    blogIconUtils    = require('../../utils/blog-icon');
+var urlService = require('../../services/url'),
+    settingsCache = require('../../settings/cache'),
+    blogIconUtils = require('../../utils/blog-icon');
 
 function getBlogLogo() {
     var logo = {};
 
     if (settingsCache.get('logo')) {
-        logo.url = utils.url.urlFor('image', {image: settingsCache.get('logo')}, true);
+        logo.url = urlService.utils.urlFor('image', {image: settingsCache.get('logo')}, true);
     } else {
         // CASE: no publication logo is updated. We can try to use either an uploaded publication icon
         // or use the default one to make

--- a/core/server/data/meta/canonical_url.js
+++ b/core/server/data/meta/canonical_url.js
@@ -1,8 +1,8 @@
-var utils  = require('../../utils'),
+var urlService = require('../../services/url'),
     getUrl = require('./url');
 
 function getCanonicalUrl(data) {
-    var url = utils.url.urlJoin(utils.url.urlFor('home', true), getUrl(data, false));
+    var url = urlService.utils.urlJoin(urlService.utils.urlFor('home', true), getUrl(data, false));
 
     if (url.indexOf('/amp/')) {
         url = url.replace(/\/amp\/$/i, '/');

--- a/core/server/data/meta/cover_image.js
+++ b/core/server/data/meta/cover_image.js
@@ -1,6 +1,6 @@
-var utils            = require('../../utils'),
+var urlService = require('../../services/url'),
     getContextObject = require('./context_object.js'),
-    _                = require('lodash');
+    _ = require('lodash');
 
 function getCoverImage(data) {
     var context = data.context ? data.context : null,
@@ -8,11 +8,11 @@ function getCoverImage(data) {
 
     if (_.includes(context, 'home') || _.includes(context, 'author')) {
         if (contextObject.cover_image) {
-            return utils.url.urlFor('image', {image: contextObject.cover_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.cover_image}, true);
         }
     } else {
         if (contextObject.feature_image) {
-            return utils.url.urlFor('image', {image: contextObject.feature_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.feature_image}, true);
         }
     }
     return null;

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -1,6 +1,6 @@
 var Promise = require('bluebird'),
     settingsCache = require('../../settings/cache'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
     logging = require('../../logging'),
     getUrl = require('./url'),
     getImageDimensions = require('./image-dimensions'),
@@ -61,7 +61,7 @@ function getMetaData(data, root) {
             blog: {
                 title: settingsCache.get('title'),
                 description: settingsCache.get('description'),
-                url: utils.url.urlFor('home', true),
+                url: urlService.utils.urlFor('home', true),
                 facebook: settingsCache.get('facebook'),
                 twitter: settingsCache.get('twitter'),
                 timezone: settingsCache.get('active_timezone'),

--- a/core/server/data/meta/og_image.js
+++ b/core/server/data/meta/og_image.js
@@ -1,6 +1,6 @@
-var utils            = require('../../utils'),
+var urlService = require('../../services/url'),
     getContextObject = require('./context_object.js'),
-    _                = require('lodash');
+    _ = require('lodash');
 
 function getOgImage(data) {
     var context = data.context ? data.context : null,
@@ -8,9 +8,9 @@ function getOgImage(data) {
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.og_image) {
-            return utils.url.urlFor('image', {image: contextObject.og_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.og_image}, true);
         } else if (contextObject.feature_image) {
-            return utils.url.urlFor('image', {image: contextObject.feature_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.feature_image}, true);
         }
     }
 

--- a/core/server/data/meta/paginated_url.js
+++ b/core/server/data/meta/paginated_url.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     config = require('../../config'),
-    utils = require('../../utils');
+    urlService = require('../../services/url');
 
 function getPaginatedUrl(page, data, absolute) {
     // If we don't have enough information, return null right away
@@ -8,7 +8,7 @@ function getPaginatedUrl(page, data, absolute) {
         return null;
     }
 
-    var pagePath = utils.url.urlJoin('/', config.get('routeKeywords').page, '/'),
+    var pagePath = urlService.utils.urlJoin('/', config.get('routeKeywords').page, '/'),
         // Try to match the base url, as whatever precedes the pagePath
         baseUrlPattern = new RegExp('(.+)?(/' + config.get('routeKeywords').page + '/\\d+/)'),
         baseUrlMatch = data.relativeUrl.match(baseUrlPattern),
@@ -17,20 +17,20 @@ function getPaginatedUrl(page, data, absolute) {
         newRelativeUrl;
 
     if (page === 'next' && data.pagination.next) {
-        newRelativeUrl = utils.url.urlJoin(pagePath, data.pagination.next, '/');
+        newRelativeUrl = urlService.utils.urlJoin(pagePath, data.pagination.next, '/');
     } else if (page === 'prev' && data.pagination.prev) {
-        newRelativeUrl = data.pagination.prev > 1 ? utils.url.urlJoin(pagePath, data.pagination.prev, '/') : '/';
+        newRelativeUrl = data.pagination.prev > 1 ? urlService.utils.urlJoin(pagePath, data.pagination.prev, '/') : '/';
     } else if (_.isNumber(page)) {
-        newRelativeUrl = page > 1 ? utils.url.urlJoin(pagePath, page, '/') : '/';
+        newRelativeUrl = page > 1 ? urlService.utils.urlJoin(pagePath, page, '/') : '/';
     } else {
         // If none of the cases match, return null right away
         return null;
     }
 
     // baseUrl can be undefined, if there was nothing preceding the pagePath (e.g. first page of the index channel)
-    newRelativeUrl = baseUrl ? utils.url.urlJoin(baseUrl, newRelativeUrl) : newRelativeUrl;
+    newRelativeUrl = baseUrl ? urlService.utils.urlJoin(baseUrl, newRelativeUrl) : newRelativeUrl;
 
-    return utils.url.urlFor({relativeUrl: newRelativeUrl, secure: data.secure}, absolute);
+    return urlService.utils.urlFor({relativeUrl: newRelativeUrl, secure: data.secure}, absolute);
 }
 
 module.exports = getPaginatedUrl;

--- a/core/server/data/meta/rss_url.js
+++ b/core/server/data/meta/rss_url.js
@@ -1,7 +1,7 @@
-var utils = require('../../utils');
+var urlService = require('../../services/url');
 
 function getRssUrl(data, absolute) {
-    return utils.url.urlFor('rss', {secure: data.secure}, absolute);
+    return urlService.utils.urlFor('rss', {secure: data.secure}, absolute);
 }
 
 module.exports = getRssUrl;

--- a/core/server/data/meta/twitter_image.js
+++ b/core/server/data/meta/twitter_image.js
@@ -1,6 +1,6 @@
-var utils            = require('../../utils'),
+var urlService = require('../../services/url'),
     getContextObject = require('./context_object.js'),
-    _                = require('lodash');
+    _ = require('lodash');
 
 function getTwitterImage(data) {
     var context = data.context ? data.context : null,
@@ -8,9 +8,9 @@ function getTwitterImage(data) {
 
     if (_.includes(context, 'post') || _.includes(context, 'page') || _.includes(context, 'amp')) {
         if (contextObject.twitter_image) {
-            return utils.url.urlFor('image', {image: contextObject.twitter_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.twitter_image}, true);
         } else if (contextObject.feature_image) {
-            return utils.url.urlFor('image', {image: contextObject.feature_image}, true);
+            return urlService.utils.urlFor('image', {image: contextObject.feature_image}, true);
         }
     }
 

--- a/core/server/data/meta/url.js
+++ b/core/server/data/meta/url.js
@@ -1,5 +1,5 @@
 var schema = require('../schema').checks,
-    utils = require('../../utils');
+    urlService = require('../../services/url');
 
 // This cleans the url from any `/amp` postfixes, so we'll never
 // output a url with `/amp` in the end, except for the needed `amphtml`
@@ -13,23 +13,23 @@ function sanitizeAmpUrl(url) {
 
 function getUrl(data, absolute) {
     if (schema.isPost(data)) {
-        return utils.url.urlFor('post', {post: data, secure: data.secure}, absolute);
+        return urlService.utils.urlFor('post', {post: data, secure: data.secure}, absolute);
     }
 
     if (schema.isTag(data)) {
-        return utils.url.urlFor('tag', {tag: data, secure: data.secure}, absolute);
+        return urlService.utils.urlFor('tag', {tag: data, secure: data.secure}, absolute);
     }
 
     if (schema.isUser(data)) {
-        return utils.url.urlFor('author', {author: data, secure: data.secure}, absolute);
+        return urlService.utils.urlFor('author', {author: data, secure: data.secure}, absolute);
     }
 
     if (schema.isNav(data)) {
-        return utils.url.urlFor('nav', {nav: data, secure: data.secure}, absolute);
+        return urlService.utils.urlFor('nav', {nav: data, secure: data.secure}, absolute);
     }
 
     // sanitize any trailing `/amp` in the url
-    return sanitizeAmpUrl(utils.url.urlFor(data, {}, absolute));
+    return sanitizeAmpUrl(urlService.utils.urlFor(data, {}, absolute));
 }
 
 module.exports = getUrl;

--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -7,7 +7,7 @@ var schema    = require('../schema').tables,
     errors    = require('../../errors'),
     i18n      = require('../../i18n'),
     settingsCache = require('../../settings/cache'),
-    utils = require('../../utils/url'),
+    urlService = require('../../services/url'),
 
     validatePassword,
     validateSchema,
@@ -95,7 +95,7 @@ validator.extend('isSlug', function isSlug(str) {
 validatePassword = function validatePassword(password, email, blogTitle) {
     var validationResult = {isValid: true},
         disallowedPasswords = ['password', 'ghost', 'passw0rd'],
-        blogUrl = utils.urlFor('home', true),
+        blogUrl = urlService.utils.urlFor('home', true),
         badPasswords = [
             '1234567890',
             'qwertyuiop',

--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -1,11 +1,11 @@
-var _         = require('lodash'),
-    xml       = require('xml'),
-    moment    = require('moment'),
-    utils     = require('../../../utils'),
-    events    = require('../../../events'),
-    localUtils  = require('./utils'),
-    Promise   = require('bluebird'),
-    path      = require('path'),
+var _ = require('lodash'),
+    xml = require('xml'),
+    moment = require('moment'),
+    Promise = require('bluebird'),
+    path = require('path'),
+    urlService = require('../../../services/url'),
+    events = require('../../../events'),
+    localUtils = require('./utils'),
     CHANGE_FREQ = 'weekly',
     XMLNS_DECLS;
 
@@ -133,11 +133,11 @@ _.extend(BaseSiteMapGenerator.prototype, {
     },
 
     getUrlForDatum: function () {
-        return utils.url.urlFor('home', true);
+        return urlService.utils.urlFor('home', true);
     },
 
     getUrlForImage: function (image) {
-        return utils.url.urlFor('image', {image: image}, true);
+        return urlService.utils.urlFor('image', {image: image}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/index-generator.js
+++ b/core/server/data/xml/sitemap/index-generator.js
@@ -1,7 +1,7 @@
 var _       = require('lodash'),
     xml     = require('xml'),
     moment  = require('moment'),
-    utils  = require('../../../utils'),
+    urlService = require('../../../services/url'),
     localUtils   = require('./utils'),
     RESOURCES,
     XMLNS_DECLS;
@@ -35,7 +35,7 @@ _.extend(SiteMapIndexGenerator.prototype, {
         var self = this;
 
         return _.map(RESOURCES, function (resourceType) {
-            var url = utils.url.urlFor({
+            var url = urlService.utils.urlFor({
                     relativeUrl: '/sitemap-' + resourceType + '.xml'
                 }, true),
                 lastModified = self[resourceType].lastModified;

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    utils  = require('../../../utils'),
+    urlService = require('../../../services/url'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -46,10 +46,10 @@ _.extend(PageMapGenerator.prototype, {
 
     getUrlForDatum: function (post) {
         if (post.id === 0 && !_.isEmpty(post.name)) {
-            return utils.url.urlFor(post.name, true);
+            return urlService.utils.urlFor(post.name, true);
         }
 
-        return utils.url.urlFor('post', {post: post}, true);
+        return urlService.utils.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -1,6 +1,6 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    utils  = require('../../../utils'),
+var _ = require('lodash'),
+    api = require('../../../api'),
+    urlService = require('../../../services/url'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -42,7 +42,7 @@ _.extend(PostMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (post) {
-        return utils.url.urlFor('post', {post: post}, true);
+        return urlService.utils.urlFor('post', {post: post}, true);
     },
 
     getPriorityForDatum: function (post) {

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    utils  = require('../../../utils'),
+    urlService = require('../../../services/url'),
     BaseMapGenerator = require('./base-generator');
 
 // A class responsible for generating a sitemap from posts and keeping it updated
@@ -38,7 +38,7 @@ _.extend(TagsMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (tag) {
-        return utils.url.urlFor('tag', {tag: tag}, true);
+        return urlService.utils.urlFor('tag', {tag: tag}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,6 +1,6 @@
 var _      = require('lodash'),
     api    = require('../../../api'),
-    utils  = require('../../../utils'),
+    urlService = require('../../../services/url'),
     validator        = require('validator'),
     BaseMapGenerator = require('./base-generator'),
     // @TODO: figure out a way to get rid of this
@@ -42,7 +42,7 @@ _.extend(UserMapGenerator.prototype, {
     },
 
     getUrlForDatum: function (user) {
-        return utils.url.urlFor('author', {author: user}, true);
+        return urlService.utils.urlFor('author', {author: user}, true);
     },
 
     getPriorityForDatum: function () {

--- a/core/server/data/xml/sitemap/utils.js
+++ b/core/server/data/xml/sitemap/utils.js
@@ -1,9 +1,9 @@
-var utils = require('../../../utils'),
+var urlService = require('../../../services/url'),
     sitemapsUtils;
 
 sitemapsUtils = {
     getDeclarations: function () {
-        var baseUrl = utils.url.urlFor('sitemap_xsl', true);
+        var baseUrl = urlService.utils.urlFor('sitemap_xsl', true);
         baseUrl = baseUrl.replace(/^(http:|https:)/, '');
         return '<?xml version="1.0" encoding="UTF-8"?>' +
             '<?xml-stylesheet type="text/xsl" href="' + baseUrl + '"?>';

--- a/core/server/ghost-server.js
+++ b/core/server/ghost-server.js
@@ -9,7 +9,7 @@ var debug = require('ghost-ignition').debug('server'),
     events = require('./events'),
     logging = require('./logging'),
     config = require('./config'),
-    utils = require('./utils'),
+    urlService = require('./services/url'),
     i18n = require('./i18n'),
     moment = require('moment');
 
@@ -193,7 +193,7 @@ GhostServer.prototype.logStartMessages = function () {
     // Startup & Shutdown messages
     if (config.get('env') === 'production') {
         logging.info(i18n.t('notices.httpServer.ghostIsRunningIn', {env: config.get('env')}));
-        logging.info(i18n.t('notices.httpServer.yourBlogIsAvailableOn', {url: utils.url.urlFor('home', true)}));
+        logging.info(i18n.t('notices.httpServer.yourBlogIsAvailableOn', {url: urlService.utils.urlFor('home', true)}));
         logging.info(i18n.t('notices.httpServer.ctrlCToShutDown'));
     } else {
         logging.info(i18n.t('notices.httpServer.ghostIsRunningIn', {env: config.get('env')}));
@@ -201,7 +201,7 @@ GhostServer.prototype.logStartMessages = function () {
             host: config.get('server').socket || config.get('server').host,
             port: config.get('server').port
         }));
-        logging.info(i18n.t('notices.httpServer.urlConfiguredAs', {url: utils.url.urlFor('home', true)}));
+        logging.info(i18n.t('notices.httpServer.urlConfiguredAs', {url: urlService.utils.urlFor('home', true)}));
         logging.info(i18n.t('notices.httpServer.ctrlCToShutDown'));
     }
 

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -63,7 +63,7 @@ module.exports = {
     // Various utils, needs cleaning up / simplifying
     socialUrls: require('../utils/social-urls'),
     blogIcon: require('../utils/blog-icon'),
-    url: require('../utils').url,
+    url: require('../services/url').utils,
     utils: {
         findKey: function findKey(key /* ...objects... */) {
             var objects = Array.prototype.slice.call(arguments, 1);

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -11,6 +11,7 @@
  * - overrides is the first package to load
  */
 require('./overrides');
+require('./services/url');
 
 // Module dependencies
 var debug = require('ghost-ignition').debug('boot:init'),
@@ -28,7 +29,6 @@ var debug = require('ghost-ignition').debug('boot:init'),
     utils = require('./utils'),
 
     // Services that need initialisation
-    urlService = require('./services/url'),
     apps = require('./services/apps'),
     xmlrpc = require('./services/xmlrpc'),
     slack = require('./services/slack'),
@@ -66,9 +66,7 @@ function init() {
             // Initialize slack ping
             slack.listen(),
             // Initialize webhook pings
-            webhooks.listen(),
-            // Url Service
-            urlService.init()
+            webhooks.listen()
         );
     }).then(function () {
         debug('Apps, XMLRPC, Slack done');

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -11,7 +11,6 @@
  * - overrides is the first package to load
  */
 require('./overrides');
-require('./services/url');
 
 // Module dependencies
 var debug = require('ghost-ignition').debug('boot:init'),
@@ -26,7 +25,7 @@ var debug = require('ghost-ignition').debug('boot:init'),
     scheduling = require('./adapters/scheduling'),
     settings = require('./settings'),
     themes = require('./themes'),
-    utils = require('./utils'),
+    urlService = require('./services/url'),
 
     // Services that need initialisation
     apps = require('./services/apps'),
@@ -94,7 +93,7 @@ function init() {
         return scheduling.init({
             schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
-            apiUrl: utils.url.urlFor('api', true),
+            apiUrl: urlService.utils.urlFor('api', true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         });

--- a/core/server/mail/GhostMailer.js
+++ b/core/server/mail/GhostMailer.js
@@ -7,7 +7,7 @@ var _ = require('lodash'),
     errors = require('../errors'),
     settingsCache = require('../settings/cache'),
     i18n = require('../i18n'),
-    utils = require('../utils');
+    urlService = require('../services/url');
 
 function GhostMailer() {
     var nodemailer = require('nodemailer'),
@@ -40,7 +40,7 @@ GhostMailer.prototype.from = function () {
 
 // Moved it to its own module
 GhostMailer.prototype.getDomain = function () {
-    var domain = utils.url.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
+    var domain = urlService.utils.urlFor('home', true).match(new RegExp('^https?://([^/:?#]+)(?:[/:?#]|$)', 'i'));
     return domain && domain[1];
 };
 

--- a/core/server/mail/utils.js
+++ b/core/server/mail/utils.js
@@ -3,7 +3,7 @@ var _ = require('lodash').runInContext(),
     Promise = require('bluebird'),
     path = require('path'),
     htmlToText = require('html-to-text'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     templatesDir = path.resolve(__dirname, '..', 'mail', 'templates');
 
 _.templateSettings.interpolate = /{{([\s\S]+?)}}/g;
@@ -13,7 +13,7 @@ exports.generateContent = function generateContent(options) {
         data;
 
     defaults = {
-        siteUrl: utils.url.urlFor('home', true)
+        siteUrl: urlService.utils.urlFor('home', true)
     };
 
     data = _.defaults(defaults, options.data);

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -15,7 +15,8 @@ var _ = require('lodash'),
     errors = require('../../errors'),
     filters = require('../../filters'),
     schema = require('../../data/schema'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
+    globalUtils = require('../../utils'),
     validation = require('../../data/validation'),
     plugins = require('../plugins'),
     i18n = require('../../i18n'),
@@ -739,7 +740,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         // the slug may never be longer than the allowed limit of 191 chars, but should also
         // take the counter into count. We reduce a too long slug to 185 so we're always on the
         // safe side, also in terms of checking for existing slugs already.
-        slug = utils.safeString(base, options);
+        slug = globalUtils.safeString(base, options);
 
         if (slug.length > 185) {
             // CASE: don't cut the slug on import
@@ -765,7 +766,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         // Check the filtered slug doesn't match any of the reserved keywords
         return filters.doFilter('slug.reservedSlugs', config.get('slugs').reserved).then(function then(slugList) {
             // Some keywords cannot be changed
-            slugList = _.union(slugList, utils.url.getProtectedSlugs());
+            slugList = _.union(slugList, urlService.utils.getProtectedSlugs());
 
             return _.includes(slugList, slug) ? slug + '-' + baseName : slug;
         }).then(function then(slug) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -12,7 +12,8 @@ var _ = require('lodash'),
     ghostBookshelf = require('./base'),
     events = require('../events'),
     config = require('../config'),
-    utils = require('../utils'),
+    globalUtils = require('../utils'),
+    urlService = require('../services/url'),
     i18n = require('../i18n'),
     Post,
     Posts;
@@ -217,7 +218,7 @@ Post = ghostBookshelf.Model.extend({
         ghostBookshelf.Model.prototype.onSaving.call(this, model, attr, options);
 
         if (mobiledoc) {
-            this.set('html', utils.mobiledocConverter.render(JSON.parse(mobiledoc)));
+            this.set('html', globalUtils.mobiledocConverter.render(JSON.parse(mobiledoc)));
         }
 
         if (this.hasChanged('html') || !this.get('plaintext')) {
@@ -375,7 +376,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {
-            attrs.url = utils.url.urlPathForPost(attrs);
+            attrs.url = urlService.utils.urlPathForPost(attrs);
         }
 
         if (oldPostId) {

--- a/core/server/services/channels/router.js
+++ b/core/server/services/channels/router.js
@@ -3,7 +3,7 @@ var express = require('express'),
     config = require('../../config'),
     errors = require('../../errors'),
     i18n = require('../../i18n'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
     channelController = require('../../controllers/channel'),
     rssController = require('../../controllers/rss'),
     rssRouter,
@@ -18,9 +18,9 @@ function handlePageParam(req, res, next, page) {
     if (page === 1) {
         // Page 1 is an alias, do a permanent 301 redirect
         if (rssRegex.test(req.url)) {
-            return utils.url.redirect301(res, req.originalUrl.replace(rssRegex, '/rss/'));
+            return urlService.utils.redirect301(res, req.originalUrl.replace(rssRegex, '/rss/'));
         } else {
-            return utils.url.redirect301(res, req.originalUrl.replace(pageRegex, '/'));
+            return urlService.utils.redirect301(res, req.originalUrl.replace(pageRegex, '/'));
         }
     } else if (page < 1 || isNaN(page)) {
         // Nothing less than 1 is a valid page number, go straight to a 404
@@ -50,14 +50,14 @@ rssRouter = function rssRouter(channelMiddleware) {
     // @TODO move this to an RSS module
     var router = express.Router({mergeParams: true}),
         baseRoute = '/rss/',
-        pageRoute = utils.url.urlJoin(baseRoute, ':page(\\d+)/');
+        pageRoute = urlService.utils.urlJoin(baseRoute, ':page(\\d+)/');
 
     // @TODO figure out how to collapse this into a single rule
     router.get(baseRoute, channelMiddleware, rssConfigMiddleware, rssController);
     router.get(pageRoute, channelMiddleware, rssConfigMiddleware, rssController);
     // Extra redirect rule
     router.get('/feed/', function redirectToRSS(req, res) {
-        return utils.url.redirect301(res, utils.url.urlJoin(utils.url.getSubdir(), req.baseUrl, baseRoute));
+        return urlService.utils.redirect301(res, urlService.utils.urlJoin(urlService.utils.getSubdir(), req.baseUrl, baseRoute));
     });
 
     router.param('page', handlePageParam);
@@ -67,7 +67,7 @@ rssRouter = function rssRouter(channelMiddleware) {
 channelRouter = function channelRouter(channel) {
     var channelRouter = express.Router({mergeParams: true}),
         baseRoute = '/',
-        pageRoute = utils.url.urlJoin('/', config.get('routeKeywords').page, ':page(\\d+)/'),
+        pageRoute = urlService.utils.urlJoin('/', config.get('routeKeywords').page, ':page(\\d+)/'),
         middleware = [channelConfigMiddleware(channel)];
 
     channelRouter.get(baseRoute, middleware, channelController);
@@ -83,7 +83,7 @@ channelRouter = function channelRouter(channel) {
 
     if (channel.editRedirect) {
         channelRouter.get('/edit/', function redirect(req, res) {
-            utils.url.redirectToAdmin(302, res, channel.editRedirect.replace(':slug', req.params.slug));
+            urlService.utils.redirectToAdmin(302, res, channel.editRedirect.replace(':slug', req.params.slug));
         });
     }
 

--- a/core/server/services/rss/generate-feed.js
+++ b/core/server/services/rss/generate-feed.js
@@ -1,6 +1,6 @@
 var downsize = require('downsize'),
     RSS = require('rss'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
     filters = require('../../filters'),
     processUrls = require('../../utils/make-absolute-urls'),
 
@@ -22,7 +22,7 @@ generateTags = function generateTags(data) {
 };
 
 generateItem = function generateItem(post, siteUrl, secure) {
-    var itemUrl = utils.url.urlFor('post', {post: post, secure: secure}, true),
+    var itemUrl = urlService.utils.urlFor('post', {post: post, secure: secure}, true),
         htmlContent = processUrls(post.html, siteUrl, itemUrl),
         item = {
             title: post.title,
@@ -38,7 +38,7 @@ generateItem = function generateItem(post, siteUrl, secure) {
         imageUrl;
 
     if (post.feature_image) {
-        imageUrl = utils.url.urlFor('image', {image: post.feature_image, secure: secure}, true);
+        imageUrl = urlService.utils.urlFor('image', {image: post.feature_image, secure: secure}, true);
 
         // Add a media content tag
         item.custom_elements.push({
@@ -73,15 +73,15 @@ generateItem = function generateItem(post, siteUrl, secure) {
  * @param {{title, description, safeVersion, secure, posts}} data
  */
 generateFeed = function generateFeed(baseUrl, data) {
-    var siteUrl = utils.url.urlFor('home', {secure: data.secure}, true),
-        feedUrl = utils.url.urlFor({relativeUrl: baseUrl, secure: data.secure}, true),
+    var siteUrl = urlService.utils.urlFor('home', {secure: data.secure}, true),
+        feedUrl = urlService.utils.urlFor({relativeUrl: baseUrl, secure: data.secure}, true),
         feed = new RSS({
             title: data.title,
             description: data.description,
             generator: 'Ghost ' + data.safeVersion,
             feed_url: feedUrl,
             site_url: siteUrl,
-            image_url: utils.url.urlFor({relativeUrl: 'favicon.png'}, true),
+            image_url: urlService.utils.urlFor({relativeUrl: 'favicon.png'}, true),
             ttl: '60',
             custom_namespaces: {
                 content: 'http://purl.org/rss/1.0/modules/content/',

--- a/core/server/services/slack.js
+++ b/core/server/services/slack.js
@@ -2,7 +2,7 @@ var https = require('https'),
     url = require('url'),
     errors = require('../errors'),
     logging = require('../logging'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     blogIconUtils = require('../utils/blog-icon'),
     events = require('../events'),
     settingsCache = require('../settings/cache'),
@@ -50,7 +50,7 @@ function ping(post) {
 
     // If this is a post, we want to send the link of the post
     if (schema.isPost(post)) {
-        message = utils.url.urlFor('post', {post: post}, true);
+        message = urlService.utils.urlFor('post', {post: post}, true);
     } else {
         message = post.message;
     }

--- a/core/server/services/url/Resource.js
+++ b/core/server/services/url/Resource.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const _ = require('lodash'),
-    api = require('../../api'),
-    utils = require('../../utils'),
+    localUtils = require('./utils'),
     prefetchDefaults = {
         context: {
             internal: true
@@ -23,7 +22,7 @@ class Resource {
     fetchAll() {
         const options = _.defaults(this.prefetchOptions, prefetchDefaults);
 
-        return api[this.api]
+        return require('../../api')[this.api]
             .browse(options)
             .then((resp) => {
                 this.items = resp[this.api];
@@ -35,7 +34,7 @@ class Resource {
         const data = {
             [this.urlLookup]: item
         };
-        return utils.url.urlFor(this.urlLookup, data);
+        return localUtils.urlFor(this.urlLookup, data);
     }
 
     toData(item) {

--- a/core/server/services/url/UrlService.js
+++ b/core/server/services/url/UrlService.js
@@ -19,12 +19,34 @@ const _ = require('lodash'),
     utils = require('../../utils');
 
 class UrlService {
-    constructor() {
+    constructor(options) {
         this.resources = [];
 
         _.each(resourceConfig, (config) => {
             this.resources.push(new Resource(config));
         });
+
+        // You can disable the url preload, in case we encounter a problem with the new url service.
+        if (options.disableUrlPreload) {
+            return;
+        }
+
+        this.bind();
+
+        // Hardcoded routes
+        // @TODO figure out how to do this from channel or other config
+        // @TODO get rid of name concept (for compat with sitemaps)
+        UrlService.cacheRoute('/', {name: 'home'});
+
+        // @TODO figure out how to do this from apps
+        // @TODO only do this if subscribe is enabled!
+        UrlService.cacheRoute('/subscribe/', {});
+
+        // Register a listener for server-start to load all the known urls
+        events.on('server:start', (() => {
+            debug('URL service, loading all URLS');
+            this.loadResourceUrls();
+        }));
     }
 
     bind() {

--- a/core/server/services/url/UrlService.js
+++ b/core/server/services/url/UrlService.js
@@ -16,11 +16,12 @@ const _ = require('lodash'),
     resourceConfig = require('./config.json'),
     Resource = require('./Resource'),
     urlCache = require('./cache'),
-    utils = require('../../utils');
+    localUtils = require('./utils');
 
 class UrlService {
     constructor(options) {
         this.resources = [];
+        this.utils = localUtils;
 
         _.each(resourceConfig, (config) => {
             this.resources.push(new Resource(config));
@@ -135,7 +136,7 @@ class UrlService {
     }
 
     static cacheRoute(relativeUrl, data) {
-        const url = utils.url.urlFor({relativeUrl: relativeUrl});
+        const url = localUtils.urlFor({relativeUrl: relativeUrl});
         data.static = true;
         urlCache.set(url, data);
     }

--- a/core/server/services/url/index.js
+++ b/core/server/services/url/index.js
@@ -1,32 +1,10 @@
-const debug = require('ghost-ignition').debug('services:url:init'),
-    config = require('../../config'),
-    events = require('../../events'),
-    UrlService = require('./UrlService');
+'use strict';
 
-// @TODO we seriously should move this or make it do almost nothing...
-module.exports.init = function init() {
-    // Temporary config value just in case this causes problems
-    // @TODO delete this
-    if (config.get('disableUrlService')) {
-        return;
-    }
-
-    // Kick off the constructor
-    const urlService = new UrlService();
-
-    urlService.bind();
-
-    // Hardcoded routes
-    // @TODO figure out how to do this from channel or other config
-    // @TODO get rid of name concept (for compat with sitemaps)
-    UrlService.cacheRoute('/', {name: 'home'});
-    // @TODO figure out how to do this from apps
-    // @TODO only do this if subscribe is enabled!
-    UrlService.cacheRoute('/subscribe/', {});
-
-    // Register a listener for server-start to load all the known urls
-    events.on('server:start', function loadAllUrls() {
-        debug('URL service, loading all URLS');
-        urlService.loadResourceUrls();
+const config = require('../../config'),
+    UrlService = require('./UrlService'),
+    urlService = new UrlService({
+        disableUrlPreload: config.get('disableUrlPreload')
     });
-};
+
+// Singleton
+module.exports = urlService;

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -1,13 +1,13 @@
 // Contains all path information to be used throughout the codebase.
 // Assumes that config.url is set, and is valid
 
-var moment            = require('moment-timezone'),
-    _                 = require('lodash'),
-    url               = require('url'),
-    config            = require('./../config'),
-    settingsCache     = require('./../settings/cache'),
+var moment = require('moment-timezone'),
+    _ = require('lodash'),
+    url = require('url'),
+    config = require('../../config/index'),
+    settingsCache = require('../../settings/cache'),
     // @TODO: unify this with the path in server/app.js
-    API_PATH          = '/ghost/api/v0.1/',
+    API_PATH = '/ghost/api/v0.1/',
     STATIC_IMAGE_URL_PREFIX = 'content/images';
 
 /**
@@ -174,13 +174,27 @@ function urlPathForPost(post) {
         primaryTagFallback = config.get('routeKeywords').primaryTagFallback,
         publishedAtMoment = moment.tz(post.published_at || Date.now(), settingsCache.get('active_timezone')),
         tags = {
-            year: function () { return publishedAtMoment.format('YYYY'); },
-            month: function () { return publishedAtMoment.format('MM'); },
-            day: function () { return publishedAtMoment.format('DD'); },
-            author: function () { return post.author.slug; },
-            primary_tag: function () { return post.primary_tag ? post.primary_tag.slug : primaryTagFallback; },
-            slug: function () { return post.slug; },
-            id: function () { return post.id; }
+            year: function () {
+                return publishedAtMoment.format('YYYY');
+            },
+            month: function () {
+                return publishedAtMoment.format('MM');
+            },
+            day: function () {
+                return publishedAtMoment.format('DD');
+            },
+            author: function () {
+                return post.author.slug;
+            },
+            primary_tag: function () {
+                return post.primary_tag ? post.primary_tag.slug : primaryTagFallback;
+            },
+            slug: function () {
+                return post.slug;
+            },
+            id: function () {
+                return post.id;
+            }
         };
 
     if (post.page) {

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -2,7 +2,7 @@ var _ = require('lodash'),
     http = require('http'),
     xml = require('xml'),
     config = require('../config'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     errors = require('../errors'),
     logging = require('../logging'),
     events = require('../events'),
@@ -30,7 +30,7 @@ var _ = require('lodash'),
 function ping(post) {
     var pingXML,
         title = post.title,
-        url = utils.url.urlFor('post', {post: post}, true);
+        url = urlService.utils.urlFor('post', {post: post}, true);
 
     if (post.page || config.isPrivacyDisabled('useRpcPing') || settingsCache.get('is_private')) {
         return;

--- a/core/server/themes/Storage.js
+++ b/core/server/themes/Storage.js
@@ -5,7 +5,7 @@ var fs = require('fs-extra'),
     path = require('path'),
     Promise = require('bluebird'),
     config = require('../config'),
-    utils = require('../utils'),
+    globalUtils = require('../utils'),
     LocalFileStorage = require('../adapters/storage/LocalFileStorage'),
     remove = Promise.promisify(fs.remove);
 
@@ -31,13 +31,13 @@ class ThemeStorage extends LocalFileStorage {
                 themePath = path.join(self.storagePath, themeName),
                 zipName = themeName + '.zip',
                 // store this in a unique temporary folder
-                zipBasePath = path.join(os.tmpdir(), utils.uid(10)),
+                zipBasePath = path.join(os.tmpdir(), globalUtils.uid(10)),
                 zipPath = path.join(zipBasePath, zipName),
                 stream;
 
             Promise.promisify(fs.ensureDir)(zipBasePath)
                 .then(function () {
-                    return Promise.promisify(utils.zipFolder)(themePath, zipPath);
+                    return Promise.promisify(globalUtils.zipFolder)(themePath, zipPath);
                 })
                 .then(function (length) {
                     res.set({

--- a/core/server/themes/middleware.js
+++ b/core/server/themes/middleware.js
@@ -1,6 +1,6 @@
 var _  = require('lodash'),
     hbs = require('./engine'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     errors = require('../errors'),
     config = require('../config'),
     i18n = require('../i18n'),
@@ -69,7 +69,7 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
     // Request-specific information
     // These things are super dependent on the request, so they need to be in middleware
     // Serve the blog url without trailing slash
-    blogData.url = utils.url.urlFor('home', {secure: req.secure, trailingSlash: false}, true);
+    blogData.url = urlService.utils.urlFor('home', {secure: req.secure, trailingSlash: false}, true);
 
     // Pass 'secure' flag to the view engine
     // so that templates can choose to render https or http 'url', see url utility

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -20,21 +20,21 @@
 // - theme - name of the currently active theme
 // - apps - names of any active apps
 
-var crypto   = require('crypto'),
-    exec     = require('child_process').exec,
-    https    = require('https'),
-    http    = require('http'),
-    moment   = require('moment'),
-    semver   = require('semver'),
-    Promise  = require('bluebird'),
-    _        = require('lodash'),
-    url      = require('url'),
-    api      = require('./api'),
-    config   = require('./config'),
-    utils    = require('./utils'),
-    logging  = require('./logging'),
-    errors   = require('./errors'),
-    i18n     = require('./i18n'),
+var crypto = require('crypto'),
+    exec = require('child_process').exec,
+    https = require('https'),
+    http = require('http'),
+    moment = require('moment'),
+    semver = require('semver'),
+    Promise = require('bluebird'),
+    _ = require('lodash'),
+    url = require('url'),
+    api = require('./api'),
+    config = require('./config'),
+    urlService = require('./services/url'),
+    logging = require('./logging'),
+    errors = require('./errors'),
+    i18n = require('./i18n'),
     currentVersion = require('./utils/ghost-version').full,
     internal = {context: {internal: true}},
     checkEndpoint = config.get('updateCheckUrl') || 'https://updates.ghost.org';
@@ -87,14 +87,14 @@ function updateCheckData() {
     var data = {},
         mailConfig = config.get('mail');
 
-    data.ghost_version   = currentVersion;
-    data.node_version    = process.versions.node;
-    data.env             = config.get('env');
-    data.database_type   = config.get('database').client;
+    data.ghost_version = currentVersion;
+    data.node_version = process.versions.node;
+    data.env = config.get('env');
+    data.database_type = config.get('database').client;
     data.email_transport = mailConfig &&
-    (mailConfig.options && mailConfig.options.service ?
-        mailConfig.options.service :
-        mailConfig.transport);
+        (mailConfig.options && mailConfig.options.service ?
+            mailConfig.options.service :
+            mailConfig.transport);
 
     return Promise.props({
         hash: api.settings.read(_.extend({key: 'db_hash'}, internal)).reflect(),
@@ -105,29 +105,31 @@ function updateCheckData() {
 
                 apps = JSON.parse(apps.value);
 
-                return _.reduce(apps, function (memo, item) { return memo === '' ? memo + item : memo + ', ' + item; }, '');
+                return _.reduce(apps, function (memo, item) {
+                    return memo === '' ? memo + item : memo + ', ' + item;
+                }, '');
             }).reflect(),
         posts: api.posts.browse().reflect(),
         users: api.users.browse(internal).reflect(),
         npm: Promise.promisify(exec)('npm -v').reflect()
     }).then(function (descriptors) {
-        var hash             = descriptors.hash.value().settings[0],
-            theme            = descriptors.theme.value().settings[0],
-            apps             = descriptors.apps.value(),
-            posts            = descriptors.posts.value(),
-            users            = descriptors.users.value(),
-            npm              = descriptors.npm.value(),
-            blogUrl          = url.parse(utils.url.urlFor('home', true)),
-            blogId           = blogUrl.hostname + blogUrl.pathname.replace(/\//, '') + hash.value;
+        var hash = descriptors.hash.value().settings[0],
+            theme = descriptors.theme.value().settings[0],
+            apps = descriptors.apps.value(),
+            posts = descriptors.posts.value(),
+            users = descriptors.users.value(),
+            npm = descriptors.npm.value(),
+            blogUrl = url.parse(urlService.utils.urlFor('home', true)),
+            blogId = blogUrl.hostname + blogUrl.pathname.replace(/\//, '') + hash.value;
 
-        data.blog_id         = crypto.createHash('md5').update(blogId).digest('hex');
-        data.theme           = theme ? theme.value : '';
-        data.apps            = apps || '';
-        data.post_count      = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
-        data.user_count      = users && users.users && users.users.length ? users.users.length : 0;
+        data.blog_id = crypto.createHash('md5').update(blogId).digest('hex');
+        data.theme = theme ? theme.value : '';
+        data.apps = apps || '';
+        data.post_count = posts && posts.meta && posts.meta.pagination ? posts.meta.pagination.total : 0;
+        data.user_count = users && users.users && users.users.length ? users.users.length : 0;
         data.blog_created_at = users && users.users && users.users[0] && users.users[0].created_at ? moment(users.users[0].created_at).unix() : '';
-        data.npm_version     = npm.trim();
-        data.lts             = false;
+        data.npm_version = npm.trim();
+        data.lts = false;
 
         return data;
     }).catch(updateCheckError);
@@ -158,8 +160,12 @@ function updateCheckRequest() {
                 method: 'POST',
                 headers: headers
             }, function handler(res) {
-                res.on('error', function onError(error) { reject(error); });
-                res.on('data', function onData(chunk) { resData += chunk; });
+                res.on('error', function onError(error) {
+                    reject(error);
+                });
+                res.on('data', function onData(chunk) {
+                    resData += chunk;
+                });
                 res.on('end', function onEnd() {
                     try {
                         resData = JSON.parse(resData);

--- a/core/server/utils/blog-icon.js
+++ b/core/server/utils/blog-icon.js
@@ -1,12 +1,12 @@
 var sizeOf = require('image-size'),
-    errors = require('../errors'),
-    url = require('./url'),
     Promise = require('bluebird'),
-    i18n = require('../i18n'),
-    settingsCache = require('../settings/cache'),
     _ = require('lodash'),
     path = require('path'),
+    i18n = require('../i18n'),
+    errors = require('../errors'),
+    settingsCache = require('../settings/cache'),
     config = require('../config'),
+    urlService = require('../services/url'),
     storageUtils = require('../adapters/storage/utils'),
     getIconDimensions,
     isIcoImageType,
@@ -81,15 +81,15 @@ getIconUrl = function getIconUrl(absolut) {
 
     if (absolut) {
         if (blogIcon) {
-            return isIcoImageType(blogIcon) ? url.urlFor({relativeUrl: '/favicon.ico'}, true) : url.urlFor({relativeUrl: '/favicon.png'}, true);
+            return isIcoImageType(blogIcon) ? urlService.utils.urlFor({relativeUrl: '/favicon.ico'}, true) : urlService.utils.urlFor({relativeUrl: '/favicon.png'}, true);
         } else {
-            return url.urlFor({relativeUrl: '/favicon.ico'}, true);
+            return urlService.utils.urlFor({relativeUrl: '/favicon.ico'}, true);
         }
     } else {
         if (blogIcon) {
-            return isIcoImageType(blogIcon) ? url.urlFor({relativeUrl: '/favicon.ico'}) : url.urlFor({relativeUrl: '/favicon.png'});
+            return isIcoImageType(blogIcon) ? urlService.utils.urlFor({relativeUrl: '/favicon.ico'}) : urlService.utils.urlFor({relativeUrl: '/favicon.png'});
         } else {
-            return url.urlFor({relativeUrl: '/favicon.ico'});
+            return urlService.utils.urlFor({relativeUrl: '/favicon.ico'});
         }
     }
 };

--- a/core/server/utils/image-size.js
+++ b/core/server/utils/image-size.js
@@ -3,7 +3,7 @@ var debug = require('ghost-ignition').debug('utils:image-size'),
     url = require('url'),
     Promise = require('bluebird'),
     request = require('../utils/request'),
-    utils = require('../utils'),
+    urlService = require('../services/url'),
     errors = require('../errors'),
     config = require('../config'),
     storage = require('../adapters/storage'),
@@ -85,7 +85,7 @@ getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
 
     // CASE: pre 1.0 users were able to use an asset path for their blog logo
     if (imagePath.match(/^\/assets/)) {
-        imagePath = utils.url.urlJoin(utils.url.urlFor('home', true), utils.url.getSubdir(), '/', imagePath);
+        imagePath = urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', imagePath);
     }
 
     parsedUrl = url.parse(imagePath);
@@ -174,7 +174,7 @@ getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
 getImageSizeFromFilePath = function getImageSizeFromFilePath(imagePath) {
     var filePath;
 
-    imagePath = utils.url.urlFor('image', {image: imagePath}, true);
+    imagePath = urlService.utils.urlFor('image', {image: imagePath}, true);
 
     // get the storage readable filePath
     filePath = storageUtils.getLocalFileStoragePath(imagePath);

--- a/core/server/utils/index.js
+++ b/core/server/utils/index.js
@@ -136,7 +136,6 @@ utils = {
     removeOpenRedirectFromUrl: require('./remove-open-redirect-from-url'),
     zipFolder: require('./zip-folder'),
     generateAssetHash: require('./asset-hash'),
-    url: require('./url'),
     tokens: require('./tokens'),
     sequence: require('./sequence'),
     ghostVersion: require('./ghost-version'),

--- a/core/server/utils/make-absolute-urls.js
+++ b/core/server/utils/make-absolute-urls.js
@@ -1,6 +1,6 @@
-var cheerio  = require('cheerio'),
-    url      = require('url'),
-    utils  = require('../utils');
+var cheerio = require('cheerio'),
+    url = require('url'),
+    urlService = require('../services/url');
 
 /**
  * Make absolute URLs
@@ -50,7 +50,7 @@ function makeAbsoluteUrls(html, siteUrl, itemUrl) {
             // if the relative URL begins with a '/' use the blog URL (including sub-directory)
             // as the base URL, otherwise use the post's URL.
             baseUrl = attributeValue[0] === '/' ? siteUrl : itemUrl;
-            attributeValue = utils.url.urlJoin(baseUrl, attributeValue);
+            attributeValue = urlService.utils.urlJoin(baseUrl, attributeValue);
             el.attr(attributeName, attributeValue);
         });
     });

--- a/core/server/web/admin/app.js
+++ b/core/server/web/admin/app.js
@@ -3,7 +3,8 @@ var debug = require('ghost-ignition').debug('admin'),
 
     // App requires
     config = require('../../config'),
-    utils = require('../../utils'),
+    globalUtils = require('../../utils'),
+    urlService = require('../../services/url'),
 
     // Middleware
     // Admin only middleware
@@ -34,7 +35,7 @@ module.exports = function setupAdminApp() {
     configMaxAge = config.get('caching:admin:maxAge');
     adminApp.use('/assets', serveStatic(
         config.get('paths').clientAssets,
-        {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : utils.ONE_YEAR_MS, fallthrough: false}
+        {maxAge: (configMaxAge || configMaxAge === 0) ? configMaxAge : globalUtils.ONE_YEAR_MS, fallthrough: false}
     ));
 
     // Service Worker for offline support
@@ -43,7 +44,7 @@ module.exports = function setupAdminApp() {
     // Ember CLI's live-reload script
     if (config.get('env') === 'development') {
         adminApp.get('/ember-cli-live-reload.js', function (req, res) {
-            res.redirect('http://localhost:4200' + utils.url.getSubdir() + '/ghost/ember-cli-live-reload.js');
+            res.redirect('http://localhost:4200' + urlService.utils.getSubdir() + '/ghost/ember-cli-live-reload.js');
         });
     }
 

--- a/core/server/web/admin/middleware.js
+++ b/core/server/web/admin/middleware.js
@@ -1,12 +1,12 @@
-var utils = require('../../utils');
+var urlService = require('../../services/url');
 
 function redirectAdminUrls(req, res, next) {
-    var subdir = utils.url.getSubdir(),
+    var subdir = urlService.utils.getSubdir(),
         ghostPathRegex = new RegExp('^' + subdir + '/ghost/(.+)'),
         ghostPathMatch = req.originalUrl.match(ghostPathRegex);
 
     if (ghostPathMatch) {
-        return res.redirect(utils.url.urlJoin(utils.url.urlFor('admin'), '#', ghostPathMatch[1]));
+        return res.redirect(urlService.utils.urlJoin(urlService.utils.urlFor('admin'), '#', ghostPathMatch[1]));
     }
 
     next();

--- a/core/server/web/middleware/admin-redirects.js
+++ b/core/server/web/middleware/admin-redirects.js
@@ -1,10 +1,10 @@
 var express = require('express'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
     adminRedirect;
 
 adminRedirect = function adminRedirect(path) {
     return function doRedirect(req, res) {
-        return utils.url.redirectToAdmin(301, res, path);
+        return urlService.utils.redirectToAdmin(301, res, path);
     };
 };
 

--- a/core/server/web/middleware/api/cors.js
+++ b/core/server/web/middleware/api/cors.js
@@ -2,7 +2,7 @@ var cors = require('cors'),
     _ = require('lodash'),
     url = require('url'),
     os = require('os'),
-    utils = require('../../../utils'),
+    urlService = require('../../../services/url'),
     whitelist = [],
     ENABLE_CORS = {origin: true, maxAge: 86400},
     DISABLE_CORS = {origin: false};
@@ -32,8 +32,8 @@ function getIPs() {
 }
 
 function getUrls() {
-    var blogHost = url.parse(utils.url.urlFor('home', true)).hostname,
-        adminHost = url.parse(utils.url.urlFor('admin', true)).hostname,
+    var blogHost = url.parse(urlService.utils.urlFor('home', true)).hostname,
+        adminHost = url.parse(urlService.utils.urlFor('admin', true)).hostname,
         urls = [];
 
     urls.push(blogHost);

--- a/core/server/web/middleware/serve-favicon.js
+++ b/core/server/web/middleware/serve-favicon.js
@@ -2,8 +2,8 @@ var fs = require('fs'),
     path = require('path'),
     crypto = require('crypto'),
     storage = require('../../adapters/storage'),
-    utils  = require('../../utils'),
-    config  = require('../../config'),
+    urlService = require('../../services/url'),
+    config = require('../../config'),
     settingsCache = require('../../settings/cache'),
     blogIconUtils = require('../../utils/blog-icon'),
     buildContentResponse,
@@ -46,7 +46,7 @@ function serveFavicon() {
             if (settingsCache.get('icon')) {
                 // depends on the uploaded icon extension
                 if (originalExtension !== requestedExtension) {
-                    return res.redirect(302, utils.url.urlFor({relativeUrl: '/favicon' + originalExtension}));
+                    return res.redirect(302, urlService.utils.urlFor({relativeUrl: '/favicon' + originalExtension}));
                 }
 
                 storage.getStorage()
@@ -64,7 +64,7 @@ function serveFavicon() {
 
                 // CASE: always redirect to .ico for default icon
                 if (originalExtension !== requestedExtension) {
-                    return res.redirect(302, utils.url.urlFor({relativeUrl: '/favicon.ico'}));
+                    return res.redirect(302, urlService.utils.urlFor({relativeUrl: '/favicon.ico'}));
                 }
 
                 fs.readFile(filePath, function readFile(err, buf) {

--- a/core/server/web/middleware/serve-public-file.js
+++ b/core/server/web/middleware/serve-public-file.js
@@ -1,8 +1,8 @@
 var crypto = require('crypto'),
-    fs     = require('fs'),
-    path   = require('path'),
+    fs = require('fs'),
+    path = require('path'),
     config = require('../../config'),
-    utils  = require('../../utils');
+    urlService = require('../../services/url');
 
 // ### servePublicFile Middleware
 // Handles requests to robots.txt and favicon.ico (and caches them)
@@ -27,8 +27,8 @@ function servePublicFile(file, type, maxAge) {
                     }
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
-                        buf = buf.toString().replace(blogRegex, utils.url.urlFor('home', true).replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, utils.url.urlFor('api', {cors: true}, true));
+                        buf = buf.toString().replace(blogRegex, urlService.utils.urlFor('home', true).replace(/\/$/, ''));
+                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true}, true));
                     }
                     content = {
                         headers: {

--- a/core/server/web/middleware/uncapitalise.js
+++ b/core/server/web/middleware/uncapitalise.js
@@ -12,9 +12,10 @@
 //  req.baseUrl = /blog
 //  req.path =  /ghost/signin/
 
-var utils = require('../../utils'),
+var urlService = require('../../services/url'),
     errors = require('../../errors'),
     i18n = require('../../i18n'),
+    globalUtils = require('../../utils'),
     uncapitalise;
 
 uncapitalise = function uncapitalise(req, res, next) {
@@ -47,10 +48,10 @@ uncapitalise = function uncapitalise(req, res, next) {
      */
     if (/[A-Z]/.test(decodedURI)) {
         redirectPath = (
-            utils.removeOpenRedirectFromUrl((req.originalUrl || req.url).replace(pathToTest, pathToTest.toLowerCase()))
+            globalUtils.removeOpenRedirectFromUrl((req.originalUrl || req.url).replace(pathToTest, pathToTest.toLowerCase()))
         );
 
-        return utils.url.redirect301(res, redirectPath);
+        return urlService.utils.redirect301(res, redirectPath);
     }
 
     next();

--- a/core/server/web/middleware/url-redirects.js
+++ b/core/server/web/middleware/url-redirects.js
@@ -1,6 +1,6 @@
 var url = require('url'),
     debug = require('ghost-ignition').debug('url-redirects'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
     urlRedirects,
     _private = {};
 
@@ -26,8 +26,8 @@ _private.redirectUrl = function redirectUrl(options) {
 };
 
 _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
-    var blogHostWithProtocol = utils.url.urlFor('home', true),
-        adminHostWithProtocol = utils.url.urlFor('admin', true),
+    var blogHostWithProtocol = urlService.utils.urlFor('home', true),
+        adminHostWithProtocol = urlService.utils.urlFor('admin', true),
         adminHostWithoutProtocol = adminHostWithProtocol.replace(/(^\w+:|^)\/\//, ''),
         blogHostWithoutProtocol = blogHostWithProtocol.replace(/(^\w+:|^)\/\//, ''),
         requestedHost = options.requestedHost,
@@ -41,8 +41,8 @@ _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
     // If url and admin.url are not equal AND the requested host does not match, redirect.
     // The first condition is the most important, because it ensures that you have a custom admin url configured,
     // because we don't force an admin redirect if you have a custom url configured, but no admin url.
-    if (adminHostWithoutProtocol !== utils.url.urlJoin(blogHostWithoutProtocol, 'ghost/') &&
-        adminHostWithoutProtocol !== utils.url.urlJoin(requestedHost, utils.url.getSubdir(), 'ghost/')) {
+    if (adminHostWithoutProtocol !== urlService.utils.urlJoin(blogHostWithoutProtocol, 'ghost/') &&
+        adminHostWithoutProtocol !== urlService.utils.urlJoin(requestedHost, urlService.utils.getSubdir(), 'ghost/')) {
         debug('redirect because admin host does not match');
 
         return _private.redirectUrl({
@@ -53,7 +53,7 @@ _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
     }
 
     // CASE: configured admin url is HTTPS, but request is HTTP
-    if (utils.url.isSSL(adminHostWithProtocol) && !secure) {
+    if (urlService.utils.isSSL(adminHostWithProtocol) && !secure) {
         debug('redirect because protocol does not match');
 
         return _private.redirectUrl({
@@ -65,7 +65,7 @@ _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
 };
 
 _private.getBlogRedirectUrl = function getBlogRedirectUrl(options) {
-    var blogHostWithProtocol = utils.url.urlFor('home', true),
+    var blogHostWithProtocol = urlService.utils.urlFor('home', true),
         requestedHost = options.requestedHost,
         requestedUrl = options.requestedUrl,
         queryParameters = options.queryParameters,
@@ -74,7 +74,7 @@ _private.getBlogRedirectUrl = function getBlogRedirectUrl(options) {
     debug('getBlogRedirectUrl', requestedHost, requestedUrl, blogHostWithProtocol);
 
     // CASE: configured canonical url is HTTPS, but request is HTTP, redirect to requested host + SSL
-    if (utils.url.isSSL(blogHostWithProtocol) && !secure) {
+    if (urlService.utils.isSSL(blogHostWithProtocol) && !secure) {
         debug('redirect because protocol does not match');
 
         return _private.redirectUrl({
@@ -102,7 +102,7 @@ urlRedirects = function urlRedirects(req, res, next) {
 
     if (redirectUrl) {
         debug('url redirect to: ' + redirectUrl);
-        return utils.url.redirect301(res, redirectUrl);
+        return urlService.utils.redirect301(res, redirectUrl);
     }
 
     debug('no url redirect');

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -4,8 +4,9 @@ var debug = require('ghost-ignition').debug('blog'),
 
     // App requires
     config = require('../../config'),
+    globalUtils = require('../../utils'),
     storage = require('../../adapters/storage'),
-    utils = require('../../utils'),
+    urlService = require('../../services/url'),
 
     // This should probably be an internal app
     sitemapHandler = require('../../data/xml/sitemap/handler'),
@@ -51,21 +52,21 @@ module.exports = function setupSiteApp() {
     // Favicon
     siteApp.use(serveFavicon());
     // /public/ghost-sdk.js
-    siteApp.use(servePublicFile('public/ghost-sdk.js', 'application/javascript', utils.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost-sdk.min.js', 'application/javascript', utils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost-sdk.js', 'application/javascript', globalUtils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost-sdk.min.js', 'application/javascript', globalUtils.ONE_HOUR_S));
     // Serve sitemap.xsl file
-    siteApp.use(servePublicFile('sitemap.xsl', 'text/xsl', utils.ONE_DAY_S));
+    siteApp.use(servePublicFile('sitemap.xsl', 'text/xsl', globalUtils.ONE_DAY_S));
 
     // Serve stylesheets for default templates
-    siteApp.use(servePublicFile('public/ghost.css', 'text/css', utils.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost.min.css', 'text/css', utils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost.css', 'text/css', globalUtils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost.min.css', 'text/css', globalUtils.ONE_HOUR_S));
 
     // Serve images for default templates
-    siteApp.use(servePublicFile('public/404-ghost@2x.png', 'png', utils.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/404-ghost.png', 'png', utils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/404-ghost@2x.png', 'png', globalUtils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/404-ghost.png', 'png', globalUtils.ONE_HOUR_S));
 
     // Serve blog images using the storage adapter
-    siteApp.use('/' + utils.url.STATIC_IMAGE_URL_PREFIX, storage.getStorage().serve());
+    siteApp.use('/' + urlService.utils.STATIC_IMAGE_URL_PREFIX, storage.getStorage().serve());
 
     // @TODO find this a better home
     // We do this here, at the top level, because helpers require so much stuff.
@@ -86,7 +87,7 @@ module.exports = function setupSiteApp() {
     debug('Static content done');
 
     // Serve robots.txt if not found in theme
-    siteApp.use(servePublicFile('robots.txt', 'text/plain', utils.ONE_HOUR_S));
+    siteApp.use(servePublicFile('robots.txt', 'text/plain', globalUtils.ONE_HOUR_S));
 
     // setup middleware for internal apps
     // @TODO: refactor this to be a proper app middleware hook for internal & external apps

--- a/core/server/web/site/routes.js
+++ b/core/server/web/site/routes.js
@@ -13,12 +13,12 @@ var debug = require('ghost-ignition').debug('site:routes'),
     // Utils for creating paths
     // @TODO: refactor these away
     config = require('../../config'),
-    utils = require('../../utils');
+    urlService = require('../../services/url');
 
 module.exports = function siteRoutes() {
     // @TODO move this path out of this file!
     // Note this also exists in api/index.js
-    var previewRoute = utils.url.urlJoin('/', config.get('routeKeywords').preview, ':uuid', ':options?');
+    var previewRoute = urlService.utils.urlJoin('/', config.get('routeKeywords').preview, ':uuid', ':options?');
 
     // Preview - register controller as route
     // Ideal version, as we don't want these paths all over the place

--- a/core/test/integration/api/api_subscribers_spec.js
+++ b/core/test/integration/api/api_subscribers_spec.js
@@ -7,7 +7,7 @@ var should = require('should'),
     _ = require('lodash'),
     context = testUtils.context,
     errors = require('../../../server/errors'),
-    serverUtils = require('../../../server/utils'),
+    globalUtils = require('../../../server/utils'),
     apiUtils = require('../../../server/api/utils'),
     SubscribersAPI = require('../../../server/api/subscribers'),
 
@@ -284,7 +284,7 @@ describe('Subscribers API', function () {
             });
             sandbox.stub(apiUtils, 'checkFileExists').returns(true);
             stub = sandbox.stub(apiUtils, 'checkFileIsValid').returns(true);
-            sandbox.stub(serverUtils, 'readCSV').callsFake(function () {
+            sandbox.stub(globalUtils, 'readCSV').callsFake(function () {
                 if (scope.csvError) {
                     return Promise.reject(new Error('csv'));
                 }

--- a/core/test/integration/export_spec.js
+++ b/core/test/integration/export_spec.js
@@ -5,7 +5,7 @@ var should = require('should'),
 
     // Stuff we are testing
     exporter = require('../../server/data/export'),
-    utils = require('../../server/utils'),
+    globalUtils = require('../../server/utils'),
 
     sandbox = sinon.sandbox.create();
 
@@ -29,7 +29,7 @@ describe('Exporter', function () {
             should.exist(exportData.meta);
             should.exist(exportData.data);
 
-            exportData.meta.version.should.equal(utils.ghostVersion.full);
+            exportData.meta.version.should.equal(globalUtils.ghostVersion.full);
 
             _.each(tables, function (name) {
                 should.exist(exportData.data[name]);

--- a/core/test/integration/model/model_accesstoken_spec.js
+++ b/core/test/integration/model/model_accesstoken_spec.js
@@ -1,9 +1,8 @@
 var should = require('should'),
     sinon = require('sinon'),
     testUtils = require('../../utils'),
-
     events = require('../../../server/events'),
-    utils = require('../../../server/utils'),
+    globalUtils = require('../../../server/utils'),
 
     // Stuff we are testing
     AccesstokenModel = require('../../../server/models/accesstoken').Accesstoken,
@@ -31,7 +30,7 @@ describe('Accesstoken Model', function () {
             token: 'foobartoken',
             user_id: testUtils.DataGenerator.Content.users[0].id,
             client_id: testUtils.DataGenerator.forKnex.clients[0].id,
-            expires: Date.now() + utils.ONE_MONTH_MS
+            expires: Date.now() + globalUtils.ONE_MONTH_MS
         })
             .then(function (token) {
                 should.exist(token);

--- a/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
+++ b/core/test/unit/adapters/scheduling/post-scheduling/index_spec.js
@@ -11,7 +11,7 @@ var should = require('should'),
     schedulingUtils = require(config.get('paths').corePath + '/server/adapters/scheduling/utils'),
     SchedulingDefault = require(config.get('paths').corePath + '/server/adapters/scheduling/SchedulingDefault'),
     postScheduling = require(config.get('paths').corePath + '/server/adapters/scheduling/post-scheduling'),
-    generalUtils = require(__dirname + '/../../../../../server/utils'),
+    urlService = require('../../../../../server/services/url'),
 
     sandbox = sinon.sandbox.create();
 
@@ -70,7 +70,7 @@ describe('Scheduling: Post Scheduling', function () {
 
                     scope.adapter.schedule.calledWith({
                         time: moment(scope.post.get('published_at')).valueOf(),
-                        url: generalUtils.url.urlJoin(scope.apiUrl, 'schedules', 'posts', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
+                        url: urlService.utils.urlJoin(scope.apiUrl, 'schedules', 'posts', scope.post.get('id')) + '?client_id=' + scope.client.get('slug') + '&client_secret=' + scope.client.get('secret'),
                         extra: {
                             httpMethod: 'PUT',
                             oldTime: null

--- a/core/test/unit/adapters/storage/utils_spec.js
+++ b/core/test/unit/adapters/storage/utils_spec.js
@@ -1,6 +1,6 @@
 var should = require('should'),
     sinon = require('sinon'),
-    utils = require('../../../../server/utils'),
+    urlService = require('../../../../server/services/url'),
 
     // Stuff we are testing
     storageUtils = require('../../../../server/adapters/storage/utils'),
@@ -24,9 +24,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -41,9 +41,9 @@ describe('storage utils', function () {
             var url = 'https://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -55,9 +55,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -69,9 +69,9 @@ describe('storage utils', function () {
             var filePath = '/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(filePath);
@@ -83,9 +83,9 @@ describe('storage utils', function () {
             var filePath = '/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.getLocalFileStoragePath(filePath);
@@ -97,9 +97,9 @@ describe('storage utils', function () {
             var url = 'http://example-blog.com/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.getLocalFileStoragePath(url);
@@ -113,9 +113,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -130,9 +130,9 @@ describe('storage utils', function () {
             var url = 'https://myblog.com/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -144,9 +144,9 @@ describe('storage utils', function () {
             var url = 'http://myblog.com/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
@@ -158,9 +158,9 @@ describe('storage utils', function () {
             var url = '/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);
@@ -172,9 +172,9 @@ describe('storage utils', function () {
             var url = '/blog/content/images/2017/07/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = storageUtils.isLocalImage(url);
@@ -186,9 +186,9 @@ describe('storage utils', function () {
             var url = 'http://somewebsite.com/ghost-logo.png',
                 result;
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = storageUtils.isLocalImage(url);

--- a/core/test/unit/auth/auth-strategies_spec.js
+++ b/core/test/unit/auth/auth-strategies_spec.js
@@ -6,6 +6,7 @@ var should = require('should'),
     authStrategies = require('../../../server/auth/auth-strategies'),
     Models = require('../../../server/models'),
     errors = require('../../../server/errors'),
+    urlService = require('../../../server/services/url'),
     globalUtils = require('../../../server/utils'),
 
     sandbox = sinon.sandbox.create(),

--- a/core/test/unit/ghost_sdk_spec.js
+++ b/core/test/unit/ghost_sdk_spec.js
@@ -1,7 +1,7 @@
 var should = require('should'), // jshint ignore:line
     ghostSdk = require('../../server/public/ghost-sdk'),
     configUtils = require('../utils/configUtils'),
-    utils = require('../../server/utils');
+    urlService = require('../../server/services/url');
 
 describe('Ghost Ajax Helper', function () {
     beforeEach(function () {
@@ -27,7 +27,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -41,7 +41,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         ghostSdk.url.api().should.equal('https://testblog.com/ghost/api/v0.1/');
@@ -58,7 +58,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         ghostSdk.url.api().should.equal('https://admin.testblog.com/ghost/api/v0.1/');
@@ -68,7 +68,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         ghostSdk.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -78,7 +78,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -88,7 +88,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostSdk.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -126,7 +126,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -146,7 +146,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', true)
+            url: urlService.utils.urlFor('api', true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -165,7 +165,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', true)
+            url: urlService.utils.urlFor('api', true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -185,7 +185,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: utils.url.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true}, true)
         });
 
         var rendered = ghostSdk.url.api('posts', {limit: 3}),

--- a/core/test/unit/services/slack_spec.js
+++ b/core/test/unit/services/slack_spec.js
@@ -10,7 +10,7 @@ var should = require('should'), // jshint ignore:line,
     // Stuff we test
     slack = rewire('../../../server/services/slack'),
     events = require('../../../server/events'),
-    utils = require('../../../server/utils'),
+    urlService = require('../../../server/services/url'),
     schema = require('../../../server/data/schema').checks,
     settingsCache = require('../../../server/settings/cache'),
 
@@ -165,7 +165,7 @@ describe('Slack', function () {
 
         beforeEach(function () {
             isPostStub = sandbox.stub(schema, 'isPost');
-            urlForSpy = sandbox.spy(utils.url, 'urlFor');
+            urlForSpy = sandbox.spy(urlService.utils, 'urlFor');
 
             settingsCacheStub = sandbox.stub(settingsCache, 'get');
 

--- a/core/test/unit/sitemap/generator_spec.js
+++ b/core/test/unit/sitemap/generator_spec.js
@@ -6,7 +6,7 @@ var should = require('should'),
 
     // Stuff we are testing
     api = require('../../../server/api'),
-    utils = require('../../../server/utils'),
+    urlService = require('../../../server/services/url'),
     BaseGenerator = require('../../../server/data/xml/sitemap/base-generator'),
     PostGenerator = require('../../../server/data/xml/sitemap/post-generator'),
     PageGenerator = require('../../../server/data/xml/sitemap/page-generator'),
@@ -237,7 +237,7 @@ describe('Generators', function () {
             generator.init().then(function () {
                 should.exist(generator.siteMapContent);
 
-                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('home', true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
                 // <loc> should exist exactly one time
                 generator.siteMapContent.indexOf('<loc>').should.eql(generator.siteMapContent.lastIndexOf('<loc>'));
 
@@ -259,8 +259,8 @@ describe('Generators', function () {
             generator.init().then(function () {
                 should.exist(generator.siteMapContent);
 
-                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('home', true) + '</loc>');
-                generator.siteMapContent.should.containEql('<loc>' + utils.url.urlFor('page', {url: 'magic'}, true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
+                generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('page', {url: 'magic'}, true) + '</loc>');
 
                 done();
             }).catch(done);

--- a/core/test/unit/utils/image-size_spec.js
+++ b/core/test/unit/utils/image-size_spec.js
@@ -2,11 +2,11 @@ var should = require('should'),
     sinon = require('sinon'),
     rewire = require('rewire'),
     nock = require('nock'),
+    path = require('path'),
     configUtils = require('../../utils/configUtils'),
-    utils = require('../../../server/utils'),
+    urlService = require('../../../server/services/url'),
     errors = require('../../../server/errors'),
     storage = require('../../../server/adapters/storage'),
-    path = require('path'),
 
     // Stuff we are testing
     imageSize = rewire('../../../server/utils/image-size'),
@@ -151,9 +151,9 @@ describe('Image Size', function () {
                     width: 100
                 };
 
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             requestMock = nock('http://myblog.com')
@@ -264,10 +264,10 @@ describe('Image Size', function () {
                 };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/favicon.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             requestMock = nock('http://myblog.com')
@@ -371,10 +371,10 @@ describe('Image Size', function () {
                 };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/ghost-logo.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromFilePath(url).then(function (res) {
@@ -401,10 +401,10 @@ describe('Image Size', function () {
                 };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/blog/content/images/favicon_too_large.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('/blog');
 
             result = imageSize.getImageSizeFromFilePath(url).then(function (res) {
@@ -431,10 +431,10 @@ describe('Image Size', function () {
                 };
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/favicon_multi_sizes.ico');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromFilePath(url).then(function (res) {
@@ -455,10 +455,10 @@ describe('Image Size', function () {
                 urlGetSubdirStub;
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/not-existing-image.png');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromFilePath(url)
@@ -479,10 +479,10 @@ describe('Image Size', function () {
             imageSize.__set__('sizeOf', sizeOfStub);
 
             storage.getStorage().storagePath = path.join(__dirname, '../../../test/utils/fixtures/images/');
-            urlForStub = sandbox.stub(utils.url, 'urlFor');
+            urlForStub = sandbox.stub(urlService.utils, 'urlFor');
             urlForStub.withArgs('image').returns('http://myblog.com/content/images/ghost-logo.pngx');
             urlForStub.withArgs('home').returns('http://myblog.com/');
-            urlGetSubdirStub = sandbox.stub(utils.url, 'getSubdir');
+            urlGetSubdirStub = sandbox.stub(urlService.utils, 'getSubdir');
             urlGetSubdirStub.returns('');
 
             result = imageSize.getImageSizeFromFilePath(url)

--- a/core/test/unit/utils/read-csv_spec.js
+++ b/core/test/unit/utils/read-csv_spec.js
@@ -1,11 +1,11 @@
 var should = require('should'),
-    utils = require('../../../server/utils'),
     path = require('path'),
+    globalUtils = require('../../../server/utils'),
     csvPath = path.join(__dirname, '../../utils/fixtures/csv/');
 
 describe('read csv', function () {
     it('read csv: one column', function (done) {
-        utils.readCSV({
+        globalUtils.readCSV({
             path: csvPath + 'single-column-with-header.csv',
             columnsToExtract: [{name: 'email', lookup: /email/i}]
         }).then(function (result) {
@@ -19,7 +19,7 @@ describe('read csv', function () {
     });
 
     it('read csv: two columns, 1 filter', function (done) {
-        utils.readCSV({
+        globalUtils.readCSV({
             path: csvPath + 'two-columns-with-header.csv',
             columnsToExtract: [{name: 'email', lookup: /email/i}]
         }).then(function (result) {
@@ -34,7 +34,7 @@ describe('read csv', function () {
     });
 
     it('read csv: two columns, 2 filters', function (done) {
-        utils.readCSV({
+        globalUtils.readCSV({
             path: csvPath + 'two-columns-obscure-header.csv',
             columnsToExtract: [
                 {name: 'email', lookup: /email/i},

--- a/core/test/unit/utils/url_spec.js
+++ b/core/test/unit/utils/url_spec.js
@@ -3,7 +3,8 @@ var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
     moment = require('moment-timezone'),
-    utils = require('../../../server/utils'),
+    urlService = require('../../../server/services/url'),
+    globalUtils = require('../../../server/utils'),
     settingsCache = require('../../../server/settings/cache'),
     configUtils = require('../../utils/configUtils'),
     testUtils = require('../../utils'),
@@ -23,180 +24,192 @@ describe('Url', function () {
 
     describe('getProtectedSlugs', function () {
         it('defaults', function () {
-            utils.url.getProtectedSlugs().should.eql(['ghost', 'rss', 'amp']);
+            urlService.utils.getProtectedSlugs().should.eql(['ghost', 'rss', 'amp']);
         });
 
         it('url has subdir', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.getProtectedSlugs().should.eql(['ghost', 'rss', 'amp', 'blog']);
+            urlService.utils.getProtectedSlugs().should.eql(['ghost', 'rss', 'amp', 'blog']);
         });
     });
 
     describe('getSubdir', function () {
         it('url has no subdir', function () {
-            utils.url.getSubdir().should.eql('');
+            urlService.utils.getSubdir().should.eql('');
         });
 
         it('url has subdir', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.getSubdir().should.eql('/blog');
+            urlService.utils.getSubdir().should.eql('/blog');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-            utils.url.getSubdir().should.eql('/blog');
+            urlService.utils.getSubdir().should.eql('/blog');
 
             configUtils.set({url: 'http://my-ghost-blog.com/my/blog'});
-            utils.url.getSubdir().should.eql('/my/blog');
+            urlService.utils.getSubdir().should.eql('/my/blog');
 
             configUtils.set({url: 'http://my-ghost-blog.com/my/blog/'});
-            utils.url.getSubdir().should.eql('/my/blog');
+            urlService.utils.getSubdir().should.eql('/my/blog');
         });
 
         it('should not return a slash for subdir', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.getSubdir().should.eql('');
+            urlService.utils.getSubdir().should.eql('');
 
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.getSubdir().should.eql('');
+            urlService.utils.getSubdir().should.eql('');
         });
     });
 
     describe('urlJoin', function () {
         it('should deduplicate slashes', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.urlJoin('/', '/my/', '/blog/').should.equal('/my/blog/');
-            utils.url.urlJoin('/', '//my/', '/blog/').should.equal('/my/blog/');
-            utils.url.urlJoin('/', '/', '/').should.equal('/');
+            urlService.utils.urlJoin('/', '/my/', '/blog/').should.equal('/my/blog/');
+            urlService.utils.urlJoin('/', '//my/', '/blog/').should.equal('/my/blog/');
+            urlService.utils.urlJoin('/', '/', '/').should.equal('/');
         });
 
         it('should not deduplicate slashes in protocol', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.urlJoin('http://myurl.com', '/rss').should.equal('http://myurl.com/rss');
-            utils.url.urlJoin('https://myurl.com/', '/rss').should.equal('https://myurl.com/rss');
+            urlService.utils.urlJoin('http://myurl.com', '/rss').should.equal('http://myurl.com/rss');
+            urlService.utils.urlJoin('https://myurl.com/', '/rss').should.equal('https://myurl.com/rss');
         });
 
         it('should permit schemeless protocol', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.urlJoin('/', '/').should.equal('/');
-            utils.url.urlJoin('//myurl.com', '/rss').should.equal('//myurl.com/rss');
-            utils.url.urlJoin('//myurl.com/', '/rss').should.equal('//myurl.com/rss');
-            utils.url.urlJoin('//myurl.com//', 'rss').should.equal('//myurl.com/rss');
-            utils.url.urlJoin('', '//myurl.com', 'rss').should.equal('//myurl.com/rss');
+            urlService.utils.urlJoin('/', '/').should.equal('/');
+            urlService.utils.urlJoin('//myurl.com', '/rss').should.equal('//myurl.com/rss');
+            urlService.utils.urlJoin('//myurl.com/', '/rss').should.equal('//myurl.com/rss');
+            urlService.utils.urlJoin('//myurl.com//', 'rss').should.equal('//myurl.com/rss');
+            urlService.utils.urlJoin('', '//myurl.com', 'rss').should.equal('//myurl.com/rss');
         });
 
         it('should deduplicate subdir', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlJoin('blog', 'blog/about').should.equal('blog/about');
-            utils.url.urlJoin('blog/', 'blog/about').should.equal('blog/about');
+            urlService.utils.urlJoin('blog', 'blog/about').should.equal('blog/about');
+            urlService.utils.urlJoin('blog/', 'blog/about').should.equal('blog/about');
             configUtils.set({url: 'http://my-ghost-blog.com/my/blog'});
-            utils.url.urlJoin('my/blog', 'my/blog/about').should.equal('my/blog/about');
-            utils.url.urlJoin('my/blog/', 'my/blog/about').should.equal('my/blog/about');
+            urlService.utils.urlJoin('my/blog', 'my/blog/about').should.equal('my/blog/about');
+            urlService.utils.urlJoin('my/blog/', 'my/blog/about').should.equal('my/blog/about');
         });
     });
 
     describe('urlFor', function () {
         it('should return the home url with no options', function () {
-            utils.url.urlFor().should.equal('/');
+            urlService.utils.urlFor().should.equal('/');
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor().should.equal('/blog/');
+            urlService.utils.urlFor().should.equal('/blog/');
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-            utils.url.urlFor().should.equal('/blog/');
+            urlService.utils.urlFor().should.equal('/blog/');
         });
 
         it('should return home url when asked for', function () {
             var testContext = 'home';
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext).should.equal('/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
-            utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext).should.equal('/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.urlFor(testContext).should.equal('/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
-            utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext).should.equal('/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext).should.equal('/blog/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
-            utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-            utils.url.urlFor(testContext).should.equal('/blog/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
-            utils.url.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, {secure: true}, true).should.equal('https://my-ghost-blog.com/blog/');
 
             // Output blog url without trailing slash
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext).should.equal('/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
-            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com');
+            urlService.utils.urlFor(testContext).should.equal('/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, {
+                secure: true,
+                trailingSlash: false
+            }, true).should.equal('https://my-ghost-blog.com');
 
             configUtils.set({url: 'http://my-ghost-blog.com/'});
-            utils.url.urlFor(testContext).should.equal('/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
-            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com');
+            urlService.utils.urlFor(testContext).should.equal('/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, {
+                secure: true,
+                trailingSlash: false
+            }, true).should.equal('https://my-ghost-blog.com');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext).should.equal('/blog/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
-            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com/blog');
+            urlService.utils.urlFor(testContext).should.equal('/blog/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, {
+                secure: true,
+                trailingSlash: false
+            }, true).should.equal('https://my-ghost-blog.com/blog');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-            utils.url.urlFor(testContext).should.equal('/blog/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
-            utils.url.urlFor(testContext, {secure: true, trailingSlash: false}, true).should.equal('https://my-ghost-blog.com/blog');
+            urlService.utils.urlFor(testContext).should.equal('/blog/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, {
+                secure: true,
+                trailingSlash: false
+            }, true).should.equal('https://my-ghost-blog.com/blog');
         });
 
         it('should return rss url when asked for', function () {
             var testContext = 'rss';
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext).should.equal('/rss/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/rss/');
+            urlService.utils.urlFor(testContext).should.equal('/rss/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/rss/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext).should.equal('/blog/rss/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/rss/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/rss/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/rss/');
         });
 
         it('should handle weird cases by always returning /', function () {
-            utils.url.urlFor('').should.equal('/');
-            utils.url.urlFor('post', {}).should.equal('/');
-            utils.url.urlFor('post', {post: {}}).should.equal('/');
-            utils.url.urlFor(null).should.equal('/');
-            utils.url.urlFor(undefined).should.equal('/');
-            utils.url.urlFor({}).should.equal('/');
-            utils.url.urlFor({relativeUrl: ''}).should.equal('/');
-            utils.url.urlFor({relativeUrl: null}).should.equal('/');
-            utils.url.urlFor({relativeUrl: undefined}).should.equal('/');
+            urlService.utils.urlFor('').should.equal('/');
+            urlService.utils.urlFor('post', {}).should.equal('/');
+            urlService.utils.urlFor('post', {post: {}}).should.equal('/');
+            urlService.utils.urlFor(null).should.equal('/');
+            urlService.utils.urlFor(undefined).should.equal('/');
+            urlService.utils.urlFor({}).should.equal('/');
+            urlService.utils.urlFor({relativeUrl: ''}).should.equal('/');
+            urlService.utils.urlFor({relativeUrl: null}).should.equal('/');
+            urlService.utils.urlFor({relativeUrl: undefined}).should.equal('/');
         });
 
         it('should return url for a random path when asked for', function () {
             var testContext = {relativeUrl: '/about/'};
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext).should.equal('/about/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/about/');
+            urlService.utils.urlFor(testContext).should.equal('/about/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/about/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext).should.equal('/blog/about/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/about/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
         });
 
         it('should deduplicate subdirectories in paths', function () {
             var testContext = {relativeUrl: '/blog/about/'};
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext).should.equal('/blog/about/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/about/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext).should.equal('/blog/about/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/about/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
-            utils.url.urlFor(testContext).should.equal('/blog/about/');
-            utils.url.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
+            urlService.utils.urlFor(testContext).should.equal('/blog/about/');
+            urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
         });
 
         it('should return url for a post from post object', function () {
@@ -206,16 +219,16 @@ describe('Url', function () {
             // url is now provided on the postmodel, permalinkSetting tests are in the model_post_spec.js test
             testData.post.url = '/short-and-sweet/';
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext, testData).should.equal('/short-and-sweet/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
             testData.post.url = '/blog-one/';
-            utils.url.urlFor(testContext, testData).should.equal('/blog/blog-one/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/blog-one/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
         });
 
         it('should return url for a tag when asked for', function () {
@@ -223,12 +236,12 @@ describe('Url', function () {
                 testData = {tag: testUtils.DataGenerator.Content.tags[0]};
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
         });
 
         it('should return url for an author when asked for', function () {
@@ -236,12 +249,12 @@ describe('Url', function () {
                 testData = {author: testUtils.DataGenerator.Content.users[0]};
 
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            utils.url.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
         });
 
         it('should return url for an image when asked for', function () {
@@ -251,34 +264,34 @@ describe('Url', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
 
             testData = {image: '/content/images/my-image.jpg'};
-            utils.url.urlFor(testContext, testData).should.equal('/content/images/my-image.jpg');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/content/images/my-image.jpg');
+            urlService.utils.urlFor(testContext, testData).should.equal('/content/images/my-image.jpg');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/content/images/my-image.jpg');
 
             testData = {image: 'http://placekitten.com/500/200'};
-            utils.url.urlFor(testContext, testData).should.equal('http://placekitten.com/500/200');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://placekitten.com/500/200');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://placekitten.com/500/200');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://placekitten.com/500/200');
 
             testData = {image: '/blog/content/images/my-image2.jpg'};
-            utils.url.urlFor(testContext, testData).should.equal('/blog/content/images/my-image2.jpg');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/content/images/my-image2.jpg');
             // We don't make image urls absolute if they don't look like images relative to the image path
-            utils.url.urlFor(testContext, testData, true).should.equal('/blog/content/images/my-image2.jpg');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('/blog/content/images/my-image2.jpg');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
 
             testData = {image: '/content/images/my-image3.jpg'};
-            utils.url.urlFor(testContext, testData).should.equal('/content/images/my-image3.jpg');
+            urlService.utils.urlFor(testContext, testData).should.equal('/content/images/my-image3.jpg');
             // We don't make image urls absolute if they don't look like images relative to the image path
-            utils.url.urlFor(testContext, testData, true).should.equal('/content/images/my-image3.jpg');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('/content/images/my-image3.jpg');
 
             testData = {image: '/blog/content/images/my-image4.jpg'};
-            utils.url.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
-            utils.url.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/content/images/my-image4.jpg');
+            urlService.utils.urlFor(testContext, testData).should.equal('/blog/content/images/my-image4.jpg');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/content/images/my-image4.jpg');
 
             // Test case for blogs with optional https -
             // they may be configured with http url but the actual connection may be over https (#8373)
             configUtils.set({url: 'http://my-ghost-blog.com'});
             testData = {image: '/content/images/my-image.jpg', secure: true};
-            utils.url.urlFor(testContext, testData, true).should.equal('https://my-ghost-blog.com/content/images/my-image.jpg');
+            urlService.utils.urlFor(testContext, testData, true).should.equal('https://my-ghost-blog.com/content/images/my-image.jpg');
         });
 
         it('should return a url for a nav item when asked for it', function () {
@@ -288,65 +301,65 @@ describe('Url', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
 
             testData = {nav: {url: 'http://my-ghost-blog.com/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com/short-and-sweet/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/short-and-sweet/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com//short-and-sweet/'}, secure: true};
-            utils.url.urlFor(testContext, testData).should.equal('https://my-ghost-blog.com/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('https://my-ghost-blog.com/short-and-sweet/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com:3000/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com:3000/short-and-sweet/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/short-and-sweet/');
 
             testData = {nav: {url: 'http://sub.my-ghost-blog.com/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/');
 
             testData = {nav: {url: '//sub.my-ghost-blog.com/'}};
-            utils.url.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/');
 
             testData = {nav: {url: 'mailto:sub@my-ghost-blog.com/'}};
-            utils.url.urlFor(testContext, testData).should.equal('mailto:sub@my-ghost-blog.com/');
+            urlService.utils.urlFor(testContext, testData).should.equal('mailto:sub@my-ghost-blog.com/');
 
             testData = {nav: {url: '#this-anchor'}};
-            utils.url.urlFor(testContext, testData).should.equal('#this-anchor');
+            urlService.utils.urlFor(testContext, testData).should.equal('#this-anchor');
 
             testData = {nav: {url: 'http://some-external-page.com/my-ghost-blog.com'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://some-external-page.com/my-ghost-blog.com');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://some-external-page.com/my-ghost-blog.com');
 
             testData = {nav: {url: 'http://some-external-page.com/stuff-my-ghost-blog.com-around'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://some-external-page.com/stuff-my-ghost-blog.com-around');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://some-external-page.com/stuff-my-ghost-blog.com-around');
 
             testData = {nav: {url: 'mailto:marshmallow@my-ghost-blog.com'}};
-            utils.url.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
+            urlService.utils.urlFor(testContext, testData).should.equal('mailto:marshmallow@my-ghost-blog.com');
 
             configUtils.set({url: 'http://my-ghost-blog.com/blog'});
             testData = {nav: {url: 'http://my-ghost-blog.com/blog/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com/blog/short-and-sweet/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com:3000/blog/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/blog/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/blog/');
 
             testData = {nav: {url: 'http://my-ghost-blog.com:3000/blog/short-and-sweet/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/blog/short-and-sweet/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://my-ghost-blog.com:3000/blog/short-and-sweet/');
 
             testData = {nav: {url: 'http://sub.my-ghost-blog.com/blog/'}};
-            utils.url.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, testData).should.equal('http://sub.my-ghost-blog.com/blog/');
 
             testData = {nav: {url: '//sub.my-ghost-blog.com/blog/'}};
-            utils.url.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/blog/');
+            urlService.utils.urlFor(testContext, testData).should.equal('//sub.my-ghost-blog.com/blog/');
         });
 
         it('sitemap: should return other known paths when requested', function () {
             configUtils.set({url: 'http://my-ghost-blog.com'});
-            utils.url.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
-            utils.url.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
+            urlService.utils.urlFor('sitemap_xsl').should.equal('/sitemap.xsl');
+            urlService.utils.urlFor('sitemap_xsl', true).should.equal('http://my-ghost-blog.com/sitemap.xsl');
         });
 
         it('admin: relative', function () {
@@ -354,7 +367,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('admin').should.equal('/ghost/');
+            urlService.utils.urlFor('admin').should.equal('/ghost/');
         });
 
         it('admin: url is http', function () {
@@ -362,7 +375,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://my-ghost-blog.com/ghost/');
         });
 
         it('admin: custom admin url is set', function () {
@@ -373,7 +386,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('admin', true).should.equal('https://admin.my-ghost-blog.com/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('https://admin.my-ghost-blog.com/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -381,7 +394,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -389,7 +402,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog/'
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://my-ghost-blog.com/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -397,7 +410,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            utils.url.urlFor('admin').should.equal('/blog/ghost/');
+            urlService.utils.urlFor('admin').should.equal('/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -408,7 +421,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -419,7 +432,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -430,7 +443,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
         it('admin: blog is on subdir', function () {
@@ -441,7 +454,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
+            urlService.utils.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
         it('api: should return admin url is set', function () {
@@ -452,7 +465,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('api', true).should.eql('https://something.de/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', true).should.eql('https://something.de/ghost/api/v0.1/');
         });
 
         it('api: url has subdir', function () {
@@ -460,11 +473,11 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
         });
 
         it('api: relative path is correct', function () {
-            utils.url.urlFor('api').should.eql('/ghost/api/v0.1/');
+            urlService.utils.urlFor('api').should.eql('/ghost/api/v0.1/');
         });
 
         it('api: relative path with subdir is correct', function () {
@@ -472,7 +485,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            utils.url.urlFor('api').should.eql('/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api').should.eql('/blog/ghost/api/v0.1/');
         });
 
         it('api: should return http if config.url is http', function () {
@@ -480,7 +493,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: should return https if config.url is https', function () {
@@ -488,7 +501,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is http: should return no protocol', function () {
@@ -496,7 +509,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is http: cors should return no protocol', function () {
@@ -507,7 +520,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('api', {cors: true}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is https: should return with protocol', function () {
@@ -518,7 +531,7 @@ describe('Url', function () {
                 }
             });
 
-            utils.url.urlFor('api', {cors: true}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is https: should return with protocol', function () {
@@ -526,7 +539,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            utils.url.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
     });
 
@@ -545,7 +558,7 @@ describe('Url', function () {
             var testData = testUtils.DataGenerator.Content.posts[2],
                 postLink = '/short-and-sweet/';
 
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:year/:month/:day/:slug, blog timezone is Los Angeles', function () {
@@ -556,7 +569,7 @@ describe('Url', function () {
                 postLink = '/2016/05/17/short-and-sweet/';
 
             testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:year/:month/:day/:slug, blog timezone is Asia Tokyo', function () {
@@ -567,7 +580,7 @@ describe('Url', function () {
                 postLink = '/2016/05/18/short-and-sweet/';
 
             testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('post is page, no permalink usage allowed at all', function () {
@@ -577,7 +590,7 @@ describe('Url', function () {
             var testData = testUtils.DataGenerator.Content.posts[5],
                 postLink = '/static-page-test/';
 
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:year/:id:/:author', function () {
@@ -588,7 +601,7 @@ describe('Url', function () {
                 postLink = '/2015/3/joe-blog/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:year/:id:/:author', function () {
@@ -599,7 +612,7 @@ describe('Url', function () {
                 postLink = '/2016/3/joe-blog/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:primary_tag/:slug/ and there is a primary_tag', function () {
@@ -610,7 +623,7 @@ describe('Url', function () {
                 postLink = '/bitcoin/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('permalink is /:primary_tag/:slug/ and there is NO primary_tag', function () {
@@ -621,7 +634,7 @@ describe('Url', function () {
                 postLink = '/all/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('shows "undefined" for unknown route segments', function () {
@@ -633,7 +646,7 @@ describe('Url', function () {
                 postLink = '/undefined/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
 
         it('post is not published yet', function () {
@@ -648,16 +661,16 @@ describe('Url', function () {
             postLink = postLink.replace('MM', nowMoment.format('MM'));
             postLink = postLink.replace('DD', nowMoment.format('DD'));
 
-            utils.url.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.urlPathForPost(testData).should.equal(postLink);
         });
     });
 
     describe('isSSL', function () {
-       it('detects https protocol correctly', function () {
-           utils.url.isSSL('https://my.blog.com').should.be.true();
-           utils.url.isSSL('http://my.blog.com').should.be.false();
-           utils.url.isSSL('http://my.https.com').should.be.false();
-       });
+        it('detects https protocol correctly', function () {
+            urlService.utils.isSSL('https://my.blog.com').should.be.true();
+            urlService.utils.isSSL('http://my.blog.com').should.be.false();
+            urlService.utils.isSSL('http://my.https.com').should.be.false();
+        });
     });
 
     describe('redirects', function () {
@@ -669,12 +682,12 @@ describe('Url', function () {
             res.redirect = function (code, path) {
                 code.should.equal(301);
                 path.should.eql('my/awesome/path');
-                res.set.calledWith({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}).should.be.true();
+                res.set.calledWith({'Cache-Control': 'public, max-age=' + globalUtils.ONE_YEAR_S}).should.be.true();
 
                 done();
             };
 
-            utils.url.redirect301(res, 'my/awesome/path');
+            urlService.utils.redirect301(res, 'my/awesome/path');
         });
 
         it('performs an admin 301 redirect correctly', function (done) {
@@ -685,12 +698,12 @@ describe('Url', function () {
             res.redirect = function (code, path) {
                 code.should.equal(301);
                 path.should.eql('/ghost/#/my/awesome/path/');
-                res.set.calledWith({'Cache-Control': 'public, max-age=' + utils.ONE_YEAR_S}).should.be.true();
+                res.set.calledWith({'Cache-Control': 'public, max-age=' + globalUtils.ONE_YEAR_S}).should.be.true();
 
                 done();
             };
 
-            utils.url.redirectToAdmin(301, res, '#/my/awesome/path');
+            urlService.utils.redirectToAdmin(301, res, '#/my/awesome/path');
         });
 
         it('performs an admin 302 redirect correctly', function (done) {
@@ -705,7 +718,7 @@ describe('Url', function () {
                 done();
             };
 
-            utils.url.redirectToAdmin(302, res, '#/my/awesome/path');
+            urlService.utils.redirectToAdmin(302, res, '#/my/awesome/path');
         });
     });
 });

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -17,7 +17,7 @@ var Promise = require('bluebird'),
     schema = require('../../server/data/schema').tables,
     schemaTables = Object.keys(schema),
     models = require('../../server/models'),
-    utils = require('../../server/utils'),
+    urlService = require('../../server/services/url'),
     events = require('../../server/events'),
     SettingsLib = require('../../server/settings'),
     customRedirectsMiddleware = require('../../server/web/middleware/custom-redirects'),
@@ -904,7 +904,7 @@ startGhost = function startGhost(options) {
 
             if (options.subdir) {
                 parentApp = express();
-                parentApp.use(utils.url.getSubdir(), ghostServer.rootApp);
+                parentApp.use(urlService.utils.getSubdir(), ghostServer.rootApp);
                 return ghostServer.start(parentApp);
             }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var startTime = Date.now(),
     debug = require('ghost-ignition').debug('boot:index'),
-    ghost, express, logging, errors, utils, parentApp;
+    ghost, express, logging, errors, urlService, parentApp;
 
 debug('First requires...');
 
@@ -14,13 +14,13 @@ debug('Required ghost');
 express = require('express');
 logging = require('./core/server/logging');
 errors = require('./core/server/errors');
-utils = require('./core/server/utils');
+urlService = require('./core/server/services/url');
 parentApp = express();
 
 debug('Initialising Ghost');
 ghost().then(function (ghostServer) {
     // Mount our Ghost instance on our desired subdirectory path if it exists.
-    parentApp.use(utils.url.getSubdir(), ghostServer.rootApp);
+    parentApp.use(urlService.utils.getSubdir(), ghostServer.rootApp);
 
     debug('Starting Ghost');
     // Let Ghost handle starting our server instance.


### PR DESCRIPTION
Two commits.
refs #9178

- Small UrlService optimisations ([commit](https://github.com/TryGhost/Ghost/commit/b4c11bb5408859f11806487f3295995e754f5d5d))
  - optimise the bootstrap of the service
  - rename the config option to disable url pre-load
- Moved utils/url.js to UrlService ([commit](https://github.com/TryGhost/Ghost/commit/2a6faf88e237c3d09de25a37c4b30933703c05aa))
   - simply move the file to the url service and replace the occurances
   - everybody now uses `require('services/url')` (before that we had a mixture of require('utils') or require('utils/url`) or...
   - always use `globalUtils` and `localUtils` for the rest