### PR TITLE
Fetch relations by default when insert/updating posts

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -604,6 +604,10 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         permittedOptions = _.union(permittedOptions, extraAllowedProperties);
         options = _.pick(options, permittedOptions);
 
+        if (this.defaultRelations) {
+            options = this.defaultRelations(methodName, options);
+        }
+
         return options;
     },
 
@@ -642,6 +646,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      * Find results by page - returns an object containing the
      * information about the request (page, limit), along with the
      * info needed for pagination (pages, total).
+     *
+     * @TODO: This model function does return JSON O_O.
      *
      * **response:**
      *

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -432,6 +432,7 @@ DataGenerator.forKnex = (function () {
             uuid: uuid.v4(),
             title: 'title',
             status: 'published',
+            feature_image: null,
             featured: false,
             page: false,
             author_id: DataGenerator.Content.users[0].id,


### PR DESCRIPTION
no issue

- required for model events
- otherwise you won't receive a full data set
  - in worst case you have to re-fetch the post
- required for the url service
  - the url service always needs relations (authors,tags) to be able to generate the url properly

@IMPORTANT
- no API change, we still return what you are asking for
  - we first edit/add the resource
  - then we fetch the data with the API options
  - @TODO: this can be optimised and will improve performance
    	   picking/selecting it from the insert/update response
- this is an internal change