### PR TITLE
[HOLD]  Render 503 if url service did not finish

### DIFF
--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -172,6 +172,7 @@
         },
         "general": {
             "maintenance": "Ghost is currently undergoing maintenance, please wait a moment then retry.",
+            "maintenanceUrlService": "Ghost currently generates your blog urls. Please try again.",
             "requiredOnFuture": "This will be required in future. Please see {link}",
             "internalError": "Something went wrong.",
             "jsonParse": "Could not parse JSON: {context}."

--- a/core/server/web/middleware/index.js
+++ b/core/server/web/middleware/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    get maintenance() {
+        return require('./maintenance');
+    }
+};

--- a/core/server/web/middleware/maintenance.js
+++ b/core/server/web/middleware/maintenance.js
@@ -1,10 +1,17 @@
 var config = require('../../config'),
-    common = require('../../lib/common');
+    common = require('../../lib/common'),
+    urlService = require('../../services/url');
 
 module.exports = function maintenance(req, res, next) {
     if (config.get('maintenance').enabled) {
         return next(new common.errors.MaintenanceError({
             message: common.i18n.t('errors.general.maintenance')
+        }));
+    }
+
+    if (!urlService.hasFinished()) {
+        return next(new common.errors.MaintenanceError({
+            message: common.i18n.t('errors.general.maintenanceUrlService')
         }));
     }
 

--- a/core/test/integration/site_spec.js
+++ b/core/test/integration/site_spec.js
@@ -5,6 +5,7 @@ const should = require('should'), // jshint ignore:line
     testUtils = require('../utils/index'),
     configUtils = require('../utils/configUtils'),
     siteApp = require('../../server/web/site/app'),
+    urlService = require('../../server/services/url'),
     models = require('../../server/models'),
     sandbox = sinon.sandbox.create();
 
@@ -14,6 +15,7 @@ describe('Integration - Web - Site', function () {
     beforeEach(function () {
         app = siteApp();
 
+        sandbox.stub(urlService, 'hasFinished').returns(true);
         return testUtils.configureGhost(sandbox);
     });
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -931,6 +931,21 @@ startGhost = function startGhost(options) {
                 return themes.init();
             })
             .then(function () {
+                let timeout;
+
+                return new Promise(function (resolve) {
+                    (function retry() {
+                        clearTimeout(timeout);
+
+                        if (urlService.hasFinished()) {
+                            return resolve();
+                        }
+
+                        timeout = setTimeout(retry, 50);
+                    })();
+                });
+            })
+            .then(function () {
                 customRedirectsMiddleware.reload();
 
                 common.events.emit('server.start');
@@ -960,6 +975,21 @@ startGhost = function startGhost(options) {
             }
 
             return ghostServer.start();
+        })
+        .then(function () {
+            let timeout;
+
+            return new Promise(function (resolve) {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (urlService.hasFinished()) {
+                        return resolve();
+                    }
+
+                    timeout = setTimeout(retry, 50);
+                })();
+            });
         })
         .then(function returnGhost() {
             return ghostServer;


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9601

On bootstrap, we generate all possible urls for resources. It can happen that the url service needs a little, little longer. We return a 503 in that case. This is the first solution, we will iterate on further ideas in the near future.

This is on HOLD till we have all missing components together.

- [x] code quality check
- [x] final testing
