### PR TITLE
Removed bluebird promise wrap in request lib

### DIFF
--- a/core/server/lib/request.js
+++ b/core/server/lib/request.js
@@ -1,5 +1,4 @@
 var got = require('got'),
-    Promise = require('bluebird'),
     _ = require('lodash'),
     validator = require('../data/validation').validator,
     common = require('./common');
@@ -13,14 +12,5 @@ module.exports = function request(url, options) {
         }));
     }
 
-    return new Promise(function (resolve, reject) {
-        return got(
-            url,
-            options
-        ).then(function (response) {
-            return resolve(response);
-        }).catch(function (err) {
-            return reject(err);
-        });
-    });
+    return got(url, options);
 };

--- a/core/test/unit/lib/image/image-size_spec.js
+++ b/core/test/unit/lib/image/image-size_spec.js
@@ -300,6 +300,20 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     requestMock.isDone().should.be.true();
                     should.exist(err);
+                    err.errorType.should.be.equal('NotFoundError');
+                    err.message.should.be.equal('Image not found.');
+                    done();
+                });
+        });
+
+        it('[failure] handles invalid URL', function (done) {
+            var url = 'Not-a-valid-url';
+
+            result = imageSize.getImageSizeFromUrl(url)
+                .catch(function (err) {
+                    should.exist(err);
+                    err.errorType.should.be.equal('InternalServerError');
+                    err.message.should.be.equal('URL empty or invalid.');
                     done();
                 });
         });
@@ -317,6 +331,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     requestMock.isDone().should.be.true();
                     should.exist(err);
+                    err.errorType.should.be.equal('InternalServerError');
+                    err.message.should.be.equal('Request timed out.');
                     done();
                 });
         });
@@ -338,6 +354,8 @@ describe('lib/image: image size', function () {
                 .catch(function (err) {
                     requestMock.isDone().should.be.true();
                     should.exist(err);
+                    err.errorType.should.be.equal('InternalServerError');
+                    err.error.should.be.equal('image-size could not find dimensions');
                     done();
                 });
         });
@@ -347,12 +365,14 @@ describe('lib/image: image size', function () {
 
             requestMock = nock('https://notarealwebsite.com')
                 .get('/images/notapicture.jpg')
-                .reply(404, {message: 'something awful happened', code: 'AWFUL_ERROR'});
+                .reply(500, {message: 'something awful happened', code: 'AWFUL_ERROR'});
 
             result = imageSize.getImageSizeFromUrl(url)
                 .catch(function (err) {
                     requestMock.isDone().should.be.true();
                     should.exist(err);
+                    err.errorType.should.be.equal('InternalServerError');
+                    err.message.should.be.equal('Unknown Request error.');
                     done();
                 });
         });


### PR DESCRIPTION
refs #9178, refs #8988

With https://github.com/TryGhost/Ghost/commit/7353c87d7f88eea0485ea022365dc4bfe1d608f2 we use Bluebird globally for Promises. Therefore, the request lib doesn't need to be wrapped in a bluebird Promise anymore.

This was originally done, so we can work with catch predicated in our image-size lib.

Updated the tests to proof, that the catch predicates work.

The tests fail, as soon as the Promise overwrite is commented out.