### PR TITLE
Removed change frequency and priority from sitemap

### DIFF
--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -3,8 +3,7 @@ const _ = require('lodash'),
     moment = require('moment'),
     path = require('path'),
     urlService = require('../../../services/url'),
-    localUtils = require('./utils'),
-    CHANGE_FREQ = 'weekly';
+    localUtils = require('./utils');
 
 // Sitemap specific xml namespace declarations that should not change
 const XMLNS_DECLS = {
@@ -65,10 +64,6 @@ class BaseSiteMapGenerator {
         this.lastModified = Date.now();
     }
 
-    getPriorityForDatum() {
-        return 1.0;
-    }
-
     getLastModifiedForDatum(datum) {
         return datum.updated_at || datum.published_at || datum.created_at;
     }
@@ -82,15 +77,12 @@ class BaseSiteMapGenerator {
     }
 
     createUrlNodeFromDatum(url, datum) {
-        const priority = this.getPriorityForDatum(datum);
         let node, imgNode;
 
         node = {
             url: [
                 {loc: url},
-                {lastmod: moment(this.getLastModifiedForDatum(datum)).toISOString()},
-                {changefreq: CHANGE_FREQ},
-                {priority: priority}
+                {lastmod: moment(this.getLastModifiedForDatum(datum)).toISOString()}
             ]
         };
 

--- a/core/server/data/xml/sitemap/page-generator.js
+++ b/core/server/data/xml/sitemap/page-generator.js
@@ -9,14 +9,6 @@ class PageMapGenerator extends BaseMapGenerator {
 
         _.extend(this, opts);
     }
-
-    /**
-     * @TODO:
-     * We could influence this with priority or meta information
-     */
-    getPriorityForDatum(page) {
-        return page && page.staticRoute ? 1.0 : 0.8;
-    }
 }
 
 module.exports = PageMapGenerator;

--- a/core/server/data/xml/sitemap/post-generator.js
+++ b/core/server/data/xml/sitemap/post-generator.js
@@ -9,11 +9,6 @@ class PostMapGenerator extends BaseMapGenerator {
 
         _.extend(this, opts);
     }
-
-    getPriorityForDatum(post) {
-        // give a slightly higher priority to featured posts
-        return post.featured ? 0.9 : 0.8;
-    }
 }
 
 module.exports = PostMapGenerator;

--- a/core/server/data/xml/sitemap/tag-generator.js
+++ b/core/server/data/xml/sitemap/tag-generator.js
@@ -8,14 +8,6 @@ class TagsMapGenerator extends BaseMapGenerator {
         this.name = 'tags';
         _.extend(this, opts);
     }
-
-    /**
-     * @TODO:
-     * We could influence this with priority or meta information
-     */
-    getPriorityForDatum() {
-        return 0.6;
-    }
 }
 
 module.exports = TagsMapGenerator;

--- a/core/server/data/xml/sitemap/user-generator.js
+++ b/core/server/data/xml/sitemap/user-generator.js
@@ -10,14 +10,6 @@ class UserMapGenerator extends BaseMapGenerator {
         _.extend(this, opts);
     }
 
-    /**
-     * @TODO:
-     * We could influence this with priority or meta information
-     */
-    getPriorityForDatum() {
-        return 0.6;
-    }
-
     validateImageUrl(imageUrl) {
         return imageUrl && validator.isURL(imageUrl, {protocols: ['http', 'https'], require_protocol: true});
     }

--- a/core/server/public/sitemap.xsl
+++ b/core/server/public/sitemap.xsl
@@ -100,9 +100,7 @@
                             <thead>
                                 <tr>
                                     <th width="70%">URL (<xsl:value-of select="count(sitemap:urlset/sitemap:url)"/> total)</th>
-                                    <th title="Priority" width="5%">Prio</th>
-                                    <th width="5%">Images</th>
-                                    <th title="Change Frequency" width="5%">Ch. Freq.</th>
+                                    <th width="15%">Images</th>
                                     <th title="Last Modification Time" width="15%">Last Modified</th>
                                 </tr>
                             </thead>
@@ -120,13 +118,7 @@
                                             </a>
                                         </td>
                                         <td>
-                                            <xsl:value-of select="concat(sitemap:priority*100,'%')"/>
-                                        </td>
-                                        <td>
                                             <xsl:value-of select="count(image:image)"/>
-                                        </td>
-                                        <td>
-                                            <xsl:value-of select="concat(translate(substring(sitemap:changefreq, 1, 1),concat($lower, $upper),concat($upper, $lower)),substring(sitemap:changefreq, 2))"/>
                                         </td>
                                         <td>
                                             <xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)))"/>

--- a/core/test/unit/data/xml/sitemap/generator_spec.js
+++ b/core/test/unit/data/xml/sitemap/generator_spec.js
@@ -21,9 +21,9 @@ should.Assertion.add('ValidUrlNode', function (options) {
     urlNode.url.should.be.an.Array();
 
     if (options.withImage) {
-        urlNode.url.should.have.lengthOf(5);
+        urlNode.url.should.have.lengthOf(3);
     } else {
-        urlNode.url.should.have.lengthOf(4);
+        urlNode.url.should.have.lengthOf(2);
     }
 
     /**
@@ -31,8 +31,6 @@ should.Assertion.add('ValidUrlNode', function (options) {
      * { url:
      *   [ { loc: 'http://127.0.0.1:2369/author/' },
      *     { lastmod: '2014-12-22T11:54:00.100Z' },
-     *     { changefreq: 'weekly' },
-     *     { priority: 0.6 },
      *     { 'image:image': [
      *       { 'image:loc': 'post-100.jpg' },
      *       { 'image:caption': 'post-100.jpg' }
@@ -42,9 +40,9 @@ should.Assertion.add('ValidUrlNode', function (options) {
     flatNode = _.extend.apply(_, urlNode.url);
 
     if (options.withImage) {
-        flatNode.should.be.an.Object().with.keys('loc', 'lastmod', 'changefreq', 'priority', 'image:image');
+        flatNode.should.be.an.Object().with.keys('loc', 'lastmod', 'image:image');
     } else {
-        flatNode.should.be.an.Object().with.keys('loc', 'lastmod', 'changefreq', 'priority');
+        flatNode.should.be.an.Object().with.keys('loc', 'lastmod');
     }
 });
 
@@ -82,20 +80,6 @@ describe('Generators', function () {
     describe('PostGenerator', function () {
         beforeEach(function () {
             generator = new PostGenerator();
-        });
-
-        describe('fn: getPriorityForDatum', function () {
-            it('uses 0.9 priority for featured posts', function () {
-                generator.getPriorityForDatum({
-                    featured: true
-                }).should.equal(0.9);
-            });
-
-            it('uses 0.8 priority for all other (non-featured) posts', function () {
-                generator.getPriorityForDatum({
-                    featured: false
-                }).should.equal(0.8);
-            });
         });
 
         describe('fn: createNodeFromDatum', function () {
@@ -221,41 +205,17 @@ describe('Generators', function () {
                 generator.siteMapContent.match(/<loc>/g).length.should.eql(3);
             });
         });
-
-        describe('fn: getPriorityForDatum', function () {
-            it('uses 1 priority for static routes', function () {
-                generator.getPriorityForDatum({
-                    staticRoute: true
-                }).should.equal(1);
-            });
-
-            it('uses 0.8 priority for static pages or collection indexes', function () {
-                generator.getPriorityForDatum({}).should.equal(0.8);
-            });
-        });
     });
 
     describe('TagGenerator', function () {
         beforeEach(function () {
             generator = new TagGenerator();
         });
-
-        describe('fn: getPriorityForDatum', function () {
-            it('uses 0.6 priority for all tags', function () {
-                generator.getPriorityForDatum({}).should.equal(0.6);
-            });
-        });
     });
 
     describe('UserGenerator', function () {
         beforeEach(function () {
             generator = new UserGenerator();
-        });
-
-        describe('fn: getPriorityForDatum', function () {
-            it('uses 0.6 priority for author links', function () {
-                generator.getPriorityForDatum({}).should.equal(0.6);
-            });
         });
 
         describe('fn: validateImageUrl', function () {


### PR DESCRIPTION
Removed change freq and priority from sitemap and tests

closes #9765
Google says that change frequency and priority are not important when search engines crawl through pages. Therefore, these two properties are unimportant and removed from Ghost. [Reference](https://www.seroundtable.com/google-priority-change-frequency-xml-sitemap-20273.html) 
