### PR TITLE
Refactored how we require shared middlewares from web/

### DIFF
--- a/core/server/api/authentication.js
+++ b/core/server/api/authentication.js
@@ -10,7 +10,7 @@ const Promise = require('bluebird'),
     urlService = require('../services/url'),
     localUtils = require('./utils'),
     models = require('../models'),
-    spamPrevention = require('../web/shared/middlewares/api/spam-prevention'),
+    web = require('../web'),
     mailAPI = require('./mail'),
     settingsAPI = require('./settings'),
     tokenSecurity = {};
@@ -314,7 +314,8 @@ authentication = {
                         }));
                     }
 
-                    spamPrevention.userLogin().reset(opts.ip, `${tokenParts.email}login`);
+                    web.shared.middlewares.api.spamPrevention.userLogin()
+                        .reset(opts.ip, `${tokenParts.email}login`);
 
                     return models.User.changePassword({
                         oldPassword: oldPassword,

--- a/core/server/api/redirects.js
+++ b/core/server/api/redirects.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra'),
     common = require('../lib/common'),
     validation = require('../data/validation'),
     localUtils = require('./utils'),
-    customRedirectsMiddleware = require('../web/shared/middlewares/custom-redirects');
+    web = require('../web');
 
 let redirectsAPI,
     _private = {};
@@ -80,7 +80,7 @@ redirectsAPI = {
                             })
                             .then(() => {
                                 // CASE: trigger that redirects are getting re-registered
-                                customRedirectsMiddleware.reload();
+                                web.shared.middlewares.customRedirects.reload();
                             });
                     });
             });

--- a/core/server/apps/private-blogging/lib/router.js
+++ b/core/server/apps/private-blogging/lib/router.js
@@ -3,7 +3,7 @@ const path = require('path'),
     middleware = require('./middleware'),
     bodyParser = require('body-parser'),
     routing = require('../../../services/routing'),
-    brute = require('../../../web/shared/middlewares/brute'),
+    web = require('../../../web'),
     templateName = 'private',
     privateRouter = express.Router();
 
@@ -36,7 +36,7 @@ privateRouter
     .post(
         bodyParser.urlencoded({extended: true}),
         middleware.isPrivateSessionAuth,
-        brute.privateBlog,
+        web.shared.middlewares.brute.privateBlog,
         middleware.authenticateProtection,
         _renderer
     );

--- a/core/server/services/auth/oauth.js
+++ b/core/server/services/auth/oauth.js
@@ -3,7 +3,7 @@ var oauth2orize = require('oauth2orize'),
     passport = require('passport'),
     models = require('../../models'),
     authUtils = require('./utils'),
-    spamPrevention = require('../../web/shared/middlewares/api/spam-prevention'),
+    web = require('../../web'),
     common = require('../../lib/common'),
     oauthServer,
     oauth;
@@ -31,7 +31,8 @@ function exchangeRefreshToken(client, refreshToken, scope, body, authInfo, done)
                 }
 
                 // @TODO: this runs outside of the transaction
-                spamPrevention.userLogin().reset(authInfo.ip, body.refresh_token + 'login');
+                web.shared.middlewares.api.spamPrevention.userLogin()
+                    .reset(authInfo.ip, body.refresh_token + 'login');
 
                 return authUtils.createTokens({
                     clientId: token.client_id,
@@ -76,7 +77,9 @@ function exchangePassword(client, username, password, scope, body, authInfo, don
             });
         })
         .then(function then(response) {
-            spamPrevention.userLogin().reset(authInfo.ip, username + 'login');
+            web.shared.middlewares.api.spamPrevention.userLogin()
+                .reset(authInfo.ip, username + 'login');
+
             return done(null, response.access_token, response.refresh_token, {expires_in: response.expires_in});
         })
         .catch(function (err) {
@@ -104,7 +107,8 @@ function exchangeAuthorizationCode(req, res, next) {
             }));
         }
 
-        spamPrevention.userLogin().reset(req.authInfo.ip, req.body.authorizationCode + 'login');
+        web.shared.middlewares.api.spamPrevention.userLogin()
+            .reset(req.authInfo.ip, req.body.authorizationCode + 'login');
 
         authUtils.createTokens({
             clientId: req.client.id,

--- a/core/server/web/api/v2/admin/app.js
+++ b/core/server/web/api/v2/admin/app.js
@@ -1,21 +1,9 @@
-// # API routes
 const debug = require('ghost-ignition').debug('api');
 const boolParser = require('express-query-boolean');
 const express = require('express');
-
-// routes
+const bodyParser = require('body-parser');
+const shared = require('../../../shared');
 const routes = require('./routes');
-
-// Include the middleware
-
-// API specific
-const versionMatch = require('../../../shared/middlewares/api/version-match'); // global
-
-// Shared
-const bodyParser = require('body-parser'); // global, shared
-const cacheControl = require('../../../shared/middlewares/cache-control'); // global, shared
-const maintenance = require('../../../shared/middlewares/maintenance'); // global, shared
-const errorHandler = require('../../../shared/middlewares/error-handler'); // global, shared
 
 module.exports = function setupApiApp() {
     debug('Admin API v2 setup start');
@@ -31,21 +19,21 @@ module.exports = function setupApiApp() {
     apiApp.use(boolParser());
 
     // send 503 json response in case of maintenance
-    apiApp.use(maintenance);
+    apiApp.use(shared.middlewares.maintenance);
 
     // Check version matches for API requests, depends on res.locals.safeVersion being set
     // Therefore must come after themeHandler.ghostLocals, for now
-    apiApp.use(versionMatch);
+    apiApp.use(shared.middlewares.api.versionMatch);
 
     // API shouldn't be cached
-    apiApp.use(cacheControl('private'));
+    apiApp.use(shared.middlewares.cacheControl('private'));
 
     // Routing
     apiApp.use(routes());
 
     // API error handling
-    apiApp.use(errorHandler.resourceNotFound);
-    apiApp.use(errorHandler.handleJSONResponse);
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponse);
 
     debug('Admin API v2 setup end');
 

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -1,7 +1,5 @@
-const prettyURLs = require('../../../shared/middlewares/pretty-urls');
-const cors = require('../../../shared/middlewares/api/cors');
-const {adminRedirect} = require('../../../shared/middlewares/url-redirects');
 const auth = require('../../../../services/auth');
+const shared = require('../../../shared');
 
 /**
  * Authentication for private endpoints
@@ -10,9 +8,9 @@ module.exports.authenticatePrivate = [
     auth.authenticate.authenticateClient,
     auth.authenticate.authenticateUser,
     auth.authorize.requiresAuthorizedUser,
-    cors,
-    adminRedirect,
-    prettyURLs
+    shared.middlewares.api.cors,
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls
 ];
 
 /**
@@ -23,8 +21,8 @@ module.exports.authenticateClient = function authenticateClient(client) {
         auth.authenticate.authenticateClient,
         auth.authenticate.authenticateUser,
         auth.authorize.requiresAuthorizedClient(client),
-        cors,
-        adminRedirect,
-        prettyURLs
+        shared.middlewares.api.cors,
+        shared.middlewares.urlRedirects.adminRedirect,
+        shared.middlewares.prettyUrls
     ];
 };

--- a/core/server/web/api/v2/content/app.js
+++ b/core/server/web/api/v2/content/app.js
@@ -1,17 +1,8 @@
-// # API routes
 const debug = require('ghost-ignition').debug('api');
 const boolParser = require('express-query-boolean');
 const express = require('express');
-
-// routes
+const shared = require('../../../shared');
 const routes = require('./routes');
-
-// Include the middleware
-
-// Shared
-const cacheControl = require('../../../shared/middlewares/cache-control'); // global, shared
-const maintenance = require('../../../shared/middlewares/maintenance'); // global, shared
-const errorHandler = require('../../../shared/middlewares/error-handler'); // global, shared
 
 module.exports = function setupApiApp() {
     debug('Content API v2 setup start');
@@ -23,17 +14,17 @@ module.exports = function setupApiApp() {
     apiApp.use(boolParser());
 
     // send 503 json response in case of maintenance
-    apiApp.use(maintenance);
+    apiApp.use(shared.middlewares.maintenance);
 
     // API shouldn't be cached
-    apiApp.use(cacheControl('private'));
+    apiApp.use(shared.middlewares.cacheControl('private'));
 
     // Routing
     apiApp.use(routes());
 
     // API error handling
-    apiApp.use(errorHandler.resourceNotFound);
-    apiApp.use(errorHandler.handleJSONResponse);
+    apiApp.use(shared.middlewares.errorHandler.resourceNotFound);
+    apiApp.use(shared.middlewares.errorHandler.handleJSONResponse);
 
     debug('Content API v2 setup end');
 

--- a/core/server/web/api/v2/content/middleware.js
+++ b/core/server/web/api/v2/content/middleware.js
@@ -1,7 +1,5 @@
-const prettyURLs = require('../../../shared/middlewares/pretty-urls');
-const cors = require('../../../shared/middlewares/api/cors');
-const {adminRedirect} = require('../../../shared/middlewares/url-redirects');
 const auth = require('../../../../services/auth');
+const shared = require('../../../shared');
 
 /**
  * Auth Middleware Packages
@@ -20,7 +18,7 @@ module.exports.authenticatePublic = [
     auth.authenticate.authenticateUser,
     // This is a labs-enabled middleware
     auth.authorize.requiresAuthorizedUserPublicAPI,
-    cors,
-    adminRedirect,
-    prettyURLs
+    shared.middlewares.api.cors,
+    shared.middlewares.urlRedirects.adminRedirect,
+    shared.middlewares.prettyUrls
 ];

--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -1,16 +1,7 @@
 const express = require('express');
-// This essentially provides the controllers for the routes
 const api = require('../../../../api');
-
-// Middleware
+const shared = require('../../../shared');
 const mw = require('./middleware');
-
-// API specific
-const cors = require('../../../shared/middlewares/api/cors');
-
-// Temporary
-// @TODO find a more appy way to do this!
-const labs = require('../../../shared/middlewares/labs');
 
 module.exports = function apiRoutes() {
     const router = express.Router();
@@ -19,7 +10,7 @@ module.exports = function apiRoutes() {
     router.del = router.delete;
 
     // ## CORS pre-flight check
-    router.options('*', cors);
+    router.options('*', shared.middlewares.api.cors);
 
     // ## Configuration
     router.get('/configuration', api.http(api.configuration.read));
@@ -40,7 +31,8 @@ module.exports = function apiRoutes() {
     router.get('/tags/slug/:slug', mw.authenticatePublic, api.http(api.tags.read));
 
     // ## Subscribers
-    router.post('/subscribers', labs.subscribers, mw.authenticatePublic, api.http(api.subscribers.add));
+    // @TODO: find a way than `middlewares.labs`
+    router.post('/subscribers', shared.middlewares.labs.subscribers, mw.authenticatePublic, api.http(api.subscribers.add));
 
     // ## Clients
     router.get('/clients/slug/:slug', api.http(api.clients.read));

--- a/core/server/web/index.js
+++ b/core/server/web/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+    get shared() {
+        return require('./shared');
+    }
+};

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -1,16 +1,9 @@
 const debug = require('ghost-ignition').debug('app');
 const express = require('express');
-
-// App requires
 const config = require('../config');
-
-// middleware
 const compress = require('compression');
 const netjet = require('netjet');
-
-// local middleware
-const ghostLocals = require('./shared/middlewares/ghost-locals');
-const logRequest = require('./shared/middlewares/log-request');
+const shared = require('./shared');
 
 module.exports = function setupParentApp(options = {}) {
     debug('ParentApp setup start');
@@ -22,7 +15,7 @@ module.exports = function setupParentApp(options = {}) {
     // (X-Forwarded-Proto header will be checked, if present)
     parentApp.enable('trust proxy');
 
-    parentApp.use(logRequest);
+    parentApp.use(shared.middlewares.logRequest);
 
     // enabled gzip compression by default
     if (config.get('compress') !== false) {
@@ -39,7 +32,7 @@ module.exports = function setupParentApp(options = {}) {
     }
 
     // This sets global res.locals which are needed everywhere
-    parentApp.use(ghostLocals);
+    parentApp.use(shared.middlewares.ghostLocals);
 
     // Mount the  apps on the parentApp
     // API

--- a/core/server/web/shared/index.js
+++ b/core/server/web/shared/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+    get middlewares() {
+        return require('./middlewares');
+    },
+
+    get utils() {
+        return require('./utils');
+    }
+};

--- a/core/server/web/shared/middlewares/api/index.js
+++ b/core/server/web/shared/middlewares/api/index.js
@@ -1,0 +1,13 @@
+module.exports = {
+    get cors() {
+        return require('./cors');
+    },
+
+    get spamPrevention() {
+        return require('./spam-prevention');
+    },
+
+    get versionMatch() {
+        return require('./version-match');
+    }
+};

--- a/core/server/web/shared/middlewares/index.js
+++ b/core/server/web/shared/middlewares/index.js
@@ -1,5 +1,77 @@
 module.exports = {
+    get api() {
+        return require('./api');
+    },
+
+    get image() {
+        return require('./image');
+    },
+
+    get validation() {
+        return require('./validation');
+    },
+
+    get adminRedirects() {
+        return require('./admin-redirects');
+    },
+
+    get brute() {
+        return require('./brute');
+    },
+
+    get cacheControl() {
+        return require('./cache-control');
+    },
+
+    get customRedirects() {
+        return require('./custom-redirects');
+    },
+
+    get errorHandler() {
+        return require('./error-handler');
+    },
+
+    get frontendClient() {
+        return require('./frontend-client');
+    },
+
+    get ghostLocals() {
+        return require('./ghost-locals');
+    },
+
+    get labs() {
+        return require('./labs');
+    },
+
+    get logRequest() {
+        return require('./log-request');
+    },
+
     get maintenance() {
         return require('./maintenance');
+    },
+
+    get prettyUrls() {
+        return require('./pretty-urls');
+    },
+
+    get serveFavicon() {
+        return require('./serve-favicon');
+    },
+
+    get servePublicFile() {
+        return require('./serve-public-file');
+    },
+
+    get staticTheme() {
+        return require('./static-theme');
+    },
+
+    get uncapitalise() {
+        return require('./uncapitalise');
+    },
+
+    get urlRedirects() {
+        return require('./url-redirects');
     }
 };

--- a/core/server/web/shared/middlewares/validation/index.js
+++ b/core/server/web/shared/middlewares/validation/index.js
@@ -1,2 +1,9 @@
-exports.upload = require('./upload');
-exports.blogIcon = require('./blog-icon');
+module.exports = {
+    get upload() {
+        return require('./upload');
+    },
+
+    get blogIcon() {
+        return require('./blog-icon');
+    }
+};

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -9,7 +9,7 @@ const constants = require('../../lib/constants');
 const storage = require('../../adapters/storage');
 const urlService = require('../../services/url');
 const sitemapHandler = require('../../data/xml/sitemap/handler');
-const themeService = require('../../services/themes');
+const themeMiddleware = require('../../services/themes').middleware;
 const siteRoutes = require('./routes');
 const shared = require('../shared');
 
@@ -71,7 +71,7 @@ module.exports = function setupSiteApp(options = {}) {
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates
     // At this point the active theme object is already updated, so we have the right path, so it can probably
     // go after staticTheme() as well, however I would really like to simplify this and be certain
-    siteApp.use(themeService.middleware);
+    siteApp.use(themeMiddleware);
     debug('Themes done');
 
     // Theme static assets/files

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -8,30 +8,10 @@ const apps = require('../../services/apps');
 const constants = require('../../lib/constants');
 const storage = require('../../adapters/storage');
 const urlService = require('../../services/url');
-
-// This should probably be an internal app
 const sitemapHandler = require('../../data/xml/sitemap/handler');
-
-// Route Service
+const themeService = require('../../services/themes');
 const siteRoutes = require('./routes');
-
-// Global/shared middleware
-const cacheControl = require('../shared/middlewares/cache-control');
-const errorHandler = require('../shared/middlewares/error-handler');
-const frontendClient = require('../shared/middlewares/frontend-client');
-const maintenance = require('../shared/middlewares/maintenance');
-const prettyURLs = require('../shared/middlewares/pretty-urls');
-const urlRedirects = require('../shared/middlewares/url-redirects');
-
-// local middleware
-const servePublicFile = require('../shared/middlewares/serve-public-file');
-const staticTheme = require('../shared/middlewares/static-theme');
-const customRedirects = require('../shared/middlewares/custom-redirects');
-const serveFavicon = require('../shared/middlewares/serve-favicon');
-const adminRedirects = require('../shared/middlewares/admin-redirects');
-
-// middleware for themes
-const themeMiddleware = require('../../services/themes').middleware;
+const shared = require('../shared');
 
 let router;
 
@@ -50,32 +30,32 @@ module.exports = function setupSiteApp(options = {}) {
 
     // you can extend Ghost with a custom redirects file
     // see https://github.com/TryGhost/Ghost/issues/7707
-    customRedirects.use(siteApp);
+    shared.middlewares.customRedirects.use(siteApp);
 
     // More redirects
-    siteApp.use(adminRedirects());
+    siteApp.use(shared.middlewares.adminRedirects());
 
     // force SSL if blog url is set to https. The redirects handling must happen before asset and page routing,
     // otherwise we serve assets/pages with http. This can cause mixed content warnings in the admin client.
-    siteApp.use(urlRedirects);
+    siteApp.use(shared.middlewares.urlRedirects);
 
     // Static content/assets
     // @TODO make sure all of these have a local 404 error handler
     // Favicon
-    siteApp.use(serveFavicon());
+    siteApp.use(shared.middlewares.serveFavicon());
     // /public/ghost-sdk.js
-    siteApp.use(servePublicFile('public/ghost-sdk.js', 'application/javascript', constants.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost-sdk.min.js', 'application/javascript', constants.ONE_YEAR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/ghost-sdk.js', 'application/javascript', constants.ONE_HOUR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/ghost-sdk.min.js', 'application/javascript', constants.ONE_YEAR_S));
     // Serve sitemap.xsl file
-    siteApp.use(servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
+    siteApp.use(shared.middlewares.servePublicFile('sitemap.xsl', 'text/xsl', constants.ONE_DAY_S));
 
     // Serve stylesheets for default templates
-    siteApp.use(servePublicFile('public/ghost.css', 'text/css', constants.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/ghost.min.css', 'text/css', constants.ONE_YEAR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/ghost.css', 'text/css', constants.ONE_HOUR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/ghost.min.css', 'text/css', constants.ONE_YEAR_S));
 
     // Serve images for default templates
-    siteApp.use(servePublicFile('public/404-ghost@2x.png', 'png', constants.ONE_HOUR_S));
-    siteApp.use(servePublicFile('public/404-ghost.png', 'png', constants.ONE_HOUR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/404-ghost@2x.png', 'png', constants.ONE_HOUR_S));
+    siteApp.use(shared.middlewares.servePublicFile('public/404-ghost.png', 'png', constants.ONE_HOUR_S));
 
     // Serve blog images using the storage adapter
     siteApp.use('/' + urlService.utils.STATIC_IMAGE_URL_PREFIX, storage.getStorage().serve());
@@ -91,15 +71,15 @@ module.exports = function setupSiteApp(options = {}) {
     // This should happen AFTER any shared assets are served, as it only changes things to do with templates
     // At this point the active theme object is already updated, so we have the right path, so it can probably
     // go after staticTheme() as well, however I would really like to simplify this and be certain
-    siteApp.use(themeMiddleware);
+    siteApp.use(themeService.middleware);
     debug('Themes done');
 
     // Theme static assets/files
-    siteApp.use(staticTheme());
+    siteApp.use(shared.middlewares.staticTheme());
     debug('Static content done');
 
     // Serve robots.txt if not found in theme
-    siteApp.use(servePublicFile('robots.txt', 'text/plain', constants.ONE_HOUR_S));
+    siteApp.use(shared.middlewares.servePublicFile('robots.txt', 'text/plain', constants.ONE_HOUR_S));
 
     // setup middleware for internal apps
     // @TODO: refactor this to be a proper app middleware hook for internal & external apps
@@ -116,18 +96,18 @@ module.exports = function setupSiteApp(options = {}) {
     debug('Internal apps done');
 
     // send 503 error page in case of maintenance
-    siteApp.use(maintenance);
+    siteApp.use(shared.middlewares.maintenance);
 
     // Add in all trailing slashes & remove uppercase
     // must happen AFTER asset loading and BEFORE routing
-    siteApp.use(prettyURLs);
+    siteApp.use(shared.middlewares.prettyUrls);
 
     // ### Caching
     // Site frontend is cacheable
-    siteApp.use(cacheControl('public'));
+    siteApp.use(shared.middlewares.cacheControl('public'));
 
     // Fetch the frontend client into res.locals
-    siteApp.use(frontendClient);
+    siteApp.use(shared.middlewares.frontendClient);
 
     debug('General middleware done');
 
@@ -138,8 +118,8 @@ module.exports = function setupSiteApp(options = {}) {
     siteApp.use(SiteRouter);
 
     // ### Error handlers
-    siteApp.use(errorHandler.pageNotFound);
-    siteApp.use(errorHandler.handleThemeResponse);
+    siteApp.use(shared.middlewares.errorHandler.pageNotFound);
+    siteApp.use(shared.middlewares.errorHandler.handleThemeResponse);
 
     debug('Site setup end');
 

--- a/core/test/utils/index.js
+++ b/core/test/utils/index.js
@@ -23,7 +23,7 @@ var Promise = require('bluebird'),
     settingsService = require('../../server/services/settings'),
     settingsCache = require('../../server/services/settings/cache'),
     imageLib = require('../../server/lib/image'),
-    customRedirectsMiddleware = require('../../server/web/shared/middlewares/custom-redirects'),
+    web = require('../../server/web'),
     permissions = require('../../server/services/permissions'),
     sequence = require('../../server/lib/promise/sequence'),
     themes = require('../../server/services/themes'),
@@ -943,7 +943,7 @@ startGhost = function startGhost(options) {
                 });
             })
             .then(function () {
-                customRedirectsMiddleware.reload();
+                web.shared.middlewares.customRedirects.reload();
 
                 common.events.emit('server.start');
                 return ghostServer;


### PR DESCRIPTION
refs #9866

- use package notation
- get rid of x requires for middlewares
- improved readability
- do not refactor web/api/v0.1