### PR TITLE
Disallow indexing of preview urls

### DIFF
--- a/core/server/helpers/ghost_head.js
+++ b/core/server/helpers/ghost_head.js
@@ -87,7 +87,7 @@ function getAjaxHelper(clientId, clientSecret) {
  *  }
  *
  * `blog`, `labs` and `config` are the templateOptions, search for `hbs.updateTemplateOptions` in the code base.
- *  Also see how the root object get's created, https://github.com/wycats/handlebars.js/blob/v4.0.6/lib/handlebars/runtime.js#L259
+ *  Also see how the root object gets created, https://github.com/wycats/handlebars.js/blob/v4.0.6/lib/handlebars/runtime.js#L259
  */
 // We use the name ghost_head to match the helper for consistency:
 module.exports = function ghost_head(options) { // eslint-disable-line camelcase
@@ -135,6 +135,11 @@ module.exports = function ghost_head(options) { // eslint-disable-line camelcase
                 head.push('<link rel="canonical" href="' +
                     escapeExpression(metaData.canonicalUrl) + '" />');
                 head.push('<meta name="referrer" content="' + referrerPolicy + '" />');
+
+                // don't allow indexing of preview URLs!
+                if (_.includes(context, 'preview')) {
+                    head.push(writeMetaTag('robots', 'noindex,nofollow', 'name'));
+                }
 
                 // show amp link in post when 1. we are not on the amp page and 2. amp is enabled
                 if (_.includes(context, 'post') && !_.includes(context, 'amp') && settingsCache.get('amp')) {

--- a/core/server/public/robots.txt
+++ b/core/server/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Sitemap: {{blog-url}}/sitemap.xml
 Disallow: /ghost/
+Disallow: /p/

--- a/core/server/services/routing/helpers/context.js
+++ b/core/server/services/routing/helpers/context.js
@@ -18,7 +18,8 @@ const labs = require('../../labs'),
     subscribePattern = new RegExp('^\\/subscribe\\/'),
     // routeKeywords.amp: 'amp'
     ampPattern = new RegExp('\\/amp\\/$'),
-    homePattern = new RegExp('^\\/$');
+    homePattern = new RegExp('^\\/$'),
+    previewPattern = new RegExp('^\\/p\\/');
 
 function setResponseContext(req, res, data) {
     var pageParam = req.params && req.params.page !== undefined ? parseInt(req.params.page, 10) : 1;
@@ -44,6 +45,10 @@ function setResponseContext(req, res, data) {
     // Add context 'amp' to either post or page, if we have an `*/amp` route
     if (ampPattern.test(res.locals.relativeUrl) && data.post) {
         res.locals.context.push('amp');
+    }
+
+    if (previewPattern.test(res.locals.relativeUrl)) {
+        res.locals.context.push('preview');
     }
 
     // Each page can only have at most one of these

--- a/core/test/integration/helpers/ghost_head_spec.js
+++ b/core/test/integration/helpers/ghost_head_spec.js
@@ -1218,6 +1218,32 @@ describe('{{ghost_head}} helper', function () {
             }).catch(done);
         });
 
+        it('disallows indexing for preview pages', function (done) {
+            helpers.ghost_head(testUtils.createHbsResponse({
+                locals: {
+                    context: ['preview', 'post']
+                }
+            })).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.match(/<meta name="robots" content="noindex,nofollow" \/>/);
+
+                done();
+            }).catch(done);
+        });
+
+        it('implicit indexing settings for non-preview pages', function (done) {
+            helpers.ghost_head(testUtils.createHbsResponse({
+                locals: {
+                    context: ['featured', 'paged', 'index', 'post', 'amp', 'home', 'unicorn']
+                }
+            })).then(function (rendered) {
+                should.exist(rendered);
+                rendered.string.should.not.match(/<meta name="robots" content="noindex,nofollow" \/>/);
+
+                done();
+            }).catch(done);
+        });
+
         it('outputs structured data but not schema for custom collection', function (done) {
             helpers.ghost_head(testUtils.createHbsResponse({
                 locals: {


### PR DESCRIPTION
closes #9749

 - disallow indexing of /p/ in robots.txt
 - add meta robots tag to preview pages
   - robots.txt wont' be applied for blogs not mounted to the root (i.e. https://example.com/blog/)

I went ahead and disabled travis for now since I had a couple of questions 😄 