### PR TITLE
🐛 Koenig - Fixed Vimeo, Hulu, and Facebook Post embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "netjet": "1.3.0",
     "nodemailer": "0.7.1",
     "oauth2orize": "1.11.0",
-    "oembed-parser": "1.1.1",
+    "oembed-parser": "https://github.com/kevinansfield/oembed-parser.git#ghost",
     "passport": "0.4.0",
     "passport-http-bearer": "1.0.1",
     "passport-oauth2-client-password": "0.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,9 +4311,9 @@ object.pick@^1.2.0, object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-oembed-parser@1.1.1:
+"oembed-parser@https://github.com/kevinansfield/oembed-parser.git#ghost":
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/oembed-parser/-/oembed-parser-1.1.1.tgz#6c7e8fb87faefbf99a9408f87325151e274aa80a"
+  resolved "https://github.com/kevinansfield/oembed-parser.git#448496419130fa4c6c40c2471b6403bc6025f36a"
   dependencies:
     bellajs "^7.2.2"
     node-fetch "^2.1.2"


### PR DESCRIPTION
no issue
- bumped `oembed-parser` dependency to a forked version
  - contains fix for oembed.com providers that include `{format}` in the `url`
  - contains updated `providers.json` file including the `Facebook (Post)` provider (thanks @lunaticmonk)