### PR TITLE
👽 [SPIKE]: try out using mingo instead of jsonpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "markdown-it-footnote": "3.0.1",
     "markdown-it-lazy-headers": "0.1.3",
     "markdown-it-mark": "2.0.0",
+    "mingo": "2.2.2",
     "mobiledoc-dom-renderer": "0.6.5",
     "moment": "2.22.2",
     "moment-timezone": "0.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,6 +3758,10 @@ mimic-response@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
+mingo@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mingo/-/mingo-2.2.2.tgz#be69d486ae6e0ac54b979dc5f4412db21851f693"
+
 minimatch@0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-0.3.0.tgz#275d8edaac4f1bb3326472089e7949c8394699dd"


### PR DESCRIPTION
- There is an idea to replace GQL's internal JSON format with mongo's query format
- This spike shows that if we get the JSON format right, we can use it to filter JSON directly via mingo
- Mingo would be part of the GQL library, not Ghost, but for now, this looks cool?!

