### PR TITLE
🐛Fixed 1.25 migration for mobiledoc field being null

### DIFF
--- a/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
+++ b/core/server/data/migrations/versions/1.25/1-update-koenig-beta-html.js
@@ -42,7 +42,7 @@ module.exports.up = function regenerateKoenigBetaHTML(options) {
 
                 if (
                     post.get('html').match(/^<div class="kg-post">/)
-                    || !mobiledocIsCompatibleWithV1(mobiledoc)
+                    || (mobiledoc && !mobiledocIsCompatibleWithV1(mobiledoc))
                 ) {
                     // change imagecard.payload.imageStyle to imagecard.payload.cardWidth
                     mobiledoc.cards.forEach((card) => {


### PR DESCRIPTION
refs #9751

- the mobiledoc field can be null
- e.g. if you import a JSON with no markdown/mobiledoc or html field

**The migration script for 1.25 had only the purpose to migrate existing Koenig Beta posts.**
