### PR TITLE
🐛 Fixed infinite redirect for admin when subdir matches end of url

### DIFF
--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -63,9 +63,11 @@ function deduplicateSubDir(url) {
     }
 
     subDir = subDir.replace(/^\/|\/+$/, '');
-    subDirRegex = new RegExp(subDir + '\/' + subDir + '\/');
+    // we can have subdirs that match TLDs so we need to restrict matches to
+    // duplicates that start with a / or the beginning of the url
+    subDirRegex = new RegExp('(^|\/)' + subDir + '\/' + subDir + '\/');
 
-    return url.replace(subDirRegex, subDir + '/');
+    return url.replace(subDirRegex, '$1' + subDir + '/');
 }
 
 function getProtectedSlugs() {

--- a/core/server/web/middleware/url-redirects.js
+++ b/core/server/web/middleware/url-redirects.js
@@ -37,7 +37,7 @@ _private.getAdminRedirectUrl = function getAdminRedirectUrl(options) {
         queryParameters = options.queryParameters,
         secure = options.secure;
 
-    debug('getAdminRedirectUrl', requestedHost, requestedUrl, adminHostWithProtocol);
+    debug('getAdminRedirectUrl', requestedHost, requestedUrl, adminHostWithoutProtocol, blogHostWithoutProtocol, urlService.utils.urlJoin(blogHostWithoutProtocol, 'ghost/'));
 
     // CASE: we only redirect the admin access if `admin.url` is configured
     // If url and admin.url are not equal AND the requested host does not match, redirect.

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -92,6 +92,12 @@ describe('Url', function () {
             urlService.utils.urlJoin('my/blog', 'my/blog/about').should.equal('my/blog/about');
             urlService.utils.urlJoin('my/blog/', 'my/blog/about').should.equal('my/blog/about');
         });
+
+        it('should handle subdir matching tld', function () {
+            configUtils.set({url: 'http://ghost.blog/blog'});
+            urlService.utils.urlJoin('ghost.blog/blog', 'ghost/').should.equal('ghost.blog/blog/ghost/');
+            urlService.utils.urlJoin('ghost.blog', 'blog', 'ghost/').should.equal('ghost.blog/blog/ghost/');
+        });
     });
 
     describe('urlFor', function () {


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/9620
- adjust the `deduplicateSubDir` function's regex to only match duplicate subdirectories when the `url` is only a path rather than full url or the duplicate match starts with a `/`
