### PR TITLE
🐛 Reload translations if active theme get's overridden

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -115,7 +115,6 @@ themes = {
                 }
             })
             .then(function storeNewTheme() {
-                common.events.emit('theme.uploaded', zip.shortName);
                 // store extracted theme
                 return themeUtils.storage.save({
                     name: zip.shortName,
@@ -172,7 +171,6 @@ themes = {
         // Permissions
             .handlePermissions('themes', 'read')(options)
             .then(function sendTheme() {
-                common.events.emit('theme.downloaded', themeName);
                 return themeUtils.storage.serve({
                     name: themeName
                 });
@@ -212,7 +210,6 @@ themes = {
             // And some extra stuff to maintain state here
             .then(function deleteTheme() {
                 themeList.del(themeName);
-                common.events.emit('theme.deleted', themeName);
                 // Delete returns an empty 204 response
             });
     }

--- a/core/server/lib/common/i18n.js
+++ b/core/server/lib/common/i18n.js
@@ -31,8 +31,11 @@ var supportedLocales = ['en'],
 
 /**
  * When active theme changes, we reload theme translations
+ * We listen on the service event, because of the following known case:
+ *  1. you override a theme, which is already active
+ *  2. The data has not changed, no event is triggered.
  */
-events.on('settings.active_theme.edited', function () {
+events.on('services.themes.activated', function () {
     I18n.loadThemeTranslations();
 });
 

--- a/core/server/services/themes/index.js
+++ b/core/server/services/themes/index.js
@@ -84,6 +84,7 @@ module.exports = {
         // Use the two theme objects to set the current active theme
         try {
             active.set(loadedTheme, checkedTheme, error);
+            common.events.emit('services.themes.activated');
         } catch (err) {
             common.logging.error(new common.errors.InternalServerError({
                 message: common.i18n.t('errors.middleware.themehandler.activateFailed', {theme: loadedTheme.name}),


### PR DESCRIPTION
no issue

- discovered while testing
  - activate theme
  - download theme
  - modify theme
  - upload theme
  - override? yes
  - translation files are not reloaded, because the database is up-to-date
- remove un-used events in theme api layer
- trigger event from theme service