### PR TITLE
Change minimum password length from 10 to 8

### DIFF
--- a/core/server/data/validation/index.js
+++ b/core/server/data/validation/index.js
@@ -111,8 +111,8 @@ validatePassword = function validatePassword(password, email, blogTitle) {
     blogTitle = blogTitle ? blogTitle : settingsCache.get('title');
     blogUrl = blogUrl.replace(/^http(s?):\/\//, '');
 
-    // password must be longer than 10 characters
-    if (!validator.isLength(password, 10)) {
+    // password must be longer than 8 characters
+    if (!validator.isLength(password, 8)) {
         validationResult.isValid = false;
         validationResult.message = common.i18n.t('errors.models.user.passwordDoesNotComplyLength', {minLength: 10});
 


### PR DESCRIPTION
The minimum password length of 10 is a lot too much compared to today's web standards (which is 8), this PR is more a proposition than a real improvement.
