### PR TITLE
Removed html usage in error messages

### DIFF
--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -28,8 +28,7 @@ function sendMail(object) {
                         type: 'warn',
                         message: [
                             common.i18n.t('warnings.index.unableToSendEmail'),
-                            common.i18n.t('common.seeLinkForInstructions',
-                                {link: '<a href=\'https://docs.ghost.org/v1/docs/mail-config\' target=\'_blank\'>Checkout our mail configuration docs!</a>'})
+                            common.i18n.t('common.seeLinkForInstructions', {link: 'https://docs.ghost.org/v1/docs/mail-config'})
                         ].join(' ')
                     }]
                 },

--- a/core/server/helpers/tpl/subscribe_form.hbs
+++ b/core/server/helpers/tpl/subscribe_form.hbs
@@ -11,5 +11,5 @@
 </form>
 
 {{#if error}}
-    <p class="main-error">{{{error.message}}}</p>
+    <p class="main-error">{{error.message}}</p>
 {{/if}}

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -233,7 +233,6 @@
                 "notEnoughPermission": "You do not have permission to perform this action",
                 "noUserWithEnteredEmailAddr": "There is no user with that email address.",
                 "userIsInactive": "The user with that email address is inactive.",
-                "incorrectPasswordAttempts": "Your password is incorrect. <br /> {remaining} attempt{s} remaining!",
                 "userUpdateError": {
                     "emailIsAlreadyInUse": "Email is already in use",
                     "context": "Error thrown from user update during login",
@@ -545,9 +544,7 @@
     },
     "notices": {
         "index": {
-            "welcomeToGhost": "Welcome to Ghost.",
-            "youAreRunningUnderEnvironment": "You're running under the <strong> {environment} </strong> environment.",
-            "yourURLisSetTo": "Your URL is set to <strong> {url} </strong>."
+            "welcomeToGhost": "Welcome to Ghost."
         },
         "httpServer": {
             "cantTouchThis": "Can't touch this",
@@ -572,9 +569,7 @@
         },
         "data": {
             "fixtures": {
-                "canSafelyDelete": "<!-- You can safely delete this line if your theme does not require jQuery -->\n",
-                "jQueryRemoved": "jQuery has been removed from Ghost core and is now being loaded from the jQuery Foundation's CDN.",
-                "canBeChanged": "This can be changed or removed in your <strong>Code Injection</strong> settings area."
+                "jQueryRemoved": "jQuery has been removed from Ghost core and is now being loaded from the jQuery Foundation's CDN."
             },
             "utils": {
                 "index": {


### PR DESCRIPTION
no issue

- all of the error message keys were unused
- the only html anchor i found was for mail, but this doesn't change anything, because the admin does only show the message and not the context at the moment

