### PR TITLE
✨ Multiple authors

### DIFF
--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -7,6 +7,9 @@ var Promise = require('bluebird'),
     models = require('../models'),
     common = require('../lib/common'),
     docName = 'posts',
+    /**
+     * @deprecated: `author`, will be removed in Ghost 2.0
+     */
     allowedIncludes = [
         'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors', 'authors.roles'
     ],

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -8,7 +8,7 @@ var Promise = require('bluebird'),
     common = require('../lib/common'),
     docName = 'posts',
     allowedIncludes = [
-        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors'
+        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors', 'authors.roles'
     ],
     unsafeAttrs = ['author_id', 'status', 'authors'],
     posts;

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -8,9 +8,9 @@ var Promise = require('bluebird'),
     common = require('../lib/common'),
     docName = 'posts',
     allowedIncludes = [
-        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields'
+        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors'
     ],
-    unsafeAttrs = ['author_id', 'status'],
+    unsafeAttrs = ['author_id', 'status', 'authors'],
     posts;
 
 /**

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -316,11 +316,38 @@ utils = {
             }));
         }
 
-        // convert author property to author_id to match the name in the database
         if (docName === 'posts') {
+            // convert author property to author_id to match the name in the database
             if (object.posts[0].hasOwnProperty('author')) {
                 object.posts[0].author_id = object.posts[0].author;
                 delete object.posts[0].author;
+            }
+
+            /**
+             * Ensure correct incoming `post.authors` structure.
+             *
+             * NOTE:
+             * The `post.authors[*].id` attribute is required till we release Ghost 2.0.
+             * Ghost 1.x keeps the deprecated support for `post.author_id`, which is the primary author id and needs to be
+             * updated if the order of the `post.authors` array changes.
+             * If we allow adding authors via the post endpoint e.g. `authors=[{name: 'newuser']` (no id property), it's hard
+             * to update the primary author id (`post.author_id`), because the new author `id` is generated when attaching
+             * the author to the post. And the attach operation happens in bookshelf-relations, which happens after
+             * the event handling in the post model.
+             *
+             * It's solvable, but not worth right now solving, because the admin UI does not support this feature.
+             *
+             * TLDR; You can only attach existing authors to a post.
+             *
+             * @TODO: remove `id` restriction in Ghost 2.0
+             */
+            if (object.posts[0].hasOwnProperty('authors')) {
+                if (!_.isArray(object.posts[0].authors) ||
+                    (object.posts[0].authors.length && _.filter(object.posts[0].authors, 'id').length !== object.posts[0].authors.length)) {
+                    return Promise.reject(new common.errors.BadRequestError({
+                        message: common.i18n.t('errors.api.utils.invalidStructure', {key: 'posts[*].authors'})
+                    }));
+                }
             }
         }
 

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -317,7 +317,11 @@ utils = {
         }
 
         if (docName === 'posts') {
-            // convert author property to author_id to match the name in the database
+            /**
+             * Convert author property to author_id to match the name in the database.
+             *
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             if (object.posts[0].hasOwnProperty('author')) {
                 object.posts[0].author_id = object.posts[0].author;
                 delete object.posts[0].author;

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -27,7 +27,8 @@
         "private": "private",
         "subscribe": "subscribe",
         "amp": "amp",
-        "primaryTagFallback": "all"
+        "primaryTagFallback": "all",
+        "primaryAuthorFallback": "all"
     },
     "slugs": {
         "reserved": ["admin", "app", "apps", "categories",

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -19,7 +19,7 @@ queryDefaults = {
 // Default post query needs to always include author & tags
 _.extend(defaultPostQuery, queryDefaults, {
     options: {
-        include: 'author,tags'
+        include: 'author,authors,tags'
     }
 });
 

--- a/core/server/controllers/frontend/fetch-data.js
+++ b/core/server/controllers/frontend/fetch-data.js
@@ -3,7 +3,7 @@
  * Dynamically build and execute queries on the API for channels
  */
 var api = require('../../api'),
-    _   = require('lodash'),
+    _ = require('lodash'),
     Promise = require('bluebird'),
     themes = require('../../services/themes'),
     queryDefaults,
@@ -16,7 +16,11 @@ queryDefaults = {
     options: {}
 };
 
-// Default post query needs to always include author & tags
+/**
+ * Default post query needs to always include author, authors & tags
+ *
+ * @deprecated: `author`, will be removed in Ghost 2.0
+ */
 _.extend(defaultPostQuery, queryDefaults, {
     options: {
         include: 'author,authors,tags'
@@ -85,8 +89,7 @@ function processQuery(query, slugParam) {
  */
 function fetchData(channelOptions) {
     // @TODO improve this further
-    var pageOptions = channelOptions.isRSS ?
-            {options: channelOptions.postOptions} : fetchPostsPerPage(channelOptions.postOptions),
+    var pageOptions = channelOptions.isRSS ? {options: channelOptions.postOptions} : fetchPostsPerPage(channelOptions.postOptions),
         postQuery,
         props = {};
 

--- a/core/server/controllers/frontend/post-lookup.js
+++ b/core/server/controllers/frontend/post-lookup.js
@@ -41,7 +41,7 @@ function postLookup(postUrl) {
     }
 
     // Query database to find post
-    return api.posts.read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,tags'})).then(function then(result) {
+    return api.posts.read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,authors,tags'})).then(function then(result) {
         var post = result.posts[0];
 
         if (!post) {

--- a/core/server/controllers/frontend/post-lookup.js
+++ b/core/server/controllers/frontend/post-lookup.js
@@ -40,7 +40,11 @@ function postLookup(postUrl) {
         isEditURL = true;
     }
 
-    // Query database to find post
+    /**
+     * Query database to find post.
+     *
+     * @deprecated: `author`, will be removed in Ghost 2.0
+     */
     return api.posts.read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,authors,tags'})).then(function then(result) {
         var post = result.posts[0];
 

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -31,8 +31,6 @@ class PostsImporter extends BaseImporter {
 
     /**
      * Naive function to attach related tags and authors.
-     * @TODO: is there a possible case where a target related tag was not yet inserted?
-     *        because this won't work and throw an error, because you need a minimal set of attributes to insert a tag
      */
     addNestedRelations() {
         this.requiredFromFile.posts_tags = _.orderBy(this.requiredFromFile.posts_tags, ['post_id', 'sort_order'], ['asc', 'asc']);

--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -11,7 +11,7 @@ class PostsImporter extends BaseImporter {
         super(allDataFromFile, {
             modelName: 'Post',
             dataKeyToImport: 'posts',
-            requiredFromFile: ['posts', 'tags', 'posts_tags'],
+            requiredFromFile: ['posts', 'tags', 'posts_tags', 'posts_authors'],
             requiredImportedData: ['tags'],
             requiredExistingData: ['tags']
         });
@@ -30,90 +30,100 @@ class PostsImporter extends BaseImporter {
     }
 
     /**
-     * Naive function to attach related tags.
-     * Target tags should not be created. We add the relation by foreign key.
+     * Naive function to attach related tags and authors.
+     * @TODO: is there a possible case where a target related tag was not yet inserted?
+     *        because this won't work and throw an error, because you need a minimal set of attributes to insert a tag
      */
     addNestedRelations() {
         this.requiredFromFile.posts_tags = _.orderBy(this.requiredFromFile.posts_tags, ['post_id', 'sort_order'], ['asc', 'asc']);
+        this.requiredFromFile.posts_authors = _.orderBy(this.requiredFromFile.posts_authors, ['post_id', 'sort_order'], ['asc', 'asc']);
 
         /**
-         * {post_id: 1, tag_id: 2}
+         * from {post_id: 1, tag_id: 2} to post.tags=[{id:id}]
+         * from {post_id: 1, author_id: 2} post.authors=[{id:id}]
          */
-        _.each(this.requiredFromFile.posts_tags, (postTagRelation) => {
-            if (!postTagRelation.post_id) {
-                return;
-            }
+        const run = (relations, target, fk) => {
+            _.each(relations, (relation) => {
+                if (!relation.post_id) {
+                    return;
+                }
 
-            let postToImport = _.find(this.dataToImport, {id: postTagRelation.post_id});
+                let postToImport = _.find(this.dataToImport, {id: relation.post_id});
 
-            // CASE: we won't import a relation when the target post does not exist
-            if (!postToImport) {
-                return;
-            }
+                // CASE: we won't import a relation when the target post does not exist
+                if (!postToImport) {
+                    return;
+                }
 
-            if (!postToImport.tags || !_.isArray(postToImport.tags)) {
-                postToImport.tags = [];
-            }
+                if (!postToImport[target] || !_.isArray(postToImport[target])) {
+                    postToImport[target] = [];
+                }
 
-            // CASE: duplicate relation?
-            if (!_.find(postToImport.tags, {tag_id: postTagRelation.tag_id})) {
-                postToImport.tags.push({
-                    tag_id: postTagRelation.tag_id
-                });
-            }
-        });
+                // CASE: detect duplicate relations
+                if (!_.find(postToImport[target], {id: relation[fk]})) {
+                    postToImport[target].push({
+                        id: relation[fk]
+                    });
+                }
+            });
+        };
+
+        run(this.requiredFromFile.posts_tags, 'tags', 'tag_id');
+        run(this.requiredFromFile.posts_authors, 'authors', 'author_id');
     }
 
     /**
-     * Replace all `tag_id` references.
+     * Replace all identifier references.
      */
     replaceIdentifiers() {
-        /**
-         * {post_id: 1, tag_id: 2}
-         */
-        _.each(this.dataToImport, (postToImport, postIndex) => {
-            if (!postToImport.tags || !postToImport.tags.length) {
+        const run = (postToImport, postIndex, targetProperty, tableName) => {
+            if (!postToImport[targetProperty] || !postToImport[targetProperty].length) {
                 return;
             }
 
             let indexesToRemove = [];
-            _.each(postToImport.tags, (tag, tagIndex) => {
-                let tagInFile = _.find(this.requiredFromFile.tags, {id: tag.tag_id});
+            _.each(postToImport[targetProperty], (object, index) => {
+                let objectInFile = _.find(this.requiredFromFile[tableName], {id: object.id});
 
-                if (!tagInFile) {
-                    let existingTag = _.find(this.requiredExistingData.tags, {id: tag.tag_id});
+                if (!objectInFile) {
+                    let existingObject = _.find(this.requiredExistingData[tableName], {id: object.id});
 
-                    // CASE: tag is not in file, tag is not in db
-                    if (!existingTag) {
-                        indexesToRemove.push(tagIndex);
+                    // CASE: is not in file, is not in db
+                    if (!existingObject) {
+                        indexesToRemove.push(index);
                         return;
                     } else {
-                        this.dataToImport[postIndex].tags[tagIndex].tag_id = existingTag.id;
+                        this.dataToImport[postIndex][targetProperty][index].id = existingObject.id;
                         return;
                     }
                 }
 
                 // CASE: search through imported data
-                let importedTag = _.find(this.requiredImportedData.tags, {slug: tagInFile.slug});
+                let importedObject = _.find(this.requiredImportedData[tableName], {slug: objectInFile.slug});
 
-                if (importedTag) {
-                    this.dataToImport[postIndex].tags[tagIndex].tag_id = importedTag.id;
+                if (importedObject) {
+                    this.dataToImport[postIndex][targetProperty][index].id = importedObject.id;
                     return;
                 }
 
                 // CASE: search through existing data
-                let existingTag = _.find(this.requiredExistingData.tags, {slug: tagInFile.slug});
+                let existingObject = _.find(this.requiredExistingData[tableName], {slug: objectInFile.slug});
 
-                if (existingTag) {
-                    this.dataToImport[postIndex].tags[tagIndex].tag_id = existingTag.id;
+                if (existingObject) {
+                    this.dataToImport[postIndex][targetProperty][index].id = existingObject.id;
                 } else {
-                    indexesToRemove.push(tagIndex);
+                    indexesToRemove.push(index);
                 }
             });
 
-            this.dataToImport[postIndex].tags = _.filter(this.dataToImport[postIndex].tags, ((tag, index) => {
+            this.dataToImport[postIndex][targetProperty] = _.filter(this.dataToImport[postIndex][targetProperty], ((object, index) => {
                 return indexesToRemove.indexOf(index) === -1;
             }));
+        };
+
+        _.each(this.dataToImport, (postToImport, postIndex) => {
+            run(postToImport, postIndex, 'tags', 'tags');
+            run(postToImport, postIndex, 'authors', 'users');
         });
 
         return super.replaceIdentifiers();

--- a/core/server/data/meta/author_fb_url.js
+++ b/core/server/data/meta/author_fb_url.js
@@ -5,8 +5,8 @@ function getAuthorFacebookUrl(data) {
     var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.facebook) {
-        return contextObject.author.facebook;
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.primary_author && contextObject.primary_author.facebook) {
+        return contextObject.primary_author.facebook;
     } else if (_.includes(context, 'author') && contextObject.facebook) {
         return contextObject.facebook;
     }

--- a/core/server/data/meta/author_image.js
+++ b/core/server/data/meta/author_image.js
@@ -6,8 +6,8 @@ function getAuthorImage(data, absolute) {
     var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.profile_image) {
-        return urlService.utils.urlFor('image', {image: contextObject.author.profile_image}, absolute);
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.primary_author && contextObject.primary_author.profile_image) {
+        return urlService.utils.urlFor('image', {image: contextObject.primary_author.profile_image}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -8,8 +8,9 @@ function getAuthorUrl(data, absolute) {
     if (data.author) {
         return urlService.utils.urlFor('author', {author: data.author}, absolute);
     }
-    if (data[context] && data[context].author) {
-        return urlService.utils.urlFor('author', {author: data[context].author}, absolute);
+
+    if (data[context] && data[context].primary_author) {
+        return urlService.utils.urlFor('author', {author: data[context].primary_author}, absolute);
     }
     return null;
 }

--- a/core/server/data/meta/creator_url.js
+++ b/core/server/data/meta/creator_url.js
@@ -5,8 +5,8 @@ function getCreatorTwitterUrl(data) {
     var context = data.context ? data.context : null,
         contextObject = getContextObject(data, context);
 
-    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.author && contextObject.author.twitter) {
-        return contextObject.author.twitter;
+    if ((_.includes(context, 'post') || _.includes(context, 'page')) && contextObject.primary_author && contextObject.primary_author.twitter) {
+        return contextObject.primary_author.twitter;
     } else if (_.includes(context, 'author') && contextObject.twitter) {
         return contextObject.twitter;
     }

--- a/core/server/data/meta/index.js
+++ b/core/server/data/meta/index.js
@@ -90,8 +90,8 @@ function getMetaData(data, root) {
         metaData.excerpt = customExcerpt ? customExcerpt : metaDescription ? metaDescription : fallbackExcerpt;
     }
 
-    if (data.post && data.post.author && data.post.author.name) {
-        metaData.authorName = data.post.author.name;
+    if (data.post && data.post.primary_author && data.post.primary_author.name) {
+        metaData.authorName = data.post.primary_author.name;
     }
 
     return Promise.props(getImageDimensions(metaData)).then(function () {

--- a/core/server/data/meta/schema.js
+++ b/core/server/data/meta/schema.js
@@ -39,14 +39,14 @@ function trimSameAs(data, context) {
     var sameAs = [];
 
     if (context === 'post') {
-        if (data.post.author.website) {
-            sameAs.push(escapeExpression(data.post.author.website));
+        if (data.post.primary_author.website) {
+            sameAs.push(escapeExpression(data.post.primary_author.website));
         }
-        if (data.post.author.facebook) {
-            sameAs.push(social.urls.facebook(data.post.author.facebook));
+        if (data.post.primary_author.facebook) {
+            sameAs.push(social.urls.facebook(data.post.primary_author.facebook));
         }
-        if (data.post.author.twitter) {
-            sameAs.push(social.urls.twitter(data.post.author.twitter));
+        if (data.post.primary_author.twitter) {
+            sameAs.push(social.urls.twitter(data.post.primary_author.twitter));
         }
     } else if (context === 'author') {
         if (data.author.website) {
@@ -79,12 +79,12 @@ function getPostSchema(metaData, data) {
         },
         author: {
             '@type': 'Person',
-            name: escapeExpression(data.post.author.name),
+            name: escapeExpression(data.post.primary_author.name),
             image: schemaImageObject(metaData.authorImage),
             url: metaData.authorUrl,
             sameAs: trimSameAs(data, 'post'),
-            description: data.post.author.metaDescription ?
-                escapeExpression(data.post.author.metaDescription) :
+            description: data.post.primary_author.metaDescription ?
+                escapeExpression(data.post.primary_author.metaDescription) :
                 null
         },
         headline: escapeExpression(metaData.metaTitle),

--- a/core/server/data/migrations/versions/1.22/1-multiple-authors-DDL.js
+++ b/core/server/data/migrations/versions/1.22/1-multiple-authors-DDL.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Promise = require('bluebird'),
+    common = require('../../../../lib/common'),
+    commands = require('../../../schema').commands,
+    table = 'posts_authors',
+    message1 = 'Adding table: ' + table,
+    message2 = 'Dropping table: ' + table;
+
+module.exports.up = function addMultipleAuthorsTable(options) {
+    let connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return Promise.resolve();
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = function removeMultipleAuthorsTable(options) {
+    let connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return Promise.resolve();
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
+++ b/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
@@ -10,7 +10,7 @@ module.exports.config = {
 };
 
 module.exports.up = function handleMultipleAuthors(options) {
-    const postAllColumns = ['id', 'author_id', 'slug', 'title'],
+    const postAllColumns = ['id', 'author_id', 'slug', 'title', 'plaintext'],
         userColumns = ['id'];
 
     let localOptions = _.merge({

--- a/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
+++ b/core/server/data/migrations/versions/1.22/1-multiple-authors-DML.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const _ = require('lodash'),
+    Promise = require('bluebird'),
+    common = require('../../../../lib/common'),
+    models = require('../../../../models');
+
+module.exports.config = {
+    transaction: true
+};
+
+module.exports.up = function handleMultipleAuthors(options) {
+    const postAllColumns = ['id', 'author_id', 'slug', 'title'],
+        userColumns = ['id'];
+
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    return models.User.getOwnerUser(_.merge({columns: userColumns}, localOptions))
+        .then(function (ownerUser) {
+            return models.Post.findAll(_.merge({columns: postAllColumns}, localOptions))
+                .then(function (posts) {
+                    common.logging.info('Adding `posts_authors` relations');
+
+                    // CASE: ensure `post.author_id` is a valid user id
+                    return Promise.map(posts.models, function (post) {
+                        return models.User.findOne({id: post.get('author_id')}, _.merge({columns: userColumns}, localOptions))
+                            .then(function (user) {
+                                if (!user) {
+                                    post.set('author_id', ownerUser.id);
+                                }
+                            })
+                            .then(function () {
+                                // CASE: insert primary author
+                                post.set('authors', [
+                                    {
+                                        id: post.get('author_id')
+                                    }
+                                ]);
+
+                                return post.save(null, localOptions);
+                            });
+                    }, {concurrency: 100});
+                });
+        });
+};
+
+module.exports.down = function handleMultipleAuthors(options) {
+    common.logging.info('Removing `posts_authors` relations');
+    return options.connection('posts_authors').truncate();
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -60,7 +60,7 @@
             "defaultValue": "/:slug/",
             "validations": {
                 "matches": "^(\/:?[a-z0-9_-]+){1,5}\/$",
-                "matches": "(:id|:slug|:year|:month|:day|:author|:primary_tag)",
+                "matches": "(:id|:slug|:year|:month|:day|:author|:primary_tag|:primary_author)",
                 "notContains": "/ghost/"
             }
         },

--- a/core/server/data/schema/fixtures/fixtures.json
+++ b/core/server/data/schema/fixtures/fixtures.json
@@ -1,109 +1,6 @@
 {
     "models": [
         {
-            "name": "Post",
-            "entries": [
-                {
-                    "title": "Setting up your own Ghost theme",
-                    "slug": "themes",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Creating a totally custom design for your publication\\n\\nGhost comes with a beautiful default theme called Casper, which is designed to be a clean, readable publication layout and can be easily adapted for most purposes. However, Ghost can also be completely themed to suit your needs. Rather than just giving you a few basic settings which act as a poor proxy for code, we just let you write code.\\n\\nThere are a huge range of both free and premium pre-built themes which you can get from the [Ghost Theme Marketplace](http:\/\/marketplace.ghost.org), or you can simply create your own from scratch.\\n\\n[![marketplace](https:\/\/casper.ghost.org\/v1.0.0\/images\/marketplace.jpg)](http:\/\/marketplace.ghost.org)\\n\\n> Anyone can write a completely custom Ghost theme, with just some solid knowledge of HTML and CSS\\n\\nGhost themes are written with a templating language called handlebars, which has a bunch of dynamic helpers to insert your data into template files. Like `{{author.name}}`, for example, outputs the name of the current author.\\n\\nThe best way to learn how to write your own Ghost theme is to have a look at [the source code for Casper](https:\/\/github.com\/TryGhost\/Casper), which is heavily commented and should give you a sense of how everything fits together.\\n\\n- `default.hbs` is the main template file, all contexts will load inside this file unless specifically told to use a different template.\\n- `post.hbs` is the file used in the context of viewing a post.\\n- `index.hbs` is the file used in the context of viewing the home page.\\n- and so on\\n\\nWe've got [full and extensive theme documentation](http:\/\/themes.ghost.org\/docs\/about) which outlines every template file, context and helper that you can use.\\n\\nIf you want to chat with other people making Ghost themes to get any advice or help, there's also a **#themes** channel in our [public Slack community](https:\/\/slack.ghost.org) which we always recommend joining!\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/design.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Advanced Markdown tips",
-                    "slug": "advanced-markdown",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"There are lots of powerful things you can do with the Ghost editor\\n\\nIf you've gotten pretty comfortable with [all the basics](\/the-editor\/) of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!\\n\\nAs with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.\\n\\n\\n## Special formatting\\n\\nAs well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:\\n\\n+ ~~strike through~~\\n+ ==highlight==\\n+ \\\\*escaped characters\\\\*\\n\\n\\n## Writing code blocks\\n\\nThere are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, `like this`. Larger snippets of code can be displayed across multiple lines using triple back ticks:\\n\\n```\\n.my-link {\\n    text-decoration: underline;\\n}\\n```\\n\\nIf you want to get really fancy, you can even add syntax highlighting using [Prism.js](http:\/\/prismjs.com\/).\\n\\n\\n## Full bleed images\\n\\nOne neat trick which you can use in Markdown to distinguish between different types of images is to add a `#hash` value to the end of the source URL, and then target images containing the hash with special styling. For example:\\n\\n![walking](https:\/\/casper.ghost.org\/v1.0.0\/images\/walking.jpg#full)\\n\\nwhich is styled with...\\n\\n```\\nimg[src$=\\\"#full\\\"] {\\n    max-width: 100vw;\\n}\\n```\\n\\nThis creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.\\n\\n\\n## Reference lists\\n\\n**The quick brown [fox][1], jumped over the lazy [dog][2].**\\n\\n[1]: https:\/\/en.wikipedia.org\/wiki\/Fox \\\"Wikipedia: Fox\\\"\\n[2]: https:\/\/en.wikipedia.org\/wiki\/Dog \\\"Wikipedia: Dog\\\"\\n\\nAnother way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.\\n\\n\\n## Creating footnotes\\n\\nThe quick brown fox[^1] jumped over the lazy dog[^2].\\n\\n[^1]: Foxes are red\\n[^2]: Dogs are usually not red\\n\\nFootnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.\\n\\n\\n## Full HTML\\n\\nPerhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:\\n\\n<iframe width=\\\"560\\\" height=\\\"315\\\" src=\\\"https:\/\/www.youtube.com\/embed\/Cniqsc9QfDo?rel=0&amp;showinfo=0\\\" frameborder=\\\"0\\\" allowfullscreen><\/iframe>\\n\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/advanced.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Making your site private",
-                    "slug": "private-sites",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Sometimes you might want to put your site behind closed doors\\n\\nIf you've got a publication that you don't want the world to see yet because it's not ready to launch, you can hide your Ghost site behind a simple shared pass-phrase.\\n\\nYou can toggle this preference on at the bottom of Ghost's General Settings\\n\\n![private](https://casper.ghost.org/v1.0.0/images/private.png)\\n\\nGhost will give you a short, randomly generated pass-phrase which you can share with anyone who needs access to the site while you're working on it. While this setting is enabled, all search engine optimisation features will be switched off to help keep the site off the radar.\\n\\nDo remember though, this is *not* secure authentication. You shouldn't rely on this feature for protecting important private data. It's just a simple, shared pass-phrase for very basic privacy.\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/locked.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Managing Ghost users",
-                    "slug": "managing-users",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost has a number of different user roles for your team\\n\\n\\n### Authors\\n\\nThe base user level in Ghost is an author. Authors can write posts, edit their own posts, and publish their own posts. Authors are **trusted** users. If you don't trust users to be allowed to publish their own posts, you shouldn't invite them to Ghost admin.\\n\\n\\n### Editors\\n\\nEditors are the 2nd user level in Ghost. Editors can do everything that an Author can do, but they can also edit and publish the posts of others - as well as their own. Editors can also invite new authors to the site.\\n\\n\\n### Administrators\\n\\nThe top user level in Ghost is Administrator. Again, administrators can do everything that Authors and Editors can do, but they can also edit all site settings and data, not just content. Additionally, administrators have full access to invite, manage or remove any other user of the site.\\n\\n\\n### The Owner\\n\\nThere is only ever one owner of a Ghost site. The owner is a special user which has all the same permissions as an Administrator, but with two exceptions: The Owner can never be deleted. And in some circumstances the owner will have access to additional special settings if applicable — for example, billing details, if using Ghost(Pro).\\n\\n---\\n\\nIt's a good idea to ask all of your users to fill out their user profiles, including bio and social links. These will populate rich structured data for posts and generally create more opportunities for themes to fully populate their design. \"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/team.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Organising your content with tags",
-                    "slug": "using-tags",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost has a single, powerful organisational taxonomy, called tags.\\n\\nIt doesn't matter whether you want to call them categories, tags, boxes, or anything else. You can think of Ghost tags a lot like Gmail labels. By tagging posts with one or more keyword, you can organise articles into buckets of related content.\\n\\n\\n## Basic tagging\\n\\nWhen you write a post, you can assign tags to help differentiate between categories of content. For example, you might tag some posts with `News` and other posts with `Cycling`, which would create two distinct categories of content listed on `/tag/news/` and `/tag/cycling/`, respectively.\\n\\nIf you tag a post with both `News` *and* `Cycling` - then it appears in both sections.\\n\\nTag archives are like dedicated home-pages for each category of content that you have. They have their own pages, their own RSS feeds, and can support their own cover images and meta data.\\n\\n\\n## The primary tag\\n\\nInside the Ghost editor, you can drag and drop tags into a specific order. The first tag in the list is always given the most importance, and some themes will only display the primary tag (the first tag in the list) by default. So you can add the most important tag which you want to show up in your theme, but also add a bunch of related tags which are less important.\\n\\n==**News**, Cycling, Bart Stevens, Extreme Sports==\\n\\nIn this example, **News** is the primary tag which will be displayed by the theme, but the post will also still receive all the other tags, and show up in their respective archives.\\n\\n\\n## Private tags\\n\\nSometimes you may want to assign a post a specific tag, but you don't necessarily want that tag appearing in the theme or creating an archive page. In Ghost, hashtags are private and can be used for special styling.\\n\\nFor example, if you sometimes publish posts with video content - you might want your theme to adapt and get rid of the sidebar for these posts, to give more space for an embedded video to fill the screen. In this case, you could use private tags to tell your theme what to do.\\n\\n==**News**, Cycling, #video==\\n\\nHere, the theme would assign the post publicly displayed tags of `News`, and `Cycling` - but it would also keep a private record of the post being tagged with `#video`.\\n\\nIn your theme, you could then look for private tags conditionally and give them special formatting:\\n\\n```\\n{{#post}}\\n    {{#has tag=\\\"#video\\\"}}\\n        ...markup for a nice big video post layout...\\n    {{else}}\\n        ...regular markup for a post...\\n    {{/has}}\\n{{/post}}\\n```\\n\\nYou can find documentation for theme development techniques like this and many more over on Ghost's extensive [theme documentation](https://themes.ghost.org/).\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/tags.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Using the Ghost editor",
-                    "slug": "the-editor",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost uses a language called **Markdown** to format text.\\n\\nWhen you go to edit a post and see special characters and colours intertwined between the words, those are Markdown shortcuts which tell Ghost what to do with the words in your document. The biggest benefit of Markdown is that you can quickly apply formatting as you type, without needing to pause.\\n\\nAt the bottom of the editor, you'll find a toolbar with basic formatting options to help you get started as easily as possible. You'll also notice that there's a **?** icon, which contains more advanced shortcuts.\\n\\nFor now, though, let's run you through some of the basics. You'll want to make sure you're editing this post in order to see all the Markdown we've used.\\n\\n\\n## Formatting text\\n\\nThe most common shortcuts are of course, **bold** text, _italic_ text, and [hyperlinks](https://example.com). These generally make up the bulk of any document. You can type the characters out, but you can also use keyboard shortcuts.\\n\\n* `CMD/Ctrl + B` for Bold\\n* `CMD/Ctrl + I` for Italic\\n* `CMD/Ctrl + K` for a Link\\n* `CMD/Ctrl + H` for a Heading (Press multiple times for h2/h3/h4/etc)\\n\\nWith just a couple of extra characters here and there, you're well on your way to creating a beautifully formatted story.\\n\\n\\n## Inserting images\\n\\nImages in Markdown look just the same as links, except they're prefixed with an exclamation mark, like this:\\n\\n`![Image description](/path/to/image.jpg)`\\n\\n![Computer](https://casper.ghost.org/v1.0.0/images/computer.jpg)\\n\\nMost Markdown editors don't make you type this out, though. In Ghost you can click on the image icon in the toolbar at the bottom of the editor, or you can just click and drag an image from your desktop directly into the editor. Both will upload the image for you and generate the appropriate Markdown.\\n\\n_**Important Note:** Ghost does not currently have automatic image resizing, so it's always a good idea to make sure your images aren't gigantic files **before** uploading them to Ghost._\\n\\n\\n## Making lists\\n\\nLists in HTML are a formatting nightmare, but in Markdown they become an absolute breeze with just a couple of characters and a bit of smart automation. For numbered lists, just write out the numbers. For bullet lists, just use `*` or `-` or `+`. Like this:\\n\\n1. Crack the eggs over a bowl\\n2. Whisk them together\\n3. Make an omelette\\n\\nor\\n\\n- Remember to buy milk\\n- Feed the cat\\n- Come up with idea for next story\\n\\n\\n## Adding quotes\\n\\nWhen you want to pull out a particularly good excerpt in the middle of a piece, you can use `>` at the beginning of a paragraph to turn it into a Blockquote. You might've seen this formatting before in email clients.\\n\\n> A well placed quote guides a reader through a story, helping them to understand the most important points being made\\n\\nAll themes handles blockquotes slightly differently. Sometimes they'll look better kept shorter, while other times you can quote fairly hefty amounts of text and get away with it. Generally, the safest option is to use blockquotes sparingly.\\n\\n\\n## Dividing things up\\n\\nIf you're writing a piece in parts and you just feel like you need to divide a couple of sections distinctly from each other, a horizontal rule might be just what you need. Dropping `---` on a new line will create a sleek divider, anywhere you want it.\\n\\n---\\n\\nThis should get you going with the vast majority of what you need to do in the editor, but if you're still curious about more advanced tips then check out the [Advanced Markdown Guide](/advanced-markdown/) - or if you'd rather learn about how Ghost taxononomies work, we've got a overview of [how to use Ghost tags](/using-tags/).\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/writing.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                },
-                {
-                    "title": "Welcome to Ghost",
-                    "slug": "welcome",
-                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Hey! Welcome to Ghost, it's great to have you :)\\n\\nWe know that first impressions are important, so we've populated your new site with some initial **Getting Started** posts that will help you get familiar with everything in no time. This is the first one!\\n\\n\\n### There are a few things that you should know up-front:\\n\\n1. Ghost is designed for ambitious, professional publishers who want to actively build a business around their content. That's who it works best for. If you're using Ghost for some other purpose, that's fine too - but it might not be the best choice for you.\\n\\n2. The entire platform can be modified and customized to suit your needs, which is very powerful, but doing so **does** require some knowledge of code. Ghost is not necessarily a good platform for beginners or people who just want a simple personal blog.\\n\\n3. For the best experience we recommend downloading the [Ghost Desktop App](https://ghost.org/downloads/) for your computer, which is the best way to access your Ghost site on a desktop device.\\n\\nGhost is made by an independent non-profit organisation called the Ghost Foundation. We are 100% self funded by revenue from our [Ghost(Pro)](https://ghost.org/pricing) service, and every penny we make is re-invested into funding further development of free, open source technology for modern journalism.\\n\\nThe main thing you'll want to read about next is probably: [the Ghost editor](/the-editor/).\\n\\nOnce you're done reading, you can simply delete the default **Ghost** user from your team to remove all of these introductory posts!\"}]],\"sections\":[[10,0]]}",
-                    "feature_image": "https://casper.ghost.org/v1.0.0/images/welcome.jpg",
-                    "featured": false,
-                    "page": false,
-                    "status": "published",
-                    "meta_title": null,
-                    "meta_description": null,
-                    "created_by": "5951f5fca366002ebd5dbef7",
-                    "published_by": "5951f5fca366002ebd5dbef7",
-                    "author_id": "5951f5fca366002ebd5dbef7"
-                }
-            ]
-        },
-        {
             "name": "Tag",
             "entries": [
                 {
@@ -457,8 +354,110 @@
                     "roles": ["Author"]
                 }
             ]
+        },
+        {
+            "name": "Post",
+            "entries": [
+                {
+                    "title": "Setting up your own Ghost theme",
+                    "slug": "themes",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Creating a totally custom design for your publication\\n\\nGhost comes with a beautiful default theme called Casper, which is designed to be a clean, readable publication layout and can be easily adapted for most purposes. However, Ghost can also be completely themed to suit your needs. Rather than just giving you a few basic settings which act as a poor proxy for code, we just let you write code.\\n\\nThere are a huge range of both free and premium pre-built themes which you can get from the [Ghost Theme Marketplace](http:\/\/marketplace.ghost.org), or you can simply create your own from scratch.\\n\\n[![marketplace](https:\/\/casper.ghost.org\/v1.0.0\/images\/marketplace.jpg)](http:\/\/marketplace.ghost.org)\\n\\n> Anyone can write a completely custom Ghost theme, with just some solid knowledge of HTML and CSS\\n\\nGhost themes are written with a templating language called handlebars, which has a bunch of dynamic helpers to insert your data into template files. Like `{{author.name}}`, for example, outputs the name of the current author.\\n\\nThe best way to learn how to write your own Ghost theme is to have a look at [the source code for Casper](https:\/\/github.com\/TryGhost\/Casper), which is heavily commented and should give you a sense of how everything fits together.\\n\\n- `default.hbs` is the main template file, all contexts will load inside this file unless specifically told to use a different template.\\n- `post.hbs` is the file used in the context of viewing a post.\\n- `index.hbs` is the file used in the context of viewing the home page.\\n- and so on\\n\\nWe've got [full and extensive theme documentation](http:\/\/themes.ghost.org\/docs\/about) which outlines every template file, context and helper that you can use.\\n\\nIf you want to chat with other people making Ghost themes to get any advice or help, there's also a **#themes** channel in our [public Slack community](https:\/\/slack.ghost.org) which we always recommend joining!\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/design.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Advanced Markdown tips",
+                    "slug": "advanced-markdown",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"There are lots of powerful things you can do with the Ghost editor\\n\\nIf you've gotten pretty comfortable with [all the basics](\/the-editor\/) of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!\\n\\nAs with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.\\n\\n\\n## Special formatting\\n\\nAs well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:\\n\\n+ ~~strike through~~\\n+ ==highlight==\\n+ \\\\*escaped characters\\\\*\\n\\n\\n## Writing code blocks\\n\\nThere are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, `like this`. Larger snippets of code can be displayed across multiple lines using triple back ticks:\\n\\n```\\n.my-link {\\n    text-decoration: underline;\\n}\\n```\\n\\nIf you want to get really fancy, you can even add syntax highlighting using [Prism.js](http:\/\/prismjs.com\/).\\n\\n\\n## Full bleed images\\n\\nOne neat trick which you can use in Markdown to distinguish between different types of images is to add a `#hash` value to the end of the source URL, and then target images containing the hash with special styling. For example:\\n\\n![walking](https:\/\/casper.ghost.org\/v1.0.0\/images\/walking.jpg#full)\\n\\nwhich is styled with...\\n\\n```\\nimg[src$=\\\"#full\\\"] {\\n    max-width: 100vw;\\n}\\n```\\n\\nThis creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.\\n\\n\\n## Reference lists\\n\\n**The quick brown [fox][1], jumped over the lazy [dog][2].**\\n\\n[1]: https:\/\/en.wikipedia.org\/wiki\/Fox \\\"Wikipedia: Fox\\\"\\n[2]: https:\/\/en.wikipedia.org\/wiki\/Dog \\\"Wikipedia: Dog\\\"\\n\\nAnother way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.\\n\\n\\n## Creating footnotes\\n\\nThe quick brown fox[^1] jumped over the lazy dog[^2].\\n\\n[^1]: Foxes are red\\n[^2]: Dogs are usually not red\\n\\nFootnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.\\n\\n\\n## Full HTML\\n\\nPerhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:\\n\\n<iframe width=\\\"560\\\" height=\\\"315\\\" src=\\\"https:\/\/www.youtube.com\/embed\/Cniqsc9QfDo?rel=0&amp;showinfo=0\\\" frameborder=\\\"0\\\" allowfullscreen><\/iframe>\\n\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/advanced.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Making your site private",
+                    "slug": "private-sites",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Sometimes you might want to put your site behind closed doors\\n\\nIf you've got a publication that you don't want the world to see yet because it's not ready to launch, you can hide your Ghost site behind a simple shared pass-phrase.\\n\\nYou can toggle this preference on at the bottom of Ghost's General Settings\\n\\n![private](https://casper.ghost.org/v1.0.0/images/private.png)\\n\\nGhost will give you a short, randomly generated pass-phrase which you can share with anyone who needs access to the site while you're working on it. While this setting is enabled, all search engine optimisation features will be switched off to help keep the site off the radar.\\n\\nDo remember though, this is *not* secure authentication. You shouldn't rely on this feature for protecting important private data. It's just a simple, shared pass-phrase for very basic privacy.\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/locked.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Managing Ghost users",
+                    "slug": "managing-users",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost has a number of different user roles for your team\\n\\n\\n### Authors\\n\\nThe base user level in Ghost is an author. Authors can write posts, edit their own posts, and publish their own posts. Authors are **trusted** users. If you don't trust users to be allowed to publish their own posts, you shouldn't invite them to Ghost admin.\\n\\n\\n### Editors\\n\\nEditors are the 2nd user level in Ghost. Editors can do everything that an Author can do, but they can also edit and publish the posts of others - as well as their own. Editors can also invite new authors to the site.\\n\\n\\n### Administrators\\n\\nThe top user level in Ghost is Administrator. Again, administrators can do everything that Authors and Editors can do, but they can also edit all site settings and data, not just content. Additionally, administrators have full access to invite, manage or remove any other user of the site.\\n\\n\\n### The Owner\\n\\nThere is only ever one owner of a Ghost site. The owner is a special user which has all the same permissions as an Administrator, but with two exceptions: The Owner can never be deleted. And in some circumstances the owner will have access to additional special settings if applicable — for example, billing details, if using Ghost(Pro).\\n\\n---\\n\\nIt's a good idea to ask all of your users to fill out their user profiles, including bio and social links. These will populate rich structured data for posts and generally create more opportunities for themes to fully populate their design. \"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/team.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Organising your content with tags",
+                    "slug": "using-tags",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost has a single, powerful organisational taxonomy, called tags.\\n\\nIt doesn't matter whether you want to call them categories, tags, boxes, or anything else. You can think of Ghost tags a lot like Gmail labels. By tagging posts with one or more keyword, you can organise articles into buckets of related content.\\n\\n\\n## Basic tagging\\n\\nWhen you write a post, you can assign tags to help differentiate between categories of content. For example, you might tag some posts with `News` and other posts with `Cycling`, which would create two distinct categories of content listed on `/tag/news/` and `/tag/cycling/`, respectively.\\n\\nIf you tag a post with both `News` *and* `Cycling` - then it appears in both sections.\\n\\nTag archives are like dedicated home-pages for each category of content that you have. They have their own pages, their own RSS feeds, and can support their own cover images and meta data.\\n\\n\\n## The primary tag\\n\\nInside the Ghost editor, you can drag and drop tags into a specific order. The first tag in the list is always given the most importance, and some themes will only display the primary tag (the first tag in the list) by default. So you can add the most important tag which you want to show up in your theme, but also add a bunch of related tags which are less important.\\n\\n==**News**, Cycling, Bart Stevens, Extreme Sports==\\n\\nIn this example, **News** is the primary tag which will be displayed by the theme, but the post will also still receive all the other tags, and show up in their respective archives.\\n\\n\\n## Private tags\\n\\nSometimes you may want to assign a post a specific tag, but you don't necessarily want that tag appearing in the theme or creating an archive page. In Ghost, hashtags are private and can be used for special styling.\\n\\nFor example, if you sometimes publish posts with video content - you might want your theme to adapt and get rid of the sidebar for these posts, to give more space for an embedded video to fill the screen. In this case, you could use private tags to tell your theme what to do.\\n\\n==**News**, Cycling, #video==\\n\\nHere, the theme would assign the post publicly displayed tags of `News`, and `Cycling` - but it would also keep a private record of the post being tagged with `#video`.\\n\\nIn your theme, you could then look for private tags conditionally and give them special formatting:\\n\\n```\\n{{#post}}\\n    {{#has tag=\\\"#video\\\"}}\\n        ...markup for a nice big video post layout...\\n    {{else}}\\n        ...regular markup for a post...\\n    {{/has}}\\n{{/post}}\\n```\\n\\nYou can find documentation for theme development techniques like this and many more over on Ghost's extensive [theme documentation](https://themes.ghost.org/).\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/tags.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Using the Ghost editor",
+                    "slug": "the-editor",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Ghost uses a language called **Markdown** to format text.\\n\\nWhen you go to edit a post and see special characters and colours intertwined between the words, those are Markdown shortcuts which tell Ghost what to do with the words in your document. The biggest benefit of Markdown is that you can quickly apply formatting as you type, without needing to pause.\\n\\nAt the bottom of the editor, you'll find a toolbar with basic formatting options to help you get started as easily as possible. You'll also notice that there's a **?** icon, which contains more advanced shortcuts.\\n\\nFor now, though, let's run you through some of the basics. You'll want to make sure you're editing this post in order to see all the Markdown we've used.\\n\\n\\n## Formatting text\\n\\nThe most common shortcuts are of course, **bold** text, _italic_ text, and [hyperlinks](https://example.com). These generally make up the bulk of any document. You can type the characters out, but you can also use keyboard shortcuts.\\n\\n* `CMD/Ctrl + B` for Bold\\n* `CMD/Ctrl + I` for Italic\\n* `CMD/Ctrl + K` for a Link\\n* `CMD/Ctrl + H` for a Heading (Press multiple times for h2/h3/h4/etc)\\n\\nWith just a couple of extra characters here and there, you're well on your way to creating a beautifully formatted story.\\n\\n\\n## Inserting images\\n\\nImages in Markdown look just the same as links, except they're prefixed with an exclamation mark, like this:\\n\\n`![Image description](/path/to/image.jpg)`\\n\\n![Computer](https://casper.ghost.org/v1.0.0/images/computer.jpg)\\n\\nMost Markdown editors don't make you type this out, though. In Ghost you can click on the image icon in the toolbar at the bottom of the editor, or you can just click and drag an image from your desktop directly into the editor. Both will upload the image for you and generate the appropriate Markdown.\\n\\n_**Important Note:** Ghost does not currently have automatic image resizing, so it's always a good idea to make sure your images aren't gigantic files **before** uploading them to Ghost._\\n\\n\\n## Making lists\\n\\nLists in HTML are a formatting nightmare, but in Markdown they become an absolute breeze with just a couple of characters and a bit of smart automation. For numbered lists, just write out the numbers. For bullet lists, just use `*` or `-` or `+`. Like this:\\n\\n1. Crack the eggs over a bowl\\n2. Whisk them together\\n3. Make an omelette\\n\\nor\\n\\n- Remember to buy milk\\n- Feed the cat\\n- Come up with idea for next story\\n\\n\\n## Adding quotes\\n\\nWhen you want to pull out a particularly good excerpt in the middle of a piece, you can use `>` at the beginning of a paragraph to turn it into a Blockquote. You might've seen this formatting before in email clients.\\n\\n> A well placed quote guides a reader through a story, helping them to understand the most important points being made\\n\\nAll themes handles blockquotes slightly differently. Sometimes they'll look better kept shorter, while other times you can quote fairly hefty amounts of text and get away with it. Generally, the safest option is to use blockquotes sparingly.\\n\\n\\n## Dividing things up\\n\\nIf you're writing a piece in parts and you just feel like you need to divide a couple of sections distinctly from each other, a horizontal rule might be just what you need. Dropping `---` on a new line will create a sleek divider, anywhere you want it.\\n\\n---\\n\\nThis should get you going with the vast majority of what you need to do in the editor, but if you're still curious about more advanced tips then check out the [Advanced Markdown Guide](/advanced-markdown/) - or if you'd rather learn about how Ghost taxononomies work, we've got a overview of [how to use Ghost tags](/using-tags/).\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/writing.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                },
+                {
+                    "title": "Welcome to Ghost",
+                    "slug": "welcome",
+                    "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Hey! Welcome to Ghost, it's great to have you :)\\n\\nWe know that first impressions are important, so we've populated your new site with some initial **Getting Started** posts that will help you get familiar with everything in no time. This is the first one!\\n\\n\\n### There are a few things that you should know up-front:\\n\\n1. Ghost is designed for ambitious, professional publishers who want to actively build a business around their content. That's who it works best for. If you're using Ghost for some other purpose, that's fine too - but it might not be the best choice for you.\\n\\n2. The entire platform can be modified and customized to suit your needs, which is very powerful, but doing so **does** require some knowledge of code. Ghost is not necessarily a good platform for beginners or people who just want a simple personal blog.\\n\\n3. For the best experience we recommend downloading the [Ghost Desktop App](https://ghost.org/downloads/) for your computer, which is the best way to access your Ghost site on a desktop device.\\n\\nGhost is made by an independent non-profit organisation called the Ghost Foundation. We are 100% self funded by revenue from our [Ghost(Pro)](https://ghost.org/pricing) service, and every penny we make is re-invested into funding further development of free, open source technology for modern journalism.\\n\\nThe main thing you'll want to read about next is probably: [the Ghost editor](/the-editor/).\\n\\nOnce you're done reading, you can simply delete the default **Ghost** user from your team to remove all of these introductory posts!\"}]],\"sections\":[[10,0]]}",
+                    "feature_image": "https://casper.ghost.org/v1.0.0/images/welcome.jpg",
+                    "featured": false,
+                    "page": false,
+                    "status": "published",
+                    "meta_title": null,
+                    "meta_description": null,
+                    "created_by": "5951f5fca366002ebd5dbef7",
+                    "published_by": "5951f5fca366002ebd5dbef7",
+                    "author_id": "5951f5fca366002ebd5dbef7"
+                }
+            ]
         }
-
     ],
     "relations": [
         {

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -16,6 +16,7 @@ module.exports = {
         visibility: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'public', validations: {isIn: [['public']]}},
         meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
+        // NOTE: keep, because you can easier query post.author_id than posts_authors[*].sort_order
         author_id: {type: 'string', maxlength: 24, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
@@ -61,6 +62,12 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
+    },
+    posts_authors: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id'},
+        author_id: {type: 'string', maxlength: 24, nullable: false, references: 'users.id'},
+        sort_order: {type: 'integer', nullable: false, unsigned: true, defaultTo: 0}
     },
     roles: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -13,10 +13,19 @@ module.exports = {
         page: {type: 'bool', nullable: false, defaultTo: false},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'draft'},
         locale: {type: 'string', maxlength: 6, nullable: true},
-        visibility: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'public', validations: {isIn: [['public']]}},
+        visibility: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'public',
+            validations: {isIn: [['public']]}
+        },
         meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
-        // NOTE: keep, because you can easier query post.author_id than posts_authors[*].sort_order
+        /**
+         * @deprecated: `author_id`, will be (maybe) removed in Ghost 2.0
+         * If we keep it, then only, because you can easier query post.author_id than posts_authors[*].sort_order.
+         */
         author_id: {type: 'string', maxlength: 24, nullable: false},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
@@ -53,7 +62,13 @@ module.exports = {
         accessibility: {type: 'text', maxlength: 65535, nullable: true},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'active'},
         locale: {type: 'string', maxlength: 6, nullable: true},
-        visibility: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'public', validations: {isIn: [['public']]}},
+        visibility: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'public',
+            validations: {isIn: [['public']]}
+        },
         meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
         tour: {type: 'text', maxlength: 65535, nullable: true},
@@ -113,7 +128,13 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         key: {type: 'string', maxlength: 50, nullable: false, unique: true},
         value: {type: 'text', maxlength: 65535, nullable: true},
-        type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'core', validations: {isIn: [['core', 'blog', 'theme', 'app', 'plugin', 'private']]}},
+        type: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'core',
+            validations: {isIn: [['core', 'blog', 'theme', 'app', 'plugin', 'private']]}
+        },
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
@@ -126,7 +147,13 @@ module.exports = {
         description: {type: 'text', maxlength: 65535, nullable: true, validations: {isLength: {max: 500}}},
         feature_image: {type: 'string', maxlength: 2000, nullable: true},
         parent_id: {type: 'string', nullable: true},
-        visibility: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'public', validations: {isIn: [['public', 'internal']]}},
+        visibility: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'public',
+            validations: {isIn: [['public', 'internal']]}
+        },
         meta_title: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 300}}},
         meta_description: {type: 'string', maxlength: 2000, nullable: true, validations: {isLength: {max: 500}}},
         created_at: {type: 'dateTime', nullable: false},
@@ -186,7 +213,13 @@ module.exports = {
         auth_uri: {type: 'string', maxlength: 2000, nullable: true},
         logo: {type: 'string', maxlength: 2000, nullable: true},
         status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'development'},
-        type: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'ua', validations: {isIn: [['ua', 'web', 'native']]}},
+        type: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'ua',
+            validations: {isIn: [['ua', 'web', 'native']]}
+        },
         description: {type: 'string', maxlength: 2000, nullable: true},
         created_at: {type: 'dateTime', nullable: false},
         created_by: {type: 'string', maxlength: 24, nullable: false},
@@ -217,7 +250,13 @@ module.exports = {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         name: {type: 'string', maxlength: 191, nullable: true},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['subscribed', 'pending', 'unsubscribed']]}},
+        status: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'pending',
+            validations: {isIn: [['subscribed', 'pending', 'unsubscribed']]}
+        },
         post_id: {type: 'string', maxlength: 24, nullable: true},
         subscribed_url: {type: 'string', maxlength: 2000, nullable: true, validations: {isEmptyOrURL: true}},
         subscribed_referrer: {type: 'string', maxlength: 2000, nullable: true, validations: {isEmptyOrURL: true}},
@@ -231,7 +270,13 @@ module.exports = {
     invites: {
         id: {type: 'string', maxlength: 24, nullable: false, primary: true},
         role_id: {type: 'string', maxlength: 24, nullable: false},
-        status: {type: 'string', maxlength: 50, nullable: false, defaultTo: 'pending', validations: {isIn: [['pending', 'sent']]}},
+        status: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            defaultTo: 'pending',
+            validations: {isIn: [['pending', 'sent']]}
+        },
         token: {type: 'string', maxlength: 191, nullable: false, unique: true},
         email: {type: 'string', maxlength: 191, nullable: false, unique: true, validations: {isEmail: true}},
         expires: {type: 'bigInteger', nullable: false},

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -31,6 +31,10 @@ _.extend(PostMapGenerator.prototype, {
             status: 'published',
             staticPages: false,
             limit: 'all',
+            /**
+             * Is required for permalinks e.g. `/:author/:slug/`.
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             include: 'author,tags'
         }).then(function (resp) {
             return resp.posts;

--- a/core/server/helpers/author.js
+++ b/core/server/helpers/author.js
@@ -17,6 +17,9 @@ var proxy = require('./proxy'),
     templates = proxy.templates,
     url = proxy.url;
 
+/**
+ * @deprecated: will be removed in Ghost 2.0
+ */
 module.exports = function author(options) {
     if (options.fn) {
         return handlebars.helpers.with.call(this, this.author, options);

--- a/core/server/helpers/authors.js
+++ b/core/server/helpers/authors.js
@@ -1,0 +1,53 @@
+// # Authors Helper
+// Usage: `{{authors}}`, `{{authors separator=' - '}}`
+//
+// Returns a string of the authors on the post.
+// By default, authors are separated by commas.
+//
+// Note that the standard {{#each authors}} implementation is unaffected by this helper.
+
+var proxy = require('./proxy'),
+    _ = require('lodash'),
+    SafeString = proxy.SafeString,
+    templates = proxy.templates,
+    url = proxy.url,
+    models = proxy.models;
+
+module.exports = function authors(options) {
+    options = options || {};
+    options.hash = options.hash || {};
+
+    var autolink = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
+        separator = _.isString(options.hash.separator) ? options.hash.separator : ', ',
+        prefix = _.isString(options.hash.prefix) ? options.hash.prefix : '',
+        suffix = _.isString(options.hash.suffix) ? options.hash.suffix : '',
+        limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
+        from = options.hash.from ? parseInt(options.hash.from, 10) : 1,
+        to = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
+        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility),
+        output = '';
+
+    function createAuthorsList(authors) {
+        function processAuthor(author) {
+            return autolink ? templates.link({
+                url: url.urlFor('author', {author: author}),
+                text: _.escape(author.name)
+            }) : _.escape(author.name);
+        }
+
+        return models.Base.Model.filterByVisibility(authors, visibilityArr, !!options.hash.visibility, processAuthor);
+    }
+
+    if (this.authors && this.authors.length) {
+        output = createAuthorsList(this.authors);
+        from -= 1; // From uses 1-indexed, but array uses 0-indexed.
+        to = to || limit + from || output.length;
+        output = output.slice(from, to).join(separator);
+    }
+
+    if (output) {
+        output = prefix + output + suffix;
+    }
+
+    return new SafeString(output);
+};

--- a/core/server/helpers/has.js
+++ b/core/server/helpers/has.js
@@ -15,14 +15,14 @@ var proxy = require('./proxy'),
 function handleCount(ctxAttr, data) {
     let count;
 
-    if (ctxAttr.match(/count:\d/)) {
-        count = Number(ctxAttr.match(/count:(\d)/)[1]);
+    if (ctxAttr.match(/count:\d+/)) {
+        count = Number(ctxAttr.match(/count:(\d+)/)[1]);
         return count === data.length;
     } else if (ctxAttr.match(/count:>\d/)) {
-        count = Number(ctxAttr.match(/count:>(\d)/)[1]);
+        count = Number(ctxAttr.match(/count:>(\d+)/)[1]);
         return count < data.length;
     } else if (ctxAttr.match(/count:<\d/)) {
-        count = Number(ctxAttr.match(/count:<(\d)/)[1]);
+        count = Number(ctxAttr.match(/count:<(\d+)/)[1]);
         return count > data.length;
     }
 

--- a/core/server/helpers/has.js
+++ b/core/server/helpers/has.js
@@ -1,5 +1,8 @@
+'use strict';
+
 // # Has Helper
 // Usage: `{{#has tag="video, music"}}`, `{{#has author="sam, pat"}}`
+//        `{{#has author="count:1"}}`, `{{#has tag="count:>1"}}`
 //
 // Checks if a post has a particular property
 
@@ -8,6 +11,23 @@ var proxy = require('./proxy'),
     logging = proxy.logging,
     i18n = proxy.i18n,
     validAttrs = ['tag', 'author', 'slug', 'id', 'number', 'index', 'any', 'all'];
+
+function handleCount(ctxAttr, data) {
+    let count;
+
+    if (ctxAttr.match(/count:\d/)) {
+        count = Number(ctxAttr.match(/count:(\d)/)[1]);
+        return count === data.length;
+    } else if (ctxAttr.match(/count:>\d/)) {
+        count = Number(ctxAttr.match(/count:>(\d)/)[1]);
+        return count < data.length;
+    } else if (ctxAttr.match(/count:<\d/)) {
+        count = Number(ctxAttr.match(/count:<(\d)/)[1]);
+        return count > data.length;
+    }
+
+    return false;
+}
 
 function evaluateTagList(expr, tags) {
     return expr.split(',').map(function (v) {
@@ -22,12 +42,38 @@ function evaluateTagList(expr, tags) {
     }, false);
 }
 
-function evaluateAuthorList(expr, author) {
+function handleTag(data, attrs) {
+    if (!attrs.tag) {
+        return false;
+    }
+
+    if (attrs.tag.match(/count:/)) {
+        return handleCount(attrs.tag, data.tags);
+    }
+
+    return evaluateTagList(attrs.tag, _.map(data.tags, 'name')) || false;
+}
+
+function evaluateAuthorList(expr, authors) {
     var authorList = expr.split(',').map(function (v) {
         return v.trim().toLocaleLowerCase();
     });
 
-    return _.includes(authorList, author.toLocaleLowerCase());
+    return _.filter(authors, (author) => {
+        return _.includes(authorList, author.name.toLocaleLowerCase());
+    }).length;
+}
+
+function handleAuthor(data, attrs) {
+    if (!attrs.author) {
+        return false;
+    }
+
+    if (attrs.author.match(/count:/)) {
+        return handleCount(attrs.author, data.authors);
+    }
+
+    return evaluateAuthorList(attrs.author, data.authors) || false;
 }
 
 function evaluateIntegerMatch(expr, integer) {
@@ -77,14 +123,30 @@ module.exports = function has(options) {
         attrs = _.pick(options.hash, validAttrs),
         data = _.pick(options.data, ['blog', 'config', 'labs']),
         checks = {
-            tag: function () { return attrs.tag && evaluateTagList(attrs.tag, _.map(self.tags, 'name')) || false; },
-            author: function () { return attrs.author && evaluateAuthorList(attrs.author, _.get(self, 'author.name')) || false; },
-            number: function () { return attrs.number && evaluateIntegerMatch(attrs.number, options.data.number) || false; },
-            index: function () { return attrs.index && evaluateIntegerMatch(attrs.index, options.data.index) || false; },
-            slug: function () { return attrs.slug && evaluateStringMatch(attrs.slug, self.slug, true) || false; },
-            id: function () { return attrs.id && evaluateStringMatch(attrs.id, self.id, true) || false; },
-            any: function () { return attrs.any && evaluateList('some', attrs.any, self, data) || false; },
-            all: function () { return attrs.all && evaluateList('every', attrs.all, self, data) || false; }
+            tag: function () {
+                return handleTag(self, attrs);
+            },
+            author: function () {
+                return handleAuthor(self, attrs);
+            },
+            number: function () {
+                return attrs.number && evaluateIntegerMatch(attrs.number, options.data.number) || false;
+            },
+            index: function () {
+                return attrs.index && evaluateIntegerMatch(attrs.index, options.data.index) || false;
+            },
+            slug: function () {
+                return attrs.slug && evaluateStringMatch(attrs.slug, self.slug, true) || false;
+            },
+            id: function () {
+                return attrs.id && evaluateStringMatch(attrs.id, self.id, true) || false;
+            },
+            any: function () {
+                return attrs.any && evaluateList('some', attrs.any, self, data) || false;
+            },
+            all: function () {
+                return attrs.all && evaluateList('every', attrs.all, self, data) || false;
+            }
         },
         result;
 

--- a/core/server/helpers/index.js
+++ b/core/server/helpers/index.js
@@ -6,6 +6,7 @@ var coreHelpers = {},
 
 coreHelpers.asset = require('./asset');
 coreHelpers.author = require('./author');
+coreHelpers.authors = require('./authors');
 coreHelpers.body_class = require('./body_class');
 coreHelpers.content = require('./content');
 coreHelpers.date = require('./date');
@@ -40,6 +41,7 @@ registerAllCoreHelpers = function registerAllCoreHelpers() {
     // Register theme helpers
     registerThemeHelper('asset', coreHelpers.asset);
     registerThemeHelper('author', coreHelpers.author);
+    registerThemeHelper('authors', coreHelpers.authors);
     registerThemeHelper('body_class', coreHelpers.body_class);
     registerThemeHelper('content', coreHelpers.content);
     registerThemeHelper('date', coreHelpers.date);

--- a/core/server/helpers/prev_next.js
+++ b/core/server/helpers/prev_next.js
@@ -24,7 +24,7 @@ buildApiOptions = function buildApiOptions(options, post) {
         op = options.name === 'prev_post' ? '<=' : '>',
         order = options.name === 'prev_post' ? 'desc' : 'asc',
         apiOptions = {
-            include: 'author,tags',
+            include: 'author,authors,tags',
             order: 'published_at ' + order,
             limit: 1,
             // This line deliberately uses double quotes because GQL cannot handle either double quotes
@@ -35,6 +35,8 @@ buildApiOptions = function buildApiOptions(options, post) {
     if (_.get(options, 'hash.in')) {
         if (options.hash.in === 'primary_tag' && _.get(post, 'primary_tag.slug')) {
             apiOptions.filter += '+primary_tag:' + post.primary_tag.slug;
+        } else if (options.hash.in === 'primary_author' && _.get(post, 'primary_author.slug')) {
+            apiOptions.filter += '+primary_author:' + post.primary_author.slug;
         } else if (options.hash.in === 'author' && _.get(post, 'author.slug')) {
             apiOptions.filter += '+author:' + post.author.slug;
         }

--- a/core/server/helpers/prev_next.js
+++ b/core/server/helpers/prev_next.js
@@ -24,6 +24,9 @@ buildApiOptions = function buildApiOptions(options, post) {
         op = options.name === 'prev_post' ? '<=' : '>',
         order = options.name === 'prev_post' ? 'desc' : 'asc',
         apiOptions = {
+            /**
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             include: 'author,authors,tags',
             order: 'published_at ' + order,
             limit: 1,

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -49,11 +49,19 @@ ghostBookshelf.plugin('bookshelf-relations', {
     hooks: {
         belongsToMany: {
             after: function (existing, targets, options) {
-                // reorder tags
+                // reorder tags/authors
+                var queryOptions = {
+                    query: {
+                        where: {}
+                    }
+                };
+
                 return Promise.each(targets.models, function (target, index) {
+                    queryOptions.query.where[existing.relatedData.otherKey] = target.id;
+
                     return existing.updatePivot({
                         sort_order: index
-                    }, _.extend({}, options, {query: {where: {tag_id: target.id}}}));
+                    }, _.extend({}, options, queryOptions));
                 });
             },
             beforeRelationCreation: function onCreatingRelation(model, data) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -106,6 +106,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             'fetching',
             'fetching:collection',
             'fetched',
+            'fetched:collection',
             'creating',
             'created',
             'updating',

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -6,7 +6,7 @@
 // accesses the models directly. All other parts of Ghost, including the blog frontend, admin UI, and apps are only
 // allowed to access data via the API.
 var _ = require('lodash'),
-    bookshelf = require('bookshelf-0.10.3'),
+    bookshelf = require('bookshelf'),
     moment = require('moment'),
     Promise = require('bluebird'),
     ObjectId = require('bson-objectid'),

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -6,7 +6,7 @@
 // accesses the models directly. All other parts of Ghost, including the blog frontend, admin UI, and apps are only
 // allowed to access data via the API.
 var _ = require('lodash'),
-    bookshelf = require('bookshelf'),
+    bookshelf = require('bookshelf-0.10.3'),
     moment = require('moment'),
     Promise = require('bluebird'),
     ObjectId = require('bson-objectid'),

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -161,6 +161,9 @@ filter = function filter(Bookshelf) {
                 options.groups.push('posts.id');
             }
 
+            /**
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             if (joinTables && joinTables.indexOf('author') > -1) {
                 this
                     .query('join', 'users as author', 'author.id', '=', 'posts.author_id');

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -95,6 +95,17 @@ filter = function filter(Bookshelf) {
                     ]
                 };
             });
+
+            this._filters.statements = gql.json.replaceStatements(this._filters.statements, {prop: /primary_author/}, function (statement) {
+                statement.prop = 'authors.slug';
+                return {
+                    group: [
+                        statement,
+                        {prop: 'posts_authors.sort_order', op: '=', value: 0},
+                        {prop: 'authors.visibility', op: '=', value: 'public'}
+                    ]
+                };
+            });
         },
 
         /**
@@ -120,6 +131,28 @@ filter = function filter(Bookshelf) {
                 if (gql.json.findStatement(this._filters.statements, {prop: /^tags/, op: 'IN'})) {
                     // TODO make this count the number of MATCHING tags, not just the number of tags
                     this.query('orderByRaw', 'count(tags.id) DESC');
+                }
+
+                // We need to add a group by to counter the double left outer join
+                // TODO improve on the group by handling
+                options.groups = options.groups || [];
+                options.groups.push('posts.id');
+            }
+
+            if (joinTables && joinTables.indexOf('authors') > -1) {
+                // We need to use leftOuterJoin to insure we still include posts which don't have tags in the result
+                // The where clause should restrict which items are returned
+                this
+                    .query('leftOuterJoin', 'posts_authors', 'posts_authors.post_id', '=', 'posts.id')
+                    .query('leftOuterJoin', 'users as authors', 'posts_authors.author_id', '=', 'authors.id');
+
+                // The order override should ONLY happen if we are doing an "IN" query
+                // TODO move the order handling to the query building that is currently inside pagination
+                // TODO make the order handling in pagination handle orderByRaw
+                // TODO extend this handling to all joins
+                if (gql.json.findStatement(this._filters.statements, {prop: /^authors/, op: 'IN'})) {
+                    // TODO make this count the number of MATCHING tags, not just the number of tags
+                    this.query('orderByRaw', 'count(users.id) DESC');
                 }
 
                 // We need to add a group by to counter the double left outer join

--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -151,8 +151,8 @@ filter = function filter(Bookshelf) {
                 // TODO make the order handling in pagination handle orderByRaw
                 // TODO extend this handling to all joins
                 if (gql.json.findStatement(this._filters.statements, {prop: /^authors/, op: 'IN'})) {
-                    // TODO make this count the number of MATCHING tags, not just the number of tags
-                    this.query('orderByRaw', 'count(users.id) DESC');
+                    // TODO make this count the number of MATCHING authors, not just the number of authors
+                    this.query('orderByRaw', 'count(authors.id) DESC');
                 }
 
                 // We need to add a group by to counter the double left outer join

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -658,7 +658,7 @@ Post = ghostBookshelf.Model.extend({
 
         if (isContributor) {
             // Note: at the moment primary_tag is a computed field,
-            // meaning we don't add it to this list. However, if the primary_tag
+            // meaning we don't add it to this list. However, if the primary_tag/primary_author
             // ever becomes a db field rather than a computed field, add it to this list
             // TODO: once contributors are able to edit existing tags, this can be removed
             // @TODO: we need a concept for making a diff between incoming tags and existing tags

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -37,7 +37,7 @@ Post = ghostBookshelf.Model.extend({
         };
     },
 
-    relationships: ['tags'],
+    relationships: ['tags', 'authors'],
 
     /**
      * The base model keeps only the columns, which are defined in the schema.
@@ -328,6 +328,12 @@ Post = ghostBookshelf.Model.extend({
 
     published_by: function publishedBy() {
         return this.belongsTo('User', 'published_by');
+    },
+
+    authors: function authors() {
+        return this.belongsToMany('User', 'posts_authors', 'post_id', 'author_id')
+            .withPivot('sort_order')
+            .query('orderBy', 'sort_order', 'ASC');
     },
 
     tags: function tags() {

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -184,6 +184,16 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 delete attrs.authors;
             }
 
+            // If the current column settings allow it...
+            if (!options.columns || (options.columns && options.columns.indexOf('primary_author') > -1)) {
+                // ... attach a computed property of primary_author which is the first tag
+                if (attrs.authors && attrs.authors.length) {
+                    attrs.primary_author = attrs.authors[0];
+                } else {
+                    attrs.primary_author = null;
+                }
+            }
+
             return attrs;
         }
     }, {

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -126,7 +126,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
             // CASE: you can't delete all authors
             if (model.get('authors') && !model.get('authors').length) {
                 throw new common.errors.ValidationError({
-                    message: 'The server could not understand the request.'
+                    message: 'At least one author is required.'
                 });
             }
 

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -1,0 +1,318 @@
+'use strict';
+
+const _ = require('lodash'),
+    Promise = require('bluebird'),
+    common = require('../../lib/common/index');
+
+/**
+ * Why and when do we have to fetch `authors` by default?
+ *
+ * # CASE 1
+ * We fetch the `authors` relations when you either request `withRelated=['authors']` or `withRelated=['author`].
+ * The old `author` relation was removed, but we still have to support this case.
+ *
+ * # CASE 2
+ * We fetch when editing a post.
+ * Imagine you change `author_id` and you have 3 existing `posts_authors`.
+ * We now need to set `author_id` as primary author `post.authors[0]`.
+ * Furthermore, we now longer have a `author` relationship.
+ *
+ * # CASE 3:
+ * If you request `include=author`, we have to fill this object with `post.authors[0]`.
+ * Otherwise we can't return `post.author = User`.
+ *
+ * ---
+ *
+ * It's impossible to implement a default `withRelated` feature nicely at the moment, because we can't hook into bookshelf
+ * and support all model queries and collection queries (e.g. fetchAll). The hardest part is to remember
+ * if the user requested the `authors` or not. Overriding `sync` does not work for collections.
+ * And overriding the sync method of Collection does not trigger sync - probably a bookshelf bug, i have
+ * not investigated.
+ *
+ * That's why we remember `_originalOptions` for now - only specific to posts.
+ *
+ * NOTE: If we fetch the multiple authors manually on the events, we run into the same problem. We have to remember
+ * the original options. Plus: we would fetch the authors twice in some cases.
+ */
+module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
+    const proto = Post.prototype;
+
+    const Model = Post.extend({
+        _handleOptions: function _handleOptions(fnName) {
+            const self = this;
+
+            return function innerHandleOptions(model, attrs, options) {
+                model._originalOptions = _.cloneDeep(_.pick(options, ['withRelated']));
+
+                if (!options.withRelated) {
+                    options.withRelated = [];
+                }
+
+                if (options.withRelated.indexOf('author') !== -1) {
+                    options.withRelated.splice(options.withRelated.indexOf('author'), 1);
+                    options.withRelated.push('authors');
+                }
+
+                if (options.forUpdate &&
+                    ['onFetching', 'onFetchingCollection'].indexOf(fnName) !== -1 &&
+                    options.withRelated.indexOf('authors') === -1) {
+                    options.withRelated.push('authors');
+                }
+
+                return proto[fnName].call(self, model, attrs, options);
+            };
+        },
+
+        onFetching: function onFetching(model, attrs, options) {
+            return this._handleOptions('onFetching')(model, attrs, options);
+        },
+
+        onFetchingCollection: function onFetchingCollection(collection, attrs, options) {
+            return this._handleOptions('onFetchingCollection')(collection, attrs, options);
+        },
+
+        onFetchedCollection: function (collection, attrs, options) {
+            _.each(collection.models, ((model) => {
+                model._originalOptions = collection._originalOptions;
+            }));
+
+            return proto.onFetchingCollection.call(this, collection, attrs, options);
+        },
+
+        // NOTE: sending `post.author = {}` was always ignored [unsupported]
+        onCreating: function onCreating(model, attrs, options) {
+            if (!model.get('author_id')) {
+                model.set('author_id', this.contextUser(options));
+            }
+
+            if (!model.get('authors')) {
+                model.set('authors', [{
+                    id: model.get('author_id')
+                }]);
+            }
+
+            return this._handleOptions('onCreating')(model, attrs, options);
+        },
+
+        onUpdating: function onUpdating(model, attrs, options) {
+            return this._handleOptions('onUpdating')(model, attrs, options);
+        },
+
+        // NOTE: `post.author` was always ignored [unsupported]
+        onSaving: function (model, attrs, options) {
+            model.unset('author');
+
+            // CASE: `post.author_id` has changed
+            if (model.hasChanged('author_id')) {
+                // CASE: you don't send `post.authors`
+                // SOLUTION: we have to update the primary author
+                if (!model.get('authors')) {
+                    let existingAuthors = model.related('authors').toJSON();
+
+                    // CASE: override primary author
+                    existingAuthors[0] = {
+                        id: model.get('author_id')
+                    };
+
+                    model.set('authors', existingAuthors);
+                } else {
+                    // CASE: you send `post.authors` next to `post.author_id`
+                    if (model.get('authors')[0].id !== model.get('author_id')) {
+                        model.set('author_id', model.get('authors')[0].id);
+                    }
+                }
+            }
+
+            // CASE: you can't delete all authors
+            if (model.get('authors') && !model.get('authors').length) {
+                throw new common.errors.ValidationError({
+                    message: 'The server could not understand the request.'
+                });
+            }
+
+            // CASE: if you change `post.author_id`, we have to update the primary author
+            // CASE: if the `author_id` has change and you pass `posts.authors`, we already check above that
+            //       the primary author id must be equal
+            if (model.hasChanged('author_id') && !model.get('authors')) {
+                let existingAuthors = model.related('authors').toJSON();
+
+                // CASE: override primary author
+                existingAuthors[0] = {
+                    id: model.get('author_id')
+                };
+
+                model.set('authors', existingAuthors);
+            }
+
+            return proto.onSaving.call(this, model, attrs, options);
+        },
+
+        serialize: function serialize(options) {
+            const authors = this.related('authors');
+
+            let attrs = proto.serialize.call(this, options);
+
+            // CASE: e.g. you stub model response in the test
+            // CASE: you delete a model without fetching before
+            if (!this._originalOptions) {
+                this._originalOptions = {};
+            }
+
+            // CASE: `author` was requested, `posts.authors` must exist
+            if (this._originalOptions.withRelated && this._originalOptions.withRelated && this._originalOptions.withRelated.indexOf('author') !== -1) {
+                if (!authors.models.length) {
+                    throw new common.errors.ValidationError({
+                        message: 'The target post has no primary author.'
+                    });
+                }
+
+                attrs.author = attrs.authors[0];
+                delete attrs.author_id;
+            } else {
+                // CASE: we return `post.author=id` with or without requested columns.
+                if (!options.columns || (options.columns && options.columns.indexOf('author') !== -1)) {
+                    attrs.author = attrs.author_id;
+                    delete attrs.author_id;
+                }
+            }
+
+            // CASE: `posts.authors` was not requested, but fetched in specific cases (see top)
+            if (!this._originalOptions || !this._originalOptions.withRelated || this._originalOptions.withRelated.indexOf('authors') === -1) {
+                delete attrs.authors;
+            }
+
+            return attrs;
+        }
+    }, {
+        /**
+         * ### destroyByAuthor
+         * @param  {[type]} options has context and id. Context is the user doing the destroy, id is the user to destroy
+         */
+        destroyByAuthor: function destroyByAuthor(unfilteredOptions) {
+            let options = this.filterOptions(unfilteredOptions, 'destroyByAuthor', {extraAllowedProperties: ['id']}),
+                postCollection = Posts.forge(),
+                authorId = options.id;
+
+            if (!authorId) {
+                return Promise.reject(new common.errors.NotFoundError({
+                    message: common.i18n.t('errors.models.post.noUserFound')
+                }));
+            }
+
+            // CASE: if you are the primary author of a post, the whole post and it's relations get's deleted.
+            //       `posts_authors` are automatically removed (bookshelf-relations)
+            // CASE: if you are the secondary author of a post, you are just deleted as author.
+            //       must happen manually
+            const destroyPost = (() => {
+                return postCollection
+                    .query('where', 'author_id', '=', authorId)
+                    .fetch(options)
+                    .call('invokeThen', 'destroy', options)
+                    .then(function (response) {
+                        return (options.transacting || ghostBookshelf.knex)('posts_authors')
+                            .where('author_id', authorId)
+                            .del()
+                            .return(response);
+                    })
+                    .catch((err) => {
+                        throw new common.errors.GhostError({err: err});
+                    });
+            });
+
+            if (!options.transacting) {
+                return ghostBookshelf.transaction((transacting) => {
+                    options.transacting = transacting;
+                    return destroyPost();
+                });
+            }
+
+            return destroyPost();
+        },
+
+        permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+            var self = this,
+                postModel = postModelOrId,
+                origArgs, isContributor, isAuthor, isEdit, isAdd, isDestroy,
+                result = {};
+
+            // If we passed in an id instead of a model, get the model
+            // then check the permissions
+            if (_.isNumber(postModelOrId) || _.isString(postModelOrId)) {
+                // Grab the original args without the first one
+                origArgs = _.toArray(arguments).slice(1);
+
+                // Get the actual post model
+                return this.findOne({id: postModelOrId, status: 'all'}, {withRelated: ['authors']})
+                    .then(function then(foundPostModel) {
+                        if (!foundPostModel) {
+                            throw new common.errors.NotFoundError({
+                                level: 'critical',
+                                message: common.i18n.t('errors.models.post.postNotFound')
+                            });
+                        }
+
+                        // Build up the original args but substitute with actual model
+                        const newArgs = [foundPostModel].concat(origArgs);
+                        return self.permissible.apply(self, newArgs);
+                    });
+            }
+
+            isContributor = loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Contributor'});
+            isAuthor = loadedPermissions.user && _.some(loadedPermissions.user.roles, {name: 'Author'});
+            isEdit = (action === 'edit');
+            isAdd = (action === 'add');
+            isDestroy = (action === 'destroy');
+
+            function isChanging(attr) {
+                return unsafeAttrs[attr] && unsafeAttrs[attr] !== postModel.get(attr);
+            }
+
+            function isOwner() {
+                return unsafeAttrs.author_id && unsafeAttrs.author_id === context.user;
+            }
+
+            function isCurrentOwner() {
+                return context.user === postModel.get('author_id');
+            }
+
+            if (isContributor && isEdit) {
+                hasUserPermission = !isChanging('author_id') && isCurrentOwner();
+            } else if (isContributor && isAdd) {
+                hasUserPermission = isOwner();
+            } else if (isContributor && isDestroy) {
+                hasUserPermission = isCurrentOwner();
+            } else if (isAuthor && isEdit) {
+                hasUserPermission = isCurrentOwner() && !isChanging('author_id');
+            } else if (isAuthor && isAdd) {
+                hasUserPermission = isOwner();
+            } else if (postModel) {
+                hasUserPermission = hasUserPermission || isCurrentOwner();
+            }
+
+            // @TODO: we need a concept for making a diff between incoming authors and existing authors
+            // @TODO: for now we simply re-use the new concept of `excludedAttrs` - if you send `authors`, they are getting ignored
+            if (isContributor || isAuthor) {
+                result.excludedAttrs = ['authors'];
+            }
+
+            if (hasUserPermission && hasAppPermission) {
+                return Post.permissible.call(
+                    this,
+                    postModelOrId,
+                    action, context,
+                    unsafeAttrs,
+                    loadedPermissions,
+                    hasUserPermission,
+                    hasAppPermission,
+                    result
+                );
+            }
+
+            return Promise.reject(new common.errors.NoPermissionError({
+                message: common.i18n.t('errors.models.post.notEnoughPermission')
+            }));
+        }
+    });
+
+    return Model;
+};

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -142,6 +142,9 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 };
 
                 model.set('authors', existingAuthors);
+            } else if (model.get('authors') && model.get('authors').length) {
+                // ensure we update the primary author id
+                model.set('author_id', model.get('authors')[0].id);
             }
 
             return proto.onSaving.call(this, model, attrs, options);

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -100,6 +100,9 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
 
         // NOTE: `post.author` was always ignored [unsupported]
         onSaving: function (model, attrs, options) {
+            /**
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             model.unset('author');
 
             // CASE: `post.author_id` has changed
@@ -161,7 +164,10 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 this._originalOptions = {};
             }
 
-            // CASE: `author` was requested, `posts.authors` must exist
+            /**
+             * CASE: `author` was requested, `posts.authors` must exist
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             if (this._originalOptions.withRelated && this._originalOptions.withRelated && this._originalOptions.withRelated.indexOf('author') !== -1) {
                 if (!authors.models.length) {
                     throw new common.errors.ValidationError({

--- a/core/server/models/relations/index.js
+++ b/core/server/models/relations/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    get authors() {
+        return require('./authors');
+    }
+};

--- a/core/server/services/rss/generate-feed.js
+++ b/core/server/services/rss/generate-feed.js
@@ -30,7 +30,7 @@ generateItem = function generateItem(post, siteUrl, secure) {
             url: itemUrl,
             date: post.published_at,
             categories: generateTags(post),
-            author: post.author ? post.author.name : null,
+            author: post.primary_author ? post.primary_author.name : null,
             custom_elements: []
         },
         imageUrl;

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -186,6 +186,9 @@ function urlPathForPost(post) {
             day: function () {
                 return publishedAtMoment.format('DD');
             },
+            /**
+             * @deprecated: `author`, will be removed in Ghost 2.0
+             */
             author: function () {
                 return post.author.slug;
             },

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -174,6 +174,7 @@ function urlPathForPost(post) {
     var output = '',
         permalinks = settingsCache.get('permalinks'),
         primaryTagFallback = config.get('routeKeywords').primaryTagFallback,
+        primaryAuthorFallback = config.get('routeKeywords').primaryAuthorFallback,
         publishedAtMoment = moment.tz(post.published_at || Date.now(), settingsCache.get('active_timezone')),
         tags = {
             year: function () {
@@ -190,6 +191,9 @@ function urlPathForPost(post) {
             },
             primary_tag: function () {
                 return post.primary_tag ? post.primary_tag.slug : primaryTagFallback;
+            },
+            primary_author: function () {
+                return post.primary_author ? post.primary_author.slug : primaryAuthorFallback;
             },
             slug: function () {
                 return post.slug;

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -404,6 +404,7 @@
             "utils": {
                 "noPermissionToCall": "You do not have permission to {method} {docName}",
                 "noRootKeyProvided": "No root key ('{docName}') provided.",
+                "invalidStructure": "No valid object structure provided for: {key}",
                 "invalidIdProvided": "Invalid id provided."
             },
             "invites": {

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -404,7 +404,7 @@ describe('Post API', function () {
                     });
             });
 
-            it('can retrieve a post with author, created_by, and tags', function (done) {
+            it('[DEPRECATED] can retrieve a post with author, created_by, and tags', function (done) {
                 request.get(testUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?include=author,tags,created_by'))
                     .set('Authorization', 'Bearer ' + ownerAccessToken)
                     .expect('Content-Type', /json/)
@@ -424,6 +424,36 @@ describe('Post API', function () {
 
                         jsonResponse.posts[0].author.should.be.an.Object();
                         testUtils.API.checkResponse(jsonResponse.posts[0].author, 'user');
+                        jsonResponse.posts[0].tags[0].should.be.an.Object();
+                        testUtils.API.checkResponse(jsonResponse.posts[0].tags[0], 'tag');
+                        done();
+                    });
+            });
+
+            it('can retrieve a post with authors, created_by, and tags', function (done) {
+                request.get(testUtils.API.getApiQuery('posts/' + testUtils.DataGenerator.Content.posts[0].id + '/?include=authors,tags,created_by'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse);
+                        should.exist(jsonResponse.posts);
+
+                        testUtils.API.checkResponse(jsonResponse.posts[0], 'post', ['tags', 'authors']);
+
+                        jsonResponse.posts[0].author.should.be.a.String();
+                        jsonResponse.posts[0].page.should.not.be.ok();
+
+                        jsonResponse.posts[0].authors[0].should.be.an.Object();
+                        testUtils.API.checkResponse(jsonResponse.posts[0].authors[0], 'user');
+
                         jsonResponse.posts[0].tags[0].should.be.an.Object();
                         testUtils.API.checkResponse(jsonResponse.posts[0].tags[0], 'tag');
                         done();

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -1437,10 +1437,9 @@ describe('Post API', function () {
                         slug: 'author-post',
                         author_id: author.id
                     }
-                })
-                    .then(function (post) {
-                        authorPostId = post.id;
-                    });
+                }).then(function (post) {
+                    authorPostId = post.id;
+                });
             });
 
             it('can edit own post', function (done) {
@@ -1573,13 +1572,13 @@ describe('Post API', function () {
 
             before(function () {
                 return testUtils.createPost({
-                        post: {
-                            title: 'Contributor\'s test post',
-                            slug: 'contributor-post',
-                            author_id: contributor.id,
-                            status: 'draft'
-                        }
-                    })
+                    post: {
+                        title: 'Contributor\'s test post',
+                        slug: 'contributor-post',
+                        author_id: contributor.id,
+                        status: 'draft'
+                    }
+                })
                     .then(function (post) {
                         contributorPostId = post.id;
                     });

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -154,9 +154,9 @@ describe('Advanced Browse', function () {
             });
         });
 
-        describe('[DEPRECATED] 4. Posts - filter="author:[leslie,pat]+(tag:hash-audio,image:-null)"', function () {
+        describe('4. Posts - filter="author:[leslie,pat]+(tag:hash-audio,image:-null)"', function () {
             // Note that `pat` doesn't exist (it's `pat-smith`)
-            it('Will fetch posts by the author `leslie` or `pat` which are either have tag `hash-audio` or an image.', function (done) {
+            it('[DEPRECATED] will fetch posts by the author `leslie` or `pat` which are either have tag `hash-audio` or an image.', function (done) {
                 PostAPI.browse({
                     filter: 'author:[leslie,pat]+(tag:hash-audio,feature_image:-null)',
                     include: 'author,tags'
@@ -197,6 +197,65 @@ describe('Advanced Browse', function () {
                         testUtils.filterData.data.posts[8].id,
                         testUtils.filterData.data.posts[7].id,
                         testUtils.filterData.data.posts[6].id
+                    ]);
+
+                    // 3. The meta object should contain the right details
+                    result.meta.should.have.property('pagination');
+                    result.meta.pagination.should.be.an.Object().with.properties(['page', 'limit', 'pages', 'total', 'next', 'prev']);
+                    result.meta.pagination.page.should.eql(1);
+                    result.meta.pagination.limit.should.eql(15);
+                    result.meta.pagination.pages.should.eql(1);
+                    result.meta.pagination.total.should.eql(6);
+                    should.equal(result.meta.pagination.next, null);
+                    should.equal(result.meta.pagination.prev, null);
+
+                    done();
+                }).catch(done);
+            });
+
+            it('will fetch posts by the authors `leslie` or `pat` which are either have tag `hash-audio` or an image.', function (done) {
+                PostAPI.browse({
+                    filter: 'authors:[leslie,pat]+(tag:hash-audio,feature_image:-null)',
+                    include: 'authors,tags'
+                }).then(function (result) {
+                    var ids, authors;
+                    // 1. Result should have the correct base structure
+                    should.exist(result);
+                    result.should.have.property('posts');
+                    result.should.have.property('meta');
+
+                    // 2. The data part of the response should be correct
+                    // We should have 2 matching items
+                    result.posts.should.be.an.Array().with.lengthOf(6);
+
+                    // Each post must either have the author 'leslie' or 'pat'
+                    authors = _.map(result.posts, function (post) {
+                        return post.authors[0].slug;
+                    });
+                    authors.should.matchAny(/leslie|pat/);
+
+                    // Each post must either be featured or have the tag 'hash-audio'
+                    _.each(result.posts, function (post) {
+                        var tags = _.map(post.tags, 'slug');
+                        // This construct ensures we get an assertion or a failure
+                        if (!_.isEmpty(post.feature_image)) {
+                            post.feature_image.should.not.be.empty();
+                        } else {
+                            tags = _.map(post.tags, 'slug');
+                            tags.should.containEql('hash-audio');
+                        }
+                    });
+
+                    ids = _.map(result.posts, 'id');
+
+                    // ordered by authors.id
+                    ids.should.eql([
+                        testUtils.filterData.data.posts[6].id,
+                        testUtils.filterData.data.posts[13].id,
+                        testUtils.filterData.data.posts[11].id,
+                        testUtils.filterData.data.posts[10].id,
+                        testUtils.filterData.data.posts[8].id,
+                        testUtils.filterData.data.posts[7].id
                     ]);
 
                     // 3. The meta object should contain the right details

--- a/core/test/integration/api/advanced_browse_spec.js
+++ b/core/test/integration/api/advanced_browse_spec.js
@@ -154,7 +154,7 @@ describe('Advanced Browse', function () {
             });
         });
 
-        describe('4. Posts - filter="author:[leslie,pat]+(tag:hash-audio,image:-null)"', function () {
+        describe('[DEPRECATED] 4. Posts - filter="author:[leslie,pat]+(tag:hash-audio,image:-null)"', function () {
             // Note that `pat` doesn't exist (it's `pat-smith`)
             it('Will fetch posts by the author `leslie` or `pat` which are either have tag `hash-audio` or an image.', function (done) {
                 PostAPI.browse({
@@ -773,7 +773,7 @@ describe('Advanced Browse', function () {
                 }).catch(done);
             });
 
-            it('Will fetch posts with a given author', function (done) {
+            it('[DEPRECATED] Will fetch posts with a given author', function (done) {
                 PostAPI.browse({
                     filter: 'author:leslie',
                     include: 'tag,author',

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -33,6 +33,7 @@ describe('Configuration API', function () {
                 page: 'page',
                 preview: 'p',
                 primaryTagFallback: 'all',
+                primaryAuthorFallback: 'all',
                 private: 'private',
                 subscribe: 'subscribe',
                 amp: 'amp'

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -283,11 +283,34 @@ describe('Post API', function () {
             }).catch(done);
         });
 
-        it('can include author', function (done) {
+        it('[DEPRECATED] can include author (using status:all)', function (done) {
             PostAPI.browse({context: {user: 1}, status: 'all', include: 'author'}).then(function (results) {
                 should.exist(results.posts);
                 should.exist(results.posts[0].author.name);
                 results.posts[0].author.name.should.eql('Joe Bloggs');
+
+                done();
+            }).catch(done);
+        });
+
+        it('[DEPRECATED] can include author', function (done) {
+            PostAPI.read({
+                context: {user: testUtils.DataGenerator.Content.users[1].id},
+                id: testUtils.DataGenerator.Content.posts[1].id,
+                include: 'author'
+            }).then(function (results) {
+                should.exist(results.posts[0].author.name);
+                results.posts[0].author.name.should.eql('Joe Bloggs');
+                done();
+            }).catch(done);
+        });
+
+        it('can include authors', function (done) {
+            PostAPI.browse({context: {user: 1}, status: 'all', include: 'authors'}).then(function (results) {
+                should.exist(results.posts);
+                should.exist(results.posts[0].authors);
+                should.exist(results.posts[0].authors[0]);
+                results.posts[0].authors[0].name.should.eql('Joe Bloggs');
 
                 done();
             }).catch(done);
@@ -311,27 +334,29 @@ describe('Post API', function () {
             }).catch(done);
         });
 
-        it('can include author and be case insensitive', function (done) {
-            PostAPI.browse({context: {user: 1}, status: 'all', include: 'Author'}).then(function (results) {
+        it('can include authors and be case insensitive', function (done) {
+            PostAPI.browse({context: {user: 1}, status: 'all', include: 'Authors'}).then(function (results) {
                 should.exist(results.posts);
-                should.exist(results.posts[0].author.name);
-                results.posts[0].author.name.should.eql('Joe Bloggs');
+                should.exist(results.posts[0].authors);
+                should.exist(results.posts[0].authors[0]);
+                results.posts[0].authors[0].name.should.eql('Joe Bloggs');
 
                 done();
             }).catch(done);
         });
 
-        it('can include author and ignore space in include', function (done) {
-            PostAPI.browse({context: {user: 1}, status: 'all', include: ' author'}).then(function (results) {
+        it('can include authors and ignore space in include', function (done) {
+            PostAPI.browse({context: {user: 1}, status: 'all', include: ' authors'}).then(function (results) {
                 should.exist(results.posts);
-                should.exist(results.posts[0].author.name);
-                results.posts[0].author.name.should.eql('Joe Bloggs');
+                should.exist(results.posts[0].authors);
+                should.exist(results.posts[0].authors[0]);
+                results.posts[0].authors[0].name.should.eql('Joe Bloggs');
 
                 done();
             }).catch(done);
         });
 
-        it('can fetch all posts for an author', function (done) {
+        it('[DEPRECATED] can fetch all posts for an author', function (done) {
             PostAPI.browse({
                 context: {user: 1},
                 status: 'all',
@@ -362,7 +387,7 @@ describe('Post API', function () {
         });
 
         it.skip('cannot fetch all posts for an author with invalid slug', function (done) {
-            PostAPI.browse({filter: 'author:invalid!'}).then(function () {
+            PostAPI.browse({filter: 'authors:invalid!'}).then(function () {
                 done(new Error('Should not return a result with invalid author'));
             }).catch(function (err) {
                 should.exist(err);
@@ -611,18 +636,6 @@ describe('Post API', function () {
             }).then(function (results) {
                 should.exist(results.posts[0].tags);
                 results.posts[0].tags[0].slug.should.eql('chorizo');
-                done();
-            }).catch(done);
-        });
-
-        it('can include author', function (done) {
-            PostAPI.read({
-                context: {user: testUtils.DataGenerator.Content.users[1].id},
-                id: testUtils.DataGenerator.Content.posts[1].id,
-                include: 'author'
-            }).then(function (results) {
-                should.exist(results.posts[0].author.name);
-                results.posts[0].author.name.should.eql('Joe Bloggs');
                 done();
             }).catch(done);
         });

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -374,6 +374,24 @@ describe('Post API', function () {
             }).catch(done);
         });
 
+        it('can fetch all posts for an author', function (done) {
+            PostAPI.browse({
+                context: {user: 1},
+                status: 'all',
+                filter: 'authors:joe-bloggs',
+                include: 'authors'
+            }).then(function (results) {
+                should.exist(results.posts);
+                results.posts.length.should.eql(6);
+
+                _.each(results.posts, function (post) {
+                    post.primary_author.slug.should.eql('joe-bloggs');
+                });
+
+                done();
+            }).catch(done);
+        });
+
         // @TODO: ensure filters are fully validated
         it.skip('cannot fetch all posts for a tag with invalid slug', function (done) {
             PostAPI.browse({filter: 'tags:invalid!'}).then(function () {

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -1865,16 +1865,22 @@ describe('Import (new test structure)', function () {
                     users[2].slug.should.eql(exportData.data.users[2].slug);
                     users[3].slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
 
-                    posts.length.should.eql(2);
-                    posts[0].author.should.eql(users[0].id);
-                    posts[0].authors.length.should.eql(1);
-                    posts[0].authors[0].id.should.eql(users[0].id);
+                    posts.length.should.eql(3);
 
-                    posts[1].author.should.eql(users[1].id);
-                    posts[1].authors.length.should.eql(3);
-                    posts[1].authors[0].id.should.eql(users[1].id);
-                    posts[1].authors[1].id.should.eql(users[0].id);
-                    posts[1].authors[2].id.should.eql(users[2].id);
+                    // has three posts_authors relations, but 2 of them are invalid
+                    posts[0].author.should.eql(users[2].id);
+                    posts[0].authors.length.should.eql(1);
+                    posts[0].authors[0].id.should.eql(users[2].id);
+
+                    posts[1].author.should.eql(users[0].id);
+                    posts[1].authors.length.should.eql(1);
+                    posts[1].authors[0].id.should.eql(users[0].id);
+
+                    posts[2].author.should.eql(users[1].id);
+                    posts[2].authors.length.should.eql(3);
+                    posts[2].authors[0].id.should.eql(users[1].id);
+                    posts[2].authors[1].id.should.eql(users[0].id);
+                    posts[2].authors[2].id.should.eql(users[2].id);
                 });
             });
         });

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -1809,31 +1809,73 @@ describe('Import (new test structure)', function () {
         });
     });
 
-    describe('1.0: basic import test', function () {
+    describe('1.0: tests', function () {
         var exportData;
 
-        before(function doImport() {
-            // initialize the blog with some data
-            return testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
-                return testUtils.fixtures.loadExportFixture('export-basic-test');
-            }).then(function (exported) {
-                exportData = exported.db[0];
-                return dataImporter.doImport(exportData, importOptions);
+        afterEach(testUtils.teardown);
+
+        describe('amp/comment', function () {
+            before(function doImport() {
+                // initialize the blog with some data
+                return testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
+                    return testUtils.fixtures.loadExportFixture('export-basic-test');
+                }).then(function (exported) {
+                    exportData = exported.db[0];
+                    return dataImporter.doImport(exportData, importOptions);
+                });
+            });
+
+            it('keeps the value of the amp field', function () {
+                return models.Post.findPage(_.merge({formats: 'amp'}, testUtils.context.internal)).then(function (response) {
+                    should.exist(response.posts);
+
+                    response.posts.length.should.eql(exportData.data.posts.length);
+                    response.posts[0].amp.should.eql(exportData.data.posts[1].id);
+                    response.posts[1].amp.should.eql(exportData.data.posts[0].amp);
+
+                    response.posts[0].comment_id.should.eql(response.posts[0].amp);
+                    response.posts[1].comment_id.should.eql(response.posts[1].amp);
+                });
             });
         });
 
-        after(testUtils.teardown);
+        describe('authors', function () {
+            before(function doImport() {
+                // initialize the blog with some data
+                return testUtils.initFixtures('roles', 'owner', 'settings').then(function () {
+                    return testUtils.fixtures.loadExportFixture('export-authors');
+                }).then(function (exported) {
+                    exportData = exported.db[0];
+                    return dataImporter.doImport(exportData, importOptions);
+                });
+            });
 
-        it('keeps the value of the amp field', function () {
-            return models.Post.findPage(_.merge({formats: 'amp'}, testUtils.context.internal)).then(function (response) {
-                should.exist(response.posts);
+            it('imports authors successfully', function () {
+                return Promise.join(
+                    models.Post.findPage(_.merge({withRelated: ['authors']}, testUtils.context.internal)),
+                    models.User.findPage(testUtils.context.internal)
+                ).then(function (importedData) {
+                    const posts = importedData[0].posts,
+                        users = importedData[1].users;
 
-                response.posts.length.should.eql(exportData.data.posts.length);
-                response.posts[0].amp.should.eql(exportData.data.posts[1].id);
-                response.posts[1].amp.should.eql(exportData.data.posts[0].amp);
+                    // owner + 3 imported users
+                    users.length.should.eql(4);
+                    users[0].slug.should.eql(exportData.data.users[0].slug);
+                    users[1].slug.should.eql(exportData.data.users[1].slug);
+                    users[2].slug.should.eql(exportData.data.users[2].slug);
+                    users[3].slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
 
-                response.posts[0].comment_id.should.eql(response.posts[0].amp);
-                response.posts[1].comment_id.should.eql(response.posts[1].amp);
+                    posts.length.should.eql(2);
+                    posts[0].author.should.eql(users[0].id);
+                    posts[0].authors.length.should.eql(1);
+                    posts[0].authors[0].id.should.eql(users[0].id);
+
+                    posts[1].author.should.eql(users[1].id);
+                    posts[1].authors.length.should.eql(3);
+                    posts[1].authors[0].id.should.eql(users[1].id);
+                    posts[1].authors[1].id.should.eql(users[0].id);
+                    posts[1].authors[2].id.should.eql(users[2].id);
+                });
             });
         });
     });

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1645,7 +1645,7 @@ describe('Post Model', function () {
                     })
                     .then(function () {
                         return PostModel.edit({
-                            authors: [{name: 'new-tag-1'}],
+                            authors: [testUtils.DataGenerator.Content.users[3]],
                             updated_at: moment().subtract(1, 'day').format()
                         }, _.extend({}, context, {id: postToUpdate.id}));
                     })

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -1038,21 +1038,6 @@ describe('Post Model', function () {
                 });
             });
 
-            it('[unsupported] can\'t add `author` as object', function () {
-                var newPost = testUtils.DataGenerator.forModel.posts[2];
-
-                // `post.author` relation get's ignored in Ghost - unsupported
-                newPost.author = {id: testUtils.DataGenerator.Content.users[3].id};
-                delete newPost.author_id;
-
-                return PostModel.add(newPost, context)
-                    .then(function (createdPost) {
-                        // fallsback to logged in user
-                        createdPost.get('author_id').should.eql(context.context.user);
-                        createdPost.get('author_id').should.not.eql(testUtils.DataGenerator.Content.users[3].id);
-                    });
-            });
-
             it('can add, defaults are all correct', function (done) {
                 var createdPostUpdatedDate,
                     newPost = testUtils.DataGenerator.forModel.posts[2],
@@ -1759,12 +1744,14 @@ describe('Post Model', function () {
     });
 
     describe('Post tag handling edge cases', function () {
-        beforeEach(testUtils.setup());
+        before(testUtils.teardown);
 
         var postJSON,
             tagJSON,
             editOptions,
             createTag = testUtils.DataGenerator.forKnex.createTag;
+
+        beforeEach(testUtils.setup('owner'));
 
         beforeEach(function () {
             tagJSON = [];
@@ -1786,8 +1773,6 @@ describe('Post Model', function () {
 
             return Promise.props({
                 post: PostModel.add(post, _.extend({}, context, {withRelated: ['tags']})),
-                role: RoleModel.add(testUtils.DataGenerator.forKnex.roles[2], context),
-                user: UserModel.add(testUtils.DataGenerator.forKnex.users[0], context),
                 tag1: TagModel.add(extraTags[0], context),
                 tag2: TagModel.add(extraTags[1], context),
                 tag3: TagModel.add(extraTags[2], context)
@@ -1840,22 +1825,6 @@ describe('Post Model', function () {
                 updatedPost.tags[0].slug.should.eql('eins');
                 updatedPost.tags[0].id.should.eql(postJSON.tags[0].id);
             });
-        });
-
-        it('[unsupported] can\'t edit `author` as object', function () {
-            var newJSON = _.cloneDeep(postJSON),
-                modelOptions = _.clone(editOptions);
-
-            newJSON.author.should.eql(testUtils.DataGenerator.Content.users[0].id);
-            newJSON.author = {id: testUtils.DataGenerator.Content.users[3].id};
-            delete newJSON.author_id;
-
-            modelOptions.withRelated.push('author');
-            return PostModel.edit(newJSON, modelOptions)
-                .then(function (updatedPost) {
-                    updatedPost.get('author_id').should.eql(testUtils.DataGenerator.Content.users[0].id);
-                    updatedPost.related('author').toJSON().slug.should.eql(testUtils.DataGenerator.Content.users[0].slug);
-                });
         });
 
         it('can\'t edit dates and authors of existing tag', function () {

--- a/core/test/integration/model/model_tags_spec.js
+++ b/core/test/integration/model/model_tags_spec.js
@@ -17,7 +17,7 @@ describe('Tag Model', function () {
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
-    beforeEach(testUtils.setup());
+    beforeEach(testUtils.setup('users:roles'));
 
     afterEach(function () {
         sandbox.restore();

--- a/core/test/unit/api/utils_spec.js
+++ b/core/test/unit/api/utils_spec.js
@@ -424,6 +424,71 @@ describe('API Utils', function () {
                 done();
             }).catch(done);
         });
+
+        describe('invalid post.authors structure', function () {
+            it('post.authors is not present', function (done) {
+                var object = {posts: [{id: 1}]};
+
+                apiUtils.checkObject(_.cloneDeep(object), 'posts')
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
+            it('post.authors is no array', function (done) {
+                var object = {posts: [{id: 1, authors: null}]};
+
+                apiUtils.checkObject(_.cloneDeep(object), 'posts')
+                    .then(function () {
+                        "Test should fail".should.eql(false);
+                    })
+                    .catch(function (err) {
+                        (err instanceof common.errors.BadRequestError).should.be.true;
+                        err.message.should.eql('No valid object structure provided for: posts[*].authors');
+                        done();
+                    });
+            });
+
+            it('post.authors is empty', function (done) {
+                var object = {posts: [{id: 1, authors: []}]};
+
+                apiUtils.checkObject(_.cloneDeep(object), 'posts')
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
+            it('post.authors contains id property', function (done) {
+                var object = {
+                    posts: [{
+                        id: 1,
+                        authors: [{id: 'objectid', name: 'Kate'}, {id: 'objectid', name: 'Steffen'}]
+                    }]
+                };
+
+                apiUtils.checkObject(_.cloneDeep(object), 'posts')
+                    .then(function () {
+                        done();
+                    })
+                    .catch(done);
+            });
+
+            it('post.authors does not contain id property', function (done) {
+                var object = {posts: [{id: 1, authors: [{id: 'objectid', name: 'Kate'}, {name: 'Steffen'}]}]};
+
+                apiUtils.checkObject(_.cloneDeep(object), 'posts')
+                    .then(function () {
+                        "Test should fail".should.eql(false);
+                    })
+                    .catch(function (err) {
+                        (err instanceof common.errors.BadRequestError).should.be.true;
+                        err.message.should.eql('No valid object structure provided for: posts[*].authors');
+                        done();
+                    });
+            });
+        });
     });
 
     describe('isPublicContext', function () {

--- a/core/test/unit/api/utils_spec.js
+++ b/core/test/unit/api/utils_spec.js
@@ -351,7 +351,7 @@ describe('API Utils', function () {
             }).catch(done);
         });
 
-        it('should do author_id to author conversion for posts', function (done) {
+        it('[DEPRECATED] should do author_id to author conversion for posts', function (done) {
             var object = {posts: [{id: 1, author: 4}]};
             apiUtils.checkObject(_.cloneDeep(object), 'posts').then(function (data) {
                 should.exist(data);
@@ -364,7 +364,7 @@ describe('API Utils', function () {
             }).catch(done);
         });
 
-        it('should not do author_id to author conversion for posts if not needed', function (done) {
+        it('[DEPRECATED] should not do author_id to author conversion for posts if not needed', function (done) {
             var object = {posts: [{id: 1, author_id: 4}]};
             apiUtils.checkObject(_.cloneDeep(object), 'posts').then(function (data) {
                 should.exist(data);

--- a/core/test/unit/controllers/frontend/fetch-data_spec.js
+++ b/core/test/unit/controllers/frontend/fetch-data_spec.js
@@ -87,7 +87,7 @@ describe('fetchData', function () {
                 result.data.featured.should.not.have.properties('data');
 
                 apiPostsStub.calledTwice.should.be.true();
-                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags');
+                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,authors,tags');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');
                 apiPostsStub.secondCall.args[0].should.have.property('limit', 3);
@@ -118,7 +118,7 @@ describe('fetchData', function () {
                 result.data.featured.should.not.have.properties('data');
 
                 apiPostsStub.calledTwice.should.be.true();
-                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,tags');
+                apiPostsStub.firstCall.args[0].should.have.property('include', 'author,authors,tags');
                 apiPostsStub.firstCall.args[0].should.have.property('limit', 10);
                 apiPostsStub.firstCall.args[0].should.have.property('page', 2);
                 apiPostsStub.secondCall.args[0].should.have.property('filter', 'featured:true');

--- a/core/test/unit/controllers/frontend/post-lookup_spec.js
+++ b/core/test/unit/controllers/frontend/post-lookup_spec.js
@@ -28,7 +28,7 @@ describe('postLookup', function () {
         beforeEach(function () {
             localSettingsCache.permalinks = '/:slug/';
 
-            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
+            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,authors,tags'})
                 .returns(new Promise.resolve({
                     posts: [{
                         url: '/welcome-to-ghost/',
@@ -86,7 +86,7 @@ describe('postLookup', function () {
         beforeEach(function () {
             localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
-            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
+            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,authors,tags'})
                 .returns(new Promise.resolve({
                     posts: [{
                         url: '/2016/01/01/welcome-to-ghost/',
@@ -144,7 +144,7 @@ describe('postLookup', function () {
         beforeEach(function () {
             localSettingsCache.permalinks = '/:slug/';
 
-            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
+            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,authors,tags'})
                 .returns(new Promise.resolve({
                     posts: [{
                         url: '/welcome-to-ghost/',
@@ -206,7 +206,7 @@ describe('postLookup', function () {
         beforeEach(function () {
             localSettingsCache.permalinks = '/:slug/';
 
-            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,tags'})
+            postAPIStub.withArgs({slug: 'welcome-to-ghost', include: 'author,authors,tags'})
                 .returns(new Promise.resolve({
                     posts: [{
                         url: '/welcome-to-ghost/',

--- a/core/test/unit/data/export/index_spec.js
+++ b/core/test/unit/data/export/index_spec.js
@@ -63,18 +63,19 @@ describe('Exporter', function () {
 
                 knexMock.getCall(0).args[0].should.eql('posts');
                 knexMock.getCall(1).args[0].should.eql('users');
-                knexMock.getCall(2).args[0].should.eql('roles');
-                knexMock.getCall(3).args[0].should.eql('roles_users');
-                knexMock.getCall(4).args[0].should.eql('permissions');
-                knexMock.getCall(5).args[0].should.eql('permissions_users');
-                knexMock.getCall(6).args[0].should.eql('permissions_roles');
-                knexMock.getCall(7).args[0].should.eql('permissions_apps');
-                knexMock.getCall(8).args[0].should.eql('settings');
-                knexMock.getCall(9).args[0].should.eql('tags');
-                knexMock.getCall(10).args[0].should.eql('posts_tags');
-                knexMock.getCall(11).args[0].should.eql('apps');
-                knexMock.getCall(12).args[0].should.eql('app_settings');
-                knexMock.getCall(13).args[0].should.eql('app_fields');
+                knexMock.getCall(2).args[0].should.eql('posts_authors');
+                knexMock.getCall(3).args[0].should.eql('roles');
+                knexMock.getCall(4).args[0].should.eql('roles_users');
+                knexMock.getCall(5).args[0].should.eql('permissions');
+                knexMock.getCall(6).args[0].should.eql('permissions_users');
+                knexMock.getCall(7).args[0].should.eql('permissions_roles');
+                knexMock.getCall(8).args[0].should.eql('permissions_apps');
+                knexMock.getCall(9).args[0].should.eql('settings');
+                knexMock.getCall(10).args[0].should.eql('tags');
+                knexMock.getCall(11).args[0].should.eql('posts_tags');
+                knexMock.getCall(12).args[0].should.eql('apps');
+                knexMock.getCall(13).args[0].should.eql('app_settings');
+                knexMock.getCall(14).args[0].should.eql('app_fields');
 
                 knexMock.calledWith('clients').should.be.false();
                 knexMock.calledWith('client_trusted_domains').should.be.false();

--- a/core/test/unit/data/meta/author_fb_url_spec.js
+++ b/core/test/unit/data/meta/author_fb_url_spec.js
@@ -7,7 +7,7 @@ describe('getAuthorFacebookUrl', function () {
             var facebookUrl = getAuthorFacebookUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         facebook: 'https://www.facebook.com/user'
                     }
                 }
@@ -20,7 +20,7 @@ describe('getAuthorFacebookUrl', function () {
             var facebookUrl = getAuthorFacebookUrl({
                 context: ['amp', 'post'],
                 post: {
-                    author: {
+                    primary_author: {
                         facebook: 'https://www.facebook.com/user'
                     }
                 }
@@ -33,7 +33,7 @@ describe('getAuthorFacebookUrl', function () {
             var facebookUrl = getAuthorFacebookUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         facebook: ''
                     }
                 }

--- a/core/test/unit/data/meta/author_image_spec.js
+++ b/core/test/unit/data/meta/author_image_spec.js
@@ -12,7 +12,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     profile_image: '/content/images/2016/01/myimage.jpg'
                 }
             }
@@ -25,7 +25,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     profile_image: '/content/images/2016/01/myimage.jpg'
                 }
             }
@@ -38,7 +38,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['amp', 'post'],
             post: {
-                author: {
+                primary_author: {
                     profile_image: '/content/images/2016/01/myimage.jpg'
                 }
             }
@@ -50,7 +50,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['amp', 'post'],
             post: {
-                author: {
+                primary_author: {
                     profile_image: '/content/images/2016/01/myimage.jpg'
                 }
             }
@@ -63,7 +63,7 @@ describe('getAuthorImage', function () {
         var imageUrl = getAuthorImage({
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     name: 'Test Author'
                 }
             }

--- a/core/test/unit/data/meta/author_url_spec.js
+++ b/core/test/unit/data/meta/author_url_spec.js
@@ -7,7 +7,7 @@ describe('getAuthorUrl', function () {
             var authorUrl = getAuthorUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         slug: 'test-author'
                     }
                 }
@@ -20,7 +20,7 @@ describe('getAuthorUrl', function () {
             var authorUrl = getAuthorUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         slug: 'test-author'
                     }
                 }
@@ -34,7 +34,7 @@ describe('getAuthorUrl', function () {
             var authorUrl = getAuthorUrl({
                 context: ['amp', 'post'],
                 post: {
-                    author: {
+                    primary_author: {
                         slug: 'test-author'
                     }
                 }
@@ -47,7 +47,7 @@ describe('getAuthorUrl', function () {
             var authorUrl = getAuthorUrl({
                 context: ['amp', 'post'],
                 post: {
-                    author: {
+                    primary_author: {
                         slug: 'test-author'
                     }
                 }

--- a/core/test/unit/data/meta/creator_url_spec.js
+++ b/core/test/unit/data/meta/creator_url_spec.js
@@ -7,7 +7,7 @@ describe('getCreatorTwitterUrl', function () {
             var twitterUrl = getCreatorTwitterUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         twitter: 'https://twitter.com/user'
                     }
                 }
@@ -20,7 +20,7 @@ describe('getCreatorTwitterUrl', function () {
             var twitterUrl = getCreatorTwitterUrl({
                 context: ['post'],
                 post: {
-                    author: {
+                    primary_author: {
                         twitter: ''
                     }
                 }
@@ -41,7 +41,7 @@ describe('getCreatorTwitterUrl', function () {
             var twitterUrl = getCreatorTwitterUrl({
                 context: ['amp', 'post'],
                 post: {
-                    author: {
+                    primary_author: {
                         twitter: 'https://twitter.com/user'
                     }
                 }
@@ -54,7 +54,7 @@ describe('getCreatorTwitterUrl', function () {
             var twitterUrl = getCreatorTwitterUrl({
                 context: ['amp', 'post'],
                 post: {
-                    author: {
+                    primary_author: {
                         twitter: ''
                     }
                 }

--- a/core/test/unit/data/meta/schema_spec.js
+++ b/core/test/unit/data/meta/schema_spec.js
@@ -43,7 +43,7 @@ describe('getSchema', function () {
         },  data = {
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     name: 'Post Author',
                     website: 'http://myblogsite.com/',
                     bio: 'My author bio.',
@@ -146,7 +146,7 @@ describe('getSchema', function () {
                 slug: 'my-amp-post-slug',
                 mobiledoc: markdownToMobiledoc('some markdown'),
                 html: 'some html',
-                author: {
+                primary_author: {
                     name: 'Post Author',
                     website: 'http://myblogsite.com/',
                     bio: 'My author bio.',
@@ -225,7 +225,7 @@ describe('getSchema', function () {
         },  data = {
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     name: 'Post Author',
                     website: undefined,
                     bio: null,
@@ -290,7 +290,7 @@ describe('getSchema', function () {
         },  data = {
             context: ['post'],
             post: {
-                author: {
+                primary_author: {
                     name: 'Post Author',
                     website: 'http://myblogsite.com/',
                     bio: 'My author bio.',

--- a/core/test/unit/data/schema/fixtures/utils_spec.js
+++ b/core/test/unit/data/schema/fixtures/utils_spec.js
@@ -103,7 +103,7 @@ describe('Migration Fixture Utils', function () {
             var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve()),
                 postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
 
-            fixtureUtils.addFixturesForModel(fixtures.models[0]).then(function (result) {
+            fixtureUtils.addFixturesForModel(fixtures.models[5]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 7);
@@ -119,7 +119,8 @@ describe('Migration Fixture Utils', function () {
         it('should not call add for main post fixture if it is already found', function (done) {
             var postOneStub = sandbox.stub(models.Post, 'findOne').returns(Promise.resolve({})),
                 postAddStub = sandbox.stub(models.Post, 'add').returns(Promise.resolve({}));
-            fixtureUtils.addFixturesForModel(fixtures.models[0]).then(function (result) {
+
+            fixtureUtils.addFixturesForModel(fixtures.models[5]).then(function (result) {
                 should.exist(result);
                 result.should.be.an.Object();
                 result.should.have.property('expected', 7);

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,8 +19,8 @@ var should = require('should'), // jshint ignore:line
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    var currentSchemaHash = '329f9b498944c459040426e16fc65b11',
-        currentFixturesHash = 'bd814f2c2aa19c745fc84f9ecc615140';
+    var currentSchemaHash = '2073bee126f6e419ef86196f719caea6',
+        currentFixturesHash = '15c259b97f62ef5981370b9416628ab6';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,
     // and the values above will need updating as confirmation

--- a/core/test/unit/helpers/authors_spec.js
+++ b/core/test/unit/helpers/authors_spec.js
@@ -1,0 +1,173 @@
+var should = require('should'), // jshint ignore:line
+    sinon = require('sinon'),
+    helpers = require('../../../server/helpers'),
+    models = require('../../../server/models'),
+    sandbox = sinon.sandbox.create();
+
+describe('{{authors}} helper', function () {
+    before(function () {
+        models.init();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('can return string with authors', function () {
+        var authors = [{name: 'Michael'}, {name: 'Thomas'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {autolink: 'false'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('Michael, Thomas');
+    });
+
+    it('can use a different separator', function () {
+        var authors = [{name: 'haunted'}, {name: 'ghost'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {separator: '|', autolink: 'false'}}
+            );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('haunted|ghost');
+    });
+
+    it('can add a single prefix to multiple authors', function () {
+        var authors = [{name: 'haunted'}, {name: 'ghost'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {prefix: 'on ', autolink: 'false'}}
+            );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('on haunted, ghost');
+    });
+
+    it('can add a single suffix to multiple authors', function () {
+        var authors = [{name: 'haunted'}, {name: 'ghost'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {suffix: ' forever', autolink: 'false'}}
+            );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('haunted, ghost forever');
+    });
+
+    it('can add a prefix and suffix to multiple authors', function () {
+        var authors = [{name: 'haunted'}, {name: 'ghost'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}}
+            );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('on haunted, ghost forever');
+    });
+
+    it('can add a prefix and suffix with HTML', function () {
+        var authors = [{name: 'haunted'}, {name: 'ghost'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}}
+            );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('&hellip; haunted, ghost &bull;');
+    });
+
+    it('does not add prefix or suffix if no authors exist', function () {
+        var rendered = helpers.authors.call(
+            {},
+            {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}}
+        );
+
+        should.exist(rendered);
+
+        String(rendered).should.equal('');
+    });
+
+    it('can autolink authors to author pages', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
+            rendered = helpers.authors.call(
+                {authors: authors}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>, <a href="/author/bar/">bar</a>');
+    });
+
+    it('can limit no. authors output to 1', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {limit: '1'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>');
+    });
+
+    it('can list authors from a specified no.', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {from: '2'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/bar/">bar</a>');
+    });
+
+    it('can list authors to a specified no.', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {to: '1'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>');
+    });
+
+    it('can list authors in a range', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {from: '2', to: '3'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/bar/">bar</a>, <a href="/author/baz/">baz</a>');
+    });
+
+    it('can limit no. authors and output from 2', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {from: '2', limit: '1'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/bar/">bar</a>');
+    });
+
+    it('can list authors in a range (ignore limit)', function () {
+        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
+            rendered = helpers.authors.call(
+                {authors: authors},
+                {hash: {from: '1', to: '3', limit: '2'}}
+            );
+        should.exist(rendered);
+
+        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>, <a href="/author/bar/">bar</a>, <a href="/author/baz/">baz</a>');
+    });
+});

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -5,6 +5,7 @@ var should = require('should'), // jshint ignore:line
     moment = require('moment'),
     testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
+    models = require('../../../server/models'),
     helpers = require('../../../server/helpers'),
     imageLib = require('../../../server/lib/image'),
     proxy = require('../../../server/helpers/proxy'),
@@ -15,6 +16,10 @@ var should = require('should'), // jshint ignore:line
     sandbox = sinon.sandbox.create();
 
 describe('{{ghost_head}} helper', function () {
+    before(function () {
+        models.init();
+    });
+
     afterEach(function () {
         sandbox.restore();
         configUtils.restore();
@@ -128,7 +133,7 @@ describe('{{ghost_head}} helper', function () {
                     twitter_title: '',
                     twitter_description: '',
                     page: true,
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author',
@@ -200,7 +205,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     page: true,
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author',
@@ -534,7 +539,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author',
@@ -627,7 +632,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author',
@@ -711,7 +716,7 @@ describe('{{ghost_head}} helper', function () {
                     custom_excerpt: '',
                     title: 'Welcome to Ghost',
                     html: '<p>This is a short post</p>',
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author'
@@ -778,7 +783,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http://testauthorurl.com',
                         slug: 'Author',
@@ -865,7 +870,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -950,7 +955,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -1032,7 +1037,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -1135,7 +1140,7 @@ describe('{{ghost_head}} helper', function () {
                 post: {
                     title: 'Welcome to Ghost',
                     html: '<p>This is a short post</p>',
-                    author: {
+                    primary_author: {
                         name: 'Author name'
                     }
                 }
@@ -1165,7 +1170,7 @@ describe('{{ghost_head}} helper', function () {
                 post: {
                     title: 'Welcome to Ghost',
                     html: '<p>This is a short post</p>',
-                    author: {
+                    primary_author: {
                         name: 'Author name'
                     }
                 }
@@ -1337,7 +1342,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -1484,7 +1489,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -1571,7 +1576,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',
@@ -1627,7 +1632,7 @@ describe('{{ghost_head}} helper', function () {
                     published_at: moment('2008-05-31T19:18:15').toISOString(),
                     updated_at: moment('2014-10-06T15:23:54').toISOString(),
                     tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    author: {
+                    primary_author: {
                         name: 'Author name',
                         url: 'http//:testauthorurl.com',
                         slug: 'Author',

--- a/core/test/unit/helpers/has_spec.js
+++ b/core/test/unit/helpers/has_spec.js
@@ -99,11 +99,65 @@ describe('{{#has}} helper', function () {
             fn.called.should.be.false();
             inverse.called.should.be.false();
         });
+
+        it('count:0', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:0'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:3', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:3'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('count:>3', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:>3'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:>2', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:>2'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('count:<1', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:<1'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:<3', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:<3'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
     });
 
     describe('author match', function () {
         it('should handle author list that evaluates to true', function () {
-            thisCtx = {author: {name: 'sam'}};
+            thisCtx = {authors: [{name: 'sam'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
@@ -112,7 +166,7 @@ describe('{{#has}} helper', function () {
         });
 
         it('should handle author list that evaluates to false', function () {
-            thisCtx = {author: {name: 'jamie'}};
+            thisCtx = {authors: [{name: 'jamie'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat'});
 
@@ -121,7 +175,7 @@ describe('{{#has}} helper', function () {
         });
 
         it('should handle authors with case-insensitivity', function () {
-            thisCtx = {author: {name: 'Sam'}};
+            thisCtx = {authors: [{name: 'Sam'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sAm, pat'});
 
@@ -130,7 +184,7 @@ describe('{{#has}} helper', function () {
         });
 
         it('should handle tags and authors like an OR query (pass)', function () {
-            thisCtx = {author: {name: 'sam'}, tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+            thisCtx = {authors: [{name: 'sam'}], tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
@@ -139,7 +193,7 @@ describe('{{#has}} helper', function () {
         });
 
         it('should handle tags and authors like an OR query (pass)', function () {
-            thisCtx = {author: {name: 'sam'}, tags: [{name: 'much'}, {name: 'bar'}, {name: 'baz'}]};
+            thisCtx = {authors: [{name: 'sam'}], tags: [{name: 'much'}, {name: 'bar'}, {name: 'baz'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
@@ -148,12 +202,75 @@ describe('{{#has}} helper', function () {
         });
 
         it('should handle tags and authors like an OR query (fail)', function () {
-            thisCtx = {author: {name: 'fred'}, tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+            thisCtx = {authors: [{name: 'fred'}], tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
 
             callHasHelper(thisCtx, {author: 'joe, sam, pat', tag: 'much, such, wow'});
 
             fn.called.should.be.false();
             inverse.called.should.be.true();
+        });
+
+        it('count:0', function () {
+            thisCtx = {authors: [{name: 'fred'}]};
+
+            callHasHelper(thisCtx, {author: 'count:0'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:1', function () {
+            thisCtx = {authors: [{name: 'fred'}]};
+
+            callHasHelper(thisCtx, {author: 'count:1'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('count:>1', function () {
+            thisCtx = {authors: [{name: 'fred'}]};
+
+            callHasHelper(thisCtx, {author: 'count:>1'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:>1', function () {
+            thisCtx = {authors: [{name: 'fred'}, {name: 'sam'}]};
+
+            callHasHelper(thisCtx, {author: 'count:>1'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
+        });
+
+        it('count:>2', function () {
+            thisCtx = {authors: [{name: 'fred'}, {name: 'sam'}]};
+
+            callHasHelper(thisCtx, {author: 'count:>2'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:<1', function () {
+            thisCtx = {authors: [{name: 'fred'}, {name: 'sam'}]};
+
+            callHasHelper(thisCtx, {author: 'count:<1'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
+        it('count:<3', function () {
+            thisCtx = {authors: [{name: 'fred'}, {name: 'sam'}]};
+
+            callHasHelper(thisCtx, {author: 'count:<3'});
+
+            fn.called.should.be.true();
+            inverse.called.should.be.false();
         });
     });
 

--- a/core/test/unit/helpers/has_spec.js
+++ b/core/test/unit/helpers/has_spec.js
@@ -118,6 +118,15 @@ describe('{{#has}} helper', function () {
             inverse.called.should.be.false();
         });
 
+        it('count:11', function () {
+            thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
+
+            callHasHelper(thisCtx, {tag: 'count:11'});
+
+            fn.called.should.be.false();
+            inverse.called.should.be.true();
+        });
+
         it('count:>3', function () {
             thisCtx = {tags: [{name: 'foo'}, {name: 'bar'}, {name: 'baz'}]};
 

--- a/core/test/unit/helpers/index_spec.js
+++ b/core/test/unit/helpers/index_spec.js
@@ -9,7 +9,7 @@ var should = require('should'), // jshint ignore:line
 describe('Helpers', function () {
     var hbsHelpers = ['each', 'if', 'unless', 'with', 'helperMissing', 'blockHelperMissing', 'log', 'lookup'],
         ghostHelpers = [
-            'asset', 'author', 'body_class', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
+            'asset', 'author', 'authors', 'body_class', 'content', 'date', 'encode', 'excerpt', 'facebook_url', 'foreach', 'get',
             'ghost_foot', 'ghost_head', 'has', 'img_url', 'is', 'lang', 'meta_description', 'meta_title', 'navigation',
             'next_post', 'page_url', 'pagination', 'plural', 'post_class', 'prev_post', 'reading_time', 't', 'tags', 'title', 'twitter_url',
             'url'

--- a/core/test/unit/helpers/next_post_spec.js
+++ b/core/test/unit/helpers/next_post_spec.js
@@ -50,7 +50,7 @@ describe('{{next_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
 
                     done();
                 })
@@ -227,8 +227,40 @@ describe('{{next_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.match(/\+primary_tag:test/);
+
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('shows \'if\' template with prev post data with primary_author set', function (done) {
+            var fn = sinon.spy(),
+                inverse = sinon.spy(),
+                optionsData = {name: 'next_post', fn: fn, inverse: inverse, hash: {in: 'primary_author'}};
+
+            helpers.next_post
+                .call({
+                    html: 'content',
+                    status: 'published',
+                    mobiledoc: markdownToMobiledoc('ff'),
+                    title: 'post2',
+                    slug: 'current',
+                    published_at: new Date(0),
+                    primary_author: {slug: 'hans'},
+                    url: '/current/'
+                }, optionsData)
+                .then(function () {
+                    fn.calledOnce.should.be.true();
+                    inverse.calledOnce.should.be.false();
+
+                    fn.firstCall.args.should.have.lengthOf(2);
+                    fn.firstCall.args[0].should.have.properties('slug', 'title');
+                    fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
+                    browsePostStub.calledOnce.should.be.true();
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
+                    browsePostStub.firstCall.args[0].filter.should.match(/\+primary_author:hans/);
 
                     done();
                 })
@@ -259,7 +291,7 @@ describe('{{next_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.match(/\+author:author-name/);
 
                     done();
@@ -290,7 +322,7 @@ describe('{{next_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.not.match(/\+author:/);
 
                     done();
@@ -322,7 +354,7 @@ describe('{{next_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.not.match(/\+magic/);
 
                     done();

--- a/core/test/unit/helpers/prev_post_spec.js
+++ b/core/test/unit/helpers/prev_post_spec.js
@@ -50,7 +50,7 @@ describe('{{prev_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
 
                     done();
                 })
@@ -227,8 +227,40 @@ describe('{{prev_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.match(/\+primary_tag:test/);
+
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('shows \'if\' template with prev post data with primary_author set', function (done) {
+            var fn = sinon.spy(),
+                inverse = sinon.spy(),
+                optionsData = {name: 'prev_post', fn: fn, inverse: inverse, hash: {in: 'primary_author'}};
+
+            helpers.prev_post
+                .call({
+                    html: 'content',
+                    status: 'published',
+                    mobiledoc: markdownToMobiledoc('ff'),
+                    title: 'post2',
+                    slug: 'current',
+                    published_at: new Date(0),
+                    primary_author: {slug: 'hans'},
+                    url: '/current/'
+                }, optionsData)
+                .then(function () {
+                    fn.calledOnce.should.be.true();
+                    inverse.calledOnce.should.be.false();
+
+                    fn.firstCall.args.should.have.lengthOf(2);
+                    fn.firstCall.args[0].should.have.properties('slug', 'title');
+                    fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
+                    browsePostStub.calledOnce.should.be.true();
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
+                    browsePostStub.firstCall.args[0].filter.should.match(/\+primary_author:hans/);
 
                     done();
                 })
@@ -259,7 +291,7 @@ describe('{{prev_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.match(/\+author:author-name/);
 
                     done();
@@ -290,7 +322,7 @@ describe('{{prev_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.not.match(/\+author:/);
 
                     done();
@@ -322,7 +354,7 @@ describe('{{prev_post}} helper', function () {
                     fn.firstCall.args[0].should.have.properties('slug', 'title');
                     fn.firstCall.args[1].should.be.an.Object().and.have.property('data');
                     browsePostStub.calledOnce.should.be.true();
-                    browsePostStub.firstCall.args[0].include.should.eql('author,tags');
+                    browsePostStub.firstCall.args[0].include.should.eql('author,authors,tags');
                     browsePostStub.firstCall.args[0].filter.should.not.match(/\+magic/);
 
                     done();

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -1,15 +1,37 @@
 'use strict';
 
-var should = require('should'), // jshint ignore:line
+const should = require('should'), // jshint ignore:line
     sinon = require('sinon'),
+    testUtils = require('../../utils'),
+    knex = require('../../../server/data/db').knex,
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
-    testUtils = require('../../utils'),
+    security = require('../../../server/lib/security'),
+    utils = require('../../utils'),
     sandbox = sinon.sandbox.create();
 
 describe('Unit: models/post', function () {
+    let knexMock;
+
     before(function () {
         models.init();
+    });
+
+    before(function () {
+        knexMock = new testUtils.mocks.knex();
+        knexMock.mock();
+    });
+
+    beforeEach(function () {
+        sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    after(function () {
+        knexMock.unmock();
     });
 
     after(function () {
@@ -17,17 +39,6 @@ describe('Unit: models/post', function () {
     });
 
     describe('Edit', function () {
-        let knexMock;
-
-        before(function () {
-            knexMock = new testUtils.mocks.knex();
-            knexMock.mock();
-        });
-
-        after(function () {
-            knexMock.unmock();
-        });
-
         it('resets given empty value to null', function () {
             return models.Post.findOne({slug: 'html-ipsum'})
                 .then(function (post) {
@@ -41,6 +52,448 @@ describe('Unit: models/post', function () {
                     should(post.get('feature_image')).be.null();
                     post.get('custom_excerpt').should.eql('');
                 });
+        });
+    });
+
+    describe('Relations', function () {
+        describe('author/authors', function () {
+            describe('add', function () {
+                it('with invalid post.author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id = '12345';
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[2].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function () {
+                        'Expected error'.should.eql(false);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.eql(true);
+                    });
+                });
+
+                it('with invalid post.authors[0].id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    delete post.author_id;
+                    delete post.author;
+
+                    post.authors = [{
+                        id: '12345'
+                    }];
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[2].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function () {
+                        'Expected error'.should.eql(false);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.eql(true);
+                    });
+                });
+
+                // NOTE: this can be supported as soon as we remove the deprecation for post.author_id
+                it('[unsupported] insert post.authors[0]', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    delete post.author_id;
+                    delete post.author;
+
+                    post.authors = [{
+                        name: 'Gregor'
+                    }];
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[2].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function () {
+                        'Expected error'.should.eql(false);
+                    }).catch(function (err) {
+                        (err[0] instanceof common.errors.ValidationError).should.eql(true);
+                    });
+                });
+
+                it('with invalid post.author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id = '12345';
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[2].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function () {
+                        'Expected error'.should.eql(false);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.eql(true);
+                    });
+                });
+
+                it('without author_id/author/authors', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    delete post.author_id;
+                    delete post.author;
+                    delete post.authors;
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[2].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                        post.authors.length.should.eql(1);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+
+                it('without author/authors', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+
+                    return models.Post.add(post, {withRelated: ['author', 'authors']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors.length.should.eql(1);
+                            post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        });
+                });
+
+                it('without author/authors', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+
+                    return models.Post.add(post, {withRelated: ['author']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            should.not.exist(post.authors);
+                        });
+                });
+
+                it('with author, with author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    post.author = {
+                        id: testUtils.DataGenerator.forKnex.users[1].id
+                    };
+
+                    return models.Post.add(post, {withRelated: ['author']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            should.not.exist(post.authors);
+                        });
+                });
+
+                it('[unsupported] with author, without author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    delete post.author_id;
+                    post.author = {
+                        id: testUtils.DataGenerator.forKnex.users[2].id
+                    };
+
+                    return models.Post.add(post, {
+                        withRelated: ['author'],
+                        context: {user: testUtils.DataGenerator.forKnex.users[0].id}
+                    }).then(function (post) {
+                        post = post.toJSON();
+
+                        // no update happened, because `post.author` is ignored
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        should.not.exist(post.authors);
+                    });
+                });
+
+                it('with authors, with author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    post.author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    post.authors = [{
+                        id: testUtils.DataGenerator.forKnex.users[0].id
+                    }];
+
+                    return models.Post.add(post, {withRelated: ['author', 'authors']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors.length.should.eql(1);
+                            post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        });
+                });
+
+                it('with authors, without author_id', function () {
+                    const post = testUtils.DataGenerator.forKnex.createPost();
+                    delete post.author_id;
+                    post.authors = [{
+                        id: testUtils.DataGenerator.forKnex.users[0].id
+                    }];
+
+                    return models.Post.add(post, {
+                        context: {user: testUtils.DataGenerator.forKnex.users[0].id},
+                        withRelated: ['author', 'authors']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        post.authors.length.should.eql(1);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    });
+                });
+            });
+
+            describe('findOne', function () {
+                it('withRelated: []', function () {
+                    return models.Post.findOne({id: testUtils.DataGenerator.forKnex.posts[3].id}, {withRelated: []})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            should.not.exist(post.authors);
+                            should.not.exist(post.author_id);
+                        });
+                });
+
+                it('withRelated: [author]', function () {
+                    return models.Post.findOne({id: testUtils.DataGenerator.forKnex.posts[3].id}, {withRelated: ['author']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            should.not.exist(post.authors);
+                        });
+                });
+
+                it('withRelated: [authors]', function () {
+                    return models.Post.findOne({id: testUtils.DataGenerator.forKnex.posts[3].id}, {withRelated: ['authors']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors.length.should.eql(2);
+                            post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                        });
+                });
+
+                it('withRelated: [authors, author]', function () {
+                    return models.Post.findOne({id: testUtils.DataGenerator.forKnex.posts[3].id}, {withRelated: ['authors', 'author']})
+                        .then(function (post) {
+                            post = post.toJSON();
+                            post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors.length.should.eql(2);
+                            post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                            post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                        });
+                });
+            });
+
+            describe('edit', function () {
+                beforeEach(function () {
+                    knexMock.resetDb();
+
+                    // posts[3] has the following author_id
+                    testUtils.DataGenerator.forKnex.posts[3].author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+
+                    // posts[3] has two authors relations
+                    testUtils.DataGenerator.forKnex.posts_authors[3].post_id.should.eql(testUtils.DataGenerator.forKnex.posts[3].id);
+                    testUtils.DataGenerator.forKnex.posts_authors[3].author_id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    testUtils.DataGenerator.forKnex.posts_authors[4].post_id.should.eql(testUtils.DataGenerator.forKnex.posts[3].id);
+                    testUtils.DataGenerator.forKnex.posts_authors[4].author_id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                });
+
+                it('[not allowed] post.authors = []', function () {
+                    const data = {
+                        authors: []
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function () {
+                        'Expected Error'.should.eql(true);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.be.true;
+                    });
+                });
+
+                it('[not allowed] primary authors are not equal', function () {
+                    const data = {
+                        author_id: testUtils.DataGenerator.forKnex.users[2].id,
+                        authors: [{
+                            id: testUtils.DataGenerator.forKnex.users[1].id
+                        }]
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function () {
+                        'Expected Error'.should.eql(true);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.be.true;
+                    });
+                });
+
+                it('[not allowed] primary authors are not equal', function () {
+                    const data = {
+                        author: {
+                            id: testUtils.DataGenerator.forKnex.users[2].id
+                        },
+                        authors: [{
+                            id: testUtils.DataGenerator.forKnex.users[1].id
+                        }]
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function () {
+                        'Expected Error'.should.eql(true);
+                    }).catch(function (err) {
+                        (err instanceof common.errors.ValidationError).should.be.true;
+                    });
+                });
+
+                it('change post.author_id [has existing post.authors]', function () {
+                    const data = {
+                        author_id: testUtils.DataGenerator.forKnex.users[1].id
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+
+                it('change post.author_id [has existing post.authors] [without `withRelated`]', function () {
+                    const data = {
+                        author_id: testUtils.DataGenerator.forKnex.users[1].id
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                        should.not.exist(post.authors);
+                        return models.Post.findOne({id: testUtils.DataGenerator.forKnex.posts[3].id}, {withRelated: ['authors']});
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+
+                it('change post.authors', function () {
+                    testUtils.DataGenerator.forKnex.posts[3].author_id.should.not.equal(testUtils.DataGenerator.forKnex.users[3].id);
+
+                    const data = {
+                        authors: [
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[3].id
+                            },
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[2].id
+                            }
+                        ]
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[3].id);
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[3].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+
+                it('change post.authors and post.author_id (different primary author)', function () {
+                    const data = {
+                        authors: [
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[1].id
+                            }
+                        ],
+                        author_id: testUtils.DataGenerator.forKnex.users[4].id
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                        post.authors.length.should.eql(1);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[1].id);
+                    });
+                });
+
+                it('change order of existing post.authors', function () {
+                    const data = {
+                        authors: [
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[2].id
+                            },
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[0].id
+                            }
+                        ]
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                    });
+                });
+
+                it('[unsupported] change post.author', function () {
+                    const data = {
+                        author: {
+                            id: testUtils.DataGenerator.forKnex.users[4].id
+                        }
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors', 'author']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[0].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+            });
+
+            describe('destroy', function () {
+                it('by author', function () {
+                    const authorId = testUtils.DataGenerator.forKnex.users[0].id;
+
+                    return knex('posts_authors')
+                        .where('author_id', authorId)
+                        .then(function (postAuthors) {
+                            postAuthors.length.should.eql(8);
+
+                            return models.Post.destroyByAuthor({id: authorId});
+                        })
+                        .then(function () {
+                            return knex('posts_authors')
+                                .where('author_id', authorId);
+                        })
+                        .then(function (postAuthors) {
+                            postAuthors.length.should.eql(0);
+                        });
+                });
+            });
         });
     });
 
@@ -81,7 +534,6 @@ describe('Unit: models/post', function () {
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
 
-                    mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.get.withArgs('author_id').returns(1);
 
                     models.Post.permissible(
@@ -96,7 +548,7 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledTwice).be.true();
+                        should(mockPostObj.get.calledOnce).be.true();
                         done();
                     });
                 });
@@ -123,7 +575,7 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledThrice).be.true();
+                        should(mockPostObj.get.callCount).eql(4);
                         done();
                     });
                 });
@@ -150,7 +602,7 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.callCount).eql(4);
+                        should(mockPostObj.get.callCount).eql(2);
                         done();
                     });
                 });
@@ -175,7 +627,7 @@ describe('Unit: models/post', function () {
                         true
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['tags']);
+                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
                         should(mockPostObj.get.callCount).eql(4);
                     });
                 });
@@ -247,7 +699,7 @@ describe('Unit: models/post', function () {
                         true
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['tags']);
+                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
                         should(mockPostObj.get.called).be.false();
                     });
                 });
@@ -324,7 +776,7 @@ describe('Unit: models/post', function () {
                         true
                     ).then((result) => {
                         should.exist(result);
-                        should(result.excludedAttrs).deepEqual(['tags']);
+                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
                         should(mockPostObj.get.calledTwice).be.true();
                     });
                 });

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -528,13 +528,14 @@ describe('Unit: models/post', function () {
             describe('Editing', function () {
                 it('rejects if changing status', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'published'};
 
                     mockPostObj.get.withArgs('status').returns('draft');
-                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -548,14 +549,16 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledOnce).be.true();
                         done();
                     });
                 });
 
                 it('rejects if changing author id', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
@@ -575,19 +578,78 @@ describe('Unit: models/post', function () {
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
                         should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.called).be.false();
                         done();
                     });
                 });
 
+                it('rejects if changing authors.0', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledTwice).be.false();
+                        done();
+                    });
+                });
+
+                it('ignores if changes authors.1', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', authors: [{id: 1}, {id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+                    mockPostObj.get.withArgs('status').returns('draft');
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then((result) => {
+                        should.exist(result);
+                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
+                        should(mockPostObj.get.callCount).eql(2);
+                        should(mockPostObj.related.callCount).eql(2);
+                        done();
+                    }).catch(done);
+                });
+
                 it('rejects if post is not draft', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'published', author_id: 1};
 
                     mockPostObj.get.withArgs('status').returns('published');
                     mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -601,20 +663,23 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.callCount).eql(4);
+                        should(mockPostObj.get.callCount).eql(3);
+                        should(mockPostObj.related.callCount).eql(1);
                         done();
                     });
                 });
 
                 it('rejects if contributor is not author of post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 2};
 
                     mockPostObj.get.withArgs('status').returns('draft');
-                    mockPostObj.get.withArgs('author_id').returns(2);
+                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -628,20 +693,23 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.callCount).eql(2);
+                        should(mockPostObj.get.callCount).eql(1);
+                        should(mockPostObj.related.callCount).eql(0);
                         done();
                     });
                 });
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {status: 'draft', author_id: 1};
 
                     mockPostObj.get.withArgs('status').returns('draft');
                     mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     return models.Post.permissible(
                         mockPostObj,
@@ -654,7 +722,8 @@ describe('Unit: models/post', function () {
                     ).then((result) => {
                         should.exist(result);
                         should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.callCount).eql(4);
+                        should(mockPostObj.get.callCount).eql(3);
+                        should(mockPostObj.related.callCount).eql(1);
                     });
                 });
             });
@@ -708,6 +777,101 @@ describe('Unit: models/post', function () {
                     });
                 });
 
+                it('rejects if different logged in user and `authors.0`', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', authors: [{id: 2}]};
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'add',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        done();
+                    });
+                });
+
+                it('rejects if same logged in user and `authors.0`, but different author_id', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', author_id: 3, authors: [{id: 1}]};
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'add',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        done();
+                    });
+                });
+
+                it('rejects if different logged in user and `authors.0`, but correct author_id', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', author_id: 1, authors: [{id: 2}]};
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'add',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        done();
+                    });
+                });
+
+                it('resolves if same logged in user and `authors.0`', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {status: 'draft', authors: [{id: 1}]};
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'add',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.contributor,
+                        false,
+                        true
+                    ).then((result) => {
+                        should.exist(result);
+                        should(result.excludedAttrs).deepEqual(['authors', 'tags']);
+                        should(mockPostObj.get.called).be.false();
+                        done();
+                    }).catch(done);
+                });
+
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
                             get: sandbox.stub()
@@ -734,11 +898,12 @@ describe('Unit: models/post', function () {
             describe('Destroying', function () {
                 it('rejects if destroying another author\'s post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1};
 
-                    mockPostObj.get.withArgs('author_id').returns(2);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -753,17 +918,19 @@ describe('Unit: models/post', function () {
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
                         should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
                         done();
                     });
                 });
 
                 it('rejects if destroying a published post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1};
 
-                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
                     mockPostObj.get.withArgs('status').returns('published');
 
                     models.Post.permissible(
@@ -778,19 +945,21 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledTwice).be.true();
+                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
                         done();
                     });
                 });
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1};
 
                     mockPostObj.get.withArgs('status').returns('draft');
-                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     return models.Post.permissible(
                         mockPostObj,
@@ -803,7 +972,8 @@ describe('Unit: models/post', function () {
                     ).then((result) => {
                         should.exist(result);
                         should(result.excludedAttrs).deepEqual(['authors', 'tags']);
-                        should(mockPostObj.get.calledTwice).be.true();
+                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
                     });
                 });
             });
@@ -813,11 +983,13 @@ describe('Unit: models/post', function () {
             describe('Editing', function () {
                 it('rejects if editing another\'s post', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 2};
 
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
                     mockPostObj.get.withArgs('author_id').returns(2);
 
                     models.Post.permissible(
@@ -832,19 +1004,21 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledOnce).be.true();
                         done();
                     });
                 });
 
-                it('rejects if changing author', function (done) {
+                it('rejects if editing another\'s post (using `authors`)', function (done) {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
-                        unsafeAttrs = {author_id: 2};
+                        unsafeAttrs = {authors: [{id: 2}]};
 
-                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -858,19 +1032,137 @@ describe('Unit: models/post', function () {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
                         error.should.be.an.instanceof(common.errors.NoPermissionError);
-                        should(mockPostObj.get.calledTwice).be.true();
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledTwice).be.true();
+                        done();
+                    });
+                });
+
+                it('rejects if changing author', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {author_id: 2};
+
+                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
+                        done();
+                    });
+                });
+
+                it('rejects if changing authors', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {authors: [{id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        should(mockPostObj.related.calledTwice).be.true();
+                        done();
+                    });
+                });
+
+                it('rejects if changing authors and author_id', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {authors: [{id: 1}], author_id: 2};
+
+                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
+                        done();
+                    });
+                });
+
+                it('rejects if changing authors and author_id', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {authors: [{id: 2}], author_id: 1};
+
+                    mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'edit',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        mockPostObj.get.callCount.should.eql(1);
+                        mockPostObj.related.callCount.should.eql(2);
                         done();
                     });
                 });
 
                 it('resolves if none of the above cases are true', function () {
                     var mockPostObj = {
-                            get: sandbox.stub()
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 1};
 
                     mockPostObj.get.withArgs('author_id').returns(1);
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     return models.Post.permissible(
                         mockPostObj,
@@ -881,7 +1173,8 @@ describe('Unit: models/post', function () {
                         false,
                         true
                     ).then(() => {
-                        should(mockPostObj.get.calledTwice).be.true();
+                        should(mockPostObj.get.calledOnce).be.true();
+                        should(mockPostObj.related.calledOnce).be.true();
                     });
                 });
             });
@@ -893,6 +1186,33 @@ describe('Unit: models/post', function () {
                         },
                         context = {user: 1},
                         unsafeAttrs = {author_id: 2};
+
+                    models.Post.permissible(
+                        mockPostObj,
+                        'add',
+                        context,
+                        unsafeAttrs,
+                        testUtils.permissions.author,
+                        false,
+                        true
+                    ).then(() => {
+                        done(new Error('Permissible function should have rejected.'));
+                    }).catch((error) => {
+                        error.should.be.an.instanceof(common.errors.NoPermissionError);
+                        should(mockPostObj.get.called).be.false();
+                        done();
+                    });
+                });
+
+                it('rejects if different authors', function (done) {
+                    var mockPostObj = {
+                            get: sandbox.stub(),
+                            related: sandbox.stub()
+                        },
+                        context = {user: 1},
+                        unsafeAttrs = {authors: [{id: 2}]};
+
+                    mockPostObj.related.withArgs('authors').returns({models: [{id: 1}]});
 
                     models.Post.permissible(
                         mockPostObj,
@@ -936,11 +1256,13 @@ describe('Unit: models/post', function () {
         describe('Everyone Else', function () {
             it('rejects if hasUserPermissions is false and not current owner', function (done) {
                 var mockPostObj = {
-                        get: sandbox.stub()
+                        get: sandbox.stub(),
+                        related: sandbox.stub()
                     },
                     context = {user: 1},
                     unsafeAttrs = {author_id: 2};
 
+                mockPostObj.related.withArgs('authors').returns({models: [{id: 2}]});
                 mockPostObj.get.withArgs('author_id').returns(2);
 
                 models.Post.permissible(
@@ -955,7 +1277,8 @@ describe('Unit: models/post', function () {
                     done(new Error('Permissible function should have rejected.'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
-                    should(mockPostObj.get.calledOnce).be.true();
+                    should(mockPostObj.get.called).be.false();
+                    should(mockPostObj.related.calledOnce).be.true();
                     done();
                 });
             });

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -409,6 +409,32 @@ describe('Unit: models/post', function () {
                     });
                 });
 
+                it('change post.authors, do not include `author`', function () {
+                    testUtils.DataGenerator.forKnex.posts[3].author_id.should.not.equal(testUtils.DataGenerator.forKnex.users[3].id);
+
+                    const data = {
+                        authors: [
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[3].id
+                            },
+                            {
+                                id: testUtils.DataGenerator.forKnex.users[2].id
+                            }
+                        ]
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[3].id,
+                        withRelated: ['authors']
+                    }).then(function (post) {
+                        post = post.toJSON();
+                        post.author.should.eql(testUtils.DataGenerator.forKnex.users[3].id);
+                        post.authors.length.should.eql(2);
+                        post.authors[0].id.should.eql(testUtils.DataGenerator.forKnex.users[3].id);
+                        post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
+                    });
+                });
+
                 it('change post.authors and post.author_id (different primary author)', function () {
                     const data = {
                         authors: [

--- a/core/test/unit/services/channels/parent-router_spec.js
+++ b/core/test/unit/services/channels/parent-router_spec.js
@@ -176,7 +176,7 @@ describe('Channels', function () {
                 this.locals.context.should.containEql('index');
 
                 postAPIStub.calledOnce.should.be.true();
-                postAPIStub.calledWith({page: 1, limit: 5, include: 'author,tags'}).should.be.true();
+                postAPIStub.calledWith({page: 1, limit: 5, include: 'author,authors,tags'}).should.be.true();
             }, done);
         });
 
@@ -192,7 +192,7 @@ describe('Channels', function () {
                 this.locals.context.should.containEql('index');
 
                 postAPIStub.calledOnce.should.be.true();
-                postAPIStub.calledWith({page: 1, limit: 5, include: 'author,tags'}).should.be.true();
+                postAPIStub.calledWith({page: 1, limit: 5, include: 'author,authors,tags'}).should.be.true();
             }, done);
         });
 
@@ -207,7 +207,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('index');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({page: 2, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({page: 2, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 }, done);
             });
 
@@ -221,7 +221,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('index');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({page: 2, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({page: 2, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 }, done);
             });
 
@@ -235,7 +235,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('index');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({page: 3, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({page: 3, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 }, done);
             });
 
@@ -326,7 +326,7 @@ describe('Channels', function () {
                 this.locals.context.should.containEql('tag');
 
                 postAPIStub.calledOnce.should.be.true();
-                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,tags'}).should.be.true();
+                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 tagAPIStub.calledOnce.should.be.true();
                 tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
             }, done);
@@ -344,7 +344,7 @@ describe('Channels', function () {
                 this.locals.context.should.containEql('tag');
 
                 postAPIStub.calledOnce.should.be.true();
-                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,tags'}).should.be.true();
+                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 tagAPIStub.calledOnce.should.be.true();
                 tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
             }, done);
@@ -363,7 +363,7 @@ describe('Channels', function () {
                 this.locals.context.should.containEql('tag');
 
                 postAPIStub.calledOnce.should.be.true();
-                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,tags'}).should.be.true();
+                postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 1, limit: 5, include: 'author,authors,tags'}).should.be.true();
                 tagAPIStub.calledOnce.should.be.true();
                 tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
             }, done);
@@ -390,7 +390,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('tag');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 2, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 2, limit: 5, include: 'author,authors,tags'}).should.be.true();
                     tagAPIStub.calledOnce.should.be.true();
                     tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
                 }, done);
@@ -409,7 +409,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('tag');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 2, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 2, limit: 5, include: 'author,authors,tags'}).should.be.true();
                     tagAPIStub.calledOnce.should.be.true();
                     tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
                 }, done);
@@ -433,7 +433,7 @@ describe('Channels', function () {
                     this.locals.context.should.containEql('tag');
 
                     postAPIStub.calledOnce.should.be.true();
-                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 3, limit: 5, include: 'author,tags'}).should.be.true();
+                    postAPIStub.calledWith({filter: 'tags:\'my-tag\'+tags.visibility:public', page: 3, limit: 5, include: 'author,authors,tags'}).should.be.true();
                     tagAPIStub.calledOnce.should.be.true();
                     tagAPIStub.calledWith({slug: 'my-tag', visibility: 'public'}).should.be.true();
                 }, done);

--- a/core/test/unit/services/permissions/can-this_spec.js
+++ b/core/test/unit/services/permissions/can-this_spec.js
@@ -24,7 +24,12 @@ describe('Permissions', function () {
         });
 
         findPostSpy = sandbox.stub(models.Post, 'findOne').callsFake(function () {
-            return Promise.resolve(models.Post.forge(testUtils.DataGenerator.Content.posts[0]));
+            // @TODO: the test env has no concept of including relations
+            let post = models.Post.forge(testUtils.DataGenerator.Content.posts[0]),
+                authors = [testUtils.DataGenerator.Content.users[0]];
+
+            post.related('authors').set(authors);
+            return Promise.resolve(post);
         });
 
         findTagSpy = sandbox.stub(models.Tag, 'findOne').callsFake(function () {

--- a/core/test/unit/services/permissions/can-this_spec.js
+++ b/core/test/unit/services/permissions/can-this_spec.js
@@ -1,4 +1,6 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
+
+const should = require('should'), // jshint ignore:line
     sinon = require('sinon'),
     testUtils = require('../../../utils'),
     Promise = require('bluebird'),

--- a/core/test/unit/services/rss/generate-feed_spec.js
+++ b/core/test/unit/services/rss/generate-feed_spec.js
@@ -20,7 +20,7 @@ describe('RSS: Generate Feed', function () {
         _.each(posts, function (post, i) {
             post.id = i;
             post.url = '/' + post.slug + '/';
-            post.author = {name: 'Joe Bloggs'};
+            post.primary_author = {name: 'Joe Bloggs'};
         });
     });
 
@@ -126,7 +126,7 @@ describe('RSS: Generate Feed', function () {
     });
 
     it('should no error if author is somehow not present', function (done) {
-        data.posts = [_.omit(posts[2], 'author')];
+        data.posts = [_.omit(posts[2], 'primary_author')];
 
         generateFeed(baseUrl, data).then(function (xmlData) {
             should.exist(xmlData);

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -22,8 +22,8 @@ var _ = require('lodash'),
             .keys()
             // by default we only return html
             .without('mobiledoc', 'amp', 'plaintext')
-            // swaps author_id to author, and always returns computed properties: url, comment_id, primary_tag
-            .without('author_id').concat('author', 'url', 'comment_id', 'primary_tag')
+            // swaps author_id to author, and always returns computed properties: url, comment_id, primary_tag, primary_author
+            .without('author_id').concat('author', 'url', 'comment_id', 'primary_tag', 'primary_author')
             .value(),
         user: {
             default: _(schema.users).keys().without('password').without('ghost_auth_access_token').value(),

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -375,6 +375,7 @@ DataGenerator.forKnex = (function () {
     var posts,
         tags,
         posts_tags,
+        posts_authors,
         apps,
         app_fields,
         roles,
@@ -695,6 +696,63 @@ DataGenerator.forKnex = (function () {
         }
     ];
 
+    posts_authors = [
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[0].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[1].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[2].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[3].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[3].id,
+            author_id: DataGenerator.Content.users[2].id,
+            sort_order: 1
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[4].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[5].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[6].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        },
+        {
+            id: ObjectId.generate(),
+            post_id: DataGenerator.Content.posts[7].id,
+            author_id: DataGenerator.Content.users[0].id,
+            sort_order: 0
+        }
+    ];
+
     apps = [
         createBasic(DataGenerator.Content.apps[0]),
         createBasic(DataGenerator.Content.apps[1]),
@@ -740,6 +798,7 @@ DataGenerator.forKnex = (function () {
         posts: posts,
         tags: tags,
         posts_tags: posts_tags,
+        posts_authors: posts_authors,
         apps: apps,
         app_fields: app_fields,
         roles: roles,

--- a/core/test/utils/fixtures/export/export-authors.json
+++ b/core/test/utils/fixtures/export/export-authors.json
@@ -1,0 +1,225 @@
+{
+    "db": [
+        {
+            "meta": {
+                "exported_on": 1504269105806,
+                "version": "1.8.1"
+            },
+            "data": {
+                "posts": [
+                    {
+                        "id": "59a952be7d79ed06b0d21127",
+                        "uuid": "8c414ae2-dce6-4b0f-8ee6-5c403fa2ae86",
+                        "title": "Setting up your own Ghost theme",
+                        "slug": "themes",
+                        "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"Creating a totally custom design for your publication\\n\\nGhost comes with a beautiful default theme called Casper, which is designed to be a clean, readable publication layout and can be easily adapted for most purposes. However, Ghost can also be completely themed to suit your needs. Rather than just giving you a few basic settings which act as a poor proxy for code, we just let you write code.\\n\\nThere are a huge range of both free and premium pre-built themes which you can get from the [Ghost Theme Marketplace](http://marketplace.ghost.org), or you can simply create your own from scratch.\\n\\n[![marketplace](https://casper.ghost.org/v1.0.0/images/marketplace.jpg)](http://marketplace.ghost.org)\\n\\n> Anyone can write a completely custom Ghost theme, with just some solid knowledge of HTML and CSS\\n\\nGhost themes are written with a templating language called handlebars, which has a bunch of dynamic helpers to insert your data into template files. Like `{{author.name}}`, for example, outputs the name of the current author.\\n\\nThe best way to learn how to write your own Ghost theme is to have a look at [the source code for Casper](https://github.com/TryGhost/Casper), which is heavily commented and should give you a sense of how everything fits together.\\n\\n- `default.hbs` is the main template file, all contexts will load inside this file unless specifically told to use a different template.\\n- `post.hbs` is the file used in the context of viewing a post.\\n- `index.hbs` is the file used in the context of viewing the home page.\\n- and so on\\n\\nWe've got [full and extensive theme documentation](http://themes.ghost.org/docs/about) which outlines every template file, context and helper that you can use.\\n\\nIf you want to chat with other people making Ghost themes to get any advice or help, there's also a **#themes** channel in our [public Slack community](https://slack.ghost.org) which we always recommend joining!\"}]],\"sections\":[[10,0]]}",
+                        "html": "<div class=\"kg-card-markdown\"><p>Creating a totally custom design for your publication</p>\n<p>Ghost comes with a beautiful default theme called Casper, which is designed to be a clean, readable publication layout and can be easily adapted for most purposes. However, Ghost can also be completely themed to suit your needs. Rather than just giving you a few basic settings which act as a poor proxy for code, we just let you write code.</p>\n<p>There are a huge range of both free and premium pre-built themes which you can get from the <a href=\"http://marketplace.ghost.org\">Ghost Theme Marketplace</a>, or you can simply create your own from scratch.</p>\n<p><a href=\"http://marketplace.ghost.org\"><img src=\"https://casper.ghost.org/v1.0.0/images/marketplace.jpg\" alt=\"marketplace\"></a></p>\n<blockquote>\n<p>Anyone can write a completely custom Ghost theme, with just some solid knowledge of HTML and CSS</p>\n</blockquote>\n<p>Ghost themes are written with a templating language called handlebars, which has a bunch of dynamic helpers to insert your data into template files. Like <code>{{author.name}}</code>, for example, outputs the name of the current author.</p>\n<p>The best way to learn how to write your own Ghost theme is to have a look at <a href=\"https://github.com/TryGhost/Casper\">the source code for Casper</a>, which is heavily commented and should give you a sense of how everything fits together.</p>\n<ul>\n<li><code>default.hbs</code> is the main template file, all contexts will load inside this file unless specifically told to use a different template.</li>\n<li><code>post.hbs</code> is the file used in the context of viewing a post.</li>\n<li><code>index.hbs</code> is the file used in the context of viewing the home page.</li>\n<li>and so on</li>\n</ul>\n<p>We've got <a href=\"http://themes.ghost.org/docs/about\">full and extensive theme documentation</a> which outlines every template file, context and helper that you can use.</p>\n<p>If you want to chat with other people making Ghost themes to get any advice or help, there's also a <strong>#themes</strong> channel in our <a href=\"https://slack.ghost.org\">public Slack community</a> which we always recommend joining!</p>\n</div>",
+                        "amp": "1",
+                        "plaintext": "Creating a totally custom design for your publication\n\nGhost comes with a beautiful default theme called Casper, which is designed to\nbe a clean, readable publication layout and can be easily adapted for most\npurposes. However, Ghost can also be completely themed to suit your needs.\nRather than just giving you a few basic settings which act as a poor proxy for\ncode, we just let you write code.\n\nThere are a huge range of both free and premium pre-built themes which you can\nget from the Ghost Theme Marketplace [http://marketplace.ghost.org], or you can\nsimply create your own from scratch.\n\n  [http://marketplace.ghost.org]\n\nAnyone can write a completely custom Ghost theme, with just some solid knowledge\nof HTML and CSS\n\nGhost themes are written with a templating language called handlebars, which has\na bunch of dynamic helpers to insert your data into template files. Like \n{{author.name}}, for example, outputs the name of the current author.\n\nThe best way to learn how to write your own Ghost theme is to have a look at \nthe\nsource code for Casper [https://github.com/TryGhost/Casper], which is heavily\ncommented and should give you a sense of how everything fits together.\n\n * default.hbs  is the main template file, all contexts will load inside this\n   file unless specifically told to use a different template.\n * post.hbs  is the file used in the context of viewing a post.\n * index.hbs  is the file used in the context of viewing the home page.\n * and so on\n\nWe've got full and extensive theme documentation\n[http://themes.ghost.org/docs/about]  which outlines every template file,\ncontext and helper that you can use.\n\nIf you want to chat with other people making Ghost themes to get any advice or\nhelp, there's also a #themes  channel in our public Slack community\n[https://slack.ghost.org]  which we always recommend joining!",
+                        "feature_image": "https://casper.ghost.org/v1.0.0/images/design.jpg",
+                        "featured": 0,
+                        "page": 0,
+                        "status": "published",
+                        "locale": null,
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "author_id": "5951f5fca366002ebd5dbef7",
+                        "created_at": "2017-09-01T12:29:50.000Z",
+                        "created_by": "5951f5fca366002ebd5dbef7",
+                        "updated_at": "2017-09-01T12:29:50.000Z",
+                        "updated_by": "5951f5fca366002ebd5dbef7",
+                        "published_at": "2017-09-01T12:29:50.000Z",
+                        "published_by": "5951f5fca366002ebd5dbef7",
+                        "custom_excerpt": null,
+                        "codeinjection_head": null,
+                        "codeinjection_foot": null,
+                        "og_image": null,
+                        "og_title": null,
+                        "og_description": null,
+                        "twitter_image": null,
+                        "twitter_title": null,
+                        "twitter_description": null
+                    },
+                    {
+                        "id": "59a952be7d79ed06b0d21128",
+                        "uuid": "8a6fdc10-fcde-48ba-b662-4d366cef5653",
+                        "title": "Advanced Markdown tips",
+                        "slug": "advanced-markdown",
+                        "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"There are lots of powerful things you can do with the Ghost editor\\n\\nIf you've gotten pretty comfortable with [all the basics](/the-editor/) of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!\\n\\nAs with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.\\n\\n\\n## Special formatting\\n\\nAs well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:\\n\\n+ ~~strike through~~\\n+ ==highlight==\\n+ \\\\*escaped characters\\\\*\\n\\n\\n## Writing code blocks\\n\\nThere are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, `like this`. Larger snippets of code can be displayed across multiple lines using triple back ticks:\\n\\n```\\n.my-link {\\n    text-decoration: underline;\\n}\\n```\\n\\nIf you want to get really fancy, you can even add syntax highlighting using [Prism.js](http://prismjs.com/).\\n\\n\\n## Full bleed images\\n\\nOne neat trick which you can use in Markdown to distinguish between different types of images is to add a `#hash` value to the end of the source URL, and then target images containing the hash with special styling. For example:\\n\\n![walking](https://casper.ghost.org/v1.0.0/images/walking.jpg#full)\\n\\nwhich is styled with...\\n\\n```\\nimg[src$=\\\"#full\\\"] {\\n    max-width: 100vw;\\n}\\n```\\n\\nThis creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.\\n\\n\\n## Reference lists\\n\\n**The quick brown [fox][1], jumped over the lazy [dog][2].**\\n\\n[1]: https://en.wikipedia.org/wiki/Fox \\\"Wikipedia: Fox\\\"\\n[2]: https://en.wikipedia.org/wiki/Dog \\\"Wikipedia: Dog\\\"\\n\\nAnother way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.\\n\\n\\n## Creating footnotes\\n\\nThe quick brown fox[^1] jumped over the lazy dog[^2].\\n\\n[^1]: Foxes are red\\n[^2]: Dogs are usually not red\\n\\nFootnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.\\n\\n\\n## Full HTML\\n\\nPerhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:\\n\\n<iframe width=\\\"560\\\" height=\\\"315\\\" src=\\\"https://www.youtube.com/embed/Cniqsc9QfDo?rel=0&amp;showinfo=0\\\" frameborder=\\\"0\\\" allowfullscreen></iframe>\\n\"}]],\"sections\":[[10,0]]}",
+                        "html": "<div class=\"kg-card-markdown\"><p>There are lots of powerful things you can do with the Ghost editor</p>\n<p>If you've gotten pretty comfortable with <a href=\"/the-editor/\">all the basics</a> of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!</p>\n<p>As with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.</p>\n<h2 id=\"specialformatting\">Special formatting</h2>\n<p>As well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:</p>\n<ul>\n<li><s>strike through</s></li>\n<li><mark>highlight</mark></li>\n<li>*escaped characters*</li>\n</ul>\n<h2 id=\"writingcodeblocks\">Writing code blocks</h2>\n<p>There are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, <code>like this</code>. Larger snippets of code can be displayed across multiple lines using triple back ticks:</p>\n<pre><code>.my-link {\n    text-decoration: underline;\n}\n</code></pre>\n<p>If you want to get really fancy, you can even add syntax highlighting using <a href=\"http://prismjs.com/\">Prism.js</a>.</p>\n<h2 id=\"fullbleedimages\">Full bleed images</h2>\n<p>One neat trick which you can use in Markdown to distinguish between different types of images is to add a <code>#hash</code> value to the end of the source URL, and then target images containing the hash with special styling. For example:</p>\n<p><img src=\"https://casper.ghost.org/v1.0.0/images/walking.jpg#full\" alt=\"walking\"></p>\n<p>which is styled with...</p>\n<pre><code>img[src$=&quot;#full&quot;] {\n    max-width: 100vw;\n}\n</code></pre>\n<p>This creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.</p>\n<h2 id=\"referencelists\">Reference lists</h2>\n<p><strong>The quick brown <a href=\"https://en.wikipedia.org/wiki/Fox\" title=\"Wikipedia: Fox\">fox</a>, jumped over the lazy <a href=\"https://en.wikipedia.org/wiki/Dog\" title=\"Wikipedia: Dog\">dog</a>.</strong></p>\n<p>Another way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.</p>\n<h2 id=\"creatingfootnotes\">Creating footnotes</h2>\n<p>The quick brown fox<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">[1]</a></sup> jumped over the lazy dog<sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\">[2]</a></sup>.</p>\n<p>Footnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.</p>\n<h2 id=\"fullhtml\">Full HTML</h2>\n<p>Perhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:</p>\n<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/Cniqsc9QfDo?rel=0&amp;showinfo=0\" frameborder=\"0\" allowfullscreen></iframe>\n<hr class=\"footnotes-sep\">\n<section class=\"footnotes\">\n<ol class=\"footnotes-list\">\n<li id=\"fn1\" class=\"footnote-item\"><p>Foxes are red <a href=\"#fnref1\" class=\"footnote-backref\">↩︎</a></p>\n</li>\n<li id=\"fn2\" class=\"footnote-item\"><p>Dogs are usually not red <a href=\"#fnref2\" class=\"footnote-backref\">↩︎</a></p>\n</li>\n</ol>\n</section>\n</div>",
+                        "amp": null,
+                        "plaintext": "There are lots of powerful things you can do with the Ghost editor\n\nIf you've gotten pretty comfortable with all the basics [/the-editor/]  of\nwriting in Ghost, then you may enjoy some more advanced tips about the types of\nthings you can do with Markdown!\n\nAs with the last post about the editor, you'll want to be actually editing this\npost as you read it so that you can see all the Markdown code we're using.\n\nSpecial formatting\nAs well as bold and italics, you can also use some other special formatting in\nMarkdown when the need arises, for example:\n\n * strike through\n * highlight\n * *escaped characters*\n\nWriting code blocks\nThere are two types of code elements which can be inserted in Markdown, the\nfirst is inline, and the other is block. Inline code is formatted by wrapping\nany word or words in back-ticks, like this. Larger snippets of code can be\ndisplayed across multiple lines using triple back ticks:\n\n.my-link {\n    text-decoration: underline;\n}\n\n\nIf you want to get really fancy, you can even add syntax highlighting using \nPrism.js [http://prismjs.com/].\n\nFull bleed images\nOne neat trick which you can use in Markdown to distinguish between different\ntypes of images is to add a #hash  value to the end of the source URL, and then\ntarget images containing the hash with special styling. For example:\n\n\n\nwhich is styled with...\n\nimg[src$=\"#full\"] {\n    max-width: 100vw;\n}\n\n\nThis creates full-bleed images in the Casper theme, which stretch beyond their\nusual boundaries right up to the edge of the window. Every theme handles these\ntypes of things slightly differently, but it's a great trick to play with if you\nwant to have a variety of image sizes and styles.\n\nReference lists\nThe quick brown fox [https://en.wikipedia.org/wiki/Fox], jumped over the lazy \ndog [https://en.wikipedia.org/wiki/Dog].\n\nAnother way to insert links in markdown is using reference lists. You might want\nto use this style of linking to cite reference material in a Wikipedia-style.\nAll of the links are listed at the end of the document, so you can maintain full\nseparation between content and its source or reference.\n\nCreating footnotes\nThe quick brown fox[1]  jumped over the lazy dog[2].\n\nFootnotes are a great way to add additional contextual details when appropriate.\nGhost will automatically add footnote content to the very end of your post.\n\nFull HTML\nPerhaps the best part of Markdown is that you're never limited to just Markdown.\nYou can write HTML directly in the Ghost editor and it will just work as HTML\nusually does. No limits! Here's a standard YouTube embed code as an example:\n\n\n--------------------------------------------------------------------------------\n\n 1. Foxes are red ↩︎\n    \n    \n 2. Dogs are usually not red ↩︎",
+                        "feature_image": "https://casper.ghost.org/v1.0.0/images/advanced.jpg",
+                        "featured": 0,
+                        "page": 0,
+                        "status": "published",
+                        "locale": null,
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "author_id": "5951f5fca366002ebd5dbef7",
+                        "created_at": "2017-09-01T12:29:50.000Z",
+                        "created_by": "5951f5fca366002ebd5dbef7",
+                        "updated_at": "2017-09-01T12:29:50.000Z",
+                        "updated_by": "5951f5fca366002ebd5dbef7",
+                        "published_at": "2017-09-01T12:29:51.000Z",
+                        "published_by": "5951f5fca366002ebd5dbef7",
+                        "custom_excerpt": null,
+                        "codeinjection_head": null,
+                        "codeinjection_foot": null,
+                        "og_image": null,
+                        "og_title": null,
+                        "og_description": null,
+                        "twitter_image": null,
+                        "twitter_title": null,
+                        "twitter_description": null
+                    }
+                ],
+                "posts_tags": [
+                    {
+                        "id": "59a952bf7d79ed06b0d211cb",
+                        "post_id": "59a952be7d79ed06b0d21127",
+                        "tag_id": "59a952be7d79ed06b0d2112e",
+                        "sort_order": 0
+                    }
+                ],
+                "tags": [
+                    {
+                        "id": "59a952be7d79ed06b0d2112e",
+                        "name": "tag1",
+                        "slug": "tag1",
+                        "description": null,
+                        "feature_image": "/content/images/2017/05/tagImage-1.jpeg",
+                        "parent_id": null,
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "created_at": "2017-05-30T08:44:09.000Z",
+                        "created_by": "5951f5fca366002ebd5dbef7",
+                        "updated_at": "2017-05-30T12:03:10.000Z",
+                        "updated_by": "5951f5fca366002ebd5dbef7"
+                    }
+                ],
+                "users": [
+                    {
+                        "id": "5951f5fca366002ebd5dbef7",
+                        "name": "Joe Blogg's Brother",
+                        "slug": "joe-bloggs-brother",
+                        "ghost_auth_access_token": null,
+                        "ghost_auth_id": null,
+                        "password": "$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKABC",
+                        "email": "jbloggsbrother@example.com",
+                        "profile_image": "/content/images/2017/05/authorlogo.jpeg",
+                        "cover_image": "/content/images/2017/05/authorcover.jpeg",
+                        "bio": "I'm Joe's brother, the good looking one!",
+                        "website": "http://joebloggsbrother.com",
+                        "location": null,
+                        "facebook": null,
+                        "twitter": null,
+                        "accessibility": null,
+                        "status": "active",
+                        "locale": "en_US",
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "tour": "[\"getting-started\",\"using-the-editor\",\"static-post\",\"featured-post\",\"upload-a-theme\"]",
+                        "last_seen": "2017-09-01T12:30:37.000Z",
+                        "created_at": "2017-09-01T12:29:51.000Z",
+                        "created_by": "1",
+                        "updated_at": "2017-09-01T12:30:59.000Z",
+                        "updated_by": "5951f5fca366002ebd5dbef8"
+                    },
+                    {
+                        "id": "5951f5fca366002ebd5dbef8",
+                        "name": "Joe Blogg's Mother",
+                        "slug": "joe-bloggs-mother",
+                        "ghost_auth_access_token": null,
+                        "ghost_auth_id": null,
+                        "password": "$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKABC",
+                        "email": "jbloggsmother@example.com",
+                        "profile_image": "/content/images/2017/05/authorlogo.jpeg",
+                        "cover_image": "/content/images/2017/05/authorcover.jpeg",
+                        "bio": "I'm Joe's brother, the good looking one!",
+                        "website": "http://joebloggsmother.com",
+                        "location": null,
+                        "facebook": null,
+                        "twitter": null,
+                        "accessibility": null,
+                        "status": "active",
+                        "locale": "en_US",
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "tour": "[\"getting-started\",\"using-the-editor\",\"static-post\",\"featured-post\",\"upload-a-theme\"]",
+                        "last_seen": "2017-08-01T12:30:37.000Z",
+                        "created_at": "2017-09-01T12:29:51.000Z",
+                        "created_by": "1",
+                        "updated_at": "2017-09-01T12:30:59.000Z",
+                        "updated_by": "1"
+                    },
+                    {
+                        "id": "5951f5fca366002ebd5dbef9",
+                        "name": "Joe Blogg's Father",
+                        "slug": "joe-bloggs-father",
+                        "ghost_auth_access_token": null,
+                        "ghost_auth_id": null,
+                        "password": "$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKABC",
+                        "email": "jbloggsfather@example.com",
+                        "profile_image": "/content/images/2017/05/authorlogo.jpeg",
+                        "cover_image": "/content/images/2017/05/authorcover.jpeg",
+                        "bio": "I'm Joe's father, the good looking one!",
+                        "website": "http://joebloggsfather.com",
+                        "location": null,
+                        "facebook": null,
+                        "twitter": null,
+                        "accessibility": null,
+                        "status": "active",
+                        "locale": "en_US",
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "tour": "[\"getting-started\",\"using-the-editor\",\"static-post\",\"featured-post\",\"upload-a-theme\"]",
+                        "last_seen": "2017-07-01T12:30:37.000Z",
+                        "created_at": "2017-09-01T12:29:51.000Z",
+                        "created_by": "1",
+                        "updated_at": "2017-09-01T12:30:59.000Z",
+                        "updated_by": "1"
+                    }
+                ],
+                "posts_authors": [
+                    {
+                        "id": "5a8c0aa22a49c40927b18474",
+                        "post_id": "59a952be7d79ed06b0d21127",
+                        "author_id": "5951f5fca366002ebd5dbef8",
+                        "sort_order": 0
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18474",
+                        "post_id": "59a952be7d79ed06b0d21127",
+                        "author_id": "5951f5fca366002ebd5dbef8",
+                        "sort_order": 0
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18475",
+                        "post_id": "unknown",
+                        "author_id": "5951f5fca366002ebd5dbef7",
+                        "sort_order": 1
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18476",
+                        "post_id": "59a952be7d79ed06b0d21127",
+                        "author_id": "5951f5fca366002ebd5dbef7",
+                        "sort_order": 2
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18477",
+                        "post_id": "59a952be7d79ed06b0d21127",
+                        "author_id": "5951f5fca366002ebd5dbef9",
+                        "sort_order": 4
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/core/test/utils/fixtures/export/export-authors.json
+++ b/core/test/utils/fixtures/export/export-authors.json
@@ -74,6 +74,40 @@
                         "twitter_image": null,
                         "twitter_title": null,
                         "twitter_description": null
+                    },
+                    {
+                        "id": "59a952be7d79ed06b0d21129",
+                        "uuid": "8a6fdc10-fcde-48ba-b662-4d366cef5653",
+                        "title": "Advanced Markdown tips",
+                        "slug": "advanced-markdown-2",
+                        "mobiledoc": "{\"version\":\"0.3.1\",\"markups\":[],\"atoms\":[],\"cards\":[[\"card-markdown\",{\"cardName\":\"card-markdown\",\"markdown\":\"There are lots of powerful things you can do with the Ghost editor\\n\\nIf you've gotten pretty comfortable with [all the basics](/the-editor/) of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!\\n\\nAs with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.\\n\\n\\n## Special formatting\\n\\nAs well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:\\n\\n+ ~~strike through~~\\n+ ==highlight==\\n+ \\\\*escaped characters\\\\*\\n\\n\\n## Writing code blocks\\n\\nThere are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, `like this`. Larger snippets of code can be displayed across multiple lines using triple back ticks:\\n\\n```\\n.my-link {\\n    text-decoration: underline;\\n}\\n```\\n\\nIf you want to get really fancy, you can even add syntax highlighting using [Prism.js](http://prismjs.com/).\\n\\n\\n## Full bleed images\\n\\nOne neat trick which you can use in Markdown to distinguish between different types of images is to add a `#hash` value to the end of the source URL, and then target images containing the hash with special styling. For example:\\n\\n![walking](https://casper.ghost.org/v1.0.0/images/walking.jpg#full)\\n\\nwhich is styled with...\\n\\n```\\nimg[src$=\\\"#full\\\"] {\\n    max-width: 100vw;\\n}\\n```\\n\\nThis creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.\\n\\n\\n## Reference lists\\n\\n**The quick brown [fox][1], jumped over the lazy [dog][2].**\\n\\n[1]: https://en.wikipedia.org/wiki/Fox \\\"Wikipedia: Fox\\\"\\n[2]: https://en.wikipedia.org/wiki/Dog \\\"Wikipedia: Dog\\\"\\n\\nAnother way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.\\n\\n\\n## Creating footnotes\\n\\nThe quick brown fox[^1] jumped over the lazy dog[^2].\\n\\n[^1]: Foxes are red\\n[^2]: Dogs are usually not red\\n\\nFootnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.\\n\\n\\n## Full HTML\\n\\nPerhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:\\n\\n<iframe width=\\\"560\\\" height=\\\"315\\\" src=\\\"https://www.youtube.com/embed/Cniqsc9QfDo?rel=0&amp;showinfo=0\\\" frameborder=\\\"0\\\" allowfullscreen></iframe>\\n\"}]],\"sections\":[[10,0]]}",
+                        "html": "<div class=\"kg-card-markdown\"><p>There are lots of powerful things you can do with the Ghost editor</p>\n<p>If you've gotten pretty comfortable with <a href=\"/the-editor/\">all the basics</a> of writing in Ghost, then you may enjoy some more advanced tips about the types of things you can do with Markdown!</p>\n<p>As with the last post about the editor, you'll want to be actually editing this post as you read it so that you can see all the Markdown code we're using.</p>\n<h2 id=\"specialformatting\">Special formatting</h2>\n<p>As well as bold and italics, you can also use some other special formatting in Markdown when the need arises, for example:</p>\n<ul>\n<li><s>strike through</s></li>\n<li><mark>highlight</mark></li>\n<li>*escaped characters*</li>\n</ul>\n<h2 id=\"writingcodeblocks\">Writing code blocks</h2>\n<p>There are two types of code elements which can be inserted in Markdown, the first is inline, and the other is block. Inline code is formatted by wrapping any word or words in back-ticks, <code>like this</code>. Larger snippets of code can be displayed across multiple lines using triple back ticks:</p>\n<pre><code>.my-link {\n    text-decoration: underline;\n}\n</code></pre>\n<p>If you want to get really fancy, you can even add syntax highlighting using <a href=\"http://prismjs.com/\">Prism.js</a>.</p>\n<h2 id=\"fullbleedimages\">Full bleed images</h2>\n<p>One neat trick which you can use in Markdown to distinguish between different types of images is to add a <code>#hash</code> value to the end of the source URL, and then target images containing the hash with special styling. For example:</p>\n<p><img src=\"https://casper.ghost.org/v1.0.0/images/walking.jpg#full\" alt=\"walking\"></p>\n<p>which is styled with...</p>\n<pre><code>img[src$=&quot;#full&quot;] {\n    max-width: 100vw;\n}\n</code></pre>\n<p>This creates full-bleed images in the Casper theme, which stretch beyond their usual boundaries right up to the edge of the window. Every theme handles these types of things slightly differently, but it's a great trick to play with if you want to have a variety of image sizes and styles.</p>\n<h2 id=\"referencelists\">Reference lists</h2>\n<p><strong>The quick brown <a href=\"https://en.wikipedia.org/wiki/Fox\" title=\"Wikipedia: Fox\">fox</a>, jumped over the lazy <a href=\"https://en.wikipedia.org/wiki/Dog\" title=\"Wikipedia: Dog\">dog</a>.</strong></p>\n<p>Another way to insert links in markdown is using reference lists. You might want to use this style of linking to cite reference material in a Wikipedia-style. All of the links are listed at the end of the document, so you can maintain full separation between content and its source or reference.</p>\n<h2 id=\"creatingfootnotes\">Creating footnotes</h2>\n<p>The quick brown fox<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">[1]</a></sup> jumped over the lazy dog<sup class=\"footnote-ref\"><a href=\"#fn2\" id=\"fnref2\">[2]</a></sup>.</p>\n<p>Footnotes are a great way to add additional contextual details when appropriate. Ghost will automatically add footnote content to the very end of your post.</p>\n<h2 id=\"fullhtml\">Full HTML</h2>\n<p>Perhaps the best part of Markdown is that you're never limited to just Markdown. You can write HTML directly in the Ghost editor and it will just work as HTML usually does. No limits! Here's a standard YouTube embed code as an example:</p>\n<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/Cniqsc9QfDo?rel=0&amp;showinfo=0\" frameborder=\"0\" allowfullscreen></iframe>\n<hr class=\"footnotes-sep\">\n<section class=\"footnotes\">\n<ol class=\"footnotes-list\">\n<li id=\"fn1\" class=\"footnote-item\"><p>Foxes are red <a href=\"#fnref1\" class=\"footnote-backref\">↩︎</a></p>\n</li>\n<li id=\"fn2\" class=\"footnote-item\"><p>Dogs are usually not red <a href=\"#fnref2\" class=\"footnote-backref\">↩︎</a></p>\n</li>\n</ol>\n</section>\n</div>",
+                        "amp": null,
+                        "plaintext": "There are lots of powerful things you can do with the Ghost editor\n\nIf you've gotten pretty comfortable with all the basics [/the-editor/]  of\nwriting in Ghost, then you may enjoy some more advanced tips about the types of\nthings you can do with Markdown!\n\nAs with the last post about the editor, you'll want to be actually editing this\npost as you read it so that you can see all the Markdown code we're using.\n\nSpecial formatting\nAs well as bold and italics, you can also use some other special formatting in\nMarkdown when the need arises, for example:\n\n * strike through\n * highlight\n * *escaped characters*\n\nWriting code blocks\nThere are two types of code elements which can be inserted in Markdown, the\nfirst is inline, and the other is block. Inline code is formatted by wrapping\nany word or words in back-ticks, like this. Larger snippets of code can be\ndisplayed across multiple lines using triple back ticks:\n\n.my-link {\n    text-decoration: underline;\n}\n\n\nIf you want to get really fancy, you can even add syntax highlighting using \nPrism.js [http://prismjs.com/].\n\nFull bleed images\nOne neat trick which you can use in Markdown to distinguish between different\ntypes of images is to add a #hash  value to the end of the source URL, and then\ntarget images containing the hash with special styling. For example:\n\n\n\nwhich is styled with...\n\nimg[src$=\"#full\"] {\n    max-width: 100vw;\n}\n\n\nThis creates full-bleed images in the Casper theme, which stretch beyond their\nusual boundaries right up to the edge of the window. Every theme handles these\ntypes of things slightly differently, but it's a great trick to play with if you\nwant to have a variety of image sizes and styles.\n\nReference lists\nThe quick brown fox [https://en.wikipedia.org/wiki/Fox], jumped over the lazy \ndog [https://en.wikipedia.org/wiki/Dog].\n\nAnother way to insert links in markdown is using reference lists. You might want\nto use this style of linking to cite reference material in a Wikipedia-style.\nAll of the links are listed at the end of the document, so you can maintain full\nseparation between content and its source or reference.\n\nCreating footnotes\nThe quick brown fox[1]  jumped over the lazy dog[2].\n\nFootnotes are a great way to add additional contextual details when appropriate.\nGhost will automatically add footnote content to the very end of your post.\n\nFull HTML\nPerhaps the best part of Markdown is that you're never limited to just Markdown.\nYou can write HTML directly in the Ghost editor and it will just work as HTML\nusually does. No limits! Here's a standard YouTube embed code as an example:\n\n\n--------------------------------------------------------------------------------\n\n 1. Foxes are red ↩︎\n    \n    \n 2. Dogs are usually not red ↩︎",
+                        "feature_image": "https://casper.ghost.org/v1.0.0/images/advanced.jpg",
+                        "featured": 0,
+                        "page": 0,
+                        "status": "published",
+                        "locale": null,
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "author_id": "5951f5fca366002ebd5dbef7",
+                        "created_at": "2017-09-01T12:29:50.000Z",
+                        "created_by": "5951f5fca366002ebd5dbef7",
+                        "updated_at": "2017-09-01T12:29:50.000Z",
+                        "updated_by": "5951f5fca366002ebd5dbef7",
+                        "published_at": "2017-09-01T12:29:51.000Z",
+                        "published_by": "5951f5fca366002ebd5dbef7",
+                        "custom_excerpt": null,
+                        "codeinjection_head": null,
+                        "codeinjection_foot": null,
+                        "og_image": null,
+                        "og_title": null,
+                        "og_description": null,
+                        "twitter_image": null,
+                        "twitter_title": null,
+                        "twitter_description": null
                     }
                 ],
                 "posts_tags": [
@@ -185,6 +219,34 @@
                         "created_by": "1",
                         "updated_at": "2017-09-01T12:30:59.000Z",
                         "updated_by": "1"
+                    },
+                    {
+                        "id": "5951f5fca366002ebd5dbef10",
+                        "name": "Joe Blogg's Father",
+                        "slug": "joe-bloggs-father",
+                        "ghost_auth_access_token": null,
+                        "ghost_auth_id": null,
+                        "password": "$2a$10$.pZeeBE0gHXd0PTnbT/ph.GEKgd0Wd3q2pWna3ynTGBkPKnGIKABC",
+                        "email": "jbloggsfather@example.com",
+                        "profile_image": "/content/images/2017/05/authorlogo.jpeg",
+                        "cover_image": "/content/images/2017/05/authorcover.jpeg",
+                        "bio": "I'm Joe's father, the good looking one!",
+                        "website": "http://joebloggsfather.com",
+                        "location": null,
+                        "facebook": null,
+                        "twitter": null,
+                        "accessibility": null,
+                        "status": "active",
+                        "locale": "en_US",
+                        "visibility": "public",
+                        "meta_title": null,
+                        "meta_description": null,
+                        "tour": "[\"getting-started\",\"using-the-editor\",\"static-post\",\"featured-post\",\"upload-a-theme\"]",
+                        "last_seen": "2017-07-01T12:30:37.000Z",
+                        "created_at": "2017-09-01T12:29:51.000Z",
+                        "created_by": "1",
+                        "updated_at": "2017-09-01T12:30:59.000Z",
+                        "updated_by": "1"
                     }
                 ],
                 "posts_authors": [
@@ -217,6 +279,23 @@
                         "post_id": "59a952be7d79ed06b0d21127",
                         "author_id": "5951f5fca366002ebd5dbef9",
                         "sort_order": 4
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18478",
+                        "post_id": "59a952be7d79ed06b0d21129",
+                        "author_id": "5951f5fca366002ebd5dbef9",
+                        "sort_order": 0
+                    },
+                    {
+                        "id": "5a8c0aa22a49c40927b18479",
+                        "post_id": "59a952be7d79ed06b0d21129",
+                        "author_id": "5951f5fca366002ebd5dbefff",
+                        "sort_order": 1
+                    },                    {
+                        "id": "5a8c0aa22a49c40927b18479",
+                        "post_id": "59a952be7d79ed06b0d21129",
+                        "author_id": "5951f5fca366002ebd5dbef10",
+                        "sort_order": 2
                     }
                 ]
             }

--- a/core/test/utils/fixtures/filter-param/index.js
+++ b/core/test/utils/fixtures/filter-param/index.js
@@ -1,9 +1,9 @@
 /**
  * These fixtures are just for testing the filter spec
  */
-var _    = require('lodash'),
+var _ = require('lodash'),
     ObjectId = require('bson-objectid'),
-    db   = require('../../../../server/data/db'),
+    db = require('../../../../server/data/db'),
     markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc,
     data = {};
 
@@ -317,7 +317,8 @@ function createTags(knex, DataGenerator) {
 }
 
 function createPosts(knex, DataGenerator) {
-    var postsTags = [];
+    var postsTags = [], postsAuthors = [];
+
     data.posts = _.map(data.posts, function (post) {
         post = DataGenerator.forKnex.createPost(post);
 
@@ -333,10 +334,20 @@ function createPosts(knex, DataGenerator) {
         return post;
     });
 
+    _.each(data.posts, function (post) {
+        postsAuthors.push({
+            id: ObjectId.generate(),
+            post_id: post.id,
+            author_id: post.author_id
+        });
+    });
+
     // Next, insert it into the database & return the correctly indexed data
     return writeFetchFix(knex, 'posts').then(function (createdPosts) {
         return knex('posts_tags').insert(postsTags).then(function () {
             return createdPosts;
+        }).then(function () {
+            return knex('posts_authors').insert(postsAuthors);
         });
     });
 }

--- a/core/test/utils/mocks/knex.js
+++ b/core/test/utils/mocks/knex.js
@@ -18,7 +18,7 @@ class KnexMock {
     initialiseDb() {
         this.db = {};
 
-        _.each(_.pick(_.cloneDeep(DataGenerator.forKnex), ['posts', 'users', 'tags', 'permissions', 'roles']), (objects, tableName) => {
+        _.each(_.pick(_.cloneDeep(DataGenerator.forKnex), ['posts', 'users', 'tags', 'permissions', 'roles', 'posts_authors']), (objects, tableName) => {
             this.db[tableName] = [];
 
             _.each(objects, (object) => {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ghost-storage-base": "0.0.1",
     "glob": "5.0.15",
     "got": "7.1.0",
-    "gscan": "1.3.4",
+    "gscan": "1.4.0",
     "html-to-text": "3.3.0",
     "image-size": "0.6.2",
     "intl": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "express-hbs": "1.0.4",
     "extract-zip": "1.6.6",
     "fs-extra": "3.0.1",
-    "ghost-gql": "0.0.8",
+    "ghost-gql": "0.0.9",
     "ghost-ignition": "2.9.0",
     "ghost-storage-base": "0.0.1",
     "glob": "5.0.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,9 +2124,9 @@ getsetdeep@~2.0.0:
   dependencies:
     typechecker "~2.0.1"
 
-ghost-gql@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/ghost-gql/-/ghost-gql-0.0.8.tgz#630410cf1f71ccffbdab3d9d01419981c794b0ce"
+ghost-gql@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/ghost-gql/-/ghost-gql-0.0.9.tgz#46b80b07651e71fac77b94d8fabf688baabf2c32"
   dependencies:
     lodash "^4.17.4"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,8 +115,8 @@ analytics-node@2.4.1:
     superagent-retry "^0.6.0"
 
 ansi-escapes@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -476,10 +476,11 @@ bignumber.js@4.0.4:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.4.tgz#7c40f5abcd2d6623ab7b99682ee7db81b11889a4"
 
 bl@^1.0.0, bl@^1.0.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.1.tgz#cac328f7bee45730d404b692203fcb590e172d5e"
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
   dependencies:
-    readable-stream "^2.0.5"
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
 
 bl@~0.4.1:
   version "0.4.2"
@@ -621,6 +622,10 @@ buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
+buffer-from@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.0.0.tgz#4cb8832d23612589b0406e9e2956c17f06fdf531"
+
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
@@ -713,8 +718,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000815"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000815.tgz#0e218fa133d0d071c886aa041b435258cc746891"
+  version "1.0.30000820"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000820.tgz#7c20e25cea1768b261b724f82e3a6a253aaa1468"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -847,12 +852,12 @@ cliui@^3.0.3:
     wrap-ansi "^2.0.0"
 
 clone@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.3.tgz#298d7e2231660f40c003c2ed3140decf3f53085f"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
 
 clone@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
 
 co@^4.6.0:
   version "4.6.0"
@@ -952,8 +957,8 @@ commander@2.9.0:
     graceful-readlink ">= 1.0.0"
 
 commander@^2.13.0, commander@^2.9.0, commander@~2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.0.tgz#ad2a23a1c3b036e392469b8012cec6b33b4c1322"
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
@@ -1003,9 +1008,10 @@ concat-stream@1.6.0:
     typedarray "^0.0.6"
 
 concat-stream@^1.4.1, concat-stream@^1.5.0, concat-stream@^1.6.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.1.tgz#261b8f518301f1d834e36342b9fea095d2620a26"
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   dependencies:
+    buffer-from "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
@@ -1468,8 +1474,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.39"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.39.tgz#d7a4696409ca0995e2750156da612c221afad84d"
+  version "1.3.40"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz#1fbd6d97befd72b8a6f921dc38d22413d2f6fddf"
 
 emits@^3.0.0:
   version "3.0.0"
@@ -1551,9 +1557,52 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@4.19.0, eslint@^4.0.0:
+eslint@4.19.0:
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.0.tgz#9e900efb5506812ac374557034ef6f5c3642fc4c"
+  dependencies:
+    ajv "^5.3.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^3.7.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^3.5.4"
+    esquery "^1.0.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.0.1"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^1.0.1"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "4.0.2"
+    text-table "~0.2.0"
+
+eslint@^4.0.0:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -1952,8 +2001,8 @@ form-data@^2.3.1, form-data@~2.3.1:
     mime-types "^2.1.12"
 
 formidable@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.0.tgz#ce291bfec67c176e282f891ece2c37de0c83ae84"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -1987,7 +2036,7 @@ fs-extra@^0.26.2:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-minipass@^1.2.3:
+fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
   dependencies:
@@ -2195,8 +2244,8 @@ global-prefix@^1.0.1:
     which "^1.2.14"
 
 globals@^11.0.1:
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.3.0.tgz#e04fdb7b9796d8adac9c8f64c14837b2313378b0"
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.4.0.tgz#b85c793349561c16076a3c13549238a27945f1bc"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2968,8 +3017,8 @@ is-path-cwd@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
 
 is-path-in-cwd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz#5ac48b345ef675339bd6c7a48a912110b241cf52"
   dependencies:
     is-path-inside "^1.0.0"
 
@@ -3537,8 +3586,8 @@ loud-rejection@^1.0.0:
     signal-exit "^3.0.0"
 
 lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
 lru-cache@2:
   version "2.7.3"
@@ -3667,8 +3716,8 @@ methods@^1.1.1, methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
 micromatch@^3.0.4:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.9.tgz#15dc93175ae39e52e93087847096effc73efcf89"
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
     arr-diff "^4.0.0"
     array-unique "^0.3.2"
@@ -3682,7 +3731,7 @@ micromatch@^3.0.4:
     object.pick "^1.3.0"
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
-    to-regex "^3.0.1"
+    to-regex "^3.0.2"
 
 "mime-db@>= 1.33.0 < 2", mime-db@~1.33.0:
   version "1.33.0"
@@ -3763,10 +3812,11 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.1.tgz#5ada97538b1027b4cf7213432428578cb564011f"
+minipass@^2.2.1, minipass@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.4.tgz#03c824d84551ec38a8d1bb5bc350a5a30a354a40"
   dependencies:
+    safe-buffer "^5.1.1"
     yallist "^3.0.0"
 
 minizlib@^1.1.0:
@@ -4653,8 +4703,8 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.14:
-  version "6.0.20"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.20.tgz#686107e743a12d5530cb68438c590d5b2bf72c3c"
+  version "6.0.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.21.tgz#8265662694eddf9e9a5960db6da33c39e4cd069d"
   dependencies:
     chalk "^2.3.2"
     source-map "^0.6.1"
@@ -4668,8 +4718,8 @@ posthtml-parser@^0.2.0:
     isobject "^2.1.0"
 
 posthtml-render@^1.0.5:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.1.tgz#a5ff704a6787c835a476eebff747e39f14069788"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/posthtml-render/-/posthtml-render-1.1.2.tgz#1755717c3ad12f4e6d8846767fa2f0bafdd7f33f"
 
 posthtml@^0.9.0:
   version "0.9.2"
@@ -4887,7 +4937,7 @@ readable-stream@2.3.3:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.5.tgz#b4f85003a938cbb6ecbce2a124fb1012bd1a838d"
   dependencies:
@@ -5039,8 +5089,8 @@ resolve@1.1.7, resolve@1.1.x, resolve@~1.1.0:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.4.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.6.0.tgz#0fbd21278b27b4004481c395349e7aba60a9ff5c"
   dependencies:
     path-parse "^1.0.5"
 
@@ -5697,14 +5747,15 @@ tar@^2.0.0:
     inherits "2"
 
 tar@^4:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.0.tgz#3aaf8c29b6b800a8215f33efb4df1c95ce2ac2f5"
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.1.tgz#b25d5a8470c976fd7a9a8a350f42c59e9fa81749"
   dependencies:
     chownr "^1.0.1"
-    fs-minipass "^1.2.3"
-    minipass "^2.2.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
     minizlib "^1.1.0"
     mkdirp "^0.5.0"
+    safe-buffer "^5.1.1"
     yallist "^3.0.2"
 
 tarn@^1.1.2:
@@ -5788,7 +5839,7 @@ to-regex-range@^2.1.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
 
-to-regex@^3.0.1:
+to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,9 +2531,9 @@ grunt@~0.4.0:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-gscan@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.3.4.tgz#24bd6f2a2e88d7cb9e6691f45e0d6f2c0de58471"
+gscan@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.4.0.tgz#c2df7f422d3094e012f96c8d3be4fa1463d3915f"
   dependencies:
     bluebird "^3.4.6"
     chalk "^1.1.1"


### PR DESCRIPTION
no issue

This PR will add the server side logic for multiple authors. This adds the ability to add  multiple authors per post. We keep and support single authors (maybe till the next major - this is still in discussion)

**NOTE: The client implementation will happen separately (probably till mid/end of march).**
**UPDATE:** Client PR is ready.

The commits are clean and contain information.

### key notes

- `authors` are not fetched by default, only if we need them
- the migration script iterates over all posts and figures out if an author_id is valid and exists (in master we can add invalid author_id's) and then adds the relation (falls back to owner if invalid)
- ~~i had to push a fork of bookshelf to npm because we currently can't bump bookshelf + the two bugs i discovered are anyway not yet merged (https://github.com/kirrg001/bookshelf/commits/master)~~ replaced by new bookshelf release
- the implementation of single & multiple authors lives in a single place (introduction of a new concept: model relation)
- if you destroy an author, we keep the behaviour for now -> remove all posts where the primary author id matches. furthermore, remove all relations in posts_authors (e.g. secondary author)
- we make re-use of the `excludeAttrs` concept which was invented in the contributors PR (to protect editing authors as author/contributor role) -> i've added a clear todo that we need a logic to make a diff of the target relation -> both for tags and authors
- `authors` helper available (same as `tags` helper)
- `primary_author` computed field available
- `primary_author` functionality available (same as `primary_tag` e.g. permalinks, prev/next helper etc)

### Tasks
- [x] fix travis
- [x] tests performance did not decrease
- [x] add migration script for DDL&DML
- [x] the migration script should figure out if you have invalid author id's stored and fallback to owner id (+create table)
- [x] test migration script with a larger DB
- [x] the importer must understand `posts_authors`
- [x] `primary_author` computed + functionality
- [x] PR's to bookshelf
- [x] use bookshelf fork of 0.10.3 for now
- [x] push side-fixes to master straight
- [x] clean commits
- [x] add more context to each commit if needed
- [x] add validation for the structure of `post.authors`
- [x] https://github.com/TryGhost/Ghost/pull/9426/commits/8299d2ff2129cc24c79dde6afb1c6dd4fb1a5843#diff-e712df50c0dc7cf33746eeff0564003cR34
- [x] change error message to "At least one author is required"
- [x] deny adding authors for now e.g. authors=[{name: 'test'}] - we don't have the id to update author_id -> tricky
- [x] permission layer - we must protect that you can't edit/add posts when sending authors[0] (depending on the role) - extend authors extension with `permissible`
- [x] test collision detecting with multiple authors
- [x] assert that deleting posts by author removes the authors relation (should work out of the box)
- [x] authors extensions
- [x] all tests green
- [x] unit tests
- [x] authors helper (like tags)
- [x] fetch authors if needed (but don't return them if not requested)
- [x] migrate with sqlite
- [x] ensure `{{get include=authors}}`
- [x] test exporter exports `posts_authors`
- [x] test sending invalid `author_id` -  this works currently on master, but doesn't anymore with multiple authors, because you can't insert a relationship which is invalid (will give you MySQL reference error) - this currently simply throws a validation error
- [x] extend permission layer (A: so we can deprecate `author_id` more easily and B: we don't require you to send `author_id`)
- [x] simplify migration script
- [x] has helper extension (use authors and not author)
- [x] has helper count functionality
- [x] gql bump + more filter tests for `filter=authors:`
- [x] replace `author` usage as much as possible (by primary_author)

### Meta Tasks

- [x] gscan bump (add `authors` helper)
- [x] add more deprecation notes in the code base
- [x] use newest bookshelf release when it's out (!)
- [x] documentation on themes.ghost.org + api.ghost.org
- [x] mark deprecated tests

### Test deprecation / old behaviour (nothing should break)
- [x] has helper
- [x] author helper
- [x] tags helper
- [x] ensure we don't break `fields=author`
- [x] ensure `?include=author` still works
- [x] ensure `{{get include=author}}` still works