### PR TITLE
Normalised how we require models

### DIFF
--- a/core/server/api/themes.js
+++ b/core/server/api/themes.js
@@ -5,7 +5,7 @@ const debug = require('ghost-ignition').debug('api:themes'),
     fs = require('fs-extra'),
     localUtils = require('./utils'),
     common = require('../lib/common'),
-    settingsModel = require('../models/settings').Settings,
+    models = require('../models'),
     settingsCache = require('../services/settings/cache'),
     themeUtils = require('../services/themes'),
     themeList = themeUtils.list;
@@ -64,7 +64,7 @@ themes = {
             .then((_checkedTheme) => {
                 checkedTheme = _checkedTheme;
                 // We use the model, not the API here, as we don't want to trigger permissions
-                return settingsModel.edit(newSettings, options);
+                return models.Settings.edit(newSettings, options);
             })
             // Call activate
             .then(() => {

--- a/core/server/services/settings/index.js
+++ b/core/server/services/settings/index.js
@@ -3,12 +3,12 @@
  * A collection of utilities for handling settings including a cache
  */
 const _ = require('lodash'),
-    SettingsModel = require('../../models/settings').Settings,
+    debug = require('ghost-ignition').debug('services:settings:index'),
+    common = require('../../lib/common'),
+    models = require('../../models'),
     SettingsCache = require('./cache'),
     SettingsLoader = require('./loader'),
-    ensureSettingsFiles = require('./ensure-settings'),
-    common = require('../../lib/common'),
-    debug = require('ghost-ignition').debug('services:settings:index');
+    ensureSettingsFiles = require('./ensure-settings');
 
 module.exports = {
     init: function init() {
@@ -21,7 +21,7 @@ module.exports = {
         return ensureSettingsFiles(knownSettings)
             .then(() => {
                 // Update the defaults
-                return SettingsModel.populateDefaults();
+                return models.Settings.populateDefaults();
             })
             .then((settingsCollection) => {
                 // Initialise the cache with the result


### PR DESCRIPTION
refs #9866

- if i want to do a project search and looks for model usages e.g. `models.`, then i won't find these usages
- normalise how we require models -> consistency