### PR TITLE
ES6 Migrations: server/adapters/scheduling/post-scheduling

### DIFF
--- a/core/server/adapters/scheduling/index.js
+++ b/core/server/adapters/scheduling/index.js
@@ -1,4 +1,4 @@
-var postScheduling = require(__dirname + '/post-scheduling');
+const postScheduling = require(__dirname + '/post-scheduling');
 
 /**
  * scheduling modules:

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -12,7 +12,7 @@ _private.normalize = function normalize(options) {
 
     return {
         time: moment(object.get('published_at')).valueOf(),
-        url: urlService.utils.urlJoin(apiUrl, 'schedules', 'posts', object.get('id')) + '?client_id=' + client.get('slug') + '&client_secret=' + client.get('secret'),
+        url: `${urlService.utils.urlJoin(apiUrl, 'schedules', 'posts', object.get('id'))}?client_id=${client.get('slug')}&client_secret=${client.get('secret')}`,
         extra: {
             httpMethod: 'PUT',
             oldTime: object.updated('published_at') ? moment(object.updated('published_at')).valueOf() : null

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -24,9 +24,9 @@ _private.loadClient = function loadClient() {
     return models.Client.findOne({slug: 'ghost-scheduler'}, {columns: ['slug', 'secret']});
 };
 
-_private.loadScheduledPosts = function () {
+_private.loadScheduledPosts = () => {
     return schedules.getScheduledPosts()
-        .then(function (result) {
+        .then((result) => {
             return result.posts || [];
         });
 };
@@ -46,48 +46,48 @@ exports.init = function init(options) {
     }
 
     return _private.loadClient()
-        .then(function (_client) {
+        .then((_client) => {
             client = _client;
             return localUtils.createAdapter(config);
         })
-        .then(function (_adapter) {
+        .then((_adapter) => {
             adapter = _adapter;
             if (!adapter.rescheduleOnBoot) {
                 return [];
             }
             return _private.loadScheduledPosts();
         })
-        .then(function (scheduledPosts) {
+        .then((scheduledPosts) => {
             if (!scheduledPosts.length) {
                 return;
             }
 
-            scheduledPosts.forEach(function (object) {
+            scheduledPosts.forEach((object) => {
                 adapter.reschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
             });
         })
-        .then(function () {
+        .then(() => {
             adapter.run();
         })
-        .then(function () {
+        .then(() => {
             common.events.onMany([
                 'post.scheduled',
                 'page.scheduled'
-            ], function (object) {
+            ], (object) => {
                 adapter.schedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
             });
 
             common.events.onMany([
                 'post.rescheduled',
                 'page.rescheduled'
-            ], function (object) {
+            ], (object) => {
                 adapter.reschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
             });
 
             common.events.onMany([
                 'post.unscheduled',
                 'page.unscheduled'
-            ], function (object) {
+            ], (object) => {
                 adapter.unschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
             });
         });

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -24,7 +24,7 @@ _private.loadClient = function loadClient() {
     return models.Client.findOne({slug: 'ghost-scheduler'}, {columns: ['slug', 'secret']});
 };
 
-_private.loadScheduledPosts = () => {
+_private.loadScheduledPosts = function () {
     return schedules.getScheduledPosts()
         .then((result) => {
             return result.posts || [];

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -63,7 +63,7 @@ exports.init = function init(options) {
             }
 
             scheduledPosts.forEach((object) => {
-                adapter.reschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
+                adapter.reschedule(_private.normalize({object, apiUrl, client}));
             });
         })
         .then(() => {
@@ -74,21 +74,21 @@ exports.init = function init(options) {
                 'post.scheduled',
                 'page.scheduled'
             ], (object) => {
-                adapter.schedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
+                adapter.schedule(_private.normalize({object, apiUrl, client}));
             });
 
             common.events.onMany([
                 'post.rescheduled',
                 'page.rescheduled'
             ], (object) => {
-                adapter.reschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
+                adapter.reschedule(_private.normalize({object, apiUrl, client}));
             });
 
             common.events.onMany([
                 'post.unscheduled',
                 'page.unscheduled'
             ], (object) => {
-                adapter.unschedule(_private.normalize({object: object, apiUrl: apiUrl, client: client}));
+                adapter.unschedule(_private.normalize({object, apiUrl, client}));
             });
         });
 };

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -1,4 +1,4 @@
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     moment = require('moment'),
     localUtils = require('../utils'),
     common = require('../../../lib/common'),
@@ -8,9 +8,7 @@ var Promise = require('bluebird'),
     _private = {};
 
 _private.normalize = function normalize(options) {
-    var object = options.object,
-        apiUrl = options.apiUrl,
-        client = options.client;
+    const {object, apiUrl, client} = options;
 
     return {
         time: moment(object.get('published_at')).valueOf(),
@@ -34,9 +32,9 @@ _private.loadScheduledPosts = function () {
 };
 
 exports.init = function init(options) {
-    var config = options || {},
-        apiUrl = config.apiUrl,
-        adapter = null,
+    const config = options || {};
+    const {apiUrl} = config;
+    let adapter = null,
         client = null;
 
     if (!config) {

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -31,13 +31,12 @@ _private.loadScheduledPosts = () => {
         });
 };
 
-exports.init = function init(options) {
-    const config = options || {};
-    const {apiUrl} = config;
+exports.init = function init(options = {}) {
+    const {apiUrl} = options;
     let adapter = null,
         client = null;
 
-    if (!config) {
+    if (!options) {
         return Promise.reject(new common.errors.IncorrectUsageError({message: 'post-scheduling: no config was provided'}));
     }
 
@@ -48,7 +47,7 @@ exports.init = function init(options) {
     return _private.loadClient()
         .then((_client) => {
             client = _client;
-            return localUtils.createAdapter(config);
+            return localUtils.createAdapter(options);
         })
         .then((_adapter) => {
             adapter = _adapter;

--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -36,7 +36,7 @@ exports.init = function init(options = {}) {
     let adapter = null,
         client = null;
 
-    if (!options) {
+    if (!Object.keys(options).length) {
         return Promise.reject(new common.errors.IncorrectUsageError({message: 'post-scheduling: no config was provided'}));
     }
 


### PR DESCRIPTION
ES6 Migration: server/adapters/scheduling/post-scheduling

issue #9589

- Replaces `var`s with `let`/`const`s
- Replace concatenated strings with template literals
- Replace anonymous function expressions with ES6 arrow functions
- Use ES6 object shorthand (Replace `{object: object}` with `{object}`)
