### PR TITLE
🛠 Change setup tooling to use `yarn setup`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "node index",
     "dev": "DEBUG=ghost:* grunt dev",
     "test": "grunt validate --verbose",
-    "init": "yarn global add knex-migrator ember-cli grunt-cli && yarn install && grunt symlink && grunt init || true"
+    "setup": "yarn install && knex-migrator init && grunt symlink && grunt init || true"
   },
   "engines": {
     "node": "^4.5.0 || ^6.9.0 || ^8.9.0",


### PR DESCRIPTION
no issue

I have already updated our [working with Ghost](https://docs.ghost.org/docs/working-with-ghost#section-day-to-day-development-commands) docs to work this way.

Will update the Ghost-Admin ones too shortly.

1. renamed alias:
  - we have a special alias that does initial setup tasks that are only supposed to be run once
  - changing the alias to be `setup` rather than `init` otherwise it is too easy to confuse with `grunt init`
2. require globals to be installed manually
  - yarn is RUBBISH at managing globals
  - internally we use npm for this (actually we have a managed list of globals) and yarn for everything else
  - by moving this to documentation, rather than a command, we have flexibility to do this differently
  - also explicit globals are better than installing these without the user knowing IMO
3. setup includes knex-migrator
  - do this automatically instead of knex-migrator init being a separate command
  - every other time knex-migrator is needed, Ghost _should_ tell you what to do

