### PR TITLE
Updated overrides config for api versions with v0.1 to deprecated

### DIFF
--- a/core/server/api/v0.1/index.js
+++ b/core/server/api/v0.1/index.js
@@ -115,7 +115,7 @@ const cacheInvalidationHeader = (req, result) => {
  * @return {String} Resolves to header string
  */
 const locationHeader = (req, result) => {
-    const apiRoot = urlService.utils.urlFor('api', {version: 'stable'});
+    const apiRoot = urlService.utils.urlFor('api', {version: 'deprecated'});
     let location,
         newObject,
         statusQuery;

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -71,11 +71,11 @@
                 "admin": "v2/admin",
                 "content": "v2/content"
             },
-            "stable": {
+            "stable": {},
+            "deprecated": {
                 "admin": "v0.1",
                 "content": "v0.1"
-            },
-            "deprecated": {}
+            }
         }
     }
 }

--- a/core/server/index.js
+++ b/core/server/index.js
@@ -44,7 +44,7 @@ function initialiseServices() {
         scheduling.init({
             schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
-            apiUrl: urlService.utils.urlFor('api', {version: 'stable'}, true),
+            apiUrl: urlService.utils.urlFor('api', {version: 'deprecated'}, true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         })

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -10,13 +10,13 @@ const moment = require('moment-timezone'),
     STATIC_IMAGE_URL_PREFIX = 'content/images';
 
 /**
- * Returns API path combining base path and path for specific version asked or stable by default
- * @param {string} version version for which to get the path(stable, actice, deprecated: content, admin), defaults to stable:content
+ * Returns API path combining base path and path for specific version asked or deprecated by default
+ * @param {string} version version for which to get the path(stable, actice, deprecated: content, admin), defaults to deprecated:content
  * @return {string} API Path for version
  */
-function getApiPath(version = 'stable', admin = false) {
+function getApiPath(version = 'deprecated', admin = false) {
     const apiVersions = config.get('api:versions');
-    let versionType = apiVersions[version] || apiVersions.stable;
+    let versionType = apiVersions[version] || apiVersions.deprecated;
     let versionPath = admin ? versionType.admin : versionType.content;
     return `${BASE_API_PATH}${versionPath}/`;
 }
@@ -313,7 +313,7 @@ function urlFor(context, data, absolute) {
         }
     } else if (context === 'api') {
         urlPath = getAdminUrl() || getBlogUrl();
-        let apiPath = getApiPath('stable');
+        let apiPath = getApiPath('deprecated');
         // CASE: with or without protocol? If your blog url (or admin url) is configured to http, it's still possible that e.g. nginx allows both https+http.
         // So it depends how you serve your blog. The main focus here is to avoid cors problems.
         // @TODO: rename cors

--- a/core/server/web/shared/middlewares/serve-public-file.js
+++ b/core/server/web/shared/middlewares/serve-public-file.js
@@ -26,7 +26,7 @@ function servePublicFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, urlService.utils.urlFor('home', true).replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true, version: 'stable'}, true));
+                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true));
                     }
                     content = {
                         headers: {

--- a/core/test/unit/public/ghost_sdk_spec.js
+++ b/core/test/unit/public/ghost_sdk_spec.js
@@ -27,7 +27,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -41,7 +41,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         ghostSdk.url.api().should.equal('https://testblog.com/ghost/api/v0.1/');
@@ -58,7 +58,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         ghostSdk.url.api().should.equal('https://admin.testblog.com/ghost/api/v0.1/');
@@ -68,7 +68,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         ghostSdk.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -78,7 +78,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -88,7 +88,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         var rendered = ghostSdk.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -126,7 +126,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -146,7 +146,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', true)
+            url: urlService.utils.urlFor('api', {version: 'deprecated'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -165,7 +165,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', true)
+            url: urlService.utils.urlFor('api', {version: 'deprecated'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -185,7 +185,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts', {limit: 3}),

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -446,7 +446,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', true).should.eql('https://something.de/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('https://something.de/ghost/api/v0.1/');
         });
 
         it('api: url has subdir', function () {
@@ -454,11 +454,11 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            urlService.utils.urlFor('api', true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
         });
 
         it('api: relative path is correct', function () {
-            urlService.utils.urlFor('api').should.eql('/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}).should.eql('/ghost/api/v0.1/');
         });
 
         it('api: relative path with subdir is correct', function () {
@@ -466,7 +466,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            urlService.utils.urlFor('api').should.eql('/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}).should.eql('/blog/ghost/api/v0.1/');
         });
 
         it('api: should return http if config.url is http', function () {
@@ -474,7 +474,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: should return https if config.url is https', function () {
@@ -482,7 +482,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is http: should return no protocol', function () {
@@ -490,7 +490,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is http: cors should return no protocol', function () {
@@ -501,7 +501,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', {cors: true}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is https: should return with protocol', function () {
@@ -512,7 +512,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is https: should return with protocol', function () {
@@ -520,7 +520,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with stable version, blog url is https: should return stable content api path', function () {
@@ -528,7 +528,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "stable"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: "deprecated"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with stable version and admin true, blog url is https: should return stable admin api path', function () {
@@ -536,7 +536,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "stable", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: "deprecated", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with active version, blog url is https: should return active content api path', function () {


### PR DESCRIPTION
refs #9866
- v0.1 is considered `deprecated` instead of `stable`