### PR TITLE
Added processOptions check to base model findPage

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -695,7 +695,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         // This applies default properties like 'staticPages' and 'status'
         // And then converts them to 'where' options... this behaviour is effectively deprecated in favour
         // of using filter - it's only be being kept here so that we can transition cleanly.
-        this.processOptions(options);
+        if (this.processOptions) {
+            this.processOptions(options);
+        }
 
         // Add Filter behaviour
         itemCollection.applyDefaultAndCustomFilters(options);


### PR DESCRIPTION
no-issue

When calling findPage on a model with no processOptions defined this
throws an error.

just like here: https://github.com/TryGhost/Ghost/blob/master/core/server/models/base/index.js#L646