### PR TITLE
Increased importer perf by 50% and allow adding nested relations by foreign key

### DIFF
--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const debug = require('ghost-ignition').debug('importer:base'),
+    _ = require('lodash'),
+    Promise = require('bluebird'),
+    ObjectId = require('bson-objectid'),
     common = require('../../../../lib/common'),
     sequence = require('../../../../lib/promise/sequence'),
-    models = require('../../../../models'),
-    _ = require('lodash'),
-    Promise = require('bluebird');
+    models = require('../../../../models');
 
 class Base {
     constructor(allDataFromFile, options) {
@@ -29,9 +30,16 @@ class Base {
 
         this.dataKeyToImport = options.dataKeyToImport;
         this.dataToImport = _.cloneDeep(allDataFromFile[this.dataKeyToImport] || []);
+
         this.importedDataToReturn = [];
+        this.importedData = [];
+
+        this.options.requiredImportedData = ['users'];
+        this.options.requiredExistingData = ['users'];
 
         this.requiredFromFile = {};
+        this.requiredImportedData = {};
+        this.requiredExistingData = {};
 
         if (!this.options.requiredFromFile) {
             this.options.requiredFromFile = ['users'];
@@ -76,9 +84,20 @@ class Base {
         });
     }
 
+    generateIdentifier() {
+        _.each(this.dataToImport, (obj) => {
+            obj.id = ObjectId.generate();
+        });
+    }
+
+    fetchExisting() {
+        return Promise.resolve();
+    }
+
     beforeImport() {
         this.stripProperties(['id']);
         this.sanitizeValues();
+        this.generateIdentifier();
         return Promise.resolve();
     }
 
@@ -146,6 +165,130 @@ class Base {
         return Promise.reject(errorsToReject);
     }
 
+    /**
+     * Data is now prepared. Last step is to replace identifiers.
+     *
+     * `dataToImport`: the objects to import (contain the new ID already)
+     * `requiredExistingData`: the importer allows you to ask for existing database objects
+     * `requiredFromFile`: the importer allows you to ask for data from the file
+     * `requiredImportedData`: the importer allows you to ask for already imported data
+     */
+    replaceIdentifiers() {
+        const ownerUserId = _.find(this.requiredExistingData.users, (user) => {
+            if (user.roles[0].name === 'Owner') {
+                return true;
+            }
+        }).id;
+
+        let userReferenceProblems = {};
+
+        const handleObject = (obj, key) => {
+            if (!obj.hasOwnProperty(key)) {
+                return;
+            }
+
+            // CASE: you import null, fallback to owner
+            if (!obj[key]) {
+                if (!userReferenceProblems[obj.id]) {
+                    userReferenceProblems[obj.id] = {obj: obj, keys: []};
+                }
+
+                userReferenceProblems[obj.id].keys.push(key);
+                obj[key] = ownerUserId;
+                return;
+            }
+
+            // CASE: first match the user reference with in the imported file
+            let userFromFile = _.find(this.requiredFromFile.users, {id: obj[key]});
+
+            if (!userFromFile) {
+                // CASE: if user does not exist in file, try to lookup the existing db users
+                let existingUser = _.find(this.requiredExistingData.users, {id: obj[key].toString()});
+
+                // CASE: fallback to owner
+                if (!existingUser) {
+                    if (!userReferenceProblems[obj.id]) {
+                        userReferenceProblems[obj.id] = {obj: obj, keys: []};
+                    }
+
+                    userReferenceProblems[obj.id].keys.push(key);
+
+                    obj[key] = ownerUserId;
+                    return;
+                } else {
+                    // CASE: user exists in the database, ID is correct, skip
+                    return;
+                }
+            }
+
+            // CASE: users table is the first data we insert. we have no access to the imported data yet
+            // Result: `this.requiredImportedData.users` will be empty.
+            // We already generate identifiers for each object in the importer layer. Accessible via `dataToImport`.
+            if (this.modelName === 'User' && !this.requiredImportedData.users.length) {
+                let userToImport = _.find(this.dataToImport, {slug: userFromFile.slug});
+
+                if (userToImport) {
+                    obj[key] = userToImport.id;
+                    return;
+                } else {
+                    // CASE: unknown
+                    return;
+                }
+            }
+
+            // CASE: user exists in the file, let's find his db id
+            // NOTE: lookup by email, because slug can change on insert
+            let importedUser = _.find(this.requiredImportedData.users, {email: userFromFile.email});
+
+            // CASE: found. let's assign the new ID
+            if (importedUser) {
+                obj[key] = importedUser.id;
+                return;
+            }
+
+            // CASE: user was not imported, let's figure out if the user exists in the database
+            let existingUser = _.find(this.requiredExistingData.users, {slug: userFromFile.slug});
+
+            if (!existingUser) {
+                // CASE: let's try by ID
+                existingUser = _.find(this.requiredExistingData.users, {id: userFromFile.id.toString()});
+
+                if (!existingUser) {
+                    if (!userReferenceProblems[obj.id]) {
+                        userReferenceProblems[obj.id] = {obj: obj, keys: []};
+                    }
+
+                    userReferenceProblems[obj.id].keys.push(key);
+
+                    obj[key] = ownerUserId;
+                }
+            } else {
+                obj[key] = existingUser.id;
+            }
+        };
+
+        // Iterate over all possible user relations
+        _.each(this.dataToImport, (obj) => {
+            _.each([
+                'author_id',
+                'published_by',
+                'created_by',
+                'updated_by'
+            ], (key) => {
+                return handleObject(obj, key);
+            });
+        });
+
+        _.each(userReferenceProblems, (entry) => {
+            this.problems.push({
+                message: 'Entry was imported, but we were not able to resolve the following user references: ' +
+                entry.keys.join(', ') + '. The user does not exist, fallback to owner user.',
+                help: this.modelName,
+                context: JSON.stringify(entry.obj)
+            });
+        });
+    }
+
     doImport(options, importOptions) {
         debug('doImport', this.modelName, this.dataToImport.length);
 
@@ -162,6 +305,13 @@ class Base {
                         if (importOptions.returnImportedData) {
                             this.importedDataToReturn.push(importedModel.toJSON());
                         }
+
+                        // for identifier lookup
+                        this.importedData.push({
+                            id: importedModel.id,
+                            slug: importedModel.get('slug'),
+                            email: importedModel.get('email')
+                        });
 
                         return importedModel;
                     })
@@ -180,75 +330,6 @@ class Base {
          *       Promise.map(.., {concurrency: Int}) was not really improving the end performance for me.
          */
         return sequence(ops);
-    }
-
-    /**
-     * Update all user reference fields e.g. published_by
-     *
-     * Background:
-     *  - we never import the id field
-     *  - almost each imported model has a reference to a user reference
-     *  - we update all fields after the import (!)
-     */
-    afterImport(options) {
-        debug('afterImport', this.modelName);
-
-        return models.User.getOwnerUser(options)
-            .then((ownerUser) => {
-                return Promise.each(this.dataToImport, (obj) => {
-                    if (!obj.model) {
-                        return;
-                    }
-
-                    return Promise.each(['author_id', 'published_by', 'created_by', 'updated_by'], (key) => {
-                        // CASE: not all fields exist on each model, skip them if so
-                        if (!obj[key]) {
-                            return Promise.resolve();
-                        }
-
-                        let oldUser = _.find(this.requiredFromFile.users, {id: obj[key]});
-
-                        if (!oldUser) {
-                            this.problems.push({
-                                message: 'Entry was imported, but we were not able to update user reference field: ' +
-                                key + '. The user does not exist, fallback to owner user.',
-                                help: this.modelName,
-                                context: JSON.stringify(obj)
-                            });
-
-                            oldUser = {
-                                email: ownerUser.get('email')
-                            };
-                        }
-
-                        return models.User.findOne({
-                            email: oldUser.email,
-                            status: 'all'
-                        }, options).then((userModel) => {
-                            // CASE: user could not be imported e.g. multiple roles attached
-                            if (!userModel) {
-                                userModel = {
-                                    id: ownerUser.id
-                                };
-                            }
-
-                            let dataToEdit = {};
-                            dataToEdit[key] = userModel.id;
-
-                            let context;
-
-                            // CASE: updated_by is taken from the context object
-                            if (key === 'updated_by') {
-                                context = {context: {user: userModel.id}};
-                            } else {
-                                context = {};
-                            }
-
-                            return models[this.modelName].edit(dataToEdit, _.merge({}, options, {id: obj.model.id}, context));
-                        });
-                    });
-                });
-            });
     }
 }
 

--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -34,12 +34,21 @@ class Base {
         this.importedDataToReturn = [];
         this.importedData = [];
 
-        this.options.requiredImportedData = ['users'];
-        this.options.requiredExistingData = ['users'];
-
         this.requiredFromFile = {};
         this.requiredImportedData = {};
         this.requiredExistingData = {};
+
+        if (!this.options.requiredImportedData) {
+            this.options.requiredImportedData = ['users'];
+        } else {
+            this.options.requiredImportedData.push('users');
+        }
+
+        if (!this.options.requiredExistingData) {
+            this.options.requiredExistingData = ['users'];
+        } else {
+            this.options.requiredExistingData.push('users');
+        }
 
         if (!this.options.requiredFromFile) {
             this.options.requiredFromFile = ['users'];

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -66,6 +66,10 @@ class SettingsImporter extends BaseImporter {
         return super.beforeImport();
     }
 
+    generateIdentifier() {
+        return Promise.resolve();
+    }
+
     doImport(options) {
         debug('doImport', this.dataToImport.length);
 

--- a/core/server/data/importer/importers/data/tags.js
+++ b/core/server/data/importer/importers/data/tags.js
@@ -19,6 +19,13 @@ class TagsImporter extends BaseImporter {
         };
     }
 
+    fetchExisting(modelOptions) {
+        return models.Tag.findAll(_.merge({columns: ['id', 'slug']}, modelOptions))
+            .then((existingData) => {
+                this.existingData = existingData.toJSON();
+            });
+    }
+
     beforeImport() {
         debug('beforeImport');
         return super.beforeImport();
@@ -28,7 +35,7 @@ class TagsImporter extends BaseImporter {
      * Find tag before adding.
      * Background:
      *   - the tag model is smart enough to regenerate unique fields
-     *   - so if you import a tag name "test" and the same tag name exists, it would add "test-2"
+     *   - so if you import a tag slug "test" and the same tag slug exists, it would add "test-2"
      *   - that's why we add a protection here to first find the tag
      *
      * @TODO: Add a flag to the base implementation e.g. `fetchBeforeAdd`
@@ -56,6 +63,12 @@ class TagsImporter extends BaseImporter {
                             if (importOptions.returnImportedData) {
                                 this.importedDataToReturn.push(importedModel.toJSON());
                             }
+
+                            // for identifier lookup
+                            this.importedData.push({
+                                id: importedModel.id,
+                                slug: importedModel.get('slug')
+                            });
 
                             return importedModel;
                         })

--- a/core/server/data/importer/importers/data/tags.js
+++ b/core/server/data/importer/importers/data/tags.js
@@ -29,7 +29,7 @@ class TagsImporter extends BaseImporter {
      * Background:
      *   - the tag model is smart enough to regenerate unique fields
      *   - so if you import a tag name "test" and the same tag name exists, it would add "test-2"
-     *   - that's we add a protection here to first find the tag
+     *   - that's why we add a protection here to first find the tag
      *
      * @TODO: Add a flag to the base implementation e.g. `fetchBeforeAdd`
      */

--- a/core/server/data/importer/importers/data/users.js
+++ b/core/server/data/importer/importers/data/users.js
@@ -2,7 +2,8 @@
 
 const debug = require('ghost-ignition').debug('importer:users'),
     _ = require('lodash'),
-    BaseImporter = require('./base');
+    BaseImporter = require('./base'),
+    models = require('../../../../models');
 
 class UsersImporter extends BaseImporter {
     constructor(allDataFromFile) {
@@ -18,6 +19,13 @@ class UsersImporter extends BaseImporter {
             cover: 'cover_image',
             last_login: 'last_seen'
         };
+    }
+
+    fetchExisting(modelOptions) {
+        return models.User.findAll(_.merge({columns: ['id', 'slug', 'email'], withRelated: ['roles']}, modelOptions))
+            .then((existingData) => {
+                this.existingData = existingData.toJSON();
+            });
     }
 
     /**

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -44,7 +44,7 @@ ghostBookshelf.plugin(plugins.collision);
 
 // Manages nested updates (relationships)
 ghostBookshelf.plugin('bookshelf-relations', {
-    allowedOptions: ['context'],
+    allowedOptions: ['context', 'importing'],
     unsetRelations: true,
     hooks: {
         belongsToMany: {
@@ -179,7 +179,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
             }
         }
 
-        this.set('updated_by', this.contextUser(options));
+        if (!options.importing) {
+            this.set('updated_by', this.contextUser(options));
+        }
 
         if (!newObj.get('created_at')) {
             newObj.set('created_at', new Date());
@@ -210,7 +212,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      *   - if no context
      */
     onUpdating: function onUpdating(newObj, attr, options) {
-        this.set('updated_by', this.contextUser(options));
+        if (!options.importing) {
+            this.set('updated_by', this.contextUser(options));
+        }
 
         if (options && options.context && !options.internal && !options.importing) {
             if (newObj.hasDateChanged('created_at', {beforeWrite: true})) {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -211,7 +211,7 @@ Post = ghostBookshelf.Model.extend({
             //  and deduplicate upper/lowercase tags
             _.each(this.get('tags'), function each(item) {
                 for (i = 0; i < tagsToSave.length; i = i + 1) {
-                    if (tagsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
+                    if (tagsToSave[i].name && item.name && tagsToSave[i].name.toLocaleLowerCase() === item.name.toLocaleLowerCase()) {
                         return;
                     }
                 }

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -54,7 +54,7 @@ describe('Import', function () {
             }).catch(done);
         });
 
-        it('removes duplicate posts', function (done) {
+        it('removes duplicate posts, cares about invalid dates', function (done) {
             var exportData;
 
             testUtils.fixtures.loadExportFixture('export-003', {lts: true}).then(function (exported) {
@@ -63,7 +63,26 @@ describe('Import', function () {
             }).then(function (importResult) {
                 should.exist(importResult.data.posts);
                 importResult.data.posts.length.should.equal(1);
-                importResult.problems.length.should.eql(3);
+                importResult.problems.length.should.eql(4);
+
+                importResult.problems[0].message.should.eql('Entry was imported, but we were not able to ' +
+                    'resolve the following user references: updated_by. The user does not exist, fallback to owner user.');
+                importResult.problems[0].help.should.eql('User');
+
+                importResult.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+                importResult.problems[1].help.should.eql('User');
+
+                importResult.problems[2].message.should.eql('Date is in a wrong format and invalid. ' +
+                    'It was replaced with the current timestamp.');
+                importResult.problems[2].help.should.eql('Post');
+
+                importResult.problems[3].message.should.eql('Theme not imported, please upload in Settings - Design');
+                importResult.problems[3].help.should.eql('Settings');
+
+                moment(importResult.data.posts[0].created_at).isValid().should.eql(true);
+                moment(importResult.data.posts[0].updated_at).format().should.eql('2013-10-18T23:58:44Z');
+                moment(importResult.data.posts[0].published_at).format().should.eql('2013-12-29T11:58:30Z');
+                moment(importResult.data.tags[0].updated_at).format().should.eql('2016-07-17T12:02:54Z');
 
                 done();
             }).catch(done);
@@ -91,6 +110,7 @@ describe('Import', function () {
 
             testUtils.fixtures.loadExportFixture('export-003-duplicate-tags', {lts: true}).then(function (exported) {
                 exportData = exported;
+
                 return dataImporter.doImport(exportData, importOptions);
             }).then(function (importResult) {
                 should.exist(importResult.data.tags);
@@ -106,30 +126,40 @@ describe('Import', function () {
                     return postTag.tag_id !== 2;
                 });
 
-                importResult.problems.length.should.equal(3);
+                importResult.problems.length.should.equal(4);
 
-                importResult.problems[2].message.should.equal('Theme not imported, please upload in Settings - Design');
+                importResult.problems[0].message.should.eql('Entry was imported, but we were not able to ' +
+                    'resolve the following user references: updated_by. The user does not exist, fallback to owner user.');
+                importResult.problems[0].help.should.eql('User');
+
+                importResult.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+                importResult.problems[1].help.should.eql('User');
+
+                importResult.problems[2].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+                importResult.problems[2].help.should.eql('Tag');
+
+                importResult.problems[3].message.should.eql('Theme not imported, please upload in Settings - Design');
+                importResult.problems[3].help.should.eql('Settings');
 
                 done();
             }).catch(done);
         });
 
-        it('cares about invalid dates', function (done) {
+        it('removes broken tags from post (not in db, not in file)', function (done) {
             var exportData;
 
-            testUtils.fixtures.loadExportFixture('export-003', {lts: true}).then(function (exported) {
+            testUtils.fixtures.loadExportFixture('export-003-broken-tags', {lts: true}).then(function (exported) {
                 exportData = exported;
+
                 return dataImporter.doImport(exportData, importOptions);
-            }).then(function (importResult) {
-                should.exist(importResult.data.posts);
-                importResult.data.posts.length.should.equal(1);
-                importResult.problems.length.should.eql(3);
-
-                moment(importResult.data.posts[0].created_at).isValid().should.eql(true);
-                moment(importResult.data.posts[0].updated_at).format().should.eql('2013-10-18T23:58:44Z');
-                moment(importResult.data.posts[0].published_at).format().should.eql('2013-12-29T11:58:30Z');
-                moment(importResult.data.tags[0].updated_at).format().should.eql('2016-07-17T12:02:54Z');
-
+            }).then(function () {
+                return Promise.all([
+                    models.Post.findPage({withRelated: ['tags']})
+                ]);
+            }).then(function (data) {
+                data[0].posts.length.should.eql(1);
+                data[0].posts[0].slug.should.eql('welcome-to-ghost-2');
+                data[0].posts[0].tags.length.should.eql(0);
                 done();
             }).catch(done);
         });
@@ -392,7 +422,7 @@ describe('Import', function () {
             }).then(function () {
                 done(new Error('Allowed import of duplicate data'));
             }).catch(function (response) {
-                response.length.should.equal(4);
+                response.length.should.equal(3);
 
                 // NOTE: a duplicated tag.slug is a warning
                 response[0].errorType.should.equal('ValidationError');
@@ -400,9 +430,8 @@ describe('Import', function () {
                 response[1].errorType.should.equal('ValidationError');
                 response[1].message.should.eql('Value in [posts.title] cannot be blank.');
                 response[2].errorType.should.equal('ValidationError');
-                response[2].message.should.eql('Value in [tags.name] cannot be blank.');
-                response[3].errorType.should.equal('ValidationError');
-                response[3].message.should.eql('Value in [settings.key] cannot be blank.');
+                response[2].message.should.eql('Value in [settings.key] cannot be blank.');
+
                 done();
             }).catch(done);
         });
@@ -416,13 +445,17 @@ describe('Import', function () {
             }).then(function (importedData) {
                 importedData.data.posts.length.should.eql(1);
 
-                importedData.problems.length.should.eql(3);
-                importedData.problems[0].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
-                importedData.problems[0].help.should.eql('Tag');
+                importedData.problems.length.should.eql(4);
+
+                importedData.problems[0].message.should.eql('Entry was imported, but we were not able to ' +
+                    'resolve the following user references: updated_by. The user does not exist, fallback to owner user.');
+                importedData.problems[0].help.should.eql('User');
                 importedData.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
                 importedData.problems[1].help.should.eql('Tag');
                 importedData.problems[2].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
-                importedData.problems[2].help.should.eql('Post');
+                importedData.problems[2].help.should.eql('Tag');
+                importedData.problems[3].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+                importedData.problems[3].help.should.eql('Post');
                 done();
             }).catch(done);
         });
@@ -437,9 +470,16 @@ describe('Import', function () {
                 // NOTE: we detect invalid author references as warnings, because ember can handle this
                 // The owner can simply update the author reference in the UI
                 importedData.problems.length.should.eql(3);
+
+                importedData.problems[0].message.should.eql('Entry was imported, but we were not able to resolve the ' +
+                    'following user references: updated_by. The user does not exist, fallback to owner user.');
+                importedData.problems[0].help.should.eql('User');
+
+                importedData.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+                importedData.problems[1].help.should.eql('User');
+
                 importedData.problems[2].message.should.eql('Entry was imported, but we were not able to ' +
-                    'update user reference field: published_by. The user does not exist, fallback to owner user.');
-                importedData.problems[2].help.should.eql('Post');
+                    'resolve the following user references: author_id, published_by. The user does not exist, fallback to owner user.');
 
                 // Grab the data from tables
                 return Promise.all([
@@ -1530,11 +1570,15 @@ describe('Import (new test structure)', function () {
 
                     // Check feature image is correctly mapped for a post
                     firstPost.feature_image.should.eql('/content/images/2017/05/post-image.jpg');
+
                     // Check logo and cover images are correctly mapped for a user
                     users[1].cover_image.should.eql(exportData.data.users[0].cover);
                     users[1].profile_image.should.eql(exportData.data.users[0].image);
                     // Check feature image is correctly mapped for a tag
                     tags[0].feature_image.should.eql(exportData.data.tags[0].image);
+
+                    // updated_by: 2 could not be resolved, fallback to owner
+                    settings[5].updated_by.should.eql(users[0].id);
 
                     // Check logo image is correctly mapped for a blog
                     settings[5].key.should.eql('logo');

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -427,8 +427,10 @@ describe('Import', function () {
                 // NOTE: a duplicated tag.slug is a warning
                 response[0].errorType.should.equal('ValidationError');
                 response[0].message.should.eql('Value in [tags.name] cannot be blank.');
+
                 response[1].errorType.should.equal('ValidationError');
                 response[1].message.should.eql('Value in [posts.title] cannot be blank.');
+
                 response[2].errorType.should.equal('ValidationError');
                 response[2].message.should.eql('Value in [settings.key] cannot be blank.');
 
@@ -480,6 +482,7 @@ describe('Import', function () {
 
                 importedData.problems[2].message.should.eql('Entry was imported, but we were not able to ' +
                     'resolve the following user references: author_id, published_by. The user does not exist, fallback to owner user.');
+                importedData.problems[2].help.should.eql('Post');
 
                 // Grab the data from tables
                 return Promise.all([
@@ -527,11 +530,9 @@ describe('Import', function () {
             }).then(function () {
                 done(new Error('Allowed import of invalid tags data'));
             }).catch(function (response) {
-                response.length.should.equal(2);
+                response.length.should.equal(1);
                 response[0].errorType.should.equal('ValidationError');
                 response[0].message.should.eql('Value in [tags.name] cannot be blank.');
-                response[1].errorType.should.equal('ValidationError');
-                response[1].message.should.eql('Value in [tags.name] cannot be blank.');
                 done();
             }).catch(done);
         });

--- a/core/test/utils/fixtures/export/lts/export-003-broken-tags.json
+++ b/core/test/utils/fixtures/export/lts/export-003-broken-tags.json
@@ -1,0 +1,44 @@
+{
+    "meta": {
+        "exported_on": 1388318311015,
+        "version": "003"
+    },
+    "data": {
+        "posts": [
+            {
+                "id": 2,
+                "uuid": "8492fbba-1102-4b53-8e3e-abe207952f0c",
+                "title": "Welcome to Ghost",
+                "slug": "welcome-to-ghost-2",
+                "markdown": "You're live! Nice.",
+                "html": "<p>You're live! Nice.</p>",
+                "image": null,
+                "featured": 0,
+                "page": 0,
+                "status": "published",
+                "language": "en_US",
+                "meta_title": null,
+                "meta_description": null,
+                "author_id": 1,
+                "created_at": 1388318310782,
+                "created_by": 1,
+                "updated_at": 1388318310782,
+                "updated_by": 1,
+                "published_at": 1388318310783,
+                "published_by": 1
+            }
+        ],
+        "posts_tags": [
+            {
+                "id": 1,
+                "post_id": 2,
+                "tag_id": 100
+            },
+            {
+                "id": 2,
+                "post_id": 2,
+                "tag_id": 200
+            }
+        ]
+    }
+}

--- a/core/test/utils/fixtures/export/lts/export-003-mu.json
+++ b/core/test/utils/fixtures/export/lts/export-003-mu.json
@@ -131,7 +131,7 @@
                 "created_at": 1388319501897,
                 "created_by": 1,
                 "updated_at": null,
-                "updated_by": null
+                "updated_by": 10
             },
             {
                 "id": 3,

--- a/core/test/utils/fixtures/export/lts/export-lts-legacy-fields.json
+++ b/core/test/utils/fixtures/export/lts/export-lts-legacy-fields.json
@@ -1366,7 +1366,7 @@
                 "created_at": "2016-10-28T13:43:36.000Z",
                 "created_by": 1,
                 "updated_at": "2017-05-30T12:03:55.000Z",
-                "updated_by": 1
+                "updated_by": 2
             },
             {
                 "id": 10,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bluebird": "3.5.1",
     "body-parser": "1.18.2",
     "bookshelf": "0.10.3",
-    "bookshelf-relations": "0.1.5",
+    "bookshelf-relations": "0.1.10",
     "brute-knex": "https://github.com/cobbspur/brute-knex/tarball/8979834383c7d3ee868d9e18d9ee6f71976dfec4",
     "bson-objectid": "1.2.2",
     "chalk": "1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -538,9 +538,9 @@ body-parser@~1.14.0:
     raw-body "~2.1.5"
     type-is "~1.6.10"
 
-bookshelf-relations@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-0.1.5.tgz#514b3b83874113540634430b15a8d8ac7e203fe1"
+bookshelf-relations@0.1.10:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/bookshelf-relations/-/bookshelf-relations-0.1.10.tgz#91ad66e8d6800dc043241a0738a8515df5e394bc"
   dependencies:
     bluebird "^3.4.1"
     ghost-ignition "^2.8.16"


### PR DESCRIPTION
no issue

## Speed improvement

- *change behaviour from updating user references after the actual import to update the user reference before the actual import*
  - updating user references after the import is way less case intense
  - that was the initial decision for updating the references afterwards (was easier to implement)
  - but that does not play well with adding nested relations by identifier (foreign key)
- the refactoring is required for multiple authors
  - if we e.g. store invalid author id's, we won't be able to add a belongs-to-many relation for multiple authors
  - bookshelf-relations is generic and always tries to find a matching target before attching a model
  - invalid user references in the database are in general not acceptable
  - we have to keep backwards compatibility in the importer
  - e.g. you import `author_id`, we have to detect that and insert the correct `post_authors` relation
  - but if we try to add `posts_authors` with an invalid `author_id`, bookshelf-relations will complain, because it ensures that adding nested relations requires a valid and existent target (**it does not allow adding broken references to the database**)


### This change has a very good side affect
  - 17mb takes on master ~1,5m
    - on this branch it takes ~42seconds 🙊
  - 40mb times out on master
    - on this branch it takes 1,5m
  - memory looks like the same

---

## Insert nested tags by foreign key

- because of the importer change, we can proof that adding nested relations by foreign key works
- `tags` runs already through bookshelf-relations
- replace logic for preparing nested tags
  - we added nested relations by `name`
  - this is not needed, because the matching tag was already imported
  - also: the notation `post.tags=[{name: 'x'}]` doesn't even make use of the target tag id
  - bookshelf-relations is smart and can handle that case, but this notation looks like you would like to add a tag
  - adding nested tags by `name` can also trouble, because `name` is not even unique (!)
- what we do now
  - we simply would like to add the relationship to the database
  - use same approach as base class
  - add `posts_tags` to target post model
  - update identifiers
  - insert relation by foreign key `tag_id` e.g. `post.tags=[{tag_id: '...'}]`
- bump bookshelf-relations to 0.1.10 (which supports attaching relations by foreign key)

---

- [x] tested example files in the browser
- [x] push side-fixes to master straight (!)

@cobbspur I've assigned you. To A: share knowledge that we refactored a piece of the importer and B: it would be great if you could do a second browser test and compare the result 👍 The importer still works like the same, it's just faster. You don't have to review the code.