### PR TITLE
✨ Add date support to the get helper

### DIFF
--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -61,10 +61,17 @@ function resolvePaths(data, value) {
         // Handle Handlebars .[] style arrays
         path = path.replace(/\.\[/g, '[');
 
-        // Do the query, and convert from array to string
-        result = jsonpath.query(data, path).join(',');
+        // Do the query, which always returns an array of matches
+        result = jsonpath.query(data, path);
 
-        return result;
+        // Handle the case where the single data property we return is a Date
+        // Data.toString() is not DB compatible, so use `toISOString()` instead
+        if (_.isDate(result[0])) {
+            result[0] = result[0].toISOString();
+        }
+
+        // Concatenate the results with a comma, handles common case of multiple tag slugs
+        return result.join(',');
     });
 
     return value;

--- a/core/test/unit/helpers/get_spec.js
+++ b/core/test/unit/helpers/get_spec.js
@@ -300,9 +300,11 @@ describe('{{#get}} helper', function () {
     });
 
     describe('path resolution', function () {
-        var browseStub, readStub, data = {
-            post: {id: 3, title: 'Test 3', author: {slug: 'cameron'}, tags: [{slug: 'test'}, {slug: 'magic'}]}
-        };
+        var browseStub, readStub,
+            pubDate = new Date(),
+            data = {
+                post: {id: 3, title: 'Test 3', author: {slug: 'cameron'}, tags: [{slug: 'test'}, {slug: 'magic'}], published_at: pubDate}
+            };
 
         beforeEach(function () {
             browseStub = sandbox.stub(api.posts, 'browse').returns(new Promise.resolve());
@@ -360,6 +362,20 @@ describe('{{#get}} helper', function () {
                 browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
                 browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
                 browseStub.firstCall.args[0].filter.should.eql('tags:test');
+
+                done();
+            }).catch(done);
+        });
+
+        it('should handle dates', function (done) {
+            helpers.get.call(
+                data,
+                'posts',
+                {hash: {filter: "published_at:<='{{post.published_at}}'"}, fn: fn, inverse: inverse}
+            ).then(function () {
+                browseStub.firstCall.args.should.be.an.Array().with.lengthOf(1);
+                browseStub.firstCall.args[0].should.be.an.Object().with.property('filter');
+                browseStub.firstCall.args[0].filter.should.eql(`published_at:<='${pubDate.toISOString()}'`);
 
                 done();
             }).catch(done);


### PR DESCRIPTION
Back when I originally implemented GQL & the Get helper, I thought that date comparisons didn't work at all in the API. Then recently, when re-implementing the previous/next feature using GQL, I realised that they do in fact work just fine.

I removed the comment from the get helper docs about them not working, and added examples for how queries worked in the api filtering docs.

What I totally missed is that there is _no possible way_ to inject a valid date into a get helper filter, unless you write it out manually:

- `{{#get "posts" filter="published_at:<='{{date}}'"}}` - doesn't work because date is a function helper, not a path helper, and get filters only support paths, and so we can't use this function to modify the format.

`{{#get "posts" filter="published_at:<='{{published_at}}'"}}` - should work, but doesn't because the standard JS Date.toString() function gets called, which outputs the Date in a weird custom format that no one else understands - particularly not databases.

This change looks for real dates being passed around, and calls` toISOString()` on them, before the inner workings of JavaScript gets a chance to call its pesky `toString()` function.

With this change, the following will now work as expected:

`{{#get "posts" filter="published_at:<='{{published_at}}'"}}{{/get}}`

Note to anyone viewing or testing this, when working with dates in filters, quotes are **required**.

----

- Date comparisons are possible via API, but there's no way to inject a valid date into the get helper
- JavaScript's Date.toString() function outputs dates in a useless format
- Swap to using Date.toISOString() and now the format can be understood anywhere!