### PR TITLE
[HOLD]  Re-work usage of url utility

### DIFF
--- a/core/server/apps/subscribers/lib/helpers/subscribe_form.js
+++ b/core/server/apps/subscribers/lib/helpers/subscribe_form.js
@@ -5,7 +5,7 @@ var _ = require('lodash'),
     // (Less) dirty requires
     proxy = require('../../../../helpers/proxy'),
     templates = proxy.templates,
-    url = proxy.url,
+    urlService = proxy.urlService,
     SafeString = proxy.SafeString,
 
     params = ['error', 'success', 'email'],
@@ -39,7 +39,7 @@ module.exports = function subscribe_form(options) { // eslint-disable-line camel
     var root = options.data.root,
         data = _.merge({}, options.hash, _.pick(root, params), {
             // routeKeywords.subscribe: 'subscribe'
-            action: url.urlJoin('/', url.getSubdir(), 'subscribe/'),
+            action: urlService.utils.urlJoin('/', urlService.utils.getSubdir(), 'subscribe/'),
             script: new SafeString(subscribeScript),
             hidden: new SafeString(
                 makeHidden('confirm') +

--- a/core/server/controllers/entry.js
+++ b/core/server/controllers/entry.js
@@ -34,8 +34,18 @@ module.exports = function entryController(req, res, next) {
             return urlService.utils.redirectToAdmin(302, res, '#/editor/' + post.id);
         }
 
-        // CASE: permalink is not valid anymore, we redirect him permanently to the correct one
-        if (post.url !== req.path) {
+        //
+        /**
+         * CASE: Permalink is not valid anymore, we redirect him permanently to the correct one
+         *       This usually only happens if you switch to date permalinks or if you have date permalinks
+         *       enabled and the published date changes.
+         *
+         * @NOTE
+         *
+         * The resource url always contains the subdirectory. This was different before dynamic routing.
+         * That's why we have to use the original url, which contains the sub-directory.
+         */
+        if (post.url !== req.originalUrl) {
             return urlService.utils.redirect301(res, post.url);
         }
 

--- a/core/server/controllers/preview.js
+++ b/core/server/controllers/preview.js
@@ -37,7 +37,7 @@ module.exports = function previewController(req, res, next) {
         }
 
         if (post.status === 'published') {
-            return urlService.utils.redirect301(res, urlService.utils.urlFor('post', {post: post}));
+            return urlService.utils.redirect301(res, urlService.getUrlByResourceId(post.id));
         }
 
         setRequestIsSecure(req, post);

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -6,12 +6,13 @@ function getAuthorUrl(data, absolute) {
     context = context === 'amp' ? 'post' : context;
 
     if (data.author) {
-        return urlService.utils.urlFor('author', {author: data.author}, absolute);
+        return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, secure: data.author.secure});
     }
 
     if (data[context] && data[context].primary_author) {
-        return urlService.utils.urlFor('author', {author: data[context].primary_author}, absolute);
+        return urlService.getUrlByResourceId(data[context].primary_author.id, {absolute: absolute, secure: data[context].secure});
     }
+
     return null;
 }
 

--- a/core/server/data/meta/url.js
+++ b/core/server/data/meta/url.js
@@ -12,16 +12,8 @@ function sanitizeAmpUrl(url) {
 }
 
 function getUrl(data, absolute) {
-    if (schema.isPost(data)) {
-        return urlService.utils.urlFor('post', {post: data, secure: data.secure}, absolute);
-    }
-
-    if (schema.isTag(data)) {
-        return urlService.utils.urlFor('tag', {tag: data, secure: data.secure}, absolute);
-    }
-
-    if (schema.isUser(data)) {
-        return urlService.utils.urlFor('author', {author: data, secure: data.secure}, absolute);
+    if (schema.isPost(data) || schema.isTag(data) || schema.isUser(data)) {
+        return urlService.getUrlByResourceId(data.id, {secure: data.secure, absolute: absolute});
     }
 
     if (schema.isNav(data)) {

--- a/core/server/data/schema/checks.js
+++ b/core/server/data/schema/checks.js
@@ -5,7 +5,7 @@ function isPost(jsonData) {
 
 function isTag(jsonData) {
     return jsonData.hasOwnProperty('name') && jsonData.hasOwnProperty('slug') &&
-        jsonData.hasOwnProperty('description') && jsonData.hasOwnProperty('parent');
+        jsonData.hasOwnProperty('description');
 }
 
 function isUser(jsonData) {

--- a/core/server/data/xml/sitemap/handler.js
+++ b/core/server/data/xml/sitemap/handler.js
@@ -1,66 +1,37 @@
-var _       = require('lodash'),
-    config  = require('../../../config'),
-    sitemap = require('./index');
+'use strict';
+
+const config  = require('../../../config'),
+    Manager = require('./manager'),
+    manager = new Manager();
 
 // Responsible for handling requests for sitemap files
 module.exports = function handler(siteApp) {
-    var resourceTypes = ['posts', 'authors', 'tags', 'pages'],
-        verifyResourceType = function verifyResourceType(req, res, next) {
-            if (!_.includes(resourceTypes, req.params.resource)) {
-                return res.sendStatus(404);
-            }
+    const verifyResourceType = function verifyResourceType(req, res, next) {
+        if (!manager.hasOwnProperty(req.params.resource)) {
+            return res.sendStatus(404);
+        }
 
-            next();
-        },
-        getResourceSiteMapXml = function getResourceSiteMapXml(type, page) {
-            return sitemap.getSiteMapXml(type, page);
-        };
+        next();
+    };
 
-    siteApp.get('/sitemap.xml', function sitemapXML(req, res, next) {
-        var siteMapXml = sitemap.getIndexXml();
-
+    siteApp.get('/sitemap.xml', function sitemapXML(req, res) {
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
         });
 
-        // CASE: returns null if sitemap is not initialized as below
-        if (!siteMapXml) {
-            sitemap.init()
-                .then(function () {
-                    siteMapXml = sitemap.getIndexXml();
-                    res.send(siteMapXml);
-                })
-                .catch(function (err) {
-                    next(err);
-                });
-        } else {
-            res.send(siteMapXml);
-        }
+        res.send(manager.getIndexXml());
     });
 
-    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res, next) {
+    siteApp.get('/sitemap-:resource.xml', verifyResourceType, function sitemapResourceXML(req, res) {
         var type = req.params.resource,
-            page = 1,
-            siteMapXml = getResourceSiteMapXml(type, page);
+            page = 1;
 
         res.set({
             'Cache-Control': 'public, max-age=' + config.get('caching:sitemap:maxAge'),
             'Content-Type': 'text/xml'
         });
 
-        // CASE: returns null if sitemap is not initialized
-        if (!siteMapXml) {
-            sitemap.init()
-                .then(function () {
-                    siteMapXml = getResourceSiteMapXml(type, page);
-                    res.send(siteMapXml);
-                })
-                .catch(function (err) {
-                    next(err);
-                });
-        } else {
-            res.send(siteMapXml);
-        }
+        res.send(manager.getSiteMapXml(type, page));
     });
 };

--- a/core/server/data/xml/sitemap/index-generator.js
+++ b/core/server/data/xml/sitemap/index-generator.js
@@ -1,27 +1,25 @@
-var _       = require('lodash'),
-    xml     = require('xml'),
-    moment  = require('moment'),
+'use strict';
+
+const _ = require('lodash'),
+    xml = require('xml'),
+    moment = require('moment'),
     urlService = require('../../../services/url'),
-    localUtils   = require('./utils'),
-    RESOURCES,
-    XMLNS_DECLS;
+    localUtils = require('./utils');
 
-RESOURCES = ['pages', 'posts', 'authors', 'tags'];
-
-XMLNS_DECLS = {
+const XMLNS_DECLS = {
     _attr: {
         xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9'
     }
 };
 
-function SiteMapIndexGenerator(opts) {
-    // Grab the other site map generators from the options
-    _.extend(this, _.pick(opts, RESOURCES));
-}
+class SiteMapIndexGenerator {
+    constructor(options) {
+        options = options || {};
+        this.types = options.types;
+    }
 
-_.extend(SiteMapIndexGenerator.prototype, {
-    getIndexXml: function () {
-        var urlElements = this.generateSiteMapUrlElements(),
+    getXml() {
+        const urlElements = this.generateSiteMapUrlElements(),
             data = {
                 // Concat the elements to the _attr declaration
                 sitemapindex: [XMLNS_DECLS].concat(urlElements)
@@ -29,16 +27,12 @@ _.extend(SiteMapIndexGenerator.prototype, {
 
         // Return the xml
         return localUtils.getDeclarations() + xml(data);
-    },
+    }
 
-    generateSiteMapUrlElements: function () {
-        var self = this;
-
-        return _.map(RESOURCES, function (resourceType) {
-            var url = urlService.utils.urlFor({
-                    relativeUrl: '/sitemap-' + resourceType + '.xml'
-                }, true),
-                lastModified = self[resourceType].lastModified;
+    generateSiteMapUrlElements() {
+        return _.map(this.types, (resourceType) => {
+            var url = urlService.utils.urlFor({relativeUrl: '/sitemap-' + resourceType.name + '.xml'}, true),
+                lastModified = resourceType.lastModified;
 
             return {
                 sitemap: [
@@ -48,6 +42,6 @@ _.extend(SiteMapIndexGenerator.prototype, {
             };
         });
     }
-});
+}
 
 module.exports = SiteMapIndexGenerator;

--- a/core/server/data/xml/sitemap/index.js
+++ b/core/server/data/xml/sitemap/index.js
@@ -1,3 +1,0 @@
-var SiteMapManager = require('./manager');
-
-module.exports = new SiteMapManager();

--- a/core/server/data/xml/sitemap/manager.js
+++ b/core/server/data/xml/sitemap/manager.js
@@ -1,75 +1,65 @@
-var _       = require('lodash'),
-    Promise = require('bluebird'),
+'use strict';
+
+const common = require('../../../lib/common'),
     IndexMapGenerator = require('./index-generator'),
     PagesMapGenerator = require('./page-generator'),
     PostsMapGenerator = require('./post-generator'),
     UsersMapGenerator = require('./user-generator'),
-    TagsMapGenerator  = require('./tag-generator'),
-    SiteMapManager;
+    TagsMapGenerator  = require('./tag-generator');
 
-SiteMapManager = function (opts) {
-    opts = opts || {};
+class SiteMapManager {
+    constructor(options) {
+        options = options || {};
 
-    this.initialized = false;
+        this.pages = options.pages || this.createPagesGenerator(options);
+        this.posts = options.posts || this.createPostsGenerator(options);
+        this.users = this.authors = options.authors || this.createUsersGenerator(options);
+        this.tags = options.tags || this.createTagsGenerator(options);
+        this.index = options.index || this.createIndexGenerator(options);
 
-    this.pages = opts.pages || this.createPagesGenerator(opts);
-    this.posts = opts.posts || this.createPostsGenerator(opts);
-    this.authors = opts.authors || this.createUsersGenerator(opts);
-    this.tags = opts.tags || this.createTagsGenerator(opts);
-
-    this.index = opts.index || this.createIndexGenerator(opts);
-};
-
-_.extend(SiteMapManager.prototype, {
-    createIndexGenerator: function () {
-        return new IndexMapGenerator(_.pick(this, 'pages', 'posts', 'authors', 'tags'));
-    },
-
-    createPagesGenerator: function (opts) {
-        return new PagesMapGenerator(opts);
-    },
-
-    createPostsGenerator: function (opts) {
-        return new PostsMapGenerator(opts);
-    },
-
-    createUsersGenerator: function (opts) {
-        return new UsersMapGenerator(opts);
-    },
-
-    createTagsGenerator: function (opts) {
-        return new TagsMapGenerator(opts);
-    },
-
-    init: function () {
-        var self = this,
-            initOps = [
-                this.pages.init(),
-                this.posts.init(),
-                this.authors.init(),
-                this.tags.init()
-            ];
-
-        return Promise.all(initOps).then(function () {
-            self.initialized = true;
+        common.events.on('url.added', (obj) => {
+            this[obj.resource.config.type].addUrl(obj.url.absolute, obj.resource.data);
         });
-    },
 
-    getIndexXml: function () {
-        if (!this.initialized) {
-            return '';
-        }
-
-        return this.index.getIndexXml();
-    },
-
-    getSiteMapXml: function (type) {
-        if (!this.initialized || !this[type]) {
-            return null;
-        }
-
-        return this[type].siteMapContent;
+        common.events.on('url.removed', (obj) => {
+            this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
+        });
     }
-});
+
+    createIndexGenerator() {
+        return new IndexMapGenerator({
+            types: {
+                pages: this.pages,
+                posts: this.posts,
+                authors: this.authors,
+                tags: this.tags
+            }
+        });
+    }
+
+    createPagesGenerator(options) {
+        return new PagesMapGenerator(options);
+    }
+
+    createPostsGenerator(options) {
+        return new PostsMapGenerator(options);
+    }
+
+    createUsersGenerator(options) {
+        return new UsersMapGenerator(options);
+    }
+
+    createTagsGenerator(options) {
+        return new TagsMapGenerator(options);
+    }
+
+    getIndexXml() {
+        return this.index.getXml();
+    }
+
+    getSiteMapXml(type) {
+        return this[type].getXml();
+    }
+}
 
 module.exports = SiteMapManager;

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -1,61 +1,26 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
+'use strict';
+
+const _  = require('lodash'),
     urlService = require('../../../services/url'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function PageMapGenerator(opts) {
-    _.extend(this, opts);
+class PageMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'pages';
 
-// Inherit from the base generator class
-_.extend(PageMapGenerator.prototype, BaseMapGenerator.prototype);
-
-_.extend(PageMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('page.published', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('page.published.edited', self.addOrUpdateUrl.bind(self));
-        // Note: This is called if a published post is deleted
-        this.dataEvents.on('page.unpublished', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.posts.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'published',
-            staticPages: true,
-            limit: 'all'
-        }).then(function (resp) {
-            var homePage = {
-                id: 0,
-                name: 'home'
-            };
-            return [homePage].concat(resp.posts);
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.name === 'home' || (datum.page === true && datum.visibility === 'public');
-    },
-
-    getUrlForDatum: function (post) {
-        if (post.id === 0 && !_.isEmpty(post.name)) {
-            return urlService.utils.urlFor(post.name, true);
-        }
-
-        return urlService.utils.urlFor('post', {post: post}, true);
-    },
-
-    getPriorityForDatum: function (post) {
-        // TODO: We could influence this with priority or meta information
-        return post && post.name === 'home' ? 1.0 : 0.8;
+        _.extend(this, opts);
+        this.addUrl(urlService.utils.urlFor('home', true), {slug: 'name'});
     }
-});
+
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum(page) {
+        return page && page.name === 'home' ? 1.0 : 0.8;
+    }
+}
 
 module.exports = PageMapGenerator;

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -1,58 +1,21 @@
-var _ = require('lodash'),
-    api = require('../../../api'),
-    urlService = require('../../../services/url'),
+'use strict';
+
+const _ = require('lodash'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function PostMapGenerator(opts) {
-    _.extend(this, opts);
+class PostMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'posts';
 
-// Inherit from the base generator class
-_.extend(PostMapGenerator.prototype, BaseMapGenerator.prototype);
+        _.extend(this, opts);
+    }
 
-_.extend(PostMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('post.published', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('post.published.edited', self.addOrUpdateUrl.bind(self));
-        // Note: This is called if a published post is deleted
-        this.dataEvents.on('post.unpublished', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.posts.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'published',
-            staticPages: false,
-            limit: 'all',
-            /**
-             * Is required for permalinks e.g. `/:author/:slug/`.
-             * @deprecated: `author`, will be removed in Ghost 2.0
-             */
-            include: 'author,tags'
-        }).then(function (resp) {
-            return resp.posts;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.page === false && datum.visibility === 'public';
-    },
-
-    getUrlForDatum: function (post) {
-        return urlService.utils.urlFor('post', {post: post}, true);
-    },
-
-    getPriorityForDatum: function (post) {
+    getPriorityForDatum(post) {
         // give a slightly higher priority to featured posts
         return post.featured ? 0.9 : 0.8;
     }
-});
+}
 
 module.exports = PostMapGenerator;

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -1,50 +1,23 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    urlService = require('../../../services/url'),
+'use strict';
+
+const _  = require('lodash'),
     BaseMapGenerator = require('./base-generator');
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function TagsMapGenerator(opts) {
-    _.extend(this, opts);
+class TagsMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-    BaseMapGenerator.apply(this, arguments);
-}
+        this.name = 'tags';
+        _.extend(this, opts);
+    }
 
-// Inherit from the base generator class
-_.extend(TagsMapGenerator.prototype, BaseMapGenerator.prototype);
-
-_.extend(TagsMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('tag.added', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('tag.deleted', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.tags.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            limit: 'all'
-        }).then(function (resp) {
-            return resp.tags;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.visibility === 'public';
-    },
-
-    getUrlForDatum: function (tag) {
-        return urlService.utils.urlFor('tag', {tag: tag}, true);
-    },
-
-    getPriorityForDatum: function () {
-        // TODO: We could influence this with meta information
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum() {
         return 0.6;
     }
-});
+}
 
 module.exports = TagsMapGenerator;

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -1,58 +1,28 @@
-var _      = require('lodash'),
-    api    = require('../../../api'),
-    urlService = require('../../../services/url'),
-    validator        = require('validator'),
-    BaseMapGenerator = require('./base-generator'),
-    // @TODO: figure out a way to get rid of this
-    activeStates   = ['active', 'warn-1', 'warn-2', 'warn-3', 'warn-4', 'locked'];
+'use strict';
 
-// A class responsible for generating a sitemap from posts and keeping it updated
-function UserMapGenerator(opts) {
-    _.extend(this, opts);
+const _ = require('lodash'),
+    validator = require('validator'),
+    BaseMapGenerator = require('./base-generator');
 
-    BaseMapGenerator.apply(this, arguments);
-}
+class UserMapGenerator extends BaseMapGenerator {
+    constructor(opts) {
+        super();
 
-// Inherit from the base generator class
-_.extend(UserMapGenerator.prototype, BaseMapGenerator.prototype);
+        this.name = 'authors';
+        _.extend(this, opts);
+    }
 
-_.extend(UserMapGenerator.prototype, {
-    bindEvents: function () {
-        var self = this;
-        this.dataEvents.on('user.activated', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.activated.edited', self.addOrUpdateUrl.bind(self));
-        this.dataEvents.on('user.deactivated', self.removeUrl.bind(self));
-    },
-
-    getData: function () {
-        return api.users.browse({
-            context: {
-                internal: true
-            },
-            filter: 'visibility:public',
-            status: 'active',
-            limit: 'all'
-        }).then(function (resp) {
-            return resp.users;
-        });
-    },
-
-    validateDatum: function (datum) {
-        return datum.visibility === 'public' && _.includes(activeStates, datum.status);
-    },
-
-    getUrlForDatum: function (user) {
-        return urlService.utils.urlFor('author', {author: user}, true);
-    },
-
-    getPriorityForDatum: function () {
-        // TODO: We could influence this with meta information
+    /**
+     * @TODO:
+     * We could influence this with priority or meta information
+     */
+    getPriorityForDatum() {
         return 0.6;
-    },
+    }
 
-    validateImageUrl: function (imageUrl) {
+    validateImageUrl(imageUrl) {
         return imageUrl && validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
     }
-});
+}
 
 module.exports = UserMapGenerator;

--- a/core/server/data/xml/sitemap/utils.js
+++ b/core/server/data/xml/sitemap/utils.js
@@ -1,7 +1,8 @@
-var urlService = require('../../../services/url'),
-    sitemapsUtils;
+'use strict';
 
-sitemapsUtils = {
+const urlService = require('../../../services/url');
+
+module.exports = {
     getDeclarations: function () {
         var baseUrl = urlService.utils.urlFor('sitemap_xsl', true);
         baseUrl = baseUrl.replace(/^(http:|https:)/, '');
@@ -9,5 +10,3 @@ sitemapsUtils = {
             '<?xml-stylesheet type="text/xsl" href="' + baseUrl + '"?>';
     }
 };
-
-module.exports = sitemapsUtils;

--- a/core/server/helpers/author.js
+++ b/core/server/helpers/author.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // # Author Helper
 // Usage: `{{author}}` OR `{{#author}}{{/author}}`
 //
@@ -9,13 +11,12 @@
 //
 // Block helper: `{{#author}}{{/author}}`
 // This is the default handlebars behaviour of dropping into the author object scope
-
-var proxy = require('./proxy'),
+const proxy = require('./proxy'),
     _ = require('lodash'),
+    urlService = require('../services/url'),
     SafeString = proxy.SafeString,
     handlebars = proxy.hbs.handlebars,
-    templates = proxy.templates,
-    url = proxy.url;
+    templates = proxy.templates;
 
 /**
  * @deprecated: will be removed in Ghost 2.0
@@ -25,13 +26,13 @@ module.exports = function author(options) {
         return handlebars.helpers.with.call(this, this.author, options);
     }
 
-    var autolink = _.isString(options.hash.autolink) && options.hash.autolink === 'false' ? false : true,
-        output = '';
+    const autolink = _.isString(options.hash.autolink) && options.hash.autolink === 'false' ? false : true;
+    let output = '';
 
     if (this.author && this.author.name) {
         if (autolink) {
             output = templates.link({
-                url: url.urlFor('author', {author: this.author}),
+                url: urlService.getUrlByResourceId(this.author.id),
                 text: _.escape(this.author.name)
             });
         } else {

--- a/core/server/helpers/authors.js
+++ b/core/server/helpers/authors.js
@@ -1,3 +1,4 @@
+'use strict';
 // # Authors Helper
 // Usage: `{{authors}}`, `{{authors separator=' - '}}`
 //
@@ -5,32 +6,32 @@
 // By default, authors are separated by commas.
 //
 // Note that the standard {{#each authors}} implementation is unaffected by this helper.
-
-var proxy = require('./proxy'),
+const proxy = require('./proxy'),
     _ = require('lodash'),
+    urlService = require('../services/url'),
     SafeString = proxy.SafeString,
     templates = proxy.templates,
-    url = proxy.url,
     models = proxy.models;
 
 module.exports = function authors(options) {
     options = options || {};
     options.hash = options.hash || {};
 
-    var autolink = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
+    const autolink = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
         separator = _.isString(options.hash.separator) ? options.hash.separator : ', ',
         prefix = _.isString(options.hash.prefix) ? options.hash.prefix : '',
         suffix = _.isString(options.hash.suffix) ? options.hash.suffix : '',
         limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
+        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility);
+
+    let output = '',
         from = options.hash.from ? parseInt(options.hash.from, 10) : 1,
-        to = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
-        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility),
-        output = '';
+        to = options.hash.to ? parseInt(options.hash.to, 10) : undefined;
 
     function createAuthorsList(authors) {
         function processAuthor(author) {
             return autolink ? templates.link({
-                url: url.urlFor('author', {author: author}),
+                url: urlService.getUrlByResourceId(author.id),
                 text: _.escape(author.name)
             }) : _.escape(author.name);
         }

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -8,7 +8,7 @@
 // `absolute` flag outputs absolute URL, else URL is relative.
 
 var proxy = require('./proxy'),
-    url = proxy.url;
+    urlService = proxy.urlService;
 
 module.exports = function imgUrl(attr, options) {
     // CASE: if no attribute is passed, e.g. `{{img_url}}` we show a warning
@@ -27,7 +27,7 @@ module.exports = function imgUrl(attr, options) {
     }
 
     if (attr) {
-        return url.urlFor('image', {image: attr}, absolute);
+        return urlService.utils.urlFor('image', {image: attr}, absolute);
     }
 
     // CASE: if you pass e.g. cover_image, but it is not set, then attr is null!

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -63,6 +63,6 @@ module.exports = {
     // Various utils, needs cleaning up / simplifying
     socialUrls: require('../lib/social/urls'),
     blogIcon: require('../lib/image/blog-icon'),
-    url: require('../services/url').utils,
+    urlService: require('../services/url'),
     localUtils: require('./utils')
 };

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // # Tags Helper
 // Usage: `{{tags}}`, `{{tags separator=' - '}}`
 //
@@ -5,32 +7,32 @@
 // By default, tags are separated by commas.
 //
 // Note that the standard {{#each tags}} implementation is unaffected by this helper
-
-var proxy = require('./proxy'),
+const proxy = require('./proxy'),
     _ = require('lodash'),
+    urlService = proxy.urlService,
     SafeString = proxy.SafeString,
     templates = proxy.templates,
-    url = proxy.url,
     models = proxy.models;
 
 module.exports = function tags(options) {
     options = options || {};
     options.hash = options.hash || {};
 
-    var autolink = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
+    const autolink = !(_.isString(options.hash.autolink) && options.hash.autolink === 'false'),
         separator = _.isString(options.hash.separator) ? options.hash.separator : ', ',
         prefix = _.isString(options.hash.prefix) ? options.hash.prefix : '',
         suffix = _.isString(options.hash.suffix) ? options.hash.suffix : '',
         limit = options.hash.limit ? parseInt(options.hash.limit, 10) : undefined,
+        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility);
+
+    let output = '',
         from = options.hash.from ? parseInt(options.hash.from, 10) : 1,
-        to = options.hash.to ? parseInt(options.hash.to, 10) : undefined,
-        visibilityArr = models.Base.Model.parseVisibilityString(options.hash.visibility),
-        output = '';
+        to = options.hash.to ? parseInt(options.hash.to, 10) : undefined;
 
     function createTagList(tags) {
         function processTag(tag) {
             return autolink ? templates.link({
-                url: url.urlFor('tag', {tag: tag}),
+                url: urlService.getUrlByResourceId(tag.id),
                 text: _.escape(tag.name)
             }) : _.escape(tag.name);
         }

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -439,7 +439,7 @@ Post = ghostBookshelf.Model.extend({
         }
 
         if (!options.columns || (options.columns && options.columns.indexOf('url') > -1)) {
-            attrs.url = urlService.utils.urlPathForPost(attrs);
+            attrs.url = urlService.getUrlByResourceId(attrs.id);
         }
 
         if (oldPostId) {

--- a/core/server/services/rss/generate-feed.js
+++ b/core/server/services/rss/generate-feed.js
@@ -20,7 +20,7 @@ generateTags = function generateTags(data) {
 };
 
 generateItem = function generateItem(post, siteUrl, secure) {
-    var itemUrl = urlService.utils.urlFor('post', {post: post, secure: secure}, true),
+    var itemUrl = urlService.getUrlByResourceId(post.id, {secure: secure, absolute: true}),
         htmlContent = urlService.utils.makeAbsoluteUrls(post.html, siteUrl, itemUrl),
         item = {
             title: post.title,

--- a/core/server/services/slack.js
+++ b/core/server/services/slack.js
@@ -28,7 +28,7 @@ function ping(post) {
 
     // If this is a post, we want to send the link of the post
     if (schema.isPost(post)) {
-        message = urlService.utils.urlFor('post', {post: post}, true);
+        message = urlService.getUrlByResourceId(post.id, {absolute: true});
     } else {
         message = post.message;
     }

--- a/core/server/services/url/Queue.js
+++ b/core/server/services/url/Queue.js
@@ -203,6 +203,14 @@ class Queue extends EventEmitter {
 
         this.toNotify = {};
     }
+
+    softReset() {
+        _.each(this.toNotify, (obj) => {
+            clearTimeout(obj.timeout);
+        });
+
+        this.toNotify = {};
+    }
 }
 
 module.exports = Queue;

--- a/core/server/services/url/Resources.js
+++ b/core/server/services/url/Resources.js
@@ -248,6 +248,14 @@ class Resources {
         this.listeners = [];
         this.data = {};
     }
+
+    softReset() {
+        this.data = {};
+
+        _.each(resourcesConfig, (resourceConfig) => {
+            this.data[resourceConfig.type] = [];
+        });
+    }
 }
 
 module.exports = Resources;

--- a/core/server/services/url/UrlGenerator.js
+++ b/core/server/services/url/UrlGenerator.js
@@ -1,11 +1,9 @@
 'use strict';
 
 const _ = require('lodash'),
-    moment = require('moment-timezone'),
     jsonpath = require('jsonpath'),
     debug = require('ghost-ignition').debug('services:url:generator'),
     localUtils = require('./utils'),
-    settingsCache = require('../settings/cache'),
     /**
      * @TODO: This is a fake version of the upcoming GQL tool.
      * GQL will offer a tool to match a JSON against a filter.
@@ -140,57 +138,10 @@ class UrlGenerator {
      * We currently generate relative urls.
      */
     _generateUrl(resource) {
-        let url = this.routingType.getPermalinks().getValue();
-        url = this._replacePermalink(url, resource);
+        const permalink = this.routingType.getPermalinks().getValue();
+        const url = localUtils.replacePermalink(permalink, resource.data);
 
         return localUtils.createUrl(url, false, false);
-    }
-
-    /**
-     * @TODO:
-     * This is a copy of `replacePermalink` of our url utility, see ./utils.
-     * But it has modifications, because the whole url utility doesn't work anymore.
-     * We will rewrite some of the functions in the utility.
-     */
-    _replacePermalink(url, resource) {
-        var output = url,
-            primaryTagFallback = 'all',
-            publishedAtMoment = moment.tz(resource.data.published_at || Date.now(), settingsCache.get('active_timezone')),
-            permalink = {
-                year: function () {
-                    return publishedAtMoment.format('YYYY');
-                },
-                month: function () {
-                    return publishedAtMoment.format('MM');
-                },
-                day: function () {
-                    return publishedAtMoment.format('DD');
-                },
-                author: function () {
-                    return resource.data.primary_author.slug;
-                },
-                primary_author: function () {
-                    return resource.data.primary_author ? resource.data.primary_author.slug : primaryTagFallback;
-                },
-                primary_tag: function () {
-                    return resource.data.primary_tag ? resource.data.primary_tag.slug : primaryTagFallback;
-                },
-                slug: function () {
-                    return resource.data.slug;
-                },
-                id: function () {
-                    return resource.data.id;
-                }
-            };
-
-        // replace tags like :slug or :year with actual values
-        output = output.replace(/(:[a-z_]+)/g, function (match) {
-            if (_.has(permalink, match.substr(1))) {
-                return permalink[match.substr(1)]();
-            }
-        });
-
-        return output;
     }
 
     /**

--- a/core/server/services/url/UrlService.js
+++ b/core/server/services/url/UrlService.js
@@ -46,9 +46,6 @@ class UrlService {
 
         this._onQueueEndedListener = this._onQueueEnded.bind(this);
         this.queue.addListener('ended', this._onQueueEnded.bind(this));
-
-        this._resetListener = this.reset.bind(this);
-        common.events.on('server.stop', this._resetListener);
     }
 
     _onQueueStarted(event) {
@@ -116,18 +113,38 @@ class UrlService {
 
     /**
      * Get url by resource id.
+     * e.g. tags, authors, posts, pages
+     *
+     * If we can't find a url for an id, we have to return a url.
+     * There are many components in Ghost which call `getUrlByResourceId` and
+     * based on the return value, they set the resource url somewhere e.g. meta data.
+     * Or if you define no collections in your yaml file and serve a page.
+     * You will see a suggestion of posts, but they all don't belong to a collection.
+     * They would show localhost:2368/null/.
      */
-    getUrlByResourceId(id) {
+    getUrlByResourceId(id, options) {
+        options = options || {};
+
         const obj = this.urls.getByResourceId(id);
 
         if (obj) {
+            if (options.absolute) {
+                return this.utils.createUrl(obj.url, options.absolute, options.secure);
+            }
+
             return obj.url;
         }
 
-        return null;
+        // @TODO: yes/no? reconsider!
+        if (options.absolute) {
+            return this.utils.createUrl('/404/', options.absolute, options.secure);
+        }
+
+        return '/404/';
     }
 
     reset() {
+        debug('reset');
         this.urlGenerators = [];
 
         this.urls.reset();
@@ -137,7 +154,13 @@ class UrlService {
         this._onQueueStartedListener && this.queue.removeListener('started', this._onQueueStartedListener);
         this._onQueueEndedListener && this.queue.removeListener('ended', this._onQueueEndedListener);
         this._onRoutingTypeListener && common.events.removeListener('routingType.created', this._onRoutingTypeListener);
-        this._resetListener && common.events.removeListener('server.stop', this._resetListener);
+    }
+
+    softReset() {
+        debug('softReset');
+        this.urls.softReset();
+        this.queue.softReset();
+        this.resources.softReset();
     }
 }
 

--- a/core/server/services/url/Urls.js
+++ b/core/server/services/url/Urls.js
@@ -104,6 +104,10 @@ class Urls {
     reset() {
         this.urls = {};
     }
+
+    softReset() {
+        this.urls = {};
+    }
 }
 
 module.exports = Urls;

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -166,19 +166,12 @@ function createUrl(urlPath, absolute, secure) {
 
 /**
  * creates the url path for a post based on blog timezone and permalink pattern
- *
- * @param {JSON} post
- * @returns {string}
  */
-function urlPathForPost(post) {
-    var output = '',
-        permalinks = settingsCache.get('permalinks'),
-        // routeKeywords.primaryTagFallback: 'all'
+function replacePermalink(permalink, resource) {
+    let output = permalink,
         primaryTagFallback = 'all',
-        // routeKeywords.primaryAuthorFallback: 'all'
-        primaryAuthorFallback = 'all',
-        publishedAtMoment = moment.tz(post.published_at || Date.now(), settingsCache.get('active_timezone')),
-        tags = {
+        publishedAtMoment = moment.tz(resource.published_at || Date.now(), settingsCache.get('active_timezone')),
+        permalinkLookUp = {
             year: function () {
                 return publishedAtMoment.format('YYYY');
             },
@@ -188,36 +181,27 @@ function urlPathForPost(post) {
             day: function () {
                 return publishedAtMoment.format('DD');
             },
-            /**
-             * @deprecated: `author`, will be removed in Ghost 2.0
-             */
             author: function () {
-                return post.author.slug;
-            },
-            primary_tag: function () {
-                return post.primary_tag ? post.primary_tag.slug : primaryTagFallback;
+                return resource.primary_author.slug;
             },
             primary_author: function () {
-                return post.primary_author ? post.primary_author.slug : primaryAuthorFallback;
+                return resource.primary_author ? resource.primary_author.slug : primaryTagFallback;
+            },
+            primary_tag: function () {
+                return resource.primary_tag ? resource.primary_tag.slug : primaryTagFallback;
             },
             slug: function () {
-                return post.slug;
+                return resource.slug;
             },
             id: function () {
-                return post.id;
+                return resource.id;
             }
         };
 
-    if (post.page) {
-        output += '/:slug/';
-    } else {
-        output += permalinks;
-    }
-
     // replace tags like :slug or :year with actual values
     output = output.replace(/(:[a-z_]+)/g, function (match) {
-        if (_.has(tags, match.substr(1))) {
-            return tags[match.substr(1)]();
+        if (_.has(permalinkLookUp, match.substr(1))) {
+            return permalinkLookUp[match.substr(1)]();
         }
     });
 
@@ -226,17 +210,13 @@ function urlPathForPost(post) {
 
 // ## urlFor
 // Synchronous url creation for a given context
-// Can generate a url for a named path, given path, or known object (post)
+// Can generate a url for a named path and given path.
 // Determines what sort of context it has been given, and delegates to the correct generation method,
 // Finally passing to createUrl, to ensure any subdirectory is honoured, and the url is absolute if needed
 // Usage:
 // urlFor('home', true) -> http://my-ghost-blog.com/
 // E.g. /blog/ subdir
 // urlFor({relativeUrl: '/my-static-page/'}) -> /blog/my-static-page/
-// E.g. if post object represents welcome post, and slugs are set to standard
-// urlFor('post', {...}) -> /welcome-to-ghost/
-// E.g. if post object represents welcome post, and slugs are set to date
-// urlFor('post', {...}) -> /2014/01/01/welcome-to-ghost/
 // Parameters:
 // - context - a string, or json object describing the context for which you need a url
 // - data (optional) - a json object containing data needed to generate a url
@@ -246,7 +226,7 @@ function urlPathForPost(post) {
 function urlFor(context, data, absolute) {
     var urlPath = '/',
         secure, imagePathRe,
-        knownObjects = ['post', 'tag', 'author', 'image', 'nav'], baseUrl,
+        knownObjects = ['image', 'nav'], baseUrl,
         hostname,
 
         // this will become really big
@@ -269,19 +249,7 @@ function urlFor(context, data, absolute) {
     if (_.isObject(context) && context.relativeUrl) {
         urlPath = context.relativeUrl;
     } else if (_.isString(context) && _.indexOf(knownObjects, context) !== -1) {
-        // trying to create a url for an object
-        if (context === 'post' && data.post) {
-            urlPath = data.post.url;
-            secure = data.secure;
-        } else if (context === 'tag' && data.tag) {
-            // routeKeywords.tag: 'tag'
-            urlPath = urlJoin('/tag', data.tag.slug, '/');
-            secure = data.tag.secure;
-        } else if (context === 'author' && data.author) {
-            // routeKeywords.author: 'author'
-            urlPath = urlJoin('/author', data.author.slug, '/');
-            secure = data.author.secure;
-        } else if (context === 'image' && data.image) {
+        if (context === 'image' && data.image) {
             urlPath = data.image;
             imagePathRe = new RegExp('^' + getSubdir() + '/' + STATIC_IMAGE_URL_PREFIX);
             absolute = imagePathRe.test(data.image) ? absolute : false;
@@ -441,7 +409,7 @@ module.exports.getSubdir = getSubdir;
 module.exports.urlJoin = urlJoin;
 module.exports.urlFor = urlFor;
 module.exports.isSSL = isSSL;
-module.exports.urlPathForPost = urlPathForPost;
+module.exports.replacePermalink = replacePermalink;
 module.exports.redirectToAdmin = redirectToAdmin;
 module.exports.redirect301 = redirect301;
 module.exports.createUrl = createUrl;

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -28,7 +28,7 @@ var _ = require('lodash'),
 function ping(post) {
     var pingXML,
         title = post.title,
-        url = urlService.utils.urlFor('post', {post: post}, true);
+        url = urlService.getUrlByResourceId(post.id, {absolute: true});
 
     if (post.page || config.isPrivacyDisabled('useRpcPing') || settingsCache.get('is_private')) {
         return;

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -172,6 +172,7 @@
         },
         "general": {
             "maintenance": "Ghost is currently undergoing maintenance, please wait a moment then retry.",
+            "maintenanceUrlService": "Ghost currently generates your blog urls. Please try again.",
             "requiredOnFuture": "This will be required in future. Please see {link}",
             "internalError": "Something went wrong.",
             "jsonParse": "Could not parse JSON: {context}."

--- a/core/server/web/middleware/index.js
+++ b/core/server/web/middleware/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+    get maintenance() {
+        return require('./maintenance');
+    }
+};

--- a/core/server/web/middleware/maintenance.js
+++ b/core/server/web/middleware/maintenance.js
@@ -1,10 +1,17 @@
 var config = require('../../config'),
-    common = require('../../lib/common');
+    common = require('../../lib/common'),
+    urlService = require('../../services/url');
 
 module.exports = function maintenance(req, res, next) {
     if (config.get('maintenance').enabled) {
         return next(new common.errors.MaintenanceError({
             message: common.i18n.t('errors.general.maintenance')
+        }));
+    }
+
+    if (!urlService.hasFinished()) {
+        return next(new common.errors.MaintenanceError({
+            message: common.i18n.t('errors.general.maintenanceUrlService')
         }));
     }
 

--- a/core/test/integration/api/api_posts_spec.js
+++ b/core/test/integration/api/api_posts_spec.js
@@ -9,6 +9,7 @@ var should = require('should'),
     db = require('../../../server/data/db'),
     models = require('../../../server/models'),
     PostAPI = require('../../../server/api/posts'),
+    urlService = require('../../../server/services/url'),
     settingsCache = require('../../../server/services/settings/cache'),
 
     sandbox = sinon.sandbox.create();
@@ -422,6 +423,8 @@ describe('Post API', function () {
         });
 
         it('with context.user can fetch url and author fields', function (done) {
+            sandbox.stub(urlService, 'getUrlByResourceId').withArgs(testUtils.DataGenerator.Content.posts[7].id).returns('/html-ipsum/');
+
             PostAPI.browse({context: {user: 1}, status: 'all', limit: 5}).then(function (results) {
                 should.exist(results.posts);
 

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -220,7 +220,11 @@ describe('Import', function () {
             testUtils.fixtures.loadExportFixture('export-001', {lts: true}).then(function (exported) {
                 exportData = exported;
                 return dataImporter.doImport(exportData, importOptions);
-            }).then(function () {
+            }).then(function (result) {
+                // NOTE: the user in the JSON is not imported (!) - duplicate email
+                result.problems[1].help.should.eql('User');
+                result.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+
                 // Grab the data from tables
                 return Promise.all([
                     knex('users').select(),
@@ -248,10 +252,9 @@ describe('Import', function () {
                     hashedPassword: users[0].password,
                     plainPassword: testUtils.DataGenerator.Content.users[0].password
                 }).then(function () {
-                    // but the name, slug, and bio should have been overridden
                     users[0].name.should.equal(exportData.data.users[0].name);
                     users[0].slug.should.equal(exportData.data.users[0].slug);
-                    should.not.exist(users[0].bio, 'bio is not imported');
+                    users[0].email.should.equal(exportData.data.users[0].email);
 
                     // import no longer requires all data to be dropped, and adds posts
                     posts.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
@@ -323,7 +326,11 @@ describe('Import', function () {
             testUtils.fixtures.loadExportFixture('export-002', {lts: true}).then(function (exported) {
                 exportData = exported;
                 return dataImporter.doImport(exportData, importOptions);
-            }).then(function () {
+            }).then(function (result) {
+                // NOTE: the user in the JSON is not imported (!) - duplicate email
+                result.problems[1].help.should.eql('User');
+                result.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+
                 // Grab the data from tables
                 return Promise.all([
                     knex('users').select(),
@@ -351,10 +358,9 @@ describe('Import', function () {
                     hashedPassword: users[0].password,
                     plainPassword: testUtils.DataGenerator.Content.users[0].password
                 }).then(function () {
-                    // but the name, slug, and bio should have been overridden
                     users[0].name.should.equal(exportData.data.users[0].name);
                     users[0].slug.should.equal(exportData.data.users[0].slug);
-                    should.not.exist(users[0].bio, 'bio is not imported');
+                    users[0].email.should.equal(exportData.data.users[0].email);
 
                     // import no longer requires all data to be dropped, and adds posts
                     posts.length.should.equal(exportData.data.posts.length, 'Wrong number of posts');
@@ -390,7 +396,11 @@ describe('Import', function () {
             testUtils.fixtures.loadExportFixture('export-003', {lts: true}).then(function (exported) {
                 exportData = exported;
                 return dataImporter.doImport(exportData, importOptions);
-            }).then(function () {
+            }).then(function (result) {
+                // NOTE: the user in the JSON is not imported (!) - duplicate email
+                result.problems[1].help.should.eql('User');
+                result.problems[1].message.should.eql('Entry was not imported and ignored. Detected duplicated entry.');
+
                 // Grab the data from tables
                 return Promise.all([
                     knex('users').select(),
@@ -413,10 +423,9 @@ describe('Import', function () {
                     hashedPassword: users[0].password,
                     plainPassword: testUtils.DataGenerator.Content.users[0].password
                 }).then(function () {
-                    // but the name, slug, and bio should have been overridden
                     users[0].name.should.equal(exportData.data.users[0].name);
                     users[0].slug.should.equal(exportData.data.users[0].slug);
-                    should.not.exist(users[0].bio, 'bio is not imported');
+                    users[0].email.should.equal(exportData.data.users[0].email);
 
                     // test posts
                     posts.length.should.equal(1, 'Wrong number of posts');
@@ -521,10 +530,8 @@ describe('Import', function () {
                     hashedPassword: users[0].password,
                     plainPassword: testUtils.DataGenerator.Content.users[0].password
                 }).then(function () {
-                    // but the name, slug, and bio should have been overridden
                     users[0].name.should.equal('Joe Bloggs');
                     users[0].slug.should.equal('joe-bloggs');
-                    should.not.exist(users[0].bio, 'bio is not imported');
 
                     // test posts
                     posts.length.should.equal(1, 'Wrong number of posts');

--- a/core/test/integration/model/model_posts_spec.js
+++ b/core/test/integration/model/model_posts_spec.js
@@ -6,6 +6,7 @@ var should = require('should'),
     Promise = require('bluebird'),
     sequence = require('../../../server/lib/promise/sequence'),
     settingsCache = require('../../../server/services/settings/cache'),
+    urlService = require('../../../server/services/url'),
     ghostBookshelf = require('../../../server/models/base'),
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
@@ -32,6 +33,10 @@ describe('Post Model', function () {
 
     afterEach(function () {
         sandbox.restore();
+    });
+
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId').withArgs(testUtils.DataGenerator.Content.posts[0].id).returns('/html-ipsum/');
     });
 
     function checkFirstPostData(firstPost, options) {
@@ -418,6 +423,8 @@ describe('Post Model', function () {
                             permalinks: '/:year/:month/:day/:slug/'
                         }[key];
                     });
+
+                    urlService.getUrlByResourceId.withArgs(testUtils.DataGenerator.Content.posts[0].id).returns('/2015/01/01/html-ipsum/');
 
                     models.Post.findOne({id: testUtils.DataGenerator.Content.posts[0].id})
                         .then(function (result) {
@@ -1785,14 +1792,14 @@ describe('Post Model', function () {
 
             var post = _.cloneDeep(testUtils.DataGenerator.forModel.posts[0]),
                 postTags = [
-                    createTag({name: 'tag1'}),
-                    createTag({name: 'tag2'}),
-                    createTag({name: 'tag3'})
+                    createTag({name: 'tag1', slug: 'tag1'}),
+                    createTag({name: 'tag2', slug: 'tag2'}),
+                    createTag({name: 'tag3', slug: 'tag3'})
                 ],
                 extraTags = [
-                    createTag({name: 'existing tag a'}),
-                    createTag({name: 'existing-tag-b'}),
-                    createTag({name: 'existing_tag_c'})
+                    createTag({name: 'existing tag a', slug: 'existing-tag-a'}),
+                    createTag({name: 'existing-tag-b', slug: 'existing-tag-b'}),
+                    createTag({name: 'existing_tag_c', slug: 'existing_tag_c'})
                 ];
 
             post.tags = postTags;

--- a/core/test/integration/site_spec.js
+++ b/core/test/integration/site_spec.js
@@ -5,6 +5,7 @@ const should = require('should'), // jshint ignore:line
     testUtils = require('../utils/index'),
     configUtils = require('../utils/configUtils'),
     siteApp = require('../../server/web/site/app'),
+    urlService = require('../../server/services/url'),
     models = require('../../server/models'),
     sandbox = sinon.sandbox.create();
 
@@ -14,6 +15,7 @@ describe('Integration - Web - Site', function () {
     beforeEach(function () {
         app = siteApp();
 
+        sandbox.stub(urlService, 'hasFinished').returns(true);
         return testUtils.configureGhost(sandbox);
     });
 

--- a/core/test/integration/site_spec.js
+++ b/core/test/integration/site_spec.js
@@ -37,6 +37,7 @@ describe('Integration - Web - Site', function () {
                 .then(function (response) {
                     response.statusCode.should.eql(301);
                     response.headers.location.should.eql('/prettify-me/');
+                    urlService.hasFinished.calledOnce.should.be.true();
                 });
         });
     });
@@ -44,10 +45,13 @@ describe('Integration - Web - Site', function () {
     describe('component: url redirects', function () {
         describe('page', function () {
             it('success', function () {
+                const post = testUtils.DataGenerator.forKnex.createPost({slug: 'cars'});
                 configUtils.set('url', 'https://example.com');
 
                 sandbox.stub(models.Post, 'findOne')
-                    .resolves(models.Post.forge(testUtils.DataGenerator.forKnex.createPost({slug: 'cars'})));
+                    .resolves(models.Post.forge(post));
+
+                sandbox.stub(urlService, 'getUrlByResourceId').withArgs(post.id).returns('/cars/');
 
                 const req = {
                     secure: true,
@@ -60,6 +64,7 @@ describe('Integration - Web - Site', function () {
                     .then(function (response) {
                         response.statusCode.should.eql(200);
                         response.template.should.eql('post');
+                        urlService.hasFinished.calledOnce.should.be.true();
                     });
             });
 

--- a/core/test/unit/controllers/entry_spec.js
+++ b/core/test/unit/controllers/entry_spec.js
@@ -141,14 +141,14 @@ describe('Controllers', function () {
         describe('static pages', function () {
             describe('custom page templates', function () {
                 it('it will render a custom page-slug template if it exists', function (done) {
-                    req.path = '/' + mockPosts[2].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('page-' + mockPosts[2].posts[0].slug);
                         context.post.should.equal(mockPosts[2].posts[0]);
                         done();
                     };
-                    mockPosts[2].posts[0].url = req.path;
+                    mockPosts[2].posts[0].url = req.originalUrl;
 
                     controllers.entry(req, res, failTest(done));
                 });
@@ -156,14 +156,14 @@ describe('Controllers', function () {
                 it('it will use page.hbs if it exists and no page-slug template is present', function (done) {
                     hasTemplateStub.withArgs('page-about').returns(false);
 
-                    req.path = '/' + mockPosts[2].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('page');
                         context.post.should.equal(mockPosts[2].posts[0]);
                         done();
                     };
-                    mockPosts[2].posts[0].url = req.path;
+                    mockPosts[2].posts[0].url = req.originalUrl;
 
                     controllers.entry(req, res, failTest(done));
                 });
@@ -172,14 +172,14 @@ describe('Controllers', function () {
                     hasTemplateStub.withArgs('page-about').returns(false);
                     hasTemplateStub.withArgs('page').returns(false);
 
-                    req.path = '/' + mockPosts[2].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[2].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('post');
                         context.post.should.equal(mockPosts[2].posts[0]);
                         done();
                     };
-                    mockPosts[2].posts[0].url = req.path;
+                    mockPosts[2].posts[0].url = req.originalUrl;
 
                     controllers.entry(req, res, failTest(done));
                 });
@@ -187,7 +187,7 @@ describe('Controllers', function () {
 
             describe('permalink set to slug', function () {
                 it('will render static page via /:slug/', function (done) {
-                    req.path = '/' + mockPosts[0].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[0].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('page');
@@ -199,7 +199,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render static page via /YYY/MM/DD/:slug', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[0].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -208,7 +208,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render static page via /:author/:slug', function (done) {
-                    req.path = '/' + ['test', mockPosts[0].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[0].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -217,7 +217,7 @@ describe('Controllers', function () {
                 });
 
                 it('will redirect static page to admin edit page via /:slug/edit', function (done) {
-                    req.path = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
                         res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[0].posts[0].id + '/');
@@ -228,7 +228,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect static page to admin edit page via /YYYY/MM/DD/:slug/edit', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -238,7 +238,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect static page to admin edit page via /:author/:slug/edit', function (done) {
-                    req.path = '/' + ['test', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -254,7 +254,7 @@ describe('Controllers', function () {
                 });
 
                 it('will render static page via /:slug', function (done) {
-                    req.path = '/' + mockPosts[0].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[0].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('page');
@@ -266,7 +266,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render static page via /YYYY/MM/DD/:slug', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[0].posts[0].slug].join('/') + '/';
                     res.render = sinon.spy();
 
                     controllers.entry(req, res, function () {
@@ -276,7 +276,7 @@ describe('Controllers', function () {
                 });
 
                 it('will redirect static page to admin edit page via /:slug/edit', function (done) {
-                    req.path = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
                     res.render = sinon.spy();
                     res.redirect = function (arg) {
                         res.render.called.should.be.false();
@@ -288,7 +288,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect static page to admin edit page via /YYYY/MM/DD/:slug/edit', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[0].posts[0].slug, 'edit'].join('/') + '/';
                     res.render = sinon.spy();
                     res.redirect = sinon.spy();
 
@@ -308,7 +308,7 @@ describe('Controllers', function () {
                 });
 
                 it('will render post via /:slug/', function (done) {
-                    req.path = '/' + mockPosts[1].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[1].posts[0].slug + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('post');
@@ -321,7 +321,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /YYYY/MM/DD/:slug', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -330,7 +330,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /:author/:slug', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -340,7 +340,7 @@ describe('Controllers', function () {
 
                 // Handle Edit append
                 it('will redirect post to admin edit page via /:slug/edit', function (done) {
-                    req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
                         res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
@@ -351,7 +351,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect post to admin edit page via /YYYY/MM/DD/:slug/edit', function (done) {
-                    req.path = '/' + ['2012/12/30', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['2012/12/30', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -361,7 +361,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect post to admin edit page via /:author/:slug/edit', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -371,7 +371,7 @@ describe('Controllers', function () {
                 });
 
                 it('should call next if post is not found', function (done) {
-                    req.path = '/unknown/';
+                    req.originalUrl = '/unknown/';
 
                     controllers.entry(req, res, function (err) {
                         if (err) {
@@ -396,7 +396,7 @@ describe('Controllers', function () {
 
                 it('will render post via /YYYY/MM/DD/:slug/', function (done) {
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
-                    req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
                     req.route = {path: '*'};
 
                     res.render = function (view, context) {
@@ -410,7 +410,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /:slug/', function (done) {
-                    req.path = '/' + mockPosts[1].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[1].posts[0].slug + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -419,7 +419,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /:author/:slug/', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -431,7 +431,7 @@ describe('Controllers', function () {
                 it('will redirect post to admin edit page via /YYYY/MM/DD/:slug/edit/', function (done) {
                     var dateFormat = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
 
-                    req.path = '/' + [dateFormat, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [dateFormat, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
                     res.redirect = function (arg) {
                         res.render.called.should.be.false();
                         arg.should.eql(adminEditPagePath + mockPosts[1].posts[0].id + '/');
@@ -442,7 +442,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect post to admin edit page via /:slug/edit/', function (done) {
-                    req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -452,7 +452,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect post to admin edit page via /:author/:slug/edit/', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -471,7 +471,7 @@ describe('Controllers', function () {
                 });
 
                 it('will render post via /:author/:slug/', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug].join('/') + '/';
                     req.route = {path: '*'};
                     res.render = function (view, context) {
                         view.should.equal('post');
@@ -485,7 +485,7 @@ describe('Controllers', function () {
 
                 it('will NOT render post via /YYYY/MM/DD/:slug/', function (done) {
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
-                    req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -494,7 +494,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /:author/:slug/ when author does not match post author', function (done) {
-                    req.path = '/' + ['test-2', mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + ['test-2', mockPosts[1].posts[0].slug].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -503,7 +503,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT render post via /:slug/', function (done) {
-                    req.path = '/' + mockPosts[1].posts[0].slug + '/';
+                    req.originalUrl = '/' + mockPosts[1].posts[0].slug + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -513,7 +513,7 @@ describe('Controllers', function () {
 
                 // Handle Edit append
                 it('will redirect post to admin edit page via /:author/:slug/edit/', function (done) {
-                    req.path = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + ['test', mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     res.redirect = function (arg) {
                         res.render.called.should.be.false();
@@ -526,7 +526,7 @@ describe('Controllers', function () {
 
                 it('will NOT redirect post to admin edit page via /YYYY/MM/DD/:slug/edit/', function (done) {
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY/MM/DD');
-                    req.path = '/' + [date, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [date, mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -536,7 +536,7 @@ describe('Controllers', function () {
                 });
 
                 it('will NOT redirect post to admin edit page /:slug/edit/', function (done) {
-                    req.path = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
+                    req.originalUrl = '/' + [mockPosts[1].posts[0].slug, 'edit'].join('/') + '/';
 
                     controllers.entry(req, res, function () {
                         res.render.called.should.be.false();
@@ -557,7 +557,7 @@ describe('Controllers', function () {
                 it('will render post via /:year/:slug/', function (done) {
                     var date = moment(mockPosts[1].posts[0].published_at).format('YYYY');
 
-                    req.path = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
+                    req.originalUrl = '/' + [date, mockPosts[1].posts[0].slug].join('/') + '/';
                     req.route = {path: '*'};
 
                     res = {

--- a/core/test/unit/data/meta/amp_url_spec.js
+++ b/core/test/unit/data/meta/amp_url_spec.js
@@ -1,83 +1,83 @@
-var should = require('should'),
-    getAmpUrl = require('../../../../server/data/meta/amp_url'),
-    markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
+'use strict';
+
+const should = require('should'),
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+    sandbox = sinon.sandbox.create(),
+    urlService = require('../../../../server/services/url'),
+    testUtils = require('../../../utils');
+
+let getAmpUrl = rewire('../../../../server/data/meta/amp_url');
 
 describe('getAmpUrl', function () {
-    it('should return amp url for post only', function () {
-        var ampUrl = getAmpUrl({
-            url: '/this-is-a-test-post/',
-            html: '<h1>Test 123</h1>',
-            markdown: markdownToMobiledoc('# Test 123'),
-            title: 'This is a test post',
-            slug: 'this-is-a-test-post',
-            secure: true,
-            context: ['post']
-        });
+    let getUrlStub;
 
-        ampUrl.should.not.equal('/this-is-a-test-post/');
-        ampUrl.should.match(/\/this-is-a-test-post\/amp\/$/);
-        ampUrl.should.not.match(/^https:/);
+    beforeEach(function () {
+        getUrlStub = sandbox.stub();
+
+        getAmpUrl = rewire('../../../../server/data/meta/amp_url');
+        getAmpUrl.__set__('getUrl', getUrlStub);
+
+        sandbox.stub(urlService.utils, 'urlJoin');
+        sandbox.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
+    });
+
+    afterEach(function () {
+       sandbox.restore();
+    });
+
+    it('should return amp url for post', function () {
+        const post = testUtils.DataGenerator.forKnex.createPost();
+
+        // @TODO: WTF?
+        post.context = ['post'];
+
+        getUrlStub.withArgs(post, false).returns('url');
+        urlService.utils.urlJoin.withArgs('http://localhost:9999', 'url', 'amp/').returns('url');
+
+        should.exist(getAmpUrl(post));
+
+        urlService.utils.urlJoin.calledOnce.should.be.true();
+        urlService.utils.urlFor.calledOnce.should.be.true();
+        getUrlStub.calledOnce.should.be.true();
     });
 
     it('should not return amp url for tag', function () {
-        var ampUrl = getAmpUrl({
-            parent: null,
-            name: 'testing',
-            slug: 'testing',
-            description: 'We need testing',
-            secure: true,
-            context: ['tag']
-        });
+        const tag = testUtils.DataGenerator.forKnex.createTag();
 
-        should.not.exist(ampUrl);
+        // @TODO: WTF?
+        tag.context = ['tag'];
+
+        should.not.exist(getAmpUrl(tag));
+
+        urlService.utils.urlJoin.called.should.be.false();
+        urlService.utils.urlFor.called.should.be.false();
+        getUrlStub.called.should.be.false();
     });
 
     it('should not return amp url for author', function () {
-        var ampUrl = getAmpUrl({
-            name: 'Test User',
-            bio: 'This is all about testing',
-            website: 'http://my-testing-site.com',
-            status: 'testing',
-            location: 'Wounderland',
-            slug: 'test-user',
-            secure: true,
-            context: ['author']
-        });
-        should.not.exist(ampUrl);
+        const author = testUtils.DataGenerator.forKnex.createUser();
+
+        // @TODO: WTF?
+        author.context = ['author'];
+
+        should.not.exist(getAmpUrl(author));
+
+        urlService.utils.urlJoin.called.should.be.false();
+        urlService.utils.urlFor.called.should.be.false();
+        getUrlStub.called.should.be.false();
     });
 
     it('should not return amp url for amp post', function () {
-        var ampUrl = getAmpUrl({
-            name: 'Test User',
-            bio: 'This is all about testing',
-            website: 'http://my-testing-site.com',
-            status: 'testing',
-            location: 'Wounderland',
-            slug: 'test-user',
-            secure: true,
-            context: ['amp', 'post']
-        });
-        should.not.exist(ampUrl);
-    });
+        const post = testUtils.DataGenerator.forKnex.createPost();
 
-    it('should not return amp url for amp page', function () {
-        var ampUrl = getAmpUrl({
-            name: 'Test User',
-            bio: 'This is all about testing',
-            website: 'http://my-testing-site.com',
-            status: 'testing',
-            location: 'Wounderland',
-            slug: 'test-user',
-            secure: true,
-            context: ['amp', 'page']
-        });
-        should.not.exist(ampUrl);
-    });
+        // @TODO: WTF?
+        post.context = ['amp', 'post'];
 
-    it('should return home if empty secure data', function () {
-        var ampUrl = getAmpUrl({
-            secure: true
-        });
-        should.not.exist(ampUrl);
+        should.not.exist(getAmpUrl(post));
+
+        urlService.utils.urlJoin.called.should.be.false();
+        urlService.utils.urlFor.called.should.be.false();
+        getUrlStub.called.should.be.false();
     });
 });

--- a/core/test/unit/data/meta/author_url_spec.js
+++ b/core/test/unit/data/meta/author_url_spec.js
@@ -1,85 +1,87 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
+    sinon = require('sinon'),
+    ObjectId = require('bson-objectid'),
+    sandbox = sinon.sandbox.create(),
+    urlService = require('../../../../server/services/url'),
     getAuthorUrl = require('../../../../server/data/meta/author_url');
 
 describe('getAuthorUrl', function () {
-    it('should return author url if context contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                context: ['post'],
-                post: {
-                    primary_author: {
-                        slug: 'test-author'
-                    }
-                }
-            });
-            authorUrl.should.equal('/author/test-author/');
-        });
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId');
+    });
 
-    it('should return absolute author url if context contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                context: ['post'],
-                post: {
-                    primary_author: {
-                        slug: 'test-author'
-                    }
-                }
-            }, true);
-            authorUrl.should.not.equal('/author/test-author/');
-            authorUrl.should.match(/\/author\/test-author\/$/);
-        });
+    afterEach(function () {
+        sandbox.restore();
+    });
 
-    it('should return author url for AMP if context contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                context: ['amp', 'post'],
-                post: {
-                    primary_author: {
-                        slug: 'test-author'
-                    }
-                }
-            });
-            authorUrl.should.equal('/author/test-author/');
-        });
+    it('should return author url if context contains primary author', function () {
+        const post = {
+            primary_author: {
+                id: ObjectId.generate(),
+                slug: 'test-author'
+            }
+        };
 
-    it('should return absolute author url for AMP if context contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                context: ['amp', 'post'],
-                post: {
-                    primary_author: {
-                        slug: 'test-author'
-                    }
-                }
-            }, true);
-            authorUrl.should.not.equal('/author/test-author/');
-            authorUrl.should.match(/\/author\/test-author\/$/);
-        });
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined})
+            .returns('author url');
 
-    it('should return author url if data contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                author: {
-                    slug: 'test-author'
-                }
-            });
-            authorUrl.should.equal('/author/test-author/');
-        });
+        should.exist(getAuthorUrl({
+            context: ['post'],
+            post: post
+        }));
+    });
 
-    it('should return absolute author url if data contains author',
-        function () {
-            var authorUrl = getAuthorUrl({
-                author: {
-                    slug: 'test-author'
-                }
-            }, true);
-            authorUrl.should.not.equal('/author/test-author/');
-            authorUrl.should.match(/\/author\/test-author\/$/);
-        });
+    it('should return absolute author url if context contains primary author', function () {
+        const post = {
+            primary_author: {
+                id: ObjectId.generate(),
+                slug: 'test-author'
+            }
+        };
 
-    it('should return null if no author on data or context',
-        function () {
-            var authorUrl = getAuthorUrl({}, true);
-            should(authorUrl).equal(null);
-        });
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: true, secure: undefined})
+            .returns('absolute author url');
+
+        should.exist(getAuthorUrl({
+            context: ['post'],
+            post: post
+        }, true));
+    });
+
+    it('should return author url for AMP if context contains primary author', function () {
+        const post = {
+            primary_author: {
+                id: ObjectId.generate(),
+                slug: 'test-author'
+            }
+        };
+
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined})
+            .returns('author url');
+
+        should.exist(getAuthorUrl({
+            context: ['amp', 'post'],
+            post: post
+        }));
+    });
+
+    it('should return author url if data contains author', function () {
+        const author = {
+            id: ObjectId.generate(),
+            slug: 'test-author'
+        };
+
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined})
+            .returns('author url');
+
+        should.exist(getAuthorUrl({
+            author: author
+        }));
+    });
+
+    it('should return null if no author on data or context', function () {
+        should.not.exist(getAuthorUrl({}, true));
+    });
 });

--- a/core/test/unit/data/meta/canonical_url_spec.js
+++ b/core/test/unit/data/meta/canonical_url_spec.js
@@ -1,70 +1,65 @@
-var should = require('should'), // jshint ignore:line
-    getCanonicalUrl = require('../../../../server/data/meta/canonical_url'),
-    markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
+'use strict';
+
+const should = require('should'),
+    sinon = require('sinon'),
+    rewire = require('rewire'),
+    sandbox = sinon.sandbox.create(),
+    urlService = require('../../../../server/services/url'),
+    testUtils = require('../../../utils');
+
+let getCanonicalUrl = rewire('../../../../server/data/meta/canonical_url');
 
 describe('getCanonicalUrl', function () {
-    it('should return absolute canonical url for post', function () {
-        var canonicalUrl = getCanonicalUrl({
-            url: '/this-is-a-test-post/',
-            html: '<h1>Test 123</h1>',
-            mobiledoc: markdownToMobiledoc('# Test 123'),
-            title: 'This is a test post',
-            slug: 'this-is-a-test-post',
-            secure: true
-        });
-        canonicalUrl.should.not.equal('/this-is-a-test-post/');
-        canonicalUrl.should.match(/\/this-is-a-test-post\/$/);
-        canonicalUrl.should.not.match(/^https:/);
+    let getUrlStub;
+
+    beforeEach(function () {
+        getUrlStub = sandbox.stub();
+
+        getCanonicalUrl = rewire('../../../../server/data/meta/canonical_url');
+        getCanonicalUrl.__set__('getUrl', getUrlStub);
+
+        sandbox.stub(urlService.utils, 'urlJoin');
+        sandbox.stub(urlService.utils, 'urlFor').withArgs('home', true).returns('http://localhost:9999');
     });
 
-    it('should return absolute canonical url for amp post without /amp/ in url', function () {
-        var canonicalUrl = getCanonicalUrl({
-            url: '/this-is-a-test-post/amp/',
-            html: '<h1>Test 123</h1>',
-            mobiledoc: markdownToMobiledoc('# Test 123'),
-            title: 'This is a test post',
-            slug: 'this-is-a-test-post',
-            secure: true
-        });
-        canonicalUrl.should.not.equal('/this-is-a-test-post/amp/');
-        canonicalUrl.should.match(/\/this-is-a-test-post\/$/);
-        canonicalUrl.should.not.match(/^https:/);
+    afterEach(function () {
+        sandbox.restore();
     });
 
-    it('should return absolute canonical url for tag', function () {
-        var canonicalUrl = getCanonicalUrl({
-            parent: null,
-            name: 'testing',
-            slug: 'testing',
-            description: 'We need testing',
-            secure: true
-        });
-        canonicalUrl.should.not.equal('/tag/testing/');
-        canonicalUrl.should.match(/\/tag\/testing\/$/);
-        canonicalUrl.should.not.match(/^https:/);
+    it('should return canonical url', function () {
+        const post = testUtils.DataGenerator.forKnex.createPost();
+
+        getUrlStub.withArgs(post, false).returns('/post-url/');
+        urlService.utils.urlJoin.withArgs('http://localhost:9999', '/post-url/').returns('canonical url');
+
+        getCanonicalUrl(post).should.eql('canonical url');
+
+        urlService.utils.urlJoin.calledOnce.should.be.true();
+        urlService.utils.urlFor.calledOnce.should.be.true();
+        getUrlStub.calledOnce.should.be.true();
     });
 
-    it('should return absolute canonical url for author', function () {
-        var canonicalUrl = getCanonicalUrl({
-            name: 'Test User',
-            bio: 'This is all about testing',
-            website: 'http://my-testing-site.com',
-            profile_image: null,
-            location: 'Wounderland',
-            slug: 'test-user',
-            secure: true
-        });
-        canonicalUrl.should.not.equal('/author/test-user/');
-        canonicalUrl.should.match(/\/author\/test-user\/$/);
-        canonicalUrl.should.not.match(/^https:/);
+    it('should return canonical url for amp post without /amp/ in url', function () {
+        const post = testUtils.DataGenerator.forKnex.createPost();
+
+        getUrlStub.withArgs(post, false).returns('/post-url/amp/');
+        urlService.utils.urlJoin.withArgs('http://localhost:9999', '/post-url/amp/').returns('*/amp/');
+
+        getCanonicalUrl(post).should.eql('*/');
+
+        urlService.utils.urlJoin.calledOnce.should.be.true();
+        urlService.utils.urlFor.calledOnce.should.be.true();
+        getUrlStub.calledOnce.should.be.true();
     });
 
     it('should return home if empty secure data', function () {
-        var canonicalUrl = getCanonicalUrl({
-            secure: true
-        });
-        canonicalUrl.should.not.equal('/');
-        canonicalUrl.should.match(/\/$/);
-        canonicalUrl.should.not.match(/^https:/);
+        getUrlStub.withArgs({secure: true}, false).returns('/');
+        urlService.utils.urlJoin.withArgs('http://localhost:9999', '/').returns('canonical url');
+
+        getCanonicalUrl({secure: true}).should.eql('canonical url');
+
+        urlService.utils.urlJoin.calledOnce.should.be.true();
+        urlService.utils.urlFor.calledOnce.should.be.true();
+        getUrlStub.calledOnce.should.be.true();
     });
 });

--- a/core/test/unit/data/meta/url_spec.js
+++ b/core/test/unit/data/meta/url_spec.js
@@ -1,133 +1,123 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
+
+const should = require('should'),
+    sinon = require('sinon'),
+    sandbox = sinon.sandbox.create(),
+    urlService = require('../../../../server/services/url'),
     getUrl = require('../../../../server/data/meta/url'),
-    markdownToMobiledoc = require('../../../utils/fixtures/data-generator').markdownToMobiledoc;
+    testUtils = require('../../../utils/');
 
 describe('getUrl', function () {
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId');
+        sandbox.stub(urlService.utils, 'urlFor');
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
     it('should return url for a post', function () {
-        var url = getUrl({
-            html: '<p>Welcome to my post.</p>',
-            mobiledoc: markdownToMobiledoc('Welcome to my post.'),
-            title: 'Welcome Post',
-            slug: 'welcome-post',
-            url: '/post/welcome-post/'
-        });
-        url.should.equal('/post/welcome-post/');
+        const post = testUtils.DataGenerator.forKnex.createPost();
+
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined})
+            .returns('post url');
+
+        getUrl(post).should.eql('post url');
     });
 
     it('should return absolute url for a post', function () {
-        var url = getUrl({
-            html: '<p>Welcome to my post.</p>',
-            mobiledoc: markdownToMobiledoc('Welcome to my post.'),
-            title: 'Welcome Post',
-            slug: 'welcome-post',
-            url: '/post/welcome-post/'
-        }, true);
-        url.should.equal('http://127.0.0.1:2369/post/welcome-post/');
-    });
+        const post = testUtils.DataGenerator.forKnex.createPost();
 
-    it('should return url for a post and remove /amp/ in url', function () {
-        var url = getUrl({
-            relativeUrl: '/welcome-post/amp/',
-            post: {
-                html: '<p>Welcome to my post.</p>',
-                title: 'Welcome Post',
-                slug: 'welcome-post',
-                url: '/welcome-post/amp/'
-            }
-        });
-        url.should.equal('/welcome-post/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: true, secure: undefined})
+            .returns('absolute post url');
+
+        getUrl(post, true).should.eql('absolute post url');
     });
 
     it('should return absolute url for a post and remove /amp/ in url', function () {
-        var url = getUrl({
-            relativeUrl: '/welcome-post/amp/',
-            post: {
-                html: '<p>Welcome to my post.</p>',
-                title: 'Welcome Post',
-                slug: 'welcome-post',
-                url: '/welcome-post/amp/'
-            }
-        }, true);
-        url.should.equal('http://127.0.0.1:2369/welcome-post/');
+        const data = {relativeUrl: '/*/amp/'};
+
+        urlService.utils.urlFor.withArgs(data, {}, true).returns('absolute/*/amp/');
+        getUrl(data, true).should.eql('absolute/*/');
+        urlService.getUrlByResourceId.called.should.be.false();
     });
 
     it('should return url for a tag', function () {
-        var url = getUrl({
-            name: 'Great',
-            slug: 'great',
-            description: 'My great tag',
-            parent: null
-        });
-        url.should.equal('/tag/great/');
+        const tag = testUtils.DataGenerator.forKnex.createTag();
+
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined})
+            .returns('tag url');
+
+        getUrl(tag).should.eql('tag url');
     });
 
-    it('should return secure absolute url for a tag', function () {
-        var url = getUrl({
-            name: 'Great',
-            slug: 'great',
-            description: 'My great tag',
-            parent: null,
-            secure: true
-        }, true);
-        url.should.equal('https://127.0.0.1:2369/tag/great/');
+    it('should return secure url for a tag', function () {
+        const tag = testUtils.DataGenerator.forKnex.createTag();
+
+        // @TODO: WTF
+        tag.secure = true;
+
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: true})
+            .returns('secure tag url');
+
+        getUrl(tag).should.eql('secure tag url');
     });
 
     it('should return url for a author', function () {
-        var url = getUrl({
-            name: 'Author Name',
-            bio: 'I am fun bio!',
-            website: 'http://myoksite.com',
-            profile_image: null,
-            location: 'London',
-            slug: 'author-name'
-        });
-        url.should.equal('/author/author-name/');
+        const author = testUtils.DataGenerator.forKnex.createUser();
+
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined})
+            .returns('author url');
+
+        getUrl(author).should.eql('author url');
     });
 
     it('should return secure absolute url for a author', function () {
-        var url = getUrl({
-            name: 'Author Name',
-            bio: 'I am fun bio!',
-            website: 'http://myoksite.com',
-            profile_image: null,
-            location: 'London',
-            slug: 'author-name',
-            secure: true
-        }, true);
-        url.should.equal('https://127.0.0.1:2369/author/author-name/');
+        const author = testUtils.DataGenerator.forKnex.createUser();
+
+        // @TODO: WTF
+        author.secure = true;
+
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: true, secure: true})
+            .returns('absolute secure author url');
+
+        getUrl(author, true).should.eql('absolute secure author url');
     });
 
     it('should return url for a nav', function () {
-        var url = getUrl({
+        const data = {
             label: 'About Me',
             url: '/about-me/',
             slug: 'about-me',
             current: true
-        });
-        url.should.equal('/about-me/');
+        };
+
+        urlService.utils.urlFor.withArgs('nav', {nav: data, secure: data.secure}, undefined)
+            .returns('nav url');
+
+        getUrl(data).should.equal('nav url');
     });
 
     it('should return absolute url for a nav', function () {
-        var url = getUrl({
+        const data = {
             label: 'About Me',
             url: '/about-me/',
             slug: 'about-me',
             current: true
-        }, true);
-        url.should.equal('http://127.0.0.1:2369/about-me/');
+        };
+
+        urlService.utils.urlFor.withArgs('nav', {nav: data, secure: data.secure}, true)
+            .returns('absolute nav url');
+
+        getUrl(data, true).should.equal('absolute nav url');
     });
 
-    it('should return url for a context object with relative url', function () {
-        var url = getUrl({
-            relativeUrl: '/my/relative/url/'
-        });
-        url.should.equal('/my/relative/url/');
-    });
+    it('should return `relativeUrl` and remove /amp/ in url', function () {
+        const data = {relativeUrl: '/*/amp/'};
 
-    it('should return url for a context object with relative url and remove /amp/ in url', function () {
-        var url = getUrl({
-            relativeUrl: '/my/relative/url/amp/'
-        });
-        url.should.equal('/my/relative/url/');
+        urlService.utils.urlFor.withArgs(data, {}, undefined).returns(data.relativeUrl);
+        getUrl(data).should.eql('/*/');
+        urlService.getUrlByResourceId.called.should.be.false();
     });
 });

--- a/core/test/unit/data/xml/sitemap/generator_spec.js
+++ b/core/test/unit/data/xml/sitemap/generator_spec.js
@@ -1,24 +1,26 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
     Promise = require('bluebird'),
     validator = require('validator'),
     _ = require('lodash'),
-
-    // Stuff we are testing
+    testUtils = require('../../../../utils'),
     api = require('../../../../../server/api'),
     urlService = require('../../../../../server/services/url'),
-    BaseGenerator = require('../../../../../server/data/xml/sitemap/base-generator'),
+    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator'),
     PostGenerator = require('../../../../../server/data/xml/sitemap/post-generator'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
     UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
-
     sandbox = sinon.sandbox.create();
 
 should.Assertion.add('ValidUrlNode', function (options) {
     // Check urlNode looks correct
-    var urlNode = this.obj,
-        flatNode;
+    /*eslint no-invalid-this: "off"*/
+    let urlNode = this.obj;
+    let flatNode;
+
     urlNode.should.be.an.Object().with.key('url');
     urlNode.url.should.be.an.Array();
 
@@ -51,80 +53,33 @@ should.Assertion.add('ValidUrlNode', function (options) {
 });
 
 describe('Generators', function () {
-    var stubUrl = function (generator) {
-            sandbox.stub(generator, 'getUrlForDatum').callsFake(function (datum) {
-                return 'http://my-ghost-blog.com/url/' + datum.id;
-            });
-            sandbox.stub(generator, 'getUrlForImage').callsFake(function (image) {
-                return 'http://my-ghost-blog.com/images/' + image;
-            });
-
-            return generator;
-        },
-        makeFakeDatum = function (id) {
-            return {
-                id: id,
-                created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + id,
-                visibility: 'public'
-            };
-        },
-        generator;
+    let generator;
 
     afterEach(function () {
         sandbox.restore();
     });
 
-    describe('BaseGenerator', function () {
+    describe('IndexGenerator', function () {
         beforeEach(function () {
-            generator = new BaseGenerator();
-        });
-
-        it('can initialize with empty siteMapContent', function (done) {
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
-
-                validator.contains(generator.siteMapContent, '<loc>').should.equal(false);
-
-                done();
-            }).catch(done);
-        });
-
-        it('can initialize with non-empty siteMapContent', function (done) {
-            stubUrl(generator);
-
-            sandbox.stub(generator, 'getData').callsFake(function () {
-                return Promise.resolve([
-                    makeFakeDatum(100),
-                    makeFakeDatum(200),
-                    makeFakeDatum(300)
-                ]);
+            generator = new IndexGenerator({
+                types: {
+                    posts: new PostGenerator(),
+                    pages: new PageGenerator(),
+                    tags: new TagGenerator(),
+                    authors: new UserGenerator()
+                }
             });
+        });
 
-            generator.init().then(function () {
-                var idxFirst,
-                    idxSecond,
-                    idxThird;
+        describe('fn: getXml', function () {
+            it('default', function () {
+                const xml = generator.getXml();
 
-                should.exist(generator.siteMapContent);
-
-                // TODO: We should validate the contents against the XSD:
-                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
-
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
-
-                // Validate order newest to oldest
-                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
-                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
-                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
-
-                idxFirst.should.be.below(idxSecond);
-                idxSecond.should.be.below(idxThird);
-
-                done();
-            }).catch(done);
+                xml.should.match(/sitemap-tags.xml/);
+                xml.should.match(/sitemap-posts.xml/);
+                xml.should.match(/sitemap-pages.xml/);
+                xml.should.match(/sitemap-authors.xml/);
+            });
         });
     });
 
@@ -133,93 +88,119 @@ describe('Generators', function () {
             generator = new PostGenerator();
         });
 
-        it('uses 0.9 priority for featured posts', function () {
-            generator.getPriorityForDatum({
-                featured: true
-            }).should.equal(0.9);
-        });
-
-        it('uses 0.8 priority for all other (non-featured) posts', function () {
-            generator.getPriorityForDatum({
-                featured: false
-            }).should.equal(0.8);
-        });
-
-        it('does not create a node for a post with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'private',
-                page: false
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('does not create a node for a page', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                page: true
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if post has a cover image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'post-100.jpg',
-                page: false
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
-        });
-
-        it('can initialize with non-empty siteMapContent', function (done) {
-            stubUrl(generator);
-
-            sandbox.stub(generator, 'getData').callsFake(function () {
-                return Promise.resolve([
-                    _.extend(makeFakeDatum(100), {
-                        feature_image: 'post-100.jpg',
-                        page: false
-                    }),
-                    _.extend(makeFakeDatum(200), {
-                        page: false
-                    }),
-                    _.extend(makeFakeDatum(300), {
-                        feature_image: 'post-300.jpg',
-                        page: false
-                    })
-                ]);
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.9 priority for featured posts', function () {
+                generator.getPriorityForDatum({
+                    featured: true
+                }).should.equal(0.9);
             });
 
-            generator.init().then(function () {
-                var idxFirst,
-                    idxSecond,
-                    idxThird;
+            it('uses 0.8 priority for all other (non-featured) posts', function () {
+                generator.getPriorityForDatum({
+                    featured: false
+                }).should.equal(0.8);
+            });
+        });
 
-                should.exist(generator.siteMapContent);
+        describe('fn: createNodeFromDatum', function () {
+            it('adds an image:image element if post has a cover image', function () {
+                const urlNode = generator.createUrlNodeFromDatum('https://myblog.com/test/', testUtils.DataGenerator.forKnex.createPost({
+                    feature_image: 'post-100.jpg',
+                    page: false,
+                    slug: 'test'
+                }));
 
-                // TODO: We should validate the contents against the XSD:
-                // xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                // xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+                urlNode.should.be.a.ValidUrlNode({withImage: true});
+            });
+        });
 
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/100</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/200</loc>');
-                generator.siteMapContent.should.containEql('<loc>http://my-ghost-blog.com/url/300</loc>');
+        describe('fn: getXml', function () {
+            beforeEach(function () {
+                sandbox.stub(urlService.utils, 'urlFor');
+            });
 
-                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-100.jpg</image:loc>');
+            it('get cached xml', function () {
+                sandbox.spy(generator, 'generateXmlFromNodes');
+                generator.siteMapContent = 'something';
+                generator.getXml().should.eql('something');
+                generator.siteMapContent = null;
+                generator.generateXmlFromNodes.called.should.eql(false);
+            });
+
+            it('compare content output', function () {
+                let idxFirst, idxSecond, idxThird;
+
+                urlService.utils.urlFor.withArgs('image', {image: 'post-100.jpg'}, true).returns('http://my-ghost-blog.com/images/post-100.jpg');
+                urlService.utils.urlFor.withArgs('image', {image: 'post-200.jpg'}, true).returns('http://my-ghost-blog.com/images/post-200.jpg');
+                urlService.utils.urlFor.withArgs('image', {image: 'post-300.jpg'}, true).returns('http://my-ghost-blog.com/images/post-300.jpg');
+                urlService.utils.urlFor.withArgs('sitemap_xsl', true).returns('http://my-ghost-blog.com/sitemap.xsl');
+
+                generator.addUrl('http://my-ghost-blog.com/url/100/', testUtils.DataGenerator.forKnex.createPost({
+                    feature_image: 'post-100.jpg',
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 100,
+                    updated_at: null,
+                    published_at: null,
+                    slug: '100'
+                }));
+
+                generator.addUrl('http://my-ghost-blog.com/url/200/', testUtils.DataGenerator.forKnex.createPost({
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 200,
+                    updated_at: null,
+                    published_at: null,
+                    slug: '200'
+                }));
+
+                generator.addUrl('http://my-ghost-blog.com/url/300/', testUtils.DataGenerator.forKnex.createPost({
+                    created_at: (Date.UTC(2014, 11, 22, 12) - 360000) + 300,
+                    feature_image: 'post-300.jpg',
+                    updated_at: null,
+                    published_at: null,
+                    slug: '300'
+                }));
+
+                const xml = generator.getXml();
+
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/100/</loc>');
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/200/</loc>');
+                xml.should.containEql('<loc>http://my-ghost-blog.com/url/300/</loc>');
+
+                xml.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-100.jpg</image:loc>');
                 // This should NOT be present
-                generator.siteMapContent.should.not.containEql('<image:loc>http://my-ghost-blog.com/images/post-200.jpg</image:loc>');
-                generator.siteMapContent.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-300.jpg</image:loc>');
+                xml.should.not.containEql('<image:loc>http://my-ghost-blog.com/images/post-200.jpg</image:loc>');
+                xml.should.containEql('<image:loc>http://my-ghost-blog.com/images/post-300.jpg</image:loc>');
 
                 // Validate order newest to oldest
-                idxFirst = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/300</loc>');
-                idxSecond = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/200</loc>');
-                idxThird = generator.siteMapContent.indexOf('<loc>http://my-ghost-blog.com/url/100</loc>');
+                idxFirst = xml.indexOf('<loc>http://my-ghost-blog.com/url/300/</loc>');
+                idxSecond = xml.indexOf('<loc>http://my-ghost-blog.com/url/200/</loc>');
+                idxThird = xml.indexOf('<loc>http://my-ghost-blog.com/url/100/</loc>');
 
                 idxFirst.should.be.below(idxSecond);
                 idxSecond.should.be.below(idxThird);
+            });
+        });
 
-                done();
-            }).catch(done);
+        describe('fn: removeUrl', function () {
+            let post;
+
+            beforeEach(function () {
+                post = testUtils.DataGenerator.forKnex.createPost();
+                generator.nodeLookup[post.id] = 'node';
+            });
+
+            afterEach(function () {
+                generator.nodeLookup = {};
+                generator.nodeTimeLookup = {};
+            });
+
+            it('remove none existend url', function () {
+                generator.removeUrl('https://myblog.com/blog/podcast/featured/', testUtils.DataGenerator.forKnex.createPost());
+                Object.keys(generator.nodeLookup).length.should.eql(1);
+            });
+
+            it('remove existing url', function () {
+                generator.removeUrl('https://myblog.com/blog/test/', post);
+                Object.keys(generator.nodeLookup).length.should.eql(0);
+            });
         });
     });
 
@@ -228,77 +209,35 @@ describe('Generators', function () {
             generator = new PageGenerator();
         });
 
-        it('has a home item even if pages are empty', function (done) {
-            // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse').callsFake(function () {
-                return Promise.resolve({posts: []});
-            });
-
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
-
+        describe('fn: getXml', function () {
+            it('has a home item even if pages are empty', function () {
+                generator.getXml();
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
                 // <loc> should exist exactly one time
                 generator.siteMapContent.indexOf('<loc>').should.eql(generator.siteMapContent.lastIndexOf('<loc>'));
-
-                done();
-            }).catch(done);
-        });
-
-        it('has a home item when pages are not empty', function (done) {
-            // Fake the api call to return no posts
-            sandbox.stub(api.posts, 'browse').callsFake(function () {
-                return Promise.resolve({
-                    posts: [_.extend(makeFakeDatum(100), {
-                        page: true,
-                        url: 'magic'
-                    })]
-                });
             });
 
-            generator.init().then(function () {
-                should.exist(generator.siteMapContent);
+            it('has a home item when pages are not empty', function () {
+                generator.addUrl('magic', testUtils.DataGenerator.forKnex.createPost({
+                    page: true,
+                    slug: 'static-page'
+                }));
 
+                generator.getXml();
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('home', true) + '</loc>');
                 generator.siteMapContent.should.containEql('<loc>' + urlService.utils.urlFor('page', {url: 'magic'}, true) + '</loc>');
-
-                done();
-            }).catch(done);
+            });
         });
 
-        it('uses 1 priority for home page', function () {
-            generator.getPriorityForDatum({
-                name: 'home'
-            }).should.equal(1);
-        });
-        it('uses 0.8 priority for static pages', function () {
-            generator.getPriorityForDatum({}).should.equal(0.8);
-        });
-
-        it('does not create a node for a page with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'internal',
-                page: true
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('does not create a node for a post', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                page: false
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if page has an image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'page-100.jpg',
-                page: true
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 1 priority for home page', function () {
+                generator.getPriorityForDatum({
+                    name: 'home'
+                }).should.equal(1);
+            });
+            it('uses 0.8 priority for static pages', function () {
+                generator.getPriorityForDatum({}).should.equal(0.8);
+            });
         });
     });
 
@@ -307,24 +246,10 @@ describe('Generators', function () {
             generator = new TagGenerator();
         });
 
-        it('uses 0.6 priority for all tags', function () {
-            generator.getPriorityForDatum({}).should.equal(0.6);
-        });
-
-        it('does not create a node for a tag with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                visibility: 'internal'
-            }));
-
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if tag has an image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                feature_image: 'tag-100.jpg'
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.6 priority for all tags', function () {
+                generator.getPriorityForDatum({}).should.equal(0.6);
+            });
         });
     });
 
@@ -333,36 +258,28 @@ describe('Generators', function () {
             generator = new UserGenerator();
         });
 
-        it('uses 0.6 priority for author links', function () {
-            generator.getPriorityForDatum({}).should.equal(0.6);
+        describe('fn: getPriorityForDatum', function () {
+            it('uses 0.6 priority for author links', function () {
+                generator.getPriorityForDatum({}).should.equal(0.6);
+            });
         });
 
-        it('does not create a node for invited users', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover: 'user-100.jpg',
-                status: 'invited'
-            }));
+        describe('fn: validateImageUrl', function () {
+            it('image url is localhost', function () {
+                generator.validateImageUrl('http://localhost:2368/content/images/1.jpg').should.be.true();
+            });
 
-            urlNode.should.be.false();
-        });
+            it('image url is https', function () {
+                generator.validateImageUrl('https://myblog.com/content/images/1.png').should.be.true();
+            });
 
-        it('does not create a node for a user with visibility that is not public', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover_image: 'user-100.jpg',
-                status: 'active',
-                visibility: 'notpublic'
-            }));
+            it('image url is external', function () {
+                generator.validateImageUrl('https://myblog.com/1.jpg').should.be.true();
+            });
 
-            urlNode.should.be.false();
-        });
-
-        it('adds an image:image element if user has a cover image', function () {
-            var urlNode = generator.createUrlNodeFromDatum(_.extend(makeFakeDatum(100), {
-                cover_image: '/content/images/2016/01/user-100.jpg',
-                status: 'active'
-            }));
-
-            urlNode.should.be.a.ValidUrlNode({withImage: true});
+            it('no host', function () {
+                generator.validateImageUrl('/content/images/1.jpg').should.be.false();
+            });
         });
     });
 });

--- a/core/test/unit/data/xml/sitemap/manager_spec.js
+++ b/core/test/unit/data/xml/sitemap/manager_spec.js
@@ -1,6 +1,7 @@
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
-    Promise = require('bluebird'),
 
     // Stuff we are testing
     common = require('../../../../../server/lib/common'),
@@ -9,268 +10,111 @@ var should = require('should'),
     PageGenerator = require('../../../../../server/data/xml/sitemap/page-generator'),
     TagGenerator = require('../../../../../server/data/xml/sitemap/tag-generator'),
     UserGenerator = require('../../../../../server/data/xml/sitemap/user-generator'),
+    IndexGenerator = require('../../../../../server/data/xml/sitemap/index-generator'),
 
     sandbox = sinon.sandbox.create();
 
-describe('Sitemap', function () {
-    var makeStubManager = function () {
-        var posts, pages, tags, authors;
-        sandbox.stub(PostGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(PageGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(TagGenerator.prototype, 'refreshAll').returns(Promise.resolve());
-        sandbox.stub(UserGenerator.prototype, 'refreshAll').returns(Promise.resolve());
+describe('Unit: sitemap/manager', function () {
+    let eventsToRemember;
 
+    const makeStubManager = function () {
+        let posts, pages, tags, authors, index;
+
+        index = new IndexGenerator();
         posts = new PostGenerator();
         pages = new PageGenerator();
         tags = new TagGenerator();
         authors = new UserGenerator();
 
-        sandbox.spy(posts, 'init');
-        sandbox.spy(pages, 'init');
-        sandbox.spy(tags, 'init');
-        sandbox.spy(authors, 'init');
-
-        sandbox.stub(posts, 'addOrUpdateUrl');
-        sandbox.stub(pages, 'addOrUpdateUrl');
-        sandbox.stub(tags, 'addOrUpdateUrl');
-        sandbox.stub(authors, 'addOrUpdateUrl');
-
-        sandbox.stub(posts, 'removeUrl');
-        sandbox.stub(pages, 'removeUrl');
-        sandbox.stub(tags, 'removeUrl');
-        sandbox.stub(authors, 'removeUrl');
-
         return new SiteMapManager({posts: posts, pages: pages, tags: tags, authors: authors});
     };
 
+    beforeEach(function () {
+        eventsToRemember = {};
+
+        sandbox.stub(common.events, 'on').callsFake(function (eventName, callback) {
+            eventsToRemember[eventName] = callback;
+        });
+
+        sandbox.stub(PostGenerator.prototype, 'getXml');
+        sandbox.stub(PostGenerator.prototype, 'addUrl');
+        sandbox.stub(PostGenerator.prototype, 'removeUrl');
+        sandbox.stub(IndexGenerator.prototype, 'getXml');
+    });
+
     afterEach(function () {
         sandbox.restore();
-        common.events.removeAllListeners();
     });
 
     describe('SiteMapManager', function () {
-        var manager, fake;
-
-        should.exist(SiteMapManager);
+        let manager, fake;
 
         beforeEach(function () {
             manager = makeStubManager();
             fake = sandbox.stub();
         });
 
+        it('create SiteMapManager with defaults', function () {
+            const siteMapManager = new SiteMapManager();
+            should.exist(siteMapManager.posts);
+            should.exist(siteMapManager.pages);
+            should.exist(siteMapManager.users);
+            should.exist(siteMapManager.tags);
+        });
+
         it('can create a SiteMapManager instance', function () {
             should.exist(manager);
+            Object.keys(eventsToRemember).length.should.eql(2);
+            should.exist(eventsToRemember['url.added']);
+            should.exist(eventsToRemember['url.removed']);
         });
 
-        it('can initialize', function (done) {
-            manager.initialized.should.equal(false);
-            manager.init().then(function () {
-                manager.posts.init.called.should.equal(true);
-                manager.pages.init.called.should.equal(true);
-                manager.authors.init.called.should.equal(true);
-                manager.tags.init.called.should.equal(true);
+        describe('trigger url events', function () {
+            it('url.added', function () {
+                eventsToRemember['url.added']({
+                    url: {
+                        relative: '/test/',
+                        absolute: 'https://myblog.com/test/'
+                    },
+                    resource: {
+                        config: {
+                            type: 'posts'
+                        },
+                        data: {}
+                    }
+                });
 
-                manager.initialized.should.equal(true);
+                PostGenerator.prototype.addUrl.calledOnce.should.be.true();
+            });
 
-                done();
-            }).catch(done);
+            it('url.removed', function () {
+                eventsToRemember['url.removed']({
+                    url: {
+                        relative: '/test/',
+                        absolute: 'https://myblog.com/test/'
+                    },
+                    resource: {
+                        config: {
+                            type: 'posts'
+                        },
+                        data: {}
+                    }
+                });
+
+                PostGenerator.prototype.removeUrl.calledOnce.should.be.true();
+            });
         });
 
-        it('updates page site map correctly', function (done) {
-            manager.init().then(function () {
-                common.events.on('page.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // page add events are ignored, as these are drafts
-                    manager.pages.addOrUpdateUrl.called.should.equal(false);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.edited', function () {
-                    // page edit events are ignored, as these are drafts
-                    manager.pages.addOrUpdateUrl.called.should.equal(false);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.published', function () {
-                    // page published events are when a url gets added
-                    manager.pages.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.published.edited', function () {
-                    // page published.edited events are when a url gets updated
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.deleted', function () {
-                    // page deleted events are ignored, as unpublished will be called if the page was published
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.called.should.equal(false);
-                });
-                common.events.on('page.unpublished', function () {
-                    // page unpublished events are when a url gets removed
-                    manager.pages.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.pages.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('page.added', fake);
-                common.events.emit('page.edited', fake);
-                common.events.emit('page.published', fake);
-                common.events.emit('page.published.edited', fake);
-                common.events.emit('page.deleted', fake);
-                common.events.emit('page.unpublished', fake);
-
-                done();
-            }).catch(done);
+        it('fn: getSiteMapXml', function () {
+            PostGenerator.prototype.getXml.returns('xml');
+            manager.getSiteMapXml('posts').should.eql('xml');
+            PostGenerator.prototype.getXml.calledOnce.should.be.true();
         });
 
-        it('updates post site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // post add events are ignored, as these are drafts
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.edited', function () {
-                    // post edit events are ignored, as these are drafts
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.published', function () {
-                    // post published events are when a url gets added
-                    manager.posts.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.published.edited', function () {
-                    // post published.edited events are when a url gets updated
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.deleted', function () {
-                    // post deleted events are ignored, as unpublished will be called if the post was published
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-                common.events.on('post.unpublished', function () {
-                    // post unpublished events are when a url gets removed
-                    manager.posts.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.posts.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('post.added', fake);
-                common.events.emit('post.edited', fake);
-                common.events.emit('post.published', fake);
-                common.events.emit('post.published.edited', fake);
-                common.events.emit('post.deleted', fake);
-                common.events.emit('post.unpublished', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('doesn\'t add posts until they are published', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.added', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.on('post.edited', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.on('post.published', function () {
-                    manager.posts.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.posts.removeUrl.called.should.equal(false);
-                });
-
-                common.events.emit('post.added', fake);
-                common.events.emit('post.edited', fake);
-                common.events.emit('post.published', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('deletes posts that were unpublished', function (done) {
-            manager.init().then(function () {
-                common.events.on('post.unpublished', function () {
-                    manager.posts.addOrUpdateUrl.called.should.equal(false);
-                    manager.posts.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('post.unpublished', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('updates authors site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('user.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    // user added is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.edited', function () {
-                    // user edited is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.called.should.equal(false);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.activated', function () {
-                    // user activated is the point we know the user can be added
-                    manager.authors.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.activated.edited', function () {
-                    // user activated.edited means we can be sure the user is active
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.deleted', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.called.should.equal(false);
-                });
-                common.events.on('user.deactivated', function () {
-                    // user deleted is ignored as this may be an invited user
-                    manager.authors.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.authors.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('user.added', fake);
-                common.events.emit('user.edited', fake);
-                common.events.emit('user.activated', fake);
-                common.events.emit('user.activated.edited', fake);
-                common.events.emit('user.deleted', fake);
-                common.events.emit('user.deactivated', fake);
-
-                done();
-            }).catch(done);
-        });
-
-        it('updates tags site map', function (done) {
-            manager.init().then(function () {
-                common.events.on('tag.added', function (fakeModel) {
-                    fakeModel.should.eql(fake);
-                    manager.tags.addOrUpdateUrl.calledOnce.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                common.events.on('tag.edited', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.called.should.equal(false);
-                });
-                common.events.on('tag.deleted', function () {
-                    manager.tags.addOrUpdateUrl.calledTwice.should.equal(true);
-                    manager.tags.removeUrl.calledOnce.should.equal(true);
-                });
-
-                common.events.emit('tag.added', fake);
-                common.events.emit('tag.edited', fake);
-                common.events.emit('tag.deleted', fake);
-
-                done();
-            }).catch(done);
+        it('fn: getIndexXml', function () {
+            IndexGenerator.prototype.getXml.returns('xml');
+            manager.getIndexXml().should.eql('xml');
+            IndexGenerator.prototype.getXml.calledOnce.should.be.true();
         });
     });
 });

--- a/core/test/unit/helpers/author_spec.js
+++ b/core/test/unit/helpers/author_spec.js
@@ -1,40 +1,54 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
 
-// Stuff we are testing
+const should = require('should'),
+    sinon = require('sinon'),
+    sandbox = sinon.sandbox.create(),
+    testUtils = require('../../utils'),
+    urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers');
 
 describe('{{author}} helper', function () {
-    it('Returns the link to the author from the context', function () {
-        var data = {author: {name: 'abc 123', slug: 'abc123', bio: '', website: '', status: '', location: ''}},
-            result = helpers.author.call(data, {hash: {}});
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId');
+    });
 
-        String(result).should.equal('<a href="/author/abc123/">abc 123</a>');
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('Returns the link to the author from the context', function () {
+        const author = testUtils.DataGenerator.forKnex.createUser({slug: 'abc123', name: 'abc 123'});
+
+        urlService.getUrlByResourceId.withArgs(author.id).returns('author url');
+
+        const result = helpers.author.call({author: author}, {hash: {}});
+        String(result).should.equal('<a href="author url">abc 123</a>');
     });
 
     it('Returns the full name of the author from the context if no autolink', function () {
-        var data = {author: {name: 'abc 123', slug: 'abc123'}},
-            result = helpers.author.call(data, {hash: {autolink: 'false'}});
-
+        const author = testUtils.DataGenerator.forKnex.createUser({slug: 'abc123', name: 'abc 123'});
+        const result = helpers.author.call({author: author}, {hash: {autolink: 'false'}});
         String(result).should.equal('abc 123');
+        urlService.getUrlByResourceId.called.should.be.false();
     });
 
     it('Returns a blank string where author data is missing', function () {
-        var data = {author: null},
-            result = helpers.author.call(data, {hash: {}});
-
+        const result = helpers.author.call({author:null}, {hash: {}});
         String(result).should.equal('');
     });
 
     it('Functions as block helper if called with #', function () {
-        var data = {author: {name: 'abc 123', slug: 'abc123'}},
-            // including fn emulates the #
-            result = helpers.author.call(data, {
-                hash: {}, fn: function () {
-                    return 'FN';
-                }
-            });
+        const author = testUtils.DataGenerator.forKnex.createUser({slug: 'abc123', name: 'abc 123'});
+
+        // including fn emulates the #
+        const result = helpers.author.call({author: author}, {
+            hash: {}, fn: function () {
+                return 'FN';
+            }
+        });
 
         // It outputs the result of fn
         String(result).should.equal('FN');
+        urlService.getUrlByResourceId.called.should.be.false();
     });
 });

--- a/core/test/unit/helpers/authors_spec.js
+++ b/core/test/unit/helpers/authors_spec.js
@@ -1,7 +1,11 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
+    urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers'),
     models = require('../../../server/models'),
+    testUtils = require('../../utils'),
     sandbox = sinon.sandbox.create();
 
 describe('{{authors}} helper', function () {
@@ -9,165 +13,195 @@ describe('{{authors}} helper', function () {
         models.init();
     });
 
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId');
+    });
+
     afterEach(function () {
         sandbox.restore();
     });
 
     it('can return string with authors', function () {
-        var authors = [{name: 'Michael'}, {name: 'Thomas'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'Michael'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'Thomas'})
+        ];
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('Michael, Thomas');
     });
 
     it('can use a different separator', function () {
-        var authors = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {separator: '|', autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'ghost'})
+        ];
 
+        const rendered = helpers.authors.call({authors: authors}, {hash: {separator: '|', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('haunted|ghost');
     });
 
     it('can add a single prefix to multiple authors', function () {
-        var authors = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {prefix: 'on ', autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'ghost'})
+        ];
 
+        const rendered = helpers.authors.call({authors: authors}, {hash: {prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('on haunted, ghost');
     });
 
     it('can add a single suffix to multiple authors', function () {
-        var authors = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {suffix: ' forever', autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'ghost'})
+        ];
 
+        const rendered = helpers.authors.call({authors: authors}, {hash: {suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('haunted, ghost forever');
     });
 
     it('can add a prefix and suffix to multiple authors', function () {
-        var authors = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'ghost'})
+        ];
 
+        const rendered = helpers.authors.call({authors: authors}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('on haunted, ghost forever');
     });
 
     it('can add a prefix and suffix with HTML', function () {
-        var authors = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'ghost'})
+        ];
 
+        const rendered = helpers.authors.call({authors: authors}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no authors exist', function () {
-        var rendered = helpers.authors.call(
-            {},
-            {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}}
-        );
-
+        const rendered = helpers.authors.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('');
     });
 
     it('can autolink authors to author pages', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.authors.call(
-                {authors: authors}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[0].id).returns('author url 1');
+        urlService.getUrlByResourceId.withArgs(authors[1].id).returns('author url 2');
+
+        const rendered = helpers.authors.call({authors: authors});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>, <a href="/author/bar/">bar</a>');
+        String(rendered).should.equal('<a href="author url 1">foo</a>, <a href="author url 2">bar</a>');
     });
 
     it('can limit no. authors output to 1', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {limit: '1'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[0].id).returns('author url 1');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>');
+        String(rendered).should.equal('<a href="author url 1">foo</a>');
     });
 
     it('can list authors from a specified no.', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {from: '2'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[1].id).returns('author url 2');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {from: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/bar/">bar</a>');
+        String(rendered).should.equal('<a href="author url 2">bar</a>');
     });
 
     it('can list authors to a specified no.', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {to: '1'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[0].id).returns('author url');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {to: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>');
+        String(rendered).should.equal('<a href="author url">foo</a>');
     });
 
     it('can list authors in a range', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {from: '2', to: '3'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[1].id).returns('author url 2');
+        urlService.getUrlByResourceId.withArgs(authors[2].id).returns('author url 3');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {from: '2', to: '3'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/bar/">bar</a>, <a href="/author/baz/">baz</a>');
+        String(rendered).should.equal('<a href="author url 2">bar</a>, <a href="author url 3">baz</a>');
     });
 
     it('can limit no. authors and output from 2', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {from: '2', limit: '1'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[1].id).returns('author url x');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {from: '2', limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/bar/">bar</a>');
+        String(rendered).should.equal('<a href="author url x">bar</a>');
     });
 
     it('can list authors in a range (ignore limit)', function () {
-        var authors = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.authors.call(
-                {authors: authors},
-                {hash: {from: '1', to: '3', limit: '2'}}
-            );
+        const authors = [
+            testUtils.DataGenerator.forKnex.createUser({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createUser({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(authors[0].id).returns('author url a');
+        urlService.getUrlByResourceId.withArgs(authors[1].id).returns('author url b');
+        urlService.getUrlByResourceId.withArgs(authors[2].id).returns('author url c');
+
+        const rendered = helpers.authors.call({authors: authors}, {hash: {from: '1', to: '3', limit: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/author/foo-bar/">foo</a>, <a href="/author/bar/">bar</a>, <a href="/author/baz/">baz</a>');
+        String(rendered).should.equal('<a href="author url a">foo</a>, <a href="author url b">bar</a>, <a href="author url c">baz</a>');
     });
 });

--- a/core/test/unit/helpers/ghost_head_spec.js
+++ b/core/test/unit/helpers/ghost_head_spec.js
@@ -1,4 +1,6 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
+
+var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
     Promise = require('bluebird'),
@@ -6,6 +8,7 @@ var should = require('should'), // jshint ignore:line
     testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
     models = require('../../../server/models'),
+    urlService = require('../../../server/services/url'),
     helpers = require('../../../server/helpers'),
     imageLib = require('../../../server/lib/image'),
     proxy = require('../../../server/helpers/proxy'),
@@ -16,6 +19,8 @@ var should = require('should'), // jshint ignore:line
     sandbox = sinon.sandbox.create();
 
 describe('{{ghost_head}} helper', function () {
+    let data;
+
     before(function () {
         models.init();
     });
@@ -26,6 +31,384 @@ describe('{{ghost_head}} helper', function () {
     });
 
     beforeEach(function () {
+        data = {
+            post0: {
+                id: '5ad9c8a3c7cef3f8ec9a5061',
+                meta_description: 'all about our blog',
+                title: 'About',
+                feature_image: '/content/images/test-image-about.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                og_image: '',
+                og_title: '',
+                og_description: '',
+                twitter_image: '',
+                twitter_title: '',
+                twitter_description: '',
+                page: true,
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5160',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post1: {
+                id: '5ad9c8a3c7cef3f8ec9a5059',
+                meta_description: 'all about our blog',
+                title: 'About',
+                feature_image: '/content/images/test-image-about.png',
+                og_image: '/content/images/test-og-image.png',
+                og_title: 'Custom Facebook title',
+                og_description: 'Custom Facebook description',
+                twitter_image: '/content/images/test-twitter-image.png',
+                twitter_title: 'Custom Twitter title',
+                twitter_description: 'Custom Twitter description',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                page: true,
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5161',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post2: {
+                id: '5ad9c8a3c7cef3f8ec9a5062',
+                meta_description: 'blog description',
+                custom_excerpt: '',
+                title: 'Welcome to Ghost',
+                feature_image: '/content/images/test-image.png',
+                og_image: '',
+                og_title: 'Custom Facebook title',
+                og_description: 'Custom Facebook description',
+                twitter_image: '/content/images/test-twitter-image.png',
+                twitter_title: '',
+                twitter_description: '',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5162',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    bio: 'Author bio',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            },
+
+            post3: {
+                id: '5ad9c8a3c7cef3f8ec9a5063',
+                meta_description: 'blog description',
+                custom_excerpt: 'post custom excerpt',
+                title: 'Welcome to Ghost',
+                feature_image: '/content/images/test-image.png',
+                og_image: '/content/images/test-facebook-image.png',
+                og_title: '',
+                og_description: '',
+                twitter_image: '/content/images/test-twitter-image.png',
+                twitter_title: 'Custom Twitter title',
+                twitter_description: '',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5163',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post4: {
+                id: '5ad9c8a3c7cef3f8ec9a5064',
+                meta_description: '',
+                custom_excerpt: '',
+                title: 'Welcome to Ghost',
+                html: '<p>This is a short post</p>',
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5164',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post5: {
+                id: '5ad9c8a3c7cef3f8ec9a5065',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                feature_image: '/content/images/test-image.png',
+                og_image: '/content/images/test-facebook-image.png',
+                og_title: 'Custom Facebook title',
+                og_description: '',
+                twitter_image: '/content/images/test-twitter-image.png',
+                twitter_title: 'Custom Twitter title',
+                twitter_description: '',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5165',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post6: {
+                id: '5ad9c8a3c7cef3f8ec9a5066',
+                meta_description: 'blog "test" description',
+                title: 'title',
+                meta_title: 'Welcome to Ghost "test"',
+                feature_image: '/content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5166',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post7: {
+                id: '5ad9c8a3c7cef3f8ec9a5067',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                feature_image: '/content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5167',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post8: {
+                id: '5ad9c8a3c7cef3f8ec9a5068',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                feature_image: null,
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5168',
+                    name: 'Author name',
+                    url: 'http//:testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: null,
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser'
+                }
+            },
+
+            post9: {
+                id: '5ad9c8a3c7cef3f8ec9a5069',
+                title: 'Welcome to Ghost',
+                html: '<p>This is a short post</p>',
+                primary_author: {
+                    name: 'Author name'
+                }
+            },
+
+            post10: {
+                id: '5ad9c8a3c7cef3f8ec9a5070',
+                title: 'Welcome to Ghost',
+                html: '<p>This is a short post</p>',
+                primary_author: {
+                    name: 'Author name'
+                }
+            },
+
+            post11: {
+                id: '5ad9c8a3c7cef3f8ec9a5071',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5169',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post12: {
+                id: '5ad9c8a3c7cef3f8ec9a5072',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5170',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post13: {
+                id: '5ad9c8a3c7cef3f8ec9a5073',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5171',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            post14: {
+                id: '5ad9c8a3c7cef3f8ec9a5074',
+                meta_description: 'blog description',
+                title: 'Welcome to Ghost',
+                image: 'content/images/test-image.png',
+                published_at: moment('2008-05-31T19:18:15').toISOString(),
+                updated_at: moment('2014-10-06T15:23:54').toISOString(),
+                tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
+                primary_author: {
+                    id: '5ad9c8a3c7cef3f8ec9a5172',
+                    name: 'Author name',
+                    url: 'http://testauthorurl.com',
+                    slug: 'Author',
+                    profile_image: '/content/images/test-author-image.png',
+                    website: 'http://authorwebsite.com',
+                    facebook: 'testuser',
+                    twitter: '@testuser',
+                    bio: 'Author bio'
+                }
+            },
+
+            tag1: {
+                id: '5ad9c8a3c7cef3f8ec9a5075',
+                meta_description: 'tag meta description',
+                name: 'tagtitle',
+                meta_title: 'tag meta title',
+                feature_image: '/content/images/tag-image.png'
+            },
+
+            tag2: {
+                id: '5ad9c8a3c7cef3f8ec9a5076',
+                meta_description: '',
+                description: 'tag description',
+                name: 'tagtitle',
+                meta_title: '',
+                feature_image: '/content/images/tag-image.png'
+            },
+
+            tag3: {
+                id: '5ad9c8a3c7cef3f8ec9a5077',
+                meta_description: '',
+                name: 'tagtitle',
+                meta_title: '',
+                feature_image: '/content/images/tag-image.png'
+            },
+
+            tag4: {
+                id: '5ad9c8a3c7cef3f8ec9a5078',
+                meta_description: 'tag meta description',
+                title: 'tagtitle',
+                meta_title: 'tag meta title',
+                feature_image: '/content/images/tag-image.png'
+            },
+
+            author1: {
+                id: '5ad9c8a3c7cef3f8ec9a5079',
+                name: 'Author name',
+                slug: 'AuthorName',
+                bio: 'Author bio',
+                profile_image: '/content/images/test-author-image.png',
+                cover_image: '/content/images/author-cover-image.png',
+                website: 'http://authorwebsite.com',
+                facebook: 'testuser',
+                twitter: '@testuser'
+            },
+
+            author2: {
+                id: '5ad9c8a3c7cef3f8ec9a5080',
+                name: 'Author name',
+                slug: 'AuthorName',
+                bio: 'Author bio',
+                profile_image: '/content/images/test-author-image.png',
+                cover_image: '/content/images/author-cover-image.png',
+                website: 'http://authorwebsite.com'
+            }
+        };
+
         /**
          * Each test case here requests the image dimensions.
          * The image path is e.g. localhost:port/favicon.ico, but no server is running.
@@ -40,6 +423,63 @@ describe('{{ghost_head}} helper', function () {
         }));
 
         sandbox.stub(labs, 'isSet').returns(true);
+
+        sandbox.stub(urlService, 'getUrlByResourceId').callsFake(function (id, options) {
+            let resource;
+            const blogUrl = '://localhost:65530/';
+
+            _.each(data, function (value, key) {
+                if (value.id === id) {
+                    resource = {
+                        key: key,
+                        value: value
+                    };
+                }
+
+                if (value.primary_author && value.primary_author.id === id) {
+                    resource = {
+                        key: 'author',
+                        value: value.primary_author
+                    };
+                }
+            });
+
+            if (resource.key.match(/author/)) {
+                if (options.absolute) {
+                    if (options.secure) {
+                        return 'https' + blogUrl + 'author/' + resource.value.slug + '/';
+                    }
+
+                    return 'http' + blogUrl + 'author/' + resource.value.slug + '/';
+                }
+
+                return '/author/' + resource.value.slug + '/';
+            }
+
+            if (resource.key.match(/tag/)) {
+                if (options.absolute) {
+                    if (options.secure) {
+                        return 'https' + blogUrl + 'tag/' + resource.value.slug + '/';
+                    }
+
+                    return 'http' + blogUrl + 'tag/' + resource.value.slug + '/';
+                }
+
+                return '/tag/' + resource.value.slug + '/';
+            }
+
+            if (resource.key.match(/post/)) {
+                if (options.absolute) {
+                    if (options.secure) {
+                        return 'https' + blogUrl + resource.value.slug + '/';
+                    }
+
+                    return 'http' + blogUrl + resource.value.slug + '/';
+                }
+
+                return '/' + resource.value.slug + '/';
+            }
+        });
     });
 
     describe('without Code Injection', function () {
@@ -120,30 +560,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on static page', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'all about our blog',
-                    title: 'About',
-                    feature_image: '/content/images/test-image-about.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    og_image: '',
-                    og_title: '',
-                    og_description: '',
-                    twitter_image: '',
-                    twitter_title: '',
-                    twitter_description: '',
-                    page: true,
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser',
-                        bio: 'Author bio'
-                    }
-                }
+                post: data.post0
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -192,30 +609,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on static page with custom post structured data', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'all about our blog',
-                    title: 'About',
-                    feature_image: '/content/images/test-image-about.png',
-                    og_image: '/content/images/test-og-image.png',
-                    og_title: 'Custom Facebook title',
-                    og_description: 'Custom Facebook description',
-                    twitter_image: '/content/images/test-twitter-image.png',
-                    twitter_title: 'Custom Twitter title',
-                    twitter_description: 'Custom Twitter description',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    page: true,
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser',
-                        bio: 'Author bio'
-                    }
-                }
+                post: data.post1
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -264,12 +658,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data and schema first tag page with meta description and meta title', function (done) {
             var renderObject = {
-                tag: {
-                    meta_description: 'tag meta description',
-                    name: 'tagtitle',
-                    meta_title: 'tag meta title',
-                    feature_image: '/content/images/tag-image.png'
-                }
+                tag: data.tag1
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -312,13 +701,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('tag first page without meta data if no meta title and meta description, but model description provided', function (done) {
             var renderObject = {
-                tag: {
-                    meta_description: '',
-                    description: 'tag description',
-                    name: 'tagtitle',
-                    meta_title: '',
-                    feature_image: '/content/images/tag-image.png'
-                }
+                tag: data.tag2
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -361,12 +744,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('tag first page without meta and model description returns no description fields', function (done) {
             var renderObject = {
-                tag: {
-                    meta_description: '',
-                    name: 'tagtitle',
-                    meta_title: '',
-                    feature_image: '/content/images/tag-image.png'
-                }
+                tag: data.tag3
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -390,12 +768,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('does not return structured data on paginated tag pages', function (done) {
             var renderObject = {
-                tag: {
-                    meta_description: 'tag meta description',
-                    title: 'tagtitle',
-                    meta_title: 'tag meta title',
-                    feature_image: '/content/images/tag-image.png'
-                }
+                tag: data.tag4
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -421,16 +794,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data and schema on first author page with cover image', function (done) {
             var renderObject = {
-                author: {
-                    name: 'Author name',
-                    slug: 'AuthorName',
-                    bio: 'Author bio',
-                    profile_image: '/content/images/test-author-image.png',
-                    cover_image: '/content/images/author-cover-image.png',
-                    website: 'http://authorwebsite.com',
-                    facebook: 'testuser',
-                    twitter: '@testuser'
-                }
+                author: data.author1
             }, authorBk = _.cloneDeep(renderObject.author);
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -476,14 +840,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('does not return structured data on paginated author pages', function (done) {
             var renderObject = {
-                author: {
-                    name: 'Author name',
-                    slug: 'AuthorName',
-                    bio: 'Author bio',
-                    profile_image: '/content/images/test-author-image.png',
-                    cover_image: '/content/images/author-cover-image.png',
-                    website: 'http://authorwebsite.com'
-                }
+                author: data.author2
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -525,31 +882,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on post page with author image and post cover image', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    custom_excerpt: '',
-                    title: 'Welcome to Ghost',
-                    feature_image: '/content/images/test-image.png',
-                    og_image: '',
-                    og_title: 'Custom Facebook title',
-                    og_description: 'Custom Facebook description',
-                    twitter_image: '/content/images/test-twitter-image.png',
-                    twitter_title: '',
-                    twitter_description: '',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        bio: 'Author bio',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post2
             }, postBk = _.cloneDeep(renderObject.post);
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -618,31 +951,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on post page with custom excerpt for description and meta description', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    custom_excerpt: 'post custom excerpt',
-                    title: 'Welcome to Ghost',
-                    feature_image: '/content/images/test-image.png',
-                    og_image: '/content/images/test-facebook-image.png',
-                    og_title: '',
-                    og_description: '',
-                    twitter_image: '/content/images/test-twitter-image.png',
-                    twitter_title: 'Custom Twitter title',
-                    twitter_description: '',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        bio: 'Author bio',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post3
             }, postBk = _.cloneDeep(renderObject.post);
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -711,17 +1020,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on post page with fall back excerpt if no meta description provided', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: '',
-                    custom_excerpt: '',
-                    title: 'Welcome to Ghost',
-                    html: '<p>This is a short post</p>',
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author'
-                    }
-                }
+                post: data.post4
             }, postBk = _.cloneDeep(renderObject.post);
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -770,30 +1069,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on AMP post page with author image and post cover image', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    feature_image: '/content/images/test-image.png',
-                    og_image: '/content/images/test-facebook-image.png',
-                    og_title: 'Custom Facebook title',
-                    og_description: '',
-                    twitter_image: '/content/images/test-twitter-image.png',
-                    twitter_title: 'Custom Twitter title',
-                    twitter_description: '',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http://testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        bio: 'Author bio',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post5
             }, postBk = _.cloneDeep(renderObject.post);
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -862,24 +1138,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data if metaTitle and metaDescription have double quotes', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog "test" description',
-                    title: 'title',
-                    meta_title: 'Welcome to Ghost "test"',
-                    feature_image: '/content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post6
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -948,23 +1207,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data without tags if there are no tags', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    feature_image: '/content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: '/content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post7
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1030,23 +1273,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns structured data on post page with null author image and post cover image', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    feature_image: null,
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        profile_image: null,
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post8
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1137,13 +1364,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns twitter and facebook descriptions even if no meta description available', function (done) {
             var renderObject = {
-                post: {
-                    title: 'Welcome to Ghost',
-                    html: '<p>This is a short post</p>',
-                    primary_author: {
-                        name: 'Author name'
-                    }
-                }
+                post: data.post9
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1167,13 +1388,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns canonical URL', function (done) {
             var renderObject = {
-                post: {
-                    title: 'Welcome to Ghost',
-                    html: '<p>This is a short post</p>',
-                    primary_author: {
-                        name: 'Author name'
-                    }
-                }
+                post: data.post10
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1335,23 +1550,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('does not return structured data', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    image: 'content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        image: 'content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post11
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1421,11 +1620,11 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('outputs post codeinjection as well', function (done) {
+            data.post1.codeinjection_head = 'post-codeinjection';
+
             helpers.ghost_head(testUtils.createHbsResponse({
                 renderObject: {
-                    post: {
-                        codeinjection_head: 'post-codeinjection'
-                    }
+                    post: data.post1
                 },
                 locals: {
                     context: ['paged', 'index'],
@@ -1441,11 +1640,11 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('handles post codeinjection being empty', function (done) {
+            data.post1.codeinjection_head = '';
+
             helpers.ghost_head(testUtils.createHbsResponse({
                 renderObject: {
-                    post: {
-                        codeinjection_head: ''
-                    }
+                    post: data.post1
                 },
                 locals: {
                     context: ['paged', 'index'],
@@ -1461,11 +1660,11 @@ describe('{{ghost_head}} helper', function () {
         });
 
         it('handles post codeinjection being null', function (done) {
+            data.post1.codeinjection_head = null;
+
             helpers.ghost_head(testUtils.createHbsResponse({
                 renderObject: {
-                    post: {
-                        codeinjection_head: null
-                    }
+                    post: data.post1
                 },
                 locals: {
                     context: ['paged', 'index'],
@@ -1482,23 +1681,7 @@ describe('{{ghost_head}} helper', function () {
 
         it('returns meta tag without injected code for amp context', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    image: 'content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        image: 'content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post12
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1569,23 +1752,7 @@ describe('{{ghost_head}} helper', function () {
         });
         it('does not render script tag with for amp context', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    image: 'content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        image: 'content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post13
             };
 
             helpers.ghost_head(testUtils.createHbsResponse({
@@ -1625,24 +1792,9 @@ describe('{{ghost_head}} helper', function () {
 
         it('does not contain amphtml link', function (done) {
             var renderObject = {
-                post: {
-                    meta_description: 'blog description',
-                    title: 'Welcome to Ghost',
-                    image: 'content/images/test-image.png',
-                    published_at: moment('2008-05-31T19:18:15').toISOString(),
-                    updated_at: moment('2014-10-06T15:23:54').toISOString(),
-                    tags: [{name: 'tag1'}, {name: 'tag2'}, {name: 'tag3'}],
-                    primary_author: {
-                        name: 'Author name',
-                        url: 'http//:testauthorurl.com',
-                        slug: 'Author',
-                        image: 'content/images/test-author-image.png',
-                        website: 'http://authorwebsite.com',
-                        facebook: 'testuser',
-                        twitter: '@testuser'
-                    }
-                }
+                post: data.post14
             };
+
             helpers.ghost_head(testUtils.createHbsResponse({
                 renderObject: renderObject,
                 locals: {

--- a/core/test/unit/helpers/tags_spec.js
+++ b/core/test/unit/helpers/tags_spec.js
@@ -1,257 +1,286 @@
-var should = require('should'), // jshint ignore:line
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
-
-// Stuff we are testing
+    testUtils = require('../../utils'),
+    urlService = require('../../../server/services/url'),
+    models = require('../../../server/models'),
     helpers = require('../../../server/helpers'),
-
     sandbox = sinon.sandbox.create();
 
 describe('{{tags}} helper', function () {
+    before(function () {
+        models.init();
+    });
+
+    beforeEach(function () {
+        sandbox.stub(urlService, 'getUrlByResourceId');
+    });
+
     afterEach(function () {
         sandbox.restore();
     });
 
     it('can return string with tags', function () {
-        var tags = [{name: 'foo'}, {name: 'bar'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar'})
+        ];
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('foo, bar');
     });
 
     it('can use a different separator', function () {
-        var tags = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {separator: '|', autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'ghost'})
+        ];
 
+        const rendered = helpers.tags.call({tags: tags}, {hash: {separator: '|', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('haunted|ghost');
     });
 
     it('can add a single prefix to multiple tags', function () {
-        var tags = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {prefix: 'on ', autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'ghost'})
+        ];
 
+        const rendered = helpers.tags.call({tags: tags}, {hash: {prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('on haunted, ghost');
     });
 
     it('can add a single suffix to multiple tags', function () {
-        var tags = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {suffix: ' forever', autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'ghost'})
+        ];
 
+        const rendered = helpers.tags.call({tags: tags}, {hash: {suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('haunted, ghost forever');
     });
 
     it('can add a prefix and suffix to multiple tags', function () {
-        var tags = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'ghost'})
+        ];
 
+        const rendered = helpers.tags.call({tags: tags}, {hash: {suffix: ' forever', prefix: 'on ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('on haunted, ghost forever');
     });
 
     it('can add a prefix and suffix with HTML', function () {
-        var tags = [{name: 'haunted'}, {name: 'ghost'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'haunted'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'ghost'})
+        ];
 
+        const rendered = helpers.tags.call({tags: tags}, {hash: {suffix: ' &bull;', prefix: '&hellip; ', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('&hellip; haunted, ghost &bull;');
     });
 
     it('does not add prefix or suffix if no tags exist', function () {
-        var rendered = helpers.tags.call(
-            {},
-            {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}}
-        );
-
+        const rendered = helpers.tags.call({}, {hash: {prefix: 'on ', suffix: ' forever', autolink: 'false'}});
         should.exist(rendered);
 
         String(rendered).should.equal('');
     });
 
     it('can autolink tags to tag pages', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.tags.call(
-                {tags: tags}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[0].id).returns('tag url 1');
+        urlService.getUrlByResourceId.withArgs(tags[1].id).returns('tag url 2');
+
+        const rendered = helpers.tags.call({tags: tags});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/foo-bar/">foo</a>, <a href="/tag/bar/">bar</a>');
+        String(rendered).should.equal('<a href="tag url 1">foo</a>, <a href="tag url 2">bar</a>');
     });
 
     it('can limit no. tags output to 1', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {limit: '1'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[0].id).returns('tag url 1');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/foo-bar/">foo</a>');
+        String(rendered).should.equal('<a href="tag url 1">foo</a>');
     });
 
     it('can list tags from a specified no.', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {from: '2'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[1].id).returns('tag url 2');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {from: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/bar/">bar</a>');
+        String(rendered).should.equal('<a href="tag url 2">bar</a>');
     });
 
     it('can list tags to a specified no.', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {to: '1'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[0].id).returns('tag url x');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {to: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/foo-bar/">foo</a>');
+        String(rendered).should.equal('<a href="tag url x">foo</a>');
     });
 
     it('can list tags in a range', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {from: '2', to: '3'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[1].id).returns('tag url b');
+        urlService.getUrlByResourceId.withArgs(tags[2].id).returns('tag url c');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {from: '2', to: '3'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/bar/">bar</a>, <a href="/tag/baz/">baz</a>');
+        String(rendered).should.equal('<a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
 
     it('can limit no. tags and output from 2', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {from: '2', limit: '1'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[1].id).returns('tag url b');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {from: '2', limit: '1'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/bar/">bar</a>');
+        String(rendered).should.equal('<a href="tag url b">bar</a>');
     });
 
     it('can list tags in a range (ignore limit)', function () {
-        var tags = [{name: 'foo', slug: 'foo-bar'}, {name: 'bar', slug: 'bar'}, {name: 'baz', slug: 'baz'}],
-            rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {from: '1', to: '3', limit: '2'}}
-            );
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'})
+        ];
+
+        urlService.getUrlByResourceId.withArgs(tags[0].id).returns('tag url a');
+        urlService.getUrlByResourceId.withArgs(tags[1].id).returns('tag url b');
+        urlService.getUrlByResourceId.withArgs(tags[2].id).returns('tag url c');
+
+        const rendered = helpers.tags.call({tags: tags}, {hash: {from: '1', to: '3', limit: '2'}});
         should.exist(rendered);
 
-        String(rendered).should.equal('<a href="/tag/foo-bar/">foo</a>, <a href="/tag/bar/">bar</a>, <a href="/tag/baz/">baz</a>');
+        String(rendered).should.equal('<a href="tag url a">foo</a>, <a href="tag url b">bar</a>, <a href="tag url c">baz</a>');
     });
 
     describe('Internal tags', function () {
-        var tags = [
-            {name: 'foo', slug: 'foo-bar', visibility: 'public'},
-            {name: '#bar', slug: 'hash-bar', visibility: 'internal'},
-            {name: 'bar', slug: 'bar', visibility: 'public'},
-            {name: 'baz', slug: 'baz', visibility: 'public'},
-            {name: 'buzz', slug: 'buzz'}
+        const tags = [
+            testUtils.DataGenerator.forKnex.createTag({name: 'foo', slug: 'foo-bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: '#bar', slug: 'hash-bar', visibility: 'internal'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'bar', slug: 'bar'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'baz', slug: 'baz'}),
+            testUtils.DataGenerator.forKnex.createTag({name: 'buzz', slug: 'buzz'})
         ];
 
+        const tags1 = [
+            testUtils.DataGenerator.forKnex.createTag({name: '#foo', slug: 'hash-foo-bar', visibility: 'internal'}),
+            testUtils.DataGenerator.forKnex.createTag({name: '#bar', slug: 'hash-bar', visibility: 'internal'})
+        ];
+
+        beforeEach(function () {
+            urlService.getUrlByResourceId.withArgs(tags[0].id).returns('1');
+            urlService.getUrlByResourceId.withArgs(tags[1].id).returns('2');
+            urlService.getUrlByResourceId.withArgs(tags[2].id).returns('3');
+            urlService.getUrlByResourceId.withArgs(tags[3].id).returns('4');
+            urlService.getUrlByResourceId.withArgs(tags[4].id).returns('5');
+        });
+
         it('will not output internal tags by default', function () {
-            var rendered = helpers.tags.call(
-                {tags: tags}
-            );
+            const rendered = helpers.tags.call({tags: tags});
 
             String(rendered).should.equal(
-                '<a href="/tag/foo-bar/">foo</a>, ' +
-                '<a href="/tag/bar/">bar</a>, ' +
-                '<a href="/tag/baz/">baz</a>, ' +
-                '<a href="/tag/buzz/">buzz</a>'
+                '<a href="1">foo</a>, ' +
+                '<a href="3">bar</a>, ' +
+                '<a href="4">baz</a>, ' +
+                '<a href="5">buzz</a>'
             );
         });
 
         it('should still correctly apply from & limit tags', function () {
-            var rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {from: '2', limit: '2'}}
-            );
+            const rendered = helpers.tags.call({tags: tags}, {hash: {from: '2', limit: '2'}});
 
             String(rendered).should.equal(
-                '<a href="/tag/bar/">bar</a>, ' +
-                '<a href="/tag/baz/">baz</a>'
+                '<a href="3">bar</a>, ' +
+                '<a href="4">baz</a>'
             );
         });
 
         it('should output all tags with visibility="all"', function () {
-            var rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {visibility: 'all'}}
-            );
+            const rendered = helpers.tags.call({tags: tags}, {hash: {visibility: 'all'}});
 
             String(rendered).should.equal(
-                '<a href="/tag/foo-bar/">foo</a>, ' +
-                '<a href="/tag/hash-bar/">#bar</a>, ' +
-                '<a href="/tag/bar/">bar</a>, ' +
-                '<a href="/tag/baz/">baz</a>, ' +
-                '<a href="/tag/buzz/">buzz</a>'
+                '<a href="1">foo</a>, ' +
+                '<a href="2">#bar</a>, ' +
+                '<a href="3">bar</a>, ' +
+                '<a href="4">baz</a>, ' +
+                '<a href="5">buzz</a>'
             );
         });
 
         it('should output all tags with visibility property set with visibility="public,internal"', function () {
-            var rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {visibility: 'public,internal'}}
-            );
+            const rendered = helpers.tags.call({tags: tags}, {hash: {visibility: 'public,internal'}});
             should.exist(rendered);
 
             String(rendered).should.equal(
-                '<a href="/tag/foo-bar/">foo</a>, ' +
-                '<a href="/tag/hash-bar/">#bar</a>, ' +
-                '<a href="/tag/bar/">bar</a>, ' +
-                '<a href="/tag/baz/">baz</a>'
+                '<a href="1">foo</a>, ' +
+                '<a href="2">#bar</a>, ' +
+                '<a href="3">bar</a>, ' +
+                '<a href="4">baz</a>, ' +
+                '<a href="5">buzz</a>'
             );
         });
 
         it('Should output only internal tags with visibility="internal"', function () {
-            var rendered = helpers.tags.call(
-                {tags: tags},
-                {hash: {visibility: 'internal'}}
-            );
+            const rendered = helpers.tags.call({tags: tags}, {hash: {visibility: 'internal'}});
             should.exist(rendered);
 
-            String(rendered).should.equal('<a href="/tag/hash-bar/">#bar</a>');
+            String(rendered).should.equal('<a href="2">#bar</a>');
         });
 
         it('should output nothing if all tags are internal', function () {
-            var tags = [
-                    {name: '#foo', slug: 'hash-foo-bar', visibility: 'internal'},
-                    {name: '#bar', slug: 'hash-bar', visibility: 'internal'}
-                ],
-                rendered = helpers.tags.call(
-                    {tags: tags},
-                    {hash: {prefix: 'stuff'}}
-                );
+            const rendered = helpers.tags.call({tags: tags1}, {hash: {prefix: 'stuff'}});
             should.exist(rendered);
 
             String(rendered).should.equal('');

--- a/core/test/unit/helpers/url_spec.js
+++ b/core/test/unit/helpers/url_spec.js
@@ -1,13 +1,14 @@
+'use strict';
+
 var should = require('should'), // jshint ignore:line
     sinon = require('sinon'),
     Promise = require('bluebird'),
+    testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
     markdownToMobiledoc = require('../../utils/fixtures/data-generator').markdownToMobiledoc,
-
-// Stuff we are testing
     helpers = require('../../../server/helpers'),
+    urlService = require('../../../server/services/url'),
     api = require('../../../server/api'),
-
     sandbox = sinon.sandbox.create();
 
 describe('{{url}} helper', function () {
@@ -19,6 +20,9 @@ describe('{{url}} helper', function () {
 
     beforeEach(function () {
         rendered = null;
+
+        sandbox.stub(urlService, 'getUrlByResourceId');
+
         sandbox.stub(api.settings, 'read').callsFake(function () {
             return Promise.resolve({settings: [{value: '/:slug/'}]});
         });
@@ -33,7 +37,7 @@ describe('{{url}} helper', function () {
     });
 
     it('should return the slug with a prefix slash if the context is a post', function () {
-        rendered = helpers.url.call({
+        const post = testUtils.DataGenerator.forKnex.createPost({
             html: 'content',
             mobiledoc: markdownToMobiledoc('ff'),
             title: 'title',
@@ -42,60 +46,65 @@ describe('{{url}} helper', function () {
             url: '/slug/'
         });
 
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined}).returns('/slug/');
+
+        rendered = helpers.url.call(post);
         should.exist(rendered);
         rendered.string.should.equal('/slug/');
     });
 
     it('should output an absolute URL if the option is present', function () {
-        rendered = helpers.url.call(
-            {html: 'content', mobiledoc: markdownToMobiledoc('ff'), title: 'title', slug: 'slug', url: '/slug/', created_at: new Date(0)},
-            {hash: {absolute: 'true'}}
-        );
+        const post = testUtils.DataGenerator.forKnex.createPost({
+            html: 'content',
+            mobiledoc: markdownToMobiledoc('ff'),
+            title: 'title',
+            slug: 'slug',
+            url: '/slug/',
+            created_at: new Date(0)
+        });
 
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: undefined}).returns('http://localhost:82832/slug/');
+
+        rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);
         rendered.string.should.equal('http://localhost:82832/slug/');
     });
 
     it('should output an absolute URL with https if the option is present and secure', function () {
-        rendered = helpers.url.call(
-            {
-                html: 'content', mobiledoc: markdownToMobiledoc('ff'), title: 'title', slug: 'slug',
-                url: '/slug/', created_at: new Date(0), secure: true
-            },
-            {hash: {absolute: 'true'}}
-        );
+        const post = testUtils.DataGenerator.forKnex.createPost({
+            html: 'content',
+            mobiledoc: markdownToMobiledoc('ff'),
+            title: 'title',
+            slug: 'slug',
+            url: '/slug/',
+            created_at: new Date(0),
+            secure: true
+        });
 
-        should.exist(rendered);
-        rendered.string.should.equal('https://localhost:82832/slug/');
-    });
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: true}).returns('https://localhost:82832/slug/');
 
-    it('should output an absolute URL with https if secure', function () {
-        rendered = helpers.url.call(
-            {
-                html: 'content', mobiledoc: markdownToMobiledoc('ff'), title: 'title', slug: 'slug',
-                url: '/slug/', created_at: new Date(0), secure: true
-            },
-            {hash: {absolute: 'true'}}
-        );
-
+        rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);
         rendered.string.should.equal('https://localhost:82832/slug/');
     });
 
     it('should return the slug with a prefixed /tag/ if the context is a tag', function () {
-        rendered = helpers.url.call({
+        const tag = testUtils.DataGenerator.forKnex.createTag({
             name: 'the tag',
             slug: 'the-tag',
             description: null,
             parent: null
         });
 
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined}).returns('/tag/the-tag/');
+
+        rendered = helpers.url.call(tag);
         should.exist(rendered);
         rendered.string.should.equal('/tag/the-tag/');
     });
 
     it('should return the slug with a prefixed /author/ if the context is author', function () {
-        rendered = helpers.url.call({
+        const user = testUtils.DataGenerator.forKnex.createUser({
             bio: null,
             website: null,
             profile_image: null,
@@ -103,24 +112,15 @@ describe('{{url}} helper', function () {
             slug: 'some-author'
         });
 
+        urlService.getUrlByResourceId.withArgs(user.id, {absolute: undefined, secure: undefined}).returns('/author/some-author/');
+
+        rendered = helpers.url.call(user);
         should.exist(rendered);
         rendered.string.should.equal('/author/some-author/');
     });
 
     it('should return / if not a post or tag', function () {
-        rendered = helpers.url.call({mobiledoc: markdownToMobiledoc('ff'), title: 'title', slug: 'slug'});
-        should.exist(rendered);
-        rendered.string.should.equal('/');
-
-        rendered = helpers.url.call({html: 'content', title: 'title', slug: 'slug'});
-        should.exist(rendered);
-        rendered.string.should.equal('/');
-
-        rendered = helpers.url.call({html: 'content', mobiledoc: markdownToMobiledoc('ff'), slug: 'slug'});
-        should.exist(rendered);
-        rendered.string.should.equal('/');
-
-        rendered = helpers.url.call({html: 'content', mobiledoc: markdownToMobiledoc('ff'), title: 'title'});
+        rendered = helpers.url.call({something: 'key'});
         should.exist(rendered);
         rendered.string.should.equal('/');
     });

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -7,6 +7,7 @@ const should = require('should'), // jshint ignore:line
     testUtils = require('../../utils'),
     knex = require('../../../server/data/db').knex,
     settingsCache = require('../../../server/services/settings/cache'),
+    urlService = require('../../../server/services/url'),
     schema = require('../../../server/data/schema'),
     models = require('../../../server/models'),
     common = require('../../../server/lib/common'),
@@ -28,6 +29,7 @@ describe('Unit: models/post', function () {
 
     beforeEach(function () {
         sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');
+        sandbox.stub(urlService, 'getUrlByResourceId');
     });
 
     afterEach(function () {
@@ -49,6 +51,8 @@ describe('Unit: models/post', function () {
          * Will be fixed when merging channels, because the post model has no longer generate the url.
          */
         it('[bug] permalink: /:primary_tag/:slug/, columns: [title,url]', function () {
+            urlService.getUrlByResourceId.withArgs(testUtils.DataGenerator.Content.posts[0].id).returns('/all/html-ipsum/');
+
             sandbox.stub(settingsCache, 'get').withArgs('permalinks').returns('/:primary_tag/:slug/');
 
             return models.Post.findPage({columns: ['title', 'url']})

--- a/core/test/unit/services/slack_spec.js
+++ b/core/test/unit/services/slack_spec.js
@@ -1,4 +1,6 @@
-var should = require('should'), // jshint ignore:line,
+'use strict';
+
+var should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
     nock = require('nock'),
@@ -94,7 +96,6 @@ describe('Slack', function () {
 
     describe('ping()', function () {
         var isPostStub,
-            urlForSpy,
             settingsCacheStub,
 
             slackReset,
@@ -103,7 +104,7 @@ describe('Slack', function () {
 
         beforeEach(function () {
             isPostStub = sandbox.stub(schema, 'isPost');
-            urlForSpy = sandbox.spy(urlService.utils, 'urlFor');
+            sandbox.stub(urlService, 'getUrlByResourceId');
 
             settingsCacheStub = sandbox.stub(settingsCache, 'get');
             sandbox.spy(common.logging, 'error');
@@ -122,23 +123,26 @@ describe('Slack', function () {
         it('makes a request for a post if url is provided', function () {
             var requestUrl, requestData;
 
+            const post = testUtils.DataGenerator.forKnex.createPost({slug: 'test'});
+            urlService.getUrlByResourceId.withArgs(post.id, {absolute: true}).returns('http://myblog.com/' + post.slug + '/');
+
             isPostStub.returns(true);
             settingsCacheStub.withArgs('slack').returns(slackObjWithUrl);
 
             // execute code
-            ping({});
+            ping(post);
 
             // assertions
             makeRequestStub.calledOnce.should.be.true();
             isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledTwice.should.be.true();
+            urlService.getUrlByResourceId.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack').should.be.true();
 
             requestUrl = makeRequestStub.firstCall.args[0];
             requestData = JSON.parse(makeRequestStub.firstCall.args[1].body);
 
             requestUrl.should.equal(slackObjWithUrl[0].url);
-            requestData.text.should.eql('http://myblog.com/');
+            requestData.text.should.eql('http://myblog.com/test/');
             requestData.icon_url.should.equal('http://myblog.com/favicon.ico');
             requestData.username.should.equal('Ghost');
             requestData.unfurl_links.should.equal(true);
@@ -158,7 +162,7 @@ describe('Slack', function () {
             // assertions
             makeRequestStub.calledOnce.should.be.true();
             isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledOnce.should.be.true();
+            urlService.getUrlByResourceId.called.should.be.false();
             settingsCacheStub.calledWith('slack').should.be.true();
 
             requestUrl = makeRequestStub.firstCall.args[0];
@@ -189,60 +193,46 @@ describe('Slack', function () {
         });
 
         it('does not make a request if post is a page', function () {
-            // set up
+            const post = testUtils.DataGenerator.forKnex.createPost({page: true});
             isPostStub.returns(true);
             settingsCacheStub.withArgs('slack').returns(slackObjWithUrl);
 
             // execute code
-            ping({page: true});
+            ping(post);
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
             isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledOnce.should.be.true();
-            settingsCacheStub.calledWith('slack').should.be.true();
-        });
-
-        it('does not make a request if no url is provided', function () {
-            // set up
-            isPostStub.returns(true);
-            settingsCacheStub.withArgs('slack').returns(slackObjNoUrl);
-
-            // execute code
-            ping({});
-            // assertions
-            makeRequestStub.calledOnce.should.be.false();
-            isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledOnce.should.be.true();
+            urlService.getUrlByResourceId.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack').should.be.true();
         });
 
         it('does not send webhook for \'welcome\' post', function () {
-            // set up
+            const post = testUtils.DataGenerator.forKnex.createPost({slug: 'welcome'});
             isPostStub.returns(true);
             settingsCacheStub.withArgs('slack').returns(slackObjWithUrl);
 
             // execute code
-            ping({slug: 'welcome'});
+            ping(post);
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
             isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledOnce.should.be.true();
+            urlService.getUrlByResourceId.calledOnce.should.be.true();
             settingsCacheStub.calledWith('slack').should.be.true();
         });
 
         it('handles broken slack settings', function () {
-            // set up
+            const post = testUtils.DataGenerator.forKnex.createPost({slug: 'any'});
             settingsCacheStub.withArgs('slack').returns();
 
             // execute code
-            ping({});
+            ping(post);
 
             // assertions
             makeRequestStub.calledOnce.should.be.false();
             isPostStub.calledOnce.should.be.true();
-            urlForSpy.calledOnce.should.be.false();
+            urlService.getUrlByResourceId.called.should.be.false();
             settingsCacheStub.calledWith('slack').should.be.true();
         });
     });

--- a/core/test/unit/services/url/UrlGenerator_spec.js
+++ b/core/test/unit/services/url/UrlGenerator_spec.js
@@ -6,6 +6,7 @@ const Promise = require('bluebird');
 const should = require('should');
 const jsonpath = require('jsonpath');
 const sinon = require('sinon');
+const urlUtils = require('../../../../server/services/url/utils');
 const UrlGenerator = require('../../../../server/services/url/UrlGenerator');
 const sandbox = sinon.sandbox.create();
 
@@ -259,55 +260,10 @@ describe('Unit: services/url/UrlGenerator', function () {
             });
 
             const urlGenerator = new UrlGenerator(routingType, queue, resources, urls);
-            sandbox.stub(urlGenerator, '_replacePermalink').returns('/url');
+            sandbox.stub(urlUtils, 'replacePermalink').returns('/url');
 
             urlGenerator._generateUrl(resource).should.eql('/url');
-            urlGenerator._replacePermalink.calledWith('/:slug/', resource).should.be.true();
-        });
-    });
-
-    describe('fn: _replacePermalink', function () {
-        it('/:slug/', function () {
-            const urlGenerator = new UrlGenerator(routingType, queue, resources, urls);
-            resource.data = {
-                slug: 'welcome'
-            };
-
-            urlGenerator._replacePermalink('/:slug/', resource).should.eql('/welcome/');
-        });
-
-        it('/:year/:slug/', function () {
-            const urlGenerator = new UrlGenerator(routingType, queue, resources, urls);
-            resource.data = {
-                slug: 'welcome',
-                published_at: '2017-04-13T20:00:53.584Z'
-            };
-
-            urlGenerator._replacePermalink('/:year/:slug/', resource).should.eql('/2017/welcome/');
-        });
-
-        it('/:author/:slug/', function () {
-            const urlGenerator = new UrlGenerator(routingType, queue, resources, urls);
-            resource.data = {
-                slug: 'welcome',
-                primary_author: {
-                    slug: 'joe'
-                }
-            };
-
-            urlGenerator._replacePermalink('/:author/:slug/', resource).should.eql('/joe/welcome/');
-        });
-
-        it('/:primary_tag/:slug/', function () {
-            const urlGenerator = new UrlGenerator(routingType, queue, resources, urls);
-            resource.data = {
-                slug: 'welcome',
-                primary_tag: {
-                    slug: 'football'
-                }
-            };
-
-            urlGenerator._replacePermalink('/:primary_tag/:slug/', resource).should.eql('/football/welcome/');
+            urlUtils.replacePermalink.calledWith('/:slug/', resource.data).should.be.true();
         });
     });
 

--- a/core/test/unit/services/url/UrlService_spec.js
+++ b/core/test/unit/services/url/UrlService_spec.js
@@ -174,7 +174,7 @@ describe('Unit: services/url/UrlService', function () {
             url.should.eql('/ghostly-kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[2].id);
-            should.not.exist(url);
+            url.should.eql('/404/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[0].id);
             url.should.eql('/tag/kitchen-sink/');
@@ -221,7 +221,7 @@ describe('Unit: services/url/UrlService', function () {
                     .then(function (post) {
                         // There is no collection which owns featured posts.
                         let url = urlService.getUrlByResourceId(post.id);
-                        should.not.exist(url);
+                        url.should.eql('/404/');
 
                         urlService.urlGenerators.forEach(function (generator) {
                             if (generator.routingType.getType() === 'posts') {
@@ -300,7 +300,7 @@ describe('Unit: services/url/UrlService', function () {
                     author_id: testUtils.DataGenerator.forKnex.users[4].id
                 }).then(function (post) {
                     let url = urlService.getUrlByResourceId(post.id);
-                    should.not.exist(url);
+                    url.should.eql('/404/');
 
                     let resource = urlService.getResource(url);
                     should.not.exist(resource);

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -1,5 +1,6 @@
-// jshint unused: false
-var should = require('should'),
+'use strict';
+
+const should = require('should'),
     sinon = require('sinon'),
     _ = require('lodash'),
     moment = require('moment-timezone'),
@@ -9,7 +10,6 @@ var should = require('should'),
     configUtils = require('../../../utils/configUtils'),
     testUtils = require('../../../utils'),
     config = configUtils.config,
-
     sandbox = sinon.sandbox.create();
 
 describe('Url', function () {
@@ -210,51 +210,6 @@ describe('Url', function () {
             configUtils.set({url: 'http://my-ghost-blog.com/blog/'});
             urlService.utils.urlFor(testContext).should.equal('/blog/about/');
             urlService.utils.urlFor(testContext, true).should.equal('http://my-ghost-blog.com/blog/about/');
-        });
-
-        it('should return url for a post from post object', function () {
-            var testContext = 'post',
-                testData = {post: _.cloneDeep(testUtils.DataGenerator.Content.posts[2])};
-
-            // url is now provided on the postmodel, permalinkSetting tests are in the model_post_spec.js test
-            testData.post.url = '/short-and-sweet/';
-            configUtils.set({url: 'http://my-ghost-blog.com'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/short-and-sweet/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/short-and-sweet/');
-
-            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/blog/short-and-sweet/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/short-and-sweet/');
-
-            testData.post.url = '/blog-one/';
-            urlService.utils.urlFor(testContext, testData).should.equal('/blog/blog-one/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/blog-one/');
-        });
-
-        it('should return url for a tag when asked for', function () {
-            var testContext = 'tag',
-                testData = {tag: testUtils.DataGenerator.Content.tags[0]};
-
-            configUtils.set({url: 'http://my-ghost-blog.com'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/tag/kitchen-sink/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/tag/kitchen-sink/');
-
-            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/blog/tag/kitchen-sink/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/tag/kitchen-sink/');
-        });
-
-        it('should return url for an author when asked for', function () {
-            var testContext = 'author',
-                testData = {author: testUtils.DataGenerator.Content.users[0]};
-
-            configUtils.set({url: 'http://my-ghost-blog.com'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/author/joe-bloggs/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/author/joe-bloggs/');
-
-            configUtils.set({url: 'http://my-ghost-blog.com/blog'});
-            urlService.utils.urlFor(testContext, testData).should.equal('/blog/author/joe-bloggs/');
-            urlService.utils.urlFor(testContext, testData, true).should.equal('http://my-ghost-blog.com/blog/author/joe-bloggs/');
         });
 
         it('should return url for an image when asked for', function () {
@@ -543,10 +498,8 @@ describe('Url', function () {
         });
     });
 
-    describe('urlPathForPost', function () {
-        var localSettingsCache = {
-            permalinks: '/:slug/'
-        };
+    describe('replacePermalink', function () {
+        const localSettingsCache = {};
 
         beforeEach(function () {
             sandbox.stub(settingsCache, 'get').callsFake(function (key) {
@@ -558,100 +511,82 @@ describe('Url', function () {
             var testData = testUtils.DataGenerator.Content.posts[2],
                 postLink = '/short-and-sweet/';
 
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:slug/', testData).should.equal(postLink);
         });
 
-        it('permalink is /:year/:month/:day/:slug, blog timezone is Los Angeles', function () {
+        it('permalink is /:year/:month/:day/:slug/, blog timezone is Los Angeles', function () {
             localSettingsCache.active_timezone = 'America/Los_Angeles';
-            localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
             var testData = testUtils.DataGenerator.Content.posts[2],
                 postLink = '/2016/05/17/short-and-sweet/';
 
             testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:year/:month/:day/:slug/', testData).should.equal(postLink);
         });
 
-        it('permalink is /:year/:month/:day/:slug, blog timezone is Asia Tokyo', function () {
+        it('permalink is /:year/:month/:day/:slug/, blog timezone is Asia Tokyo', function () {
             localSettingsCache.active_timezone = 'Asia/Tokyo';
-            localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
             var testData = testUtils.DataGenerator.Content.posts[2],
                 postLink = '/2016/05/18/short-and-sweet/';
 
             testData.published_at = new Date('2016-05-18T06:30:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:year/:month/:day/:slug/', testData).should.equal(postLink);
         });
 
-        it('post is page, no permalink usage allowed at all', function () {
+        it('permalink is /:year/:id/:author/, TZ is LA', function () {
             localSettingsCache.active_timezone = 'America/Los_Angeles';
-            localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
-            var testData = testUtils.DataGenerator.Content.posts[5],
-                postLink = '/static-page-test/';
-
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
-        });
-
-        it('permalink is /:year/:id:/:author', function () {
-            localSettingsCache.active_timezone = 'America/Los_Angeles';
-            localSettingsCache.permalinks = '/:year/:id/:author/';
-
-            var testData = _.merge({}, testUtils.DataGenerator.Content.posts[2], {id: 3}, {author: {slug: 'joe-blog'}}),
+            var testData = _.merge({}, testUtils.DataGenerator.Content.posts[2], {id: 3}, {primary_author: {slug: 'joe-blog'}}),
                 postLink = '/2015/3/joe-blog/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:year/:id/:author/', testData).should.equal(postLink);
         });
 
-        it('permalink is /:year/:id:/:author', function () {
+        it('permalink is /:year/:id:/:author/, TZ is Berlin', function () {
             localSettingsCache.active_timezone = 'Europe/Berlin';
-            localSettingsCache.permalinks = '/:year/:id/:author/';
 
-            var testData = _.merge({}, testUtils.DataGenerator.Content.posts[2], {id: 3}, {author: {slug: 'joe-blog'}}),
+            var testData = _.merge({}, testUtils.DataGenerator.Content.posts[2], {id: 3}, {primary_author: {slug: 'joe-blog'}}),
                 postLink = '/2016/3/joe-blog/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:year/:id/:author/', testData).should.equal(postLink);
         });
 
         it('permalink is /:primary_tag/:slug/ and there is a primary_tag', function () {
             localSettingsCache.active_timezone = 'Europe/Berlin';
-            localSettingsCache.permalinks = '/:primary_tag/:slug/';
 
             var testData = _.merge({}, testUtils.DataGenerator.Content.posts[2], {primary_tag: {slug: 'bitcoin'}}),
                 postLink = '/bitcoin/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:primary_tag/:slug/', testData).should.equal(postLink);
         });
 
         it('permalink is /:primary_tag/:slug/ and there is NO primary_tag', function () {
             localSettingsCache.active_timezone = 'Europe/Berlin';
-            localSettingsCache.permalinks = '/:primary_tag/:slug/';
 
             var testData = testUtils.DataGenerator.Content.posts[2],
                 postLink = '/all/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:primary_tag/:slug/', testData).should.equal(postLink);
         });
 
         it('shows "undefined" for unknown route segments', function () {
             localSettingsCache.active_timezone = 'Europe/Berlin';
-            localSettingsCache.permalinks = '/:tag/:slug/';
 
             var testData = testUtils.DataGenerator.Content.posts[2],
                 // @TODO: is this the correct behaviour?
                 postLink = '/undefined/short-and-sweet/';
 
             testData.published_at = new Date('2016-01-01T00:00:00.000Z');
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:tag/:slug/', testData).should.equal(postLink);
         });
 
         it('post is not published yet', function () {
             localSettingsCache.active_timezone = 'Europe/London';
-            localSettingsCache.permalinks = '/:year/:month/:day/:slug/';
 
             var testData = _.merge(testUtils.DataGenerator.Content.posts[2], {id: 3, published_at: null}),
                 nowMoment = moment().tz('Europe/London'),
@@ -661,7 +596,7 @@ describe('Url', function () {
             postLink = postLink.replace('MM', nowMoment.format('MM'));
             postLink = postLink.replace('DD', nowMoment.format('DD'));
 
-            urlService.utils.urlPathForPost(testData).should.equal(postLink);
+            urlService.utils.replacePermalink('/:year/:month/:day/:slug/', testData).should.equal(postLink);
         });
     });
 

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -404,6 +404,9 @@ DataGenerator.forKnex = (function () {
 
         return _.defaults(newObj, {
             id: ObjectId.generate(),
+            name: 'tag',
+            slug: 'slug',
+            description: 'description',
             visibility: 'public',
             created_by: DataGenerator.Content.users[0].id,
             created_at: new Date(),
@@ -435,6 +438,7 @@ DataGenerator.forKnex = (function () {
             feature_image: null,
             featured: false,
             page: false,
+            slug: 'slug',
             author_id: DataGenerator.Content.users[0].id,
             updated_at: new Date(),
             updated_by: DataGenerator.Content.users[0].id,
@@ -470,14 +474,18 @@ DataGenerator.forKnex = (function () {
         return _.defaults(newObj, {
             id: ObjectId.generate(),
             name: 'name',
+            bio: 'bio',
+            website: null,
             slug: 'slug_' + Date.now(),
+            profile_image: null,
             status: 'active',
             password: 'Sl1m3rson99',
             created_by: DataGenerator.Content.users[0].id,
             created_at: new Date(),
             updated_at: new Date(),
             updated_by: DataGenerator.Content.users[0].id,
-            visibility: 'public'
+            visibility: 'public',
+            location: 'location'
         });
     }
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -509,7 +509,10 @@ truncate = function truncate(tableName) {
 // we must always try to delete all tables
 clearData = function clearData() {
     debug('Database reset');
-    return knexMigrator.reset({force: true});
+    return knexMigrator.reset({force: true})
+        .then(function () {
+            urlService.softReset();
+        });
 };
 
 toDoList = {
@@ -931,6 +934,10 @@ startGhost = function startGhost(options) {
                 return themes.init();
             })
             .then(function () {
+                urlService.softReset();
+                urlService.finished = false;
+                common.events.emit('db.ready');
+
                 let timeout;
 
                 return new Promise(function (resolve) {
@@ -963,6 +970,8 @@ startGhost = function startGhost(options) {
             return knexMigrator.init();
         })
         .then(function initializeGhost() {
+            urlService.softReset();
+
             return ghost();
         })
         .then(function startGhost(_ghostServer) {

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -931,6 +931,21 @@ startGhost = function startGhost(options) {
                 return themes.init();
             })
             .then(function () {
+                let timeout;
+
+                return new Promise(function (resolve) {
+                    (function retry() {
+                        clearTimeout(timeout);
+
+                        if (urlService.hasFinished()) {
+                            return resolve();
+                        }
+
+                        timeout = setTimeout(retry, 50);
+                    })();
+                });
+            })
+            .then(function () {
                 customRedirectsMiddleware.reload();
 
                 common.events.emit('server.start');
@@ -960,6 +975,21 @@ startGhost = function startGhost(options) {
             }
 
             return ghostServer.start();
+        })
+        .then(function () {
+            let timeout;
+
+            return new Promise(function (resolve) {
+                (function retry() {
+                    clearTimeout(timeout);
+
+                    if (urlService.hasFinished()) {
+                        return resolve();
+                    }
+
+                    timeout = setTimeout(retry, 50);
+                })();
+            });
         })
         .then(function returnGhost() {
             return ghostServer;


### PR DESCRIPTION
Based on #9588 and #9580.

refs https://github.com/TryGhost/Ghost/issues/9601

### Sumary

Replaces all usages of e.g. `urlService.utils.urlFor('post', {post: post})` by `urlService.getByResourceId(id)`.

By this, we always rely on the urls generated and known from the url service. The old url utility generates urls based on a static routing knowledge.

- [x] rebase master
- [x] fix tests
- [x] cleanup old url utility and combine with url service