### PR TITLE
api/utils - Updated documentation

### DIFF
--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -193,7 +193,7 @@ utils = {
      * ## Handle Permissions
      * @param {String} docName
      * @param {String} method (browse || read || edit || add || destroy)
-     * * @param {Array} unsafeAttrNames - attribute names (e.g. post.status) that could change the outcome
+     * @param {Array} unsafeAttrNames - attribute names (e.g. post.status) that could change the outcome
      * @returns {Function}
      */
     handlePermissions: function handlePermissions(docName, method, unsafeAttrNames) {


### PR DESCRIPTION
Removed the extra `* ` from the JsDoc of the handlePermissions function

- [ X ] There's a clear use-case for this code change
- [ X ] Commit message has a short title & references relevant issues
- [ X ] The build will pass (run `npm test`)

Simple changes, the documentation wasn't correctly formatted.