### PR TITLE
Redirect amp links to their non-amp counterpart when amp is disabled

### DIFF
--- a/core/server/apps/amp/index.js
+++ b/core/server/apps/amp/index.js
@@ -1,5 +1,6 @@
 var router           = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
+    urlService = require('../../services/url'),
 
     // Dirty requires
     config = require('../../config'),
@@ -10,7 +11,7 @@ function ampRouter(req, res) {
         return router.apply(this, arguments);
     } else {
         var redirectUrl = req.originalUrl.replace(/amp\/$/, '');
-        res.redirect(301, redirectUrl);
+        urlService.utils.redirect301(res, redirectUrl);
     }
 }
 

--- a/core/server/apps/amp/index.js
+++ b/core/server/apps/amp/index.js
@@ -5,17 +5,20 @@ var router           = require('./lib/router'),
     config = require('../../config'),
     settingsCache = require('../../services/settings/cache');
 
+function ampRouter(req, res) {
+    if (settingsCache.get('amp') === true) {
+        return router.apply(this, arguments);
+    } else {
+        var redirectUrl = req.originalUrl.replace(/amp\/$/, '');
+        res.redirect(301, redirectUrl);
+    }
+}
+
 module.exports = {
     activate: function activate(ghost) {
         var ampRoute = '*/' + config.get('routeKeywords').amp + '/';
 
-        ghost.routeService.registerRouter(ampRoute, function settingsEnabledRouter(req, res, next) {
-            if (settingsCache.get('amp') === true) {
-                return router.apply(this, arguments);
-            }
-
-            next();
-        });
+        ghost.routeService.registerRouter(ampRoute, ampRouter);
 
         registerHelpers(ghost);
     }

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -321,7 +321,7 @@ describe('Frontend Routing', function () {
                     .end(doEnd(done));
             });
 
-            it('should not render AMP, when AMP is disabled', function (done) {
+            it('should redirect to regular post when AMP is disabled', function (done) {
                 sandbox.stub(settingsCache, 'get').callsFake(function (key, options) {
                     if (key === 'amp' && !options) {
                         return false;
@@ -330,8 +330,8 @@ describe('Frontend Routing', function () {
                 });
 
                 request.get('/welcome/amp/')
-                    .expect(404)
-                    .expect(/Page not found/)
+                    .expect('Location', '/welcome/')
+                    .expect(301)
                     .end(doEnd(done));
             });
         });


### PR DESCRIPTION
closes #9495

- Added a clause for amp being disabled
- In this clause, we strip the final 'amp/' part of the url, and redirect
- Changed corresponding test in frontend_spec.js
