### PR TITLE
Increased cache-control for ghost-sdk.min.js and ghost.min.css

### DIFF
--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -53,13 +53,13 @@ module.exports = function setupSiteApp() {
     siteApp.use(serveFavicon());
     // /public/ghost-sdk.js
     siteApp.use(servePublicFile('public/ghost-sdk.js', 'application/javascript', constants.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost-sdk.min.js', 'application/javascript', constants.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost-sdk.min.js', 'application/javascript', constants.ONE_YEAR_S));
     // Serve sitemap.xsl file
     siteApp.use(servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
 
     // Serve stylesheets for default templates
     siteApp.use(servePublicFile('public/ghost.css', 'text/css', constants.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost.min.css', 'text/css', constants.ONE_HOUR_S));
+    siteApp.use(servePublicFile('public/ghost.min.css', 'text/css', constants.ONE_YEAR_S));
 
     // Serve images for default templates
     siteApp.use(servePublicFile('public/404-ghost@2x.png', 'png', constants.ONE_HOUR_S));


### PR DESCRIPTION
no issue

- we increase the client in-memory expiry for production built assets
- as soon as there will be another release, a new asset hash is generated and the client cache is invalidated automatically (doesn't matter how long we store the file in the client)
- this change decreases the amount of requests coming in for both assets (they should only be queries if the asset hash changes)
- **the next step is to get rid of having asset hashs part as query params**
  - ghost-sdk.min.js?v=1234 is becoming e.g. ghost-sdk-1234.min.js
  - reasons:
    - A: performance tools complain about it (versioning on query params should not be used for production -> CDN's/Proxies wont cache properly)
    - B: we no longer invalidate the asset hashs for built assets if the theme changes
