### PR TITLE
🐛 Added logic to avoid updating the `updated_at` field when migrating

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -283,7 +283,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     onUpdating: function onUpdating(newObj, attr, options) {
         if (schema.tables[this.tableName].hasOwnProperty('updated_by')) {
-            if (!options.importing) {
+            if (!options.importing && !options.migrating) {
                 this.set('updated_by', this.contextUser(options));
             }
         }
@@ -304,7 +304,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         // CASE: do not allow setting only the `updated_at` field, exception: importing
         if (schema.tables[this.tableName].hasOwnProperty('updated_at') && !options.importing) {
-            if (newObj.hasChanged() && Object.keys(newObj.changed).length === 1 && newObj.changed.updated_at) {
+            if (options.migrating) {
+                newObj.set('updated_at', newObj.previous('updated_at'));
+            } else if (newObj.hasChanged() && Object.keys(newObj.changed).length === 1 && newObj.changed.updated_at) {
                 newObj.set('updated_at', newObj.previous('updated_at'));
             }
         }


### PR DESCRIPTION
no issue

- we have to explicitly reset the updated_at field, because Bookshelf auto-updates this field on each update
- detect and respect `options.migrating`

- [x] ensure `updated_at` is set when updating a post in the client
- [x] ensure `updated_by` is set when updating a post in the client
- [x] ensure `updated_at` doesn't get updated when migrating
- [x] ensure `updated_by` doesn't get updated when migrating