### PR TITLE
Updated base model destroy fn to be more generic

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -505,6 +505,7 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         case 'toJSON':
             return baseOptions.concat('shallow', 'columns', 'absolute_urls');
         case 'destroy':
+            return baseOptions.concat(extraOptions, ['id', 'destroyBy']);
         case 'edit':
             return baseOptions.concat(extraOptions, ['id']);
         default:
@@ -811,10 +812,14 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
      */
     destroy: function destroy(unfilteredOptions) {
         const options = this.filterOptions(unfilteredOptions, 'destroy');
-        const id = options.id;
+        if (!options.destroyBy) {
+            options.destroyBy = {
+                id: options.id
+            };
+        }
 
         // Fetch the object before destroying it, so that the changed data is available to events
-        return this.forge({id: id})
+        return this.forge(options.destroyBy)
             .fetch(options)
             .then(function then(obj) {
                 return obj.destroy(options);

--- a/core/test/unit/models/base/index_spec.js
+++ b/core/test/unit/models/base/index_spec.js
@@ -95,4 +95,62 @@ describe('Models: base', function () {
             base.get('a').should.eql('');
         });
     });
+
+    describe('static destroy()', function () {
+        it('forges model using destroyBy, fetches it, and calls destroy, passing filtered options', function () {
+            const unfilteredOptions = {
+                destroyBy: {
+                    prop: 'whatever'
+                }
+            };
+            const model = models.Base.Model.forge({});
+            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
+            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+                .returns(model);
+            const fetchStub = sandbox.stub(model, 'fetch')
+                .resolves(model);
+            const destroyStub = sandbox.stub(model, 'destroy');
+
+            return models.Base.Model.destroy(unfilteredOptions).then(() => {
+                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                should.equal(filterOptionsSpy.args[0][1], 'destroy');
+
+                should.deepEqual(forgeStub.args[0][0], {
+                    prop: 'whatever'
+                });
+
+                const filteredOptions = filterOptionsSpy.returnValues[0];
+
+                should.equal(fetchStub.args[0][0], filteredOptions);
+                should.equal(destroyStub.args[0][0], filteredOptions);
+            });
+        });
+
+        it('uses options.id to forge model, if no destroyBy is provided', function () {
+            const unfilteredOptions = {
+                id: 23
+            };
+            const model = models.Base.Model.forge({});
+            const filterOptionsSpy = sandbox.spy(models.Base.Model, 'filterOptions');
+            const forgeStub = sandbox.stub(models.Base.Model, 'forge')
+                .returns(model);
+            const fetchStub = sandbox.stub(model, 'fetch')
+                .resolves(model);
+            const destroyStub = sandbox.stub(model, 'destroy');
+
+            return models.Base.Model.destroy(unfilteredOptions).then(() => {
+                should.equal(filterOptionsSpy.args[0][0], unfilteredOptions);
+                should.equal(filterOptionsSpy.args[0][1], 'destroy');
+
+                should.deepEqual(forgeStub.args[0][0], {
+                    id: 23
+                });
+
+                const filteredOptions = filterOptionsSpy.returnValues[0];
+
+                should.equal(fetchStub.args[0][0], filteredOptions);
+                should.equal(destroyStub.args[0][0], filteredOptions);
+            });
+        });
+    });
 });


### PR DESCRIPTION
refs #9914

This allows us to destroy models on properties other than the id.