### PR TITLE
[i18n] `update-check` key to `updateCheck`

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -278,7 +278,7 @@
             },
             "noPermissionToAction": "You do not have permission to perform this action"
         },
-        "update-check": {
+        "updateCheck": {
             "checkingForUpdatesFailed": {
                 "error": "Checking for updates failed, your blog will continue to function.",
                 "help": "If you get this error repeatedly, please seek help from {url}."

--- a/core/server/update-check.js
+++ b/core/server/update-check.js
@@ -46,8 +46,8 @@ function updateCheckError(err) {
         internal
     );
 
-    err.context = common.i18n.t('errors.update-check.checkingForUpdatesFailed.error');
-    err.help = common.i18n.t('errors.update-check.checkingForUpdatesFailed.help', {url: 'https://docs.ghost.org/v1'});
+    err.context = common.i18n.t('errors.updateCheck.checkingForUpdatesFailed.error');
+    err.help = common.i18n.t('errors.updateCheck.checkingForUpdatesFailed.help', {url: 'https://docs.ghost.org/v1'});
     common.logging.error(err);
 }
 


### PR DESCRIPTION
pull request #9347; related pull request #8437

- one instance of hyphenated key changed; the rest of keys in file
_core/server/translations/en.json_ are already camelCase
- also converted `common.i18n.t()` calls to this key in file
_core/server/update-check.js_
- this allows to simplify i18n to an unified use of `jsonpath`
