### PR TITLE
Added notes about attribute serialization for tag parent and author author_id

### DIFF
--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -177,6 +177,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 delete attrs.author_id;
             } else {
                 // CASE: we return `post.author=id` with or without requested columns.
+                // @NOTE: this serialization should be moved into api layer, it's not being moved as it's not used
                 if (!options.columns || (options.columns && options.columns.indexOf('author') !== -1)) {
                     attrs.author = attrs.author_id;
                     delete attrs.author_id;

--- a/core/server/models/tag.js
+++ b/core/server/models/tag.js
@@ -65,6 +65,7 @@ Tag = ghostBookshelf.Model.extend({
         var options = Tag.filterOptions(unfilteredOptions, 'toJSON'),
             attrs = ghostBookshelf.Model.prototype.toJSON.call(this, options);
 
+        // @NOTE: this serialization should be moved into api layer, it's not being moved as it's not used
         attrs.parent = attrs.parent || attrs.parent_id;
         delete attrs.parent_id;
 


### PR DESCRIPTION
refs #9866

- Added notes to tag/author model attributes that are not being touched during API  introduction