### PR TITLE
Keep urls returned from store.getUniqueFileName() as-is

### DIFF
--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -31,27 +31,26 @@ class LocalFileStore extends StorageBase {
      * @returns {*}
      */
     save(image, targetDir) {
-        var targetFilename,
-            self = this;
+        var targetRelativeFilename,
+            targetAbsoluteFilename;
 
         // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
         targetDir = targetDir || this.getTargetDir(this.storagePath);
 
-        return this.getUniqueFileName(image, targetDir).then(function (filename) {
-            targetFilename = filename;
+        return Promise.all([
+            this.getUniqueFileName(image, targetDir, {useRelativePath: true}),
+            this.getUniqueFileName(image, targetDir, {useRelativePath: false})
+        ]).spread(function (relativeFilename, absoluteFilename) {
+            // This might look like 'content/images/2018/02/foo.jpg'
+            targetRelativeFilename = relativeFilename;
+            // This might look like '/blog/content/images/2018/02/foo.jpg' (i.e., it’s an URL)
+            targetAbsoluteFilename = absoluteFilename;
+
             return fs.mkdirs(targetDir);
         }).then(function () {
-            return fs.copy(image.path, targetFilename);
+            return fs.copy(image.path, targetRelativeFilename);
         }).then(function () {
-            // The src for the image must be in URI format, not a file system path, which in Windows uses \
-            // For local file system storage can use relative path so add a slash
-            var fullUrl = (
-                urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
-                    urlService.utils.STATIC_IMAGE_URL_PREFIX,
-                    path.relative(self.storagePath, targetFilename))
-            ).replace(new RegExp('\\' + path.sep, 'g'), '/');
-
-            return fullUrl;
+            return targetAbsoluteFilename;
         }).catch(function (e) {
             return Promise.reject(e);
         });
@@ -150,6 +149,29 @@ class LocalFileStore extends StorageBase {
                 resolve(bytes);
             });
         });
+    }
+
+    getUniqueFileName(image, targetDir, options) {
+        options = options || {};
+        const useRelativePath = options.useRelativePath || false;
+
+        return super.getUniqueFileName(image, targetDir)
+            .then((relativePath) => {
+                if (useRelativePath) {
+                    return relativePath;
+                } else {
+                    // The src for the image must be in URI format, not a file system path, which in Windows uses \
+                    // For local file system storage can use relative path so add a slash
+                    return urlService.utils
+                        .urlJoin(
+                            '/',
+                            urlService.utils.getSubdir(),
+                            urlService.utils.STATIC_IMAGE_URL_PREFIX,
+                            path.relative(this.storagePath, relativePath)
+                        )
+                        .replace(new RegExp('\\' + path.sep, 'g'), '/');
+                }
+            });
     }
 }
 

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -41,7 +41,7 @@ class LocalFileStore extends StorageBase {
             this.getUniqueFileName(image, targetDir, {useRelativePath: true}),
             this.getUniqueFileName(image, targetDir, {useRelativePath: false})
         ]).spread(function (relativeFilename, absoluteFilename) {
-            // This might look like 'content/images/2018/02/foo.jpg'
+            // This might look like '/var/www/content/images/2018/02/foo.jpg' (i.e., it’s a file system path)
             targetRelativeFilename = relativeFilename;
             // This might look like '/blog/content/images/2018/02/foo.jpg' (i.e., it’s an URL)
             targetAbsoluteFilename = absoluteFilename;

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -155,6 +155,9 @@ class LocalFileStore extends StorageBase {
         options = options || {};
         const useRelativePath = options.useRelativePath || false;
 
+        // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
+        targetDir = targetDir || this.getTargetDir(this.storagePath);
+
         return super.getUniqueFileName(image, targetDir)
             .then((relativePath) => {
                 if (useRelativePath) {

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -165,13 +165,15 @@ class LocalFileStore extends StorageBase {
                 } else {
                     // The src for the image must be in URI format, not a file system path, which in Windows uses \
                     // For local file system storage can use relative path so add a slash
-                    return urlService.utils
+                    const absolutePath = urlService.utils
                         .urlJoin(
                             '/',
                             urlService.utils.getSubdir(),
                             urlService.utils.STATIC_IMAGE_URL_PREFIX,
                             path.relative(this.storagePath, relativePath)
-                        )
+                        );
+
+                    return path.resolve(absolutePath)
                         .replace(new RegExp('\\' + path.sep, 'g'), '/');
                 }
             });

--- a/core/server/data/importer/handlers/image.js
+++ b/core/server/data/importer/handlers/image.js
@@ -37,9 +37,7 @@ ImageHandler = {
 
         return Promise.map(files, function (image) {
             return store.getUniqueFileName(image, image.targetDir).then(function (targetFilename) {
-                image.newPath = urlService.utils.urlJoin('/', urlService.utils.getSubdir(), urlService.utils.STATIC_IMAGE_URL_PREFIX,
-                    path.relative(config.getContentPath('images'), targetFilename));
-
+                image.newPath = targetFilename;
                 return image;
             });
         });

--- a/core/test/unit/adapters/storage/LocalFileStorage_spec.js
+++ b/core/test/unit/adapters/storage/LocalFileStorage_spec.js
@@ -227,6 +227,45 @@ describe('Local File System Storage', function () {
         });
     });
 
+    describe('getUniqueFileName', function () {
+        it('returns a modified file name if the original one is occupied', function (done) {
+            fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE.jpg')).resolves();
+            fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-1.jpg')).resolves();
+            fs.stat.withArgs(path.resolve('./content/images/2013/09/IMAGE-2.jpg')).rejects();
+
+            // windows setup
+            fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE.jpg')).resolves();
+            fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-1.jpg')).resolves();
+            fs.stat.withArgs(path.resolve('.\\content\\images\\2013\\Sep\\IMAGE-2.jpg')).rejects();
+
+            localFileStore.getUniqueFileName(image).then(function (url) {
+                url.should.equal('/content/images/2013/09/IMAGE-2.jpg');
+
+                done();
+            }).catch(done);
+        });
+
+        it('returns a relative file name if requested', function (done) {
+            localFileStore.getUniqueFileName(image, null, {useRelativePath: true})
+                .then(function (url) {
+                    url.should.equal(path.resolve(process.cwd(), 'content/images/2013/09/IMAGE.jpg'));
+
+                    done();
+                })
+                .catch(done);
+        });
+
+        it('respects the target directory', function (done) {
+            localFileStore.getUniqueFileName(image, '/fake/dir')
+                .then(function (url) {
+                    url.should.equal('/fake/dir/IMAGE.jpg');
+
+                    done();
+                })
+                .catch(done);
+        });
+    });
+
     // @TODO: remove path.join mock...
     describe('on Windows', function () {
         var truePathSep = path.sep;


### PR DESCRIPTION
no issue

This makes possible importing images with custom storage adapters. 

So:
- Ghost has an undocumented ability to import images (in addition to posts & users)
- The ability makes use of storage adapters
- However, Ghost modifies a path returned from the storage adapter making it impossible to upload the image somewhere and just return an URL

With this change, it becomes possible to write a custom storage adapter that imports images and returns full URLs. (I’m actually doing this in my fork of `ghost-storage-adapter-s3`: https://github.com/iamakulov/ghost-storage-adapter-s3/commit/98b5168f5bec9dbddab6c15979ac6610efd76cf0)

----

This PR would also make this phrase [in the docs](https://docs.ghost.org/v1/docs/using-a-custom-storage-module) irrelevant:

![image](https://user-images.githubusercontent.com/2953267/35924996-9be131e4-0c35-11e8-9ae3-2d4cf1e27db1.png)

I’m open to making a PR to remove it if we merge this.