### PR TITLE
🐛 escape `<` in reading time helper

### DIFF
--- a/core/server/helpers/reading_time.js
+++ b/core/server/helpers/reading_time.js
@@ -28,7 +28,7 @@ module.exports = function reading_time(options) {// eslint-disable-line camelcas
         readingTimeSeconds,
         readingTimeMinutes,
         readingTime,
-        seconds = _.isString(options.hash.seconds) ? options.hash.seconds : '< 1 min read',
+        seconds = _.isString(options.hash.seconds) ? options.hash.seconds : '&lt; 1 min read',
         minute = _.isString(options.hash.minute) ? options.hash.minute : '1 min read',
         minutes = _.isString(options.hash.minutes) ? options.hash.minutes : '% min read';
 

--- a/core/test/unit/helpers/reading_time_spec.js
+++ b/core/test/unit/helpers/reading_time_spec.js
@@ -29,7 +29,7 @@ describe('{{reading_time}} helper', function () {
             },
             result = helpers.reading_time.call(data);
 
-        String(result).should.equal('< 1 min read');
+        String(result).should.equal('&lt; 1 min read');
     });
 
     it('[success] renders reading time for more than one minute text correctly', function () {


### PR DESCRIPTION
No issue

The reading time helper uses the `<` without escaping, which isn't w3 compliant. Unfortunately, I don't know anything about the HTML spec documentation, so here's a manual test to show this:

1. Visit the official [w3 validator](https://validator.w3.org)
2. Select `Validate by Direct Input`
3. Paste the following HTML (meets minimum HTML standards)

```html
<!doctype html>
<html>
	<head><title>uh-oh!</title></head>
	<body>
		<p> < 1 min read</p>
	</body>
</html>
```
4. Click check; see error relating to `<`

This PR makes the reading time helper w3 compliant by escaping the `<` character