### PR TITLE
Dynamic Routing Beta: `res.routerOptions`

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -9,9 +9,7 @@ var path = require('path'),
     templateName = 'amp';
 
 function _renderer(req, res, next) {
-    // Note: this is super similar to the config middleware used in channels
-    // @TODO refactor into to something explicit & DRY this up
-    res._route = {
+    res.routerOptions = {
         type: 'custom',
         templates: templateName,
         defaultTemplate: path.resolve(__dirname, 'views', templateName + '.hbs')

--- a/core/server/apps/private-blogging/lib/router.js
+++ b/core/server/apps/private-blogging/lib/router.js
@@ -8,9 +8,7 @@ const path = require('path'),
     privateRouter = express.Router();
 
 function _renderer(req, res) {
-    // Note: this is super similar to the config middleware used in channels
-    // @TODO refactor into to something explicit & DRY this up
-    res._route = {
+    res.routerOptions = {
         type: 'custom',
         templates: templateName,
         defaultTemplate: path.resolve(__dirname, 'views', templateName + '.hbs')

--- a/core/server/apps/subscribers/lib/router.js
+++ b/core/server/apps/subscribers/lib/router.js
@@ -14,9 +14,7 @@ var path = require('path'),
     templateName = 'subscribe';
 
 function _renderer(req, res) {
-    // Note: this is super similar to the config middleware used in channels
-    // @TODO refactor into to something explicit & DRY this up
-    res._route = {
+    res.routerOptions = {
         type: 'custom',
         templates: templateName,
         defaultTemplate: path.resolve(__dirname, 'views', templateName + '.hbs')

--- a/core/server/services/routing/CollectionRouter.js
+++ b/core/server/services/routing/CollectionRouter.js
@@ -93,12 +93,13 @@ class CollectionRouter extends ParentRouter {
      * @TODO: Why do we need two context objects? O_O - refactor this out
      */
     _prepareEntriesContext(req, res, next) {
-        res.locals.routerOptions = {
+        res.routerOptions = {
+            type: 'collection',
             filter: this.filter,
             limit: this.limit,
             order: this.order,
             permalinks: this.permalinks.getValue({withUrlOptions: true}),
-            type: this.getType(),
+            resourceType: this.getResourceType(),
             context: this.context,
             frontPageTemplate: 'home',
             templates: this.templates,
@@ -107,16 +108,12 @@ class CollectionRouter extends ParentRouter {
             data: this.data.query
         };
 
-        res._route = {
-            type: 'collection'
-        };
-
         next();
     }
 
     _prepareEntryContext(req, res, next) {
-        res.locals.routerOptions.context = ['post'];
-        res._route.type = 'entry';
+        res.routerOptions.context = ['post'];
+        res.routerOptions.type = 'entry';
         next();
     }
 
@@ -143,7 +140,7 @@ class CollectionRouter extends ParentRouter {
         this.emit('updated');
     }
 
-    getType() {
+    getResourceType() {
         return 'posts';
     }
 

--- a/core/server/services/routing/ParentRouter.js
+++ b/core/server/services/routing/ParentRouter.js
@@ -68,7 +68,7 @@ class ParentRouter extends EventEmitter {
         let targetRoute = null;
 
         siteRouter.handle.stack.every((router) => {
-            if (router.handle.parent && router.handle.parent.isRedirectEnabled && router.handle.parent.isRedirectEnabled(this.getType(), slug)) {
+            if (router.handle.parent && router.handle.parent.isRedirectEnabled && router.handle.parent.isRedirectEnabled(this.getResourceType(), slug)) {
                 targetRoute = router.handle.parent.getRoute();
                 return false;
             }

--- a/core/server/services/routing/PreviewRouter.js
+++ b/core/server/services/routing/PreviewRouter.js
@@ -18,7 +18,7 @@ class PreviewRouter extends ParentRouter {
     }
 
     _prepareContext(req, res, next) {
-        res._route = {
+        res.routerOptions = {
             type: 'entry'
         };
 

--- a/core/server/services/routing/StaticPagesRouter.js
+++ b/core/server/services/routing/StaticPagesRouter.js
@@ -34,21 +34,18 @@ class StaticPagesRouter extends ParentRouter {
     }
 
     _prepareContext(req, res, next) {
-        res.locals.routerOptions = {
+        res.routerOptions = {
+            type: 'entry',
             filter: this.filter,
             permalinks: this.permalinks.getValue(),
-            type: this.getType(),
+            resourceType: this.getResourceType(),
             context: ['page']
-        };
-
-        res._route = {
-            type: 'entry'
         };
 
         next();
     }
 
-    getType() {
+    getResourceType() {
         return 'pages';
     }
 

--- a/core/server/services/routing/StaticRoutesRouter.js
+++ b/core/server/services/routing/StaticRoutesRouter.js
@@ -49,7 +49,8 @@ class StaticRoutesRouter extends ParentRouter {
     }
 
     _prepareChannelContext(req, res, next) {
-        res.locals.routerOptions = {
+        res.routerOptions = {
+            type: this.controller,
             name: this.routerName,
             context: [this.routerName],
             filter: this.filter,
@@ -57,10 +58,6 @@ class StaticRoutesRouter extends ParentRouter {
             order: this.order,
             data: this.data.query,
             templates: this.templates
-        };
-
-        res._route = {
-            type: this.controller
         };
 
         next();
@@ -74,15 +71,12 @@ class StaticRoutesRouter extends ParentRouter {
     }
 
     _prepareStaticRouteContext(req, res, next) {
-        res.locals.routerOptions = {
-            data: this.data.query,
-            context: []
-        };
-
-        res._route = {
+        res.routerOptions = {
             type: 'custom',
             templates: this.templates,
-            defaultTemplate: 'default'
+            defaultTemplate: 'default',
+            data: this.data.query,
+            context: []
         };
 
         next();

--- a/core/server/services/routing/TaxonomyRouter.js
+++ b/core/server/services/routing/TaxonomyRouter.js
@@ -50,19 +50,16 @@ class TaxonomyRouter extends ParentRouter {
     }
 
     _prepareContext(req, res, next) {
-        res.locals.routerOptions = {
+        res.routerOptions = {
+            type: 'channel',
             name: this.taxonomyKey,
             permalinks: this.permalinks.getValue(),
             data: {[this.taxonomyKey]: _.omit(RESOURCE_CONFIG.QUERY[this.taxonomyKey], 'alias')},
             filter: RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].filter,
-            type: this.getType(),
+            resourceType: this.getResourceType(),
             context: [this.taxonomyKey],
             slugTemplate: true,
             identifier: this.identifier
-        };
-
-        res._route = {
-            type: 'channel'
         };
 
         next();
@@ -72,7 +69,7 @@ class TaxonomyRouter extends ParentRouter {
         urlService.utils.redirectToAdmin(302, res, RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].editRedirect.replace(':slug', req.params.slug));
     }
 
-    getType() {
+    getResourceType() {
         return RESOURCE_CONFIG.QUERY[this.taxonomyKey].resource;
     }
 

--- a/core/server/services/routing/controllers/channel.js
+++ b/core/server/services/routing/controllers/channel.js
@@ -8,7 +8,7 @@ const _ = require('lodash'),
 
 // @TODO: the collection+rss controller does almost the same
 module.exports = function channelController(req, res, next) {
-    debug('channelController', req.params, res.locals.routerOptions);
+    debug('channelController', req.params, res.routerOptions);
 
     const pathOptions = {
         page: req.params.page !== undefined ? req.params.page : 1,
@@ -18,16 +18,16 @@ module.exports = function channelController(req, res, next) {
     if (pathOptions.page) {
         // CASE 1: routes.yaml `limit` is stronger than theme definition
         // CASE 2: use `posts_per_page` config from theme as `limit` value
-        if (res.locals.routerOptions.limit) {
+        if (res.routerOptions.limit) {
             themes.getActive().updateTemplateOptions({
                 data: {
                     config: {
-                        posts_per_page: res.locals.routerOptions.limit
+                        posts_per_page: res.routerOptions.limit
                     }
                 }
             });
 
-            pathOptions.limit = res.locals.routerOptions.limit;
+            pathOptions.limit = res.routerOptions.limit;
         } else {
             const postsPerPage = parseInt(themes.getActive().config('posts_per_page'));
 
@@ -37,7 +37,7 @@ module.exports = function channelController(req, res, next) {
         }
     }
 
-    return helpers.fetchData(pathOptions, res.locals.routerOptions)
+    return helpers.fetchData(pathOptions, res.routerOptions)
         .then(function handleResult(result) {
             // CASE: requested page is greater than number of pages we have
             if (pathOptions.page > result.meta.pagination.pages) {

--- a/core/server/services/routing/controllers/collection.js
+++ b/core/server/services/routing/controllers/collection.js
@@ -8,7 +8,7 @@ const _ = require('lodash'),
     helpers = require('../helpers');
 
 module.exports = function collectionController(req, res, next) {
-    debug('collectionController', req.params, res.locals.routerOptions);
+    debug('collectionController', req.params, res.routerOptions);
 
     const pathOptions = {
         page: req.params.page !== undefined ? req.params.page : 1,
@@ -18,16 +18,16 @@ module.exports = function collectionController(req, res, next) {
     if (pathOptions.page) {
         // CASE 1: routes.yaml `limit` is stronger than theme definition
         // CASE 2: use `posts_per_page` config from theme as `limit` value
-        if (res.locals.routerOptions.limit) {
+        if (res.routerOptions.limit) {
             themes.getActive().updateTemplateOptions({
                 data: {
                     config: {
-                        posts_per_page: res.locals.routerOptions.limit
+                        posts_per_page: res.routerOptions.limit
                     }
                 }
             });
 
-            pathOptions.limit = res.locals.routerOptions.limit;
+            pathOptions.limit = res.routerOptions.limit;
         } else {
             const postsPerPage = parseInt(themes.getActive().config('posts_per_page'));
 
@@ -37,7 +37,7 @@ module.exports = function collectionController(req, res, next) {
         }
     }
 
-    return helpers.fetchData(pathOptions, res.locals.routerOptions)
+    return helpers.fetchData(pathOptions, res.routerOptions)
         .then(function handleResult(result) {
             // CASE: requested page is greater than number of pages we have
             if (pathOptions.page > result.meta.pagination.pages) {
@@ -48,7 +48,7 @@ module.exports = function collectionController(req, res, next) {
 
             // CASE: does this post belong to this collection?
             result.posts = _.filter(result.posts, (post) => {
-                if (urlService.owns(res.locals.routerOptions.identifier, post.url)) {
+                if (urlService.owns(res.routerOptions.identifier, post.url)) {
                     return post;
                 }
             });

--- a/core/server/services/routing/controllers/entry.js
+++ b/core/server/services/routing/controllers/entry.js
@@ -10,9 +10,9 @@ const debug = require('ghost-ignition').debug('services:routing:controllers:entr
  *   - always execute `next` until no router want's to serve and 404's
  */
 module.exports = function entryController(req, res, next) {
-    debug('entryController', res.locals.routerOptions);
+    debug('entryController', res.routerOptions);
 
-    return helpers.postLookup(req.path, res.locals.routerOptions)
+    return helpers.postLookup(req.path, res.routerOptions)
         .then(function then(lookup) {
             // Format data 1
             const post = lookup ? lookup.post : false;
@@ -50,7 +50,7 @@ module.exports = function entryController(req, res, next) {
              *
              * That's why we have to check against the router type.
              */
-            if (urlService.getResourceById(post.id).config.type !== res.locals.routerOptions.type) {
+            if (urlService.getResourceById(post.id).config.type !== res.routerOptions.resourceType) {
                 debug('not my resource type');
                 return next();
             }

--- a/core/server/services/routing/controllers/rss.js
+++ b/core/server/services/routing/controllers/rss.js
@@ -34,7 +34,7 @@ module.exports = function rssController(req, res, next) {
     // @TODO: this belongs to the rss service
     const baseUrl = getBaseUrlForRSSReq(req.originalUrl, pathOptions.page);
 
-    helpers.fetchData(pathOptions, res.locals.routerOptions)
+    helpers.fetchData(pathOptions, res.routerOptions)
         .then(function formatResult(result) {
             const response = _.pick(result, ['posts', 'meta']);
 

--- a/core/server/services/routing/controllers/static.js
+++ b/core/server/services/routing/controllers/static.js
@@ -12,11 +12,11 @@ function processQuery(query) {
 }
 
 module.exports = function staticController(req, res, next) {
-    debug('staticController', res.locals.routerOptions);
+    debug('staticController', res.routerOptions);
 
     let props = {};
 
-    _.each(res.locals.routerOptions.data, function (query, name) {
+    _.each(res.routerOptions.data, function (query, name) {
         props[name] = processQuery(query);
     });
 
@@ -24,10 +24,10 @@ module.exports = function staticController(req, res, next) {
         .then(function handleResult(result) {
             let response = {};
 
-            if (res.locals.routerOptions.data) {
+            if (res.routerOptions.data) {
                 response.data = {};
 
-                _.each(res.locals.routerOptions.data, function (config, name) {
+                _.each(res.routerOptions.data, function (config, name) {
                     if (config.type === 'browse') {
                         response.data[name] = result[name];
                     } else {

--- a/core/server/services/routing/helpers/context.js
+++ b/core/server/services/routing/helpers/context.js
@@ -47,8 +47,8 @@ function setResponseContext(req, res, data) {
     }
 
     // Each page can only have at most one of these
-    if (res.locals.routerOptions) {
-        res.locals.context = res.locals.context.concat(res.locals.routerOptions.context);
+    if (res.routerOptions && res.routerOptions.context) {
+        res.locals.context = res.locals.context.concat(res.routerOptions.context);
     } else if (privatePattern.test(res.locals.relativeUrl)) {
         res.locals.context.push('private');
     } else if (subscribePattern.test(res.locals.relativeUrl) && labs.isSet('subscribers') === true) {

--- a/core/server/services/routing/helpers/templates.js
+++ b/core/server/services/routing/helpers/templates.js
@@ -158,8 +158,6 @@ _private.getTemplateForError = function getTemplateForError(statusCode) {
 };
 
 module.exports.setTemplate = function setTemplate(req, res, data) {
-    const routeConfig = res._route || {};
-
     if (res._template && !req.err) {
         return;
     }
@@ -169,15 +167,15 @@ module.exports.setTemplate = function setTemplate(req, res, data) {
         return;
     }
 
-    if (['channel', 'collection'].indexOf(routeConfig.type) !== -1) {
-        res._template = _private.getTemplateForEntries(res.locals.routerOptions, {
+    if (['channel', 'collection'].indexOf(res.routerOptions.type) !== -1) {
+        res._template = _private.getTemplateForEntries(res.routerOptions, {
             path: url.parse(req.url).pathname,
             page: req.params.page,
             slugParam: req.params.slug
         });
-    } else if (routeConfig.type === 'custom') {
-        res._template = _private.pickTemplate(routeConfig.templates, routeConfig.defaultTemplate);
-    } else if (routeConfig.type === 'entry') {
+    } else if (res.routerOptions.type === 'custom') {
+        res._template = _private.pickTemplate(res.routerOptions.templates, res.routerOptions.defaultTemplate);
+    } else if (res.routerOptions.type === 'entry') {
         res._template = _private.getTemplateForEntry(data.post);
     } else {
         res._template = 'index';

--- a/core/server/services/url/UrlGenerator.js
+++ b/core/server/services/url/UrlGenerator.js
@@ -72,7 +72,7 @@ class UrlGenerator {
         debug('_onInit', this.toString());
 
         // @NOTE: get the resources of my type e.g. posts.
-        const resources = this.resources.getAllByType(this.router.getType());
+        const resources = this.resources.getAllByType(this.router.getResourceType());
 
         _.each(resources, (resource) => {
             this._try(resource);
@@ -83,7 +83,7 @@ class UrlGenerator {
         debug('onAdded', this.toString());
 
         // CASE: you are type "pages", but the incoming type is "users"
-        if (event.type !== this.router.getType()) {
+        if (event.type !== this.router.getResourceType()) {
             return;
         }
 
@@ -167,7 +167,7 @@ class UrlGenerator {
                 action: 'added:' + resource.data.id,
                 eventData: {
                     id: resource.data.id,
-                    type: this.router.getType()
+                    type: this.router.getResourceType()
                 }
             });
         };

--- a/core/test/integration/services/url/UrlService_spec.js
+++ b/core/test/integration/services/url/UrlService_spec.js
@@ -9,7 +9,7 @@ const common = require('../../../../server/lib/common');
 const UrlService = rewire('../../../../server/services/url/UrlService');
 const sandbox = sinon.sandbox.create();
 
-describe('Unit: services/url/UrlService', function () {
+describe('Integration: services/url/UrlService', function () {
     let urlService;
 
     before(function () {
@@ -33,7 +33,7 @@ describe('Unit: services/url/UrlService', function () {
             router1 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'post collection';
@@ -43,7 +43,7 @@ describe('Unit: services/url/UrlService', function () {
             router2 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'authors';
@@ -53,7 +53,7 @@ describe('Unit: services/url/UrlService', function () {
             router3 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'tags';
@@ -63,7 +63,7 @@ describe('Unit: services/url/UrlService', function () {
             router4 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'static pages';
@@ -71,7 +71,7 @@ describe('Unit: services/url/UrlService', function () {
             };
 
             router1.getFilter.returns('featured:false');
-            router1.getType.returns('posts');
+            router1.getResourceType.returns('posts');
             router1.getPermalinks.returns({
                 getValue: function () {
                     return '/:slug/';
@@ -79,7 +79,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router2.getFilter.returns(false);
-            router2.getType.returns('users');
+            router2.getResourceType.returns('users');
             router2.getPermalinks.returns({
                 getValue: function () {
                     return '/author/:slug/';
@@ -87,7 +87,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router3.getFilter.returns(false);
-            router3.getType.returns('tags');
+            router3.getResourceType.returns('tags');
             router3.getPermalinks.returns({
                 getValue: function () {
                     return '/tag/:slug/';
@@ -95,7 +95,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router4.getFilter.returns(false);
-            router4.getType.returns('pages');
+            router4.getResourceType.returns('pages');
             router4.getPermalinks.returns({
                 getValue: function () {
                     return '/:slug/';
@@ -135,19 +135,19 @@ describe('Unit: services/url/UrlService', function () {
 
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
-                if (generator.router.getType() === 'posts') {
+                if (generator.router.getResourceType() === 'posts') {
                     generator.getUrls().length.should.eql(2);
                 }
 
-                if (generator.router.getType() === 'pages') {
+                if (generator.router.getResourceType() === 'pages') {
                     generator.getUrls().length.should.eql(1);
                 }
 
-                if (generator.router.getType() === 'tags') {
+                if (generator.router.getResourceType() === 'tags') {
                     generator.getUrls().length.should.eql(5);
                 }
 
-                if (generator.router.getType() === 'users') {
+                if (generator.router.getResourceType() === 'users') {
                     generator.getUrls().length.should.eql(5);
                 }
             });
@@ -212,11 +212,11 @@ describe('Unit: services/url/UrlService', function () {
                         url.should.eql('/404/');
 
                         urlService.urlGenerators.forEach(function (generator) {
-                            if (generator.router.getType() === 'posts') {
+                            if (generator.router.getResourceType() === 'posts') {
                                 generator.getUrls().length.should.eql(1);
                             }
 
-                            if (generator.router.getType() === 'pages') {
+                            if (generator.router.getResourceType() === 'pages') {
                                 generator.getUrls().length.should.eql(1);
                             }
                         });
@@ -231,11 +231,11 @@ describe('Unit: services/url/UrlService', function () {
                         url.should.eql('/ghostly-kitchen-sink/');
 
                         urlService.urlGenerators.forEach(function (generator) {
-                            if (generator.router.getType() === 'posts') {
+                            if (generator.router.getResourceType() === 'posts') {
                                 generator.getUrls().length.should.eql(1);
                             }
 
-                            if (generator.router.getType() === 'pages') {
+                            if (generator.router.getResourceType() === 'pages') {
                                 generator.getUrls().length.should.eql(2);
                             }
                         });
@@ -250,11 +250,11 @@ describe('Unit: services/url/UrlService', function () {
                         url.should.eql('/static-page-test/');
 
                         urlService.urlGenerators.forEach(function (generator) {
-                            if (generator.router.getType() === 'posts') {
+                            if (generator.router.getResourceType() === 'posts') {
                                 generator.getUrls().length.should.eql(3);
                             }
 
-                            if (generator.router.getType() === 'pages') {
+                            if (generator.router.getResourceType() === 'pages') {
                                 generator.getUrls().length.should.eql(0);
                             }
                         });
@@ -313,7 +313,7 @@ describe('Unit: services/url/UrlService', function () {
             router1 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'post collection 1';
@@ -323,7 +323,7 @@ describe('Unit: services/url/UrlService', function () {
             router2 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'post collection 2';
@@ -333,7 +333,7 @@ describe('Unit: services/url/UrlService', function () {
             router3 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'authors';
@@ -343,7 +343,7 @@ describe('Unit: services/url/UrlService', function () {
             router4 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'tags';
@@ -353,7 +353,7 @@ describe('Unit: services/url/UrlService', function () {
             router5 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'static pages';
@@ -361,7 +361,7 @@ describe('Unit: services/url/UrlService', function () {
             };
 
             router1.getFilter.returns('featured:true');
-            router1.getType.returns('posts');
+            router1.getResourceType.returns('posts');
             router1.getPermalinks.returns({
                 getValue: function () {
                     return '/podcast/:slug/';
@@ -369,7 +369,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router2.getFilter.returns('page:false');
-            router2.getType.returns('posts');
+            router2.getResourceType.returns('posts');
             router2.getPermalinks.returns({
                 getValue: function () {
                     return '/collection/:year/:slug/';
@@ -377,7 +377,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router3.getFilter.returns(false);
-            router3.getType.returns('users');
+            router3.getResourceType.returns('users');
             router3.getPermalinks.returns({
                 getValue: function () {
                     return '/persons/:slug/';
@@ -385,7 +385,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router4.getFilter.returns(false);
-            router4.getType.returns('tags');
+            router4.getResourceType.returns('tags');
             router4.getPermalinks.returns({
                 getValue: function () {
                     return '/category/:slug/';
@@ -393,7 +393,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router5.getFilter.returns(false);
-            router5.getType.returns('pages');
+            router5.getResourceType.returns('pages');
             router5.getPermalinks.returns({
                 getValue: function () {
                     return '/:slug/';
@@ -435,23 +435,23 @@ describe('Unit: services/url/UrlService', function () {
 
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
-                if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'page:false') {
+                if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'page:false') {
                     generator.getUrls().length.should.eql(2);
                 }
 
-                if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:true') {
+                if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:true') {
                     generator.getUrls().length.should.eql(2);
                 }
 
-                if (generator.router.getType() === 'pages') {
+                if (generator.router.getResourceType() === 'pages') {
                     generator.getUrls().length.should.eql(1);
                 }
 
-                if (generator.router.getType() === 'tags') {
+                if (generator.router.getResourceType() === 'tags') {
                     generator.getUrls().length.should.eql(5);
                 }
 
-                if (generator.router.getType() === 'users') {
+                if (generator.router.getResourceType() === 'users') {
                     generator.getUrls().length.should.eql(5);
                 }
             });
@@ -509,11 +509,11 @@ describe('Unit: services/url/UrlService', function () {
                         url.should.eql('/podcast/ghostly-kitchen-sink/');
 
                         urlService.urlGenerators.forEach(function (generator) {
-                            if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:false') {
+                            if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:false') {
                                 generator.getUrls().length.should.eql(1);
                             }
 
-                            if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:true') {
+                            if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:true') {
                                 generator.getUrls().length.should.eql(3);
                             }
                         });
@@ -528,11 +528,11 @@ describe('Unit: services/url/UrlService', function () {
                         url.should.eql('/collection/2015/short-and-sweet/');
 
                         urlService.urlGenerators.forEach(function (generator) {
-                            if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:false') {
+                            if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:false') {
                                 generator.getUrls().length.should.eql(2);
                             }
 
-                            if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:true') {
+                            if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:true') {
                                 generator.getUrls().length.should.eql(2);
                             }
                         });
@@ -552,7 +552,7 @@ describe('Unit: services/url/UrlService', function () {
             router1 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'post collection 1';
@@ -562,7 +562,7 @@ describe('Unit: services/url/UrlService', function () {
             router2 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'post collection 2';
@@ -572,7 +572,7 @@ describe('Unit: services/url/UrlService', function () {
             router3 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'authors';
@@ -582,7 +582,7 @@ describe('Unit: services/url/UrlService', function () {
             router4 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'tags';
@@ -592,7 +592,7 @@ describe('Unit: services/url/UrlService', function () {
             router5 = {
                 getFilter: sandbox.stub(),
                 addListener: sandbox.stub(),
-                getType: sandbox.stub(),
+                getResourceType: sandbox.stub(),
                 getPermalinks: sandbox.stub(),
                 toString: function () {
                     return 'static pages';
@@ -600,7 +600,7 @@ describe('Unit: services/url/UrlService', function () {
             };
 
             router1.getFilter.returns('featured:false');
-            router1.getType.returns('posts');
+            router1.getResourceType.returns('posts');
             router1.getPermalinks.returns({
                 getValue: function () {
                     return '/collection/:year/:slug/';
@@ -608,7 +608,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router2.getFilter.returns('featured:true');
-            router2.getType.returns('posts');
+            router2.getResourceType.returns('posts');
             router2.getPermalinks.returns({
                 getValue: function () {
                     return '/podcast/:slug/';
@@ -616,7 +616,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router3.getFilter.returns(false);
-            router3.getType.returns('users');
+            router3.getResourceType.returns('users');
             router3.getPermalinks.returns({
                 getValue: function () {
                     return '/persons/:slug/';
@@ -624,7 +624,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router4.getFilter.returns(false);
-            router4.getType.returns('tags');
+            router4.getResourceType.returns('tags');
             router4.getPermalinks.returns({
                 getValue: function () {
                     return '/category/:slug/';
@@ -632,7 +632,7 @@ describe('Unit: services/url/UrlService', function () {
             });
 
             router5.getFilter.returns(false);
-            router5.getType.returns('pages');
+            router5.getResourceType.returns('pages');
             router5.getPermalinks.returns({
                 getValue: function () {
                     return '/:slug/';
@@ -675,23 +675,23 @@ describe('Unit: services/url/UrlService', function () {
 
         it('getUrl', function () {
             urlService.urlGenerators.forEach(function (generator) {
-                if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:false') {
+                if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:false') {
                     generator.getUrls().length.should.eql(2);
                 }
 
-                if (generator.router.getType() === 'posts' && generator.router.getFilter() === 'featured:true') {
+                if (generator.router.getResourceType() === 'posts' && generator.router.getFilter() === 'featured:true') {
                     generator.getUrls().length.should.eql(2);
                 }
 
-                if (generator.router.getType() === 'pages') {
+                if (generator.router.getResourceType() === 'pages') {
                     generator.getUrls().length.should.eql(1);
                 }
 
-                if (generator.router.getType() === 'tags') {
+                if (generator.router.getResourceType() === 'tags') {
                     generator.getUrls().length.should.eql(5);
                 }
 
-                if (generator.router.getType() === 'users') {
+                if (generator.router.getResourceType() === 'users') {
                     generator.getUrls().length.should.eql(5);
                 }
             });

--- a/core/test/integration/web/site_spec.js
+++ b/core/test/integration/web/site_spec.js
@@ -171,7 +171,7 @@ describe('Integration - Web - Site', function () {
                         should.exist(response.res.locals.safeVersion);
                         should.exist(response.res.locals.relativeUrl);
                         should.exist(response.res.locals.secure);
-                        should.exist(response.res.locals.routerOptions);
+                        should.exist(response.res.routerOptions);
                     });
             });
 

--- a/core/test/unit/apps/amp/router_spec.js
+++ b/core/test/unit/apps/amp/router_spec.js
@@ -60,7 +60,7 @@ describe('Unit - apps/amp/lib/router', function () {
     describe('fn: renderer', function () {
         it('should render default amp page when theme has no amp template', function (done) {
             helpers.renderer.callsFake(function (req, res, data) {
-                res._route.defaultTemplate.should.eql(defaultPath);
+                res.routerOptions.defaultTemplate.should.eql(defaultPath);
                 data.should.eql({post: {title: 'test'}});
                 done();
             });

--- a/core/test/unit/services/routing/CollectionRouter_spec.js
+++ b/core/test/unit/services/routing/CollectionRouter_spec.js
@@ -37,7 +37,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             should.exist(collectionRouter.router);
 
             collectionRouter.getFilter().should.eql('page:false');
-            collectionRouter.getType().should.eql('posts');
+            collectionRouter.getResourceType().should.eql('posts');
             collectionRouter.templates.should.eql([]);
             collectionRouter.getPermalinks().getValue().should.eql('/:slug/');
 
@@ -85,7 +85,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             should.exist(collectionRouter.router);
 
             collectionRouter.getFilter().should.eql('page:false');
-            collectionRouter.getType().should.eql('posts');
+            collectionRouter.getResourceType().should.eql('posts');
             collectionRouter.templates.should.eql([]);
             collectionRouter.getPermalinks().getValue().should.eql('/blog/:year/:slug/');
 
@@ -147,7 +147,8 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             collectionRouter._prepareEntriesContext(req, res, next);
 
             next.calledOnce.should.be.true();
-            res.locals.routerOptions.should.eql({
+            res.routerOptions.should.eql({
+                type: 'collection',
                 filter: 'page:false',
                 permalinks: '/:slug/:options(edit)?/',
                 frontPageTemplate: 'home',
@@ -155,7 +156,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 identifier: collectionRouter.identifier,
                 context: ['index'],
                 name: 'index',
-                type: 'posts',
+                resourceType: 'posts',
                 data: {},
                 order: undefined,
                 limit: undefined
@@ -168,7 +169,8 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             collectionRouter._prepareEntriesContext(req, res, next);
 
             next.calledOnce.should.be.true();
-            res.locals.routerOptions.should.eql({
+            res.routerOptions.should.eql({
+                type: 'collection',
                 filter: 'page:false',
                 permalinks: '/:slug/:options(edit)?/',
                 frontPageTemplate: 'home',
@@ -176,7 +178,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 identifier: collectionRouter.identifier,
                 context: ['magic'],
                 name: 'magic',
-                type: 'posts',
+                resourceType: 'posts',
                 data: {},
                 order: 'published asc',
                 limit: 19

--- a/core/test/unit/services/routing/ParentRouter_spec.js
+++ b/core/test/unit/services/routing/ParentRouter_spec.js
@@ -55,7 +55,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
     describe('fn: _respectDominantRouter', function () {
         it('redirect', function () {
             const parentRouter = new ParentRouter();
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -85,7 +85,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect with query params', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -115,7 +115,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect rss', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -145,7 +145,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('redirect pagination', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -177,7 +177,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
             configUtils.set('url', 'http://localhost:7777/blog/');
 
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -207,7 +207,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('no redirect: different data key', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };
@@ -234,7 +234,7 @@ describe('UNIT - services/routing/ParentRouter', function () {
 
         it('no redirect: no channel defined', function () {
             const parentRouter = new ParentRouter('tag', '/tag/:slug/');
-            parentRouter.getType = sandbox.stub().returns('tags');
+            parentRouter.getResourceType = sandbox.stub().returns('tags');
             parentRouter.permalinks = {
                 getValue: sandbox.stub().returns('/tag/:slug/')
             };

--- a/core/test/unit/services/routing/StaticRoutesRouter_spec.js
+++ b/core/test/unit/services/routing/StaticRoutesRouter_spec.js
@@ -81,13 +81,13 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
             staticRoutesRouter._prepareStaticRouteContext(req, res, next);
             next.called.should.be.true();
-            res._route.should.eql({
+            res.routerOptions.should.eql({
                 type: 'custom',
                 templates: [],
-                defaultTemplate: 'default'
+                defaultTemplate: 'default',
+                context: [],
+                data: {}
             });
-
-            res.locals.routerOptions.should.eql({context: [], data: {}});
             should.not.exist(res.locals.slug);
         });
     });
@@ -189,7 +189,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 next.calledOnce.should.eql(true);
-                res.locals.routerOptions.should.eql({
+                res.routerOptions.should.eql({
+                    type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',
                     name: 'channel',
@@ -198,8 +199,6 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     order: undefined,
                     templates: []
                 });
-
-                res._route.type.should.eql('channel');
             });
 
             it('with data', function () {
@@ -210,7 +209,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 next.calledOnce.should.eql(true);
-                res.locals.routerOptions.should.eql({
+                res.routerOptions.should.eql({
+                    type: 'channel',
                     context: ['nothingcomparestoyou'],
                     name: 'nothingcomparestoyou',
                     filter: undefined,
@@ -219,8 +219,6 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     order: undefined,
                     templates: []
                 });
-
-                res._route.type.should.eql('channel');
             });
 
             it('with filter', function () {
@@ -231,7 +229,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 next.calledOnce.should.eql(true);
-                res.locals.routerOptions.should.eql({
+                res.routerOptions.should.eql({
+                    type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',
                     name: 'channel',
@@ -240,8 +239,6 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     data: {},
                     templates: []
                 });
-
-                res._route.type.should.eql('channel');
             });
 
             it('with order+limit', function () {
@@ -254,7 +251,8 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
 
                 staticRoutesRouter._prepareChannelContext(req, res, next);
                 next.calledOnce.should.eql(true);
-                res.locals.routerOptions.should.eql({
+                res.routerOptions.should.eql({
+                    type: 'channel',
                     context: ['channel'],
                     filter: 'tag:test',
                     name: 'channel',
@@ -263,8 +261,6 @@ describe('UNIT - services/routing/StaticRoutesRouter', function () {
                     data: {},
                     templates: []
                 });
-
-                res._route.type.should.eql('channel');
             });
         });
     });

--- a/core/test/unit/services/routing/TaxonomyRouter_spec.js
+++ b/core/test/unit/services/routing/TaxonomyRouter_spec.js
@@ -67,17 +67,16 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
         taxonomyRouter._prepareContext(req, res, next);
         next.calledOnce.should.eql(true);
 
-        res.locals.routerOptions.should.eql({
+        res.routerOptions.should.eql({
+            type: 'channel',
             name: 'tag',
             permalinks: '/tag/:slug/',
-            type: RESOURCE_CONFIG.QUERY.tag.resource,
+            resourceType: RESOURCE_CONFIG.QUERY.tag.resource,
             data: {tag: _.omit(RESOURCE_CONFIG.QUERY.tag, 'alias')},
             filter: RESOURCE_CONFIG.TAXONOMIES.tag.filter,
             context: ['tag'],
             slugTemplate: true,
             identifier: taxonomyRouter.identifier
         });
-
-        res._route.type.should.eql('channel');
     });
 });

--- a/core/test/unit/services/routing/controllers/channel_spec.js
+++ b/core/test/unit/services/routing/controllers/channel_spec.js
@@ -61,9 +61,7 @@ describe('Unit - services/routing/controllers/channel', function () {
         };
 
         res = {
-            locals: {
-                routerOptions: {}
-            },
+            routerOptions: {},
             render: sinon.spy(),
             redirect: sinon.spy()
         };
@@ -74,7 +72,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     });
 
     it('no params', function (done) {
-        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -101,7 +99,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('pass page param', function (done) {
         req.params.page = 2;
 
-        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -126,10 +124,10 @@ describe('Unit - services/routing/controllers/channel', function () {
     });
 
     it('update hbs engine: router defines limit', function (done) {
-        res.locals.routerOptions.limit = 3;
+        res.routerOptions.limit = 3;
         req.params.page = 2;
 
-        fetchDataStub.withArgs({page: 2, slug: undefined, limit: 3}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: 3}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -157,7 +155,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('page param too big', function (done) {
         req.params.page = 6;
 
-        fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -183,7 +181,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('slug param', function (done) {
         req.params.slug = 'unsafe';
 
-        fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -210,7 +208,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     it('invalid posts per page', function (done) {
         postsPerPage = -1;
 
-        fetchDataStub.withArgs({page: 1, slug: undefined}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -235,7 +233,7 @@ describe('Unit - services/routing/controllers/channel', function () {
     });
 
     it('ensure secure helper get\'s called for data object', function (done) {
-        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 data: {

--- a/core/test/unit/services/routing/controllers/collection_spec.js
+++ b/core/test/unit/services/routing/controllers/collection_spec.js
@@ -65,10 +65,8 @@ describe('Unit - services/routing/controllers/collection', function () {
         };
 
         res = {
-            locals: {
-                routerOptions: {
-                    identifier: 'identifier'
-                }
+            routerOptions: {
+                identifier: 'identifier'
             },
             render: sinon.spy(),
             redirect: sinon.spy()
@@ -80,7 +78,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     });
 
     it('no params', function (done) {
-        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -108,7 +106,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     it('pass page param', function (done) {
         req.params.page = 2;
 
-        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -134,10 +132,10 @@ describe('Unit - services/routing/controllers/collection', function () {
     });
 
     it('update hbs engine: router defines limit', function (done) {
-        res.locals.routerOptions.limit = 3;
+        res.routerOptions.limit = 3;
         req.params.page = 2;
 
-        fetchDataStub.withArgs({page: 2, slug: undefined, limit: 3}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 2, slug: undefined, limit: 3}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -166,7 +164,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     it('page param too big', function (done) {
         req.params.page = 6;
 
-        fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 6, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -193,7 +191,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     it('slug param', function (done) {
         req.params.slug = 'unsafe';
 
-        fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: 'safe', limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -221,7 +219,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     it('invalid posts per page', function (done) {
         postsPerPage = -1;
 
-        fetchDataStub.withArgs({page: 1, slug: undefined}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined}, res.routerOptions)
             .resolves({
                 posts: posts,
                 meta: {
@@ -247,7 +245,7 @@ describe('Unit - services/routing/controllers/collection', function () {
     });
 
     it('ensure secure helper get\'s called for data object', function (done) {
-        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 data: {
@@ -283,7 +281,7 @@ describe('Unit - services/routing/controllers/collection', function () {
             testUtils.DataGenerator.forKnex.createPost({url: '/d/'})
         ];
 
-        res.locals.routerOptions.filter = 'featured:true';
+        res.routerOptions.filter = 'featured:true';
 
         urlService.owns.reset();
         urlService.owns.withArgs('identifier', posts[0].url).returns(false);
@@ -291,7 +289,7 @@ describe('Unit - services/routing/controllers/collection', function () {
         urlService.owns.withArgs('identifier', posts[2].url).returns(false);
         urlService.owns.withArgs('identifier', posts[3].url).returns(false);
 
-        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.locals.routerOptions)
+        fetchDataStub.withArgs({page: 1, slug: undefined, limit: postsPerPage}, res.routerOptions)
             .resolves({
                 posts: posts,
                 data: {

--- a/core/test/unit/services/routing/controllers/entry_spec.js
+++ b/core/test/unit/services/routing/controllers/entry_spec.js
@@ -46,9 +46,7 @@ describe('Unit - services/routing/controllers/entry', function () {
         };
 
         res = {
-            locals: {
-                routerOptions: {}
-            },
+            routerOptions: {},
             render: sinon.spy(),
             redirect: sinon.spy()
         };
@@ -61,7 +59,7 @@ describe('Unit - services/routing/controllers/entry', function () {
     it('resource not found', function (done) {
         req.path = '/does-not-exist/';
 
-        postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+        postLookUpStub.withArgs(req.path, res.routerOptions)
             .resolves(null);
 
         controllers.entry(req, res, function (err) {
@@ -74,7 +72,7 @@ describe('Unit - services/routing/controllers/entry', function () {
         req.path = post.url;
         req.originalUrl = req.path;
 
-        res.locals.routerOptions.type = 'posts';
+        res.routerOptions.resourceType = 'posts';
 
         filters.doFilter.withArgs('prePostsRender', post, res.locals).resolves();
 
@@ -84,7 +82,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             }
         });
 
-        postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+        postLookUpStub.withArgs(req.path, res.routerOptions)
             .resolves({
                 post: post
             });
@@ -101,7 +99,7 @@ describe('Unit - services/routing/controllers/entry', function () {
         it('isUnknownOption: true', function (done) {
             req.path = post.url;
 
-            postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+            postLookUpStub.withArgs(req.path, res.routerOptions)
                 .resolves({
                     isUnknownOption: true,
                     post: post
@@ -116,7 +114,7 @@ describe('Unit - services/routing/controllers/entry', function () {
         it('isEditURL: true', function (done) {
             req.path = post.url;
 
-            postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+            postLookUpStub.withArgs(req.path, res.routerOptions)
                 .resolves({
                     isEditURL: true,
                     post: post
@@ -133,7 +131,7 @@ describe('Unit - services/routing/controllers/entry', function () {
 
         it('type of router !== type of resource', function (done) {
             req.path = post.url;
-            res.locals.routerOptions.type = 'posts';
+            res.routerOptions.resourceType = 'posts';
 
             urlService.getResourceById.withArgs(post.id).returns({
                 config: {
@@ -141,7 +139,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 }
             });
 
-            postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+            postLookUpStub.withArgs(req.path, res.routerOptions)
                 .resolves({
                     post: post
                 });
@@ -157,7 +155,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             req.path = '/2017/07' + post.url;
             req.originalUrl = req.path;
 
-            res.locals.routerOptions.type = 'posts';
+            res.routerOptions.resourceType = 'posts';
 
             urlService.getResourceById.withArgs(post.id).returns({
                 config: {
@@ -165,7 +163,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 }
             });
 
-            postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+            postLookUpStub.withArgs(req.path, res.routerOptions)
                 .resolves({
                     post: post
                 });
@@ -186,7 +184,7 @@ describe('Unit - services/routing/controllers/entry', function () {
             req.path = '/2017/07' + post.url;
             req.originalUrl = req.path + '?query=true';
 
-            res.locals.routerOptions.type = 'posts';
+            res.routerOptions.resourceType = 'posts';
 
             urlService.getResourceById.withArgs(post.id).returns({
                 config: {
@@ -194,7 +192,7 @@ describe('Unit - services/routing/controllers/entry', function () {
                 }
             });
 
-            postLookUpStub.withArgs(req.path, res.locals.routerOptions)
+            postLookUpStub.withArgs(req.path, res.routerOptions)
                 .resolves({
                     post: post
                 });

--- a/core/test/unit/services/routing/controllers/rss_spec.js
+++ b/core/test/unit/services/routing/controllers/rss_spec.js
@@ -34,9 +34,9 @@ describe('Unit - services/routing/controllers/rss', function () {
         };
 
         res = {
+            routerOptions: {},
             locals: {
-                safeVersion: '0.6',
-                routerOptions: {}
+                safeVersion: '0.6'
             }
         };
 

--- a/core/test/unit/services/routing/controllers/static_spec.js
+++ b/core/test/unit/services/routing/controllers/static_spec.js
@@ -62,9 +62,7 @@ describe('Unit - services/routing/controllers/static', function () {
         };
 
         res = {
-            locals: {
-                routerOptions: {}
-            },
+            routerOptions: {},
             render: sinon.spy(),
             redirect: sinon.spy()
         };
@@ -86,7 +84,7 @@ describe('Unit - services/routing/controllers/static', function () {
     });
 
     it('extra data to fetch', function (done) {
-        res.locals.routerOptions.data = {
+        res.routerOptions.data = {
             tag: {
                 resource: 'tags',
                 type: 'read',

--- a/core/test/unit/services/routing/helpers/context_spec.js
+++ b/core/test/unit/services/routing/helpers/context_spec.js
@@ -15,9 +15,8 @@ describe('Contexts', function () {
             body: {}
         };
         res = {
-            locals: {
-                routerOptions: {}
-            }
+            locals: {},
+            routerOptions: {}
         };
         data = {};
     });
@@ -50,7 +49,7 @@ describe('Contexts', function () {
     describe('index context', function () {
         it('should correctly identify index channel', function () {
             res.locals.relativeUrl = '/does/not/matter/';
-            res.locals.routerOptions.context = ['index'];
+            res.routerOptions.context = ['index'];
 
             helpers.context(req, res, data);
 
@@ -61,7 +60,7 @@ describe('Contexts', function () {
 
         it('should correctly identify / as home', function () {
             res.locals.relativeUrl = '/';
-            res.locals.routerOptions.context = ['index'];
+            res.routerOptions.context = ['index'];
 
             // Execute test
             helpers.context(req, res, data);
@@ -75,7 +74,7 @@ describe('Contexts', function () {
 
         it('will not identify / as index without config', function () {
             res.locals.relativeUrl = '/';
-            res.locals.routerOptions.context = [];
+            res.routerOptions.context = [];
 
             // Execute test
             helpers.context(req, res, data);
@@ -88,7 +87,7 @@ describe('Contexts', function () {
 
         it('will not identify /page/2/ as index & paged without page param', function () {
             res.locals.relativeUrl = '/page/2/';
-            res.locals.routerOptions.context = ['index'];
+            res.routerOptions.context = ['index'];
 
             helpers.context(req, res, data);
 
@@ -100,7 +99,7 @@ describe('Contexts', function () {
         it('should identify /page/2/ as index & paged with page param', function () {
             res.locals.relativeUrl = '/page/2/';
             req.params.page = 2;
-            res.locals.routerOptions.context = ['index'];
+            res.routerOptions.context = ['index'];
 
             helpers.context(req, res, data);
 
@@ -114,7 +113,7 @@ describe('Contexts', function () {
     describe('Tag', function () {
         it('should correctly identify tag channel', function () {
             res.locals.relativeUrl = '/tag/getting-started/';
-            res.locals.routerOptions.context = ['tag'];
+            res.routerOptions.context = ['tag'];
 
             helpers.context(req, res, data);
 
@@ -125,7 +124,7 @@ describe('Contexts', function () {
 
         it('will not identify tag channel url without config', function () {
             res.locals.relativeUrl = '/tag/getting-started/';
-            res.locals.routerOptions.context = [];
+            res.routerOptions.context = [];
 
             helpers.context(req, res, data);
 
@@ -135,7 +134,7 @@ describe('Contexts', function () {
 
         it('will not identify /page/2/ as paged without page param', function () {
             res.locals.relativeUrl = '/tag/getting-started/page/2/';
-            res.locals.routerOptions.context = ['tag'];
+            res.routerOptions.context = ['tag'];
 
             helpers.context(req, res, data);
 
@@ -147,7 +146,7 @@ describe('Contexts', function () {
         it('should correctly identify /page/2/ as paged with page param', function () {
             res.locals.relativeUrl = '/tag/getting-started/page/2/';
             req.params.page = 2;
-            res.locals.routerOptions.context = ['tag'];
+            res.routerOptions.context = ['tag'];
 
             helpers.context(req, res, data);
 
@@ -161,7 +160,7 @@ describe('Contexts', function () {
     describe('Author', function () {
         it('should correctly identify author channel', function () {
             res.locals.relativeUrl = '/author/pat/';
-            res.locals.routerOptions.context = ['author'];
+            res.routerOptions.context = ['author'];
 
             helpers.context(req, res, data);
 
@@ -172,7 +171,7 @@ describe('Contexts', function () {
 
         it('will not identify author channel url without config', function () {
             res.locals.relativeUrl = '/author/pat/';
-            res.locals.routerOptions.context = [];
+            res.routerOptions.context = [];
 
             helpers.context(req, res, data);
 
@@ -182,7 +181,7 @@ describe('Contexts', function () {
 
         it('will not identify /page/2/ as paged without page param', function () {
             res.locals.relativeUrl = '/author/pat/page/2/';
-            res.locals.routerOptions.context = ['author'];
+            res.routerOptions.context = ['author'];
 
             helpers.context(req, res, data);
 
@@ -194,7 +193,7 @@ describe('Contexts', function () {
         it('should correctly identify /page/2/ as paged with page param', function () {
             res.locals.relativeUrl = '/author/pat/page/2/';
             req.params.page = 2;
-            res.locals.routerOptions.context = ['author'];
+            res.routerOptions.context = ['author'];
 
             helpers.context(req, res, data);
 
@@ -208,7 +207,7 @@ describe('Contexts', function () {
     describe('Custom', function () {
         it('will use a custom context', function () {
             res.locals.relativeUrl = 'anything';
-            res.locals.routerOptions.context = ['custom-context', 'test'];
+            res.routerOptions.context = ['custom-context', 'test'];
 
             helpers.context(req, res, data);
 
@@ -222,7 +221,7 @@ describe('Contexts', function () {
     describe('Posts & Pages', function () {
         it('ensure correct context', function () {
             res.locals.relativeUrl = '/welcome-to-ghost/';
-            res.locals.routerOptions.context = ['post'];
+            res.routerOptions.context = ['post'];
 
             helpers.context(req, res, data);
 
@@ -235,7 +234,7 @@ describe('Contexts', function () {
     describe('Private', function () {
         it('should correctly identify /private/ as the private route', function () {
             res.locals.relativeUrl = '/private/?r=';
-            delete res.locals.routerOptions;
+            delete res.routerOptions;
 
             helpers.context(req, res, data);
 
@@ -250,7 +249,7 @@ describe('Contexts', function () {
             res.locals.relativeUrl = '/subscribe/';
             sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(true);
 
-            delete res.locals.routerOptions;
+            delete res.routerOptions;
             helpers.context(req, res, data);
 
             should.exist(res.locals.context);
@@ -263,7 +262,7 @@ describe('Contexts', function () {
             sandbox.stub(labs, 'isSet').withArgs('subscribers').returns(false);
             data.post = testUtils.DataGenerator.forKnex.createPost();
 
-            delete res.locals.routerOptions;
+            delete res.routerOptions;
             helpers.context(req, res, data);
 
             should.exist(res.locals.context);
@@ -277,7 +276,7 @@ describe('Contexts', function () {
             res.locals.relativeUrl = '/welcome-to-ghost/amp/';
             data.post = testUtils.DataGenerator.forKnex.createPost();
 
-            delete res.locals.routerOptions;
+            delete res.routerOptions;
             helpers.context(req, res, data);
 
             should.exist(res.locals.context);
@@ -290,7 +289,7 @@ describe('Contexts', function () {
             res.locals.relativeUrl = '/welcome-to-ghost/amp/';
             data.post = testUtils.DataGenerator.forKnex.createPost({page: true});
 
-            delete res.locals.routerOptions;
+            delete res.routerOptions;
             helpers.context(req, res, data);
 
             should.exist(res.locals.context);

--- a/core/test/unit/services/routing/helpers/templates_spec.js
+++ b/core/test/unit/services/routing/helpers/templates_spec.js
@@ -389,7 +389,7 @@ describe('templates', function () {
         beforeEach(function () {
             req = {};
             res = {
-                locals: {}
+                routerOptions: {}
             };
             data = {};
 
@@ -433,7 +433,7 @@ describe('templates', function () {
         });
 
         it('calls pickTemplate for custom routes', function () {
-            res._route = {
+            res.routerOptions = {
                 type: 'custom',
                 templates: 'test',
                 defaultTemplate: 'path/to/local/test.hbs'
@@ -455,7 +455,7 @@ describe('templates', function () {
         });
 
         it('calls pickTemplate for custom routes', function () {
-            res._route = {
+            res.routerOptions = {
                 type: 'custom',
                 templates: 'test',
                 defaultTemplate: 'path/to/local/test.hbs'
@@ -477,7 +477,7 @@ describe('templates', function () {
         });
 
         it('calls getTemplateForEntry for entry routes', function () {
-            res._route = {
+            res.routerOptions = {
                 type: 'entry'
             };
 
@@ -503,11 +503,10 @@ describe('templates', function () {
             req.url = '/';
             req.params = {};
 
-            res._route = {
-                type: 'collection'
+            res.routerOptions = {
+                type: 'collection',
+                testCollection: 'test'
             };
-
-            res.locals.routerOptions = {testCollection: 'test'};
 
             // Call setTemplate
             templates.setTemplate(req, res, data);
@@ -520,18 +519,17 @@ describe('templates', function () {
             stubs.getTemplateForEntries.called.should.be.true();
             stubs.getTemplateForError.called.should.be.false();
 
-            stubs.getTemplateForEntries.calledWith({testCollection: 'test'}).should.be.true();
+            stubs.getTemplateForEntries.calledWith({testCollection: 'test', type: 'collection'}).should.be.true();
         });
 
         it('calls getTemplateForEntries for type channel', function () {
             req.url = '/';
             req.params = {};
 
-            res._route = {
-                type: 'channel'
+            res.routerOptions = {
+                type: 'channel',
+                testChannel: 'test'
             };
-
-            res.locals.routerOptions = {testChannel: 'test'};
 
             // Call setTemplate
             templates.setTemplate(req, res, data);
@@ -544,12 +542,12 @@ describe('templates', function () {
             stubs.getTemplateForEntries.called.should.be.true();
             stubs.getTemplateForError.called.should.be.false();
 
-            stubs.getTemplateForEntries.calledWith({testChannel: 'test'}).should.be.true();
+            stubs.getTemplateForEntries.calledWith({testChannel: 'test', type: 'channel'}).should.be.true();
         });
 
         it('calls getTemplateForError if there is an error', function () {
             // Make the config look like a custom route
-            res._route = {
+            res.routerOptions = {
                 type: 'custom',
                 templateName: 'test',
                 defaultTemplate: 'path/to/local/test.hbs'

--- a/core/test/unit/services/url/UrlGenerator_spec.js
+++ b/core/test/unit/services/url/UrlGenerator_spec.js
@@ -19,7 +19,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         router = {
             getFilter: sandbox.stub(),
             addListener: sandbox.stub(),
-            getType: sandbox.stub(),
+            getResourceType: sandbox.stub(),
             getPermalinks: sandbox.stub()
         };
 
@@ -102,7 +102,7 @@ describe('Unit: services/url/UrlGenerator', function () {
 
     describe('fn: _onInit', function () {
         it('1 resource', function () {
-            router.getType.returns('posts');
+            router.getResourceType.returns('posts');
             resources.getAllByType.withArgs('posts').returns([resource]);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
@@ -113,7 +113,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         });
 
         it('no resource', function () {
-            router.getType.returns('posts');
+            router.getResourceType.returns('posts');
             resources.getAllByType.withArgs('posts').returns([]);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
@@ -126,7 +126,7 @@ describe('Unit: services/url/UrlGenerator', function () {
 
     describe('fn: _onAdded', function () {
         it('type is equal', function () {
-            router.getType.returns('posts');
+            router.getResourceType.returns('posts');
             resources.getByIdAndType.withArgs('posts', 1).returns(resource);
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
@@ -137,7 +137,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         });
 
         it('type is not equal', function () {
-            router.getType.returns('pages');
+            router.getResourceType.returns('pages');
 
             const urlGenerator = new UrlGenerator(router, queue, resources, urls);
             sandbox.stub(urlGenerator, '_try');
@@ -151,7 +151,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         describe('no filter', function () {
             it('resource is not taken', function () {
                 router.getFilter.returns(false);
-                router.getType.returns('posts');
+                router.getResourceType.returns('posts');
                 resource.isReserved.returns(false);
                 sandbox.stub(jsonpath, 'query');
 
@@ -170,7 +170,7 @@ describe('Unit: services/url/UrlGenerator', function () {
 
             it('resource is taken', function () {
                 router.getFilter.returns(false);
-                router.getType.returns('posts');
+                router.getResourceType.returns('posts');
                 resource.isReserved.returns(true);
                 sandbox.stub(jsonpath, 'query');
 
@@ -191,7 +191,7 @@ describe('Unit: services/url/UrlGenerator', function () {
         describe('custom filter', function () {
             it('matches', function () {
                 router.getFilter.returns('featured:true');
-                router.getType.returns('posts');
+                router.getResourceType.returns('posts');
                 resource.isReserved.returns(false);
                 sandbox.stub(jsonpath, 'query').returns([true]);
 
@@ -210,7 +210,7 @@ describe('Unit: services/url/UrlGenerator', function () {
 
             it('no match', function () {
                 router.getFilter.returns('featured:true');
-                router.getType.returns('posts');
+                router.getResourceType.returns('posts');
                 resource.isReserved.returns(false);
                 sandbox.stub(jsonpath, 'query').returns([]);
 
@@ -229,7 +229,7 @@ describe('Unit: services/url/UrlGenerator', function () {
 
             it('resource is taken', function () {
                 router.getFilter.returns('featured:true');
-                router.getType.returns('posts');
+                router.getResourceType.returns('posts');
                 resource.isReserved.returns(true);
                 sandbox.stub(jsonpath, 'query').returns([]);
 


### PR DESCRIPTION
refs #9601

- sort out `res._route` vs. `res.locals.routerOptions`
- it was super hard to maintain two different objects
- ensure `routerOptions` are not available in themes
