### PR TITLE
Session auth test helper

### DIFF
--- a/core/test/functional/api/v2/admin/utils.js
+++ b/core/test/functional/api/v2/admin/utils.js
@@ -1,5 +1,6 @@
 const url = require('url');
 const _ = require('lodash');
+const testUtils = require('../../../../utils');
 const API_URL = '/ghost/api/v2/admin/';
 
 module.exports = {
@@ -7,5 +8,9 @@ module.exports = {
         getApiQuery(route) {
             return url.resolve(API_URL, route);
         }
+    },
+
+    doAuth(...args) {
+        return testUtils.API.doAuth(`${API_URL}session/`, ...args);
     }
 };

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -151,13 +151,13 @@ const login = (request, API_URL) => {
                 client_secret: 'not_available'
             })
             .then(function then(res) {
-                if (res.statusCode !== 200) {
+                if (res.statusCode !== 200 && res.statusCode !== 201) {
                     return reject(new common.errors.GhostError({
                         message: res.body.errors[0].message
                     }));
                 }
 
-                resolve(res.body.access_token);
+                resolve(res.headers['set-cookie'] || res.body.access_token);
             }, reject);
     });
 };

--- a/core/test/utils/api.js
+++ b/core/test/utils/api.js
@@ -149,15 +149,16 @@ const login = (request, API_URL) => {
                 password: 'Sl1m3rson99',
                 client_id: 'ghost-admin',
                 client_secret: 'not_available'
-            }).then(function then(res) {
-            if (res.statusCode !== 200) {
-                return reject(new common.errors.GhostError({
-                    message: res.body.errors[0].message
-                }));
-            }
+            })
+            .then(function then(res) {
+                if (res.statusCode !== 200) {
+                    return reject(new common.errors.GhostError({
+                        message: res.body.errors[0].message
+                    }));
+                }
 
-            resolve(res.body.access_token);
-        }, reject);
+                resolve(res.body.access_token);
+            }, reject);
     });
 };
 


### PR DESCRIPTION
Pulled out from https://github.com/TryGhost/Ghost/pull/9963

Adds local `doAuth` method to v2 admin api test helpers so that can get access to the cookie to auth with.