### PR TITLE
Added test case for includes not being present in response

### DIFF
--- a/core/test/functional/routes/api/posts_spec.js
+++ b/core/test/functional/routes/api/posts_spec.js
@@ -186,6 +186,37 @@ describe('Post API', function () {
                     });
             });
 
+            it('fields and formats and include ignores include', function (done) {
+                request.get(testUtils.API.getApiQuery('posts/?formats=mobiledoc,html&fields=id,title&include=authors'))
+                    .set('Authorization', 'Bearer ' + ownerAccessToken)
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        should.not.exist(res.headers['x-cache-invalidate']);
+                        var jsonResponse = res.body;
+                        should.exist(jsonResponse.posts);
+                        should.not.exist(jsonResponse.posts[0].authors);
+                        testUtils.API.checkResponse(jsonResponse, 'posts');
+                        jsonResponse.posts.should.have.length(11);
+                        testUtils.API.checkResponse(
+                            jsonResponse.posts[0],
+                            'post',
+                            null,
+                            null,
+                            ['mobiledoc', 'id', 'title', 'html']
+                        );
+
+                        testUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
+
+                        done();
+                    });
+            });
+
             it('can retrieve all published posts and pages', function (done) {
                 request.get(testUtils.API.getApiQuery('posts/?staticPages=all'))
                     .set('Authorization', 'Bearer ' + ownerAccessToken)


### PR DESCRIPTION
This test case needs to be added so that https://github.com/TryGhost/Ghost/pull/9899 can be more explicit about the change in this behavior 

refs #9866

- Adds a test case checking current filtering behavior for 'include' parameter

