### PR TITLE
Finalise Koenig HTML output

### DIFF
--- a/core/server/data/migrations/versions/1.23/1-update-koenig-beta-html.js
+++ b/core/server/data/migrations/versions/1.23/1-update-koenig-beta-html.js
@@ -1,0 +1,49 @@
+const _ = require('lodash');
+const common = require('../../../../lib/common');
+const converters = require('../../../../lib/mobiledoc/converters');
+const models = require('../../../../models');
+
+const mobiledocIsCompatibleWithV1 = function mobiledocIsCompatibleWithV1(doc) {
+    if (doc
+        && doc.markups.length === 0
+        && doc.cards.length === 1
+        && doc.cards[0][0].match(/(?:card-)?markdown/)
+        && doc.sections.length === 1
+        && doc.sections[0].length === 2
+        && doc.sections[0][0] === 10
+        && doc.sections[0][1] === 0
+    ) {
+        return true;
+    }
+
+    return false;
+};
+
+module.exports.up = function regenerateKoenigBetaHTML(options) {
+    let postAllColumns = ['id', 'html', 'mobiledoc'];
+
+    let localOptions = _.merge({
+        context: {internal: true}
+    }, options);
+
+    common.logging.info('Migrating Koenig beta post\'s HTML to 2.0 format');
+
+    return models.Post.findAll(_.merge({columns: postAllColumns}, localOptions))
+        .then(function (posts) {
+            return Promise.map(posts.models, function (post) {
+                let mobiledoc = JSON.parse(post.get('mobiledoc') || null);
+
+                if (
+                    post.get('html').match(/^<div class="kg-post">/)
+                    || !mobiledocIsCompatibleWithV1(mobiledoc)
+                ) {
+                    let version = 2;
+                    let html = converters.mobiledocConverter.render(mobiledoc, version);
+
+                    return models.Post.edit({
+                        html
+                    }, _.merge({id: post.id}, localOptions));
+                }
+            }, {concurrency: 100});
+        });
+};

--- a/core/server/lib/mobiledoc/cards/image.js
+++ b/core/server/lib/mobiledoc/cards/image.js
@@ -12,8 +12,8 @@ module.exports = {
 
         let figure = dom.createElement('figure');
         let figureClass = 'kg-image-card';
-        if (payload.imageStyle) {
-            figureClass = `${figureClass} kg-width-${payload.imageStyle}`;
+        if (payload.cardWidth) {
+            figureClass = `${figureClass} kg-width-${payload.cardWidth}`;
         }
         figure.setAttribute('class', figureClass);
 

--- a/core/server/lib/mobiledoc/cards/image.js
+++ b/core/server/lib/mobiledoc/cards/image.js
@@ -11,15 +11,15 @@ module.exports = {
         }
 
         let figure = dom.createElement('figure');
-        figure.setAttribute('class', 'kg-image-card');
+        let figureClass = 'kg-image-card';
+        if (payload.imageStyle) {
+            figureClass = `${figureClass} kg-width-${payload.imageStyle}`;
+        }
+        figure.setAttribute('class', figureClass);
 
         let img = dom.createElement('img');
-        let imgClass = 'kg-image';
-        if (payload.imageStyle) {
-            imgClass = `${imgClass} kg-image-${payload.imageStyle}`;
-        }
         img.setAttribute('src', payload.src);
-        img.setAttribute('class', imgClass);
+        img.setAttribute('class', 'kg-image');
 
         figure.appendChild(img);
 

--- a/core/server/lib/mobiledoc/converters/mobiledoc-converter.js
+++ b/core/server/lib/mobiledoc/converters/mobiledoc-converter.js
@@ -118,13 +118,6 @@ module.exports = {
 
         let html = serializer.serializeChildren(rendered.result);
 
-        // full version of Koenig wraps the content with a specific class to
-        // be targetted with our default stylesheet for vertical rhythm and
-        // card-specific styles
-        if (version === 2) {
-            html = `<div class="kg-post">\n${html}\n</div>`;
-        }
-
         return html;
     }
 };

--- a/core/test/unit/lib/mobiledoc/cards/image_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/image_spec.js
@@ -53,7 +53,7 @@ describe('Image card', function () {
                 },
                 payload: {
                     src: 'https://www.ghost.org/image.png',
-                    imageStyle: ''
+                    cardWidth: ''
                 }
             };
 
@@ -67,7 +67,7 @@ describe('Image card', function () {
                 },
                 payload: {
                     src: 'https://www.ghost.org/image.png',
-                    imageStyle: 'wide'
+                    cardWidth: 'wide'
                 }
             };
 
@@ -81,7 +81,7 @@ describe('Image card', function () {
                 },
                 payload: {
                     src: 'https://www.ghost.org/image.png',
-                    imageStyle: 'full'
+                    cardWidth: 'full'
                 }
             };
 

--- a/core/test/unit/lib/mobiledoc/cards/image_spec.js
+++ b/core/test/unit/lib/mobiledoc/cards/image_spec.js
@@ -71,7 +71,7 @@ describe('Image card', function () {
                 }
             };
 
-            serializer.serialize(card.render(opts)).should.eql('<figure class="kg-image-card"><img src="https://www.ghost.org/image.png" class="kg-image kg-image-wide"></figure>');
+            serializer.serialize(card.render(opts)).should.eql('<figure class="kg-image-card kg-width-wide"><img src="https://www.ghost.org/image.png" class="kg-image"></figure>');
         });
 
         it('full', function () {
@@ -85,7 +85,7 @@ describe('Image card', function () {
                 }
             };
 
-            serializer.serialize(card.render(opts)).should.eql('<figure class="kg-image-card"><img src="https://www.ghost.org/image.png" class="kg-image kg-image-full"></figure>');
+            serializer.serialize(card.render(opts)).should.eql('<figure class="kg-image-card kg-width-full"><img src="https://www.ghost.org/image.png" class="kg-image"></figure>');
         });
     });
 });

--- a/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
+++ b/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
@@ -74,23 +74,7 @@ describe('Mobiledoc converter', function () {
                 ]
             };
 
-            converter.render(mobiledoc, 2).should.eql('<div class="kg-post">\n<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image kg-image-wide"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div><figure class="kg-embed-card"><h2>Embed card</h2></figure>\n</div>');
-        });
-
-        it('wraps output with a .kg-post div', function () {
-            let mobiledoc = {
-                version: '0.3.1',
-                atoms: [],
-                cards: [],
-                markups: [],
-                sections: [
-                    [1, 'p', [
-                        [0, [], 0, 'Test']
-                    ]]
-                ]
-            };
-
-            converter.render(mobiledoc, 2).should.eql('<div class="kg-post">\n<p>Test</p>\n</div>');
+            converter.render(mobiledoc, 2).should.eql('<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image kg-image-wide"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div><figure class="kg-embed-card"><h2>Embed card</h2></figure>');
         });
 
         it('removes final blank paragraph', function () {
@@ -107,7 +91,7 @@ describe('Mobiledoc converter', function () {
                 ]
             };
 
-            converter.render(mobiledoc, 2).should.eql('<div class="kg-post">\n<p>Test</p>\n</div>');
+            converter.render(mobiledoc, 2).should.eql('<p>Test</p>');
         });
 
         it('adds id attributes to headings', function () {

--- a/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
+++ b/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
@@ -74,7 +74,7 @@ describe('Mobiledoc converter', function () {
                 ]
             };
 
-            converter.render(mobiledoc, 2).should.eql('<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image kg-image-wide"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div><figure class="kg-embed-card"><h2>Embed card</h2></figure>');
+            converter.render(mobiledoc, 2).should.eql('<p>One<br>Two</p><h1 id="markdowncard">Markdown card</h1>\n<p>Some markdown</p>\n<p>Three</p><hr><figure class="kg-image-card kg-width-wide"><img src="/content/images/2018/04/NatGeo06.jpg" class="kg-image"><figcaption>Birdies</figcaption></figure><p>Four</p><h2>HTML card</h2>\n<div><p>Some HTML</p></div><figure class="kg-embed-card"><h2>Embed card</h2></figure>');
         });
 
         it('removes final blank paragraph', function () {

--- a/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
+++ b/core/test/unit/lib/mobiledoc/converters/mobiledoc-converter_spec.js
@@ -41,7 +41,7 @@ describe('Mobiledoc converter', function () {
                     }],
                     ['hr', {}],
                     ['image', {
-                        imageStyle: 'wide',
+                        cardWidth: 'wide',
                         src: '/content/images/2018/04/NatGeo06.jpg',
                         caption: 'Birdies'
                     }],

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -1912,7 +1912,7 @@ describe('Unit: models/post', function () {
             ).then((post) => {
                 should.exist(post);
                 post.has('html').should.equal(true);
-                post.get('html').should.equal('<div class="kg-post">\n<h2 id="testing">testing</h2>\n<p>mctesters</p>\n<ul>\n<li>test</li>\n<li>line</li>\n<li>items</li>\n</ul>\n\n</div>');
+                post.get('html').should.equal('<h2 id="testing">testing</h2>\n<p>mctesters</p>\n<ul>\n<li>test</li>\n<li>line</li>\n<li>items</li>\n</ul>\n');
             });
         });
 
@@ -1937,7 +1937,7 @@ describe('Unit: models/post', function () {
             ).then((post) => {
                 should.exist(post);
                 post.has('html').should.equal(true);
-                post.get('html').should.equal('<div class="kg-post">\n<p>Test</p>\n</div>');
+                post.get('html').should.equal('<p>Test</p>');
             });
         });
     });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/9742

We've identified some changes we need to make to the HTML output of the [new Koenig editor](
https://forum.ghost.org/t/koenig-editor-beta-release/1284/102) for future proofing and consistency across cards.

- the `<div class="kg-post">` wrapper around post content has been removed
- for image cards the `.kg-image-wide` and `.kg-image-full` classes have been changed to `.kg-width-wide` and `.kg-width-full` and applied to the `<figure>` element rather than the `<img>` element

Before:
```html
<div class="kg-post">
    <figure class="kg-image-card">
        <img class="kg-image kg-image-wide" src="...">
        <figcaption>example wide image</figcaption>
    </figure>
</div>
```

After:
```html
<figure class="kg-image-card kg-width-wide">
    <img class="kg-image" src="...">
    <figcaption>example wide image</figcaption>
</figure>
```

---

### TODO:
- [x] update Casper for the new changes (https://github.com/TryGhost/Casper/pull/463)
- [x] migration to re-render all beta Koenig posts to update the `html` field

### Optional TODO:
- [x] change image card's `payload.imageStyle` to `payload.width` so all card's can share the same implementation
  - [x] update image card renderer in Ghost
  - [x] update image card in Ghost-Admin
  - [x] migration to update beta Koenig post's `mobiledoc` fields