### PR TITLE
Improve validation errors for routes yaml

### DIFF
--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -302,6 +302,7 @@ _private.validateCollections = function validateCollections(collections) {
 };
 
 _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
+    const validRoutingTypeObjectKeys = Object.keys(RESOURCE_CONFIG.TAXONOMIES);
     _.each(taxonomies, (routingTypeObject, routingTypeObjectKey) => {
         if (!routingTypeObject) {
             throw new common.errors.ValidationError({
@@ -310,6 +311,15 @@ _private.validateTaxonomies = function validateTaxonomies(taxonomies) {
                     reason: 'Please define a taxonomy permalink route.'
                 }),
                 help: 'e.g. tag: /tag/{slug}/'
+            });
+        }
+
+        if (!validRoutingTypeObjectKeys.includes(routingTypeObjectKey)) {
+            throw new common.errors.ValidationError({
+                message: common.i18n.t('errors.services.settings.yaml.validate', {
+                    at: routingTypeObjectKey,
+                    reason: 'Unknown taxonomy.'
+                })
             });
         }
 

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -35,7 +35,7 @@ describe('UNIT: services/settings/validate', function () {
         try {
             validate({
                 taxonomies: {
-                    tags: '/categories/:slug/'
+                    tag: '/categories/:slug/'
                 }
             });
         } catch (err) {
@@ -220,7 +220,7 @@ describe('UNIT: services/settings/validate', function () {
                 }
             },
             taxonomies: {
-                tags: '/tags/{slug}/',
+                tag: '/tags/{slug}/',
                 author: '/authors/{slug}/',
             }
         });
@@ -228,7 +228,7 @@ describe('UNIT: services/settings/validate', function () {
         object.should.eql({
             routes: {},
             taxonomies: {
-                tags: '/tags/:slug/',
+                tag: '/tags/:slug/',
                 author: '/authors/:slug/'
             },
             collections: {

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -46,6 +46,21 @@ describe('UNIT: services/settings/validate', function () {
         throw new Error('should fail');
     });
 
+    it('throws error when using an undefined taxonomy', function () {
+        try {
+            validate({
+                taxonomies: {
+                    sweet_baked_good: '/patisserie/{slug}'
+                }
+            });
+        } catch (err) {
+            (err instanceof common.errors.ValidationError).should.be.true();
+            return;
+        }
+
+        throw new Error('should fail');
+    });
+
     it('throws error when permalink is missing (collection)', function () {
         try {
             validate({


### PR DESCRIPTION
Fix/Change for https://github.com/TryGhost/Ghost/issues/9870

Validates that the taxonomy is valid/understandable by ghost and errors if not.

Cleans up validate tests to use correct taxonomies.