### PR TITLE
Support oembed meta tag

### DIFF
--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -60,7 +60,7 @@ let oembed = {
 
         // see if the URL is a redirect to cater for shortened urls
         return request(url, {
-            method: 'HEAD',
+            method: 'GET',
             timeout: 2 * 1000,
             followRedirect: true
         }).then((response) => {

--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -2,6 +2,7 @@ const common = require('../lib/common');
 const {extract, hasProvider} = require('oembed-parser');
 const Promise = require('bluebird');
 const request = require('../lib/request');
+const cheerio = require('cheerio');
 
 const findUrlWithProvider = function findUrlWithProvider(url) {
     let provider;
@@ -25,6 +26,10 @@ const findUrlWithProvider = function findUrlWithProvider(url) {
     }
 
     return {url, provider};
+};
+
+const getOembedUrlFromHTML = function getOembedUrlFromHTML(html) {
+    return cheerio('link[type="application/json+oembed"]', html).attr('href');
 };
 
 let oembed = {
@@ -69,7 +74,18 @@ let oembed = {
                 return provider ? knownProvider(url) : unknownProvider();
             }
 
-            return unknownProvider();
+            const oembedUrl = getOembedUrlFromHTML(response.body);
+
+            if (!oembedUrl) {
+                return unknownProvider();
+            }
+
+            return request(oembedUrl, {
+                method: 'GET',
+                json: true
+            }).then((response) => {
+                return response.body;
+            });
         }).catch(() => {
             return unknownProvider();
         });

--- a/core/test/unit/api/oembed_spec.js
+++ b/core/test/unit/api/oembed_spec.js
@@ -41,14 +41,14 @@ describe('API: oembed', function () {
 
         it('follows redirects to get base url', function (done) {
             let redirectMock = nock('https://youtu.be')
-                .intercept('/yHohwmrxrto', 'HEAD')
+                .intercept('/yHohwmrxrto', 'GET')
                 .reply(302, undefined, {
                     // eslint-disable-next-line
                     'Location': 'https://www.youtube.com/watch?v=yHohwmrxrto&feature=youtu.be'
                 });
 
             let videoMock = nock('https://www.youtube.com')
-                .intercept('/watch', 'HEAD')
+                .intercept('/watch', 'GET')
                 .query({v: 'yHohwmrxrto', feature: 'youtu.be'})
                 .reply(200);
 
@@ -83,7 +83,7 @@ describe('API: oembed', function () {
 
         it('returns error for unsupported provider', function (done) {
             nock('http://example.com')
-                .intercept('/unknown', 'HEAD')
+                .intercept('/unknown', 'GET')
                 .reply(200);
 
             OembedAPI.read({url: 'http://example.com/unknown'})


### PR DESCRIPTION
This adds a fallback approach for when a url to be embeded has no matching provider. We look in the html of the resource to be embeded for a `<link rel="alternate" type="application/json+oembed" ... />` tag, and attempt to fetch the oembed html from there. :floppy_disk: 

closes #9786 

- [x] There's a clear use-case for this code change
- [x] Commit message has a short title & references relevant issues
- [x] The build will pass (run `npm test`)
