### PR TITLE
🐛 Fixed date helper timezone bug

### DIFF
--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -27,6 +27,7 @@ module.exports = function (date, options) {
 
     format = options.hash.format || 'MMM DD, YYYY';
     timeago = options.hash.timeago;
+    timezone = options.data.blog.timezone;
     timeNow = moment().tz(timezone);
 
     if (timeago) {

--- a/core/server/helpers/date.js
+++ b/core/server/helpers/date.js
@@ -13,14 +13,13 @@ module.exports = function (date, options) {
     if (!options && date.hasOwnProperty('hash')) {
         options = date;
         date = undefined;
-    }
+        timezone = options.data.blog.timezone;
 
-    timezone = options.data.blog.timezone;
-
-    // set to published_at by default, if it's available
-    // otherwise, this will print the current date
-    if (this.published_at) {
-        date = moment(this.published_at).tz(timezone).format();
+        // set to published_at by default, if it's available
+        // otherwise, this will print the current date
+        if (this.published_at) {
+            date = moment(this.published_at).tz(timezone).format();
+        }
     }
 
     // ensure that context is undefined, not null, as that can cause errors


### PR DESCRIPTION
closes #9381

Fixes a bug where the date helper would ignore any timezone settings, when called with a specific date option, e. g. `published_at`, as `timezone` was only ever assigned when called without options.