### PR TITLE
Updated frame.context to use req.api_key

### DIFF
--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -15,9 +15,7 @@ const http = (apiImpl) => {
             user: req.user,
             context: {
                 api_key: (req.api_key && req.api_key.id) ? req.api_key.id : null,
-                user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null,
-                client: (req.client && req.client.slug) ? req.client.slug : null,
-                client_id: (req.client && req.client.id) ? req.client.id : null
+                user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null
             }
         });
 

--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -14,6 +14,7 @@ const http = (apiImpl) => {
             params: req.params,
             user: req.user,
             context: {
+                api_key: (req.api_key && req.api_key.id) ? req.api_key.id : null,
                 user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null,
                 client: (req.client && req.client.slug) ? req.client.slug : null,
                 client_id: (req.client && req.client.id) ? req.client.id : null

--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -14,7 +14,7 @@ const http = (apiImpl) => {
             params: req.params,
             user: req.user,
             context: {
-                api_key: (req.api_key && req.api_key.id) ? req.api_key.id : null,
+                api_key_id: (req.api_key && req.api_key.id) ? req.api_key.id : null,
                 user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null
             }
         });

--- a/core/test/unit/api/shared/http_spec.js
+++ b/core/test/unit/api/shared/http_spec.js
@@ -45,6 +45,7 @@ describe('Unit: api/shared/http', function () {
         apiImpl.args[0][0].data.should.eql({a: 'a'});
         apiImpl.args[0][0].options.should.eql({
             context: {
+                api_key: null,
                 user: null,
                 client: null,
                 client_id: null

--- a/core/test/unit/api/shared/http_spec.js
+++ b/core/test/unit/api/shared/http_spec.js
@@ -46,9 +46,7 @@ describe('Unit: api/shared/http', function () {
         apiImpl.args[0][0].options.should.eql({
             context: {
                 api_key: null,
-                user: null,
-                client: null,
-                client_id: null
+                user: null
             }
         });
     });

--- a/core/test/unit/api/shared/http_spec.js
+++ b/core/test/unit/api/shared/http_spec.js
@@ -45,7 +45,7 @@ describe('Unit: api/shared/http', function () {
         apiImpl.args[0][0].data.should.eql({a: 'a'});
         apiImpl.args[0][0].options.should.eql({
             context: {
-                api_key: null,
+                api_key_id: null,
                 user: null
             }
         });


### PR DESCRIPTION
refs #9865 

This is split out from https://github.com/TryGhost/Ghost/pull/9869 to make it easier to review

It adds the id of `req.api_key`, if it exists to the context object. This is necessary so that controllers can verify permissions of api_keys.

It also removes the client and client_id parts of the context object - as they are not used past v0.1