### PR TITLE
Fix `security/password.js` not requiring Bluebird

### DIFF
--- a/core/server/lib/security/password.js
+++ b/core/server/lib/security/password.js
@@ -1,3 +1,5 @@
+const Promise = require('bluebird');
+
 module.exports.hash = function hash(plainPassword) {
     const bcrypt = require('bcryptjs'),
         bcryptGenSalt = Promise.promisify(bcrypt.genSalt),


### PR DESCRIPTION
This fixes the “Promise.promisify is not a function” error that was occurring for me when running a knex migration programmatically.

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues (no issues found)
- [x] The build will pass (run `npm test`)