### PR TITLE
passively responsive images demo relating to issue #4453

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -78,5 +78,15 @@
         "robotstxt": {
             "maxAge": 3600000
         }
+    },
+    "images": {
+        "optimize": true,
+        "quality": 60,
+        "sizes": [
+            260,
+            520,
+            1040,
+            2080
+        ]
     }
 }

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -20,7 +20,7 @@ module.exports = function content(options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
-    var html = this.html
+    var html = this.html;
     if (config.get('images').optimize) {
         html = responsive.imgs(this.html);
     }

--- a/core/server/helpers/content.js
+++ b/core/server/helpers/content.js
@@ -9,7 +9,9 @@
 var proxy = require('./proxy'),
     _ = require('lodash'),
     downsize = require('downsize'),
-    SafeString = proxy.SafeString;
+    SafeString = proxy.SafeString,
+    config = proxy.config,
+    responsive = require('../lib/image/responsive');
 
 module.exports = function content(options) {
     var truncateOptions = (options || {}).hash || {};
@@ -18,11 +20,16 @@ module.exports = function content(options) {
         truncateOptions[key] = parseInt(truncateOptions[key], 10);
     });
 
+    var html = this.html
+    if (config.get('images').optimize) {
+        html = responsive.imgs(this.html);
+    }
+
     if (truncateOptions.hasOwnProperty('words') || truncateOptions.hasOwnProperty('characters')) {
         return new SafeString(
-            downsize(this.html, truncateOptions)
+            downsize(html, truncateOptions)
         );
     }
 
-    return new SafeString(this.html);
+    return new SafeString(html);
 };

--- a/core/server/lib/image/responsive.js
+++ b/core/server/lib/image/responsive.js
@@ -1,0 +1,97 @@
+var path = require('path'),
+    fs = require('fs'),
+    jimp = require('jimp'),
+    cheerio = require('cheerio'),
+    url = require('../../services/url').utils,
+    config = require('../../config'),
+    imageSizes = config.get('images').sizes,
+    quality = config.get('images').quality;
+
+// Replace <img src="" /> tags with src replaced with lowest resolution image and srcset
+// Effectively delegating decision to consume higher resolution image assets to client
+// @see https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
+module.exports.imgs = function imgs(html) {
+  var content = cheerio.load(html, {decodeEntities: false}),
+      re = new RegExp('^/' + url.STATIC_IMAGE_URL_PREFIX);
+
+  content('img').each(function(i, img) {
+    img = content(img)
+    var uri = img.attr('src');
+    // local image without an existing srcset
+    if (uri.match(re) && !img.attr('srcset')) {
+        img.attr('srcset', srcset(uri));
+        img.attr('sizes', sizes(uri));
+        img.attr('src', src(uri));
+    }
+  });
+
+  return content.html();
+}
+
+// Return the local filesystem path for an image src path
+function systemPath(src) {
+    var base = config.getContentPath('images').replace('/' + url.STATIC_IMAGE_URL_PREFIX, '');
+    return path.join(base, src);
+}
+
+// Generate the filename encoding the size and quality, e.g.:
+// `/content/images/my-upload.jpg` returns
+// `/content/images/my-upload@640q80.jpg`
+function resizedURI(src, size, quality) {
+    var re = new RegExp('(.+)\\.([a-z0-9]+)$'),
+        parsed = src.match(re);
+
+    return [
+        parsed[1],
+        '@', size,
+        'q', quality,
+        '.', parsed[2]
+    ].join('');
+}
+
+// Returns a resized filename (via `resizedURI()`) as well as creates the
+// resized, optimized image on the local filesystem when it does not exist.
+function resizedImage(src, size, quality) {
+    var resized = resizedURI(src, size, quality);
+
+    var paths = {
+        original: systemPath(src),
+        resized: systemPath(resized)
+    };
+
+    if (!fs.existsSync(paths.resized)) {
+        jimp.read(paths.original).then(function(image) {
+            image.scaleToFit(size, size)
+                 .quality(quality)
+                 .write(paths.resized);
+        }).catch(function(error) {
+            console.error(error);
+        });
+    }
+
+  return resized;
+}
+
+// Return a string for use with `img.srcset` html attribute
+function srcset(src) {
+    return imageSizes.map(function(px, n) {
+        var density = px + 'w';
+        return [resizedImage(src, px, quality), density].join(' ');
+    }).join(', ');
+}
+
+// Return a string for use with `img.sizes` html attribute
+function sizes(src) {
+  return imageSizes.map(function(px, n) {
+      var w = px + 'px';
+      if (n === imageSizes.length) {
+          return w
+      }
+      return ['(max-width: ' + w + ')', w].join(' ');
+  }).join(', ');
+}
+
+// Return an optimized default for an original for use with `img.src` attribute
+function src(src) {
+    return resizedImage(src, imageSizes[0], quality);
+}

--- a/core/server/lib/image/responsive.js
+++ b/core/server/lib/image/responsive.js
@@ -11,22 +11,22 @@ var path = require('path'),
 // Effectively delegating decision to consume higher resolution image assets to client
 // @see https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images
 module.exports.imgs = function imgs(html) {
-  var content = cheerio.load(html, {decodeEntities: false}),
-      re = new RegExp('^/' + url.STATIC_IMAGE_URL_PREFIX);
+    var content = cheerio.load(html, {decodeEntities: false}),
+        re = new RegExp('^/' + url.STATIC_IMAGE_URL_PREFIX);
 
-  content('img').each(function(i, img) {
-    img = content(img)
-    var uri = img.attr('src');
-    // local image without an existing srcset
-    if (uri.match(re) && !img.attr('srcset')) {
-        img.attr('srcset', srcset(uri));
-        img.attr('sizes', sizes(uri));
-        img.attr('src', src(uri));
-    }
-  });
+    content('img').each(function (i, img) {
+        img = content(img);
+        var uri = img.attr('src');
+        // local image without an existing srcset
+        if (uri.match(re) && !img.attr('srcset')) {
+            img.attr('srcset', srcset(uri));
+            img.attr('sizes', sizes());
+            img.attr('src', src(uri));
+        }
+    });
 
-  return content.html();
-}
+    return content.html();
+};
 
 // Return the local filesystem path for an image src path
 function systemPath(src) {
@@ -60,35 +60,33 @@ function resizedImage(src, size, quality) {
     };
 
     if (!fs.existsSync(paths.resized)) {
-        jimp.read(paths.original).then(function(image) {
+        jimp.read(paths.original).then(function (image) {
             image.scaleToFit(size, size)
-                 .quality(quality)
-                 .write(paths.resized);
-        }).catch(function(error) {
-            console.error(error);
+                .quality(quality)
+                .write(paths.resized);
         });
     }
 
-  return resized;
+    return resized;
 }
 
 // Return a string for use with `img.srcset` html attribute
 function srcset(src) {
-    return imageSizes.map(function(px, n) {
+    return imageSizes.map(function (px) {
         var density = px + 'w';
         return [resizedImage(src, px, quality), density].join(' ');
     }).join(', ');
 }
 
 // Return a string for use with `img.sizes` html attribute
-function sizes(src) {
-  return imageSizes.map(function(px, n) {
-      var w = px + 'px';
-      if (n === imageSizes.length) {
-          return w
-      }
-      return ['(max-width: ' + w + ')', w].join(' ');
-  }).join(', ');
+function sizes() {
+    return imageSizes.map(function (px, i) {
+        var w = px + 'px';
+        if (i === imageSizes.length) {
+            return w;
+        }
+        return ['(max-width: ' + w + ')', w].join(' ');
+    }).join(', ');
 }
 
 // Return an optimized default for an original for use with `img.src` attribute

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "image-size": "0.6.2",
     "intl": "1.2.5",
     "intl-messageformat": "1.3.0",
+    "jimp": "^0.2.28",
     "js-yaml": "3.11.0",
     "jsonpath": "1.0.0",
     "knex": "0.14.6",


### PR DESCRIPTION
- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`) (there was some unrelated admin routing cache failure I feel confident is completely unrelated)

---

I caught the (recently locked) issue surrounding image/media manipulation, management and optimization. While I can't really get behind a lot of the more sophisticated ideas surrounding cropping, thumbnails, etc. etc  I wanted to try a slightly different approach. I think something like what this code demonstrates is an easy win: a passive, minimally configurable server-side optimization of resized/compressed images delivered to the client with the ability of the browsers to make the call. No interaction from the editor or the reader, really.

Essentially, when the `images.optimize` flag is set in the config (a few other `images` related configurables of interest in there) the `content` helper passes through a utility to scan the html for `img` tags, loosely check if the `src` paths are "local", and then update the tags to include a `srcset` and `sizes` attribute and values pointing to newly, optimized images generated via [jimp](https://github.com/oliver-moran/jimp).

I intended for this code to demonstrate more than suggest this is the exact solution and ready for merge. I've only spent about a day in the code so I'm sure there are likely better ways/homes for some of these things. Some immediate issues/ideas include: creation strategy currently painful on first request (especially with larger images), only optimizes for images in `{{content}}`, being unfamiliar with codebase not sure if it could be extended to things like featured images, rss/amp and other views (maybe another helper themes could use?) without more time and feedback.

@kevinansfield, @ErisDS: thoughts? I heard you all could use some help so I searched for the oldest `help wanted` issue and took a stab at it ;)