### PR TITLE
🐛 Dynamic Routing Beta: Disallow using `author` resource and `author` data key name

### DIFF
--- a/core/server/services/routing/TaxonomyRouter.js
+++ b/core/server/services/routing/TaxonomyRouter.js
@@ -54,7 +54,7 @@ class TaxonomyRouter extends ParentRouter {
             type: 'channel',
             name: this.taxonomyKey,
             permalinks: this.permalinks.getValue(),
-            data: {[this.taxonomyKey]: _.omit(RESOURCE_CONFIG.QUERY[this.taxonomyKey], 'alias')},
+            data: {[this.taxonomyKey]: _.omit(RESOURCE_CONFIG.QUERY[this.taxonomyKey], ['alias', 'internal'])},
             filter: RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].filter,
             resourceType: this.getResourceType(),
             context: [this.taxonomyKey],

--- a/core/server/services/routing/assets/resource-config.js
+++ b/core/server/services/routing/assets/resource-config.js
@@ -10,6 +10,16 @@ module.exports.QUERY = {
         }
     },
     author: {
+        internal: true,
+        alias: 'users',
+        type: 'read',
+        resource: 'users',
+        options: {
+            slug: '%s',
+            visibility: 'public'
+        }
+    },
+    user: {
         alias: 'users',
         type: 'read',
         resource: 'users',

--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -90,7 +90,20 @@ _private.validateData = function validateData(object) {
         };
 
         _.each(object.data, (value, key) => {
-            // CASE: short form e.g. data: tag.recipes
+            if (['resource', 'type', 'limit', 'order', 'include', 'filter', 'status', 'visibility', 'slug', 'redirect'].indexOf(key) !== -1) {
+                throw new common.errors.ValidationError({
+                    message: 'Please wrap the data definition into a custom name.',
+                    help: 'Example:\n data:\n  my-tag:\n    resource: tags\n    ...\n'
+                });
+            }
+
+            if (key === 'author') {
+                throw new common.errors.ValidationError({
+                    message: 'Please choose a different name. We recommend not using author.'
+                });
+            }
+
+            // CASE: short form used with custom names, resolve to longform and return
             if (typeof object.data[key] === 'string') {
                 const longForm = shortToLongForm(object.data[key], {resourceKey: key});
                 data.query = _.merge(data.query, longForm.query);

--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -48,6 +48,15 @@ _private.validateData = function validateData(object) {
 
         let [resourceKey, slug] = shortForm.split('.');
 
+        // @NOTE: `data: author.foo` is not allowed currently, because this will make {{author}} available in the theme, which is deprecated (single author usage)
+        if (!RESOURCE_CONFIG.QUERY[resourceKey] ||
+            (RESOURCE_CONFIG.QUERY[resourceKey].hasOwnProperty('internal') && RESOURCE_CONFIG.QUERY[resourceKey].internal === true)) {
+            throw new common.errors.ValidationError({
+                message: `Resource key not supported. ${resourceKey}`,
+                help: 'Please use: tag, user, post or page.'
+            });
+        }
+
         longForm.query[options.resourceKey || resourceKey] = {};
         longForm.query[options.resourceKey || resourceKey] = _.omit(_.cloneDeep(RESOURCE_CONFIG.QUERY[resourceKey]), 'alias');
 

--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -90,6 +90,7 @@ _private.validateData = function validateData(object) {
         };
 
         _.each(object.data, (value, key) => {
+            // CASE: a name is required to define the data longform
             if (['resource', 'type', 'limit', 'order', 'include', 'filter', 'status', 'visibility', 'slug', 'redirect'].indexOf(key) !== -1) {
                 throw new common.errors.ValidationError({
                     message: 'Please wrap the data definition into a custom name.',
@@ -97,6 +98,7 @@ _private.validateData = function validateData(object) {
                 });
             }
 
+            // @NOTE: We disallow author, because {{author}} is deprecated.
             if (key === 'author') {
                 throw new common.errors.ValidationError({
                     message: 'Please choose a different name. We recommend not using author.'

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -326,6 +326,9 @@ describe('UNIT: services/settings/validate', function () {
                     '/music/': {
                         data: 'tag.music'
                     },
+                    '/ghost/': {
+                        data: 'user.ghost'
+                    },
                     '/sleep/': {
                         data: {
                             bed: 'tag.bed',
@@ -370,6 +373,24 @@ describe('UNIT: services/settings/validate', function () {
                             },
                             router: {
                                 tags: [{redirect: true, slug: 'food'}]
+                            }
+                        },
+                        templates: []
+                    },
+                    '/ghost/': {
+                        data: {
+                            query: {
+                                user: {
+                                    resource: 'users',
+                                    type: 'read',
+                                    options: {
+                                        slug: 'ghost',
+                                        visibility: 'public'
+                                    }
+                                }
+                            },
+                            router: {
+                                users: [{redirect: true, slug: 'ghost'}]
                             }
                         },
                         templates: []
@@ -609,7 +630,7 @@ describe('UNIT: services/settings/validate', function () {
             });
         });
 
-        it('errors', function () {
+        it('errors: data shortform incorrect', function () {
             try {
                 validate({
                     collections: {
@@ -619,7 +640,16 @@ describe('UNIT: services/settings/validate', function () {
                         }
                     }
                 });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
 
+            throw new Error('should fail');
+        });
+
+        it('errors: data longform resource is missing', function () {
+            try {
                 validate({
                     collections: {
                         '/magic/': {
@@ -630,7 +660,16 @@ describe('UNIT: services/settings/validate', function () {
                         }
                     }
                 });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
 
+            throw new Error('should fail');
+        });
+
+        it('errors: data longform type is missing', function () {
+            try {
                 validate({
                     collections: {
                         '/magic/': {
@@ -638,6 +677,24 @@ describe('UNIT: services/settings/validate', function () {
                             data: {
                                 resource: 'subscribers'
                             }
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('errors: data shortform author is not allowed', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}/',
+                            data: 'author.food'
                         }
                     }
                 });

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -705,5 +705,47 @@ describe('UNIT: services/settings/validate', function () {
 
             throw new Error('should fail');
         });
+
+        it('errors: data longform name is author', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                author: {
+                                    resource: 'users'
+                                }
+                            }
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('errors: data longform does not use a custom name at all', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                resource: 'users'
+                            }
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
     });
 });


### PR DESCRIPTION
refs #9601

- otherwise you get access to {{author}} in the theme, which is deprecated
- we define both "user" and "author" alias for now, because taxonomies use the author alias to create it's data query object
- i don't want to refactor this now and break something
- we only disallow `data: author.foo` in the yaml validator (external usage)
- internal usage is allowed
- use `data: user.foo` by default
- also: we have disallowed using author as custom data longform key