### PR TITLE
Permitted require option for edit, destroy, findOne

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -505,9 +505,11 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
         case 'toJSON':
             return baseOptions.concat('shallow', 'columns');
         case 'destroy':
-            return baseOptions.concat(extraOptions, ['id', 'destroyBy']);
+            return baseOptions.concat(extraOptions, ['id', 'destroyBy', 'require']);
         case 'edit':
-            return baseOptions.concat(extraOptions, ['id']);
+            return baseOptions.concat(extraOptions, ['id', 'require']);
+        case 'findOne':
+            return baseOptions.concat(extraOptions, ['require']);
         default:
             return baseOptions.concat(extraOptions);
         }


### PR DESCRIPTION
no-issue

With the new framework it is hard to handle 404 errors outside of the
serialization layer, this is because we cannot force deestroy or edit
to error if the model is missing. This lets us do that.