### PR TITLE
🐛  Fixed preview url and Zapier on subdirectory

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -35,7 +35,6 @@ function _renderer(req, res, next) {
 function getPostData(req, res, next) {
     req.body = req.body || {};
 
-    const urlWithSubdirectoryWithoutAmp = req.originalUrl.match(/(.*?\/)amp/)[1];
     const urlWithoutSubdirectoryWithoutAmp = res.locals.relativeUrl.match(/(.*?\/)amp/)[1];
 
     /**
@@ -58,7 +57,7 @@ function getPostData(req, res, next) {
      *
      * The challenge is to design different types of apps e.g. extensions of routers, standalone pages etc.
      */
-    const permalinks = urlService.getPermalinkByUrl(urlWithSubdirectoryWithoutAmp, {withUrlOptions: true});
+    const permalinks = urlService.getPermalinkByUrl(urlWithoutSubdirectoryWithoutAmp, {withUrlOptions: true});
 
     if (!permalinks) {
         return next(new common.errors.NotFoundError({

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -67,7 +67,7 @@ function handleSource(req, res, next) {
     delete req.body.location;
     delete req.body.referrer;
 
-    const resource = urlService.getResource(urlService.utils.absoluteToRelative(req.body.subscribed_url));
+    const resource = urlService.getResource(urlService.utils.absoluteToRelative(req.body.subscribed_url, {withoutSubdirectory: true}));
 
     if (resource) {
         req.body.post_id = resource.data.id;

--- a/core/server/data/meta/author_url.js
+++ b/core/server/data/meta/author_url.js
@@ -6,11 +6,11 @@ function getAuthorUrl(data, absolute) {
     context = context === 'amp' ? 'post' : context;
 
     if (data.author) {
-        return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, secure: data.author.secure});
+        return urlService.getUrlByResourceId(data.author.id, {absolute: absolute, secure: data.author.secure, withSubdirectory: true});
     }
 
     if (data[context] && data[context].primary_author) {
-        return urlService.getUrlByResourceId(data[context].primary_author.id, {absolute: absolute, secure: data[context].secure});
+        return urlService.getUrlByResourceId(data[context].primary_author.id, {absolute: absolute, secure: data[context].secure, withSubdirectory: true});
     }
 
     return null;

--- a/core/server/data/meta/url.js
+++ b/core/server/data/meta/url.js
@@ -13,7 +13,7 @@ function sanitizeAmpUrl(url) {
 
 function getUrl(data, absolute) {
     if (schema.isPost(data) || schema.isTag(data) || schema.isUser(data)) {
-        return urlService.getUrlByResourceId(data.id, {secure: data.secure, absolute: absolute});
+        return urlService.getUrlByResourceId(data.id, {secure: data.secure, absolute: absolute, withSubdirectory: true});
     }
 
     if (schema.isNav(data)) {

--- a/core/server/helpers/author.js
+++ b/core/server/helpers/author.js
@@ -30,7 +30,7 @@ module.exports = function author(options) {
     if (this.author && this.author.name) {
         if (autolink) {
             output = templates.link({
-                url: urlService.getUrlByResourceId(this.author.id),
+                url: urlService.getUrlByResourceId(this.author.id, {withSubdirectory: true}),
                 text: _.escape(this.author.name)
             });
         } else {

--- a/core/server/helpers/authors.js
+++ b/core/server/helpers/authors.js
@@ -31,7 +31,7 @@ module.exports = function authors(options) {
     function createAuthorsList(authors) {
         function processAuthor(author) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(author.id),
+                url: urlService.getUrlByResourceId(author.id, {withSubdirectory: true}),
                 text: _.escape(author.name)
             }) : _.escape(author.name);
         }

--- a/core/server/helpers/tags.js
+++ b/core/server/helpers/tags.js
@@ -30,7 +30,7 @@ module.exports = function tags(options) {
     function createTagList(tags) {
         function processTag(tag) {
             return autolink ? templates.link({
-                url: urlService.getUrlByResourceId(tag.id),
+                url: urlService.getUrlByResourceId(tag.id, {withSubdirectory: true}),
                 text: _.escape(tag.name)
             }) : _.escape(tag.name);
         }

--- a/core/server/services/routing/controllers/entry.js
+++ b/core/server/services/routing/controllers/entry.js
@@ -50,7 +50,7 @@ module.exports = function entryController(req, res, next) {
              *
              * That's why we have to check against the router type.
              */
-            if (urlService.getResource(post.url).config.type !== res.locals.routerOptions.type) {
+            if (urlService.getResourceById(post.id).config.type !== res.locals.routerOptions.type) {
                 debug('not my resource type');
                 return next();
             }
@@ -60,20 +60,15 @@ module.exports = function entryController(req, res, next) {
              *       This should only happen if you have date permalinks enabled and you change
              *       your publish date.
              *
-             * @NOTE
+             * @NOTE:
              *
-             * The resource url always contains the subdirectory. This was different before dynamic routing.
-             * That's why we have to use the original url, which contains the sub-directory.
-             *
-             * @NOTE
-             *
-             * post.url contains the subdirectory if configured.
+             * Ensure we redirect to the correct post url including subdirectory.
              */
-            if (post.url !== url.parse(req.originalUrl).pathname) {
+            if (post.url !== req.path) {
                 debug('redirect');
 
                 return urlService.utils.redirect301(res, url.format({
-                    pathname: post.url,
+                    pathname: urlService.utils.createUrl(post.url, false, false, true),
                     search: url.parse(req.originalUrl).search
                 }));
             }

--- a/core/server/services/routing/controllers/preview.js
+++ b/core/server/services/routing/controllers/preview.js
@@ -30,7 +30,7 @@ module.exports = function previewController(req, res, next) {
             }
 
             if (post.status === 'published') {
-                return urlService.utils.redirect301(res, urlService.getUrlByResourceId(post.id));
+                return urlService.utils.redirect301(res, urlService.getUrlByResourceId(post.id, {withSubdirectory: true}));
             }
 
             helpers.secure(req, post);

--- a/core/server/services/url/UrlGenerator.js
+++ b/core/server/services/url/UrlGenerator.js
@@ -133,13 +133,11 @@ class UrlGenerator {
     }
 
     /**
-     * We currently generate relative urls.
+     * We currently generate relative urls without subdirectory.
      */
     _generateUrl(resource) {
         const permalink = this.router.getPermalinks().getValue();
-        const url = localUtils.replacePermalink(permalink, resource.data);
-
-        return localUtils.createUrl(url, false, false, true);
+        return localUtils.replacePermalink(permalink, resource.data);
     }
 
     /**

--- a/core/server/services/url/UrlService.js
+++ b/core/server/services/url/UrlService.js
@@ -125,6 +125,19 @@ class UrlService {
         return objects[0].resource;
     }
 
+    getResourceById(resourceId) {
+        const object = this.urls.getByResourceId(resourceId);
+
+        if (!object) {
+            throw new common.errors.InternalServerError({
+                message: 'Resource not found.',
+                code: 'URLSERVICE_RESOURCE_NOT_FOUND'
+            });
+        }
+
+        return object.resource;
+    }
+
     hasFinished() {
         return this.finished;
     }
@@ -150,11 +163,19 @@ class UrlService {
                 return this.utils.createUrl(obj.url, options.absolute, options.secure);
             }
 
+            if (options.withSubdirectory) {
+                return this.utils.createUrl(obj.url, false, options.secure, true);
+            }
+
             return obj.url;
         }
 
         if (options.absolute) {
             return this.utils.createUrl('/404/', options.absolute, options.secure);
+        }
+
+        if (options.withSubdirectory) {
+            return this.utils.createUrl('/404/', false, options.secure);
         }
 
         return '/404/';

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -408,9 +408,24 @@ function makeAbsoluteUrls(html, siteUrl, itemUrl) {
     return htmlContent;
 }
 
-function absoluteToRelative(urlToModify) {
+function absoluteToRelative(urlToModify, options) {
+    options = options || {};
+
     const urlObj = url.parse(urlToModify);
-    return urlObj.pathname;
+    const relativePath = urlObj.pathname;
+
+    if (options.withoutSubdirectory) {
+        const subDir = getSubdir();
+
+        if (!subDir) {
+            return relativePath;
+        }
+
+        const subDirRegex = new RegExp('^' + subDir);
+        return relativePath.replace(subDirRegex, '');
+    }
+
+    return relativePath;
 }
 
 function deduplicateDoubleSlashes(url) {

--- a/core/test/integration/services/url/UrlService_spec.js
+++ b/core/test/integration/services/url/UrlService_spec.js
@@ -542,7 +542,7 @@ describe('Unit: services/url/UrlService', function () {
         let router1, router2, router3, router4, router5;
 
         beforeEach(function (done) {
-            configUtils.set('url', 'http://localhost:2388/blog');
+            configUtils.set('url', 'http://localhost:2388/blog/');
 
             urlService = new UrlService();
 
@@ -694,44 +694,44 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             let url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[0].id);
-            url.should.eql('/blog/collection/2015/html-ipsum/');
+            url.should.eql('/collection/2015/html-ipsum/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[1].id);
-            url.should.eql('/blog/collection/2015/ghostly-kitchen-sink/');
+            url.should.eql('/collection/2015/ghostly-kitchen-sink/');
 
             // featured
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.posts[2].id);
-            url.should.eql('/blog/podcast/short-and-sweet/');
+            url.should.eql('/podcast/short-and-sweet/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[0].id);
-            url.should.eql('/blog/category/kitchen-sink/');
+            url.should.eql('/category/kitchen-sink/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[1].id);
-            url.should.eql('/blog/category/bacon/');
+            url.should.eql('/category/bacon/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[2].id);
-            url.should.eql('/blog/category/chorizo/');
+            url.should.eql('/category/chorizo/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[3].id);
-            url.should.eql('/blog/category/pollo/');
+            url.should.eql('/category/pollo/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.tags[4].id);
-            url.should.eql('/blog/category/injection/');
+            url.should.eql('/category/injection/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[0].id);
-            url.should.eql('/blog/persons/joe-bloggs/');
+            url.should.eql('/persons/joe-bloggs/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[1].id);
-            url.should.eql('/blog/persons/smith-wellingsworth/');
+            url.should.eql('/persons/smith-wellingsworth/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[2].id);
-            url.should.eql('/blog/persons/jimothy-bogendath/');
+            url.should.eql('/persons/jimothy-bogendath/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[3].id);
-            url.should.eql('/blog/persons/slimer-mcectoplasm/');
+            url.should.eql('/persons/slimer-mcectoplasm/');
 
             url = urlService.getUrlByResourceId(testUtils.DataGenerator.forKnex.users[4].id);
-            url.should.eql('/blog/persons/contributor/');
+            url.should.eql('/persons/contributor/');
         });
     });
 });

--- a/core/test/integration/web/site_spec.js
+++ b/core/test/integration/web/site_spec.js
@@ -595,7 +595,7 @@ describe('Integration - Web - Site', function () {
                     },
 
                     '/': {
-                        permalink: '/:slug'
+                        permalink: '/:slug/'
                     }
                 },
 

--- a/core/test/unit/apps/amp/router_spec.js
+++ b/core/test/unit/apps/amp/router_spec.js
@@ -137,7 +137,7 @@ describe('Unit - apps/amp/lib/router', function () {
             req.originalUrl = '/blog/welcome/amp';
             res.locals.relativeUrl = '/welcome/amp';
 
-            urlService.getPermalinkByUrl.withArgs('/blog/welcome/').returns('/:slug/');
+            urlService.getPermalinkByUrl.withArgs('/welcome/').returns('/:slug/');
 
             helpers.postLookup.withArgs('/welcome/', {permalinks: '/:slug/'}).resolves({
                 post: post

--- a/core/test/unit/data/meta/author_url_spec.js
+++ b/core/test/unit/data/meta/author_url_spec.js
@@ -22,7 +22,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({
@@ -39,7 +39,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: true, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: true, secure: undefined, withSubdirectory: true})
             .returns('absolute author url');
 
         should.exist(getAuthorUrl({
@@ -56,7 +56,7 @@ describe('getAuthorUrl', function () {
             }
         };
 
-        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(post.primary_author.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({
@@ -71,7 +71,7 @@ describe('getAuthorUrl', function () {
             slug: 'test-author'
         };
 
-        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('author url');
 
         should.exist(getAuthorUrl({

--- a/core/test/unit/data/meta/url_spec.js
+++ b/core/test/unit/data/meta/url_spec.js
@@ -18,7 +18,7 @@ describe('getUrl', function () {
     it('should return url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('post url');
 
         getUrl(post).should.eql('post url');
@@ -27,7 +27,7 @@ describe('getUrl', function () {
     it('should return absolute url for a post', function () {
         const post = testUtils.DataGenerator.forKnex.createPost();
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: true, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: true, secure: undefined, withSubdirectory: true})
             .returns('absolute post url');
 
         getUrl(post, true).should.eql('absolute post url');
@@ -49,7 +49,7 @@ describe('getUrl', function () {
         //        the tag object contains a `parent` attribute. the tag model contains a `parent_id` attr.
         tag.parent = null;
 
-        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('tag url');
 
         getUrl(tag).should.eql('tag url');
@@ -66,7 +66,7 @@ describe('getUrl', function () {
         // @TODO: WTF O_O
         tag.secure = true;
 
-        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: true})
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: true, withSubdirectory: true})
             .returns('secure tag url');
 
         getUrl(tag).should.eql('secure tag url');
@@ -75,7 +75,7 @@ describe('getUrl', function () {
     it('should return url for a author', function () {
         const author = testUtils.DataGenerator.forKnex.createUser();
 
-        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined})
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: undefined, secure: undefined, withSubdirectory: true})
             .returns('author url');
 
         getUrl(author).should.eql('author url');
@@ -87,7 +87,7 @@ describe('getUrl', function () {
         // @TODO: WTF
         author.secure = true;
 
-        urlService.getUrlByResourceId.withArgs(author.id, {absolute: true, secure: true})
+        urlService.getUrlByResourceId.withArgs(author.id, {absolute: true, secure: true, withSubdirectory: true})
             .returns('absolute secure author url');
 
         getUrl(author, true).should.eql('absolute secure author url');

--- a/core/test/unit/helpers/url_spec.js
+++ b/core/test/unit/helpers/url_spec.js
@@ -44,7 +44,7 @@ describe('{{url}} helper', function () {
             url: '/slug/'
         });
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined}).returns('/slug/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: undefined, secure: undefined, withSubdirectory: true}).returns('/slug/');
 
         rendered = helpers.url.call(post);
         should.exist(rendered);
@@ -61,7 +61,7 @@ describe('{{url}} helper', function () {
             created_at: new Date(0)
         });
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: undefined}).returns('http://localhost:82832/slug/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: undefined, withSubdirectory: true}).returns('http://localhost:82832/slug/');
 
         rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -79,7 +79,7 @@ describe('{{url}} helper', function () {
             secure: true
         });
 
-        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: true}).returns('https://localhost:82832/slug/');
+        urlService.getUrlByResourceId.withArgs(post.id, {absolute: 'true', secure: true, withSubdirectory: true}).returns('https://localhost:82832/slug/');
 
         rendered = helpers.url.call(post, {hash: {absolute: 'true'}});
         should.exist(rendered);
@@ -94,7 +94,7 @@ describe('{{url}} helper', function () {
             parent: null
         });
 
-        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined}).returns('/tag/the-tag/');
+        urlService.getUrlByResourceId.withArgs(tag.id, {absolute: undefined, secure: undefined, withSubdirectory: true}).returns('/tag/the-tag/');
 
         rendered = helpers.url.call(tag);
         should.exist(rendered);
@@ -110,7 +110,7 @@ describe('{{url}} helper', function () {
             slug: 'some-author'
         });
 
-        urlService.getUrlByResourceId.withArgs(user.id, {absolute: undefined, secure: undefined}).returns('/author/some-author/');
+        urlService.getUrlByResourceId.withArgs(user.id, {absolute: undefined, secure: undefined, withSubdirectory: true}).returns('/author/some-author/');
 
         rendered = helpers.url.call(user);
         should.exist(rendered);

--- a/core/test/unit/services/routing/controllers/entry_spec.js
+++ b/core/test/unit/services/routing/controllers/entry_spec.js
@@ -37,7 +37,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
         sandbox.stub(urlService.utils, 'redirectToAdmin');
         sandbox.stub(urlService.utils, 'redirect301');
-        sandbox.stub(urlService, 'getResource');
+        sandbox.stub(urlService, 'getResourceById');
 
         req = {
             path: '/',
@@ -78,7 +78,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
         filters.doFilter.withArgs('prePostsRender', post, res.locals).resolves();
 
-        urlService.getResource.withArgs(post.url).returns({
+        urlService.getResourceById.withArgs(post.id).returns({
             config: {
                 type: 'posts'
             }
@@ -135,7 +135,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             req.path = post.url;
             res.locals.routerOptions.type = 'posts';
 
-            urlService.getResource.withArgs(post.url).returns({
+            urlService.getResourceById.withArgs(post.id).returns({
                 config: {
                     type: 'pages'
                 }
@@ -153,13 +153,13 @@ describe('Unit - services/routing/controllers/entry', function () {
         });
 
         it('requested url !== resource url', function (done) {
-            post.url = '/2017/08/' + post.url;
-            req.path = '/2017/07/' + post.url;
+            post.url = '/2017/08' + post.url;
+            req.path = '/2017/07' + post.url;
             req.originalUrl = req.path;
 
             res.locals.routerOptions.type = 'posts';
 
-            urlService.getResource.withArgs(post.url).returns({
+            urlService.getResourceById.withArgs(post.id).returns({
                 config: {
                     type: 'posts'
                 }
@@ -175,17 +175,20 @@ describe('Unit - services/routing/controllers/entry', function () {
                 done();
             });
 
-            controllers.entry(req, res);
+            controllers.entry(req, res, function (err) {
+                should.exist(err);
+                done(err);
+            });
         });
 
         it('requested url !== resource url: with query params', function (done) {
-            post.url = '/2017/08/' + post.url;
-            req.path = '/2017/07/' + post.url;
+            post.url = '/2017/08' + post.url;
+            req.path = '/2017/07' + post.url;
             req.originalUrl = req.path + '?query=true';
 
             res.locals.routerOptions.type = 'posts';
 
-            urlService.getResource.withArgs(post.url).returns({
+            urlService.getResourceById.withArgs(post.id).returns({
                 config: {
                     type: 'posts'
                 }

--- a/core/test/unit/services/url/UrlGenerator_spec.js
+++ b/core/test/unit/services/url/UrlGenerator_spec.js
@@ -257,7 +257,7 @@ describe('Unit: services/url/UrlGenerator', function () {
             });
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
-            sandbox.stub(urlUtils, 'replacePermalink').returns('/url');
+            sandbox.stub(urlUtils, 'replacePermalink').returns('/url/');
 
             urlGenerator._generateUrl(resource).should.eql('/url/');
             urlUtils.replacePermalink.calledWith('/:slug/', resource.data).should.be.true();

--- a/core/test/unit/services/url/UrlService_spec.js
+++ b/core/test/unit/services/url/UrlService_spec.js
@@ -73,6 +73,22 @@ describe('Unit: services/url/UrlService', function () {
         urlService.urlGenerators.length.should.eql(1);
     });
 
+    it('fn: getResourceById', function (done) {
+        urlService.urls.getByResourceId.withArgs('id123').returns({resource: true});
+        urlService.getResourceById('id123').should.eql(true);
+
+        urlService.urls.getByResourceId.withArgs('id12345').returns(null);
+
+        try {
+            urlService.getResourceById('id12345').should.eql(true);
+            done(new Error('expected error'));
+        } catch (err) {
+            should.exist(err);
+            err.code.should.eql('URLSERVICE_RESOURCE_NOT_FOUND');
+            done();
+        }
+    });
+
     describe('fn: getResource', function () {
         it('no resource for url found', function () {
             urlService.finished = false;
@@ -235,6 +251,60 @@ describe('Unit: services/url/UrlService', function () {
 
             urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
             urlService.getUrlByResourceId(1, {absolute: true, secure: true});
+            urlService.utils.createUrl.calledWith('/post/', true, true).should.be.true();
+        });
+
+        it('not found: withSubdirectory', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns(null);
+            urlService.getUrlByResourceId(1, {withSubdirectory: true});
+            urlService.utils.createUrl.calledWith('/404/', false, undefined).should.be.true();
+        });
+
+        it('not found: withSubdirectory + secure', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns(null);
+            urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true});
+            urlService.utils.createUrl.calledWith('/404/', false, true).should.be.true();
+        });
+
+        it('not found: withSubdirectory + secure + absolute', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns(null);
+            urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true, absolute: true});
+            urlService.utils.createUrl.calledWith('/404/', true, true).should.be.true();
+        });
+
+        it('found: withSubdirectory', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
+            urlService.getUrlByResourceId(1, {withSubdirectory: true});
+            urlService.utils.createUrl.calledWith('/post/', false, undefined).should.be.true();
+        });
+
+        it('found: withSubdirectory + secure', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
+            urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true});
+            urlService.utils.createUrl.calledWith('/post/', false, true).should.be.true();
+        });
+
+        it('found: withSubdirectory + secure + absolute', function () {
+            urlService.utils = sandbox.stub();
+            urlService.utils.createUrl = sandbox.stub();
+
+            urlService.urls.getByResourceId.withArgs(1).returns({url: '/post/'});
+            urlService.getUrlByResourceId(1, {withSubdirectory: true, secure: true, absolute: true});
             urlService.utils.createUrl.calledWith('/post/', true, true).should.be.true();
         });
     });

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -20,6 +20,30 @@ describe('Url', function () {
         sandbox.restore();
     });
 
+    describe('absoluteToRelative', function () {
+        it('default', function () {
+            urlService.utils.absoluteToRelative('http://myblog.com/test/').should.eql('/test/');
+        });
+
+        it('with subdir', function () {
+            urlService.utils.absoluteToRelative('http://myblog.com/blog/test/').should.eql('/blog/test/');
+        });
+
+        it('with subdir, but request without', function () {
+            configUtils.set('url', 'http://myblog.com/blog/');
+
+            urlService.utils.absoluteToRelative('http://myblog.com/blog/test/', {withoutSubdirectory: true})
+                .should.eql('/test/');
+        });
+
+        it('with subdir, but request without', function () {
+            configUtils.set('url', 'http://myblog.com/blog');
+
+            urlService.utils.absoluteToRelative('http://myblog.com/blog/test/', {withoutSubdirectory: true})
+                .should.eql('/test/');
+        });
+    });
+
     describe('getProtectedSlugs', function () {
         it('defaults', function () {
             urlService.utils.getProtectedSlugs().should.eql(['ghost', 'rss', 'amp']);


### PR DESCRIPTION
closes #9675

- with dynamic routing we have introduced a breaking change, which we have overseen
- Ghost does not return absolute urls, that's why the clients need to concat the blog url and the resource url
- with 1.24.0 Ghost returned resource urls including the subdirectory
- this caused trouble for e.g. zapier or the preview feature in the admin client (ends in doubled subdir's)
- revert breaking change and ensure we only expose resource urls without subdirectory

### TODO

- [x] do a bigger manual test and ensure this doesn't break anything