### PR TITLE
Fixed redirect issue with private sites

### DIFF
--- a/core/server/apps/private-blogging/lib/middleware.js
+++ b/core/server/apps/private-blogging/lib/middleware.js
@@ -22,7 +22,7 @@ function verifySessionHash(salt, hash) {
 }
 
 function getRedirectUrl(query) {
-    const redirect = decodeURIComponent(query ? query.r : '/');
+    const redirect = decodeURIComponent(query.r || '/');
     try {
         return new url.URL(redirect, urlService.utils.urlFor('home', true)).pathname;
     } catch (e) {

--- a/core/test/unit/apps/private-blogging/middleware_spec.js
+++ b/core/test/unit/apps/private-blogging/middleware_spec.js
@@ -25,7 +25,9 @@ describe('Private Blogging', function () {
         var req, res, next;
 
         beforeEach(function () {
-            req = {};
+            req = {
+                query: {}
+            };
             res = {};
             settingsStub = sandbox.stub(settingsCache, 'get');
             next = sandbox.spy();


### PR DESCRIPTION
closes #9959

This issue existed because the logic assumed that if there were no
query parameters then there would be no `query` object. However this is
not the case. What we really wanted to check was for the existence of an
"r" query param - the code has been refactor to explicitly do this now.