### PR TITLE
Added migration script for new mobiledoc_revisions table

### DIFF
--- a/core/server/data/migrations/versions/2.2/5-add-mobiledoc-revisions-table.js
+++ b/core/server/data/migrations/versions/2.2/5-add-mobiledoc-revisions-table.js
@@ -1,0 +1,35 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+const table = 'mobiledoc_revisions';
+const message1 = 'Adding table: ' + table;
+const message2 = 'Dropping table: ' + table;
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return;
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return;
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/schema/commands.js
+++ b/core/server/data/schema/commands.js
@@ -43,6 +43,9 @@ function addTableColumn(tableName, table, columnName) {
     if (columnSpec.hasOwnProperty('defaultTo')) {
         column.defaultTo(columnSpec.defaultTo);
     }
+    if (columnSpec.hasOwnProperty('index') && columnSpec.index === true) {
+        column.index();
+    }
 }
 
 function addColumn(tableName, column, transaction) {

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -344,5 +344,12 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
+    },
+    mobiledoc_revisions: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        post_id: {type: 'string', maxlength: 24, nullable: false, index: true},
+        mobiledoc: {type: 'text', maxlength: 1000000000, fieldtype: 'long', nullable: true},
+        created_at_ts: {type: 'bigInteger', nullable: false},
+        created_at: {type: 'dateTime', nullable: false}
     }
 };

--- a/core/test/functional/routes/api/db_spec.js
+++ b/core/test/functional/routes/api/db_spec.js
@@ -72,7 +72,7 @@ describe('DB API', function () {
                 var jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(24);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(25);
                 done();
             });
     });
@@ -90,7 +90,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(26);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
                 done();
             });
     });

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = '1834b95684f1916f79e51bab8d6eac8f';
+    const currentSchemaHash = '1e26cc4d159e43a0607d72d1e44050d1';
     const currentFixturesHash = '20292edf9fd692cbd6485267a2ac8e75';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/pull/9929

- New migration script for `mobiledoc_revisions` table which will be used to store multiple mobiledoc versions