### PR TITLE
Permitted require options for apikey edit,destroy

### DIFF
--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -50,6 +50,17 @@ const ApiKey = ghostBookshelf.Model.extend({
     refreshSecret(data, options) {
         const secret = createSecret();
         return this.edit(Object.assign({}, data, {secret}), options);
+    },
+
+    permittedOptions(methodName, options) {
+        const defaultPermittedOptions = ghostBookshelf.Model.permittedOptions.call(this, methodName, options);
+        if (methodName === 'destroy') {
+            return defaultPermittedOptions.concat('require');
+        }
+        if (methodName === 'edit') {
+            return defaultPermittedOptions.concat('require');
+        }
+        return defaultPermittedOptions;
     }
 });
 

--- a/core/test/unit/models/api-key_spec.js
+++ b/core/test/unit/models/api-key_spec.js
@@ -85,4 +85,14 @@ describe('Unit: models/api_key', function () {
             sandbox.restore();
         });
     });
+
+    describe('permittedOptions', function () {
+        it('includes "require" when methodName is "destroy"', function () {
+            should.equal(models.ApiKey.permittedOptions('destroy').includes('require'), true);
+        });
+
+        it('includes "require" when methodName is "edit"', function () {
+            should.equal(models.ApiKey.permittedOptions('edit').includes('require'), true);
+        });
+    });
 });


### PR DESCRIPTION
refs #9865

This is so that we can force a not found error when trying to delete or
update and apikey with an non-existent id.