### PR TITLE
🐛 Fixed gscan errors not caught for corrupted zips

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ghost-storage-base": "0.0.3",
     "glob": "5.0.15",
     "got": "7.1.0",
-    "gscan": "1.4.2",
+    "gscan": "1.4.3",
     "html-to-text": "3.3.0",
     "image-size": "0.6.2",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,15 @@
   dependencies:
     samsam "1.3.0"
 
+"@tryghost/extract-zip@1.6.6":
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/@tryghost/extract-zip/-/extract-zip-1.6.6.tgz#937e0e775fec6dea937ac49d73a068bcafb67f50"
+  dependencies:
+    concat-stream "1.6.0"
+    debug "2.6.9"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 JSONSelect@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d"
@@ -1802,7 +1811,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@1.6.6, extract-zip@^1.6.5:
+extract-zip@1.6.6:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.6.6.tgz#1290ede8d20d0872b429fd3f351ca128ec5ef85c"
   dependencies:
@@ -2510,16 +2519,16 @@ grunt@~0.4.0:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-gscan@1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.4.2.tgz#df98dddd856b45e782fecea7a6e305388870dcea"
+gscan@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.4.3.tgz#ebea3c78106f4d8562225d46754d0a41c3e0a348"
   dependencies:
+    "@tryghost/extract-zip" "1.6.6"
     bluebird "^3.4.6"
     chalk "^1.1.1"
     commander "2.15.1"
     express "^4.16.2"
     express-hbs "^1.0.3"
-    extract-zip "^1.6.5"
     fs-extra "^0.26.2"
     ghost-ignition "2.9.2"
     glob "^7.0.5"


### PR DESCRIPTION
## Do not merge until TryGhost/gscan#107 is merged and we can bump to the new GScan version!!!

---

refs TryGhost/Support#426
refs TryGhost/gscan#106
needs TryGhost/gscan#107

GScan can return errors, which was not handled in our theme validator and caused Ghost to crash completely. GScan will now return an Ignition error when its not able to read the `.zip` file.

e. g.: `{"errors":[{"message":"Failed to read zip file","context":"tife.zip","errorType":"ValidationError","errorDetails":"invalid relative path: ../tife/"}]}`

UI will show this:

![image](https://user-images.githubusercontent.com/8037602/39907939-4d835de2-551e-11e8-94fc-ee4837829e21.png)

---

## Todos:
- [x] Update GScan to new version
