### PR TITLE
✨ Added advanced filtering to dynamic routing

### DIFF
--- a/core/server/services/url/UrlGenerator.js
+++ b/core/server/services/url/UrlGenerator.js
@@ -1,7 +1,9 @@
 const _ = require('lodash'),
     nql = require('@nexes/nql'),
     debug = require('ghost-ignition').debug('services:url:generator'),
-    localUtils = require('./utils');
+    localUtils = require('./utils'),
+
+    aliases = {author: 'authors.slug', tags: 'tags.slug', tag: 'tags.slug', authors: 'authors.slug'};
 
 class UrlGenerator {
     constructor(router, queue, resources, urls, position) {
@@ -16,7 +18,7 @@ class UrlGenerator {
         // CASE: routers can define custom filters, but not required.
         if (this.router.getFilter()) {
             this.filter = this.router.getFilter();
-            this.nql = nql(this.filter);
+            this.nql = nql(this.filter, {aliases});
             debug('filter', this.filter);
         }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cli": "^1.7.0"
   },
   "dependencies": {
-    "@nexes/nql": "0.0.1",
+    "@nexes/nql": "0.1.0",
     "amperize": "0.3.7",
     "analytics-node": "2.4.1",
     "archiver": "1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,22 +2,22 @@
 # yarn lockfile v1
 
 
-"@nexes/mongo-knex@0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.0.0.tgz#7a44a7263d8830c8416b90ba3c963c2c722e7b72"
+"@nexes/mongo-knex@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@nexes/mongo-knex/-/mongo-knex-0.0.1.tgz#141c8ca380e95c1460fe2abcd777d7fd2bb14e8f"
   dependencies:
     lodash "^4.17.10"
 
-"@nexes/nql-lang@0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@nexes/nql-lang/-/nql-lang-0.0.0.tgz#eb0fb807aea8aa64d3d0b454f3d1167af394f39a"
-
-"@nexes/nql@0.0.1":
+"@nexes/nql-lang@0.0.1":
   version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@nexes/nql/-/nql-0.0.1.tgz#e8f5e5352badeffd67e371f22bccd41fa0c20c24"
+  resolved "https://registry.yarnpkg.com/@nexes/nql-lang/-/nql-lang-0.0.1.tgz#a13c023873f9bc11b9e4e284449c6cfbeccc8011"
+
+"@nexes/nql@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@nexes/nql/-/nql-0.1.0.tgz#b63614d5874bebb387b58d3f1b9fb9602115cf62"
   dependencies:
-    "@nexes/mongo-knex" "0.0.0"
-    "@nexes/nql-lang" "0.0.0"
+    "@nexes/mongo-knex" "0.0.1"
+    "@nexes/nql-lang" "0.0.1"
     mingo "2.2.2"
 
 "@segment/loosely-validate-event@^1.1.2":


### PR DESCRIPTION
@kirrg001 feel free to delete this and re-do it, or update any way you like. I just wanted to do a basic upgrade and test some functionality to show that it works now!

I'm not sure if there's anywhere I could add tests for the new behaviour.

This PR adds comprehensive filtering support to dynamic routing. Some advanced logical combos which don't work in GQL's knexify / or NQLs mongo-knex when filtering via SQL DO work with mingo when filtering JSON, e.g. `tag:a+tag:-b` appears to work perfectly!

NQL does _not_ support any sort of count just yet though.

I think these are very advanced cases, and we can solve these discrepancies later, whilst still shipping code to support a very large range of use cases in the dynamic routing beta.

refs #9601

- Upgraded NQL to 0.1.0
- The new version of NQL supports aliases
- This allows us to support advanced filtering like tag:[a,b]
- In dynamic routing, we use mingo via NQL which has a slightly different feature set to GQL in the API:
   - AND NOT, OR and other advanced logic combos DO work on joined tables
   - Counts are not yet supported

