### PR TITLE
Migrate code to ES6 syntax (apps/subscribers)

### DIFF
--- a/core/server/apps/subscribers/index.js
+++ b/core/server/apps/subscribers/index.js
@@ -1,18 +1,17 @@
-var router     = require('./lib/router'),
+const router = require('./lib/router'),
     registerHelpers = require('./lib/helpers'),
-
     // Dirty requires
     labs = require('../../services/labs');
 
 module.exports = {
-    activate: function activate(ghost) {
+    activate(ghost) {
         // routeKeywords.subscribe: 'subscribe'
-        var subscribeRoute = '/subscribe/';
+        const subscribeRoute = '/subscribe/';
         // TODO, how to do all this only if the Subscribers flag is set?!
         registerHelpers(ghost);
 
         ghost.routeService.registerRouter(subscribeRoute, function labsEnabledRouter(req, res, next) {
-            if (labs.isSet('subscribers') === true) {
+            if (labs.isSet('subscribers')) {
                 return router.apply(this, arguments);
             }
 

--- a/core/server/apps/subscribers/lib/helpers/index.js
+++ b/core/server/apps/subscribers/lib/helpers/index.js
@@ -1,19 +1,18 @@
 // Dirty requires!
-var labs = require('../../../../services/labs');
+const labs = require('../../../../services/labs');
 
 module.exports = function registerHelpers(ghost) {
     ghost.helpers.register('input_email', require('./input_email'));
 
     ghost.helpers.register('subscribe_form', function labsEnabledHelper() {
-        var self = this,
-            args = arguments;
+        let self = this, args = arguments;
 
         return labs.enabledHelper({
             flagKey: 'subscribers',
             flagName: 'Subscribers',
             helperName: 'subscribe_form',
             helpUrl: 'https://help.ghost.org/hc/en-us/articles/224089787-Subscribers-Beta'
-        }, function executeHelper() {
+        }, () => {
             return require('./subscribe_form').apply(self, args);
         });
     });

--- a/core/server/apps/subscribers/lib/helpers/input_email.js
+++ b/core/server/apps/subscribers/lib/helpers/input_email.js
@@ -4,39 +4,38 @@
 // Used by `{{subscribe_form}}`
 
 // (less) dirty requires
-var proxy = require('../../../../helpers/proxy'),
-    SafeString = proxy.SafeString,
-    templates = proxy.templates;
+const proxy = require('../../../../helpers/proxy');
+const SafeString = proxy.SafeString;
+const templates = proxy.templates;
 
 // We use the name input_email to match the helper for consistency:
 module.exports = function input_email(options) { // eslint-disable-line camelcase
     options = options || {};
     options.hash = options.hash || {};
 
-    var className = (options.hash.class) ? options.hash.class : 'subscribe-email',
-        extras = '',
-        output;
+    const className = (options.hash.class) ? options.hash.class : 'subscribe-email';
+    let extras = '';
 
     if (options.hash.autofocus) {
         extras += 'autofocus="autofocus"';
     }
 
     if (options.hash.placeholder) {
-        extras += ' placeholder="' + options.hash.placeholder + '"';
+        extras += ` placeholder="${options.hash.placeholder}"`;
     }
 
     if (options.hash.value) {
-        extras += ' value="' + options.hash.value + '"';
+        extras += ` value="${options.hash.value}"`;
     }
 
     if (options.hash.id) {
         extras += ' id="' + options.hash.id + '"';
     }
 
-    output = templates.input({
+    const output = templates.input({
         type: 'email',
         name: 'email',
-        className: className,
+        className,
         extras: (extras ? extras.trim() : '')
     });
 

--- a/core/server/apps/subscribers/lib/helpers/subscribe_form.js
+++ b/core/server/apps/subscribers/lib/helpers/subscribe_form.js
@@ -1,23 +1,19 @@
 // # Subscribe Form Helper
 // Usage: `{{subscribe_form}}`
-var _ = require('lodash'),
-
+const _ = require('lodash'),
     // (Less) dirty requires
     proxy = require('../../../../helpers/proxy'),
     templates = proxy.templates,
     urlService = proxy.urlService,
     SafeString = proxy.SafeString,
-
-    params = ['error', 'success', 'email'],
-
-    subscribeScript;
+    params = ['error', 'success', 'email'];
 
 function makeHidden(name, extras) {
     return templates.input({
         type: 'hidden',
-        name: name,
+        name,
         className: name,
-        extras: extras
+        extras
     });
 }
 
@@ -26,7 +22,7 @@ function makeHidden(name, extras) {
  *
  * document.querySelector['.location']['value'] = document.querySelector('.location')['value'] || window.location.href;
  */
-subscribeScript = `
+const subscribeScript = `
 <script>
     (function(g,h,o,s,t){
         var buster = function(b,m) {
@@ -42,15 +38,15 @@ subscribeScript = `
 
 // We use the name subscribe_form to match the helper for consistency:
 module.exports = function subscribe_form(options) { // eslint-disable-line camelcase
-    var root = options.data.root,
+    const root = options.data.root,
         data = _.merge({}, options.hash, _.pick(root, params), {
             // routeKeywords.subscribe: 'subscribe'
             action: urlService.utils.urlJoin('/', urlService.utils.getSubdir(), 'subscribe/'),
             script: new SafeString(subscribeScript),
             hidden: new SafeString(
                 makeHidden('confirm') +
-                makeHidden('location', root.subscribed_url ? 'value=' + root.subscribed_url : '') +
-                makeHidden('referrer', root.subscribed_referrer ? 'value=' + root.subscribed_referrer : '')
+                makeHidden('location', root.subscribed_url ? `value=${root.subscribed_url}` : '') +
+                makeHidden('referrer', root.subscribed_referrer ? `value=${root.subscribed_referrer}` : '')
             )
         });
 

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -1,28 +1,26 @@
-var path = require('path'),
-    express = require('express'),
+const path = require('path'),
     _ = require('lodash'),
+    express = require('express'),
     subscribeRouter = express.Router(),
     bodyParser = require('body-parser'),
-
     // Dirty requires
     api = require('../../../api'),
     common = require('../../../lib/common'),
     urlService = require('../../../services/url'),
     validator = require('../../../data/validation').validator,
     routing = require('../../../services/routing'),
-
     templateName = 'subscribe';
 
 function _renderer(req, res) {
     res.routerOptions = {
         type: 'custom',
         templates: templateName,
-        defaultTemplate: path.resolve(__dirname, 'views', templateName + '.hbs')
+        defaultTemplate: path.resolve(__dirname, 'views', `${templateName}.hbs`)
     };
 
     // Renderer begin
     // Format data
-    var data = req.body;
+    const data = req.body;
 
     // Render Call
     return routing.helpers.renderer(req, res, data);
@@ -84,11 +82,11 @@ function storeSubscriber(req, res, next) {
     }
 
     return api.subscribers.add({subscribers: [req.body]}, {context: {external: true}})
-        .then(function () {
+        .then(() => {
             res.locals.success = true;
             next();
         })
-        .catch(function () {
+        .catch(() => {
             // we do not expose any information
             res.locals.success = true;
             next();


### PR DESCRIPTION
issue #9589
- use const, let, arrow function, string template

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)