### PR TITLE
Fixed issue where upper case tags in the get helper fails in case sensitive db

### DIFF
--- a/core/server/models/plugins/filter.js
+++ b/core/server/models/plugins/filter.js
@@ -85,6 +85,18 @@ filter = function filter(Bookshelf) {
         },
 
         preProcessFilters: function preProcessFilters() {
+            /* Lowercase filters for tags and slug no matter how they are passed in */
+            this._filters.statements = gql.json.replaceStatements(this._filters.statements, {prop: /tags|slug/}, function (statement) {
+                if (Array.isArray(statement.value)) {
+                    statement.value = statement.value.map(function mapValue(value) {
+                        return value.toLowerCase();
+                    });
+                } else {
+                    statement.value = statement.value.toLowerCase();
+                }
+                return statement;
+            });
+
             this._filters.statements = gql.json.replaceStatements(this._filters.statements, {prop: /primary_tag/}, function (statement) {
                 statement.prop = 'tags.slug';
                 return {

--- a/core/test/unit/models/plugins/filter_spec.js
+++ b/core/test/unit/models/plugins/filter_spec.js
@@ -226,7 +226,64 @@ describe('Filter', function () {
         });
 
         describe('Pre Process Filters', function () {
-            it('should not have tests yet, as this needs to be removed');
+            it('should lower case slug filter', function () {
+                ghostBookshelf.Model.prototype._filters = {
+                    statements: [
+                        {prop: 'slug', op: '=', value: 'TEST-123'}
+                    ]
+                };
+                ghostBookshelf.Model.prototype.preProcessFilters();
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .value.should.be.exactly('test-123');
+            });
+
+            it('should lower case tags filter', function () {
+                ghostBookshelf.Model.prototype._filters = {
+                    statements: [
+                        {prop: 'tags', op: '=', value: 'TEST-123'}
+                    ]
+                };
+                ghostBookshelf.Model.prototype.preProcessFilters();
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .value.should.be.exactly('test-123');
+            });
+
+            it('should not lower case other filter', function () {
+                ghostBookshelf.Model.prototype._filters = {
+                    statements: [
+                        {prop: 'title', op: '=', value: 'TEST-123'}
+                    ]
+                };
+                ghostBookshelf.Model.prototype.preProcessFilters();
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .value.should.be.exactly('TEST-123');
+            });
+
+            it('should lower case tags array filter', function () {
+                ghostBookshelf.Model.prototype._filters = {
+                    statements: [
+                        {prop: 'tags', op: '=', value: ['TEST-123', 'TEST-456']}
+                    ]
+                };
+                ghostBookshelf.Model.prototype.preProcessFilters();
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .value[0].should.be.exactly('test-123');
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .value[1].should.be.exactly('test-456');
+            });
+
+            it('should lower case tags filter inside groups', function () {
+                ghostBookshelf.Model.prototype._filters = {
+                    statements: [{
+                        group: [
+                            {prop: 'tags', op: '=', value: 'TEST-123'}
+                        ]
+                    }]
+                };
+                ghostBookshelf.Model.prototype.preProcessFilters();
+                ghostBookshelf.Model.prototype._filters.statements[0]
+                    .group[0].value.should.be.exactly('test-123');
+            });
         });
 
         describe('Post Process Filters', function () {


### PR DESCRIPTION
closes #9695

This seemed like the best place to do a force to lowercase when a database is case sensitive yet tags and slug is always lowercase.
