### PR TITLE
POST requests now return 201 by default

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -34,7 +34,6 @@ var _ = require('lodash'),
     http,
     addHeaders,
     cacheInvalidationHeader,
-    locationHeader,
     contentDispositionHeaderExport,
     contentDispositionHeaderSubscribers,
     contentDispositionHeaderRedirects;
@@ -110,46 +109,6 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
 };
 
 /**
- * ### Location Header
- *
- * If the API request results in the creation of a new object, construct a Location: header which points to the new
- * resource.
- *
- * @private
- * @param {Express.request} req Original HTTP Request
- * @param {Object} result API method result
- * @return {String} Resolves to header string
- */
-locationHeader = function locationHeader(req, result) {
-    var apiRoot = urlService.utils.urlFor('api'),
-        location,
-        newObject,
-        statusQuery;
-
-    if (req.method === 'POST') {
-        if (result.hasOwnProperty('posts')) {
-            newObject = result.posts[0];
-            statusQuery = '/?status=' + newObject.status;
-            location = urlService.utils.urlJoin(apiRoot, 'posts', newObject.id, statusQuery);
-        } else if (result.hasOwnProperty('notifications')) {
-            newObject = result.notifications[0];
-            location = urlService.utils.urlJoin(apiRoot, 'notifications', newObject.id, '/');
-        } else if (result.hasOwnProperty('users')) {
-            newObject = result.users[0];
-            location = urlService.utils.urlJoin(apiRoot, 'users', newObject.id, '/');
-        } else if (result.hasOwnProperty('tags')) {
-            newObject = result.tags[0];
-            location = urlService.utils.urlJoin(apiRoot, 'tags', newObject.id, '/');
-        } else if (result.hasOwnProperty('webhooks')) {
-            newObject = result.webhooks[0];
-            location = urlService.utils.urlJoin(apiRoot, 'webhooks', newObject.id, '/');
-        }
-    }
-
-    return location;
-};
-
-/**
  * ### Content Disposition Header
  * create a header that invokes the 'Save As' dialog in the browser when exporting the database to file. The 'filename'
  * parameter is governed by [RFC6266](http://tools.ietf.org/html/rfc6266#section-4.3).
@@ -181,22 +140,11 @@ contentDispositionHeaderRedirects = function contentDispositionHeaderRedirects()
 
 addHeaders = function addHeaders(apiMethod, req, res, result) {
     var cacheInvalidation,
-        location,
         contentDisposition;
 
     cacheInvalidation = cacheInvalidationHeader(req, result);
     if (cacheInvalidation) {
         res.set({'X-Cache-Invalidate': cacheInvalidation});
-    }
-
-    if (req.method === 'POST') {
-        location = locationHeader(req, result);
-        if (location) {
-            res.set({Location: location});
-            // The location header indicates that a new object was created.
-            // In this case the status code should be 201 Created
-            res.status(201);
-        }
     }
 
     // Add Export Content-Disposition Header
@@ -263,6 +211,15 @@ http = function http(apiMethod) {
         if (_.isEmpty(object)) {
             object = options;
             options = {};
+        }
+
+        if (req.method === 'POST') {
+            var path = req.route.path;
+            if (path === '/authentication/passwordreset' || path === '/authentication/revoke') {
+                res.status(200);
+            } else {
+                res.status(201);
+            }
         }
 
         return apiMethod(object, options).tap(function onSuccess(response) {

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -111,7 +111,7 @@ describe('DB API', function () {
         fsStub = sandbox.stub(fs, 'writeFile').resolves();
         request.post(testUtils.API.getApiQuery('db/backup' + backupQuery))
             .expect('Content-Type', /json/)
-            .expect(200)
+            .expect(201)
             .end(function (err, res) {
                 if (err) {
                     return done(err);
@@ -130,7 +130,7 @@ describe('DB API', function () {
         fsStub = sandbox.stub(fs, 'writeFile').resolves();
         request.post(testUtils.API.getApiQuery('db/backup' + backupQuery))
             .expect('Content-Type', /json/)
-            .expect(200)
+            .expect(201)
             .end(function (err, res) {
                 if (err) {
                     return done(err);

--- a/core/test/functional/routes/api/notifications_spec.js
+++ b/core/test/functional/routes/api/notifications_spec.js
@@ -77,15 +77,16 @@ describe('Notifications API', function () {
                         return done(err);
                     }
 
-                    var location = res.headers.location,
-                        jsonResponse = res.body;
+                    should.exist(res.body.notifications);
+                    var createdNotification = res.body.notifications[0];
 
-                    should.exist(jsonResponse.notifications);
-                    testUtils.API.checkResponse(jsonResponse.notifications[0], 'notification');
+                    testUtils.API.checkResponse(createdNotification, 'notification');
 
-                    jsonResponse.notifications[0].type.should.equal(newNotification.type);
-                    jsonResponse.notifications[0].message.should.equal(newNotification.message);
-                    jsonResponse.notifications[0].status.should.equal(newNotification.status);
+                    createdNotification.type.should.equal(newNotification.type);
+                    createdNotification.message.should.equal(newNotification.message);
+                    createdNotification.status.should.equal(newNotification.status);
+
+                    var location = testUtils.API.getApiQuery('notifications/') + createdNotification.id;
 
                     // begin delete test
                     request.del(location)

--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -597,7 +597,6 @@ describe('Post API', function () {
                         }
 
                         var draftPost = res.body;
-                        res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=draft');
                         should.exist(draftPost.posts);
                         draftPost.posts.length.should.be.above(0);
                         draftPost.posts[0].title.should.eql(newTitle);
@@ -694,7 +693,6 @@ describe('Post API', function () {
                         }
 
                         var response = res.body;
-                        res.headers.location.should.equal('/ghost/api/v0.1/posts/' + response.posts[0].id + '/?status=draft');
                         should.exist(response.posts);
                         response.posts.length.should.be.above(0);
 
@@ -783,7 +781,6 @@ describe('Post API', function () {
                         }
 
                         var draftPost = res.body;
-                        res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=draft');
                         should.exist(draftPost.posts);
                         draftPost.posts.length.should.be.above(0);
                         draftPost.posts[0].title.should.eql(newTitle);
@@ -835,7 +832,6 @@ describe('Post API', function () {
                         }
 
                         var draftPost = res.body;
-                        res.headers.location.should.equal('/ghost/api/v0.1/posts/' + draftPost.posts[0].id + '/?status=published');
                         should.exist(draftPost.posts);
                         draftPost.posts.length.should.be.above(0);
                         draftPost.posts[0].title.should.eql(newTitle);

--- a/core/test/functional/routes/api/redirects_spec.js
+++ b/core/test/functional/routes/api/redirects_spec.js
@@ -117,7 +117,7 @@ describe('Redirects API', function () {
                             .set('Origin', testUtils.API.getURL())
                             .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-init.json'))
                             .expect('Content-Type', /application\/json/)
-                            .expect(200);
+                            .expect(201);
                     })
                     .then(function (res) {
                         res.headers['x-cache-invalidate'].should.eql('/*');
@@ -159,7 +159,7 @@ describe('Redirects API', function () {
                             .set('Origin', testUtils.API.getURL())
                             .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects.json'))
                             .expect('Content-Type', /application\/json/)
-                            .expect(200);
+                            .expect(201);
                     })
                     .then(function (res) {
                         res.headers['x-cache-invalidate'].should.eql('/*');
@@ -200,7 +200,7 @@ describe('Redirects API', function () {
                             .set('Origin', testUtils.API.getURL())
                             .attach('redirects', path.join(config.get('paths:contentPath'), 'redirects-something.json'))
                             .expect('Content-Type', /application\/json/)
-                            .expect(200);
+                            .expect(201);
                     })
                     .then(function () {
                         var dataFiles = fs.readdirSync(config.getContentPath('data'));

--- a/core/test/functional/routes/api/upload_icon_spec.js
+++ b/core/test/functional/routes/api/upload_icon_spec.js
@@ -36,7 +36,7 @@ describe('Upload Icon API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/favicon.png'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -52,7 +52,7 @@ describe('Upload Icon API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/favicon_multi_sizes.ico'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -67,7 +67,7 @@ describe('Upload Icon API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/favicon_64x_single.ico'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);

--- a/core/test/functional/routes/api/upload_spec.js
+++ b/core/test/functional/routes/api/upload_spec.js
@@ -38,7 +38,7 @@ describe('Upload API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/ghost-logo.png'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -54,7 +54,7 @@ describe('Upload API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/ghosticon.jpg'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);
@@ -70,7 +70,7 @@ describe('Upload API', function () {
                 .set('Authorization', 'Bearer ' + accesstoken)
                 .expect('Content-Type', /json/)
                 .attach('uploadimage', path.join(__dirname, '/../../../utils/fixtures/images/loadingcat.gif'))
-                .expect(200)
+                .expect(201)
                 .end(function (err, res) {
                     if (err) {
                         return done(err);

--- a/core/test/functional/routes/api/webhooks_spec.js
+++ b/core/test/functional/routes/api/webhooks_spec.js
@@ -76,14 +76,15 @@ describe('Webhooks API', function () {
                             return done(err);
                         }
 
-                        var location = res.headers.location;
-                        var jsonResponse = res.body;
+                        should.exist(res.body.webhooks);
+                        var createdWebhook = res.body.webhooks[0];
 
-                        should.exist(jsonResponse.webhooks);
-                        testUtils.API.checkResponse(jsonResponse.webhooks[0], 'webhook');
+                        testUtils.API.checkResponse(createdWebhook, 'webhook');
 
-                        jsonResponse.webhooks[0].event.should.equal(newWebhook.event);
-                        jsonResponse.webhooks[0].target_url.should.equal(newWebhook.target_url);
+                        createdWebhook.event.should.equal(newWebhook.event);
+                        createdWebhook.target_url.should.equal(newWebhook.target_url);
+
+                        var location = testUtils.API.getApiQuery('webhooks/') + createdWebhook.id;
 
                         // begin delete test
                         request.del(location)


### PR DESCRIPTION
Closes #9326

There were some inconsistencies in what status code was return when creating a POST request to various endpoints. This PR rectifies these inconsistencies as well as remove the `Location` header as it is unused in Ghost-Admin and there as a remnant from the the older Backbone implementation. 

- Removed `Location` header from responses since it was unsued in the newer Ghost-Admin versions (see issue for details)
- Updated tests that relied on the Location header being present
- Some authentication POST routes still return 200, since they don't
result in creation on the server
