### PR TITLE
Rename `StaticRoutesRouter` debug namespace

### DIFF
--- a/core/server/services/routing/StaticRoutesRouter.js
+++ b/core/server/services/routing/StaticRoutesRouter.js
@@ -1,4 +1,4 @@
-const debug = require('ghost-ignition').debug('services:routing:static-pages-router');
+const debug = require('ghost-ignition').debug('services:routing:static-routes-router');
 const common = require('../../lib/common');
 const urlService = require('../../services/url');
 const RSSRouter = require('./RSSRouter');


### PR DESCRIPTION
Maybe a naming error.

StaticRoutesRouter.js

```diff
-const debug = require('ghost-ignition').debug('services:routing:static-pages-router');
+const debug = require('ghost-ignition').debug('services:routing:static-routes-router');
```