### PR TITLE
Optimised how we execute server start/stop announcement

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -1,6 +1,8 @@
 // ## Server Loader
 // Passes options through the boot process to get a server instance back
-var server = require('./server');
+const server = require('./server');
+const common = require('./server/lib/common');
+const GhostServer = require('./server/ghost-server');
 
 // Set the default environment to be `development`
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
@@ -8,7 +10,17 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 function makeGhost(options) {
     options = options || {};
 
-    return server(options);
+    return server(options)
+        .catch((err) => {
+            if (!common.errors.utils.isIgnitionError(err)) {
+                err = new common.errors.GhostError({message: err.message, err: err});
+            }
+
+            return GhostServer.announceServerStopped(err)
+                .finally(() => {
+                    throw err;
+                });
+        });
 }
 
 module.exports = makeGhost;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 
 var startTime = Date.now(),
     debug = require('ghost-ignition').debug('boot:index'),
-    ghost, express, common, urlService, parentApp, config, GhostServer;
+    ghost, express, common, urlService, parentApp;
 
 debug('First requires...');
 
@@ -12,8 +12,6 @@ ghost = require('./core');
 debug('Required ghost');
 
 express = require('express');
-GhostServer = require('./core/server/ghost-server');
-config = require('./core/server/config');
 common = require('./core/server/lib/common');
 urlService = require('./core/server/services/url');
 parentApp = express();
@@ -28,21 +26,10 @@ ghost().then(function (ghostServer) {
     return ghostServer.start(parentApp)
         .then(function afterStart() {
             common.logging.info('Ghost boot', (Date.now() - startTime) / 1000 + 's');
-
-            if (!config.get('maintenance:enabled')) {
-                return GhostServer.announceServerStart();
-            }
         });
 }).catch(function (err) {
-    if (!common.errors.utils.isIgnitionError(err)) {
-        err = new common.errors.GhostError({message: err.message, err: err});
-    }
-
-    return GhostServer.announceServerStopped(err)
-        .finally(() => {
-            common.logging.error(err);
-            setTimeout(() => {
-                process.exit(-1);
-            }, 100);
-        });
+    common.logging.error(err);
+    setTimeout(() => {
+        process.exit(-1);
+    }, 100);
 });


### PR DESCRIPTION
closes #9802

- we have to trigger both functions within Ghost core, otherwise people who are using Ghost as NPM module have to call these functions
- this is internal logic
- plus: this logic is also conditional, because of our internal maintenance flag
- make it backwards compatible in case you call announceServerStart or announceServerStopped twice

- [x] test with NPM
- [x] test with CLI
