### PR TITLE
✨Dynamic Routing Beta: Ability to disable and override RSS

### DIFF
--- a/core/server/services/routing/CollectionRouter.js
+++ b/core/server/services/routing/CollectionRouter.js
@@ -19,6 +19,8 @@ class CollectionRouter extends ParentRouter {
             value: mainRoute
         };
 
+        this.rss = object.rss !== false;
+
         this.permalinks = {
             originalValue: object.permalink,
             value: object.permalink
@@ -72,10 +74,11 @@ class CollectionRouter extends ParentRouter {
         this.router().param('page', middlewares.pageParam);
         this.mountRoute(urlService.utils.urlJoin(this.route.value, 'page', ':page(\\d+)'), controllers.collection);
 
-        this.rssRouter =  new RSSRouter();
-
-        // REGISTER: enable rss by default
-        this.mountRouter(this.route.value, this.rssRouter.router());
+        // REGISTER: is rss enabled?
+        if (this.rss) {
+            this.rssRouter =  new RSSRouter();
+            this.mountRouter(this.route.value, this.rssRouter.router());
+        }
 
         // REGISTER: context middleware for entries
         this.router().use(this._prepareEntryContext.bind(this));
@@ -151,6 +154,10 @@ class CollectionRouter extends ParentRouter {
     }
 
     getRssUrl(options) {
+        if (!this.rss) {
+            return null;
+        }
+
         return urlService.utils.createUrl(urlService.utils.urlJoin(this.route.value, this.rssRouter.route.value), options.absolute, options.secure);
     }
 

--- a/core/server/services/routing/StaticRoutesRouter.js
+++ b/core/server/services/routing/StaticRoutesRouter.js
@@ -16,6 +16,7 @@ class StaticRoutesRouter extends ParentRouter {
         debug(this.route.value, this.templates);
 
         if (this.isChannel(object)) {
+            this.rss = object.rss !== false;
             this.filter = object.filter;
             this.limit = object.limit;
             this.order = object.order;
@@ -26,6 +27,7 @@ class StaticRoutesRouter extends ParentRouter {
             debug(this.route.value, this.templates, this.filter, this.data);
             this._registerChannelRoutes();
         } else {
+            this.contentType = object.content_type;
             debug(this.route.value, this.templates);
             this._registerStaticRoute();
         }
@@ -34,9 +36,11 @@ class StaticRoutesRouter extends ParentRouter {
     _registerChannelRoutes() {
         this.router().use(this._prepareChannelContext.bind(this));
 
-        // REGISTER: enable rss by default
-        this.rssRouter = new RSSRouter();
-        this.mountRouter(this.route.value, this.rssRouter.router());
+        // REGISTER: is rss enabled?
+        if (this.rss) {
+            this.rssRouter = new RSSRouter();
+            this.mountRouter(this.route.value, this.rssRouter.router());
+        }
 
         // REGISTER: channel route
         this.mountRoute(this.route.value, controllers[this.controller]);
@@ -76,7 +80,8 @@ class StaticRoutesRouter extends ParentRouter {
             templates: this.templates,
             defaultTemplate: 'default',
             data: this.data.query,
-            context: []
+            context: [],
+            contentType: this.contentType
         };
 
         next();

--- a/core/server/services/routing/helpers/renderer.js
+++ b/core/server/services/routing/helpers/renderer.js
@@ -13,5 +13,11 @@ module.exports = function renderer(req, res, data) {
     debug('Rendering template: ' + res._template + ' for: ' + req.originalUrl);
     debug('res.locals', res.locals);
 
+    if (res.routerOptions && res.routerOptions.contentType) {
+        if (res.routerOptions.templates.indexOf(res._template) !== -1) {
+            res.type(res.routerOptions.contentType);
+        }
+    }
+
     res.render(res._template, data);
 };

--- a/core/test/unit/services/routing/StaticRoutesRouter_spec.js
+++ b/core/test/unit/services/routing/StaticRoutesRouter_spec.js
@@ -86,7 +86,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                 templates: [],
                 defaultTemplate: 'default',
                 context: [],
-                data: {}
+                data: {},
+                contentType: undefined
             });
             should.not.exist(res.locals.slug);
         });

--- a/core/test/utils/fixtures/themes/test-theme/home.hbs
+++ b/core/test/utils/fixtures/themes/test-theme/home.hbs
@@ -1,1 +1,8 @@
+<html>
+<head>
+    {{ghost_head}}
+</head>
+<body>
 home.hbs
+</body>
+</html>

--- a/core/test/utils/fixtures/themes/test-theme/podcast/rss.hbs
+++ b/core/test/utils/fixtures/themes/test-theme/podcast/rss.hbs
@@ -1,0 +1,10 @@
+<rss>
+    <channel>
+        <title>{{@blog.title}}</title>
+        {{#get "posts" filter="featured:true" limit="20"}}
+            {{#foreach posts}}
+                <link>{{url}}</link>
+            {{/foreach}}
+        {{/get}}
+    </channel>
+</rss>

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ghost-storage-base": "0.0.3",
     "glob": "5.0.15",
     "got": "7.1.0",
-    "gscan": "1.4.3",
+    "gscan": "1.5.0",
     "html-to-text": "3.3.0",
     "image-size": "0.6.3",
     "intl": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2533,9 +2533,9 @@ grunt@~0.4.0:
     underscore.string "~2.2.1"
     which "~1.0.5"
 
-gscan@1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.4.3.tgz#ebea3c78106f4d8562225d46754d0a41c3e0a348"
+gscan@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/gscan/-/gscan-1.5.0.tgz#b94446ab1ebc058c36e26f086ab0c0b97634832f"
   dependencies:
     "@tryghost/extract-zip" "1.6.6"
     bluebird "^3.4.6"


### PR DESCRIPTION
refs #9601

- `rss:false`
- ability to define a custom rss url with a target template (contentType)
- ability to disable rss for channel or collection
- ensure we use type/html if the target template can't be found

### TODO
- [x] release and confirm gscan PR
- [x] merge and release #9686 - then rebase (they both changed the same files/code snippets)