### PR TITLE
Fix comment to reference 'facebook' instead of 'twitter'

### DIFF
--- a/core/server/helpers/facebook_url.js
+++ b/core/server/helpers/facebook_url.js
@@ -1,7 +1,7 @@
 // # Facebook URL Helper
 // Usage: `{{facebook_url}}` or `{{facebook_url author.facebook}}`
 //
-// Output a url for a twitter username
+// Output a url for a facebook username
 var proxy = require('./proxy'),
     socialUrls = proxy.socialUrls,
     localUtils = proxy.localUtils;


### PR DESCRIPTION
Just a one-word change in the comment. Doesn't affect any executable code at all.

I was reading through the code base to understand how helpers work. I noticed in `facebook_url` a mention of 'twitter username' and thought it was probably a mistake leftover from copying the `twitter_url` code.
