### PR TITLE
🐛 Fixed missing mail templates in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -36,7 +36,7 @@ SECURITY.md
 .travis.yml
 *.html
 !core/server/web/admin/views/**
-!core/server/mail/templates/**
+!core/server/services/mail/templates/**
 bower_components/**
 .editorconfig
 gulpfile.js


### PR DESCRIPTION
closes #9368
- when the mail service was moved in a recent refactor the `.npmignore` was not updated resulting in the mail templates being excluded from the npm package
- updates `.npmignore` list with the new mail templates location