### PR TITLE
Case insensitive redirects

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -28,6 +28,13 @@ _private.registerRoutes = () => {
              *   - you define /my-blog-post-1/ as from property
              *   - /my-blog-post-1 or /my-blog-post-1/ should work
              */
+
+            let options = '';
+            if (redirect.from.match(/\/.*\/i/)) {
+                redirect.from = redirect.from.slice(1, -2);
+                options = 'i';
+            }
+
             if (redirect.from.match(/\/$/)) {
                 redirect.from = redirect.from.slice(0, -1);
             }
@@ -36,10 +43,8 @@ _private.registerRoutes = () => {
                 redirect.from += '/?$';
             }
 
-            const options = redirect.caseInsensitive ? 'i' : '';
-
             debug('register', redirect.from);
-            customRedirectsRouter.get(new RegExp(redirect.from), function customRedirect(req, res) {
+            customRedirectsRouter.get(new RegExp(redirect.from, options), function (req, res) {
                 const maxAge = redirect.permanent ? config.get('caching:customRedirects:maxAge') : 0,
                     parsedUrl = url.parse(req.originalUrl);
 

--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -23,17 +23,21 @@ _private.registerRoutes = () => {
 
         redirects.forEach((redirect) => {
             /**
-             * always delete trailing slashes, doesn't matter if regex or not
-             * Example:
-             *   - you define /my-blog-post-1/ as from property
-             *   - /my-blog-post-1 or /my-blog-post-1/ should work
+             * Detect case insensitive modifier when regex is enclosed by
+             * / ... /i
              */
-
             let options = '';
             if (redirect.from.match(/\/.*\/i/)) {
                 redirect.from = redirect.from.slice(1, -2);
                 options = 'i';
             }
+
+            /**
+             * always delete trailing slashes, doesn't matter if regex or not
+             * Example:
+             *   - you define /my-blog-post-1/ as from property
+             *   - /my-blog-post-1 or /my-blog-post-1/ should work
+             */
 
             if (redirect.from.match(/\/$/)) {
                 redirect.from = redirect.from.slice(0, -1);

--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -36,6 +36,8 @@ _private.registerRoutes = () => {
                 redirect.from += '/?$';
             }
 
+            const options = redirect.caseInsensitive ? 'i' : '';
+
             debug('register', redirect.from);
             customRedirectsRouter.get(new RegExp(redirect.from), function customRedirect(req, res) {
                 const maxAge = redirect.permanent ? config.get('caching:customRedirects:maxAge') : 0,
@@ -46,7 +48,7 @@ _private.registerRoutes = () => {
                 });
 
                 res.redirect(redirect.permanent ? 301 : 302, url.format({
-                    pathname: parsedUrl.pathname.replace(new RegExp(redirect.from), redirect.to),
+                    pathname: parsedUrl.pathname.replace(new RegExp(redirect.from, options), redirect.to),
                     search: parsedUrl.search
                 }));
             });

--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -27,7 +27,7 @@ _private.registerRoutes = () => {
              * / ... /i
              */
             let options = '';
-            if (redirect.from.match(/\/.*\/i/)) {
+            if (redirect.from.match(/^\/.*\/i$/)) {
                 redirect.from = redirect.from.slice(1, -2);
                 options = 'i';
             }

--- a/core/test/functional/routes/api/redirects_spec.js
+++ b/core/test/functional/routes/api/redirects_spec.js
@@ -73,7 +73,7 @@ describe('Redirects API', function () {
 
                     res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
                     res.headers['content-type'].should.eql('application/json; charset=utf-8');
-                    res.headers['content-length'].should.eql('463');
+                    res.headers['content-length'].should.eql('692');
 
                     done();
                 });

--- a/core/test/functional/routes/api/redirects_spec.js
+++ b/core/test/functional/routes/api/redirects_spec.js
@@ -73,7 +73,7 @@ describe('Redirects API', function () {
 
                     res.headers['content-disposition'].should.eql('Attachment; filename="redirects.json"');
                     res.headers['content-type'].should.eql('application/json; charset=utf-8');
-                    res.headers['content-length'].should.eql('692');
+                    res.headers['content-length'].should.eql('648');
 
                     done();
                 });

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -715,11 +715,63 @@ describe('Frontend Routing', function () {
                     });
             });
 
+            it('with case insensitive', function (done) {
+                request.get('/CaSe-InSeNsItIvE')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('/redirected-insensitive');
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('with case sensitive', function (done) {
+                request.get('/Case-Sensitive')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('/redirected-sensitive');
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('defaults to case sensitive', function (done) {
+                request.get('/Default-Sensitive')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.eql('/redirected-default');
+                        doEnd(done)(err, res);
+                    });
+            });
+
             it('should not redirect', function (done) {
                 request.get('/post/a-nice-blog-post/')
                     .end(function (err, res) {
                         res.statusCode.should.not.eql(302);
                         res.statusCode.should.not.eql(301);
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('should not redirect with case sensitive', function (done) {
+                request.get('/casE-sensitivE')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.not.eql('/redirected-sensitive');
+                        res.statusCode.should.not.eql(302);
+                        doEnd(done)(err, res);
+                    });
+            });
+
+            it('should not redirect with default case sensitive', function (done) {
+                request.get('/defaulT-sensitivE')
+                    .expect(302)
+                    .expect('Cache-Control', testUtils.cacheRules.public)
+                    .end(function (err, res) {
+                        res.headers.location.should.not.eql('/redirected-default');
+                        res.statusCode.should.not.eql(302);
                         doEnd(done)(err, res);
                     });
             });

--- a/core/test/functional/routes/frontend_spec.js
+++ b/core/test/functional/routes/frontend_spec.js
@@ -756,8 +756,6 @@ describe('Frontend Routing', function () {
 
             it('should not redirect with case sensitive', function (done) {
                 request.get('/casE-sensitivE')
-                    .expect(302)
-                    .expect('Cache-Control', testUtils.cacheRules.public)
                     .end(function (err, res) {
                         res.headers.location.should.not.eql('/redirected-sensitive');
                         res.statusCode.should.not.eql(302);
@@ -767,8 +765,6 @@ describe('Frontend Routing', function () {
 
             it('should not redirect with default case sensitive', function (done) {
                 request.get('/defaulT-sensitivE')
-                    .expect(302)
-                    .expect('Cache-Control', testUtils.cacheRules.public)
                     .end(function (err, res) {
                         res.headers.location.should.not.eql('/redirected-default');
                         res.statusCode.should.not.eql(302);

--- a/core/test/utils/fixtures/data/redirects.json
+++ b/core/test/utils/fixtures/data/redirects.json
@@ -31,5 +31,18 @@
     {
         "from": "^/prefix/([a-z0-9\\-]+)?",
         "to": "/blog/$1"
+    },
+    {
+        "from": "^\\/case-insensitive",
+        "caseInsensitive": true,
+        "to": "/redirected-insensitive"
+    },{
+        "from": "^\\/Case-Sensitive",
+        "caseInsensitive": false,
+        "to": "/redirected-sensitive"
+    },
+    {
+        "from": "^\\/Default-Sensitive",
+        "to": "/redirected-default"
     }
 ]

--- a/core/test/utils/fixtures/data/redirects.json
+++ b/core/test/utils/fixtures/data/redirects.json
@@ -33,12 +33,10 @@
         "to": "/blog/$1"
     },
     {
-        "from": "^\\/case-insensitive",
-        "caseInsensitive": true,
+        "from": "/^\\/case-insensitive/i",
         "to": "/redirected-insensitive"
     },{
         "from": "^\\/Case-Sensitive",
-        "caseInsensitive": false,
         "to": "/redirected-sensitive"
     },
     {


### PR DESCRIPTION
While migrating from Blogger to Ghost I ran into the issue that Blogger is case-insensitive in a couple of places:

 * Tag urls
 * Post urls

I've integrated Google Search Console with my current blog and I'm seeing all kinds of people hitting 404's due to them using urls in all-lower-case.

I've updated my Blogger2Ghost.NET application to generate redirects like these

```
  {
    "from": "^\\/search\\/label\\/[Hh][Dd][Mm][Ii]$",
    "to": "/tag/windows-devices",
    "permanent": false
  }
```

But that's not really nice. This Pull request adds the ability to add case-insensitivity to the redirects.json format:

```
    { 
        "from": "^\\/case-insensitive",
        "caseInsensitive": true,
        "to": "/redirected-insensitive"
    },
    {
        "from": "^\\/Case-Sensitive",
        "caseInsensitive": false,
        "to": "/redirected-sensitive"
    },
    {
        "from": "^\\/Default-Sensitive",
        "to": "/redirected-default"
    }
```

The `caseInsensitive` is a boolean option, it's optional and the default is to keep the current behavior. By adding `caseInsensitive=true` the redirect will be initialized with the "i" RegExp option. 

I've considered checking the start of the regex for `(?i:)` as well and settign the flag, which is the way for most regex flavors to set case insensitivity inline. But since that's not part of the JavaScript regexp standard, that may be confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tryghost/ghost/9755)
<!-- Reviewable:end -->
