### PR TITLE
Slugs starting with `amp` no longer result in a 404 for amp version

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -33,7 +33,7 @@ function _renderer(req, res, next) {
 function getPostData(req, res, next) {
     req.body = req.body || {};
 
-    const urlWithoutSubdirectoryWithoutAmp = res.locals.relativeUrl.match(/(.*?\/)amp/)[1];
+    const urlWithoutSubdirectoryWithoutAmp = res.locals.relativeUrl.match(/(.*?\/)amp\/?$/)[1];
 
     /**
      * @NOTE


### PR DESCRIPTION
closes #9715
- Changed the urlWithoutSubdirectoryWithoutAmp variable in the amp
router to only match /amp or /amp/ at the end of the url string, instead
of just matching any occurrance of /amp in the url string

`grunt validate` passes, and manually testing the case mentioned in #9715 shows the fix. I don't think any existing test functionality needs to be amended.
