### PR TITLE
Removed the less than 1 min reading time clause

### DIFF
--- a/core/server/helpers/reading_time.js
+++ b/core/server/helpers/reading_time.js
@@ -47,9 +47,9 @@ module.exports = function reading_time(options) {// eslint-disable-line camelcas
         readingTimeSeconds += Math.max(i, 3);
     }
 
-    readingTimeMinutes = Math.max(Math.round(readingTimeSeconds / 60), 1);
+    readingTimeMinutes = Math.round(readingTimeSeconds / 60);
 
-    if (readingTimeMinutes === 1) {
+    if (readingTimeMinutes <= 1) {
         readingTime = minute;
     } else {
         readingTime = minutes.replace('%', readingTimeMinutes);

--- a/core/server/helpers/reading_time.js
+++ b/core/server/helpers/reading_time.js
@@ -28,7 +28,6 @@ module.exports = function reading_time(options) {// eslint-disable-line camelcas
         readingTimeSeconds,
         readingTimeMinutes,
         readingTime,
-        seconds = _.isString(options.hash.seconds) ? options.hash.seconds : '&lt; 1 min read',
         minute = _.isString(options.hash.minute) ? options.hash.minute : '1 min read',
         minutes = _.isString(options.hash.minutes) ? options.hash.minutes : '% min read';
 
@@ -48,11 +47,9 @@ module.exports = function reading_time(options) {// eslint-disable-line camelcas
         readingTimeSeconds += Math.max(i, 3);
     }
 
-    readingTimeMinutes = Math.round(readingTimeSeconds / 60);
+    readingTimeMinutes = Math.max(Math.round(readingTimeSeconds / 60), 1);
 
-    if (readingTimeSeconds < 60) {
-        readingTime = seconds;
-    } else if (readingTimeMinutes === 1) {
+    if (readingTimeMinutes === 1) {
         readingTime = minute;
     } else {
         readingTime = minutes.replace('%', readingTimeMinutes);

--- a/core/test/unit/helpers/reading_time_spec.js
+++ b/core/test/unit/helpers/reading_time_spec.js
@@ -3,7 +3,7 @@ var should = require('should'), // jshint ignore:line
 // Stuff we are testing
     helpers = require('../../../server/helpers');
 
-var articleHtml =
+var almostOneMinute =
     '<div class="kg-card-markdown"><p>Ghost has a number of different user roles for your team</p>' +
     '<h3 id="authors">Authors</h3><p>The base user level in Ghost is an author. Authors can write posts,' +
     ' edit their own posts, and publish their own posts. Authors are <strong>trusted</strong> users. If you ' +
@@ -20,21 +20,34 @@ var articleHtml =
     ' users to fill out their user profiles, including bio and social links. These will populate rich structured data ' +
     'for posts and generally create more opportunities for themes to fully populate their design.</p></div>';
 
+var almostOneAndAHalfMinute = almostOneMinute +
+    '<div>' +
+    '<p>Ghost has a number of different user roles for your team</p>' +
+    '<h3 id="authors">Authors</h3><p>The base user level in Ghost is an author. Authors can write posts,' +
+    ' edit their own posts, and publish their own posts. Authors are <strong>trusted</strong> users. If you ' +
+    'don\'t trust users to be allowed to publish their own posts, you shouldn\'t invite them to Ghost admin.</p>' +
+    '<h3 id="editors">Editors</h3><p>Editors are the 2nd user level in Ghost. Editors can do everything that an' +
+    ' Author can do, but they can also edit and publish the posts of others - as well as their own. Editors can also invite new' +
+    ' authors to the site.</p><h3 id="administrators">Administrators</h3><p>The top user level in Ghost is Administrator.' +
+    ' Again, administrators can do everything that Authors and Editors can do, but they can also edit all site settings ' +
+    'and data, not just content. Additionally, administrators have full access to invite</p>' +
+    '</div>';
+
 describe('{{reading_time}} helper', function () {
-    it('[success] renders reading time for less than one minute text correctly', function () {
+    it('[success] renders reading time for less than one minute text as one minute', function () {
         var data = {
-                html: articleHtml,
+                html: almostOneMinute,
                 title: 'Test',
                 slug: 'slug'
             },
             result = helpers.reading_time.call(data);
 
-        String(result).should.equal('&lt; 1 min read');
+        String(result).should.equal('1 min read');
     });
 
-    it('[success] renders reading time for more than one minute text correctly', function () {
+    it('[success] renders reading time for one minute text as one minute', function () {
         var data = {
-                html: articleHtml +
+                html: almostOneMinute +
                       'This needed about twenty-five more words before passing the one minute reading time, ' +
                       'since the word count was 250, and the average speed is 275.',
                 title: 'Test',
@@ -45,32 +58,43 @@ describe('{{reading_time}} helper', function () {
         String(result).should.equal('1 min read');
     });
 
+    it('[success] renders reading time for just under 1.5 minutes text as one minute', function () {
+        var data = {
+                html: almostOneAndAHalfMinute,
+                title: 'Test',
+                slug: 'slug'
+            },
+            result = helpers.reading_time.call(data);
+
+        String(result).should.equal('1 min read');
+    });
+
     it('[success] adds time for feature image', function () {
         var data = {
-            html: articleHtml,
+            html: almostOneAndAHalfMinute,
             title: 'Test',
             slug: 'slug',
             feature_image: '/content/images/someimage.jpg'
             },
             result = helpers.reading_time.call(data);
 
-        // The reading time for this HTML snippet would be 55 seconds without the image
-        // Adding the 12 additional seconds for the image results in a reading time > 1 minute
-        String(result).should.equal('1 min read');
+        // The reading time for this HTML snippet would 89 seconds without the image
+        // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
+        String(result).should.equal('2 min read');
     });
 
     it('[success] adds time for inline images', function () {
         var data = {
-            html: articleHtml +
+            html: almostOneAndAHalfMinute +
                   '<img src="test.png">',
             title: 'Test',
             slug: 'slug'
             },
             result = helpers.reading_time.call(data);
 
-        // The reading time for this HTML snippet would be 55 seconds without the image
-        // Adding the 12 additional seconds for the image results in a reading time > 1 minute
-        String(result).should.equal('1 min read');
+        // The reading time for this HTML snippet would 89 seconds without the image
+        // Adding the 12 additional seconds for the image results in a readng time of over 1.5 minutes, rounded to 2
+        String(result).should.equal('2 min read');
     });
 
     it('[failure] does not render reading time when not post', function () {


### PR DESCRIPTION
closes #9569
- Removed the less than 1 minute reading time clause, effectively making 1 min the minimum reading time
- Removed the 'seconds' option for i18n strings, which contained the less than one minute display string
- Kept the other i18n string options the same
- Amended and improved tests for new functionality
