### PR TITLE
Added test for images w/o extensions for image size util

### DIFF
--- a/core/server/lib/image/image-size.js
+++ b/core/server/lib/image/image-size.js
@@ -104,7 +104,7 @@ getImageSizeFromUrl = function getImageSizeFromUrl(imagePath) {
     debug('requested imagePath:', imagePath);
     requestOptions = {
         headers: {
-            'User-Agent': 'Mozilla/5.0'
+            'User-Agent': 'Mozilla/5.0 Safari/537.36'
         },
         timeout: timeout,
         encoding: null

--- a/core/test/unit/lib/image/image-size_spec.js
+++ b/core/test/unit/lib/image/image-size_spec.js
@@ -99,6 +99,41 @@ describe('lib/image: image size', function () {
             }).catch(done);
         });
 
+        it('[success] should return image dimensions when no image extension given', function (done) {
+            // This test is mocked, but works with this specific example.
+            // You can comment out the mocks and the test should still pass.
+            var url = 'https://www.zomato.com/logo/18163505/minilogo',
+                expectedImageObject =
+                    {
+                        height: 15,
+                        url: 'https://www.zomato.com/logo/18163505/minilogo',
+                        width: 104
+                    };
+
+            requestMock = nock('https://www.zomato.com')
+                .matchHeader('User-Agent', /Mozilla\/.*Safari\/.*/)
+                .get('/logo/18163505/minilogo')
+                .reply(200, {
+                    body: '<Buffer 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52 00 00 00 68 00 00 00 0f 08 02 00 00 00 87 8f 1d 14 00 00 03 33 49 44 41 54 58 c3 ed 97 6b 48 93 51 18>'
+                });
+
+            sizeOfStub = sandbox.stub();
+            sizeOfStub.returns({width: 104, height: 15, type: 'png'});
+            imageSize.__set__('sizeOf', sizeOfStub);
+
+            result = imageSize.getImageSizeFromUrl(url).then(function (res) {
+                requestMock.isDone().should.be.true();
+                should.exist(res);
+                should.exist(res.width);
+                res.width.should.be.equal(expectedImageObject.width);
+                should.exist(res.height);
+                res.height.should.be.equal(expectedImageObject.height);
+                should.exist(res.url);
+                res.url.should.be.equal(expectedImageObject.url);
+                done();
+            }).catch(done);
+        });
+
         it('[success] should returns largest image value for .ico files', function (done) {
             var url = 'https://super-website.com/media/icon.ico',
                 expectedImageObject =


### PR DESCRIPTION
closes #9022

Images without extensions don't need to be manipulated, as we're now reading the bytes and pass those to the `image-size` lib.

This PR adds another `user-agent` to emulate multiple browser requests, as I stumbled over an example where the image without extension is protected otherwise.

Added a test, that works with above mentioned image, but is currently mocked. Nevertheless, the image worked as a PoC, that we're able to read the bytes of an image without its extension and still return the dimensions of the image.