### PR TITLE
Knex mock for unit testing && remove `isNew` usages

### DIFF
--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -131,7 +131,7 @@ User = ghostBookshelf.Model.extend({
          *     normal behaviour if not (set random password, lock user, and hash password)
          *   - no validations should run, when importing
          */
-        if (self.isNew() || self.hasChanged('password')) {
+        if (self.hasChanged('password')) {
             this.set('password', String(this.get('password')));
 
             // CASE: import with `importPersistUser` should always be an bcrypt password already,

--- a/core/test/integration/model/model_users_spec.js
+++ b/core/test/integration/model/model_users_spec.js
@@ -117,20 +117,6 @@ describe('User Model', function run() {
             }).catch(done);
         });
 
-        it('can set password of only numbers', function () {
-            var userData = testUtils.DataGenerator.forModel.users[0];
-
-            // avoid side-effects!
-            userData = _.cloneDeep(userData);
-            userData.password = 109674836589;
-
-            // mocha supports promises
-            return UserModel.add(userData, context).then(function (createdUser) {
-                should.exist(createdUser);
-                // cannot validate password
-            });
-        });
-
         it('can find by email and is case insensitive', function (done) {
             var userData = testUtils.DataGenerator.forModel.users[2],
                 email = testUtils.DataGenerator.forModel.users[2].email;

--- a/core/test/unit/models/user_spec.js
+++ b/core/test/unit/models/user_spec.js
@@ -1,14 +1,71 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
-    utils = require('../../utils'),
-
+    security = require('../../../server/lib/security'),
+    testUtils = require('../../utils'),
     sandbox = sinon.sandbox.create();
 
 describe('Models: User', function () {
+    let knexMock;
+
     before(function () {
         models.init();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('validation', function () {
+        before(function () {
+            knexMock = new testUtils.mocks.knex();
+            knexMock.mock();
+        });
+
+        beforeEach(function () {
+            sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+        });
+
+        after(function () {
+            knexMock.unmock();
+        });
+
+        describe('password', function () {
+            it('no password', function () {
+                return models.User.add({email: 'test1@ghost.org', name: 'Ghosty'})
+                    .then(function (user) {
+                        user.get('name').should.eql('Ghosty');
+                        should.exist(user.get('password'));
+                    });
+            });
+
+            it('only numbers', function () {
+                return models.User.add({email: 'test2@ghost.org', name: 'Wursti', password: 109674836589})
+                    .then(function (user) {
+                        user.get('name').should.eql('Wursti');
+                        should.exist(user.get('password'));
+                    });
+            });
+
+            it('can change password', function () {
+                let oldPassword;
+
+                return models.User.findOne({slug: 'joe-bloggs'})
+                    .then(function (user) {
+                        user.get('slug').should.eql('joe-bloggs');
+                        oldPassword = user.get('password');
+                        user.set('password', '12734!!332');
+                        return user.save();
+                    })
+                    .then(function (user) {
+                        user.get('slug').should.eql('joe-bloggs');
+                        user.get('password').should.not.eql(oldPassword);
+                    });
+            });
+        });
     });
 
     describe('Permissible', function () {
@@ -28,7 +85,7 @@ describe('Models: User', function () {
             var mockUser = getUserModel(1, 'Owner'),
                 context = {user: 1};
 
-            models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.owner, true, true).then(() => {
+            models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true).then(() => {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
                 error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -41,7 +98,7 @@ describe('Models: User', function () {
             var mockUser = getUserModel(3, 'Contributor'),
                 context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {}, utils.permissions.contributor, false, true).then(() => {
+            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true).then(() => {
                 should(mockUser.get.calledOnce).be.true();
             });
         });
@@ -51,7 +108,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, utils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -65,7 +122,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Administrator'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, utils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -79,7 +136,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Author'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, utils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -89,7 +146,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Contributor'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, utils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -99,7 +156,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 3};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -109,7 +166,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -123,7 +180,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Administrator'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -137,7 +194,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Author'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -147,7 +204,7 @@ describe('Models: User', function () {
                 var mockUser = getUserModel(3, 'Contributor'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, utils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });

--- a/core/test/utils/mocks/index.js
+++ b/core/test/utils/mocks/index.js
@@ -1,2 +1,3 @@
 exports.utils = require('./utils');
 exports.express = require('./express');
+exports.knex = require('./knex');

--- a/core/test/utils/mocks/knex.js
+++ b/core/test/utils/mocks/knex.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const mockKnex = require('mock-knex'),
+    _ = require('lodash'),
+    DataGenerator = require('../fixtures/data-generator'),
+    knex = require('../../../server/data/db').knex;
+
+/**
+ * Knex mock. The database is our Datagenerator.
+ * You can either self register queries or you simply rely on the data generator data.
+ *
+ * Please extend if you use-case does not work.
+ */
+class KnexMock {
+    initialiseDb() {
+        this.db = {};
+
+        _.each(_.pick(DataGenerator.Content, ['posts', 'users', 'tags', 'permissions', 'roles']), (objects, tableName) => {
+            this.db[tableName] = [];
+
+            _.each(objects, (object) => {
+                const lookup = {
+                    users: DataGenerator.forKnex.createUser,
+                    posts: DataGenerator.forKnex.createPost,
+                    tags: DataGenerator.forKnex.createTag,
+                    permissions: DataGenerator.forKnex.createPermission,
+                    roles: DataGenerator.forKnex.createRole,
+                };
+
+                this.db[tableName].push(lookup[tableName](object));
+            });
+        });
+    }
+
+    mock(options) {
+        options = options || {autoMock: true};
+        mockKnex.mock(knex);
+
+        this.initialiseDb();
+
+        this.tracker = mockKnex.getTracker();
+        this.tracker.install();
+
+        if (options.autoMock) {
+            this.tracker.on('query', (query) => {
+                if (query.method === 'select') {
+                    if (query.bindings.length && query.sql.match(/where/)) {
+                        query.sql = query.sql.replace(/`/g, '"');
+
+                        const tableName = query.sql.match(/from\s\"(\w+)\"/)[1],
+                            where = query.sql.match(/\"(\w+)\"\s\=\s\?/)[1],
+                            value = query.bindings[0],
+                            dbEntry = _.find(this.db[tableName], ((existing) => {
+                                if (existing[where] === value) {
+                                    return true;
+                                }
+                            }));
+
+                        if (dbEntry) {
+                            query.response([dbEntry]);
+                        } else {
+                            query.response([]);
+                        }
+                    }
+                } else if (query.method === 'insert') {
+                    query.sql = query.sql.replace(/`/g, '"');
+
+                    const tableName = query.sql.match(/into\s\"(\w+)\"/)[1];
+                    let keys = query.sql.match(/\(([^)]+)\)/)[1],
+                        entry = {};
+
+                    keys = keys.replace(/"/g, '');
+                    keys = keys.replace(/\s/g, '');
+                    keys = keys.split(',');
+
+                    _.each(keys, (key, index) => {
+                        entry[key] = query.bindings[index];
+                    });
+
+                    if (!this.db[tableName]) {
+                        this.db[tableName] = [];
+                    }
+
+                    this.db[tableName].push(entry);
+                    query.response(entry);
+                } else if (query.method === 'update') {
+                    query.sql = query.sql.replace(/`/g, '"');
+
+                    const tableName = query.sql.match(/update\s\"(\w+)\"/)[1],
+                        where = query.sql.match(/where\s\"(\w+)\"\s\=\s\?/)[1],
+                        value = query.bindings.slice(-1)[0],
+                        dbEntry = _.find(this.db[tableName], ((existing) => {
+                            if (existing[where] === value) {
+                                return true;
+                            }
+                        }));
+
+                    if (!dbEntry) {
+                        query.reject(new Error('not found'));
+                    } else {
+                        let keys = query.sql.match(/set(.*)where/)[1],
+                            entry = {};
+
+                        keys = keys.match(/\"\w+\"/g).join(',');
+                        keys = keys.replace(/"/g, '');
+                        keys = keys.replace(/\s/g, '');
+                        keys = keys.split(',');
+
+                        _.each(keys, (key, index) => {
+                            entry[key] = query.bindings[index];
+                            dbEntry[key] = entry[key];
+                        });
+
+                        query.response(entry);
+                    }
+                } else {
+                    query.reject(new Error('not implemented.'));
+                }
+            });
+        }
+
+        return this.tracker;
+    }
+
+    unmock() {
+        this.tracker.uninstall();
+        mockKnex.unmock(knex);
+    }
+}
+
+module.exports = KnexMock;

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "matchdep": "2.0.0",
     "minimist": "1.2.0",
     "mocha": "4.1.0",
+    "mock-knex": "0.4.0",
     "nock": "9.1.6",
     "rewire": "3.0.2",
     "should": "13.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3690,6 +3690,10 @@ lodash@^3.10.1, lodash@~3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.14.2:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 lodash@~0.9.2:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-0.9.2.tgz#8f3499c5245d346d682e5b0d3b40767e09f1a92c"
@@ -4040,6 +4044,14 @@ mocha@^3.1.2:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
+
+mock-knex@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mock-knex/-/mock-knex-0.4.0.tgz#32c4ed97ff7cf9c86eca2400902f34e1f7f88de1"
+  dependencies:
+    bluebird "^3.4.1"
+    lodash "^4.14.2"
+    semver "^5.3.0"
 
 moment-timezone@0.5.14:
   version "0.5.14"


### PR DESCRIPTION
Contains 2 commits.

1. Add a proper knex mock for unit testing (this is definitely not a full implementation, but should work for the basic cases for now - we can always improve).
2. Remove `model.isNew` usages - see commit details.

Will self merge. Just waiting for Travis 😜

Added more unit tests 😎 - the tests are much faster than adding them as model integration tests - i compared them - see commit details.
