### PR TITLE
🐛Fixed sitemap duplicates after routes.yaml upload

### DIFF
--- a/core/server/data/xml/sitemap/base-generator.js
+++ b/core/server/data/xml/sitemap/base-generator.js
@@ -154,6 +154,11 @@ class BaseSiteMapGenerator {
         delete this.nodeLookup[datum.id];
         delete this.nodeTimeLookup[datum.id];
     }
+
+    reset() {
+        this.nodeLookup = {};
+        this.nodeTimeLookup = {};
+    }
 }
 
 module.exports = BaseSiteMapGenerator;

--- a/core/server/data/xml/sitemap/manager.js
+++ b/core/server/data/xml/sitemap/manager.js
@@ -32,6 +32,13 @@ class SiteMapManager {
         common.events.on('url.removed', (obj) => {
             this[obj.resource.config.type].removeUrl(obj.url.absolute, obj.resource.data);
         });
+
+        common.events.on('routers.reset', () => {
+            this.pages && this.pages.reset();
+            this.posts && this.posts.reset();
+            this.users && this.users.reset();
+            this.tags && this.tags.reset();
+        });
     }
 
     createIndexGenerator() {

--- a/core/server/services/routing/bootstrap.js
+++ b/core/server/services/routing/bootstrap.js
@@ -1,5 +1,6 @@
 const debug = require('ghost-ignition').debug('services:routing:bootstrap');
 const _ = require('lodash');
+const common = require('../../lib/common');
 const settingsService = require('../settings');
 const StaticRoutesRouter = require('./StaticRoutesRouter');
 const StaticPagesRouter = require('./StaticPagesRouter');
@@ -16,6 +17,8 @@ module.exports.init = (options = {start: false}) => {
 
     registry.resetAllRouters();
     registry.resetAllRoutes();
+
+    common.events.emit('routers.reset');
 
     siteRouter = new ParentRouter('SiteRouter');
     registry.setRouter('siteRouter', siteRouter);

--- a/core/test/unit/data/xml/sitemap/manager_spec.js
+++ b/core/test/unit/data/xml/sitemap/manager_spec.js
@@ -62,10 +62,11 @@ describe('Unit: sitemap/manager', function () {
 
         it('can create a SiteMapManager instance', function () {
             should.exist(manager);
-            Object.keys(eventsToRemember).length.should.eql(3);
+            Object.keys(eventsToRemember).length.should.eql(4);
             should.exist(eventsToRemember['url.added']);
             should.exist(eventsToRemember['url.removed']);
             should.exist(eventsToRemember['router.created']);
+            should.exist(eventsToRemember['routers.reset']);
         });
 
         describe('trigger url events', function () {


### PR DESCRIPTION
closes #9956

- sitemap reset was missing
- no test, this is beta anyway

Steps to reproduce:
- upload routes.yaml and refresh sitemaps