### PR TITLE
Koenig - oembed endpoint and embed card renderer

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -29,6 +29,7 @@ var _ = require('lodash'),
     exporter = require('../data/export'),
     slack = require('./slack'),
     webhooks = require('./webhooks'),
+    oembed = require('./oembed'),
 
     http,
     addHeaders,
@@ -317,7 +318,8 @@ module.exports = {
     themes: themes,
     invites: invites,
     redirects: redirects,
-    webhooks: webhooks
+    webhooks: webhooks,
+    oembed: oembed
 };
 
 /**

--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -1,0 +1,47 @@
+const common = require('../lib/common');
+const {extract, hasProvider} = require('oembed-parser');
+const Promise = require('bluebird');
+
+let oembed = {
+    read(options) {
+        let {url} = options;
+
+        if (!url || !url.trim()) {
+            return Promise.reject(new common.errors.BadRequestError({
+                message: common.i18n.t('errors.api.oembed.noUrlProvided')
+            }));
+        }
+
+        // build up a list of URL variations to test against because the oembed
+        // providers list is not always up to date with scheme or www vs non-www
+        let base = url.replace(/https?:\/\/(?:www\.)?/, '');
+        let testUrls = [
+            `http://${base}`,
+            `https://${base}`,
+            `http://www.${base}`,
+            `https://www.${base}`
+        ];
+        let provider;
+        for (let testUrl of testUrls) {
+            provider = hasProvider(testUrl);
+            if (provider) {
+                url = testUrl;
+                break;
+            }
+        }
+
+        if (!provider) {
+            return Promise.reject(new common.errors.ValidationError({
+                message: common.i18n.t('errors.api.oembed.unknownProvider')
+            }));
+        }
+
+        return extract(url).catch((err) => {
+            return Promise.reject(new common.errors.InternalServerError({
+                message: err.message
+            }));
+        });
+    }
+};
+
+module.exports = oembed;

--- a/core/server/lib/mobiledoc/cards/embed.js
+++ b/core/server/lib/mobiledoc/cards/embed.js
@@ -1,0 +1,25 @@
+module.exports = {
+    name: 'embed',
+    type: 'dom',
+    render(opts) {
+        if (!opts.payload.html) {
+            return '';
+        }
+
+        let {payload, env: {dom}} = opts;
+
+        let figure = dom.createElement('figure');
+        figure.setAttribute('class', 'kg-embed-card');
+
+        let html = dom.createRawHTMLSection(payload.html);
+        figure.appendChild(html);
+
+        if (payload.caption) {
+            let figcaption = dom.createElement('figcaption');
+            figcaption.appendChild(dom.createTextNode(payload.caption));
+            figure.appendChild(figcaption);
+        }
+
+        return figure;
+    }
+};

--- a/core/server/lib/mobiledoc/cards/index.js
+++ b/core/server/lib/mobiledoc/cards/index.js
@@ -1,6 +1,7 @@
 module.exports = [
     require('./card-markdown'),
     require('./code'),
+    require('./embed'),
     require('./hr'),
     require('./html'),
     require('./image'),

--- a/core/server/overrides.js
+++ b/core/server/overrides.js
@@ -1,6 +1,14 @@
 const moment = require('moment-timezone');
 
 /**
+ * oembed-parser uses promise-wtf to extend the global Promise with .finally
+ *   - require it before global Bluebird Promise override so that promise-wtf
+ *     doesn't error due to Bluebird's Promise already having a .finally
+ *   - https://github.com/ndaidong/promise-wtf/issues/25
+ */
+const {extract, hasProvider} = require('oembed-parser'); // eslint-disable-line
+
+/**
  * force UTC
  *   - you can require moment or moment-timezone, both is configured to UTC
  *   - you are allowed to use new Date() to instantiate datetime values for models, because they are transformed into UTC in the model layer

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -424,6 +424,10 @@
             },
             "webhooks": {
                 "webhookAlreadyExists": "A webhook for requested event with supplied target_url already exists."
+            },
+            "oembed": {
+                "noUrlProvided": "No url provided.",
+                "unknownProvider": "No provider found for supplied URL."
             }
         },
         "data": {

--- a/core/server/web/api/routes.js
+++ b/core/server/web/api/routes.js
@@ -206,5 +206,8 @@ module.exports = function apiRoutes() {
     apiRouter.post('/webhooks', mw.authenticatePrivate, api.http(api.webhooks.add));
     apiRouter.del('/webhooks/:id', mw.authenticatePrivate, api.http(api.webhooks.destroy));
 
+    // ## Oembed (fetch response from oembed provider)
+    apiRouter.get('/oembed', mw.authenticatePrivate, api.http(api.oembed.read));
+
     return apiRouter;
 };

--- a/core/test/functional/routes/api/oembed_spec.js
+++ b/core/test/functional/routes/api/oembed_spec.js
@@ -1,0 +1,63 @@
+const config = require('../../../../../core/server/config');
+const nock = require('nock');
+const should = require('should');
+const supertest = require('supertest');
+const testUtils = require('../../../utils');
+
+const ghost = testUtils.startGhost;
+
+describe('Oembed API', function () {
+    let accesstoken = '', ghostServer, request;
+
+    before(function () {
+        return ghost()
+            .then((_ghostServer) => {
+                ghostServer = _ghostServer;
+                request = supertest.agent(config.get('url'));
+            })
+            .then(() => {
+                return testUtils.doAuth(request);
+            })
+            .then((token) => {
+                accesstoken = token;
+            });
+    });
+
+    describe('success', function () {
+        it('can fetch an embed', function (done) {
+            let requestMock = nock('https://www.youtube.com')
+                .get('/oembed')
+                .query(true)
+                .reply(200, {
+                    html: '<iframe width="480" height="270" src="https://www.youtube.com/embed/E5yFcdPAGv0?feature=oembed" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>',
+                    thumbnail_width: 480,
+                    width: 480,
+                    author_url: 'https://www.youtube.com/user/gorillaz',
+                    height: 270,
+                    thumbnail_height: 360,
+                    provider_name: 'YouTube',
+                    title: 'Gorillaz - Humility (Official Video)',
+                    provider_url: 'https://www.youtube.com/',
+                    author_name: 'Gorillaz',
+                    version: '1.0',
+                    thumbnail_url: 'https://i.ytimg.com/vi/E5yFcdPAGv0/hqdefault.jpg',
+                    type: 'video'
+                });
+
+            request.get(testUtils.API.getApiQuery('oembed/?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DE5yFcdPAGv0'))
+                .set('Authorization', 'Bearer ' + accesstoken)
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    requestMock.isDone().should.be.true();
+                    should.exist(res.body.html);
+                    done();
+                });
+        });
+    });
+});

--- a/core/test/unit/api/oembed_spec.js
+++ b/core/test/unit/api/oembed_spec.js
@@ -1,0 +1,60 @@
+const common = require('../../../server/lib/common');
+const nock = require('nock');
+const OembedAPI = require('../../../server/api/oembed');
+const should = require('should');
+
+describe('API: oembed', function () {
+    describe('fn: read', function () {
+        // https://oembed.com/providers.json only has schemes for https://reddit.com
+        it('finds match for unlisted http scheme', function (done) {
+            let requestMock = nock('https://www.reddit.com')
+                .get('/oembed')
+                .query(true)
+                .reply(200, {
+                    html: 'test'
+                });
+
+            OembedAPI.read({url: 'http://www.reddit.com/r/pics/comments/8qi5oq/breathtaking_picture_of_jupiter_with_its_moon_io/'})
+                .then((results) => {
+                    should.exist(results);
+                    should.exist(results.html);
+                    done();
+                }).catch(done);
+        });
+
+        it('returns error for missing url', function (done) {
+            OembedAPI.read({url: ''})
+                .then(() => {
+                    done(new Error('Fetch oembed without url should error'));
+                }).catch((err) => {
+                    (err instanceof common.errors.BadRequestError).should.eql(true);
+                    done();
+                });
+        });
+
+        it('returns error for unsupported provider', function (done) {
+            OembedAPI.read({url: 'http://example.com/unknown'})
+                .then(() => {
+                    done(new Error('Fetch oembed with unknown url provider should error'));
+                }).catch((err) => {
+                    (err instanceof common.errors.ValidationError).should.eql(true);
+                    done();
+                });
+        });
+
+        it('returns error for fetch failure', function (done) {
+            let requestMock = nock('https://www.youtube.com')
+                .get('/oembed')
+                .query(true)
+                .reply(500);
+
+            OembedAPI.read({url: 'https://www.youtube.com/watch?v=E5yFcdPAGv0'})
+                .then(() => {
+                    done(new Error('Fetch oembed with external failure should error'));
+                }).catch((err) => {
+                    (err instanceof common.errors.InternalServerError).should.eql(true);
+                    done();
+                });
+        });
+    });
+});

--- a/core/test/unit/lib/mobiledoc/cards/embed_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/embed_spec.js
@@ -1,0 +1,72 @@
+const should = require('should');
+const card = require('../../../../../server/lib/mobiledoc/cards/embed');
+const SimpleDom = require('simple-dom');
+const serializer = new SimpleDom.HTMLSerializer(SimpleDom.voidMap);
+
+describe('Embed card', function () {
+    it('Embed Card renders', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                html: '<h1>HEADING</h1><p>PARAGRAPH</p>'
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('<figure class="kg-embed-card"><h1>HEADING</h1><p>PARAGRAPH</p></figure>');
+    });
+
+    it('Plain content renders', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                html: 'CONTENT'
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('<figure class="kg-embed-card">CONTENT</figure>');
+    });
+
+    it('Invalid HTML returns', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                html: '<h1>HEADING<'
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('<figure class="kg-embed-card"><h1>HEADING<</figure>');
+    });
+
+    it('Renders nothing when payload is undefined', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                html: undefined
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('');
+    });
+
+    it('Renders caption when provided', function () {
+        let opts = {
+            env: {
+                dom: new SimpleDom.Document()
+            },
+            payload: {
+                html: 'Testing',
+                caption: 'Caption'
+            }
+        };
+
+        serializer.serialize(card.render(opts)).should.match('<figure class="kg-embed-card">Testing<figcaption>Caption</figcaption></figure>');
+    });
+});

--- a/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
+++ b/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
@@ -47,7 +47,10 @@ describe('Mobiledoc converter', function () {
                     }],
                     ['html', {
                         html: '<h2>HTML card</h2>\n<div><p>Some HTML</p></div>'
-                    }]
+                    }],
+                    ['embed', {
+                        html: '<h2>Embed card</h2>'
+                    }],
                 ],
                 markups: [],
                 sections: [
@@ -66,11 +69,12 @@ describe('Mobiledoc converter', function () {
                         [0, [], 0, 'Four']
                     ]],
                     [10, 3],
-                    [1, 'p', []]
+                    [10, 4],
+                    [1, 'p', []],
                 ]
             };
 
-            converter.render(mobiledoc, 2).should.eql('<div class="kg-post">\n<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image kg-image-wide"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div>\n</div>');
+            converter.render(mobiledoc, 2).should.eql('<div class="kg-post">\n<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image kg-image-wide"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div><figure class="kg-embed-card"><h2>Embed card</h2></figure>\n</div>');
         });
 
         it('wraps output with a .kg-post div', function () {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "netjet": "1.3.0",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.11.0",
+    "oembed-parser": "1.1.0",
     "passport": "0.4.0",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,10 @@ bcryptjs@2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/bcryptjs/-/bcryptjs-2.4.3.tgz#9ab5627b93e60621ff7cdac5da9733027df1d0cb"
 
+bellajs@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/bellajs/-/bellajs-7.2.2.tgz#dc6f8c13acb248dc2ef1b46d01286a16ca31025a"
+
 bignumber.js@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.4.tgz#7c40f5abcd2d6623ab7b99682ee7db81b11889a4"
@@ -4026,6 +4030,10 @@ node-abi@^2.2.0:
   dependencies:
     semver "^5.4.1"
 
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-gyp@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
@@ -4237,6 +4245,14 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   dependencies:
     isobject "^3.0.1"
+
+oembed-parser@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/oembed-parser/-/oembed-parser-1.1.0.tgz#1e61c2e89c200d9bbc46fceee1b44698b5011450"
+  dependencies:
+    bellajs "^7.2.2"
+    node-fetch "^2.1.2"
+    promise-wtf "^1.2.4"
 
 on-finished@^2.3.0, on-finished@~2.3.0:
   version "2.3.0"
@@ -4762,6 +4778,10 @@ process-nextick-args@~2.0.0:
 progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+
+promise-wtf@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/promise-wtf/-/promise-wtf-1.2.4.tgz#8cbdd31ea10dee074fbb6387cbc96e413993376c"
 
 propagate@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
refs #9623
- add `oembed-parser` module for checking provider availability for a url and fetching data from the provider
  - require it in the `overrides.js` file before the general Promise override so that the `promise-wrt` sub-dependency doesn't attempt to extend the Bluebird promise implementation
- add `/oembed` authenticated endpoint
  - takes `?url=` query parameter to match against known providers
  - adds safeguard against oembed-parser's providers list not recognising http+https and www+non-www
  - responds with `ValidationError` if no provider is found
  - responds with oembed response from matched provider's oembed endpoint if match is found

Required for Koenig's embed card implementation. Oembed requests can't be made directly by Ghost-Admin due to CORS restrictions so we need a server-side endpoint for querying providers.