### PR TITLE
Updated web/ folder with API config from overrides.json

### DIFF
--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -458,6 +458,7 @@ module.exports.redirectToAdmin = redirectToAdmin;
 module.exports.redirect301 = redirect301;
 module.exports.createUrl = createUrl;
 module.exports.deduplicateDoubleSlashes = deduplicateDoubleSlashes;
+module.exports.getApiPath = getApiPath;
 
 /**
  * If you request **any** image in Ghost, it get's served via

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -4,6 +4,7 @@ const config = require('../config');
 const compress = require('compression');
 const netjet = require('netjet');
 const shared = require('./shared');
+const urlUtils = require('../services/url/utils');
 
 module.exports = function setupParentApp(options = {}) {
     debug('ParentApp setup start');
@@ -38,9 +39,9 @@ module.exports = function setupParentApp(options = {}) {
     // API
     // @TODO: finish refactoring the API app
     // @TODO: decide what to do with these paths - config defaults? config overrides?
-    parentApp.use('/ghost/api/v0.1/', require('./api/v0.1/app')());
-    parentApp.use('/ghost/api/v2/content/', require('./api/v2/content/app')());
-    parentApp.use('/ghost/api/v2/admin/', require('./api/v2/admin/app')());
+    parentApp.use(urlUtils.getApiPath('deprecated'), require('./api/v0.1/app')());
+    parentApp.use(urlUtils.getApiPath('active'), require('./api/v2/content/app')());
+    parentApp.use(urlUtils.getApiPath('active', true), require('./api/v2/admin/app')());
 
     // ADMIN
     parentApp.use('/ghost', require('./admin')());


### PR DESCRIPTION
Refs https://github.com/TryGhost/Ghost/issues/9866

- exports `getApiPath` method from service/url/utils
- uses `getApiPath` in web/parent-app to configure API paths for supported versions