### PR TITLE
🛠  Change `grunt init` to fully setup submodules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,6 +225,28 @@ var config = require('./core/server/config'),
             // ### grunt-shell
             // Command line tools where it's easier to run a command directly than configure a grunt plugin
             shell: {
+                submodules: {
+                    command: function () {
+                        grunt.log.writeln('SUBBY');
+
+                        var upstream = grunt.option('upstream') || process.env.GHOST_UPSTREAM || 'upstream';
+                        var update = 'git submodule update --init';
+
+                        grunt.log.writeln('Updating git submodules: ' + upstream);
+
+                        // `git submodule update` will clone repos as origin,
+                        // we need to change this to whatever the user uses as upstream (probably "upstream")
+                        if (upstream !== 'origin') {
+                            grunt.log.writeln('Changing remote to: ' + upstream);
+                            update += '; cd core/client; git remote rename origin upstream; ' +
+                            'git remote set-url upstream git@github.com:TryGhost/Ghost-Admin.git; ' +
+                            'cd ../../content/themes/casper; git remote rename origin upstream; ' +
+                            'git remote set-url upstream git@github.com:TryGhost/Casper.git';
+                        }
+
+                        return update;
+                    }
+                },
                 master: {
                     command: function () {
                         var upstream = grunt.option('upstream') || process.env.GHOST_UPSTREAM || 'upstream';
@@ -656,7 +678,7 @@ var config = require('./core/server/config'),
         // `bower` does have some quirks, such as not running as root. If you have problems please try running
         // `grunt init --verbose` to see if there are any errors.
         grunt.registerTask('init', 'Prepare the project for development',
-            ['update_submodules:pinned', 'subgrunt:init', 'clean:tmp', 'default']);
+            ['shell:submodules', 'subgrunt:init', 'clean:tmp', 'default']);
 
         // ### Build assets
         // `grunt build` - will build client assets (without updating the submodule)


### PR DESCRIPTION
This is a bit of a weird one, because I don't have this problem :)

If you use `upstream` and `origin` the way GitHub intends, then the default behaviour
of submodules won't work for you, and `grunt master` won't work until you run the [commands listed here](https://docs.ghost.org/docs/working-with-the-admin-client#section-git-setup) and somehow figure out that you need to do the same for Casper.

This is because by default `git` clones submodules as "origin", but they are _actually_ pinned to the "upstream" repos. 

Normally, you have to fix this to commit 😥  or to get `grunt master` to work properly.

This change switches from running just `git submodule update --init` to also running
the commands listed in [working with ghost-admin](https://docs.ghost.org/docs/working-with-the-admin-client#section-git-setup). 

It seems to work OK for me. You would still need to add the origin to push to origin, but _at least_ `grunt master` would work out-of-the box.

Questions:
- Does this seem weird to anyone?
- Does this work with your existing workflows?
- Can we also update `grunt release` to use the new code & get rid of the update_submodules grunt dependency or will that break things?
