### PR TITLE
Replace routeKeywords in config with hard coded keywords

### DIFF
--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -29,7 +29,6 @@ function getBaseConfig() {
         publicAPI: config.get('publicAPI') === true,
         blogUrl: urlService.utils.urlFor('home', true),
         blogTitle: settingsCache.get('title'),
-        routeKeywords: config.get('routeKeywords'),
         clientExtensions: config.get('clientExtensions'),
         enableDeveloperExperiments: config.get('enableDeveloperExperiments')
     };

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -6,7 +6,6 @@
 
 var _ = require('lodash'),
     Promise = require('bluebird'),
-    config = require('../config'),
     models = require('../models'),
     urlService = require('../services/url'),
     configuration = require('./configuration'),
@@ -103,7 +102,8 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
             if (hasStatusChanged || wasPublishedUpdated) {
                 return INVALIDATE_ALL;
             } else {
-                return urlService.utils.urlFor({relativeUrl: urlService.utils.urlJoin('/', config.get('routeKeywords').preview, post.uuid, '/')});
+                // routeKeywords.preview: 'p'
+                return urlService.utils.urlFor({relativeUrl: urlService.utils.urlJoin('/p', post.uuid, '/')});
             }
         }
     }

--- a/core/server/apps/amp/index.js
+++ b/core/server/apps/amp/index.js
@@ -3,13 +3,13 @@ var router           = require('./lib/router'),
     urlService = require('../../services/url'),
 
     // Dirty requires
-    config = require('../../config'),
     settingsCache = require('../../services/settings/cache');
 
 function ampRouter(req, res) {
     if (settingsCache.get('amp') === true) {
         return router.apply(this, arguments);
     } else {
+        // routeKeywords.amp: 'amp'
         var redirectUrl = req.originalUrl.replace(/amp\/$/, '');
         urlService.utils.redirect301(res, redirectUrl);
     }
@@ -17,7 +17,8 @@ function ampRouter(req, res) {
 
 module.exports = {
     activate: function activate(ghost) {
-        var ampRoute = '*/' + config.get('routeKeywords').amp + '/';
+        // routeKeywords.amp: 'amp'
+        var ampRoute = '*/amp/';
 
         ghost.routeService.registerRouter(ampRoute, ampRouter);
 

--- a/core/server/apps/private-blogging/index.js
+++ b/core/server/apps/private-blogging/index.js
@@ -1,9 +1,10 @@
-var config = require('../../config'),
-    urlService = require('../../services/url'),
+var urlService = require('../../services/url'),
     common = require('../../lib/common'),
     middleware = require('./lib/middleware'),
     router = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
+    // routeKeywords.private: 'private'
+    PRIVATE_KEYWORD = 'private',
     checkSubdir;
 
 checkSubdir = function checkSubdir() {
@@ -12,7 +13,7 @@ checkSubdir = function checkSubdir() {
     if (urlService.utils.getSubdir()) {
         paths = urlService.utils.getSubdir().split('/');
 
-        if (paths.pop() === config.get('routeKeywords').private) {
+        if (paths.pop() === PRIVATE_KEYWORD) {
             common.logging.error(new common.errors.GhostError({
                 message: common.i18n.t('errors.config.urlCannotContainPrivateSubdir.error'),
                 context: common.i18n.t('errors.config.urlCannotContainPrivateSubdir.description'),
@@ -27,7 +28,7 @@ checkSubdir = function checkSubdir() {
 
 module.exports = {
     activate: function activate(ghost) {
-        var privateRoute = '/' + config.get('routeKeywords').private + '/';
+        var privateRoute = '/' + PRIVATE_KEYWORD + '/';
 
         checkSubdir();
 

--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -7,7 +7,8 @@ var fs = require('fs-extra'),
     constants = require('../../../lib/constants'),
     common = require('../../../lib/common'),
     settingsCache = require('../../../services/settings/cache'),
-    privateRoute = '/' + config.get('routeKeywords').private + '/',
+    // routeKeywords.private: 'private'
+    privateRoute = '/private/',
     privateBlogging;
 
 function verifySessionHash(salt, hash) {

--- a/core/server/apps/subscribers/index.js
+++ b/core/server/apps/subscribers/index.js
@@ -2,12 +2,12 @@ var router     = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
 
     // Dirty requires
-    config = require('../../config'),
     labs = require('../../services/labs');
 
 module.exports = {
     activate: function activate(ghost) {
-        var subscribeRoute = '/' + config.get('routeKeywords').subscribe + '/';
+        // routeKeywords.subscribe: 'subscribe'
+        var subscribeRoute = '/subscribe/';
         // TODO, how to do all this only if the Subscribers flag is set?!
         registerHelpers(ghost);
 

--- a/core/server/apps/subscribers/lib/helpers/subscribe_form.js
+++ b/core/server/apps/subscribers/lib/helpers/subscribe_form.js
@@ -5,7 +5,6 @@ var _ = require('lodash'),
     // (Less) dirty requires
     proxy = require('../../../../helpers/proxy'),
     templates = proxy.templates,
-    config = proxy.config,
     url = proxy.url,
     SafeString = proxy.SafeString,
 
@@ -39,7 +38,8 @@ subscribeScript =
 module.exports = function subscribe_form(options) { // eslint-disable-line camelcase
     var root = options.data.root,
         data = _.merge({}, options.hash, _.pick(root, params), {
-            action: url.urlJoin('/', url.getSubdir(), config.get('routeKeywords').subscribe, '/'),
+            // routeKeywords.subscribe: 'subscribe'
+            action: url.urlJoin('/', url.getSubdir(), 'subscribe/'),
             script: new SafeString(subscribeScript),
             hidden: new SafeString(
                 makeHidden('confirm') +

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -20,17 +20,6 @@
             "amp"
         ]
     },
-    "routeKeywords": {
-        "tag": "tag",
-        "author": "author",
-        "page": "page",
-        "preview": "p",
-        "private": "private",
-        "subscribe": "subscribe",
-        "amp": "amp",
-        "primaryTagFallback": "all",
-        "primaryAuthorFallback": "all"
-    },
     "slugs": {
         "reserved": ["admin", "app", "apps", "categories",
             "category", "dashboard", "feed", "ghost-admin", "login", "logout",

--- a/core/server/controllers/frontend/context.js
+++ b/core/server/controllers/frontend/context.js
@@ -11,13 +11,15 @@
  * 3. data - used for telling the difference between posts and pages
  */
 
-var config = require('../../config'),
-    labs = require('../../services/labs'),
+var labs = require('../../services/labs'),
 
     // Context patterns, should eventually come from Channel configuration
-    privatePattern = new RegExp('^\\/' + config.get('routeKeywords').private + '\\/'),
-    subscribePattern = new RegExp('^\\/' + config.get('routeKeywords').subscribe + '\\/'),
-    ampPattern = new RegExp('\\/' + config.get('routeKeywords').amp + '\\/$'),
+    // routeKeywords.private: 'private'
+    privatePattern = new RegExp('^\\/private\\/'),
+    // routeKeywords.subscribe: 'subscribe'
+    subscribePattern = new RegExp('^\\/subscribe\\/'),
+    // routeKeywords.amp: 'amp'
+    ampPattern = new RegExp('\\/amp\\/$'),
     homePattern = new RegExp('^\\/$');
 
 function setResponseContext(req, res, data) {

--- a/core/server/data/meta/paginated_url.js
+++ b/core/server/data/meta/paginated_url.js
@@ -1,5 +1,4 @@
 var _ = require('lodash'),
-    config = require('../../config'),
     urlService = require('../../services/url');
 
 function getPaginatedUrl(page, data, absolute) {
@@ -7,10 +6,11 @@ function getPaginatedUrl(page, data, absolute) {
     if (!data || !data.relativeUrl || !data.pagination) {
         return null;
     }
-
-    var pagePath = urlService.utils.urlJoin('/', config.get('routeKeywords').page, '/'),
+    // routeKeywords.page: 'page'
+    var pagePath = urlService.utils.urlJoin('/page/'),
         // Try to match the base url, as whatever precedes the pagePath
-        baseUrlPattern = new RegExp('(.+)?(/' + config.get('routeKeywords').page + '/\\d+/)'),
+        // routeKeywords.page: 'page'
+        baseUrlPattern = new RegExp('(.+)?(/page/\\d+/)'),
         baseUrlMatch = data.relativeUrl.match(baseUrlPattern),
         // If there is no match for pagePath, use the original url, without the trailing slash
         baseUrl = baseUrlMatch ? baseUrlMatch[1] : data.relativeUrl.slice(0, -1),

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -35,7 +35,6 @@ module.exports = {
     // Config!
     // Keys used:
     // isPrivacyDisabled & referrerPolicy used in ghost_head
-    // Subscribe app uses routeKeywords
     config: {
         get: config.get.bind(config),
         isPrivacyDisabled: config.isPrivacyDisabled.bind(config)

--- a/core/server/services/channels/Channel.js
+++ b/core/server/services/channels/Channel.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash'),
-    config  = require('../../config'),
     defaultPostOptions = {};
 
 class Channel {
@@ -50,10 +49,14 @@ class Channel {
     }
 
     translateRoute(route) {
+        const routeKeywords = {
+            tag: 'tag',
+            author: 'author'
+        };
         // @TODO find this a more general / global home, as part of the Router system,
         // so that ALL routes that get registered WITH Ghost can do this
         return route.replace(/:t_([a-zA-Z]+)/, function (fullMatch, keyword) {
-            return config.get('routeKeywords')[keyword];
+            return routeKeywords[keyword];
         });
     }
 }

--- a/core/server/services/channels/router.js
+++ b/core/server/services/channels/router.js
@@ -1,6 +1,5 @@
 var express = require('express'),
     _ = require('lodash'),
-    config = require('../../config'),
     common = require('../../lib/common'),
     urlService = require('../../services/url'),
     channelController = require('../../controllers/channel'),
@@ -9,7 +8,8 @@ var express = require('express'),
     channelRouter;
 
 function handlePageParam(req, res, next, page) {
-    var pageRegex = new RegExp('/' + config.get('routeKeywords').page + '/(.*)?/'),
+    // routeKeywords.page: 'page'
+    var pageRegex = new RegExp('/page/(.*)?/'),
         rssRegex = new RegExp('/rss/(.*)?/');
 
     page = parseInt(page, 10);
@@ -66,7 +66,8 @@ rssRouter = function rssRouter(channelMiddleware) {
 channelRouter = function channelRouter(channel) {
     var channelRouter = express.Router({mergeParams: true}),
         baseRoute = '/',
-        pageRoute = urlService.utils.urlJoin('/', config.get('routeKeywords').page, ':page(\\d+)/'),
+        // routeKeywords.page: 'page'
+        pageRoute = urlService.utils.urlJoin('/page', ':page(\\d+)/'),
         middleware = [channelConfigMiddleware(channel)];
 
     channelRouter.get(baseRoute, middleware, channelController);

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -173,8 +173,10 @@ function createUrl(urlPath, absolute, secure) {
 function urlPathForPost(post) {
     var output = '',
         permalinks = settingsCache.get('permalinks'),
-        primaryTagFallback = config.get('routeKeywords').primaryTagFallback,
-        primaryAuthorFallback = config.get('routeKeywords').primaryAuthorFallback,
+        // routeKeywords.primaryTagFallback: 'all'
+        primaryTagFallback = 'all',
+        // routeKeywords.primaryAuthorFallback: 'all'
+        primaryAuthorFallback = 'all',
         publishedAtMoment = moment.tz(post.published_at || Date.now(), settingsCache.get('active_timezone')),
         tags = {
             year: function () {
@@ -272,10 +274,12 @@ function urlFor(context, data, absolute) {
             urlPath = data.post.url;
             secure = data.secure;
         } else if (context === 'tag' && data.tag) {
-            urlPath = urlJoin('/', config.get('routeKeywords').tag, data.tag.slug, '/');
+            // routeKeywords.tag: 'tag'
+            urlPath = urlJoin('/tag', data.tag.slug, '/');
             secure = data.tag.secure;
         } else if (context === 'author' && data.author) {
-            urlPath = urlJoin('/', config.get('routeKeywords').author, data.author.slug, '/');
+            // routeKeywords.author: 'author'
+            urlPath = urlJoin('/author', data.author.slug, '/');
             secure = data.author.secure;
         } else if (context === 'image' && data.image) {
             urlPath = data.image;

--- a/core/server/web/site/routes.js
+++ b/core/server/web/site/routes.js
@@ -12,13 +12,13 @@ var debug = require('ghost-ignition').debug('site:routes'),
 
     // Utils for creating paths
     // @TODO: refactor these away
-    config = require('../../config'),
     urlService = require('../../services/url');
 
 module.exports = function siteRoutes() {
     // @TODO move this path out of this file!
     // Note this also exists in api/events.js
-    var previewRoute = urlService.utils.urlJoin('/', config.get('routeKeywords').preview, ':uuid', ':options?');
+    // routeKeywords.preview: 'p'
+    var previewRoute = urlService.utils.urlJoin('/p', ':uuid', ':options?');
 
     // Preview - register controller as route
     // Ideal version, as we don't want these paths all over the place

--- a/core/test/integration/api/api_configuration_spec.js
+++ b/core/test/integration/api/api_configuration_spec.js
@@ -27,17 +27,6 @@ describe('Configuration API', function () {
             props = response.configuration[0];
 
             props.blogUrl.should.eql('http://127.0.0.1:2369/');
-            props.routeKeywords.should.eql({
-                tag: 'tag',
-                author: 'author',
-                page: 'page',
-                preview: 'p',
-                primaryTagFallback: 'all',
-                primaryAuthorFallback: 'all',
-                private: 'private',
-                subscribe: 'subscribe',
-                amp: 'amp'
-            });
 
             props.useGravatar.should.eql(false);
             props.publicAPI.should.eql(false);


### PR DESCRIPTION
no issue

- removed the `routeKeywords` property from the config and used hard coded keywords.
- removed `routeKeywords` from public configuration API endpoint, as it's no longer used in the Admin.

Preparation PR for Dynamic Routing.

