### PR TITLE
Enforce unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# enforce unix style line endings
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # enforce unix style line endings
-* text=auto eol=lf
+*.js text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.hbs text eol=lf


### PR DESCRIPTION
On windows Git (by default) converts Unix line ends to Windows (CRLF) line ends.

This causes the tests that verify the size of the redirects.json and the routes.yaml to fail due to size differences.

It's a good practice for cross-platform development to set the line-ending-types which are expected by the repository (especially if they matter). 

This will force the line endings to be Linux, as you're expecting, even if you're on a platform where the default is different.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tryghost/ghost/9871)
<!-- Reviewable:end -->
