### PR TITLE
Migrate code to ES6 syntax (apps/amp)

### DIFF
--- a/core/server/apps/amp/index.js
+++ b/core/server/apps/amp/index.js
@@ -1,4 +1,4 @@
-var router           = require('./lib/router'),
+const router = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
     urlService = require('../../services/url'),
 
@@ -10,7 +10,7 @@ function ampRouter(req, res) {
         return router.apply(this, arguments);
     } else {
         // routeKeywords.amp: 'amp'
-        var redirectUrl = req.originalUrl.replace(/amp\/$/, '');
+        let redirectUrl = req.originalUrl.replace(/amp\/$/, '');
         urlService.utils.redirect301(res, redirectUrl);
     }
 }
@@ -18,7 +18,7 @@ function ampRouter(req, res) {
 module.exports = {
     activate: function activate(ghost) {
         // routeKeywords.amp: 'amp'
-        var ampRoute = '*/amp/';
+        let ampRoute = '*/amp/';
 
         ghost.routeService.registerRouter(ampRoute, ampRouter);
 

--- a/core/server/apps/amp/lib/helpers/amp_components.js
+++ b/core/server/apps/amp/lib/helpers/amp_components.js
@@ -8,11 +8,11 @@
 // By default supported AMP HTML tags (no additional script tag necessary):
 // amp-img, amp-ad, amp-embed, amp-video and amp-pixel.
 // (less) dirty requires
-var proxy = require('../../../../helpers/proxy'),
+const proxy = require('../../../../helpers/proxy'),
     SafeString = proxy.SafeString;
 
 function ampComponents() {
-    var components = [],
+    let components = [],
         html = this.post && this.post.html || this.html;
 
     if (!html) {

--- a/core/server/apps/amp/lib/helpers/amp_content.js
+++ b/core/server/apps/amp/lib/helpers/amp_content.js
@@ -6,22 +6,21 @@
 //
 // Converts normal HTML into AMP HTML with Amperize module and uses a cache to return it from
 // there if available. The cacheId is a combination of `updated_at` and the `slug`.
-let Promise = require('bluebird'),
+const Promise = require('bluebird'),
     moment = require('moment'),
-
-    // (less) dirty requires
     proxy = require('../../../../helpers/proxy'),
     SafeString = proxy.SafeString,
     logging = proxy.logging,
     i18n = proxy.i18n,
     errors = proxy.errors,
     urlService = require('../../../../services/url'),
-    amperizeCache = {},
-    allowedAMPTags = [],
+    amperizeCache = {};
+
+let allowedAMPTags = [],
     allowedAMPAttributes = {},
     amperize = null,
-    cleanHTML = '',
-    ampHTML = '';
+    ampHTML = '',
+    cleanHTML = '';
 
 allowedAMPTags = ['html', 'body', 'article', 'section', 'nav', 'aside', 'h1', 'h2',
     'h3', 'h4', 'h5', 'h6', 'header', 'footer', 'address', 'p', 'hr',

--- a/core/server/apps/amp/lib/helpers/amp_content.js
+++ b/core/server/apps/amp/lib/helpers/amp_content.js
@@ -6,7 +6,7 @@
 //
 // Converts normal HTML into AMP HTML with Amperize module and uses a cache to return it from
 // there if available. The cacheId is a combination of `updated_at` and the `slug`.
-var Promise = require('bluebird'),
+let Promise = require('bluebird'),
     moment = require('moment'),
 
     // (less) dirty requires
@@ -19,9 +19,9 @@ var Promise = require('bluebird'),
     amperizeCache = {},
     allowedAMPTags = [],
     allowedAMPAttributes = {},
-    amperize,
-    cleanHTML,
-    ampHTML;
+    amperize = null,
+    cleanHTML = '',
+    ampHTML = '';
 
 allowedAMPTags = ['html', 'body', 'article', 'section', 'nav', 'aside', 'h1', 'h2',
     'h3', 'h4', 'h5', 'h6', 'header', 'footer', 'address', 'p', 'hr',
@@ -119,7 +119,7 @@ function getAmperizeHTML(html, post) {
         return;
     }
 
-    var Amperize = require('amperize'),
+    let Amperize = require('amperize'),
         startedAtMoment = moment();
 
     amperize = amperize || new Amperize();
@@ -128,20 +128,20 @@ function getAmperizeHTML(html, post) {
     html = urlService.utils.makeAbsoluteUrls(html, urlService.utils.urlFor('home', true), post.url).html();
 
     if (!amperizeCache[post.id] || moment(new Date(amperizeCache[post.id].updated_at)).diff(new Date(post.updated_at)) < 0) {
-        return new Promise(function (resolve) {
-            amperize.parse(html, function (err, res) {
+        return new Promise((resolve) => {
+            amperize.parse(html, (err, res) => {
                 logging.info('amp.parse', post.url, moment().diff(startedAtMoment, 'ms') + 'ms');
 
                 if (err) {
                     if (err.src) {
                         logging.error(new errors.GhostError({
-                            message: 'AMP HTML couldn\'t get parsed: ' + err.src,
+                            message: `AMP HTML couldn\'t get parsed: ${err.src}`,
                             err: err,
                             context: post.url,
                             help: i18n.t('errors.apps.appWillNotBeLoaded.help')
                         }));
                     } else {
-                        logging.error(new errors.GhostError({err: err}));
+                        logging.error(new errors.GhostError({err}));
                     }
 
                     // save it in cache to prevent multiple calls to Amperize until
@@ -161,14 +161,14 @@ function getAmperizeHTML(html, post) {
 }
 
 function ampContent() {
-    var sanitizeHtml = require('sanitize-html'),
+    let sanitizeHtml = require('sanitize-html'),
         cheerio = require('cheerio'),
         amperizeHTML = {
             amperize: getAmperizeHTML(this.html, this)
         };
 
-    return Promise.props(amperizeHTML).then(function (result) {
-        var $;
+    return Promise.props(amperizeHTML).then((result) => {
+        let $ = null;
 
         // our Amperized HTML
         ampHTML = result.amperize || '';

--- a/core/server/apps/amp/lib/helpers/index.js
+++ b/core/server/apps/amp/lib/helpers/index.js
@@ -1,11 +1,13 @@
 // Dirty require!
-var ghostHead = require('../../../../helpers/ghost_head');
+const ghostHead = require('../../../../helpers/ghost_head');
 
-module.exports = function registerAmpHelpers(ghost) {
+function registerAmpHelpers(ghost) {
     ghost.helpers.registerAsync('amp_content', require('./amp_content'));
 
     ghost.helpers.register('amp_components', require('./amp_components'));
 
     // we use the {{ghost_head}} helper, but call it {{amp_ghost_head}}, so it's consistent
     ghost.helpers.registerAsync('amp_ghost_head', ghostHead);
-};
+}
+
+module.exports = registerAmpHelpers;

--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -1,4 +1,4 @@
-var path = require('path'),
+const path = require('path'),
     express = require('express'),
     ampRouter = express.Router(),
 
@@ -12,12 +12,12 @@ function _renderer(req, res, next) {
     res.routerOptions = {
         type: 'custom',
         templates: templateName,
-        defaultTemplate: path.resolve(__dirname, 'views', templateName + '.hbs')
+        defaultTemplate: path.resolve(__dirname, 'views', `${templateName}.hbs`)
     };
 
     // Renderer begin
     // Format data
-    var data = req.body || {};
+    let data = req.body || {};
 
     // CASE: we only support amp pages for posts that are not static pages
     if (!data.post || data.post.page) {
@@ -63,8 +63,8 @@ function getPostData(req, res, next) {
         }));
     }
 
-    helpers.postLookup(urlWithoutSubdirectoryWithoutAmp, {permalinks: permalinks})
-        .then(function handleResult(result) {
+    helpers.postLookup(urlWithoutSubdirectoryWithoutAmp, {permalinks})
+        .then((result) => {
             if (result && result.post) {
                 req.body.post = result.post;
             }


### PR DESCRIPTION
issue #9589
- use const, let, arrow function, string template

- [x] There's a clear use-case for this code change (#9589)
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)