### PR TITLE
Reordered error logging on ghost start

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,11 @@ ghost().then(function (ghostServer) {
         err = new common.errors.GhostError({err: err});
     }
 
+    common.logging.error(err);
+
     if (process.send) {
         process.send({started: false, error: err.message});
     }
 
-    common.logging.error(err);
     process.exit(-1);
 });


### PR DESCRIPTION
no issue

- if we trigger the IPC message to the CLI and the process manager is systemd, systemd will restart Ghost too early (same for local process manager) - this is a timing issue
- the consequence is that the error log won't happen in Ghost (`content/logs/[domain].error.log`  won't contain that error)
- let's reorder both executions

[See](https://github.com/TryGhost/Ghost-CLI/pull/612/files#r165817172) this comment on the CLI PR.