### PR TITLE
Disable X-Powered-By header

### DIFF
--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -22,6 +22,9 @@ module.exports = function setupParentApp() {
     // (X-Forwarded-Proto header will be checked, if present)
     parentApp.enable('trust proxy');
 
+    // Disable sending the x-powered-by header
+    parentApp.disable('x-powered-by');
+
     parentApp.use(logRequest);
 
     // enabled gzip compression by default


### PR DESCRIPTION
Remove the x-power-by header express sends by default.

It is a minor security enhancement not to send this information.