### PR TITLE
Updated method `getApiPath` to take options as param

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -44,7 +44,7 @@ function initialiseServices() {
         scheduling.init({
             schedulerUrl: config.get('scheduling').schedulerUrl,
             active: config.get('scheduling').active,
-            apiUrl: urlService.utils.urlFor('api', {version: 'deprecated'}, true),
+            apiUrl: urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true),
             internalPath: config.get('paths').internalSchedulingPath,
             contentPath: config.getContentPath('scheduling')
         })

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -327,8 +327,7 @@ function urlFor(context, data, absolute) {
         }
 
         if (data && data.version) {
-            let versionType = data.admin ? 'admin' : 'content';
-            apiPath = getApiPath({version: data.version, type: versionType});
+            apiPath = getApiPath({version: data.version, type: data.versionType});
         }
 
         if (absolute) {

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -11,13 +11,16 @@ const moment = require('moment-timezone'),
 
 /**
  * Returns API path combining base path and path for specific version asked or deprecated by default
- * @param {string} version version for which to get the path(stable, actice, deprecated: content, admin), defaults to deprecated:content
+ * @param {Object} options {version} for which to get the path(stable, actice, deprecated),
+ * {type} admin|content: defaults to {version: deprecated, type: content}
  * @return {string} API Path for version
  */
-function getApiPath(version = 'deprecated', admin = false) {
+function getApiPath(options) {
     const apiVersions = config.get('api:versions');
-    let versionType = apiVersions[version] || apiVersions.deprecated;
-    let versionPath = admin ? versionType.admin : versionType.content;
+    let version = options.version || 'deprecated';
+    let type = options.type || 'content';
+    let versionData = apiVersions[version];
+    let versionPath = versionData[type];
     return `${BASE_API_PATH}${versionPath}/`;
 }
 
@@ -313,7 +316,7 @@ function urlFor(context, data, absolute) {
         }
     } else if (context === 'api') {
         urlPath = getAdminUrl() || getBlogUrl();
-        let apiPath = getApiPath('deprecated');
+        let apiPath = getApiPath({version: 'deprecated', type: 'content'});
         // CASE: with or without protocol? If your blog url (or admin url) is configured to http, it's still possible that e.g. nginx allows both https+http.
         // So it depends how you serve your blog. The main focus here is to avoid cors problems.
         // @TODO: rename cors
@@ -324,7 +327,8 @@ function urlFor(context, data, absolute) {
         }
 
         if (data && data.version) {
-            apiPath = getApiPath(data.version, data.admin);
+            let versionType = data.admin ? 'admin' : 'content';
+            apiPath = getApiPath({version: data.version, type: versionType});
         }
 
         if (absolute) {

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -39,7 +39,7 @@ module.exports = function setupParentApp(options = {}) {
     // API
     // @TODO: finish refactoring the API app
     // @TODO: decide what to do with these paths - config defaults? config overrides?
-    parentApp.use(urlUtils.getApiPath({version: 'deprecated', type: 'content'}), require('./api/v0.1/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'deprecated'}), require('./api/v0.1/app')());
     parentApp.use(urlUtils.getApiPath({version: 'active', type: 'content'}), require('./api/v2/content/app')());
     parentApp.use(urlUtils.getApiPath({version: 'active', type: 'admin'}), require('./api/v2/admin/app')());
 

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -39,9 +39,9 @@ module.exports = function setupParentApp(options = {}) {
     // API
     // @TODO: finish refactoring the API app
     // @TODO: decide what to do with these paths - config defaults? config overrides?
-    parentApp.use(urlUtils.getApiPath('deprecated'), require('./api/v0.1/app')());
-    parentApp.use(urlUtils.getApiPath('active'), require('./api/v2/content/app')());
-    parentApp.use(urlUtils.getApiPath('active', true), require('./api/v2/admin/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'deprecated', type: 'content'}), require('./api/v0.1/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'active', type: 'content'}), require('./api/v2/content/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'active', type: 'admin'}), require('./api/v2/admin/app')());
 
     // ADMIN
     parentApp.use('/ghost', require('./admin')());

--- a/core/server/web/shared/middlewares/serve-public-file.js
+++ b/core/server/web/shared/middlewares/serve-public-file.js
@@ -26,7 +26,7 @@ function servePublicFile(file, type, maxAge) {
 
                     if (type === 'text/xsl' || type === 'text/plain' || type === 'application/javascript') {
                         buf = buf.toString().replace(blogRegex, urlService.utils.urlFor('home', true).replace(/\/$/, ''));
-                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true));
+                        buf = buf.toString().replace(apiRegex, urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true));
                     }
                     content = {
                         headers: {

--- a/core/test/unit/public/ghost_sdk_spec.js
+++ b/core/test/unit/public/ghost_sdk_spec.js
@@ -27,7 +27,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/');
@@ -41,7 +41,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         ghostSdk.url.api().should.equal('https://testblog.com/ghost/api/v0.1/');
@@ -58,7 +58,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         ghostSdk.url.api().should.equal('https://admin.testblog.com/ghost/api/v0.1/');
@@ -68,7 +68,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: '',
             clientSecret: '',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         ghostSdk.url.api('a/', '/b', '/c/').should.equal('//testblog.com/ghost/api/v0.1/a/b/c/');
@@ -78,7 +78,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         ghostSdk.url.api().should.equal('//testblog.com/ghost/api/v0.1/?client_id=ghost-frontend&client_secret=notasecret');
@@ -88,7 +88,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         var rendered = ghostSdk.url.api({a: 'string', b: 5, c: 'en coded'});
@@ -126,7 +126,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -146,7 +146,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -165,7 +165,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts/', '/tags/', '/count', {include: 'tags,tests', page: 2});
@@ -185,7 +185,7 @@ describe('Ghost Ajax Helper', function () {
         ghostSdk.init({
             clientId: 'ghost-frontend',
             clientSecret: 'notasecret',
-            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true)
+            url: urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true)
         });
 
         var rendered = ghostSdk.url.api('posts', {limit: 3}),

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -446,7 +446,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('https://something.de/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true).should.eql('https://something.de/ghost/api/v0.1/');
         });
 
         it('api: url has subdir', function () {
@@ -454,11 +454,11 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true).should.eql('http://my-ghost-blog.com/blog/ghost/api/v0.1/');
         });
 
         it('api: relative path is correct', function () {
-            urlService.utils.urlFor('api', {version: 'deprecated'}).should.eql('/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}).should.eql('/ghost/api/v0.1/');
         });
 
         it('api: relative path with subdir is correct', function () {
@@ -466,7 +466,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com/blog'
             });
 
-            urlService.utils.urlFor('api', {version: 'deprecated'}).should.eql('/blog/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}).should.eql('/blog/ghost/api/v0.1/');
         });
 
         it('api: should return http if config.url is http', function () {
@@ -474,7 +474,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true).should.eql('http://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: should return https if config.url is https', function () {
@@ -482,7 +482,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {version: 'deprecated'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {version: 'deprecated', versionType: 'content'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is http: should return no protocol', function () {
@@ -490,7 +490,7 @@ describe('Url', function () {
                 url: 'http://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true).should.eql('//my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is http: cors should return no protocol', function () {
@@ -501,7 +501,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true).should.eql('//admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, admin url is https: should return with protocol', function () {
@@ -512,7 +512,7 @@ describe('Url', function () {
                 }
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true).should.eql('https://admin.ghost.example/ghost/api/v0.1/');
         });
 
         it('api: with cors, blog url is https: should return with protocol', function () {
@@ -520,7 +520,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: 'deprecated'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: 'deprecated', versionType: 'content'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with stable version, blog url is https: should return stable content api path', function () {
@@ -528,7 +528,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "deprecated"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: "deprecated", versionType: 'content'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with stable version and admin true, blog url is https: should return stable admin api path', function () {
@@ -536,7 +536,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "deprecated", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
+            urlService.utils.urlFor('api', {cors: true, version: "deprecated", versionType: 'admin'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v0.1/');
         });
 
         it('api: with active version, blog url is https: should return active content api path', function () {
@@ -544,7 +544,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "active"}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/content/');
+            urlService.utils.urlFor('api', {cors: true, version: "active", versionType: 'content'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/content/');
         });
 
         it('api: with active version and admin true, blog url is https: should return active admin api path', function () {
@@ -552,7 +552,7 @@ describe('Url', function () {
                 url: 'https://my-ghost-blog.com'
             });
 
-            urlService.utils.urlFor('api', {cors: true, version: "active", admin: true}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/admin/');
+            urlService.utils.urlFor('api', {cors: true, version: "active", versionType: 'admin'}, true).should.eql('https://my-ghost-blog.com/ghost/api/v2/admin/');
         });
     });
 


### PR DESCRIPTION
Refs https://github.com/TryGhost/Ghost/pull/9936

- Updated methods to take single options param with `version` and `type` instead of separate values
- Updated urlFor method to use the updated syntax