### PR TITLE
🐛 Fixed missing location/referrer data with multiple {{subscribe_form}}

### DIFF
--- a/core/server/apps/subscribers/lib/helpers/subscribe_form.js
+++ b/core/server/apps/subscribers/lib/helpers/subscribe_form.js
@@ -26,13 +26,19 @@ function makeHidden(name, extras) {
  *
  * document.querySelector['.location']['value'] = document.querySelector('.location')['value'] || window.location.href;
  */
-subscribeScript =
-    '<script>' +
-    '(function(g,h,o,s,t){' +
-    'h[o](\'.location\')[s]=h[o](\'.location\')[s] || g.location.href;' +
-    'h[o](\'.referrer\')[s]=h[o](\'.referrer\')[s] || h.referrer;' +
-    '})(window,document,\'querySelector\',\'value\');' +
-    '</script>';
+subscribeScript = `
+<script>
+    (function(g,h,o,s,t){
+        var buster = function(b,m) {
+            h[o]('input.'+b).forEach(function (i) {
+                i.value=i.value || m;
+            });
+        };
+        buster('location', g.location.href);
+        buster('referrer', h.referrer);
+    })(window,document,'querySelectorAll','value');
+</script>
+`;
 
 // We use the name subscribe_form to match the helper for consistency:
 module.exports = function subscribe_form(options) { // eslint-disable-line camelcase


### PR DESCRIPTION
no issue
- replaced `querySelector` with `querySelectorAll` and a loop so that all subscribe form inputs have their values updated rather than only the first form on the page
- made the selector more specific so that it only updates `<input>` elements
- switched to a template string so it's easier to read/write