### PR TITLE
Duplicate slugs revert && Bring back importer behaviour for detection

### DIFF
--- a/core/server/data/importer/importers/data/index.js
+++ b/core/server/data/importer/importers/data/index.js
@@ -42,7 +42,6 @@ DataImporter = {
         if (importOptions && importOptions.importPersistUser) {
             modelOptions.importPersistUser = importOptions.importPersistUser;
         }
-
         this.init(importData);
 
         return models.Base.transaction(function (transacting) {

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -147,6 +147,26 @@ class PostsImporter extends BaseImporter {
             }
         });
 
+        // NOTE: We only support removing duplicate posts within the file to import.
+        // For any further future duplication detection, see https://github.com/TryGhost/Ghost/issues/8717.
+        let slugs = [];
+        this.dataToImport = _.filter(this.dataToImport, function (post) {
+            if (slugs.indexOf(post.slug) !== -1) {
+                self.problems.push({
+                    message: 'Entry was not imported and ignored. Detected duplicated entry.',
+                    help: self.modelName,
+                    context: JSON.stringify({
+                        post: post
+                    })
+                });
+
+                return false;
+            }
+
+            slugs.push(post.slug);
+            return true;
+        });
+
         // NOTE: do after, because model properties are deleted e.g. post.id
         return super.beforeImport();
     }

--- a/core/server/data/importer/importers/data/tags.js
+++ b/core/server/data/importer/importers/data/tags.js
@@ -31,6 +31,8 @@ class TagsImporter extends BaseImporter {
      *   - the tag model is smart enough to regenerate unique fields
      *   - so if you import a tag name "test" and the same tag name exists, it would add "test-2"
      *   - that's we add a protection here to first find the tag
+     *
+     * @TODO: Add a flag to the base implementation e.g. `fetchBeforeAdd`
      */
     doImport(options) {
         debug('doImport', this.modelName, this.dataToImport.length);

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -774,12 +774,6 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             if (!slug) {
                 slug = baseName;
             }
-
-            // CASE: no slug generation on import, see https://github.com/TryGhost/Ghost/issues/8717
-            if (options.importing) {
-                return slug;
-            }
-
             // Test for duplicate slugs.
             return checkIfSlugExists(slug);
         });

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -387,13 +387,15 @@ describe('Import', function () {
             }).catch(done);
         });
 
-        it('handles database errors nicely: duplicated tag slugs', function (done) {
+        it('handles database errors nicely: duplicated tag and posts slugs', function (done) {
             var exportData;
 
             testUtils.fixtures.loadExportFixture('export-003-dbErrors', {lts:true}).then(function (exported) {
                 exportData = exported;
                 return dataImporter.doImport(exportData);
             }).then(function (importedData) {
+                importedData.data.posts.length.should.eql(1);
+
                 importedData.problems.length.should.eql(3);
                 importedData.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
                 importedData.problems[0].help.should.eql('Tag');

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -394,8 +394,6 @@ describe('Import', function () {
                 exportData = exported;
                 return dataImporter.doImport(exportData);
             }).then(function (importedData) {
-                importedData.data.posts.length.should.eql(1);
-
                 importedData.problems.length.should.eql(3);
                 importedData.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
                 importedData.problems[0].help.should.eql('Tag');


### PR DESCRIPTION
Contains two commits. Please rebase and merge.

1. Revert https://github.com/TryGhost/Ghost/commit/02bd71d0f5ac853bb307e3030d70394534556d95. Please read comment [here](https://github.com/TryGhost/Ghost/issues/8717#issuecomment-355010706).

2. Add a small code snippet to bring back the functionality of the importer. 