### PR TITLE
Refactored direct usages of api controllers

### DIFF
--- a/core/server/adapters/scheduling/post-scheduling/index.js
+++ b/core/server/adapters/scheduling/post-scheduling/index.js
@@ -3,7 +3,6 @@ const Promise = require('bluebird'),
     localUtils = require('../utils'),
     common = require('../../../lib/common'),
     models = require('../../../models'),
-    schedules = require('../../../api/schedules'),
     urlService = require('../../../services/url'),
     _private = {};
 
@@ -25,7 +24,8 @@ _private.loadClient = function loadClient() {
 };
 
 _private.loadScheduledPosts = function () {
-    return schedules.getScheduledPosts()
+    const api = require('../../../api');
+    return api.schedules.getScheduledPosts()
         .then((result) => {
             return result.posts || [];
         });

--- a/core/server/api/schedules.js
+++ b/core/server/api/schedules.js
@@ -6,7 +6,7 @@ const Promise = require('bluebird'),
     models = require('../models'),
     config = require('../config'),
     common = require('../lib/common'),
-    postsAPI = require('../api/posts');
+    postsAPI = require('./posts');
 
 /**
  * Publish a scheduled post


### PR DESCRIPTION
refs #9866

- if we start with v2 controllers, the code base should not require specific api controllers
- because e.g. `require('../api/posts')` will no longer exist
- if you require the api folder, you will get the latest available version by default e.g. `require('../api').posts`
- if you want to require a specific version, it will probably look like `require('../../api/v0.1')` (but we have not 100% decided)
- this branch does not touch/refactor the test env (!)
