### PR TITLE
 🐛 Fixed large imports

### DIFF
--- a/core/server/data/importer/importers/data/index.js
+++ b/core/server/data/importer/importers/data/index.js
@@ -42,6 +42,7 @@ DataImporter = {
         if (importOptions && importOptions.importPersistUser) {
             modelOptions.importPersistUser = importOptions.importPersistUser;
         }
+
         this.init(importData);
 
         return models.Base.transaction(function (transacting) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -774,6 +774,12 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             if (!slug) {
                 slug = baseName;
             }
+
+            // CASE: no slug generation on import, see https://github.com/TryGhost/Ghost/issues/8717
+            if (options.importing) {
+                return slug;
+            }
+
             // Test for duplicate slugs.
             return checkIfSlugExists(slug);
         });

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -394,6 +394,8 @@ describe('Import', function () {
                 exportData = exported;
                 return dataImporter.doImport(exportData);
             }).then(function (importedData) {
+                importedData.data.posts.length.should.eql(1);
+
                 importedData.problems.length.should.eql(3);
                 importedData.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
                 importedData.problems[0].help.should.eql('Tag');

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bluebird": "3.5.1",
     "body-parser": "1.18.2",
     "bookshelf": "0.10.3",
-    "bookshelf-relations": "0.1.3",
+    "bookshelf-relations": "0.1.4",
     "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/37439f56965b17d29bb4ff9b3f3222b2f4bd6ce3",
     "bson-objectid": "1.2.2",
     "chalk": "1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -534,9 +534,9 @@ body-parser@~1.14.0:
     raw-body "~2.1.5"
     type-is "~1.6.10"
 
-bookshelf-relations@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-0.1.3.tgz#aa403b0fdb1bb76c67119bdae1106f6e6342b128"
+bookshelf-relations@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-0.1.4.tgz#b4ec82cff35b371747e4fc30d8c2acc2e333bc48"
   dependencies:
     bluebird "^3.4.1"
     ghost-ignition "^2.8.16"


### PR DESCRIPTION
closes #9348

- do not run import with `Promise.all`
- with a large import file, we run an enormous amount of queries in parallel, which does not allow Node to cleanup memory fast enough
- tested with an 13mb import file (on master the memory grow fast to over 1GB, because too many queries are filled up in the queue and node can't tidy up so fast)
- i've tested with 1.17.3, the import of 13mb in the browser took 1min 10 seconds
- with this PR it took 1min 30 seconds (not a very huge difference)
- if we have to increase the performance of the importer, then we definitely have to improve the general amount of queries and not run all queries in parallel)
- requires additional fixes/improvements from bookshelf-relations 0.1.4 (https://github.com/TryGhost/Ghost/commit/fccfa7614d5b1b651bd424580be4b70e09f19a85)

**Commits can be squashed to be able to roll back both changes in case this introduces any bugs. I would suggest to merge them as "Importer fixes" or similar.**

---


**NOTE: the second commit failed here**

https://github.com/TryGhost/Ghost/blob/5cb41dbcd9b6961bb12e6bcc684c08a941297ac1/core/test/integration/data/importer/importers/data_spec.js#L390

This is because the import queries now run sequentiell and if you have two duplicate post slugs in your file, the first get's inserted and the second post slug get's regenerated. When we ran the queries in parallel, both post inserts happened at the same time and they simply did a fight, who came first was inserted, the second received an insert error. So i was remembering #8717 and simply resolved the missing feature of not adding duplicates at all. It's not really nice having both fixes in one commit (fix import large files and fix duplicates, but yeah)
