### PR TITLE
Protect generated post.html and post.plaintext fields

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -183,11 +183,12 @@ Post = ghostBookshelf.Model.extend({
             newTitle = this.get('title'),
             newStatus = this.get('status'),
             olderStatus = this.previous('status'),
-            prevTitle = this._previousAttributes.title,
-            prevSlug = this._previousAttributes.slug,
+            prevTitle = this.previous('title'),
+            prevSlug = this.previous('slug'),
             publishedAt = this.get('published_at'),
             publishedAtHasChanged = this.hasDateChanged('published_at', {beforeWrite: true}),
             mobiledoc = this.get('mobiledoc'),
+            generatedFields = ['html', 'plaintext'],
             tagsToSave,
             ops = [];
 
@@ -242,6 +243,13 @@ Post = ghostBookshelf.Model.extend({
         }
 
         ghostBookshelf.Model.prototype.onSaving.call(this, model, attr, options);
+
+        // do not allow generated fields to be overridden via the API
+        generatedFields.forEach((field) => {
+            if (this.hasChanged(field)) {
+                this.set(field, this.previous(field));
+            }
+        });
 
         if (mobiledoc) {
             this.set('html', converters.mobiledocConverter.render(JSON.parse(mobiledoc)));

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -578,6 +578,32 @@ describe('Unit: models/post', function () {
                         post.authors[1].id.should.eql(testUtils.DataGenerator.forKnex.users[2].id);
                     });
                 });
+
+                it('[unsupported] change post.plaintext', function () {
+                    const data = {
+                        plaintext: 'test'
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[2].id
+                    }).then(function (post) {
+                        post = post.toJSON({formats: ['mobiledoc', 'plaintext', 'html']});
+                        post.plaintext.should.eql(testUtils.DataGenerator.forKnex.posts[2].plaintext);
+                    });
+                });
+
+                it('[unsupported] change post.html', function () {
+                    const data = {
+                        html: 'test'
+                    };
+
+                    return models.Post.edit(data, {
+                        id: testUtils.DataGenerator.forKnex.posts[2].id
+                    }).then(function (post) {
+                        post = post.toJSON({formats: ['mobiledoc', 'plaintext', 'html']});
+                        post.html.should.eql(testUtils.DataGenerator.forKnex.posts[2].html);
+                    });
+                });
             });
 
             describe('destroy', function () {

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -48,6 +48,7 @@ DataGenerator.Content = {
             slug: 'short-and-sweet',
             mobiledoc: DataGenerator.markdownToMobiledoc('## testing\n\nmctesters\n\n- test\n- line\n- items'),
             html: '<div class=\"kg-card-markdown\"><h2 id=\"testing\">testing</h2>\n<p>mctesters</p>\n<ul>\n<li>test</li>\n<li>line</li>\n<li>items</li>\n</ul>\n</div>',
+            plaintext: 'testing\nmctesters\n\n * test\n * line\n * items',
             feature_image: 'http://placekitten.com/500/200',
             meta_description: 'test stuff',
             published_at: new Date('2015-01-03'),


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9512
- loop through list of generated fields in `Post.onSaving` and reset their values if a new value was passed in via attributes