### PR TITLE
Fixed model events and transactions

### DIFF
--- a/core/server/models/accesstoken.js
+++ b/core/server/models/accesstoken.js
@@ -1,20 +1,21 @@
-var ghostBookshelf = require('./base'),
-    Basetoken = require('./base/token'),
-    common = require('../lib/common'),
+'use strict';
 
-    Accesstoken,
+const ghostBookshelf = require('./base'),
+    Basetoken = require('./base/token');
+
+let Accesstoken,
     Accesstokens;
 
 Accesstoken = Basetoken.extend({
     tableName: 'accesstokens',
 
-    emitChange: function emitChange(event) {
-        // Event named 'token' as access and refresh token will be merged in future, see #6626
-        common.events.emit('token' + '.' + event, this);
+    emitChange: function emitChange(event, options) {
+        const eventToTrigger = 'token' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
     },
 
-    onCreated: function onCreated(model) {
-        model.emitChange('added');
+    onCreated: function onCreated(model, attrs, options) {
+        model.emitChange('added', options);
     }
 });
 

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -31,9 +31,9 @@ common.events.on('user.deactivated', function (userModel, options) {
         return;
     }
 
-    models.Accesstoken.destroyByUser(_.omit(options, 'transacting'))
+    models.Accesstoken.destroyByUser(options)
         .then(function () {
-            return models.Refreshtoken.destroyByUser(_.omit(options, 'transacting'));
+            return models.Refreshtoken.destroyByUser(options);
         })
         .catch(function (err) {
             common.logging.error(new common.errors.GhostError({

--- a/core/server/models/plugins/index.js
+++ b/core/server/models/plugins/index.js
@@ -2,5 +2,6 @@ module.exports = {
     filter: require('./filter'),
     includeCount: require('./include-count'),
     pagination: require('./pagination'),
-    collision: require('./collision')
+    collision: require('./collision'),
+    transactionEvents: require('./transaction-events')
 };

--- a/core/server/models/plugins/transaction-events.js
+++ b/core/server/models/plugins/transaction-events.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * This is a feature request in knex for 1.0.
+ * https://github.com/tgriesser/knex/issues/1641
+ */
+module.exports = function (bookshelf) {
+    const orig1 = bookshelf.transaction;
+
+    bookshelf.transaction = function (cb) {
+        return orig1.bind(bookshelf)(function (t) {
+            const orig2 = t.commit;
+            const orig3 = t.rollback;
+
+            t.commit = function () {
+                t.emit('committed', true);
+                return orig2.apply(t, arguments);
+            };
+
+            t.rollback = function () {
+                t.emit('committed', false);
+                return orig3.apply(t, arguments);
+            };
+
+            return cb(t);
+        });
+    };
+};

--- a/core/server/models/settings.js
+++ b/core/server/models/settings.js
@@ -1,15 +1,15 @@
-var Settings,
-    Promise = require('bluebird'),
+'use strict';
+
+const Promise = require('bluebird'),
     _ = require('lodash'),
     uuid = require('uuid'),
     crypto = require('crypto'),
     ghostBookshelf = require('./base'),
     common = require('../lib/common'),
     validation = require('../data/validation'),
+    internalContext = {context: {internal: true}};
 
-    internalContext = {context: {internal: true}},
-
-    defaultSettings;
+let Settings, defaultSettings;
 
 // For neatness, the defaults file is split into categories.
 // It's much easier for us to work with it as a single level
@@ -58,21 +58,22 @@ Settings = ghostBookshelf.Model.extend({
     },
 
     emitChange: function emitChange(event, options) {
-        common.events.emit('settings' + '.' + event, this, options);
+        const eventToTrigger = 'settings' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
     },
 
-    onDestroyed: function onDestroyed(model, response, options) {
-        model.emitChange('deleted');
-        model.emitChange(model.attributes.key + '.' + 'deleted', options);
+    onDestroyed: function onDestroyed(model, options) {
+        model.emitChange('deleted', options);
+        model.emitChange(model._previousAttributes.key + '.' + 'deleted', options);
     },
 
     onCreated: function onCreated(model, response, options) {
-        model.emitChange('added');
+        model.emitChange('added', options);
         model.emitChange(model.attributes.key + '.' + 'added', options);
     },
 
     onUpdated: function onUpdated(model, response, options) {
-        model.emitChange('edited');
+        model.emitChange('edited', options);
         model.emitChange(model.attributes.key + '.' + 'edited', options);
     },
 

--- a/core/server/models/subscriber.js
+++ b/core/server/models/subscriber.js
@@ -1,16 +1,18 @@
-var Promise = require('bluebird'),
+'use strict';
+
+const Promise = require('bluebird'),
     ghostBookshelf = require('./base'),
-    common = require('../lib/common'),
-    Subscriber,
+    common = require('../lib/common');
+
+let Subscriber,
     Subscribers;
 
 Subscriber = ghostBookshelf.Model.extend({
     tableName: 'subscribers',
 
     emitChange: function emitChange(event, options) {
-        options = options || {};
-
-        common.events.emit('subscriber' + '.' + event, this, options);
+        const eventToTrigger = 'subscriber' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
     },
 
     defaults: function defaults() {
@@ -27,7 +29,7 @@ Subscriber = ghostBookshelf.Model.extend({
         model.emitChange('edited', options);
     },
 
-    onDestroyed: function onDestroyed(model, response, options) {
+    onDestroyed: function onDestroyed(model, options) {
         model.emitChange('deleted', options);
     }
 }, {

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -1,7 +1,7 @@
-var ghostBookshelf = require('./base'),
-    common = require('../lib/common'),
-    Tag,
-    Tags;
+'use strict';
+
+const ghostBookshelf = require('./base');
+let Tag, Tags;
 
 Tag = ghostBookshelf.Model.extend({
 
@@ -13,20 +13,21 @@ Tag = ghostBookshelf.Model.extend({
         };
     },
 
-    emitChange: function emitChange(event) {
-        common.events.emit('tag' + '.' + event, this);
+    emitChange: function emitChange(event, options) {
+        const eventToTrigger = 'tag' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
     },
 
-    onCreated: function onCreated(model) {
-        model.emitChange('added');
+    onCreated: function onCreated(model, attrs, options) {
+        model.emitChange('added', options);
     },
 
-    onUpdated: function onUpdated(model) {
-        model.emitChange('edited');
+    onUpdated: function onUpdated(model, attrs, options) {
+        model.emitChange('edited', options);
     },
 
-    onDestroyed: function onDestroyed(model) {
-        model.emitChange('deleted');
+    onDestroyed: function onDestroyed(model, options) {
+        model.emitChange('deleted', options);
     },
 
     onSaving: function onSaving(newTag, attr, options) {

--- a/core/server/models/webhook.js
+++ b/core/server/models/webhook.js
@@ -1,16 +1,17 @@
-var Promise = require('bluebird'),
-    ghostBookshelf = require('./base'),
-    common = require('../lib/common'),
-    Webhook,
+'use strict';
+
+const Promise = require('bluebird'),
+    ghostBookshelf = require('./base');
+
+let Webhook,
     Webhooks;
 
 Webhook = ghostBookshelf.Model.extend({
     tableName: 'webhooks',
 
     emitChange: function emitChange(event, options) {
-        options = options || {};
-
-        common.events.emit('webhook' + '.' + event, this, options);
+        const eventToTrigger = 'webhook' + '.' + event;
+        ghostBookshelf.Model.prototype.emitChange.bind(this)(this, eventToTrigger, options);
     },
 
     onCreated: function onCreated(model, response, options) {
@@ -21,7 +22,7 @@ Webhook = ghostBookshelf.Model.extend({
         model.emitChange('edited', options);
     },
 
-    onDestroyed: function onDestroyed(model, response, options) {
+    onDestroyed: function onDestroyed(model, options) {
         model.emitChange('deleted', options);
     }
 }, {


### PR DESCRIPTION
no issue

- if multiple queries run in a transaction, the model events are triggered before the txn finished
- if the txn rolls back, the events are anyway emitted
  - this is wrong
- the events are triggered too early

**This is a fundamental requirement for dynamic routing, because the urlsrvc needs to keep track on urls based on model events. And if it receives an event which is either not yet finished (txn) or was never finished, it will add wrong urls.**