### PR TITLE
[HOLD] Rewrite sitemaps

### DIFF
--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -1,66 +1,37 @@
-var _       = require('lodash'),
-    config  = require('../../../config'),
-    sitemap = require('./index');
+'use strict';
+
+const config  = require('../../../config'),
+    Manager = require('./manager'),
+    manager = new Manager();
 
 // Responsible for handling requests for sitemap files
 module.exports = function handler(siteApp) {
-    var resourceTypes = ['posts', 'authors', 'tags', 'pages'],
-        verifyResourceType = function verifyResourceType(req, res, next) {
-            if (!_.includes(resourceTypes, req.params.resource)) {
-                return res.sendStatus(404);
-            }
+    const verifyResourceType = function verifyResourceType(req, res, next) {
+        if (!manager.hasOwnProperty(req.params.resource)) {
+            return res.sendStatus(404);
+        }
 
-            next();
-        },
-        getResourceSiteMapXml = function getResourceSiteMapXml(type, page) {
-            return sitemap.getSiteMapXml(type, page);
-        };
+        next();
+    };
 
-    siteApp.get('/sitemap.xml', function sitemapXML(req, res, next) {
-        var siteMapXml = sitemap.getIndexXml();
-
+    siteApp.get('/sitemap.xml', function sitemapXML(req, res) {
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
         });
 
-        // CASE: returns null if sitemap is not initialized as below
-        if (!siteMapXml) {
-            sitemap.init()
-                .then(function () {
-                    siteMapXml = sitemap.getIndexXml();
-                    res.send(siteMapXml);
-                })
-                .catch(function (err) {
-                    next(err);
-                });
-        } else {
-            res.send(siteMapXml);
-        }
+        res.send(manager.getIndexXml());
     });
 
-    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res, next) {
+    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res) {
         var type = req.params.resource,
-            page = 1,
-            siteMapXml = getResourceSiteMapXml(type, page);
+            page = 1;
 
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
         });
 
-        // CASE: returns null if sitemap is not initialized
-        if (!siteMapXml) {
-            sitemap.init()
-                .then(function () {
-                    siteMapXml = getResourceSiteMapXml(type, page);
-                    res.send(siteMapXml);
-                })
-                .catch(function (err) {
-                    next(err);
-                });
-        } else {
-            res.send(siteMapXml);
-        }
+        res.send(manager.getSiteMapXml(type, page));
     });
 };

--- a/core/server/data/xml/sitemap/index-generator.js
+++ b/core/server/data/xml/sitemap/index-generator.js
@@ -1,27 +1,25 @@
-var _       = require('lodash'),
-    xml     = require('xml'),
-    moment  = require('moment'),
+'use strict';
+
+const _ = require('lodash'),
+    xml = require('xml'),
+    moment = require('moment'),
     urlService = require('../../../services/url'),
-    localUtils   = require('./utils'),
-    RESOURCES,
-    XMLNS_DECLS;
+    localUtils = require('./utils');
 
-RESOURCES = ['pages', 'posts', 'authors', 'tags'];
-
-XMLNS_DECLS = {
+const XMLNS_DECLS = {
     _attr: {
         xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9'
     }
 };
 
-function SiteMapIndexGenerator(opts) {
-    // Grab the other site map generators from the options
-    _.extend(this, _.pick(opts, RESOURCES));
-}
+class SiteMapIndexGenerator {
+    constructor(options) {
+        options = options || {};
+        this.types = options.types;
+    }
 
-_.extend(SiteMapIndexGenerator.prototype, {
-    getIndexXml: function () {
-        var urlElements = this.generateSiteMapUrlElements(),
+    getXml() {
+        const urlElements = this.generateSiteMapUrlElements(),
             data = {
                 // Concat the elements to the _attr declaration
                 sitemapindex: [XMLNS_DECLS].concat(urlElements)
@@ -29,16 +27,12 @@ _.extend(SiteMapIndexGenerator.prototype, {
 
         // Return the xml
         return localUtils.getDeclarations() + xml(data);
-    },
+    }
 
-    generateSiteMapUrlElements: function () {
-        var self = this;
-
-        return _.map(RESOURCES, function (resourceType) {
-            var url = urlService.utils.urlFor({
-                    relativeUrl: '/sitemap-' + resourceType + '.xml'
-                }, true),
-                lastModified = self[resourceType].lastModified;
+    generateSiteMapUrlElements() {
+        return _.map(this.types, (resourceType) => {
+            var url = urlService.utils.urlFor({relativeUrl: '/sitemap-' + resourceType.name + '.xml'}, true),
+                lastModified = resourceType.lastModified;
 
             return {
                 sitemap: [
@@ -48,6 +42,6 @@ _.extend(SiteMapIndexGenerator.prototype, {
             };
         });
     }
-});
+}
 
 module.exports = SiteMapIndexGenerator;

--- a/core/server/data/xml/sitemap/index.js
+++ b/core/server/data/xml/sitemap/index.js
@@ -1,3 +1,0 @@
-var SiteMapManager = require('./manager');
-
-module.exports = new SiteMapManager();

--- a/core/server/data/xml/sitemap/manager.js
+++ b/core/server/data/xml/sitemap/manager.js
@@ -1,75 +1,65 @@
-var _       = require('lodash'),
-    Promise = require('bluebird'),
+'use strict';
+
+const common = require('../../../lib/common'),
     IndexMapGenerator = require('./index-generator'),
     PagesMapGenerator = require('./page-generator'),
     PostsMapGenerator = require('./post-generator'),
     UsersMapGenerator = require('./user-generator'),
-    TagsMapGenerator  = require('./tag-generator'),
-    SiteMapManager;
+    TagsMapGenerator  = require('./tag-generator');
 
-SiteMapManager = function (opts) {
-    opts = opts || {};
+class SiteMapManager {
+    constructor(options) {
+        options = options || {};
 
-    this.initialized = false;
+        this.pages = options.pages || this.createPagesGenerator(options);
+        this.posts = options.posts || this.createPostsGenerator(options);
+        this.users = this.authors = options.authors || this.createUsersGenerator(options);
+        this.tags = options.tags || this.createTagsGenerator(options);
+        this.index = options.index || this.createIndexGenerator(options);
 
-    this.pages = opts.pages || this.createPagesGenerator(opts);
-    this.posts = opts.posts || this.createPostsGenerator(opts);
-    this.authors = opts.authors || this.createUsersGenerator(opts);
-    this.tags = opts.tags || this.createTagsGenerator(opts);
-
-    this.index = opts.index || this.createIndexGenerator(opts);
-};
-
-_.extend(SiteMapManager.prototype, {
-    createIndexGenerator: function () {
-        return new IndexMapGenerator(_.pick(this, 'pages', 'posts', 'authors', 'tags'));
-    },
-
-    createPagesGenerator: function (opts) {
-        return new PagesMapGenerator(opts);
-    },
-
-    createPostsGenerator: function (opts) {
-        return new PostsMapGenerator(opts);
-    },
-
-    createUsersGenerator: function (opts) {
-        return new UsersMapGenerator(opts);
-    },
-
-    createTagsGenerator: function (opts) {
-        return new TagsMapGenerator(opts);
-    },
-
-    init: function () {
-        var self = this,
-            initOps = [
-                this.pages.init(),
-                this.posts.init(),
-                this.authors.init(),
-                this.tags.init()
-            ];
-
-        return Promise.all(initOps).then(function () {
-            self.initialized = true;
+        common.events.on('url.added', (obj) => {
+            this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });
-    },
 
-    getIndexXml: function () {
-        if (!this.initialized) {
-            return '';
-        }
-
-        return this.index.getIndexXml();
-    },
-
-    getSiteMapXml: function (type) {
-        if (!this.initialized || !this[type]) {
-            return null;
-        }
-
-        return this[type].siteMapContent;
+        common.events.on('url.removed', (obj) => {
+            this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
+        });
     }
-});
+
+    createIndexGenerator() {
+        return new IndexMapGenerator({
+            types: {
+                pages: this.pages,
+                posts: this.posts,
+                authors: this.authors,
+                tags: this.tags
+            }
+        });
+    }
+
+    createPagesGenerator(options) {
+        return new PagesMapGenerator(options);
+    }
+
+    createPostsGenerator(options) {
+        return new PostsMapGenerator(options);
+    }
+
+    createUsersGenerator(options) {
+        return new UsersMapGenerator(options);
+    }
+
+    createTagsGenerator(options) {
+        return new TagsMapGenerator(options);
+    }
+
+    getIndexXml() {
+        return this.index.getXml();
+    }
+
+    getSiteMapXml(type) {
+        return this[type].getXml();
+    }
+}
 
 module.exports = SiteMapManager;

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -1,61 +1,26 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
+'use strict';
+
+const _  = require('lodash'),
     urlService = require('../../../services/url'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function PageMapGenerator(opts) {
-    _.extend(this, opts);
+class PageMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'pages';
 
-// Inherit from the base generator class
-_.extend(PageMapGenerator.prototype, BaseMapGenerator.prototype);
-
-_.extend(PageMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('page.published', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('page.published.edited', self.addOrUpdateUrl.bind(self));
-        // Note: This is called if a published post is deleted
-        this.dataEvents.on('page.unpublished', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.posts.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'published',
-            staticPages: true,
-            limit: 'all'
-        }).then(function (resp) {
-            var homePage = {
-                id: 0,
-                name: 'home'
-            };
-            return [homePage].concat(resp.posts);
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.name === 'home' || (datum.page === true && datum.visibility === 'public');
-    },
-
-    getUrlForDatum: function (post) {
-        if (post.id === 0 && !_.isEmpty(post.name)) {
-            return urlService.utils.urlFor(post.name, true);
-        }
-
-        return urlService.utils.urlFor('post', {post: post}, true);
-    },
-
-    getPriorityForDatum: function (post) {
-        // TODO: We could influence this with priority or meta information
-        return post && post.name === 'home' ? 1.0 : 0.8;
+        _.extend(this, opts);
+        this.addUrl(urlService.utils.urlFor('home', true), {slug: 'name'});
     }
-});
+
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum(page) {
+        return page && page.name === 'home' ? 1.0 : 0.8;
+    }
+}
 
 module.exports = PageMapGenerator;

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -1,58 +1,21 @@
-var _ = require('lodash'),
-    api = require('../../../api'),
-    urlService = require('../../../services/url'),
+'use strict';
+
+const _ = require('lodash'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function PostMapGenerator(opts) {
-    _.extend(this, opts);
+class PostMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'posts';
 
-// Inherit from the base generator class
-_.extend(PostMapGenerator.prototype, BaseMapGenerator.prototype);
+        _.extend(this, opts);
+    }
 
-_.extend(PostMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('post.published', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('post.published.edited', self.addOrUpdateUrl.bind(self));
-        // Note: This is called if a published post is deleted
-        this.dataEvents.on('post.unpublished', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.posts.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'published',
-            staticPages: false,
-            limit: 'all',
-            /**
-             * Is required for permalinks e.g. `/:author/:slug/`.
-             * @deprecated: `author`, will be removed in Ghost 2.0
-             */
-            include: 'author,tags'
-        }).then(function (resp) {
-            return resp.posts;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.page === false && datum.visibility === 'public';
-    },
-
-    getUrlForDatum: function (post) {
-        return urlService.utils.urlFor('post', {post: post}, true);
-    },
-
-    getPriorityForDatum: function (post) {
+    getPriorityForDatum(post) {
         // give a slightly higher priority to featured posts
         return post.featured ? 0.9 : 0.8;
     }
-});
+}
 
 module.exports = PostMapGenerator;

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -1,50 +1,23 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    urlService = require('../../../services/url'),
+'use strict';
+
+const _  = require('lodash'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function TagsMapGenerator(opts) {
-    _.extend(this, opts);
+class TagsMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'tags';
+        _.extend(this, opts);
+    }
 
-// Inherit from the base generator class
-_.extend(TagsMapGenerator.prototype, BaseMapGenerator.prototype);
-
-_.extend(TagsMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('tag.added', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.deleted', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.tags.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            limit: 'all'
-        }).then(function (resp) {
-            return resp.tags;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.visibility === 'public';
-    },
-
-    getUrlForDatum: function (tag) {
-        return urlService.utils.urlFor('tag', {tag: tag}, true);
-    },
-
-    getPriorityForDatum: function () {
-        // TODO: We could influence this with meta information
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum() {
         return 0.6;
     }
-});
+}
 
 module.exports = TagsMapGenerator;

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,58 +1,28 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    urlService = require('../../../services/url'),
-    validator        = require('validator'),
-    BaseMapGenerator = require('./base-generator'),
-    // @TODO: figure out a way to get rid of this
-    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
+'use strict';
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function UserMapGenerator(opts) {
-    _.extend(this, opts);
+const _ = require('lodash'),
+    validator = require('validator'),
+    BaseMapGenerator = require('./base-generator');
 
-    BaseMapGenerator.apply(this, arguments);
-}
+class UserMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-// Inherit from the base generator class
-_.extend(UserMapGenerator.prototype, BaseMapGenerator.prototype);
+        this.name = 'authors';
+        _.extend(this, opts);
+    }
 
-_.extend(UserMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('user.activated', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.activated.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.deactivated', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.users.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'active',
-            limit: 'all'
-        }).then(function (resp) {
-            return resp.users;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.visibility === 'public' && _.includes(activeStates, datum.status);
-    },
-
-    getUrlForDatum: function (user) {
-        return urlService.utils.urlFor('author', {author: user}, true);
-    },
-
-    getPriorityForDatum: function () {
-        // TODO: We could influence this with meta information
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum() {
         return 0.6;
-    },
+    }
 
-    validateImageUrl: function (imageUrl) {
+    validateImageUrl(imageUrl) {
         return imageUrl && validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
     }
-});
+}
 
 module.exports = UserMapGenerator;

--- a/core/server/data/xml/sitemap/utils.js
+++ b/core/server/data/xml/sitemap/utils.js
@@ -1,7 +1,8 @@
-var urlService = require('../../../services/url'),
-    sitemapsUtils;
+'use strict';
 
-sitemapsUtils = {
+const urlService = require('../../../services/url');
+
+module.exports = {
     getDeclarations: function () {
         var baseUrl = urlService.utils.urlFor('sitemap_xsl', true);
         baseUrl = baseUrl.replace(/^(http:|https:)/, '');
@@ -9,5 +10,3 @@ sitemapsUtils = {
             '<?xml-stylesheet type="text/xsl" href="' + baseUrl + '"?>';
     }
 };
-
-module.exports = sitemapsUtils;

--- a/core/test/unit/data/xml/sitemap/generator_spec.js
+++ b/core/test/unit/data/xml/sitemap/generator_spec.js
@@ -1,24 +1,26 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),
     validator = require('validator'),
     _ = require('lodash'),
-
-    // Stuff we are testing
+    testUtils = require('../../../../utils'),
     api = require('../../../../../server/api'),
     urlService = require('../../../../../server/services/url'),
-    BaseGenerator = require('../../../../../server/data/xml/sitemap/base-generator'),
+    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator'),
     PostGenerator = require('../../../../../server/data/xml/sitemap/post-generator'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
     UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
-
     sandbox = sinon.sandbox.create();
 
 should.Assertion.add('ValidUrlNode', function (options) {
     // Check urlNode looks correct
-    var urlNode = this.obj,
-        flatNode;
+    /*eslint no-invalid-this: "off"*/
+    let urlNode = this.obj;
+    let flatNode;
+
     urlNode.should.be.an.Object().with.key('url');
     urlNode.url.should.be.an.Array();
 
@@ -51,80 +53,33 @@ should.Assertion.add('ValidUrlNode', function (options) {
 });
 
 describe('Generators', function () {
-    var stubUrl = function (generator) {
-            sandbox.stub(generator, 'getUrlForDatum').callsFake(function (datum) {
-                return 'http://my-ghost-blog.com/url/' + datum.id;
-            });
-            sandbox.stub(generator, 'getUrlForImage').callsFake(function (image) {
-                return 'http://my-ghost-blog.com/images/' + image;
-            });
-
-            return generator;
-        },
-        makeFakeDatum = function (id) {
-            return {
-                id: id,
-                created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + id,
-                visibility: 'public'
-            };
-        },
-        generator;
+    let generator;
 
     afterEach(function () {
         sandbox.restore();
     });
 
-    describe('BaseGenerator', function () {
+    describe('IndexGenerator', function () {
         beforeEach(function () {
-            generator = new BaseGenerator();
-        });
-
-        it('can initialize with empty siteMapContent', function (done) {
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
-
-                validator.contains(generator.siteMapContent, '<loc>').should.equal(false);
-
-                done();
-            }).catch(done);
-        });
-
-        it('can initialize with non-empty siteMapContent', function (done) {
-            stubUrl(generator);
-
-            sandbox.stub(generator, 'getData').callsFake(function () {
-                return Promise.resolve([
-                    makeFakeDatum(100),
-                    makeFakeDatum(200),
-                    makeFakeDatum(300)
-                ]);
+            generator = new IndexGenerator({
+                types: {
+                    posts: new PostGenerator(),
+                    pages: new PageGenerator(),
+                    tags: new TagGenerator(),
+                    authors: new UserGenerator()
+                }
             });
+        });
 
-            generator.init().then(function () {
-                var idxFirst,
-                    idxSecond,
-                    idxThird;
+        describe('fn: getXml', function () {
+            it('default', function () {
+                const xml = generator.getXml();
 
-                should.exist(generator.siteMapContent);
-
-                // TODO: We should validate the contents against the XSD:
-                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
-
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
-
-                // Validate order newest to oldest
-                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
-                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
-                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
-
-                idxFirst.should.be.below(idxSecond);
-                idxSecond.should.be.below(idxThird);
-
-                done();
-            }).catch(done);
+                xml.should.match(/sitemap-tags.xml/);
+                xml.should.match(/sitemap-posts.xml/);
+                xml.should.match(/sitemap-pages.xml/);
+                xml.should.match(/sitemap-authors.xml/);
+            });
         });
     });
 
@@ -133,93 +88,119 @@ describe('Generators', function () {
             generator = new PostGenerator();
         });
 
-        it('uses 0.9 priority for featured posts', function () {
-            generator.getPriorityForDatum({
-                featured: true
-            }).should.equal(0.9);
-        });
-
-        it('uses 0.8 priority for all other (non-featured) posts', function () {
-            generator.getPriorityForDatum({
-                featured: false
-            }).should.equal(0.8);
-        });
-
-        it('does not create a node for a post with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'private',
-                page: false
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('does not create a node for a page', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                page: true
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if post has a cover image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'post-100.jpg',
-                page: false
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
-        });
-
-        it('can initialize with non-empty siteMapContent', function (done) {
-            stubUrl(generator);
-
-            sandbox.stub(generator, 'getData').callsFake(function () {
-                return Promise.resolve([
-                    _.extend(makeFakeDatum(100), {
-                        feature_image: 'post-100.jpg',
-                        page: false
-                    }),
-                    _.extend(makeFakeDatum(200), {
-                        page: false
-                    }),
-                    _.extend(makeFakeDatum(300), {
-                        feature_image: 'post-300.jpg',
-                        page: false
-                    })
-                ]);
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.9 priority for featured posts', function () {
+                generator.getPriorityForDatum({
+                    featured: true
+                }).should.equal(0.9);
             });
 
-            generator.init().then(function () {
-                var idxFirst,
-                    idxSecond,
-                    idxThird;
+            it('uses 0.8 priority for all other (non-featured) posts', function () {
+                generator.getPriorityForDatum({
+                    featured: false
+                }).should.equal(0.8);
+            });
+        });
 
-                should.exist(generator.siteMapContent);
+        describe('fn: createNodeFromDatum', function () {
+            it('adds an image:image element if post has a cover image', function () {
+                const urlNode = generator.createUrlNodeFromDatum('https://myblog.com/test/', testUtils.DataGenerator.forKnex.createPost({
+                    feature_image: 'post-100.jpg',
+                    page: false,
+                    slug: 'test'
+                }));
 
-                // TODO: We should validate the contents against the XSD:
-                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+                urlNode.should.be.a.ValidUrlNode({withImage: true});
+            });
+        });
 
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
+        describe('fn: getXml', function () {
+            beforeEach(function () {
+                sandbox.stub(urlService.utils, 'urlFor');
+            });
 
-                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-100.jpg</image:loc>');
+            it('get cached xml', function () {
+                sandbox.spy(generator, 'generateXmlFromNodes');
+                generator.siteMapContent = 'something';
+                generator.getXml().should.eql('something');
+                generator.siteMapContent = null;
+                generator.generateXmlFromNodes.called.should.eql(false);
+            });
+
+            it('compare content output', function () {
+                let idxFirst, idxSecond, idxThird;
+
+                urlService.utils.urlFor.withArgs('image', {image: 'post-100.jpg'}, true).returns('http://my-ghost-blog.com/images/post-100.jpg');
+                urlService.utils.urlFor.withArgs('image', {image: 'post-200.jpg'}, true).returns('http://my-ghost-blog.com/images/post-200.jpg');
+                urlService.utils.urlFor.withArgs('image', {image: 'post-300.jpg'}, true).returns('http://my-ghost-blog.com/images/post-300.jpg');
+                urlService.utils.urlFor.withArgs('sitemap_xsl', true).returns('http://my-ghost-blog.com/sitemap.xsl');
+
+                generator.addUrl('http://my-ghost-blog.com/url/100/', testUtils.DataGenerator.forKnex.createPost({
+                    feature_image: 'post-100.jpg',
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 100,
+                    updated_at: null,
+                    published_at: null,
+                    slug: '100'
+                }));
+
+                generator.addUrl('http://my-ghost-blog.com/url/200/', testUtils.DataGenerator.forKnex.createPost({
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 200,
+                    updated_at: null,
+                    published_at: null,
+                    slug: '200'
+                }));
+
+                generator.addUrl('http://my-ghost-blog.com/url/300/', testUtils.DataGenerator.forKnex.createPost({
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 300,
+                    feature_image: 'post-300.jpg',
+                    updated_at: null,
+                    published_at: null,
+                    slug: '300'
+                }));
+
+                const xml = generator.getXml();
+
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/100/</loc>');
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/200/</loc>');
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/300/</loc>');
+
+                xml.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-100.jpg</image:loc>');
                 // This should NOT be present
-                generator.siteMapContent.should.not.containEql('<image:loc>http://my-ghost-blog.com/images/post-200.jpg</image:loc>');
-                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-300.jpg</image:loc>');
+                xml.should.not.containEql('<image:loc>http://my-ghost-blog.com/images/post-200.jpg</image:loc>');
+                xml.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-300.jpg</image:loc>');
 
                 // Validate order newest to oldest
-                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
-                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
-                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
+                idxFirst = xml.indexOf('<loc>http://my-ghost-blog.com/url/300/</loc>');
+                idxSecond = xml.indexOf('<loc>http://my-ghost-blog.com/url/200/</loc>');
+                idxThird = xml.indexOf('<loc>http://my-ghost-blog.com/url/100/</loc>');
 
                 idxFirst.should.be.below(idxSecond);
                 idxSecond.should.be.below(idxThird);
+            });
+        });
 
-                done();
-            }).catch(done);
+        describe('fn: removeUrl', function () {
+            let post;
+
+            beforeEach(function () {
+                post = testUtils.DataGenerator.forKnex.createPost();
+                generator.nodeLookup[post.id] = 'node';
+            });
+
+            afterEach(function () {
+                generator.nodeLookup = {};
+                generator.nodeTimeLookup = {};
+            });
+
+            it('remove none existend url', function () {
+                generator.removeUrl('https://myblog.com/blog/podcast/featured/', testUtils.DataGenerator.forKnex.createPost());
+                Object.keys(generator.nodeLookup).length.should.eql(1);
+            });
+
+            it('remove existing url', function () {
+                generator.removeUrl('https://myblog.com/blog/test/', post);
+                Object.keys(generator.nodeLookup).length.should.eql(0);
+            });
         });
     });
 
@@ -228,77 +209,35 @@ describe('Generators', function () {
             generator = new PageGenerator();
         });
 
-        it('has a home item even if pages are empty', function (done) {
-            // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse').callsFake(function () {
-                return Promise.resolve({posts: []});
-            });
-
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
-
+        describe('fn: getXml', function () {
+            it('has a home item even if pages are empty', function () {
+                generator.getXml();
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
                 // <loc> should exist exactly one time
                 generator.siteMapContent.indexOf('<loc>').should.eql(generator.siteMapContent.lastIndexOf('<loc>'));
-
-                done();
-            }).catch(done);
-        });
-
-        it('has a home item when pages are not empty', function (done) {
-            // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse').callsFake(function () {
-                return Promise.resolve({
-                    posts: [_.extend(makeFakeDatum(100), {
-                        page: true,
-                        url: 'magic'
-                    })]
-                });
             });
 
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
+            it('has a home item when pages are not empty', function () {
+                generator.addUrl('magic', testUtils.DataGenerator.forKnex.createPost({
+                    page: true,
+                    slug: 'static-page'
+                }));
 
+                generator.getXml();
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('page', {url: 'magic'}, true) + '</loc>');
-
-                done();
-            }).catch(done);
+            });
         });
 
-        it('uses 1 priority for home page', function () {
-            generator.getPriorityForDatum({
-                name: 'home'
-            }).should.equal(1);
-        });
-        it('uses 0.8 priority for static pages', function () {
-            generator.getPriorityForDatum({}).should.equal(0.8);
-        });
-
-        it('does not create a node for a page with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'internal',
-                page: true
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('does not create a node for a post', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                page: false
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if page has an image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'page-100.jpg',
-                page: true
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 1 priority for home page', function () {
+                generator.getPriorityForDatum({
+                    name: 'home'
+                }).should.equal(1);
+            });
+            it('uses 0.8 priority for static pages', function () {
+                generator.getPriorityForDatum({}).should.equal(0.8);
+            });
         });
     });
 
@@ -307,24 +246,10 @@ describe('Generators', function () {
             generator = new TagGenerator();
         });
 
-        it('uses 0.6 priority for all tags', function () {
-            generator.getPriorityForDatum({}).should.equal(0.6);
-        });
-
-        it('does not create a node for a tag with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'internal'
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if tag has an image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'tag-100.jpg'
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.6 priority for all tags', function () {
+                generator.getPriorityForDatum({}).should.equal(0.6);
+            });
         });
     });
 
@@ -333,36 +258,28 @@ describe('Generators', function () {
             generator = new UserGenerator();
         });
 
-        it('uses 0.6 priority for author links', function () {
-            generator.getPriorityForDatum({}).should.equal(0.6);
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.6 priority for author links', function () {
+                generator.getPriorityForDatum({}).should.equal(0.6);
+            });
         });
 
-        it('does not create a node for invited users', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover: 'user-100.jpg',
-                status: 'invited'
-            }));
+        describe('fn: validateImageUrl', function () {
+            it('image url is localhost', function () {
+                generator.validateImageUrl('http://localhost:2368/content/images/1.jpg').should.be.true();
+            });
 
-            urlNode.should.be.false();
-        });
+            it('image url is https', function () {
+                generator.validateImageUrl('https://myblog.com/content/images/1.png').should.be.true();
+            });
 
-        it('does not create a node for a user with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover_image: 'user-100.jpg',
-                status: 'active',
-                visibility: 'notpublic'
-            }));
+            it('image url is external', function () {
+                generator.validateImageUrl('https://myblog.com/1.jpg').should.be.true();
+            });
 
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if user has a cover image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover_image: '/content/images/2016/01/user-100.jpg',
-                status: 'active'
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+            it('no host', function () {
+                generator.validateImageUrl('/content/images/1.jpg').should.be.false();
+            });
         });
     });
 });

--- a/core/test/unit/data/xml/sitemap/manager_spec.js
+++ b/core/test/unit/data/xml/sitemap/manager_spec.js
@@ -1,6 +1,7 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
-    Promise = require('bluebird'),
 
     // Stuff we are testing
     common = require('../../../../../server/lib/common'),
@@ -9,268 +10,111 @@ var should = require('should'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
     UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
+    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator'),
 
     sandbox = sinon.sandbox.create();
 
-describe('Sitemap', function () {
-    var makeStubManager = function () {
-        var posts, pages, tags, authors;
-        sandbox.stub(PostGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(PageGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(TagGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(UserGenerator.prototype, 'refreshAll').returns(Promise.resolve());
+describe('Unit: sitemap/manager', function () {
+    let eventsToRemember;
 
+    const makeStubManager = function () {
+        let posts, pages, tags, authors, index;
+
+        index = new IndexGenerator();
         posts = new PostGenerator();
         pages = new PageGenerator();
         tags = new TagGenerator();
         authors = new UserGenerator();
 
-        sandbox.spy(posts, 'init');
-        sandbox.spy(pages, 'init');
-        sandbox.spy(tags, 'init');
-        sandbox.spy(authors, 'init');
-
-        sandbox.stub(posts, 'addOrUpdateUrl');
-        sandbox.stub(pages, 'addOrUpdateUrl');
-        sandbox.stub(tags, 'addOrUpdateUrl');
-        sandbox.stub(authors, 'addOrUpdateUrl');
-
-        sandbox.stub(posts, 'removeUrl');
-        sandbox.stub(pages, 'removeUrl');
-        sandbox.stub(tags, 'removeUrl');
-        sandbox.stub(authors, 'removeUrl');
-
         return new SiteMapManager({posts: posts, pages: pages, tags: tags, authors: authors});
     };
 
+    beforeEach(function () {
+        eventsToRemember = {};
+
+        sandbox.stub(common.events, 'on').callsFake(function (eventName, callback) {
+            eventsToRemember[eventName] = callback;
+        });
+
+        sandbox.stub(PostGenerator.prototype, 'getXml');
+        sandbox.stub(PostGenerator.prototype, 'addUrl');
+        sandbox.stub(PostGenerator.prototype, 'removeUrl');
+        sandbox.stub(IndexGenerator.prototype, 'getXml');
+    });
+
     afterEach(function () {
         sandbox.restore();
-        common.events.removeAllListeners();
     });
 
     describe('SiteMapManager', function () {
-        var manager, fake;
-
-        should.exist(SiteMapManager);
+        let manager, fake;
 
         beforeEach(function () {
             manager = makeStubManager();
             fake = sandbox.stub();
         });
 
+        it('create SiteMapManager with defaults', function () {
+            const siteMapManager = new SiteMapManager();
+            should.exist(siteMapManager.posts);
+            should.exist(siteMapManager.pages);
+            should.exist(siteMapManager.users);
+            should.exist(siteMapManager.tags);
+        });
+
         it('can create a SiteMapManager instance', function () {
             should.exist(manager);
+            Object.keys(eventsToRemember).length.should.eql(2);
+            should.exist(eventsToRemember['url.added']);
+            should.exist(eventsToRemember['url.removed']);
         });
 
-        it('can initialize', function (done) {
-            manager.initialized.should.equal(false);
-            manager.init().then(function () {
-                manager.posts.init.called.should.equal(true);
-                manager.pages.init.called.should.equal(true);
-                manager.authors.init.called.should.equal(true);
-                manager.tags.init.called.should.equal(true);
+        describe('trigger url events', function () {
+            it('url.added', function () {
+                eventsToRemember['url.added']({
+                    url: {
+                        relative: '/test/',
+                        absolute: 'https://myblog.com/test/'
+                    },
+                    resource: {
+                        config: {
+                            type: 'posts'
+                        },
+                        data: {}
+                    }
+                });
 
-                manager.initialized.should.equal(true);
+                PostGenerator.prototype.addUrl.calledOnce.should.be.true();
+            });
 
-                done();
-            }).catch(done);
+            it('url.removed', function () {
+                eventsToRemember['url.removed']({
+                    url: {
+                        relative: '/test/',
+                        absolute: 'https://myblog.com/test/'
+                    },
+                    resource: {
+                        config: {
+                            type: 'posts'
+                        },
+                        data: {}
+                    }
+                });
+
+                PostGenerator.prototype.removeUrl.calledOnce.should.be.true();
+            });
         });
 
-        it('updates page site map correctly', function (done) {
-            manager.init().then(function () {
-                common.events.on('page.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // page add events are ignored, as these are drafts
-                    manager.pages.addOrUpdateUrl.called.should.equal(false);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.edited', function () {
-                    // page edit events are ignored, as these are drafts
-                    manager.pages.addOrUpdateUrl.called.should.equal(false);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.published', function () {
-                    // page published events are when a url gets added
-                    manager.pages.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.published.edited', function () {
-                    // page published.edited events are when a url gets updated
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.deleted', function () {
-                    // page deleted events are ignored, as unpublished will be called if the page was published
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.unpublished', function () {
-                    // page unpublished events are when a url gets removed
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('page.added', fake);
-                common.events.emit('page.edited', fake);
-                common.events.emit('page.published', fake);
-                common.events.emit('page.published.edited', fake);
-                common.events.emit('page.deleted', fake);
-                common.events.emit('page.unpublished', fake);
-
-                done();
-            }).catch(done);
+        it('fn: getSiteMapXml', function () {
+            PostGenerator.prototype.getXml.returns('xml');
+            manager.getSiteMapXml('posts').should.eql('xml');
+            PostGenerator.prototype.getXml.calledOnce.should.be.true();
         });
 
-        it('updates post site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // post add events are ignored, as these are drafts
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.edited', function () {
-                    // post edit events are ignored, as these are drafts
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.published', function () {
-                    // post published events are when a url gets added
-                    manager.posts.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.published.edited', function () {
-                    // post published.edited events are when a url gets updated
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.deleted', function () {
-                    // post deleted events are ignored, as unpublished will be called if the post was published
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.unpublished', function () {
-                    // post unpublished events are when a url gets removed
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('post.added', fake);
-                common.events.emit('post.edited', fake);
-                common.events.emit('post.published', fake);
-                common.events.emit('post.published.edited', fake);
-                common.events.emit('post.deleted', fake);
-                common.events.emit('post.unpublished', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('doesn\'t add posts until they are published', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.added', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.on('post.edited', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.on('post.published', function () {
-                    manager.posts.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.emit('post.added', fake);
-                common.events.emit('post.edited', fake);
-                common.events.emit('post.published', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('deletes posts that were unpublished', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.unpublished', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('post.unpublished', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('updates authors site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('user.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // user added is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.edited', function () {
-                    // user edited is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.activated', function () {
-                    // user activated is the point we know the user can be added
-                    manager.authors.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.activated.edited', function () {
-                    // user activated.edited means we can be sure the user is active
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.deleted', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.deactivated', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('user.added', fake);
-                common.events.emit('user.edited', fake);
-                common.events.emit('user.activated', fake);
-                common.events.emit('user.activated.edited', fake);
-                common.events.emit('user.deleted', fake);
-                common.events.emit('user.deactivated', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('updates tags site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('tag.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    manager.tags.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                common.events.on('tag.edited', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                common.events.on('tag.deleted', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('tag.added', fake);
-                common.events.emit('tag.edited', fake);
-                common.events.emit('tag.deleted', fake);
-
-                done();
-            }).catch(done);
+        it('fn: getIndexXml', function () {
+            IndexGenerator.prototype.getXml.returns('xml');
+            manager.getIndexXml().should.eql('xml');
+            IndexGenerator.prototype.getXml.calledOnce.should.be.true();
         });
     });
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9601

Rewrite sitemaps "service" (it's not really a service yet).
We've refactored the url service. The sitemaps module does no longer need to fetch the resources. It can listen on the url events. **This is super important, because only the url service knows which urls are valid**.

- listen on url events
- do not fetch resources
- the urlservice is the only component who knows which urls are valid
- ES6 adaptions
- keep caching logic -> only regenerate xml if there is a change
- update tests
- checked test coverage (100%)

- [x] do not generate the xml on bootstrap, cache the data
- [x] use proper classes / ES6
- [x] update tests
- [x] more tests
- [x] final manual tests