### PR TITLE
ES6 Migration: server/adapters/storage

### DIFF
--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -47,7 +47,7 @@ class LocalFileStore extends StorageBase {
                 urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
                     urlService.utils.STATIC_IMAGE_URL_PREFIX,
                     path.relative(storagePath, targetFilename))
-            ).replace(new RegExp('\\' + path.sep, 'g'), '/');
+            ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
 
             return fullUrl;
         }).catch((e) => {

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -30,7 +30,7 @@ class LocalFileStore extends StorageBase {
      */
     save(image, targetDir) {
         let targetFilename;
-        const self = this;
+        const {storagePath} = this;
 
         // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
         targetDir = targetDir || this.getTargetDir(this.storagePath);
@@ -46,7 +46,7 @@ class LocalFileStore extends StorageBase {
             const fullUrl = (
                 urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
                     urlService.utils.STATIC_IMAGE_URL_PREFIX,
-                    path.relative(self.storagePath, targetFilename))
+                    path.relative(storagePath, targetFilename))
             ).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
             return fullUrl;
@@ -75,13 +75,13 @@ class LocalFileStore extends StorageBase {
      * @returns {serveStaticContent}
      */
     serve() {
-        const self = this;
+        const {storagePath} = this;
 
         return function serveStaticContent(req, res, next) {
             const startedAtMoment = moment();
 
             return serveStatic(
-                self.storagePath,
+                storagePath,
                 {
                     maxAge: constants.ONE_YEAR_MS,
                     fallthrough: false,

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -30,7 +30,6 @@ class LocalFileStore extends StorageBase {
      */
     save(image, targetDir) {
         let targetFilename;
-        const {storagePath} = this;
 
         // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
         targetDir = targetDir || this.getTargetDir(this.storagePath);
@@ -46,7 +45,7 @@ class LocalFileStore extends StorageBase {
             const fullUrl = (
                 urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
                     urlService.utils.STATIC_IMAGE_URL_PREFIX,
-                    path.relative(storagePath, targetFilename))
+                    path.relative(this.storagePath, targetFilename))
             ).replace(new RegExp(`\\${path.sep}`, 'g'), '/');
 
             return fullUrl;
@@ -85,7 +84,7 @@ class LocalFileStore extends StorageBase {
                 {
                     maxAge: constants.ONE_YEAR_MS,
                     fallthrough: false,
-                    onEnd: function onEnd() {
+                    onEnd: () => {
                         common.logging.info('LocalFileStorage.serve', req.path, moment().diff(startedAtMoment, 'ms') + 'ms');
                     }
                 }

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -1,7 +1,7 @@
 // # Local File System Image Storage module
 // The (default) module for storing images, using the local file system
 
-var serveStatic = require('express').static,
+const serveStatic = require('express').static,
     fs = require('fs-extra'),
     path = require('path'),
     Promise = require('bluebird'),
@@ -29,8 +29,8 @@ class LocalFileStore extends StorageBase {
      * @returns {*}
      */
     save(image, targetDir) {
-        var targetFilename,
-            self = this;
+        let targetFilename;
+        const self = this;
 
         // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
         targetDir = targetDir || this.getTargetDir(this.storagePath);
@@ -43,7 +43,7 @@ class LocalFileStore extends StorageBase {
         }).then(function () {
             // The src for the image must be in URI format, not a file system path, which in Windows uses \
             // For local file system storage can use relative path so add a slash
-            var fullUrl = (
+            const fullUrl = (
                 urlService.utils.urlJoin('/', urlService.utils.getSubdir(),
                     urlService.utils.STATIC_IMAGE_URL_PREFIX,
                     path.relative(self.storagePath, targetFilename))
@@ -56,7 +56,7 @@ class LocalFileStore extends StorageBase {
     }
 
     exists(fileName, targetDir) {
-        var filePath = path.join(targetDir || this.storagePath, fileName);
+        const filePath = path.join(targetDir || this.storagePath, fileName);
 
         return fs.stat(filePath)
             .then(function () {
@@ -75,10 +75,10 @@ class LocalFileStore extends StorageBase {
      * @returns {serveStaticContent}
      */
     serve() {
-        var self = this;
+        const self = this;
 
         return function serveStaticContent(req, res, next) {
-            var startedAtMoment = moment();
+            const startedAtMoment = moment();
 
             return serveStatic(
                 self.storagePath,
@@ -127,7 +127,7 @@ class LocalFileStore extends StorageBase {
         // remove trailing slashes
         options.path = (options.path || '').replace(/\/$|\\$/, '');
 
-        var targetPath = path.join(this.storagePath, options.path);
+        const targetPath = path.join(this.storagePath, options.path);
 
         return new Promise(function (resolve, reject) {
             fs.readFile(targetPath, function (err, bytes) {

--- a/core/server/adapters/storage/LocalFileStorage.js
+++ b/core/server/adapters/storage/LocalFileStorage.js
@@ -35,12 +35,12 @@ class LocalFileStore extends StorageBase {
         // NOTE: the base implementation of `getTargetDir` returns the format this.storagePath/YYYY/MM
         targetDir = targetDir || this.getTargetDir(this.storagePath);
 
-        return this.getUniqueFileName(image, targetDir).then(function (filename) {
+        return this.getUniqueFileName(image, targetDir).then((filename) => {
             targetFilename = filename;
             return fs.mkdirs(targetDir);
-        }).then(function () {
+        }).then(() => {
             return fs.copy(image.path, targetFilename);
-        }).then(function () {
+        }).then(() => {
             // The src for the image must be in URI format, not a file system path, which in Windows uses \
             // For local file system storage can use relative path so add a slash
             const fullUrl = (
@@ -50,7 +50,7 @@ class LocalFileStore extends StorageBase {
             ).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
             return fullUrl;
-        }).catch(function (e) {
+        }).catch((e) => {
             return Promise.reject(e);
         });
     }
@@ -59,10 +59,10 @@ class LocalFileStore extends StorageBase {
         const filePath = path.join(targetDir || this.storagePath, fileName);
 
         return fs.stat(filePath)
-            .then(function () {
+            .then(() => {
                 return true;
             })
-            .catch(function () {
+            .catch(() => {
                 return false;
             });
     }
@@ -89,7 +89,7 @@ class LocalFileStore extends StorageBase {
                         common.logging.info('LocalFileStorage.serve', req.path, moment().diff(startedAtMoment, 'ms') + 'ms');
                     }
                 }
-            )(req, res, function (err) {
+            )(req, res, (err) => {
                 if (err) {
                     if (err.statusCode === 404) {
                         return next(new common.errors.NotFoundError({
@@ -129,8 +129,8 @@ class LocalFileStore extends StorageBase {
 
         const targetPath = path.join(this.storagePath, options.path);
 
-        return new Promise(function (resolve, reject) {
-            fs.readFile(targetPath, function (err, bytes) {
+        return new Promise((resolve, reject) => {
+            fs.readFile(targetPath, (err, bytes) => {
                 if (err) {
                     if (err.code === 'ENOENT') {
                         return reject(new common.errors.NotFoundError({

--- a/core/server/adapters/storage/index.js
+++ b/core/server/adapters/storage/index.js
@@ -41,13 +41,13 @@ function getStorage() {
         } else if (err.code === 'MODULE_NOT_FOUND' && err.message.indexOf(`${config.getContentPath('storage')}${storageChoice}`) === -1) {
             throw new common.errors.IncorrectUsageError({
                 message: 'We have detected an error in your custom storage adapter.',
-                err: err
+                err
             });
             // CASE: only throw error if module does exist
         } else if (err.code !== 'MODULE_NOT_FOUND') {
             throw new common.errors.IncorrectUsageError({
                 message: 'We have detected an unknown error in your custom storage adapter.',
-                err: err
+                err
             });
         }
     }
@@ -58,13 +58,13 @@ function getStorage() {
     } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw new common.errors.IncorrectUsageError({
-                err: err,
+                err,
                 context: `We cannot find your adapter in: ${config.getContentPath('storage')} or: ${config.get('paths').internalStoragePath}`
             });
         } else {
             throw new common.errors.IncorrectUsageError({
                 message: 'We have detected an error in your custom storage adapter.',
-                err: err
+                err
             });
         }
     }

--- a/core/server/adapters/storage/index.js
+++ b/core/server/adapters/storage/index.js
@@ -1,4 +1,4 @@
-var _ = require('lodash'),
+const _ = require('lodash'),
     StorageBase = require('ghost-storage-base'),
     config = require('../../config'),
     common = require('../../lib/common'),
@@ -8,8 +8,8 @@ var _ = require('lodash'),
  * type: images
  */
 function getStorage() {
-    var storageChoice = config.get('storage:active'),
-        storageConfig,
+    const storageChoice = config.get('storage:active');
+    let storageConfig,
         CustomStorage,
         customStorage;
 

--- a/core/server/adapters/storage/index.js
+++ b/core/server/adapters/storage/index.js
@@ -29,7 +29,7 @@ function getStorage() {
 
     // CASE: load adapter from custom path  (.../content/storage)
     try {
-        CustomStorage = require(config.getContentPath('storage') + storageChoice);
+        CustomStorage = require(`${config.getContentPath('storage')}${storageChoice}`);
     } catch (err) {
         if (err.message.match(/strict mode/gi)) {
             throw new common.errors.IncorrectUsageError({
@@ -38,7 +38,7 @@ function getStorage() {
                 err: err
             });
             // CASE: if module not found it can be an error within the adapter (cannot find bluebird for example)
-        } else if (err.code === 'MODULE_NOT_FOUND' && err.message.indexOf(config.getContentPath('storage') + storageChoice) === -1) {
+        } else if (err.code === 'MODULE_NOT_FOUND' && err.message.indexOf(`${config.getContentPath('storage')}${storageChoice}`) === -1) {
             throw new common.errors.IncorrectUsageError({
                 message: 'We have detected an error in your custom storage adapter.',
                 err: err
@@ -54,12 +54,12 @@ function getStorage() {
 
     // CASE: check in the default storage path
     try {
-        CustomStorage = CustomStorage || require(config.get('paths').internalStoragePath + storageChoice);
+        CustomStorage = CustomStorage || require(`${config.get('paths').internalStoragePath}${storageChoice}`);
     } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw new common.errors.IncorrectUsageError({
                 err: err,
-                context: 'We cannot find your adapter in: ' + config.getContentPath('storage') + ' or: ' + config.get('paths').internalStoragePath
+                context: `We cannot find your adapter in: ${config.getContentPath('storage')} or: ${config.get('paths').internalStoragePath}`
             });
         } else {
             throw new common.errors.IncorrectUsageError({

--- a/core/server/adapters/storage/utils.js
+++ b/core/server/adapters/storage/utils.js
@@ -16,8 +16,8 @@ const urlService = require('../../services/url');
 exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
     // The '/' in urlJoin is necessary to add the '/' to `content/images`, if no subdirectory is setup
     const {urlJoin, urlFor, getSubdir, STATIC_IMAGE_URL_PREFIX} = urlService.utils;
-    const urlRegExp = new RegExp('^' + urlJoin(urlFor('home', true), getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)),
-        filePathRegExp = new RegExp('^' + urlJoin(getSubdir(), '/', STATIC_IMAGE_URL_PREFIX));
+    const urlRegExp = new RegExp(`^${urlJoin(urlFor('home', true), getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)}`),
+        filePathRegExp = new RegExp(`^${urlJoin(getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)}`);
 
     if (imagePath.match(urlRegExp)) {
         return imagePath.replace(urlRegExp, '');

--- a/core/server/adapters/storage/utils.js
+++ b/core/server/adapters/storage/utils.js
@@ -15,9 +15,17 @@ const urlService = require('../../services/url');
  */
 exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
     // The '/' in urlJoin is necessary to add the '/' to `content/images`, if no subdirectory is setup
-    const {urlJoin, urlFor, getSubdir, STATIC_IMAGE_URL_PREFIX} = urlService.utils;
-    const urlRegExp = new RegExp(`^${urlJoin(urlFor('home', true), getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)}`),
-        filePathRegExp = new RegExp(`^${urlJoin(getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)}`);
+    const urlRegExp = new RegExp(`^${urlService.utils.urlJoin(
+            urlService.utils.urlFor('home', true),
+            urlService.utils.getSubdir(),
+            '/',
+            urlService.utils.STATIC_IMAGE_URL_PREFIX)}`
+        ),
+        filePathRegExp = new RegExp(`^${urlService.utils.urlJoin(
+            urlService.utils.getSubdir(),
+            '/',
+            urlService.utils.STATIC_IMAGE_URL_PREFIX)}`
+        );
 
     if (imagePath.match(urlRegExp)) {
         return imagePath.replace(urlRegExp, '');

--- a/core/server/adapters/storage/utils.js
+++ b/core/server/adapters/storage/utils.js
@@ -15,8 +15,9 @@ const urlService = require('../../services/url');
  */
 exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
     // The '/' in urlJoin is necessary to add the '/' to `content/images`, if no subdirectory is setup
-    const urlRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX)),
-        filePathRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX));
+    const {urlJoin, urlFor, getSubdir, STATIC_IMAGE_URL_PREFIX} = urlService.utils;
+    const urlRegExp = new RegExp('^' + urlJoin(urlFor('home', true), getSubdir(), '/', STATIC_IMAGE_URL_PREFIX)),
+        filePathRegExp = new RegExp('^' + urlJoin(getSubdir(), '/', STATIC_IMAGE_URL_PREFIX));
 
     if (imagePath.match(urlRegExp)) {
         return imagePath.replace(urlRegExp, '');

--- a/core/server/adapters/storage/utils.js
+++ b/core/server/adapters/storage/utils.js
@@ -1,4 +1,4 @@
-var urlService = require('../../services/url');
+const urlService = require('../../services/url');
 
 /**
  * @TODO: move `events.js` to here - e.g. storageUtils.getStorage
@@ -15,7 +15,7 @@ var urlService = require('../../services/url');
  */
 exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
     // The '/' in urlJoin is necessary to add the '/' to `content/images`, if no subdirectory is setup
-    var urlRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX)),
+    const urlRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.urlFor('home', true), urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX)),
         filePathRegExp = new RegExp('^' + urlService.utils.urlJoin(urlService.utils.getSubdir(), '/', urlService.utils.STATIC_IMAGE_URL_PREFIX));
 
     if (imagePath.match(urlRegExp)) {
@@ -34,7 +34,7 @@ exports.getLocalFileStoragePath = function getLocalFileStoragePath(imagePath) {
  */
 
 exports.isLocalImage = function isLocalImage(imagePath) {
-    var localImagePath = this.getLocalFileStoragePath(imagePath);
+    const localImagePath = this.getLocalFileStoragePath(imagePath);
 
     if (localImagePath !== imagePath) {
         return true;


### PR DESCRIPTION
ES6 Migration: server/adapters/storage

issue #9589

- Replaces `var`s with `let`/`const`s
- Replace concatenated strings with template literals
- Replace anonymous function expressions with ES6 arrow functions
- Use ES6 object shorthand (Replace `{err: err}` with `{err}`)