### PR TITLE
Cache promisified bcrypt functions

### DIFF
--- a/core/server/lib/security/password.js
+++ b/core/server/lib/security/password.js
@@ -1,16 +1,12 @@
-module.exports.hash = function hash(plainPassword) {
-    const bcrypt = require('bcryptjs'),
-        bcryptGenSalt = Promise.promisify(bcrypt.genSalt),
-        bcryptHash = Promise.promisify(bcrypt.hash);
+const bcrypt = require('bcryptjs'),
+    bcryptGenSalt = Promise.promisify(bcrypt.genSalt),
+    bcryptHash = Promise.promisify(bcrypt.hash),
+    bcryptCompare = Promise.promisify(bcrypt.compare);
 
+module.exports.hash = function hash(plainPassword) {
     return bcryptGenSalt().then(function (salt) {
         return bcryptHash(plainPassword, salt);
     });
 };
 
-module.exports.compare = function compare(plainPassword, hashedPassword) {
-    const bcrypt = require('bcryptjs'),
-        bcryptCompare = Promise.promisify(bcrypt.compare);
-
-    return bcryptCompare(plainPassword, hashedPassword);
-};
+module.exports.compare = bcryptCompare;


### PR DESCRIPTION
Unsure if this adheres to the first item in the list. In theory it should slightly speed up password logins, and password creation, as there are less function calls, but the difference is likely negligible.

- [ ] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)
