### PR TITLE
Refactoring API_PATH to allow multiple version URLs

### DIFF
--- a/core/server/api/index.js
+++ b/core/server/api/index.js
@@ -124,7 +124,7 @@ cacheInvalidationHeader = (req, result) => {
  * @return {String} Resolves to header string
  */
 locationHeader = (req, result) => {
-    const apiRoot = urlService.utils.urlFor('api');
+    const apiRoot = urlService.utils.urlFor('api', {version: 'stable'});
     let location,
         newObject,
         statusQuery;

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -64,5 +64,12 @@
     },
     "maintenance": {
         "enabled": false
+    },
+    "api": {
+        "versions": {
+            "active": "v2",
+            "stable": "v0.1",
+            "deprecated": ""
+        }
     }
 }

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -69,11 +69,11 @@
         "versions": {
             "active": {
                 "admin": "v2/admin",
-                "client": "v2/client"
+                "content": "v2/content"
             },
             "stable": {
                 "admin": "v0.1",
-                "client": "v0.1"
+                "content": "v0.1"
             },
             "deprecated": {}
         }

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -67,9 +67,15 @@
     },
     "api": {
         "versions": {
-            "active": "v2",
-            "stable": "v0.1",
-            "deprecated": ""
+            "active": {
+                "admin": "v2/admin",
+                "client": "v2/client"
+            },
+            "stable": {
+                "admin": "v0.1",
+                "client": "v0.1"
+            },
+            "deprecated": {}
         }
     }
 }

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -44,7 +44,7 @@ function initialiseServices() {
         scheduling.init({
             schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
-            apiUrl: urlService.utils.urlFor('api', true),
+            apiUrl: urlService.utils.urlFor('api', {version: 'stable'}, true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         })

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -17,7 +17,7 @@ const moment = require('moment-timezone'),
 function getApiPath(version = 'stable', admin = false) {
     const apiVersions = config.get('api:versions') || {};
     let versionType = apiVersions[version] || apiVersions.stable;
-    let versionPath = admin ? versionType['admin'] : versionType['client'];
+    let versionPath = admin ? versionType.admin : versionType.client;
     return `${BASE_API_PATH}${versionPath}/`;
 }
 

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -9,15 +9,14 @@ const moment = require('moment-timezone'),
     BASE_API_PATH = '/ghost/api/',
     STATIC_IMAGE_URL_PREFIX = 'content/images';
 
-
 /**
  * Returns API path combining base path and path for specific version asked or stable by default
  * @param {string} version version for which to get the path(stable, actice, deprecated), defaults to stable
  * @return {string} API Path for version
  */
-function getApiPath(version = "stable") {
+function getApiPath(version = 'stable') {
     const apiVersions = config.get('api:versions') || {};
-    let versionPath = apiVersions[version] || apiVersions['stable'];
+    let versionPath = apiVersions[version] || apiVersions.stable;
     return `${BASE_API_PATH}${versionPath}/`;
 }
 

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -15,7 +15,7 @@ const moment = require('moment-timezone'),
  * @return {string} API Path for version
  */
 function getApiPath(version = 'stable', admin = false) {
-    const apiVersions = config.get('api:versions') || {};
+    const apiVersions = config.get('api:versions');
     let versionType = apiVersions[version] || apiVersions.stable;
     let versionPath = admin ? versionType.admin : versionType.client;
     return `${BASE_API_PATH}${versionPath}/`;

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -11,13 +11,13 @@ const moment = require('moment-timezone'),
 
 /**
  * Returns API path combining base path and path for specific version asked or stable by default
- * @param {string} version version for which to get the path(stable, actice, deprecated: client, admin), defaults to stable:client
+ * @param {string} version version for which to get the path(stable, actice, deprecated: content, admin), defaults to stable:content
  * @return {string} API Path for version
  */
 function getApiPath(version = 'stable', admin = false) {
     const apiVersions = config.get('api:versions');
     let versionType = apiVersions[version] || apiVersions.stable;
-    let versionPath = admin ? versionType.admin : versionType.client;
+    let versionPath = admin ? versionType.admin : versionType.content;
     return `${BASE_API_PATH}${versionPath}/`;
 }
 

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -11,12 +11,13 @@ const moment = require('moment-timezone'),
 
 /**
  * Returns API path combining base path and path for specific version asked or stable by default
- * @param {string} version version for which to get the path(stable, actice, deprecated), defaults to stable
+ * @param {string} version version for which to get the path(stable, actice, deprecated: client, admin), defaults to stable:client
  * @return {string} API Path for version
  */
-function getApiPath(version = 'stable') {
+function getApiPath(version = 'stable', admin = false) {
     const apiVersions = config.get('api:versions') || {};
-    let versionPath = apiVersions[version] || apiVersions.stable;
+    let versionType = apiVersions[version] || apiVersions.stable;
+    let versionPath = admin ? versionType['admin'] : versionType['client'];
     return `${BASE_API_PATH}${versionPath}/`;
 }
 
@@ -248,7 +249,6 @@ function urlFor(context, data, absolute) {
         // this will become really big
         knownPaths = {
             home: '/',
-            api: getApiPath('stable'),
             sitemap_xsl: '/sitemap.xsl'
         };
 
@@ -324,7 +324,7 @@ function urlFor(context, data, absolute) {
         }
 
         if (data && data.version) {
-            apiPath = getApiPath(data.version);
+            apiPath = getApiPath(data.version, data.admin);
         }
 
         if (absolute) {

--- a/core/server/web/shared/middlewares/serve-public-file.js
+++ b/core/server/web/shared/middlewares/serve-public-file.js
@@ -26,7 +26,7 @@ function servePublicFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, urlService.utils.urlFor('home', true).replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true}, true));
+                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true, version: 'stable'}, true));
                     }
                     content = {
                         headers: {

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -522,6 +522,22 @@ describe('Url', function () {
 
             urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
+
+        it('api: with active version, blog url is https: should return active client api path', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            urlService.utils.urlFor('api', {cors: true, version: "active"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/client/');
+        });
+
+        it('api: with active version and admin true, blog url is https: should return active admin api path', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            urlService.utils.urlFor('api', {cors: true, version: "active", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/admin/');
+        });
     });
 
     describe('replacePermalink', function () {

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -523,12 +523,12 @@ describe('Url', function () {
             urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
-        it('api: with active version, blog url is https: should return active client api path', function () {
+        it('api: with active version, blog url is https: should return active content api path', function () {
             configUtils.set({
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "active"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/client/');
+            urlService.utils.urlFor('api', {cors: true, version: "active"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/content/');
         });
 
         it('api: with active version and admin true, blog url is https: should return active admin api path', function () {

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -523,6 +523,22 @@ describe('Url', function () {
             urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
+        it('api: with stable version, blog url is https: should return stable content api path', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            urlService.utils.urlFor('api', {cors: true, version: "stable"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
+        it('api: with stable version and admin true, blog url is https: should return stable admin api path', function () {
+            configUtils.set({
+                url: 'https://my-ghost-blog.com'
+            });
+
+            urlService.utils.urlFor('api', {cors: true, version: "stable", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+        });
+
         it('api: with active version, blog url is https: should return active content api path', function () {
             configUtils.set({
                 url: 'https://my-ghost-blog.com'


### PR DESCRIPTION
refs #9866

* remove hardcoded `API_PATH` with method to calculate path based on version
* update scheduler to use the stable(v0.1) endpoint
* serve public file uses the stable(v0.1) endpoint