### PR TITLE
Bump markdown-it to 8.4.1, so uc.micro bumps to 1.0.5 and it is now MIT licensed

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "knex": "0.12.9",
     "knex-migrator": "3.1.3",
     "lodash": "4.17.4",
-    "markdown-it": "8.4.0",
+    "markdown-it": "8.4.1",
     "markdown-it-footnote": "3.0.1",
     "markdown-it-lazy-headers": "0.1.3",
     "markdown-it-mark": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3796,15 +3796,15 @@ markdown-it-mark@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz#46a1aa947105aed8188978e0a016179e404f42c7"
 
-markdown-it@8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.0.tgz#e2400881bf171f7018ed1bd9da441dac8af6306d"
+markdown-it@8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.1.tgz#206fe59b0e4e1b78a7c73250af9b34a4ad0aaf44"
   dependencies:
     argparse "^1.0.7"
     entities "~1.1.1"
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
-    uc.micro "^1.0.3"
+    uc.micro "^1.0.5"
 
 matchdep@2.0.0:
   version "2.0.0"
@@ -6052,9 +6052,13 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-uc.micro@^1.0.1, uc.micro@^1.0.3:
+uc.micro@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
+
+uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

uc.micro npm package had a WTFL prior to 1.0.5 version, this package is a dependency for markdown-it, which is a dependency of Ghost itself.

If we bump markdown-it from 8.4.0 to 8.4.1, then uc.micro bump from 1.0.3 to 1.0.5 and all the components/packages included installing Ghost have a License OSI approved.

This is important because there are certain cloud providers that do not allow to publish software with WTFL license

- [ X ] There's a clear use-case for this code change
- [ X ] Commit message has a short title & references relevant issues
- [ X ] The build will pass (run `npm test`)

More info can be found by clicking the "guidelines for contributing" link above.
