### PR TITLE
ES6 migration: server/api/*

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -160,12 +160,12 @@ authentication = {
             let dbHash, token;
 
             return settingsAPI.read(merge({key: 'db_hash'}, options))
-                .then(function fetchedSettings(response) {
+                .then((response) => {
                     dbHash = response.settings[0].value;
 
                     return models.User.getByEmail(email, options);
                 })
-                .then(function fetchedUser(user) {
+                .then((user) => {
                     if (!user) {
                         throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')});
                     }
@@ -292,12 +292,12 @@ authentication = {
                 newPassword = data.newPassword;
 
             return settingsAPI.read(merge({key: 'db_hash'}, omit(options, 'data')))
-                .then(function fetchedSettings(response) {
+                .then((response) => {
                     dbHash = response.settings[0].value;
 
                     return models.User.getByEmail(tokenParts.email, options);
                 })
-                .then(function fetchedUser(user) {
+                .then((user) => {
                     if (!user) {
                         throw new common.errors.NotFoundError({message: common.i18n.t('errors.api.users.userNotFound')});
                     }
@@ -322,7 +322,7 @@ authentication = {
                         user_id: user.id
                     }, options);
                 })
-                .then(function changedPassword(updatedUser) {
+                .then((updatedUser) => {
                     updatedUser.set('status', 'active');
                     return updatedUser.save(options);
                 })
@@ -460,13 +460,13 @@ authentication = {
         function checkInvitation(email) {
             return models.Invite
                 .findOne({email: email, status: 'sent'}, options)
-                .then(function fetchedInvite(invite) {
+                .then((invite) => {
                     if (!invite) {
                         return {invitation: [{valid: false}]};
                     }
 
                     return models.User.findOne({id: invite.get('created_by')})
-                        .then(function fetchedUser(user) {
+                        .then((user) => {
                             return {invitation: [{valid: true, invitedBy: user.get('name')}]};
                         });
                 });

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -138,7 +138,7 @@ authentication = {
      * @param {Object} object
      * @returns {Promise<Object>} message
      */
-    generateResetToken: (object) => {
+    generateResetToken(object) {
         let tasks;
 
         function validateRequest(object) {
@@ -235,7 +235,7 @@ authentication = {
      * @param {Object} object
      * @returns {Promise<Object>} message
      */
-    resetPassword: (object, opts) => {
+    resetPassword(object, opts) {
         let tasks,
             tokenIsCorrect,
             dbHash,
@@ -362,7 +362,7 @@ authentication = {
      * @param {Object} invitation an invitation object
      * @returns {Promise<Object>}
      */
-    acceptInvitation: (invitation) => {
+    acceptInvitation(invitation) {
         let tasks,
             invite;
         const options = {context: {internal: true}};
@@ -441,7 +441,7 @@ authentication = {
      * @param {Object} options
      * @returns {Promise<Object>} An invitation status
      */
-    isInvitation: (options) => {
+    isInvitation(options) {
         let tasks;
         const localOptions = cloneDeep(options || {});
 
@@ -485,7 +485,7 @@ authentication = {
      * Checks the setup status
      * @return {Promise}
      */
-    isSetup: () => {
+    isSetup() {
         let tasks;
 
         function checkSetupStatus() {
@@ -519,7 +519,7 @@ authentication = {
      * @param  {Object} setupDetails
      * @return {Promise<Object>} a user api payload
      */
-    setup: (setupDetails) => {
+    setup(setupDetails) {
         let tasks;
 
         function doSetup(setupDetails) {
@@ -577,7 +577,7 @@ authentication = {
      * @param  {Object} options
      * @return {Promise<Object>} a User API response payload
      */
-    updateSetup: (setupDetails, options) => {
+    updateSetup(setupDetails, options) {
         let tasks;
         const localOptions = cloneDeep(options || {});
 
@@ -621,7 +621,7 @@ authentication = {
      * @param {Object} options
      * @return {Promise<Object>} an object containing the revoked token.
      */
-    revoke: (tokenDetails, options) => {
+    revoke(tokenDetails, options) {
         let tasks;
         const localOptions = cloneDeep(options || {});
 

--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -23,7 +23,7 @@ let authentication;
  * @return {Promise<Boolean>}
  */
 function checkSetup() {
-    return authentication.isSetup().then(function then(result) {
+    return authentication.isSetup().then((result) => {
         return result.setup[0].status;
     });
 }
@@ -36,7 +36,7 @@ function checkSetup() {
  */
 function assertSetupCompleted(status) {
     return function checkPermission(__) {
-        return checkSetup().then(function then(isSetup) {
+        return checkSetup().then((isSetup) => {
             if (isSetup === status) {
                 return __;
             }
@@ -61,7 +61,7 @@ function setupTasks(setupData) {
     let tasks;
 
     function validateData(setupData) {
-        return localUtils.checkObject(setupData, 'setup').then(function then(checked) {
+        return localUtils.checkObject(setupData, 'setup').then((checked) => {
             const data = checked.setup[0];
 
             return {
@@ -78,7 +78,7 @@ function setupTasks(setupData) {
         const context = {context: {internal: true}},
             User = models.User;
 
-        return User.findOne({role: 'Owner', status: 'all'}).then(function then(owner) {
+        return User.findOne({role: 'Owner', status: 'all'}).then((owner) => {
             if (!owner) {
                 throw new common.errors.GhostError({
                     message: common.i18n.t('errors.api.authentication.setupUnableToRun')
@@ -86,7 +86,7 @@ function setupTasks(setupData) {
             }
 
             return User.setup(userData, extend({id: owner.id}, context));
-        }).then(function then(user) {
+        }).then((user) => {
             return {
                 user: user,
                 userData: userData
@@ -138,11 +138,11 @@ authentication = {
      * @param {Object} object
      * @returns {Promise<Object>} message
      */
-    generateResetToken: function generateResetToken(object) {
+    generateResetToken: (object) => {
         let tasks;
 
         function validateRequest(object) {
-            return localUtils.checkObject(object, 'passwordreset').then(function then(data) {
+            return localUtils.checkObject(object, 'passwordreset').then((data) => {
                 const email = data.passwordreset[0].email;
 
                 if (typeof email !== 'string' || !validator.isEmail(email)) {
@@ -193,7 +193,7 @@ authentication = {
                     resetUrl: resetUrl
                 },
                 template: 'reset-password'
-            }).then(function then(content) {
+            }).then((content) => {
                 const payload = {
                     mail: [{
                         message: {
@@ -235,7 +235,7 @@ authentication = {
      * @param {Object} object
      * @returns {Promise<Object>} message
      */
-    resetPassword: function resetPassword(object, opts) {
+    resetPassword: (object, opts) => {
         let tasks,
             tokenIsCorrect,
             dbHash,
@@ -362,7 +362,7 @@ authentication = {
      * @param {Object} invitation an invitation object
      * @returns {Promise<Object>}
      */
-    acceptInvitation: function acceptInvitation(invitation) {
+    acceptInvitation: (invitation) => {
         let tasks,
             invite;
         const options = {context: {internal: true}};
@@ -441,7 +441,7 @@ authentication = {
      * @param {Object} options
      * @returns {Promise<Object>} An invitation status
      */
-    isInvitation: function isInvitation(options) {
+    isInvitation: (options) => {
         let tasks;
         const localOptions = cloneDeep(options || {});
 
@@ -485,7 +485,7 @@ authentication = {
      * Checks the setup status
      * @return {Promise}
      */
-    isSetup: function isSetup() {
+    isSetup: () => {
         let tasks;
 
         function checkSetupStatus() {
@@ -519,7 +519,7 @@ authentication = {
      * @param  {Object} setupDetails
      * @return {Promise<Object>} a user api payload
      */
-    setup: function setup(setupDetails) {
+    setup: (setupDetails) => {
         let tasks;
 
         function doSetup(setupDetails) {
@@ -534,7 +534,7 @@ authentication = {
             common.events.emit('setup.completed', setupUser);
 
             return mail.utils.generateContent({data: data, template: 'welcome'})
-                .then(function then(content) {
+                .then((content) => {
                     const message = {
                             to: setupUser.email,
                             subject: common.i18n.t('common.api.authentication.mail.yourNewGhostBlog'),
@@ -577,7 +577,7 @@ authentication = {
      * @param  {Object} options
      * @return {Promise<Object>} a User API response payload
      */
-    updateSetup: function updateSetup(setupDetails, options) {
+    updateSetup: (setupDetails, options) => {
         let tasks;
         const localOptions = cloneDeep(options || {});
 
@@ -621,7 +621,7 @@ authentication = {
      * @param {Object} options
      * @return {Promise<Object>} an object containing the revoked token.
      */
-    revoke: function revokeToken(tokenDetails, options) {
+    revoke: (tokenDetails, options) => {
         let tasks;
         const localOptions = cloneDeep(options || {});
 

--- a/core/server/api/clients.js
+++ b/core/server/api/clients.js
@@ -22,7 +22,7 @@ clients = {
      * @param {{id}} options
      * @return {Promise<Client>} Client
      */
-    read: function read(options) {
+    read: (options) =>  {
         const attrs = ['id', 'slug'];
         let tasks;
 

--- a/core/server/api/clients.js
+++ b/core/server/api/clients.js
@@ -37,7 +37,7 @@ clients = {
             options.data = extend(options.data, {type: 'ua'});
 
             return models.Client.findOne(options.data, omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('common.api.clients.clientNotFound')

--- a/core/server/api/clients.js
+++ b/core/server/api/clients.js
@@ -22,7 +22,7 @@ clients = {
      * @param {{id}} options
      * @return {Promise<Client>} Client
      */
-    read: (options) =>  {
+    read(options) {
         const attrs = ['id', 'slug'];
         let tasks;
 

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -51,7 +51,7 @@ configuration = {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    read: (options) => {
+    read(options) {
         options = options || {};
 
         if (!options.key) {

--- a/core/server/api/configuration.js
+++ b/core/server/api/configuration.js
@@ -51,7 +51,7 @@ configuration = {
      * @param {Object} options
      * @returns {Promise<Object>}
      */
-    read: function read(options) {
+    read: (options) => {
         options = options || {};
 
         if (!options.key) {

--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -26,7 +26,7 @@ db = {
      * @public
      * @returns {Promise} Ghost Export JSON format
      */
-    backupContent: (options) => {
+    backupContent(options) {
         let tasks;
 
         options = options || {};
@@ -51,7 +51,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Ghost Export JSON format
      */
-    exportContent: (options) => {
+    exportContent(options) {
         let tasks;
 
         options = options || {};
@@ -83,7 +83,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    importContent: (options) => {
+    importContent(options) {
         let tasks;
         options = options || {};
 
@@ -114,7 +114,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    deleteAllContent: (options) => {
+    deleteAllContent(options) {
         let tasks;
         const queryOpts = {columns: 'id', context: {internal: true}, destroyAll: true};
 

--- a/core/server/api/db.js
+++ b/core/server/api/db.js
@@ -26,7 +26,7 @@ db = {
      * @public
      * @returns {Promise} Ghost Export JSON format
      */
-    backupContent: function (options) {
+    backupContent: (options) => {
         let tasks;
 
         options = options || {};
@@ -51,7 +51,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Ghost Export JSON format
      */
-    exportContent: function exportContent(options) {
+    exportContent: (options) => {
         let tasks;
 
         options = options || {};
@@ -83,7 +83,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    importContent: function importContent(options) {
+    importContent: (options) => {
         let tasks;
         options = options || {};
 
@@ -114,7 +114,7 @@ db = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    deleteAllContent: function deleteAllContent(options) {
+    deleteAllContent: (options) => {
         let tasks;
         const queryOpts = {columns: 'id', context: {internal: true}, destroyAll: true};
 

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -67,7 +67,7 @@ function isActiveThemeUpdate(method, endpoint, result) {
  * @param {Object} result API method result
  * @return {String} Resolves to header string
  */
-cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
+cacheInvalidationHeader = (req, result) => {
     const parsedUrl = req._parsedUrl.pathname.replace(/^\/|\/$/g, '').split('/'),
         method = req.method,
         endpoint = parsedUrl[0],
@@ -123,7 +123,7 @@ cacheInvalidationHeader = function cacheInvalidationHeader(req, result) {
  * @param {Object} result API method result
  * @return {String} Resolves to header string
  */
-locationHeader = function locationHeader(req, result) {
+locationHeader = (req, result) => {
     const apiRoot = urlService.utils.urlFor('api');
     let location,
         newObject,
@@ -167,18 +167,18 @@ locationHeader = function locationHeader(req, result) {
  * @return {string}
  */
 
-contentDispositionHeaderExport = function contentDispositionHeaderExport() {
+contentDispositionHeaderExport = () => {
     return exporter.fileName().then(function then(filename) {
         return `Attachment; filename="${filename}"`;
     });
 };
 
-contentDispositionHeaderSubscribers = function contentDispositionHeaderSubscribers() {
+contentDispositionHeaderSubscribers = () => {
     const datetime = (new Date()).toJSON().substring(0, 10);
     return Promise.resolve(`Attachment; filename="subscribers.${datetime}.csv"`);
 };
 
-contentDispositionHeaderRedirects = function contentDispositionHeaderRedirects() {
+contentDispositionHeaderRedirects = () => {
     return Promise.resolve('Attachment; filename="redirects.json"');
 };
 
@@ -186,7 +186,7 @@ contentDispositionHeaderRoutes = () => {
     return Promise.resolve('Attachment; filename="routes.yaml"');
 };
 
-addHeaders = function addHeaders(apiMethod, req, res, result) {
+addHeaders = (apiMethod, req, res, result) => {
     let cacheInvalidation,
         location,
         contentDisposition;
@@ -264,7 +264,7 @@ addHeaders = function addHeaders(apiMethod, req, res, result) {
  * @param {Function} apiMethod API method to call
  * @return {Function} middleware format function to be called by the route when a matching request is made
  */
-http = function http(apiMethod) {
+http = (apiMethod) => {
     return function apiHandler(req, res, next) {
         // We define 2 properties for using as arguments in API calls:
         let object = req.body,
@@ -291,7 +291,7 @@ http = function http(apiMethod) {
         return apiMethod(object, options).tap(function onSuccess(response) {
             // Add X-Cache-Invalidate, Location, and Content-Disposition headers
             return addHeaders(apiMethod, req, res, (response || {}));
-        }).then(function then(response) {
+        }).then((response) => {
             if (req.method === 'DELETE') {
                 return res.status(204).end();
             }

--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -168,7 +168,7 @@ locationHeader = (req, result) => {
  */
 
 contentDispositionHeaderExport = () => {
-    return exporter.fileName().then(function then(filename) {
+    return exporter.fileName().then((filename) => {
         return `Attachment; filename="${filename}"`;
     });
 };
@@ -209,7 +209,7 @@ addHeaders = (apiMethod, req, res, result) => {
     // Add Export Content-Disposition Header
     if (apiMethod === db.exportContent) {
         contentDisposition = contentDispositionHeaderExport()
-            .then(function addContentDispositionHeaderExport(header) {
+            .then((header) => {
                 res.set({
                     'Content-Disposition': header
                 });
@@ -219,7 +219,7 @@ addHeaders = (apiMethod, req, res, result) => {
     // Add Subscribers Content-Disposition Header
     if (apiMethod === subscribers.exportCSV) {
         contentDisposition = contentDispositionHeaderSubscribers()
-            .then(function addContentDispositionHeaderSubscribers(header) {
+            .then((header) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'text/csv'
@@ -230,7 +230,7 @@ addHeaders = (apiMethod, req, res, result) => {
     // Add Redirects Content-Disposition Header
     if (apiMethod === redirects.download) {
         contentDisposition = contentDispositionHeaderRedirects()
-            .then(function contentDispositionHeaderRedirects(header) {
+            .then((header) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'application/json',
@@ -288,7 +288,7 @@ http = (apiMethod) => {
             options = {};
         }
 
-        return apiMethod(object, options).tap(function onSuccess(response) {
+        return apiMethod(object, options).tap((response) => {
             // Add X-Cache-Invalidate, Location, and Content-Disposition headers
             return addHeaders(apiMethod, req, res, (response || {}));
         }).then((response) => {
@@ -310,7 +310,7 @@ http = (apiMethod) => {
 
             // Send a properly formatting HTTP response containing the data with correct headers
             res.json(response || {});
-        }).catch(function onAPIError(error) {
+        }).catch((error) => {
             // To be handled by the API middleware
             next(error);
         });

--- a/core/server/api/invites.js
+++ b/core/server/api/invites.js
@@ -13,7 +13,7 @@ const Promise = require('bluebird'),
     allowedIncludes = ['created_by', 'updated_by'];
 
 const invites = {
-    browse: (options) => {
+    browse(options) {
         let tasks;
 
         function modelQuery(options) {
@@ -30,7 +30,7 @@ const invites = {
         return pipeline(tasks, options);
     },
 
-    read: (options) => {
+    read(options) {
         const attrs = ['id', 'email'];
         let tasks;
 
@@ -59,7 +59,7 @@ const invites = {
         return pipeline(tasks, options);
     },
 
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         function modelQuery(options) {
@@ -83,7 +83,7 @@ const invites = {
         return pipeline(tasks, options);
     },
 
-    add: (object, options) => {
+    add(object, options) {
         let loggedInUser = options.context.user,
             tasks,
             emailData,

--- a/core/server/api/invites.js
+++ b/core/server/api/invites.js
@@ -36,7 +36,7 @@ const invites = {
 
         function modelQuery(options) {
             return models.Invite.findOne(options.data, omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.invites.inviteNotFound')

--- a/core/server/api/mail.js
+++ b/core/server/api/mail.js
@@ -56,7 +56,7 @@ const apiMail = {
      * @param {Mail} object details of the email to send
      * @returns {Promise}
      */
-    send: (object, options) => {
+    send(object, options) {
         let tasks;
 
         /**
@@ -100,7 +100,7 @@ const apiMail = {
      * @param {Object} options required property 'to' which contains the recipient address
      * @returns {Promise}
      */
-    sendTest: (options) => {
+    sendTest(options) {
         let tasks;
 
         /**

--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -56,7 +56,7 @@ notifications = {
      * Fetch all notifications
      * @returns {Promise(Notifications)}
      */
-    browse: (options) => {
+    browse(options) {
         return canThis(options.context).browse.notification().then(() => {
             return _private.fetchAllNotifications()
                 .then((allNotifications) => {
@@ -106,7 +106,7 @@ notifications = {
          *  }] };
      * ```
      */
-    add: (object, options) => {
+    add(object, options) {
         let tasks;
 
         /**
@@ -217,7 +217,7 @@ notifications = {
      * @param {{id (required), context}} options
      * @returns {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**
@@ -289,7 +289,7 @@ notifications = {
      * @private Not exposed over HTTP
      * @returns {Promise}
      */
-    destroyAll: (options) => {
+    destroyAll(options) {
         return canThis(options.context).destroy.notification()
             .then(() => {
                 return _private.fetchAllNotifications()

--- a/core/server/api/notifications.js
+++ b/core/server/api/notifications.js
@@ -18,7 +18,7 @@ const Promise = require('bluebird'),
 let notifications,
     _private = {};
 
-_private.fetchAllNotifications = function fetchAllNotifications() {
+_private.fetchAllNotifications = () => {
     let allNotifications;
 
     return SettingsAPI.read(merge({key: 'notifications'}, internalContext))
@@ -33,7 +33,7 @@ _private.fetchAllNotifications = function fetchAllNotifications() {
         });
 };
 
-_private.publicResponse = function publicResponse(notificationsToReturn) {
+_private.publicResponse = (notificationsToReturn) => {
     notificationsToReturn.forEach((notification) => {
         delete notification.seen;
         delete notification.addedAt;

--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -33,7 +33,7 @@ const getOembedUrlFromHTML = (html) => {
 };
 
 const oembed = {
-    read: (options) => {
+    read(options) {
         let {url} = options;
 
         if (!url || !url.trim()) {

--- a/core/server/api/oembed.js
+++ b/core/server/api/oembed.js
@@ -4,7 +4,7 @@ const Promise = require('bluebird');
 const request = require('../lib/request');
 const cheerio = require('cheerio');
 
-const findUrlWithProvider = function findUrlWithProvider(url) {
+const findUrlWithProvider = (url) => {
     let provider;
 
     // build up a list of URL variations to test against because the oembed
@@ -28,12 +28,12 @@ const findUrlWithProvider = function findUrlWithProvider(url) {
     return {url, provider};
 };
 
-const getOembedUrlFromHTML = function getOembedUrlFromHTML(html) {
+const getOembedUrlFromHTML = (html) => {
     return cheerio('link[type="application/json+oembed"]', html).attr('href');
 };
 
 const oembed = {
-    read(options) {
+    read: (options) => {
         let {url} = options;
 
         if (!url || !url.trim()) {

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -95,7 +95,7 @@ posts = {
          */
         function modelQuery(options) {
             return models.Post.findOne(options.data, omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.posts.postNotFound')
@@ -142,7 +142,7 @@ posts = {
          */
         function modelQuery(options) {
             return models.Post.edit(options.data.posts[0], omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.posts.postNotFound')
@@ -196,7 +196,7 @@ posts = {
          */
         function modelQuery(options) {
             return models.Post.add(options.data.posts[0], omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     const post = model.toJSON(options);
 
                     if (post.status === 'published') {

--- a/core/server/api/posts.js
+++ b/core/server/api/posts.js
@@ -38,7 +38,7 @@ posts = {
      * @param {{context, page, limit, status, staticPages, tag, featured}} options (optional)
      * @returns {Promise<Posts>} Posts Collection with Meta
      */
-    browse: (options) => {
+    browse(options) {
         const extraOptions = ['status', 'formats', 'absolute_urls'];
         let permittedOptions,
             tasks;
@@ -80,7 +80,7 @@ posts = {
      * @param {Object} options
      * @return {Promise<Post>} Post
      */
-    read: (options) => {
+    read(options) {
         const attrs = ['id', 'slug', 'status', 'uuid'],
             // NOTE: the scheduler API uses the post API and forwards custom options
             extraAllowedOptions = options.opts || ['formats', 'absolute_urls'];
@@ -129,7 +129,7 @@ posts = {
      * @param {{id (required), context, include,...}} options
      * @return {Promise(Post)} Edited Post
      */
-    edit: (object, options) => {
+    edit(object, options) {
         let tasks;
         // NOTE: the scheduler API uses the post API and forwards custom options
         const extraAllowedOptions = options.opts || [];
@@ -185,7 +185,7 @@ posts = {
      * @param {{context, include,...}} options
      * @return {Promise(Post)} Created Post
      */
-    add: (object, options) => {
+    add(object, options) {
         let tasks;
 
         /**
@@ -229,7 +229,7 @@ posts = {
      * @param {{id (required), context,...}} options
      * @return {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**

--- a/core/server/api/redirects.js
+++ b/core/server/api/redirects.js
@@ -42,13 +42,13 @@ _private.readRedirectsFile = (customRedirectsPath) => {
 };
 
 redirectsAPI = {
-    download: (options) => {
+    download(options) {
         return localUtils.handlePermissions('redirects', 'download')(options)
             .then(() => {
                 return _private.readRedirectsFile();
             });
     },
-    upload: (options) => {
+    upload(options) {
         const redirectsPath = path.join(config.getContentPath('data'), 'redirects.json'),
             backupRedirectsPath = path.join(config.getContentPath('data'), `redirects-${moment().format('YYYY-MM-DD-HH-mm-ss')}.json`);
 

--- a/core/server/api/redirects.js
+++ b/core/server/api/redirects.js
@@ -15,7 +15,7 @@ _private.readRedirectsFile = (customRedirectsPath) => {
     const redirectsPath = customRedirectsPath || path.join(config.getContentPath('data'), 'redirects.json');
 
     return fs.readFile(redirectsPath, 'utf-8')
-        .then(function serveContent(content) {
+        .then((content) => {
             try {
                 content = JSON.parse(content);
             } catch (err) {
@@ -26,7 +26,7 @@ _private.readRedirectsFile = (customRedirectsPath) => {
 
             return content;
         })
-        .catch(function handleError(err) {
+        .catch((err) => {
             if (err.code === 'ENOENT') {
                 return Promise.resolve([]);
             }
@@ -53,7 +53,7 @@ redirectsAPI = {
             backupRedirectsPath = path.join(config.getContentPath('data'), `redirects-${moment().format('YYYY-MM-DD-HH-mm-ss')}.json`);
 
         return localUtils.handlePermissions('redirects', 'upload')(options)
-            .then(function backupOldRedirectsFile() {
+            .then(() => {
                 return fs.pathExists(redirectsPath)
                     .then((exists) => {
                         if (!exists) {
@@ -72,7 +72,7 @@ redirectsAPI = {
                                 return fs.move(redirectsPath, backupRedirectsPath);
                             });
                     })
-                    .then(function overrideFile() {
+                    .then(() => {
                         return _private.readRedirectsFile(options.path)
                             .then((content) => {
                                 validation.validateRedirects(content);

--- a/core/server/api/redirects.js
+++ b/core/server/api/redirects.js
@@ -11,7 +11,7 @@ const fs = require('fs-extra'),
 let redirectsAPI,
     _private = {};
 
-_private.readRedirectsFile = function readRedirectsFile(customRedirectsPath) {
+_private.readRedirectsFile = (customRedirectsPath) => {
     const redirectsPath = customRedirectsPath || path.join(config.getContentPath('data'), 'redirects.json');
 
     return fs.readFile(redirectsPath, 'utf-8')

--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -28,7 +28,7 @@ roles = {
      * @param {{context, permissions}} options (optional)
      * @returns {Promise(Roles)} Roles Collection
      */
-    browse:  (options) => {
+    browse: (options) => {
         let permittedOptions = ['permissions'],
             tasks;
 

--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -28,7 +28,7 @@ roles = {
      * @param {{context, permissions}} options (optional)
      * @returns {Promise(Roles)} Roles Collection
      */
-    browse: (options) => {
+    browse(options) {
         let permittedOptions = ['permissions'],
             tasks;
 

--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -28,7 +28,7 @@ roles = {
      * @param {{context, permissions}} options (optional)
      * @returns {Promise(Roles)} Roles Collection
      */
-    browse: function browse(options) {
+    browse:  (options) => {
         let permittedOptions = ['permissions'],
             tasks;
 
@@ -41,7 +41,7 @@ roles = {
         function modelQuery(options) {
             return models.Role.findAll(options)
                 .then(function onModelResponse(models) {
-                    let roles = models.map(function (role) {
+                    let roles = models.map((role) => {
                         return role.toJSON();
                     });
 
@@ -49,13 +49,13 @@ roles = {
                         return {roles: roles};
                     }
 
-                    return Promise.filter(roles.map(function (role) {
+                    return Promise.filter(roles.map((role) => {
                         return canThis(options.context).assign.role(role)
                             .return(role)
-                            .catch(function () {});
-                    }), function (value) {
+                            .catch(() => {});
+                    }), (value) => {
                         return value && value.name !== 'Owner';
-                    }).then(function (roles) {
+                    }).then((roles) => {
                         return {
                             roles: roles
                         };

--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -1,13 +1,13 @@
 // # Roles API
 // RESTful API for the Role resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
     canThis = require('../services/permissions').canThis,
     models = require('../models'),
-    docName = 'roles',
+    docName = 'roles';
 
-    roles;
+let roles;
 
 /**
  * ## Roles API Methods
@@ -29,7 +29,7 @@ roles = {
      * @returns {Promise(Roles)} Roles Collection
      */
     browse: function browse(options) {
-        var permittedOptions = ['permissions'],
+        let permittedOptions = ['permissions'],
             tasks;
 
         /**
@@ -41,7 +41,7 @@ roles = {
         function modelQuery(options) {
             return models.Role.findAll(options)
                 .then(function onModelResponse(models) {
-                    var roles = models.map(function (role) {
+                    let roles = models.map(function (role) {
                         return role.toJSON();
                     });
 

--- a/core/server/api/roles.js
+++ b/core/server/api/roles.js
@@ -40,7 +40,7 @@ roles = {
          */
         function modelQuery(options) {
             return models.Role.findAll(options)
-                .then(function onModelResponse(models) {
+                .then((models) => {
                     let roles = models.map((role) => {
                         return role.toJSON();
                     });

--- a/core/server/api/schedules.js
+++ b/core/server/api/schedules.js
@@ -1,4 +1,4 @@
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     moment = require('moment'),
     pipeline = require('../lib/promise/pipeline'),
@@ -23,7 +23,7 @@ exports.publishPost = function publishPost(object, options) {
         object = {};
     }
 
-    var post, publishedAtMoment,
+    let post, publishedAtMoment,
         publishAPostBySchedulerToleranceInMinutes = config.get('times').publishAPostBySchedulerToleranceInMinutes;
 
     // CASE: only the scheduler client is allowed to publish (hardcoded because of missing client permission system)

--- a/core/server/api/schedules.js
+++ b/core/server/api/schedules.js
@@ -85,11 +85,11 @@ exports.getScheduledPosts = function readPosts(options) {
             cleanOptions.columns = ['id', 'published_at', 'created_at'];
 
             if (cleanOptions.from) {
-                cleanOptions.filter += '+created_at:>=\'' + moment(cleanOptions.from).format('YYYY-MM-DD HH:mm:ss') + '\'';
+                cleanOptions.filter += `+created_at:>='${moment(cleanOptions.from).format('YYYY-MM-DD HH:mm:ss')}'`;
             }
 
             if (cleanOptions.to) {
-                cleanOptions.filter += '+created_at:<=\'' + moment(cleanOptions.to).format('YYYY-MM-DD HH:mm:ss') + '\'';
+                cleanOptions.filter += `+created_at:<='${moment(cleanOptions.to).format('YYYY-MM-DD HH:mm:ss')}'`;
             }
 
             return models.Post.findAll(cleanOptions)

--- a/core/server/api/schedules.js
+++ b/core/server/api/schedules.js
@@ -35,10 +35,10 @@ exports.publishPost = function publishPost(object, options) {
 
     return pipeline([
         localUtils.validate('posts', {opts: localUtils.idDefaultOptions}),
-        function (cleanOptions) {
+        (cleanOptions) => {
             cleanOptions.status = 'scheduled';
 
-            return models.Base.transaction(function (transacting) {
+            return models.Base.transaction((transacting) => {
                 cleanOptions.transacting = transacting;
                 cleanOptions.forUpdate = true;
 
@@ -46,7 +46,7 @@ exports.publishPost = function publishPost(object, options) {
                 cleanOptions.opts = ['forUpdate', 'transacting'];
 
                 return postsAPI.read(cleanOptions)
-                    .then(function (result) {
+                    .then((result) => {
                         post = result.posts[0];
                         publishedAtMoment = moment(post.published_at);
 
@@ -80,7 +80,7 @@ exports.getScheduledPosts = function readPosts(options) {
 
     return pipeline([
         localUtils.validate('posts', {opts: ['from', 'to']}),
-        function (cleanOptions) {
+        (cleanOptions) => {
             cleanOptions.filter = 'status:scheduled';
             cleanOptions.columns = ['id', 'published_at', 'created_at'];
 
@@ -93,7 +93,7 @@ exports.getScheduledPosts = function readPosts(options) {
             }
 
             return models.Post.findAll(cleanOptions)
-                .then(function (result) {
+                .then((result) => {
                     return Promise.resolve({posts: result.models});
                 });
         }

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -30,7 +30,7 @@ let settings,
  * @returns {*}
  */
 settingsFilter = function (settings, filter) {
-    return _.fromPairs(_.filter(_.toPairs(settings), function (setting) {
+    return _.fromPairs(_.toPairs(settings).filter((setting) => {
         if (filter) {
             return _.some(filter.split(','), function (f) {
                 return setting[1].type === f;
@@ -96,7 +96,7 @@ canEditAllSettings = function (settingsInfo, options) {
                 return Promise.reject(new common.errors.NoPermissionError({message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')}));
             });
         },
-        checks = _.map(settingsInfo, function (settingInfo) {
+        checks = settingsInfo.map((settingInfo) => {
             let setting = settingsCache.get(settingInfo.key, {resolve: false});
 
             if (!setting) {
@@ -139,7 +139,7 @@ settings = {
 
         // If there is no context, return only blog settings
         if (!options.context) {
-            return Promise.resolve(_.filter(result.settings, function (setting) {
+            return Promise.resolve(result.settings.filter((setting) => {
                 return setting.type === 'blog';
             }));
         }
@@ -148,7 +148,7 @@ settings = {
         return canThis(options.context).browse.setting().then(function () {
             // Omit core settings unless internal request
             if (!options.context.internal) {
-                result.settings = _.filter(result.settings, function (setting) {
+                result.settings = result.settings.filter((setting) => {
                     return setting.type !== 'core' && setting.key !== 'permalinks';
                 });
             }
@@ -218,13 +218,13 @@ settings = {
         }
 
         // clean data
-        _.each(object.settings, function (setting) {
+        object.settings.forEach((setting) => {
             if (!_.isString(setting.value)) {
                 setting.value = JSON.stringify(setting.value);
             }
         });
 
-        type = _.find(object.settings, function (setting) {
+        type = object.settings.find((setting) => {
             return setting.key === 'type';
         });
 

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -272,10 +272,10 @@ settings = {
 
         return localUtils.handlePermissions('settings', 'edit')(options)
             .then(() => {
-                return fs.copy(config.getContentPath('settings') + '/routes.yaml', backupRoutesPath);
+                return fs.copy(`${config.getContentPath('settings')}/routes.yaml`, backupRoutesPath);
             })
             .then(() => {
-                return fs.copy(options.path, config.getContentPath('settings') + '/routes.yaml');
+                return fs.copy(options.path, `${config.getContentPath('settings')}/routes.yaml`);
             })
             .then(() => {
                 urlService.resetGenerators({releaseResourcesOnly: true});
@@ -287,7 +287,7 @@ settings = {
                     return siteApp.reload();
                 } catch (err) {
                     // bring back backup, otherwise your Ghost blog is broken
-                    return fs.copy(backupRoutesPath, config.getContentPath('settings') + '/routes.yaml')
+                    return fs.copy(backupRoutesPath, `${config.getContentPath('settings')}/routes.yaml`)
                         .then(() => {
                             return siteApp.reload();
                         })

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -1,6 +1,6 @@
 // # Settings API
 // RESTful API for the Setting resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     moment = require('moment-timezone'),
     fs = require('fs-extra'),
@@ -12,8 +12,9 @@ var Promise = require('bluebird'),
     urlService = require('../services/url'),
     common = require('../lib/common'),
     settingsCache = require('../services/settings/cache'),
-    docName = 'settings',
-    settings,
+    docName = 'settings';
+
+let settings,
     settingsFilter,
     settingsResult,
     canEditAllSettings;
@@ -61,7 +62,7 @@ settingsFilter = function (settings, filter) {
  * @returns {{settings: *}}
  */
 settingsResult = function settingsResult(settings, type) {
-    var filteredSettings = _.values(settingsFilter(settings, type)),
+    let filteredSettings = _.values(settingsFilter(settings, type)),
         result = {
             settings: filteredSettings,
             meta: {}
@@ -84,7 +85,7 @@ settingsResult = function settingsResult(settings, type) {
  * @returns {*}
  */
 canEditAllSettings = function (settingsInfo, options) {
-    var checkSettingPermissions = function checkSettingPermissions(setting) {
+    let checkSettingPermissions = function checkSettingPermissions(setting) {
             if (setting.type === 'core' && !(options.context && options.context.internal)) {
                 return Promise.reject(
                     new common.errors.NoPermissionError({message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')})
@@ -96,7 +97,7 @@ canEditAllSettings = function (settingsInfo, options) {
             });
         },
         checks = _.map(settingsInfo, function (settingInfo) {
-            var setting = settingsCache.get(settingInfo.key, {resolve: false});
+            let setting = settingsCache.get(settingInfo.key, {resolve: false});
 
             if (!setting) {
                 return Promise.reject(new common.errors.NotFoundError(
@@ -134,7 +135,7 @@ settings = {
     browse: function browse(options) {
         options = options || {};
 
-        var result = settingsResult(settingsCache.getAll(), options.type);
+        let result = settingsResult(settingsCache.getAll(), options.type);
 
         // If there is no context, return only blog settings
         if (!options.context) {
@@ -166,7 +167,7 @@ settings = {
             options = {key: options};
         }
 
-        var setting = settingsCache.get(options.key, {resolve: false}),
+        let setting = settingsCache.get(options.key, {resolve: false}),
             result = {};
 
         if (!setting) {
@@ -209,8 +210,7 @@ settings = {
      */
     edit: function edit(object, options) {
         options = options || {};
-        var self = this,
-            type;
+        let type;
 
         // Allow shorthand syntax where a single key and value are passed to edit instead of object and options
         if (_.isString(object)) {
@@ -243,14 +243,14 @@ settings = {
         }
 
         return canEditAllSettings(object.settings, options).then(function () {
-            return localUtils.checkObject(object, docName).then(function (checkedData) {
-                options.user = self.user;
+            return localUtils.checkObject(object, docName).then((checkedData) => {
+                options.user = this.user;
                 return models.Settings.edit(checkedData.settings, options);
             }).then(function (settingsModelsArray) {
                 // Instead of a standard bookshelf collection, Settings.edit returns an array of Settings Models.
                 // We convert this to JSON, by calling toJSON on each Model (using invokeMap for ease)
                 // We use keyBy to create an object that uses the 'key' as a key for each setting.
-                var settingsKeyedJSON = _.keyBy(_.invokeMap(settingsModelsArray, 'toJSON'), 'key');
+                let settingsKeyedJSON = _.keyBy(_.invokeMap(settingsModelsArray, 'toJSON'), 'key');
                 return settingsResult(settingsKeyedJSON, type);
             });
         });

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -29,10 +29,10 @@ let settings,
  * @param {String} filter
  * @returns {*}
  */
-settingsFilter = function (settings, filter) {
+settingsFilter = (settings, filter) => {
     return _.fromPairs(_.toPairs(settings).filter((setting) => {
         if (filter) {
-            return _.some(filter.split(','), function (f) {
+            return _.some(filter.split(','), (f) => {
                 return setting[1].type === f;
             });
         }
@@ -61,7 +61,7 @@ settingsFilter = function (settings, filter) {
  * @param {String} type
  * @returns {{settings: *}}
  */
-settingsResult = function settingsResult(settings, type) {
+settingsResult = (settings, type) => {
     let filteredSettings = _.values(settingsFilter(settings, type)),
         result = {
             settings: filteredSettings,
@@ -84,15 +84,15 @@ settingsResult = function settingsResult(settings, type) {
  * @param {Object} settingsInfo
  * @returns {*}
  */
-canEditAllSettings = function (settingsInfo, options) {
-    let checkSettingPermissions = function checkSettingPermissions(setting) {
+canEditAllSettings = (settingsInfo, options) => {
+    let checkSettingPermissions = (setting) => {
             if (setting.type === 'core' && !(options.context && options.context.internal)) {
                 return Promise.reject(
                     new common.errors.NoPermissionError({message: common.i18n.t('errors.api.settings.accessCoreSettingFromExtReq')})
                 );
             }
 
-            return canThis(options.context).edit.setting(setting.key).catch(function () {
+            return canThis(options.context).edit.setting(setting.key).catch(() => {
                 return Promise.reject(new common.errors.NoPermissionError({message: common.i18n.t('errors.api.settings.noPermissionToEditSettings')}));
             });
         },
@@ -132,7 +132,7 @@ settings = {
      * @param {Object} options
      * @returns {*}
      */
-    browse: function browse(options) {
+    browse: (options) => {
         options = options || {};
 
         let result = settingsResult(settingsCache.getAll(), options.type);
@@ -145,7 +145,7 @@ settings = {
         }
 
         // Otherwise return whatever this context is allowed to browse
-        return canThis(options.context).browse.setting().then(function () {
+        return canThis(options.context).browse.setting().then(() => {
             // Omit core settings unless internal request
             if (!options.context.internal) {
                 result.settings = result.settings.filter((setting) => {
@@ -162,7 +162,7 @@ settings = {
      * @param {Object} options
      * @returns {*}
      */
-    read: function read(options) {
+    read: (options) => {
         if (_.isString(options)) {
             options = {key: options};
         }
@@ -194,9 +194,9 @@ settings = {
             return Promise.resolve(settingsResult(result));
         }
 
-        return canThis(options.context).read.setting(options.key).then(function () {
+        return canThis(options.context).read.setting(options.key).then(() => {
             return settingsResult(result);
-        }, function () {
+        }, () => {
             return Promise.reject(new common.errors.NoPermissionError({message: common.i18n.t('errors.api.settings.noPermissionToReadSettings')}));
         });
     },
@@ -208,7 +208,7 @@ settings = {
      * @param {{id (required), include,...}} options (optional) or a single string value
      * @return {Promise(Setting)} Edited Setting
      */
-    edit: function edit(object, options) {
+    edit: (object, options) => {
         options = options || {};
         let type;
 
@@ -232,7 +232,7 @@ settings = {
             type = type.value;
         }
 
-        object.settings = _.reject(object.settings, function (setting) {
+        object.settings = _.reject(object.settings, (setting) => {
             return setting.key === 'type';
         });
 
@@ -242,11 +242,11 @@ settings = {
             }));
         }
 
-        return canEditAllSettings(object.settings, options).then(function () {
+        return canEditAllSettings(object.settings, options).then(() => {
             return localUtils.checkObject(object, docName).then((checkedData) => {
                 options.user = this.user;
                 return models.Settings.edit(checkedData.settings, options);
-            }).then(function (settingsModelsArray) {
+            }).then((settingsModelsArray) => {
                 // Instead of a standard bookshelf collection, Settings.edit returns an array of Settings Models.
                 // We convert this to JSON, by calling toJSON on each Model (using invokeMap for ease)
                 // We use keyBy to create an object that uses the 'key' as a key for each setting.
@@ -305,7 +305,7 @@ settings = {
             .then(() => {
                 return fs.readFile(routesPath, 'utf-8');
             })
-            .catch(function handleError(err) {
+            .catch((err) => {
                 if (err.code === 'ENOENT') {
                     return Promise.resolve([]);
                 }

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -244,7 +244,6 @@ settings = {
 
         return canEditAllSettings(object.settings, options).then(() => {
             return localUtils.checkObject(object, docName).then((checkedData) => {
-                options.user = this.user;
                 return models.Settings.edit(checkedData.settings, options);
             }).then((settingsModelsArray) => {
                 // Instead of a standard bookshelf collection, Settings.edit returns an array of Settings Models.

--- a/core/server/api/settings.js
+++ b/core/server/api/settings.js
@@ -132,7 +132,7 @@ settings = {
      * @param {Object} options
      * @returns {*}
      */
-    browse: (options) => {
+    browse(options) {
         options = options || {};
 
         let result = settingsResult(settingsCache.getAll(), options.type);
@@ -162,7 +162,7 @@ settings = {
      * @param {Object} options
      * @returns {*}
      */
-    read: (options) => {
+    read(options) {
         if (_.isString(options)) {
             options = {key: options};
         }
@@ -208,7 +208,7 @@ settings = {
      * @param {{id (required), include,...}} options (optional) or a single string value
      * @return {Promise(Setting)} Edited Setting
      */
-    edit: (object, options) => {
+    edit(object, options) {
         options = options || {};
         let type;
 
@@ -266,7 +266,7 @@ settings = {
      *   - we don't destroy the resources, we only release them (this avoids reloading all resources from the db again)
      * - then we reload the whole site app, which will reset all routers and re-create the url generators
      */
-    upload: (options) => {
+    upload(options) {
         const backupRoutesPath = path.join(config.getContentPath('settings'), `routes-${moment().format('YYYY-MM-DD-HH-mm-ss')}.yaml`);
 
         return localUtils.handlePermissions('settings', 'edit')(options)
@@ -297,7 +297,7 @@ settings = {
             });
     },
 
-    download: (options) => {
+    download(options) {
         const routesPath = path.join(config.getContentPath('settings'), 'routes.yaml');
 
         return localUtils.handlePermissions('settings', 'browse')(options)

--- a/core/server/api/slack.js
+++ b/core/server/api/slack.js
@@ -19,7 +19,7 @@ slack = {
      *
      * @public
      */
-    sendTest: function () {
+    sendTest: () => {
         common.events.emit('slack.test');
         return Promise.resolve();
     }

--- a/core/server/api/slack.js
+++ b/core/server/api/slack.js
@@ -19,7 +19,7 @@ slack = {
      *
      * @public
      */
-    sendTest: () => {
+    sendTest() {
         common.events.emit('slack.test');
         return Promise.resolve();
     }

--- a/core/server/api/slack.js
+++ b/core/server/api/slack.js
@@ -1,8 +1,9 @@
 // # Slack API
 // API for sending Test Notifications to Slack
-var Promise = require('bluebird'),
-    common = require('../lib/common'),
-    slack;
+const Promise = require('bluebird'),
+    common = require('../lib/common');
+
+let slack;
 
 /**
  * ## Slack API Method

--- a/core/server/api/slugs.js
+++ b/core/server/api/slugs.js
@@ -58,7 +58,7 @@ slugs = {
          */
         function modelQuery(options) {
             return models.Base.Model.generateSlug(allowedTypes[options.type], options.data.name, {status: 'all'})
-                .then(function onModelResponse(slug) {
+                .then((slug) => {
                     if (!slug) {
                         return Promise.reject(new common.errors.GhostError({
                             message: common.i18n.t('errors.api.slugs.couldNotGenerateSlug')

--- a/core/server/api/slugs.js
+++ b/core/server/api/slugs.js
@@ -24,7 +24,7 @@ slugs = {
      * @param {{type (required), name (required), context, transacting}} options
      * @returns {Promise(String)} Unique string
      */
-    generate: function (options) {
+    generate: (options) => {
         let opts = ['type'],
             attrs = ['name'],
             tasks;

--- a/core/server/api/slugs.js
+++ b/core/server/api/slugs.js
@@ -1,12 +1,13 @@
 // # Slug API
 // RESTful API for the Slug resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
     models = require('../models'),
     common = require('../lib/common'),
-    docName = 'slugs',
-    slugs,
+    docName = 'slugs';
+
+let slugs,
     allowedTypes;
 
 /**
@@ -24,7 +25,7 @@ slugs = {
      * @returns {Promise(String)} Unique string
      */
     generate: function (options) {
-        var opts = ['type'],
+        let opts = ['type'],
             attrs = ['name'],
             tasks;
 

--- a/core/server/api/slugs.js
+++ b/core/server/api/slugs.js
@@ -24,7 +24,7 @@ slugs = {
      * @param {{type (required), name (required), context, transacting}} options
      * @returns {Promise(String)} Unique string
      */
-    generate: (options) => {
+    generate(options) {
         let opts = ['type'],
             attrs = ['name'],
             tasks;

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -65,7 +65,7 @@ subscribers = {
          */
         function doQuery(options) {
             return models.Subscriber.findOne(options.data, _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.subscribers.subscriberNotFound')
@@ -122,7 +122,7 @@ subscribers = {
                         return Promise.reject(error);
                     });
                 })
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     return {
                         subscribers: [model.toJSON(options)]
                     };
@@ -159,7 +159,7 @@ subscribers = {
          */
         function doQuery(options) {
             return models.Subscriber.edit(options.data.subscribers[0], _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.subscribers.subscriberNotFound')

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -1,6 +1,6 @@
 // # Tag API
 // RESTful API for the Tag resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     fs = require('fs-extra'),
     pipeline = require('../lib/promise/pipeline'),
@@ -8,8 +8,9 @@ var Promise = require('bluebird'),
     localUtils = require('./utils'),
     models = require('../models'),
     common = require('../lib/common'),
-    docName = 'subscribers',
-    subscribers;
+    docName = 'subscribers';
+
+let subscribers;
 
 /**
  * ### Subscribers API Methods
@@ -23,7 +24,7 @@ subscribers = {
      * @returns {Promise<Subscriber>} Subscriber Collection
      */
     browse: function browse(options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Model Query
@@ -53,7 +54,7 @@ subscribers = {
      * @return {Promise<Subscriber>} Subscriber
      */
     read: function read(options) {
-        var attrs = ['id', 'email'],
+        let attrs = ['id', 'email'],
             tasks;
 
         /**
@@ -95,7 +96,7 @@ subscribers = {
      * @returns {Promise(Subscriber)} Newly created Subscriber
      */
     add: function add(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Model Query
@@ -149,7 +150,7 @@ subscribers = {
      * @return {Promise<Subscriber>} Edited Subscriber
      */
     edit: function edit(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * Make the call to the Model layer
@@ -191,7 +192,7 @@ subscribers = {
      * @return {Promise}
      */
     destroy: function destroy(options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Delete Subscriber
@@ -247,12 +248,12 @@ subscribers = {
      * @returns {Promise} Ghost Export CSV format
      */
     exportCSV: function exportCSV(options) {
-        var tasks = [];
+        let tasks = [];
 
         options = options || {};
 
         function formatCSV(data) {
-            var fields = ['id', 'email', 'created_at', 'deleted_at'],
+            let fields = ['id', 'email', 'created_at', 'deleted_at'],
                 csv = fields.join(',') + '\r\n',
                 subscriber,
                 field,
@@ -301,11 +302,11 @@ subscribers = {
      * @returns {Promise} Success
      */
     importCSV: function (options) {
-        var tasks = [];
+        let tasks = [];
         options = options || {};
 
         function importCSV(options) {
-            var filePath = options.path,
+            let filePath = options.path,
                 fulfilled = 0,
                 invalid = 0,
                 duplicates = 0;

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -23,7 +23,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise<Subscriber>} Subscriber Collection
      */
-    browse: (options) => {
+    browse(options) {
         let tasks;
 
         /**
@@ -53,7 +53,7 @@ subscribers = {
      * @param {{id}} options
      * @return {Promise<Subscriber>} Subscriber
      */
-    read: (options) => {
+    read(options) {
         let attrs = ['id', 'email'],
             tasks;
 
@@ -95,7 +95,7 @@ subscribers = {
      * @param {Subscriber} object the subscriber to create
      * @returns {Promise(Subscriber)} Newly created Subscriber
      */
-    add: (object, options) => {
+    add(object, options) {
         let tasks;
 
         /**
@@ -149,7 +149,7 @@ subscribers = {
      * @param {{id, context, include}} options
      * @return {Promise<Subscriber>} Edited Subscriber
      */
-    edit: (object, options) => {
+    edit(object, options) {
         let tasks;
 
         /**
@@ -191,7 +191,7 @@ subscribers = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**
@@ -247,7 +247,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise} Ghost Export CSV format
      */
-    exportCSV: (options) => {
+    exportCSV(options) {
         let tasks = [];
 
         options = options || {};
@@ -301,7 +301,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    importCSV: (options) => {
+    importCSV(options) {
         let tasks = [];
         options = options || {};
 

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -23,7 +23,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise<Subscriber>} Subscriber Collection
      */
-    browse: function browse(options) {
+    browse: (options) => {
         let tasks;
 
         /**
@@ -53,7 +53,7 @@ subscribers = {
      * @param {{id}} options
      * @return {Promise<Subscriber>} Subscriber
      */
-    read: function read(options) {
+    read: (options) => {
         let attrs = ['id', 'email'],
             tasks;
 
@@ -95,7 +95,7 @@ subscribers = {
      * @param {Subscriber} object the subscriber to create
      * @returns {Promise(Subscriber)} Newly created Subscriber
      */
-    add: function add(object, options) {
+    add: (object, options) => {
         let tasks;
 
         /**
@@ -106,7 +106,7 @@ subscribers = {
          */
         function doQuery(options) {
             return models.Subscriber.getByEmail(options.data.subscribers[0].email)
-                .then(function (subscriber) {
+                .then((subscriber) => {
                     if (subscriber && options.context.external) {
                         // we don't expose this information
                         return Promise.resolve(subscriber);
@@ -114,7 +114,7 @@ subscribers = {
                         return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.subscribers.subscriberAlreadyExists')}));
                     }
 
-                    return models.Subscriber.add(options.data.subscribers[0], _.omit(options, ['data'])).catch(function (error) {
+                    return models.Subscriber.add(options.data.subscribers[0], _.omit(options, ['data'])).catch((error) => {
                         if (error.code && error.message.toLowerCase().indexOf('unique') !== -1) {
                             return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.subscribers.subscriberAlreadyExists')}));
                         }
@@ -149,7 +149,7 @@ subscribers = {
      * @param {{id, context, include}} options
      * @return {Promise<Subscriber>} Edited Subscriber
      */
-    edit: function edit(object, options) {
+    edit: (object, options) => {
         let tasks;
 
         /**
@@ -191,7 +191,7 @@ subscribers = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: function destroy(options) {
+    destroy: (options) => {
         let tasks;
 
         /**
@@ -202,7 +202,7 @@ subscribers = {
         function getSubscriberByEmail(options) {
             if (options.email) {
                 return models.Subscriber.getByEmail(options.email, options)
-                    .then(function (subscriber) {
+                    .then((subscriber) => {
                         if (!subscriber) {
                             return Promise.reject(new common.errors.NotFoundError({
                                 message: common.i18n.t('errors.api.subscribers.subscriberNotFound')
@@ -247,7 +247,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise} Ghost Export CSV format
      */
-    exportCSV: function exportCSV(options) {
+    exportCSV: (options) => {
         let tasks = [];
 
         options = options || {};
@@ -277,9 +277,9 @@ subscribers = {
 
         // Export data, otherwise send error 500
         function exportSubscribers() {
-            return models.Subscriber.findAll(options).then(function (data) {
+            return models.Subscriber.findAll(options).then((data) => {
                 return formatCSV(data.toJSON(options));
-            }).catch(function (err) {
+            }).catch((err) => {
                 return Promise.reject(new common.errors.GhostError({err: err}));
             });
         }
@@ -301,7 +301,7 @@ subscribers = {
      * @param {{context}} options
      * @returns {Promise} Success
      */
-    importCSV: function (options) {
+    importCSV: (options) => {
         let tasks = [];
         options = options || {};
 
@@ -314,13 +314,13 @@ subscribers = {
             return fsLib.readCSV({
                 path: filePath,
                 columnsToExtract: [{name: 'email', lookup: /email/i}]
-            }).then(function (result) {
-                return Promise.all(result.map(function (entry) {
+            }).then((result) => {
+                return Promise.all(result.map((entry) => {
                     return subscribers.add(
                         {subscribers: [{email: entry.email}]},
                         {context: options.context}
                     ).reflect();
-                })).each(function (inspection) {
+                })).each((inspection) => {
                     if (inspection.isFulfilled()) {
                         fulfilled = fulfilled + 1;
                     } else {
@@ -331,7 +331,7 @@ subscribers = {
                         }
                     }
                 });
-            }).then(function () {
+            }).then(() => {
                 return {
                     meta: {
                         stats: {
@@ -341,7 +341,7 @@ subscribers = {
                         }
                     }
                 };
-            }).finally(function () {
+            }).finally(() => {
                 // Remove uploaded file from tmp location
                 return fs.unlink(filePath);
             });

--- a/core/server/api/subscribers.js
+++ b/core/server/api/subscribers.js
@@ -254,7 +254,7 @@ subscribers = {
 
         function formatCSV(data) {
             let fields = ['id', 'email', 'created_at', 'deleted_at'],
-                csv = fields.join(',') + '\r\n',
+                csv = `${fields.join(',')}\r\n`,
                 subscriber,
                 field,
                 j,

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -66,7 +66,7 @@ tags = {
          */
         function doQuery(options) {
             return models.Tag.findOne(options.data, _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.tags.tagNotFound')
@@ -107,7 +107,7 @@ tags = {
          */
         function doQuery(options) {
             return models.Tag.add(options.data.tags[0], _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     return {
                         tags: [model.toJSON(options)]
                     };
@@ -144,7 +144,7 @@ tags = {
          */
         function doQuery(options) {
             return models.Tag.edit(options.data.tags[0], _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.tags.tagNotFound')

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -1,14 +1,15 @@
 // # Tag API
 // RESTful API for the Tag resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
     models = require('../models'),
     common = require('../lib/common'),
     docName = 'tags',
-    allowedIncludes = ['count.posts'],
-    tags;
+    allowedIncludes = ['count.posts'];
+
+let tags;
 
 /**
  * ### Tags API Methods
@@ -22,7 +23,7 @@ tags = {
      * @returns {Promise<Tags>} Tags Collection
      */
     browse: function browse(options) {
-        var tasks,
+        let tasks,
             permittedOptions = localUtils.browseDefaultOptions.concat('absolute_urls');
 
         /**
@@ -53,7 +54,7 @@ tags = {
      * @return {Promise<Tag>} Tag
      */
     read: function read(options) {
-        var attrs = ['id', 'slug', 'visibility'],
+        let attrs = ['id', 'slug', 'visibility'],
             permittedOptions = ['absolute_urls'],
             tasks;
 
@@ -96,7 +97,7 @@ tags = {
      * @returns {Promise(Tag)} Newly created Tag
      */
     add: function add(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Model Query
@@ -134,7 +135,7 @@ tags = {
      * @return {Promise<Tag>} Edited Tag
      */
     edit: function edit(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * Make the call to the Model layer
@@ -176,7 +177,7 @@ tags = {
      * @return {Promise}
      */
     destroy: function destroy(options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Delete Tag

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -22,7 +22,7 @@ tags = {
      * @param {{context}} options
      * @returns {Promise<Tags>} Tags Collection
      */
-    browse: function browse(options) {
+    browse: (options) => {
         let tasks,
             permittedOptions = localUtils.browseDefaultOptions.concat('absolute_urls');
 
@@ -53,7 +53,7 @@ tags = {
      * @param {{id}} options
      * @return {Promise<Tag>} Tag
      */
-    read: function read(options) {
+    read: (options) => {
         let attrs = ['id', 'slug', 'visibility'],
             permittedOptions = ['absolute_urls'],
             tasks;
@@ -96,7 +96,7 @@ tags = {
      * @param {Tag} object the tag to create
      * @returns {Promise(Tag)} Newly created Tag
      */
-    add: function add(object, options) {
+    add: (object, options) => {
         let tasks;
 
         /**
@@ -134,7 +134,7 @@ tags = {
      * @param {{id, context, include}} options
      * @return {Promise<Tag>} Edited Tag
      */
-    edit: function edit(object, options) {
+    edit: (object, options) => {
         let tasks;
 
         /**
@@ -176,7 +176,7 @@ tags = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: function destroy(options) {
+    destroy: (options) => {
         let tasks;
 
         /**

--- a/core/server/api/tags.js
+++ b/core/server/api/tags.js
@@ -22,7 +22,7 @@ tags = {
      * @param {{context}} options
      * @returns {Promise<Tags>} Tags Collection
      */
-    browse: (options) => {
+    browse(options) {
         let tasks,
             permittedOptions = localUtils.browseDefaultOptions.concat('absolute_urls');
 
@@ -53,7 +53,7 @@ tags = {
      * @param {{id}} options
      * @return {Promise<Tag>} Tag
      */
-    read: (options) => {
+    read(options) {
         let attrs = ['id', 'slug', 'visibility'],
             permittedOptions = ['absolute_urls'],
             tasks;
@@ -96,7 +96,7 @@ tags = {
      * @param {Tag} object the tag to create
      * @returns {Promise(Tag)} Newly created Tag
      */
-    add: (object, options) => {
+    add(object, options) {
         let tasks;
 
         /**
@@ -134,7 +134,7 @@ tags = {
      * @param {{id, context, include}} options
      * @return {Promise<Tag>} Edited Tag
      */
-    edit: (object, options) => {
+    edit(object, options) {
         let tasks;
 
         /**
@@ -176,7 +176,7 @@ tags = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -29,7 +29,7 @@ themes = {
         // Permissions
             .handlePermissions('themes', 'browse')(options)
             // Main action
-            .then(function makeApiResult() {
+            .then(() => {
                 // Return JSON result
                 return themeUtils.toJSON();
             });
@@ -48,7 +48,7 @@ themes = {
         // Permissions
             .handlePermissions('themes', 'activate')(options)
             // Validation
-            .then(function validateTheme() {
+            .then(() => {
                 loadedTheme = themeList.get(themeName);
 
                 if (!loadedTheme) {
@@ -61,13 +61,13 @@ themes = {
                 return themeUtils.validate.check(loadedTheme);
             })
             // Update setting
-            .then(function changeActiveThemeSetting(_checkedTheme) {
+            .then((_checkedTheme) => {
                 checkedTheme = _checkedTheme;
                 // We use the model, not the API here, as we don't want to trigger permissions
                 return settingsModel.edit(newSettings, options);
             })
             // Call activate
-            .then(function hasEditedSetting() {
+            .then(() => {
                 // Activate! (sort of)
                 debug('Activating theme (method B on API "activate")', themeName);
                 themeUtils.activate(loadedTheme, checkedTheme);
@@ -99,35 +99,35 @@ themes = {
             // Permissions
             .handlePermissions('themes', 'add')(options)
             // Validation
-            .then(function validateTheme() {
+            .then(() => {
                 return themeUtils.validate.check(zip, true);
             })
             // More validation (existence check)
-            .then(function checkExists(_checkedTheme) {
+            .then((_checkedTheme) => {
                 checkedTheme = _checkedTheme;
 
                 return themeUtils.storage.exists(zip.shortName);
             })
             // If the theme existed we need to delete it
-            .then(function removeOldTheme(themeExists) {
+            .then((themeExists) => {
                 // delete existing theme
                 if (themeExists) {
                     return themeUtils.storage.delete(zip.shortName);
                 }
             })
-            .then(function storeNewTheme() {
+            .then(() => {
                 // store extracted theme
                 return themeUtils.storage.save({
                     name: zip.shortName,
                     path: checkedTheme.path
                 });
             })
-            .then(function loadNewTheme() {
+            .then(() => {
                 // Loads the theme from the filesystem
                 // Sets the theme on the themeList
                 return themeUtils.loadOne(zip.shortName);
             })
-            .then(function activateAndReturn(loadedTheme) {
+            .then((loadedTheme) => {
                 // If this is the active theme, we are overriding
                 // This is a special case of activation
                 if (zip.shortName === settingsCache.get('active_theme')) {
@@ -171,7 +171,7 @@ themes = {
         return localUtils
         // Permissions
             .handlePermissions('themes', 'read')(options)
-            .then(function sendTheme() {
+            .then(() => {
                 return themeUtils.storage.serve({
                     name: themeName
                 });
@@ -190,7 +190,7 @@ themes = {
         // Permissions
             .handlePermissions('themes', 'destroy')(options)
             // Validation
-            .then(function validateTheme() {
+            .then(() => {
                 if (themeName === 'casper') {
                     throw new common.errors.ValidationError({message: common.i18n.t('errors.api.themes.destroyCasper')});
                 }
@@ -209,7 +209,7 @@ themes = {
                 return themeUtils.storage.delete(themeName);
             })
             // And some extra stuff to maintain state here
-            .then(function deleteTheme() {
+            .then(() => {
                 themeList.del(themeName);
                 // Delete returns an empty 204 response
             });

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -1,6 +1,6 @@
 // # Themes API
 // RESTful API for Themes
-var debug = require('ghost-ignition').debug('api:themes'),
+const debug = require('ghost-ignition').debug('api:themes'),
     Promise = require('bluebird'),
     fs = require('fs-extra'),
     localUtils = require('./utils'),
@@ -8,8 +8,9 @@ var debug = require('ghost-ignition').debug('api:themes'),
     settingsModel = require('../models/settings').Settings,
     settingsCache = require('../services/settings/cache'),
     themeUtils = require('../services/themes'),
-    themeList = themeUtils.list,
-    themes;
+    themeList = themeUtils.list;
+
+let themes;
 
 /**
  * ## Themes API Methods
@@ -35,7 +36,7 @@ themes = {
     },
 
     activate: function activate(options) {
-        var themeName = options.name,
+        let themeName = options.name,
             newSettings = [{
                 key: 'active_theme',
                 value: themeName
@@ -82,7 +83,7 @@ themes = {
         // consistent filename uploads
         options.originalname = options.originalname.toLowerCase();
 
-        var zip = {
+        let zip = {
                 path: options.path,
                 name: options.originalname,
                 shortName: themeUtils.storage.getSanitizedFileName(options.originalname.split('.zip')[0])
@@ -160,7 +161,7 @@ themes = {
     },
 
     download: function download(options) {
-        var themeName = options.name,
+        let themeName = options.name,
             theme = themeList.get(themeName);
 
         if (!theme) {
@@ -182,7 +183,7 @@ themes = {
      * remove theme folder
      */
     destroy: function destroy(options) {
-        var themeName = options.name,
+        let themeName = options.name,
             theme;
 
         return localUtils

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -24,7 +24,7 @@ themes = {
      * contains the custom templates of the active theme. These custom templates are used to show a dropdown
      * in the PSM to be able to choose a custom post template.
      */
-    browse: (options) => {
+    browse(options) {
         return localUtils
         // Permissions
             .handlePermissions('themes', 'browse')(options)
@@ -35,7 +35,7 @@ themes = {
             });
     },
 
-    activate: (options) => {
+    activate(options) {
         let themeName = options.name,
             newSettings = [{
                 key: 'active_theme',
@@ -77,7 +77,7 @@ themes = {
             });
     },
 
-    upload: (options) => {
+    upload(options) {
         options = options || {};
 
         // consistent filename uploads
@@ -160,7 +160,7 @@ themes = {
             });
     },
 
-    download: (options) => {
+    download(options) {
         let themeName = options.name,
             theme = themeList.get(themeName);
 
@@ -182,7 +182,7 @@ themes = {
      * remove theme zip
      * remove theme folder
      */
-    destroy: (options) => {
+    destroy(options) {
         let themeName = options.name,
             theme;
 

--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -24,7 +24,7 @@ themes = {
      * contains the custom templates of the active theme. These custom templates are used to show a dropdown
      * in the PSM to be able to choose a custom post template.
      */
-    browse: function browse(options) {
+    browse: (options) => {
         return localUtils
         // Permissions
             .handlePermissions('themes', 'browse')(options)
@@ -35,7 +35,7 @@ themes = {
             });
     },
 
-    activate: function activate(options) {
+    activate: (options) => {
         let themeName = options.name,
             newSettings = [{
                 key: 'active_theme',
@@ -77,7 +77,7 @@ themes = {
             });
     },
 
-    upload: function upload(options) {
+    upload: (options) => {
         options = options || {};
 
         // consistent filename uploads
@@ -139,12 +139,12 @@ themes = {
                 // @TODO: unify the name across gscan and Ghost!
                 return themeUtils.toJSON(zip.shortName, checkedTheme);
             })
-            .finally(function () {
+            .finally(() => {
                 // @TODO we should probably do this as part of saving the theme
                 // remove zip upload from multer
                 // happens in background
                 fs.remove(zip.path)
-                    .catch(function (err) {
+                    .catch((err) => {
                         common.logging.error(new common.errors.GhostError({err: err}));
                     });
 
@@ -153,14 +153,14 @@ themes = {
                 // happens in background
                 if (checkedTheme) {
                     fs.remove(checkedTheme.path)
-                        .catch(function (err) {
+                        .catch((err) => {
                             common.logging.error(new common.errors.GhostError({err: err}));
                         });
                 }
             });
     },
 
-    download: function download(options) {
+    download: (options) => {
         let themeName = options.name,
             theme = themeList.get(themeName);
 
@@ -182,7 +182,7 @@ themes = {
      * remove theme zip
      * remove theme folder
      */
-    destroy: function destroy(options) {
+    destroy: (options) => {
         let themeName = options.name,
             theme;
 

--- a/core/server/api/upload.js
+++ b/core/server/api/upload.js
@@ -20,14 +20,14 @@ upload = {
      * @param {{context}} options
      * @returns {Promise<String>} location of uploaded file
      */
-    add: Promise.method(function (options) {
+    add: Promise.method((options) => {
         const store = storage.getStorage();
 
         if (options.files) {
             return Promise.map(options.files, (file) => {
                 return store
                     .save(file)
-                    .finally(function () {
+                    .finally(() => {
                         // Remove uploaded file from tmp location
                         return fs.unlink(file.path);
                     });
@@ -36,7 +36,7 @@ upload = {
             });
         }
 
-        return store.save(options).finally(function () {
+        return store.save(options).finally(() => {
             // Remove uploaded file from tmp location
             return fs.unlink(options.path);
         });

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -25,7 +25,7 @@ users = {
      * @param {{context}} options (optional)
      * @returns {Promise<Users>} Users Collection
      */
-    browse: (options) => {
+    browse(options) {
         let extraOptions = ['status', 'absolute_urls'],
             permittedOptions = localUtils.browseDefaultOptions.concat(extraOptions),
             tasks;
@@ -57,7 +57,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise<Users>} User
      */
-    read: (options) => {
+    read(options) {
         let attrs = ['id', 'slug', 'status', 'email', 'role'],
             permittedOptions = ['absolute_urls'],
             tasks;
@@ -106,7 +106,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise<User>}
      */
-    edit: (object, options) => {
+    edit(object, options) {
         let extraOptions = ['editRoles'],
             permittedOptions = extraOptions.concat(localUtils.idDefaultOptions),
             tasks;
@@ -228,7 +228,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**
@@ -290,7 +290,7 @@ users = {
      * @param {{context}} options
      * @returns {Promise<password>} success message
      */
-    changePassword: (object, options) => {
+    changePassword(object, options) {
         let tasks;
 
         function validateRequest() {
@@ -360,7 +360,7 @@ users = {
      * @param {Object} options
      * @returns {Promise<User>}
      */
-    transferOwnership: (object, options) => {
+    transferOwnership(object, options) {
         let tasks;
 
         /**

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -25,7 +25,7 @@ users = {
      * @param {{context}} options (optional)
      * @returns {Promise<Users>} Users Collection
      */
-    browse: function browse(options) {
+    browse: (options) => {
         let extraOptions = ['status', 'absolute_urls'],
             permittedOptions = localUtils.browseDefaultOptions.concat(extraOptions),
             tasks;
@@ -57,7 +57,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise<Users>} User
      */
-    read: function read(options) {
+    read: (options) => {
         let attrs = ['id', 'slug', 'status', 'email', 'role'],
             permittedOptions = ['absolute_urls'],
             tasks;
@@ -106,7 +106,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise<User>}
      */
-    edit: function edit(object, options) {
+    edit: (object, options) => {
         let extraOptions = ['editRoles'],
             permittedOptions = extraOptions.concat(localUtils.idDefaultOptions),
             tasks;
@@ -134,7 +134,7 @@ users = {
                 options.id = options.context.user;
             }
 
-            return canThis(options.context).edit.user(options.id).then(function () {
+            return canThis(options.context).edit.user(options.id).then(() => {
                 // CASE: can't edit my own status to inactive or locked
                 if (options.id === options.context.user) {
                     if (models.User.inactiveStates.indexOf(options.data.users[0].status) !== -1) {
@@ -156,7 +156,7 @@ users = {
 
                 return models.User.findOne(
                     {id: options.context.user, status: 'all'}, {withRelated: ['roles']}
-                ).then(function (contextUser) {
+                ).then((contextUser) => {
                     let contextRoleId = contextUser.related('roles').toJSON(options)[0].id;
 
                     if (roleId !== contextRoleId && editedUserId === contextUser.id) {
@@ -165,7 +165,7 @@ users = {
                         }));
                     }
 
-                    return models.User.findOne({role: 'Owner'}).then(function (owner) {
+                    return models.User.findOne({role: 'Owner'}).then((owner) => {
                         if (contextUser.id !== owner.id) {
                             if (editedUserId === owner.id) {
                                 if (owner.related('roles').at(0).id !== roleId) {
@@ -174,7 +174,7 @@ users = {
                                     }));
                                 }
                             } else if (roleId !== contextRoleId) {
-                                return canThis(options.context).assign.role(role).then(function () {
+                                return canThis(options.context).assign.role(role).then(() => {
                                     return options;
                                 });
                             }
@@ -228,7 +228,7 @@ users = {
      * @param {{id, context}} options
      * @returns {Promise}
      */
-    destroy: function destroy(options) {
+    destroy: (options) => {
         let tasks;
 
         /**
@@ -255,17 +255,17 @@ users = {
          * @param {Object} options
          */
         function deleteUser(options) {
-            return models.Base.transaction(function (t) {
+            return models.Base.transaction((t) => {
                 options.transacting = t;
 
                 return Promise.all([
                     models.Accesstoken.destroyByUser(options),
                     models.Refreshtoken.destroyByUser(options),
                     models.Post.destroyByAuthor(options)
-                ]).then(function () {
+                ]).then(() => {
                     return models.User.destroy(options);
                 }).return(null);
-            }).catch(function (err) {
+            }).catch((err) => {
                 return Promise.reject(new common.errors.NoPermissionError({
                     err: err
                 }));
@@ -290,12 +290,12 @@ users = {
      * @param {{context}} options
      * @returns {Promise<password>} success message
      */
-    changePassword: function changePassword(object, options) {
+    changePassword: (object, options) => {
         let tasks;
 
         function validateRequest() {
             return localUtils.validate('password')(object, options)
-                .then(function (options) {
+                .then((options) => {
                     let data = options.data.password[0];
 
                     if (data.newPassword !== data.ne2Password) {
@@ -317,7 +317,7 @@ users = {
         function handlePermissions(options) {
             return canThis(options.context).edit.user(options.data.password[0].user_id).then(function permissionGranted() {
                 return options;
-            }).catch(function (err) {
+            }).catch((err) => {
                 return Promise.reject(new common.errors.NoPermissionError({
                     err: err,
                     context: common.i18n.t('errors.api.users.noPermissionToChangeUsersPwd')
@@ -360,7 +360,7 @@ users = {
      * @param {Object} options
      * @returns {Promise<User>}
      */
-    transferOwnership: function transferOwnership(object, options) {
+    transferOwnership: (object, options) => {
         let tasks;
 
         /**
@@ -370,9 +370,9 @@ users = {
          * @returns {Object} options
          */
         function handlePermissions(options) {
-            return models.Role.findOne({name: 'Owner'}).then(function (ownerRole) {
+            return models.Role.findOne({name: 'Owner'}).then((ownerRole) => {
                 return canThis(options.context).assign.role(ownerRole);
-            }).then(function () {
+            }).then(() => {
                 return options;
             });
         }

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -1,6 +1,6 @@
 // # Users API
 // RESTful API for the User resource
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
@@ -9,8 +9,9 @@ var Promise = require('bluebird'),
     common = require('../lib/common'),
     docName = 'users',
     // TODO: implement created_by, updated_by
-    allowedIncludes = ['count.posts', 'permissions', 'roles', 'roles.permissions'],
-    users;
+    allowedIncludes = ['count.posts', 'permissions', 'roles', 'roles.permissions'];
+
+let users;
 
 /**
  * ### Users API Methods
@@ -25,7 +26,7 @@ users = {
      * @returns {Promise<Users>} Users Collection
      */
     browse: function browse(options) {
-        var extraOptions = ['status', 'absolute_urls'],
+        let extraOptions = ['status', 'absolute_urls'],
             permittedOptions = localUtils.browseDefaultOptions.concat(extraOptions),
             tasks;
 
@@ -57,7 +58,7 @@ users = {
      * @returns {Promise<Users>} User
      */
     read: function read(options) {
-        var attrs = ['id', 'slug', 'status', 'email', 'role'],
+        let attrs = ['id', 'slug', 'status', 'email', 'role'],
             permittedOptions = ['absolute_urls'],
             tasks;
 
@@ -106,7 +107,7 @@ users = {
      * @returns {Promise<User>}
      */
     edit: function edit(object, options) {
-        var extraOptions = ['editRoles'],
+        let extraOptions = ['editRoles'],
             permittedOptions = extraOptions.concat(localUtils.idDefaultOptions),
             tasks;
 
@@ -149,14 +150,14 @@ users = {
                 }
 
                 // @TODO move role permissions out of here
-                var role = options.data.users[0].roles[0],
+                let role = options.data.users[0].roles[0],
                     roleId = role.id || role,
                     editedUserId = options.id;
 
                 return models.User.findOne(
                     {id: options.context.user, status: 'all'}, {withRelated: ['roles']}
                 ).then(function (contextUser) {
-                    var contextRoleId = contextUser.related('roles').toJSON(options)[0].id;
+                    let contextRoleId = contextUser.related('roles').toJSON(options)[0].id;
 
                     if (roleId !== contextRoleId && editedUserId === contextUser.id) {
                         return Promise.reject(new common.errors.NoPermissionError({
@@ -228,7 +229,7 @@ users = {
      * @returns {Promise}
      */
     destroy: function destroy(options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Handle Permissions
@@ -290,12 +291,12 @@ users = {
      * @returns {Promise<password>} success message
      */
     changePassword: function changePassword(object, options) {
-        var tasks;
+        let tasks;
 
         function validateRequest() {
             return localUtils.validate('password')(object, options)
                 .then(function (options) {
-                    var data = options.data.password[0];
+                    let data = options.data.password[0];
 
                     if (data.newPassword !== data.ne2Password) {
                         return Promise.reject(new common.errors.ValidationError({
@@ -360,7 +361,7 @@ users = {
      * @returns {Promise<User>}
      */
     transferOwnership: function transferOwnership(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Handle Permissions

--- a/core/server/api/users.js
+++ b/core/server/api/users.js
@@ -75,7 +75,7 @@ users = {
          */
         function doQuery(options) {
             return models.User.findOne(options.data, _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.users.userNotFound')
@@ -183,7 +183,7 @@ users = {
                         return options;
                     });
                 });
-            }).catch(function handleError(err) {
+            }).catch((err) => {
                 return Promise.reject(new common.errors.NoPermissionError({
                     err: err,
                     context: common.i18n.t('errors.api.users.noPermissionToEditUser')
@@ -199,7 +199,7 @@ users = {
          */
         function doQuery(options) {
             return models.User.edit(options.data.users[0], _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     if (!model) {
                         return Promise.reject(new common.errors.NotFoundError({
                             message: common.i18n.t('errors.api.users.userNotFound')
@@ -238,10 +238,10 @@ users = {
          * @returns {Object} options
          */
         function handlePermissions(options) {
-            return canThis(options.context).destroy.user(options.id).then(function permissionGranted() {
+            return canThis(options.context).destroy.user(options.id).then(() => {
                 options.status = 'all';
                 return options;
-            }).catch(function handleError(err) {
+            }).catch((err) => {
                 return Promise.reject(new common.errors.NoPermissionError({
                     err: err,
                     context: common.i18n.t('errors.api.users.noPermissionToDestroyUser')
@@ -315,7 +315,7 @@ users = {
          * @returns {Object} options
          */
         function handlePermissions(options) {
-            return canThis(options.context).edit.user(options.data.password[0].user_id).then(function permissionGranted() {
+            return canThis(options.context).edit.user(options.data.password[0].user_id).then(() => {
                 return options;
             }).catch((err) => {
                 return Promise.reject(new common.errors.NoPermissionError({
@@ -335,7 +335,7 @@ users = {
             return models.User.changePassword(
                 options.data.password[0],
                 _.omit(options, ['data'])
-            ).then(function onModelResponse() {
+            ).then(() => {
                 return Promise.resolve({
                     password: [{message: common.i18n.t('notices.api.users.pwdChangedSuccessfully')}]
                 });
@@ -385,7 +385,7 @@ users = {
          */
         function doQuery(options) {
             return models.User.transferOwnership(options.data.owner[0], _.omit(options, ['data']))
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     // NOTE: model returns json object already
                     // @TODO: why?
                     return {

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -33,7 +33,7 @@ utils = {
      * @param {Object} extras
      * @returns {Function} doValidate
      */
-    validate: function validate(docName, extras) {
+    validate: (docName, extras) => {
         /**
          * ### Do Validate
          * Validate the object and options passed to an endpoint
@@ -94,7 +94,7 @@ utils = {
 
             // If we got an object, check that too
             if (object) {
-                return utils.checkObject(object, docName, options.id).then(function (data) {
+                return utils.checkObject(object, docName, options.id).then((data) => {
                     options.data = data;
 
                     return checkOptions(options);
@@ -106,7 +106,7 @@ utils = {
         };
     },
 
-    validateOptions: function validateOptions(options) {
+    validateOptions: (options) => {
         let globalValidations = {
                 id: {matches: /^[a-f\d]{24}$|^1$|me/i},
                 uuid: {isUUID: true},
@@ -124,7 +124,7 @@ utils = {
             noValidation = ['data', 'context', 'include', 'filter', 'forUpdate', 'transacting', 'formats'],
             errors = [];
 
-        _.each(options, function (value, key) {
+        _.each(options, (value, key) => {
             // data is validated elsewhere
             if (noValidation.indexOf(key) === -1) {
                 if (globalValidations[key]) {
@@ -145,7 +145,7 @@ utils = {
      * @param {Object} options
      * @returns {Boolean}
      */
-    detectPublicContext: function detectPublicContext(options) {
+    detectPublicContext: (options) => {
         options.context = permissions.parseContext(options.context);
         return options.context.public;
     },
@@ -157,7 +157,7 @@ utils = {
      * @param {Object} options
      * @returns {Object} options
      */
-    applyPublicPermissions: function applyPublicPermissions(docName, method, options) {
+    applyPublicPermissions: (docName, method, options) => {
         return permissions.applyPublicRules(docName, method, options);
     },
 
@@ -167,7 +167,7 @@ utils = {
      * @param {String} method (read || browse)
      * @returns {Function}
      */
-    handlePublicPermissions: function handlePublicPermissions(docName, method) {
+    handlePublicPermissions: (docName, method) => {
         let singular = docName.replace(/s$/, '');
 
         /**
@@ -197,7 +197,7 @@ utils = {
      * @param {Array} unsafeAttrNames - attribute names (e.g. post.status) that could change the outcome
      * @returns {Function}
      */
-    handlePermissions: function handlePermissions(docName, method, unsafeAttrNames) {
+    handlePermissions: (docName, method, unsafeAttrNames) => {
         let singular = docName.replace(/s$/, '');
 
         /**
@@ -246,7 +246,7 @@ utils = {
         };
     },
 
-    trimAndLowerCase: function trimAndLowerCase(params) {
+    trimAndLowerCase: (params) => {
         params = params || '';
         if (_.isString(params)) {
             params = params.split(',');
@@ -257,15 +257,15 @@ utils = {
         });
     },
 
-    prepareInclude: function prepareInclude(include, allowedIncludes) {
+    prepareInclude: (include, allowedIncludes) => {
         return _.intersection(this.trimAndLowerCase(include), allowedIncludes);
     },
 
-    prepareFields: function prepareFields(fields) {
+    prepareFields: (fields) => {
         return this.trimAndLowerCase(fields);
     },
 
-    prepareFormats: function prepareFormats(formats, allowedFormats) {
+    prepareFormats: (formats, allowedFormats) => {
         return _.intersection(this.trimAndLowerCase(formats), allowedFormats);
     },
 
@@ -274,7 +274,7 @@ utils = {
      * @param {Array} allowedIncludes
      * @returns {Function} doConversion
      */
-    convertOptions: function convertOptions(allowedIncludes, allowedFormats, convertOptions = {forModel: true}) {
+    convertOptions: (allowedIncludes, allowedFormats, convertOptions = {forModel: true}) => {
         /**
          * Convert our options from API-style to Model-style (default)
          * @param {Object} options
@@ -324,7 +324,7 @@ utils = {
      * @param {String} docName
      * @returns {Promise(Object)} resolves to the original object if it checks out
      */
-    checkObject: function checkObject(object, docName, editId) {
+    checkObject: (object, docName, editId) => {
         if (_.isEmpty(object) || _.isEmpty(object[docName]) || _.isEmpty(object[docName][0])) {
             return Promise.reject(new common.errors.BadRequestError({
                 message: common.i18n.t('errors.api.utils.noRootKeyProvided', {docName: docName})
@@ -416,7 +416,7 @@ utils = {
         }
 
         // will remove unwanted null values
-        _.each(object[docName], function (value, index) {
+        _.each(object[docName], (value, index) => {
             if (!_.isObject(object[docName][index])) {
                 return;
             }

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -1,11 +1,12 @@
 // # API Utils
 // Shared helpers for working with the API
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     permissions = require('../services/permissions'),
     validation = require('../data/validation'),
-    common = require('../lib/common'),
-    utils;
+    common = require('../lib/common');
+
+let utils;
 
 utils = {
     // ## Default Options
@@ -39,7 +40,7 @@ utils = {
          * @argument {...*} [arguments] object or object and options hash
          */
         return function doValidate() {
-            var object, options, permittedOptions;
+            let object, options, permittedOptions;
 
             if (arguments.length === 2) {
                 object = arguments[0];
@@ -81,7 +82,7 @@ utils = {
                 // @TODO: should we throw an error if there are incorrect options provided?
                 options = _.pick(options, permittedOptions);
 
-                var validationErrors = utils.validateOptions(options);
+                let validationErrors = utils.validateOptions(options);
 
                 if (_.isEmpty(validationErrors)) {
                     return Promise.resolve(options);
@@ -106,7 +107,7 @@ utils = {
     },
 
     validateOptions: function validateOptions(options) {
-        var globalValidations = {
+        let globalValidations = {
                 id: {matches: /^[a-f\d]{24}$|^1$|me/i},
                 uuid: {isUUID: true},
                 slug: {isSlug: true},
@@ -167,7 +168,7 @@ utils = {
      * @returns {Function}
      */
     handlePublicPermissions: function handlePublicPermissions(docName, method) {
-        var singular = docName.replace(/s$/, '');
+        let singular = docName.replace(/s$/, '');
 
         /**
          * Check if this is a public request, if so use the public permissions, otherwise use standard canThis
@@ -175,7 +176,7 @@ utils = {
          * @returns {Object} options
          */
         return function doHandlePublicPermissions(options) {
-            var permsPromise;
+            let permsPromise;
 
             if (utils.detectPublicContext(options)) {
                 permsPromise = utils.applyPublicPermissions(docName, method, options);
@@ -197,7 +198,7 @@ utils = {
      * @returns {Function}
      */
     handlePermissions: function handlePermissions(docName, method, unsafeAttrNames) {
-        var singular = docName.replace(/s$/, '');
+        let singular = docName.replace(/s$/, '');
 
         /**
          * ### Handle Permissions
@@ -206,7 +207,7 @@ utils = {
          * @returns {Object} options
          */
         return function doHandlePermissions(options) {
-            var unsafeAttrObject = unsafeAttrNames && _.has(options, 'data.[' + docName + '][0]') ? _.pick(options.data[docName][0], unsafeAttrNames) : {},
+            let unsafeAttrObject = unsafeAttrNames && _.has(options, 'data.[' + docName + '][0]') ? _.pick(options.data[docName][0], unsafeAttrNames) : {},
                 permsPromise = permissions.canThis(options.context)[method][singular](options.id, unsafeAttrObject);
 
             return permsPromise.then(function permissionGranted(result) {

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -207,7 +207,7 @@ utils = {
          * @returns {Object} options
          */
         return function doHandlePermissions(options) {
-            let unsafeAttrObject = unsafeAttrNames && _.has(options, 'data.[' + docName + '][0]') ? _.pick(options.data[docName][0], unsafeAttrNames) : {},
+            let unsafeAttrObject = unsafeAttrNames && _.has(options, `data.[${docName}][0]`) ? _.pick(options.data[docName][0], unsafeAttrNames) : {},
                 permsPromise = permissions.canThis(options.context)[method][singular](options.id, unsafeAttrObject);
 
             return permsPromise.then(function permissionGranted(result) {
@@ -221,7 +221,7 @@ utils = {
                  * TODO: This is currently only needed because of the posts model and the contributor role. Once we extend the
                  * contributor role to be able to edit existing tags, this concept can be removed.
                  */
-                if (result && result.excludedAttrs && _.has(options, 'data.[' + docName + '][0]')) {
+                if (result && result.excludedAttrs && _.has(options, `data.[${docName}][0]`)) {
                     options.data[docName][0] = _.omit(options.data[docName][0], result.excludedAttrs);
                 }
 

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -184,7 +184,7 @@ utils = {
                 permsPromise = permissions.canThis(options.context)[method][singular](options.data);
             }
 
-            return permsPromise.then(function permissionGranted() {
+            return permsPromise.then(() => {
                 return options;
             });
         };
@@ -210,7 +210,7 @@ utils = {
             let unsafeAttrObject = unsafeAttrNames && _.has(options, `data.[${docName}][0]`) ? _.pick(options.data[docName][0], unsafeAttrNames) : {},
                 permsPromise = permissions.canThis(options.context)[method][singular](options.id, unsafeAttrObject);
 
-            return permsPromise.then(function permissionGranted(result) {
+            return permsPromise.then((result) => {
                 /*
                  * Allow the permissions function to return a list of excluded attributes.
                  * If it does, omit those attrs from the data passed through
@@ -226,7 +226,7 @@ utils = {
                 }
 
                 return options;
-            }).catch(function handleNoPermissionError(err) {
+            }).catch((err) => {
                 if (err instanceof common.errors.NoPermissionError) {
                     err.message = common.i18n.t('errors.api.utils.noPermissionToCall', {
                         method: method,

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -257,6 +257,7 @@ utils = {
         });
     },
 
+    // Not converted to ES6 arrow functions as functions use `this` context to access object function(trimAndLowerCase)
     prepareInclude: function prepareInclude(include, allowedIncludes) {
         return _.intersection(this.trimAndLowerCase(include), allowedIncludes);
     },

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -257,15 +257,15 @@ utils = {
         });
     },
 
-    prepareInclude: (include, allowedIncludes) => {
+    prepareInclude: function prepareInclude(include, allowedIncludes) {
         return _.intersection(this.trimAndLowerCase(include), allowedIncludes);
     },
 
-    prepareFields: (fields) => {
+    prepareFields: function prepareFields(fields) {
         return this.trimAndLowerCase(fields);
     },
 
-    prepareFormats: (formats, allowedFormats) => {
+    prepareFormats: function prepareFormats(formats, allowedFormats) {
         return _.intersection(this.trimAndLowerCase(formats), allowedFormats);
     },
 

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -257,7 +257,6 @@ utils = {
         });
     },
 
-    // Not converted to ES6 arrow functions as functions use `this` context to access object function(trimAndLowerCase)
     prepareInclude(include, allowedIncludes) {
         return _.intersection(this.trimAndLowerCase(include), allowedIncludes);
     },

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -252,7 +252,7 @@ utils = {
             params = params.split(',');
         }
 
-        return _.map(params, function (item) {
+        return params.map((item) => {
             return item.trim().toLowerCase();
         });
     },

--- a/core/server/api/utils.js
+++ b/core/server/api/utils.js
@@ -33,7 +33,7 @@ utils = {
      * @param {Object} extras
      * @returns {Function} doValidate
      */
-    validate: (docName, extras) => {
+    validate(docName, extras) {
         /**
          * ### Do Validate
          * Validate the object and options passed to an endpoint
@@ -106,7 +106,7 @@ utils = {
         };
     },
 
-    validateOptions: (options) => {
+    validateOptions(options) {
         let globalValidations = {
                 id: {matches: /^[a-f\d]{24}$|^1$|me/i},
                 uuid: {isUUID: true},
@@ -145,7 +145,7 @@ utils = {
      * @param {Object} options
      * @returns {Boolean}
      */
-    detectPublicContext: (options) => {
+    detectPublicContext(options) {
         options.context = permissions.parseContext(options.context);
         return options.context.public;
     },
@@ -157,7 +157,7 @@ utils = {
      * @param {Object} options
      * @returns {Object} options
      */
-    applyPublicPermissions: (docName, method, options) => {
+    applyPublicPermissions(docName, method, options) {
         return permissions.applyPublicRules(docName, method, options);
     },
 
@@ -167,7 +167,7 @@ utils = {
      * @param {String} method (read || browse)
      * @returns {Function}
      */
-    handlePublicPermissions: (docName, method) => {
+    handlePublicPermissions(docName, method) {
         let singular = docName.replace(/s$/, '');
 
         /**
@@ -197,7 +197,7 @@ utils = {
      * @param {Array} unsafeAttrNames - attribute names (e.g. post.status) that could change the outcome
      * @returns {Function}
      */
-    handlePermissions: (docName, method, unsafeAttrNames) => {
+    handlePermissions(docName, method, unsafeAttrNames) {
         let singular = docName.replace(/s$/, '');
 
         /**
@@ -246,7 +246,7 @@ utils = {
         };
     },
 
-    trimAndLowerCase: (params) => {
+    trimAndLowerCase(params) {
         params = params || '';
         if (_.isString(params)) {
             params = params.split(',');
@@ -258,15 +258,15 @@ utils = {
     },
 
     // Not converted to ES6 arrow functions as functions use `this` context to access object function(trimAndLowerCase)
-    prepareInclude: function prepareInclude(include, allowedIncludes) {
+    prepareInclude(include, allowedIncludes) {
         return _.intersection(this.trimAndLowerCase(include), allowedIncludes);
     },
 
-    prepareFields: function prepareFields(fields) {
+    prepareFields(fields) {
         return this.trimAndLowerCase(fields);
     },
 
-    prepareFormats: function prepareFormats(formats, allowedFormats) {
+    prepareFormats(formats, allowedFormats) {
         return _.intersection(this.trimAndLowerCase(formats), allowedFormats);
     },
 
@@ -275,7 +275,7 @@ utils = {
      * @param {Array} allowedIncludes
      * @returns {Function} doConversion
      */
-    convertOptions: (allowedIncludes, allowedFormats, convertOptions = {forModel: true}) => {
+    convertOptions(allowedIncludes, allowedFormats, convertOptions = {forModel: true}) {
         /**
          * Convert our options from API-style to Model-style (default)
          * @param {Object} options
@@ -325,7 +325,7 @@ utils = {
      * @param {String} docName
      * @returns {Promise(Object)} resolves to the original object if it checks out
      */
-    checkObject: (object, docName, editId) => {
+    checkObject(object, docName, editId) {
         if (_.isEmpty(object) || _.isEmpty(object[docName]) || _.isEmpty(object[docName][0])) {
             return Promise.reject(new common.errors.BadRequestError({
                 message: common.i18n.t('errors.api.utils.noRootKeyProvided', {docName: docName})

--- a/core/server/api/webhooks.js
+++ b/core/server/api/webhooks.js
@@ -83,7 +83,7 @@ webhooks = {
 
                     return models.Webhook.add(options.data.webhooks[0], _.omit(options, ['data']));
                 })
-                .then(function onModelResponse(model) {
+                .then((model) => {
                     return {
                         webhooks: [model.toJSON(options)]
                     };

--- a/core/server/api/webhooks.js
+++ b/core/server/api/webhooks.js
@@ -65,7 +65,7 @@ webhooks = {
      * @param {Webhook} object the webhook to create
      * @returns {Promise(Webhook)} newly created Webhook
      */
-    add: (object, options) => {
+    add(object, options) {
         let tasks;
 
         /**
@@ -109,7 +109,7 @@ webhooks = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: (options) => {
+    destroy(options) {
         let tasks;
 
         /**
@@ -133,7 +133,7 @@ webhooks = {
         return pipeline(tasks, options);
     },
 
-    trigger: (event, payload, options) => {
+    trigger(event, payload, options) {
         let tasks;
 
         function doQuery(options) {

--- a/core/server/api/webhooks.js
+++ b/core/server/api/webhooks.js
@@ -1,18 +1,19 @@
 // # Webhooks API
 // RESTful API for creating webhooks
 // also known as "REST Hooks", see http://resthooks.org
-var Promise = require('bluebird'),
+const Promise = require('bluebird'),
     _ = require('lodash'),
     pipeline = require('../lib/promise/pipeline'),
     localUtils = require('./utils'),
     models = require('../models'),
     common = require('../lib/common'),
     request = require('../lib/request'),
-    docName = 'webhooks',
-    webhooks;
+    docName = 'webhooks';
+
+let webhooks;
 
 function makeRequest(webhook, payload, options) {
-    var event = webhook.get('event'),
+    let event = webhook.get('event'),
         targetUrl = webhook.get('target_url'),
         webhookId = webhook.get('id'),
         reqPayload = JSON.stringify(payload);
@@ -65,7 +66,7 @@ webhooks = {
      * @returns {Promise(Webhook)} newly created Webhook
      */
     add: function add(object, options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Model Query
@@ -109,7 +110,7 @@ webhooks = {
      * @return {Promise}
      */
     destroy: function destroy(options) {
-        var tasks;
+        let tasks;
 
         /**
          * ### Delete Webhook
@@ -133,7 +134,7 @@ webhooks = {
     },
 
     trigger: function trigger(event, payload, options) {
-        var tasks;
+        let tasks;
 
         function doQuery(options) {
             return models.Webhook.findAllByEvent(event, options);

--- a/core/server/api/webhooks.js
+++ b/core/server/api/webhooks.js
@@ -28,7 +28,7 @@ function makeRequest(webhook, payload, options) {
         },
         timeout: 2 * 1000,
         retries: 5
-    }).catch(function (err) {
+    }).catch((err) => {
         // when a webhook responds with a 410 Gone response we should remove the hook
         if (err.statusCode === 410) {
             common.logging.info('webhook.destroy (410 response)', event, targetUrl);
@@ -48,7 +48,7 @@ function makeRequest(webhook, payload, options) {
 }
 
 function makeRequests(webhooksCollection, payload, options) {
-    _.each(webhooksCollection.models, function (webhook) {
+    _.each(webhooksCollection.models, (webhook) => {
         makeRequest(webhook, payload, options);
     });
 }
@@ -65,7 +65,7 @@ webhooks = {
      * @param {Webhook} object the webhook to create
      * @returns {Promise(Webhook)} newly created Webhook
      */
-    add: function add(object, options) {
+    add: (object, options) => {
         let tasks;
 
         /**
@@ -76,7 +76,7 @@ webhooks = {
          */
         function doQuery(options) {
             return models.Webhook.getByEventAndTarget(options.data.webhooks[0].event, options.data.webhooks[0].target_url, _.omit(options, ['data']))
-                .then(function (webhook) {
+                .then((webhook) => {
                     if (webhook) {
                         return Promise.reject(new common.errors.ValidationError({message: common.i18n.t('errors.api.webhooks.webhookAlreadyExists')}));
                     }
@@ -109,7 +109,7 @@ webhooks = {
      * @param {{id, context}} options
      * @return {Promise}
      */
-    destroy: function destroy(options) {
+    destroy: (options) => {
         let tasks;
 
         /**
@@ -133,7 +133,7 @@ webhooks = {
         return pipeline(tasks, options);
     },
 
-    trigger: function trigger(event, payload, options) {
+    trigger: (event, payload, options) => {
         let tasks;
 
         function doQuery(options) {


### PR DESCRIPTION
Refs: https://github.com/TryGhost/Ghost/issues/9589
 ES6 migrations applied on all `server/api` files:
- `var` -> `let` / `const`
Lodash usage removed (only where clearly array is being used)
- `_.each(array)` -> array.forEach
- `_.filter(array)` -> array.filter
- `_.map(array)` -> array.map
- `_.find(array)` -> array.find