### PR TITLE
Stop gap measure to issue #9418

### DIFF
--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -63,6 +63,9 @@ function santizeUrl(url) {
 function handleSource(req, res, next) {
     req.body.subscribed_url = santizeUrl(req.body.location);
     req.body.subscribed_referrer = santizeUrl(req.body.referrer);
+    if (validator.isEmpty(req.body.subscribed_referrer)) {
+        return next(new Error('Oops, something went wrong!'));
+    }
     delete req.body.location;
     delete req.body.referrer;
 
@@ -70,9 +73,10 @@ function handleSource(req, res, next) {
         .then(function (result) {
             if (result && result.post) {
                 req.body.post_id = result.post.id;
+                return next();
             }
-
-            next();
+            
+            next(new Error('Oops, something went wrong!'));
         })
         .catch(function (err) {
             if (err instanceof common.errors.NotFoundError) {

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -75,7 +75,7 @@ function handleSource(req, res, next) {
                 req.body.post_id = result.post.id;
                 return next();
             }
-            
+
             next(new Error('Oops, something went wrong!'));
         })
         .catch(function (err) {

--- a/core/test/functional/routes/apps/subscribers/routing_spec.js
+++ b/core/test/functional/routes/apps/subscribers/routing_spec.js
@@ -46,7 +46,8 @@ describe('Subscriber: Routing', function () {
                 .set('Content-type', 'application/x-www-form-urlencoded')
                 .send({
                     email: 'test@ghost.org',
-                    location: 'http://localhost:2368',
+                    location: 'http://localhost:2368/about',
+                    referrer: 'http://localhost:2368',
                     confirm: ''
                 })
                 .expect(200)
@@ -63,7 +64,8 @@ describe('Subscriber: Routing', function () {
                 .set('Content-type', 'application/x-www-form-urlencoded')
                 .send({
                     email: 'alphabetazeta',
-                    location: 'http://localhost:2368',
+                    location: 'http://localhost:2368/about',
+                    referrer: 'http://localhost:2368',
                     confirm: ''
                 })
                 .expect(200)
@@ -81,6 +83,60 @@ describe('Subscriber: Routing', function () {
                 .set('Content-type', 'application/x-www-form-urlencoded')
                 .send({
                     email: 'test@ghost.org',
+                    referrer: 'http://localhost:2368',
+                    confirm: ''
+                })
+                .expect(200)
+                .end(function (err, res) {
+                    should.not.exist(err);
+                    res.text.should.not.containEql('Subscribed!');
+                    res.text.should.not.containEql('test@ghost.org');
+                    done();
+                });
+        });
+
+        it('[error] location does not resolve to a post', function (done) {
+            request.post('/subscribe/')
+                .set('Content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    email: 'test@ghost.org',
+                    location: '',
+                    referrer: 'http://localhost:2368',
+                    confirm: ''
+                })
+                .expect(200)
+                .end(function (err, res) {
+                    should.not.exist(err);
+                    res.text.should.not.containEql('Subscribed!');
+                    res.text.should.not.containEql('test@ghost.org');
+                    done();
+                });
+        });
+
+        it('[error] referrer is not defined', function (done) {
+            request.post('/subscribe/')
+                .set('Content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    email: 'test@ghost.org',
+                    location: 'http://localhost:2368/about',
+                    confirm: ''
+                })
+                .expect(200)
+                .end(function (err, res) {
+                    should.not.exist(err);
+                    res.text.should.not.containEql('Subscribed!');
+                    res.text.should.not.containEql('test@ghost.org');
+                    done();
+                });
+        });
+
+        it('[error] referrer is empty', function (done) {
+            request.post('/subscribe/')
+                .set('Content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    email: 'test@ghost.org',
+                    location: 'http://localhost:2368/about',
+                    referrer: '',
                     confirm: ''
                 })
                 .expect(200)
@@ -97,7 +153,26 @@ describe('Subscriber: Routing', function () {
                 .set('Content-type', 'application/x-www-form-urlencoded')
                 .send({
                     email: 'test@ghost.org',
-                    location: 'http://localhost:2368'
+                    location: 'http://localhost:2368/about',
+                    referrer: 'http://localhost:2368'
+                })
+                .expect(200)
+                .end(function (err, res) {
+                    should.not.exist(err);
+                    res.text.should.not.containEql('Subscribed!');
+                    res.text.should.not.containEql('test@ghost.org');
+                    done();
+                });
+        });
+
+        it('[error] confirm is not empty', function (done) {
+            request.post('/subscribe/')
+                .set('Content-type', 'application/x-www-form-urlencoded')
+                .send({
+                    email: 'test@ghost.org',
+                    location: 'http://localhost:2368/about',
+                    referrer: 'http://localhost:2368',
+                    confirm: '❄'
                 })
                 .expect(200)
                 .end(function (err, res) {


### PR DESCRIPTION
Only accepts subscriptions that:

1. Have a referrer.
1. Originate from a valid blog post or static page on the Ghost site.

This prevents fake subscribers as reported in issue #9418.

A better long term solution would be to include a nonce and adding email verification to complete subscription. 