### PR TITLE
🐛 Koenig - Support schema-less URLs in embed card

### DIFF
--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -14,7 +14,7 @@ let oembed = {
 
         // build up a list of URL variations to test against because the oembed
         // providers list is not always up to date with scheme or www vs non-www
-        let base = url.replace(/https?:\/\/(?:www\.)?/, '');
+        let base = url.replace(/^\/\/|^https?:\/\/(?:www\.)?/, '');
         let testUrls = [
             `http://${base}`,
             `https://${base}`,

--- a/core/test/unit/api/oembed_spec.js
+++ b/core/test/unit/api/oembed_spec.js
@@ -22,6 +22,23 @@ describe('API: oembed', function () {
                 }).catch(done);
         });
 
+        it('finds match for schema-less urls', function (done) {
+            let requestMock = nock('https://www.reddit.com')
+                .get('/oembed')
+                .query(true)
+                .reply(200, {
+                    html: 'test'
+                });
+
+            OembedAPI.read({url: '//www.reddit.com/r/pics/comments/8qi5oq/breathtaking_picture_of_jupiter_with_its_moon_io/'})
+                .then((results) => {
+                    requestMock.isDone().should.be.true;
+                    should.exist(results);
+                    should.exist(results.html);
+                    done();
+                }).catch(done);
+        });
+
         it('returns error for missing url', function (done) {
             OembedAPI.read({url: ''})
                 .then(() => {


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9724
- adjust the "base url" regex in the oembed endpoint to strip schemaless scheme `//` as well as `https?://`