### PR TITLE
Added shared api utils for easier validation

### DIFF
--- a/core/server/api/shared/index.js
+++ b/core/server/api/shared/index.js
@@ -21,5 +21,9 @@ module.exports = {
 
     get serializers() {
         return require('./serializers');
+    },
+
+    get utils() {
+        return require('./utils');
     }
 };

--- a/core/server/api/shared/utils.js
+++ b/core/server/api/shared/utils.js
@@ -1,0 +1,21 @@
+const _ = require('lodash');
+
+const required = key => ({[key]: {required: true}});
+const allowed = (key, values) => ({[key]: {values}});
+
+const wrapValidation = (fn, type) => (...args) => ({[type]: fn(...args)});
+
+const requiredData = wrapValidation(required, 'data');
+const requiredOptions = wrapValidation(required, 'options');
+const allowedData = wrapValidation(allowed, 'data');
+const allowedOptions = wrapValidation(allowed, 'options');
+
+const mergeValidations = _.merge;
+
+module.exports = {
+    requiredData,
+    requiredOptions,
+    allowedData,
+    allowedOptions,
+    mergeValidations
+};

--- a/core/test/unit/api/shared/utils_spec.js
+++ b/core/test/unit/api/shared/utils_spec.js
@@ -1,0 +1,86 @@
+const should = require('should');
+const {
+    requiredData,
+    requiredOptions,
+    allowedData,
+    allowedOptions,
+    mergeValidations
+} = require('../../../../server/api/shared/utils');
+
+describe.only('shared api utils', function () {
+    describe('requiredData(prop)', function () {
+        it('returns a validation object requring the prop', function () {
+            should.deepEqual(requiredData('jeremy'), {
+                data: {
+                    jeremy: {
+                        required: true
+                    }
+                }
+            });
+        });
+    });
+
+    describe('requiredOptions(prop)', function () {
+        it('returns a validation object requring the prop', function () {
+            should.deepEqual(requiredOptions('mark'), {
+                options: {
+                    mark: {
+                        required: true
+                    }
+                }
+            });
+        });
+    });
+
+    describe('allowedData(prop, vals)', function () {
+        it('returns a validation object allowing the prop to have vals', function () {
+            should.deepEqual(allowedData('dinner', ['eggs', 'pizza', 'beer']), {
+                data: {
+                    dinner: {
+                        values: ['eggs', 'pizza', 'beer']
+                    }
+                }
+            });
+        });
+    });
+
+    describe('allowedOptions(prop, vals)', function () {
+        it('returns a validation object allowing the prop to have vals', function () {
+            should.deepEqual(allowedOptions('breakfast', ['eggs', 'icecream']), {
+                options: {
+                    breakfast: {
+                        values: ['eggs', 'icecream']
+                    }
+                }
+            });
+        });
+    });
+
+    describe('mergeValidations(...validations)', function () {
+        it('returns a validation object containing all the validations', function () {
+            should.deepEqual(mergeValidations(
+                requiredData('breakfast'),
+                requiredData('dinner'),
+                allowedData('dinner', ['eggs', 'pizza', 'beer']),
+                requiredOptions('egg_style'),
+                allowedOptions('egg_style', ['loads'])
+            ), {
+                data: {
+                    breakfast: {
+                        required: true
+                    },
+                    dinner: {
+                        required: true,
+                        values: ['eggs', 'pizza', 'beer']
+                    }
+                },
+                options: {
+                    egg_style: {
+                        required: true,
+                        values: ['loads']
+                    }
+                }
+            });
+        });
+    });
+});


### PR DESCRIPTION
no-issue

This adds some helper functions for building the validation object used
in the new api framework, should improve readablity by removing vertical
space.

This allows us to change from this:
```js
module.exports = {
    docName: 'api_keys',
    edit: {
        permissions: true,
        data: ['id'],
        validation: {
            data: {
                id: {
                    required: true
                }
            }
        },
        query({data, options}) {}
    },
    add: {
        permissions: true,
        data: ['integration_id', 'type'],
        validation: {
            data: {
                integration_id: {
                    required: true
                },
                type: {
                    required: true,
                    allowed: ['content', 'admin']
                }
            }
        },
        query({data, options}) {}
    },
    destroy: {
        permissions: true,
        statusCode: 204,
        responseType: 'plain',
        data: ['id'],
        validation: {
            data: {
                id: {
                    required: true
                }
            }
        },
        query({data, options}) {}
    }
};
```

to this: 
```js
const {
  requiredData,
  requiredOptions,
  allowedOptions,
  mergeValidations
} = require('../shared').utils;
module.exports = {
    docName: 'api_keys',
    edit: {
        permissions: true,
        data: ['id'],
        validation: requiredData('id'),
        query({data, options}) {}
    },
    add: {
        permissions: true,
        data: ['integration_id', 'type'],
        validation: mergeValidations(
            requiredData('integration_id'),
            requiredData('type'),
            allowedData('type', ['content', 'admin'])
        ),
        query({data, options}) {}
    },
    destroy: {
        permissions: true,
        statusCode: 204,
        responseType: 'plain',
        data: ['id'],
        validation: requiredData('id'),
        query({data, options}) {}
    }
};
```