### PR TITLE
Updates to XML RPC service

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -28,9 +28,8 @@ To automatically populate your profile picture, Ghost pings [Gravatar](http://gr
 
 ### RPC Pings
 
-When you publish a new post, Ghost sends out an RPC ping to let third party services know that new content is available on your blog. This enables search engines and other services to discover and index content on your blog more quickly. At present Ghost sends an RPC ping to the following services when you publish a new post:
+When you publish a new post, Ghost sends out an RPC ping to let third party services know that new content is available on your blog. This enables search engines and other services to discover and index content on your blog more quickly. At present Ghost sends an RPC ping to the following service when you publish a new post:
 
-- http://blogsearch.google.com
 - http://rpc.pingomatic.com
 
 RPC pings only happen when Ghost is running in the `production` environment.

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -42,7 +42,7 @@ function ping(post) {
     // Build XML object.
     pingXML = xml({
         methodCall: [{
-            methodName: 'weblogUpdate.ping'
+            methodName: 'weblogUpdates.ping'
         }, {
             params: [{
                 param: [{

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -67,7 +67,14 @@ function ping(post) {
             timeout: 2 * 1000
         };
 
+        const goodResponse = /<member><name>flerror<\/name><value><boolean>0<\/boolean><\/value><\/member>/;
+
         request(pingHost.url, options)
+            .then(function (res) {
+                if (!goodResponse.test(res.body)) {
+                    throw new Error(res.body);
+                }
+            })
             .catch(function (err) {
                 common.logging.error(new common.errors.GhostError({
                     err: err,

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -18,9 +18,6 @@ var _ = require('lodash'),
     // ToDo: Make this configurable
     pingList = [
         {
-            url: 'blogsearch.google.com/ping/RPC2'
-        },
-        {
             url: 'rpc.pingomatic.com'
         }
     ];

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -68,11 +68,14 @@ function ping(post) {
         };
 
         const goodResponse = /<member><name>flerror<\/name><value><boolean>0<\/boolean><\/value><\/member>/;
+        const errorMessage = /<name>(?:faultString|message)<\/name>[\s]+<value>[\s]+<string>([^<]+)/;
 
         request(pingHost.url, options)
             .then(function (res) {
                 if (!goodResponse.test(res.body)) {
-                    throw new Error(res.body);
+                    const matches = res.body.match(errorMessage);
+                    const message = matches ? matches[1] : res.body;
+                    throw new Error(message);
                 }
             })
             .catch(function (err) {

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -68,7 +68,7 @@ function ping(post) {
         };
 
         const goodResponse = /<member>[\s]*<name>flerror<\/name>[\s]*<value>[\s]*<boolean>0<\/boolean><\/value><\/member>/;
-        const errorMessage = /<name>(?:faultString|message)<\/name>[\s]+<value>[\s]+<string>([^<]+)/;
+        const errorMessage = /<name>(?:faultString|message)<\/name>[\s]*<value>[\s]*<string>([^<]+)/;
 
         request(pingHost.url, options)
             .then(function (res) {

--- a/core/server/services/xmlrpc.js
+++ b/core/server/services/xmlrpc.js
@@ -67,7 +67,7 @@ function ping(post) {
             timeout: 2 * 1000
         };
 
-        const goodResponse = /<member><name>flerror<\/name><value><boolean>0<\/boolean><\/value><\/member>/;
+        const goodResponse = /<member>[\s]*<name>flerror<\/name>[\s]*<value>[\s]*<boolean>0<\/boolean><\/value><\/member>/;
         const errorMessage = /<name>(?:faultString|message)<\/name>[\s]+<value>[\s]+<string>([^<]+)/;
 
         request(pingHost.url, options)

--- a/core/test/unit/services/xmlrpc_spec.js
+++ b/core/test/unit/services/xmlrpc_spec.js
@@ -165,7 +165,7 @@ describe('XMLRPC', function () {
             (function retry() {
                 if (ping1.isDone()) {
                     loggingStub.calledOnce.should.eql(true);
-                    loggingStub.args[0][0].message.should.containEql('A wee lil error');
+                    loggingStub.args[0][0].message.should.equal('Uh oh. A wee lil error.');
                     return done();
                 }
 

--- a/core/test/unit/services/xmlrpc_spec.js
+++ b/core/test/unit/services/xmlrpc_spec.js
@@ -74,14 +74,13 @@ describe('XMLRPC', function () {
         var ping = xmlrpc.__get__('ping');
 
         it('with a post should execute two pings', function (done) {
-            var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
-                ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
+            var ping1 = nock('http://rpc.pingomatic.com').post('/').reply(200),
                 testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
             ping(testPost);
 
             (function retry() {
-                if (ping1.isDone() && ping2.isDone()) {
+                if (ping1.isDone()) {
                     return done();
                 }
 
@@ -90,8 +89,7 @@ describe('XMLRPC', function () {
         });
 
         it('with default post should not execute pings', function () {
-            var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
-                ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
+            var ping1 = nock('http://rpc.pingomatic.com').post('/').reply(200),
                 testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
             testPost.slug = 'welcome';
@@ -99,23 +97,19 @@ describe('XMLRPC', function () {
             ping(testPost);
 
             ping1.isDone().should.be.false();
-            ping2.isDone().should.be.false();
         });
 
         it('with a page should not execute pings', function () {
-            var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
-                ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
+            var ping1 = nock('http://rpc.pingomatic.com').post('/').reply(200),
                 testPage = _.clone(testUtils.DataGenerator.Content.posts[5]);
 
             ping(testPage);
 
             ping1.isDone().should.be.false();
-            ping2.isDone().should.be.false();
         });
 
         it('when privacy.useRpcPing is false should not execute pings', function () {
-            var ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(200),
-                ping2 = nock('http://rpc.pingomatic.com').post('/').reply(200),
+            var ping1 = nock('http://rpc.pingomatic.com').post('/').reply(200),
                 testPost = _.clone(testUtils.DataGenerator.Content.posts[2]);
 
             configUtils.set({privacy: {useRpcPing: false}});
@@ -123,21 +117,19 @@ describe('XMLRPC', function () {
             ping(testPost);
 
             ping1.isDone().should.be.false();
-            ping2.isDone().should.be.false();
         });
 
         it('captures && logs errors from requests', function (done) {
             var testPost = _.clone(testUtils.DataGenerator.Content.posts[2]),
-                ping1 = nock('http://blogsearch.google.com').post('/ping/RPC2').reply(500),
-                ping2 = nock('http://rpc.pingomatic.com').post('/').reply(400),
+                ping1 = nock('http://rpc.pingomatic.com').post('/').reply(400),
                 loggingStub = sandbox.stub(common.logging, 'error');
 
             ping(testPost);
 
             (function retry() {
-                if (ping1.isDone() && ping2.isDone()) {
-                    loggingStub.calledTwice.should.eql(true);
-                    loggingStub.args[0][0].message.should.containEql('Response code 500');
+                if (ping1.isDone()) {
+                    loggingStub.calledOnce.should.eql(true);
+                    loggingStub.args[0][0].message.should.containEql('Response code 400');
                     return done();
                 }
 

--- a/core/test/unit/services/xmlrpc_spec.js
+++ b/core/test/unit/services/xmlrpc_spec.js
@@ -146,7 +146,12 @@ describe('XMLRPC', function () {
                      <param>
                        <value>
                          <struct>
-                           <member><name>flerror</name><value><boolean>1</boolean></value></member>
+                           <member>
+                             <name>flerror</name>
+                             <value>
+                               <boolean>1</boolean>
+                             </value>
+                           </member>
                            <member>
                              <name>message</name>
                              <value>


### PR DESCRIPTION
This PR addresses https://github.com/TryGhost/Ghost/issues/9644

It removes the old service, updates the methodName & adds some disgusting error handling :angel: 

The error handling is better than what we've got currently, but it's nasty, the right thing to do would be to parse the XML, but that means adding another dep, which slows down installs etc...

I was thinking about removing the use of `_.each` to loop the services, but I think it might be useful to leave it in for ease of adding new services.

Whatchu think @kirrg001 ?

- [x] There's a clear use-case for this code change (#9644)
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)
