### PR TITLE
Improved forwarding model options in the API layer

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -285,7 +285,7 @@ authentication = {
                 oldPassword = data.oldPassword,
                 newPassword = data.newPassword;
 
-            return settingsAPI.read(_.merge({key: 'db_hash'}, options))
+            return settingsAPI.read(_.merge({key: 'db_hash'}, _.omit(options, 'data')))
                 .then(function fetchedSettings(response) {
                     dbHash = response.settings[0].value;
 

--- a/core/server/api/invites.js
+++ b/core/server/api/invites.js
@@ -221,7 +221,7 @@ invites = {
         }
 
         function fetchLoggedInUser(options) {
-            return models.User.findOne({id: loggedInUser}, _.merge({}, options, {include: ['roles']}))
+            return models.User.findOne({id: loggedInUser}, _.merge({}, _.omit(options, 'data'), {include: ['roles']}))
                 .then(function (user) {
                     if (!user) {
                         return Promise.reject(new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')}));


### PR DESCRIPTION
no issue

- our API layer uses a unit to combine incoming data and options
- e.g. `options.data` is the end result (`.data` reflects the incoming body from the request, which is validated and scanned)
- we have to take care that we don't pass data into the model layer as model options