### PR TITLE
Replaced `setPrototypeOf` with `Object.setPrototypeOf`

### DIFF
--- a/core/server/services/routing/ParentRouter.js
+++ b/core/server/services/routing/ParentRouter.js
@@ -11,7 +11,6 @@ const debug = require('ghost-ignition').debug('services:routing:ParentRouter'),
     express = require('express'),
     _ = require('lodash'),
     url = require('url'),
-    setPrototypeOf = require('setprototypeof'),
     security = require('../../lib/security'),
     urlService = require('../url'),
     // This the route registry for the whole site
@@ -24,7 +23,7 @@ function GhostRouter(options) {
         return innerRouter.handle(req, res, next);
     }
 
-    setPrototypeOf(innerRouter, router);
+    Object.setPrototypeOf(innerRouter, router);
 
     Object.defineProperty(innerRouter, 'name', {
         value: options.parent.name,

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -2,9 +2,6 @@ const debug = require('ghost-ignition').debug('blog');
 const path = require('path');
 const express = require('express');
 
-// this module is missing in package.json
-const setPrototypeOf = require('setprototypeof');
-
 // App requires
 const config = require('../../config');
 const apps = require('../../services/apps');
@@ -135,7 +132,7 @@ module.exports = function setupSiteApp(options = {}) {
     debug('General middleware done');
 
     router = siteRoutes(options);
-    setPrototypeOf(SiteRouter, router);
+    Object.setPrototypeOf(SiteRouter, router);
 
     // Set up Frontend routes (including private blogging routes)
     siteApp.use(SiteRouter);
@@ -152,7 +149,7 @@ module.exports = function setupSiteApp(options = {}) {
 module.exports.reload = () => {
     // https://github.com/expressjs/express/issues/2596
     router = siteRoutes({start: true});
-    setPrototypeOf(SiteRouter, router);
+    Object.setPrototypeOf(SiteRouter, router);
 
     // re-initialse apps (register app routers, because we have re-initialised the site routers)
     apps.init();


### PR DESCRIPTION
no issue

- discovered here: https://github.com/TryGhost/Ghost/pull/9886#discussion_r219127231
- `setPrototypeOf` is a npm package and a dependency of e.g. express
- we can use `Object.setPrototypeOf` instead