### PR TITLE
Dynamic Routing: Added migration for routes.yaml file

### DIFF
--- a/content/settings/README.md
+++ b/content/settings/README.md
@@ -13,7 +13,6 @@ collections:
   /:
     permalink: '{globals.permalinks}'
     template:
-      - home
       - index
 
 taxonomies:

--- a/core/server/lib/security/tokens.js
+++ b/core/server/lib/security/tokens.js
@@ -1,6 +1,20 @@
 const crypto = require('crypto');
 
-module.exports.generateHash = function generateHash(options) {
+module.exports.generateFromContent = function generateFromContent(options) {
+    options = options || {};
+
+    const hash = crypto.createHash('sha256'),
+        content = options.content;
+
+    let text = '';
+
+    hash.update(content);
+
+    text += [content, hash.digest('base64')].join('|');
+    return new Buffer(text).toString('base64');
+};
+
+module.exports.generateFromEmail = function generateFromEmail(options) {
     options = options || {};
 
     const hash = crypto.createHash('sha256'),

--- a/core/server/models/invite.js
+++ b/core/server/models/invite.js
@@ -34,7 +34,7 @@ Invite = ghostBookshelf.Model.extend({
         }
 
         data.expires = Date.now() + constants.ONE_WEEK_MS;
-        data.token = security.tokens.generateHash({
+        data.token = security.tokens.generateFromEmail({
             email: data.email,
             expires: data.expires,
             secret: settingsCache.get('db_hash')

--- a/core/server/services/settings/default-routes.yaml
+++ b/core/server/services/settings/default-routes.yaml
@@ -4,7 +4,6 @@ collections:
   /:
     permalink: '{globals.permalinks}' # special 1.0 compatibility setting. See the docs for details.
     template:
-      - home
       - index
 
 taxonomies:

--- a/core/server/services/settings/ensure-settings.js
+++ b/core/server/services/settings/ensure-settings.js
@@ -3,7 +3,11 @@ const fs = require('fs-extra'),
     path = require('path'),
     debug = require('ghost-ignition').debug('services:settings:ensure-settings'),
     common = require('../../lib/common'),
-    config = require('../../config');
+    security = require('../../lib/security'),
+    config = require('../../config'),
+    yamlMigrations = {
+        homeTemplate: 'cm91dGVzOmNvbGxlY3Rpb25zOi86cGVybWFsaW5rOid7Z2xvYmFscy5wZXJtYWxpbmtzfScjc3BlY2lhbDEuMGNvbXBhdGliaWxpdHlzZXR0aW5nLlNlZXRoZWRvY3Nmb3JkZXRhaWxzLnRlbXBsYXRlOi1ob21lLWluZGV4dGF4b25vbWllczp0YWc6L3RhZy97c2x1Z30vYXV0aG9yOi9hdXRob3Ive3NsdWd9L3wwUUg4SHRFQWZvbHBBSmVTYWkyOEwwSGFNMGFIOU5SczhZWGhMcExmZ2c0PQ=='
+    };
 
 /**
  * Makes sure that all supported settings files are in the
@@ -24,7 +28,22 @@ module.exports = function ensureSettingsFiles(knownSettings) {
             defaultFileName = `default-${fileName}`,
             filePath = path.join(contentPath, fileName);
 
-        return fs.access(filePath)
+        return fs.readFile(filePath, 'utf8')
+            .then((content) => {
+                content = content.replace(/\s/g, '');
+
+                /**
+                 * routes.yaml migrations:
+                 *
+                 * 1. We have removed the "home.hbs" template from the default collection, because
+                 * this is a hardcoded behaviour in Ghost. If we don't remove the home.hbs every page of the
+                 * index collection get's rendered with the home template, but this is not the correct behaviour
+                 * < 1.24. The index collection is `/`.
+                 */
+                if (security.tokens.generateFromContent({content: content}) === yamlMigrations.homeTemplate) {
+                    throw new common.errors.ValidationError({code: 'ENOENT'});
+                }
+            })
             .catch({code: 'ENOENT'}, () => {
                 // CASE: file doesn't exist, copy it from our defaults
                 return fs.copy(

--- a/core/test/utils/fixtures/settings/badroutes.yaml
+++ b/core/test/utils/fixtures/settings/badroutes.yaml
@@ -4,7 +4,6 @@ collections:
   /
     permalink: '{globals.permalinks}'
     template:
-      - home
       - index
 
 taxonomies:

--- a/core/test/utils/fixtures/settings/goodroutes.yaml
+++ b/core/test/utils/fixtures/settings/goodroutes.yaml
@@ -4,7 +4,6 @@ collections:
   /:
     permalink: '{globals.permalinks}'
     template:
-      - home
       - index
 
 taxonomies:

--- a/core/test/utils/fixtures/settings/routes.yaml
+++ b/core/test/utils/fixtures/settings/routes.yaml
@@ -4,7 +4,6 @@ collections:
   /:
     permalink: '{globals.permalinks}'
     template:
-      - home
       - index
 
 taxonomies:


### PR DESCRIPTION
refs #9601

- the home.hbs behaviour for the default collection (`/`) is hardcoded in Ghost
- we would like to migrate existing routes.yaml files
- only replace the file if the contents of your routes.yaml file equals the old routes.yaml format (with home.hbs)
- updated README
- if we keep the home template in the routes.yaml, it means every index page get's home.hbs rendered (but it should only be PAGE 1) - backwards compatibility
- hash generation takes 1ms

### TODO

- [x] reconsider if we should compare the hash without spaces