### PR TITLE
Fixed transactions for `Tag.destroy` &&  Fixed `post.unpublished` when deleting all content

### DIFF
--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -1,6 +1,9 @@
+'use strict';
+
 // # DB API
 // API for DB operations
 var Promise = require('bluebird'),
+    _ = require('lodash'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
     exporter = require('../data/export'),
@@ -110,18 +113,39 @@ db = {
 
         options = options || {};
 
+        /**
+         * @NOTE:
+         * We fetch all posts with `columns:id` to increase the speed of this endpoint.
+         * And if you trigger `post.destroy(..)`, this will trigger bookshelf and model events.
+         * But we only have to `id` available in the model. This won't work, because:
+         *   - model layer can't trigger event e.g. `post.page` to trigger `post|page.unpublished`.
+         *   - `onDestroyed` or `onDestroying` can contain custom logic
+         */
         function deleteContent() {
-            var collections = [
-                models.Post.findAll(queryOpts),
-                models.Tag.findAll(queryOpts)
-            ];
+            return models.Base.transaction(function (transacting) {
+                queryOpts.transacting = transacting;
 
-            return Promise.each(collections, function then(Collection) {
-                return Collection.invokeThen('destroy', queryOpts);
-            }).return({db: []})
-                .catch(function (err) {
-                    throw new common.errors.GhostError({err: err});
-                });
+                return models.Post.findAll(queryOpts)
+                    .then((response) => {
+                        return Promise.map(response.models, (post) => {
+                            return models.Post.destroy(_.merge({id: post.id}, queryOpts));
+                        }, {concurrency: 100});
+                    })
+                    .then(() => {
+                        return models.Tag.findAll(queryOpts);
+                    })
+                    .then((response) => {
+                        return Promise.map(response.models, (tag) => {
+                            return models.Tag.destroy(_.merge({id: tag.id}, queryOpts));
+                        }, {concurrency: 100});
+                    })
+                    .return({db: []})
+                    .catch((err) => {
+                        throw new common.errors.GhostError({
+                            err: err
+                        });
+                    });
+            });
         }
 
         tasks = [

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -1,6 +1,8 @@
+'use strict';
+
 // # Posts API
 // RESTful API for the Post resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
@@ -13,8 +15,9 @@ var Promise = require('bluebird'),
     allowedIncludes = [
         'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors', 'authors.roles'
     ],
-    unsafeAttrs = ['author_id', 'status', 'authors'],
-    posts;
+    unsafeAttrs = ['author_id', 'status', 'authors'];
+
+let posts;
 
 /**
  * ### Posts API Methods
@@ -220,7 +223,8 @@ posts = {
 
     /**
      * ## Destroy
-     * Delete a post, cleans up tag relations, but not unused tags
+     * Delete a post, cleans up tag relations, but not unused tags.
+     * You can only delete a post by `id`.
      *
      * @public
      * @param {{id (required), context,...}} options
@@ -234,17 +238,14 @@ posts = {
          * @param  {Object} options
          */
         function deletePost(options) {
-            var Post = models.Post,
-                data = _.defaults({status: 'all'}, options),
-                fetchOpts = _.defaults({require: true, columns: 'id'}, options);
+            const opts = _.defaults({require: true}, options);
 
-            return Post.findOne(data, fetchOpts).then(function () {
-                return Post.destroy(options).return(null);
-            }).catch(Post.NotFoundError, function () {
-                throw new common.errors.NotFoundError({
-                    message: common.i18n.t('errors.api.posts.postNotFound')
+            return models.Post.destroy(opts).return(null)
+                .catch(models.Post.NotFoundError, function () {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.posts.postNotFound')
+                    });
                 });
-            });
         }
 
         // Push all of our tasks into a `tasks` array in the correct order

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -103,11 +103,15 @@ Tag = ghostBookshelf.Model.extend({
         var options = this.filterOptions(unfilteredOptions, 'destroy', {extraAllowedProperties: ['id']});
         options.withRelated = ['posts'];
 
-        return this.forge({id: options.id}).fetch(options).then(function destroyTagsAndPost(tag) {
-            return tag.related('posts').detach().then(function destroyTags() {
-                return tag.destroy(options);
+        return this.forge({id: options.id})
+            .fetch(options)
+            .then(function destroyTagsAndPost(tag) {
+                return tag.related('posts')
+                    .detach(null, options)
+                    .then(function destroyTags() {
+                        return tag.destroy(options);
+                    });
             });
-        });
     }
 });
 

--- a/core/test/integration/api/api_db_spec.js
+++ b/core/test/integration/api/api_db_spec.js
@@ -1,38 +1,86 @@
 var should = require('should'),
-    testUtils = require('../../utils'),
     _ = require('lodash'),
+    sinon = require('sinon'),
+    testUtils = require('../../utils'),
+    common = require('../../../server/lib/common'),
     dbAPI = require('../../../server/api/db'),
-    models = require('../../../server/models');
+    models = require('../../../server/models'),
+    sandbox = sinon.sandbox.create();
 
 describe('DB API', function () {
+    var eventsTriggered;
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
     // Keep the DB clean
     before(testUtils.teardown);
     afterEach(testUtils.teardown);
     beforeEach(testUtils.setup('users:roles', 'settings', 'posts', 'subscriber', 'perms:db', 'perms:init'));
 
+    beforeEach(function () {
+        eventsTriggered = {};
+
+        sandbox.stub(common.events, 'emit').callsFake(function (eventName, eventObj) {
+            if (!eventsTriggered[eventName]) {
+                eventsTriggered[eventName] = [];
+            }
+
+            eventsTriggered[eventName].push(eventObj);
+        });
+    });
+
     should.exist(dbAPI);
 
     it('delete all content (owner)', function () {
-        return dbAPI.deleteAllContent(testUtils.context.owner).then(function (result) {
-            should.exist(result.db);
-            result.db.should.be.instanceof(Array);
-            result.db.should.be.empty();
-        }).then(function () {
-            return models.Tag.findAll(testUtils.context.owner).then(function (results) {
+        return models.Post.findAll(testUtils.context.internal)
+            .then(function (results) {
+                results = results.toJSON();
+
+                results.length.should.eql(8);
+
+                _.filter(results, {page: false, status: 'published'}).length.should.equal(4);
+                _.filter(results, {page: false, status: 'draft'}).length.should.equal(1);
+                _.filter(results, {page: false, status: 'scheduled'}).length.should.equal(1);
+                _.filter(results, {page: true, status: 'published'}).length.should.equal(1);
+                _.filter(results, {page: true, status: 'draft'}).length.should.equal(1);
+            })
+            .then(function () {
+                return dbAPI.deleteAllContent(testUtils.context.owner);
+            })
+            .then(function (result) {
+                should.exist(result.db);
+                result.db.should.be.instanceof(Array);
+                result.db.should.be.empty();
+
+                return models.Tag.findAll(testUtils.context.internal);
+            })
+            .then(function (results) {
                 should.exist(results);
                 results.length.should.equal(0);
-            });
-        }).then(function () {
-            return models.Post.findAll(testUtils.context.owner).then(function (results) {
+
+                return models.Post.findAll(testUtils.context.internal);
+            })
+            .then(function (results) {
                 should.exist(results);
                 results.length.should.equal(0);
-            });
-        }).then(function () {
-            return models.Subscriber.findAll(testUtils.context.owner).then(function (results) {
+
+                return models.Subscriber.findAll(testUtils.context.internal);
+            })
+            .then(function (results) {
                 should.exist(results);
                 results.length.should.equal(1);
+            })
+            .then(function () {
+                eventsTriggered['post.unpublished'].length.should.eql(4);
+                eventsTriggered['post.deleted'].length.should.eql(6);
+
+                eventsTriggered['page.unpublished'].length.should.eql(1);
+                eventsTriggered['page.deleted'].length.should.eql(2);
+
+                eventsTriggered['tag.deleted'].length.should.eql(5);
             });
-        });
     });
 
     it('delete all content (admin)', function () {


### PR DESCRIPTION
Two commits.

- Fixed transactions for `Tag.destroy`
- Fixed `post.unpublished` when deleting all content

Discovered while working on dynamic routing.

Also interesting: https://github.com/bookshelf/bookshelf/issues/799 (Bookshelf is planning to remove collections).

- [x] tested sqlite/mysql