### PR TITLE
🐛 Fixed 'url' attribute miscalculation when when requested as the only part of fields filter

### DIFF
--- a/core/server/api/v0.1/decorators/urls.js
+++ b/core/server/api/v0.1/decorators/urls.js
@@ -1,32 +1,32 @@
 const urlService = require('../../../services/url');
 const {urlFor, makeAbsoluteUrls} = require('../../../services/url/utils');
 
-const urlsForPost = (id, post, options) => {
-    post.url = urlService.getUrlByResourceId(id);
+const urlsForPost = (id, attrs, options) => {
+    attrs.url = urlService.getUrlByResourceId(id);
 
     if (options.columns && !options.columns.includes('url')) {
-        delete post.url;
+        delete attrs.url;
     }
 
     if (options && options.context && options.context.public && options.absolute_urls) {
-        if (post.feature_image) {
-            post.feature_image = urlFor('image', {image: post.feature_image}, true);
+        if (attrs.feature_image) {
+            attrs.feature_image = urlFor('image', {image: attrs.feature_image}, true);
         }
 
-        if (post.og_image) {
-            post.og_image = urlFor('image', {image: post.og_image}, true);
+        if (attrs.og_image) {
+            attrs.og_image = urlFor('image', {image: attrs.og_image}, true);
         }
 
-        if (post.twitter_image) {
-            post.twitter_image = urlFor('image', {image: post.twitter_image}, true);
+        if (attrs.twitter_image) {
+            attrs.twitter_image = urlFor('image', {image: attrs.twitter_image}, true);
         }
 
-        if (post.html) {
-            post.html = makeAbsoluteUrls(post.html, urlFor('home', true), post.url).html();
+        if (attrs.html) {
+            attrs.html = makeAbsoluteUrls(attrs.html, urlFor('home', true), attrs.url).html();
         }
 
-        if (post.url) {
-            post.url = urlFor({relativeUrl: post.url}, true);
+        if (attrs.url) {
+            attrs.url = urlFor({relativeUrl: attrs.url}, true);
         }
     }
 
@@ -35,57 +35,57 @@ const urlsForPost = (id, post, options) => {
             // @NOTE: this block also decorates primary_tag/primary_author objects as they
             // are being passed by reference in tags/authors. Might be refactored into more explicit call
             // in the future, but is good enough for current use-case
-            if (relation === 'tags' && post.tags) {
-                post.tags = post.tags.map(tag => urlsForTag(tag.id, tag, options));
+            if (relation === 'tags' && attrs.tags) {
+                attrs.tags = attrs.tags.map(tag => urlsForTag(tag.id, tag, options));
             }
 
-            if (relation === 'author' && post.author) {
-                post.author = urlsForUser(post.author.id, post.author, options);
+            if (relation === 'author' && attrs.author) {
+                attrs.author = urlsForUser(attrs.author.id, attrs.author, options);
             }
 
-            if (relation === 'authors' && post.authors) {
-                post.authors = post.authors.map(author => urlsForUser(author.id, author, options));
+            if (relation === 'authors' && attrs.authors) {
+                attrs.authors = attrs.authors.map(author => urlsForUser(author.id, author, options));
             }
         });
     }
 
-    return post;
+    return attrs;
 };
 
-const urlsForUser = (id, user, options) => {
+const urlsForUser = (id, attrs, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
         if (id) {
-            user.url = urlFor({
+            attrs.url = urlFor({
                 relativeUrl: urlService.getUrlByResourceId(id)
             }, true);
         }
 
-        if (user.profile_image) {
-            user.profile_image = urlFor('image', {image: user.profile_image}, true);
+        if (attrs.profile_image) {
+            attrs.profile_image = urlFor('image', {image: attrs.profile_image}, true);
         }
 
-        if (user.cover_image) {
-            user.cover_image = urlFor('image', {image: user.cover_image}, true);
+        if (attrs.cover_image) {
+            attrs.cover_image = urlFor('image', {image: attrs.cover_image}, true);
         }
     }
 
-    return user;
+    return attrs;
 };
 
-const urlsForTag = (id, tag, options) => {
+const urlsForTag = (id, attrs, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
         if (id) {
-            tag.url = urlFor({
-                relativeUrl: urlService.getUrlByResourceId(tag.id)
+            attrs.url = urlFor({
+                relativeUrl: urlService.getUrlByResourceId(attrs.id)
             }, true);
         }
 
-        if (tag.feature_image) {
-            tag.feature_image = urlFor('image', {image: tag.feature_image}, true);
+        if (attrs.feature_image) {
+            attrs.feature_image = urlFor('image', {image: attrs.feature_image}, true);
         }
     }
 
-    return tag;
+    return attrs;
 };
 
 module.exports.urlsForPost = urlsForPost;

--- a/core/server/api/v0.1/decorators/urls.js
+++ b/core/server/api/v0.1/decorators/urls.js
@@ -54,11 +54,9 @@ const urlsForPost = (id, attrs, options) => {
 
 const urlsForUser = (id, attrs, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
-        if (id) {
-            attrs.url = urlFor({
-                relativeUrl: urlService.getUrlByResourceId(id)
-            }, true);
-        }
+        attrs.url = urlFor({
+            relativeUrl: urlService.getUrlByResourceId(id)
+        }, true);
 
         if (attrs.profile_image) {
             attrs.profile_image = urlFor('image', {image: attrs.profile_image}, true);
@@ -74,11 +72,9 @@ const urlsForUser = (id, attrs, options) => {
 
 const urlsForTag = (id, attrs, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
-        if (id) {
-            attrs.url = urlFor({
-                relativeUrl: urlService.getUrlByResourceId(attrs.id)
-            }, true);
-        }
+        attrs.url = urlFor({
+            relativeUrl: urlService.getUrlByResourceId(attrs.id)
+        }, true);
 
         if (attrs.feature_image) {
             attrs.feature_image = urlFor('image', {image: attrs.feature_image}, true);

--- a/core/server/api/v0.1/decorators/urls.js
+++ b/core/server/api/v0.1/decorators/urls.js
@@ -1,8 +1,8 @@
 const urlService = require('../../../services/url');
 const {urlFor, makeAbsoluteUrls} = require('../../../services/url/utils');
 
-const urlsForPost = (post, options) => {
-    post.url = urlService.getUrlByResourceId(post.id);
+const urlsForPost = (id, post, options) => {
+    post.url = urlService.getUrlByResourceId(id);
 
     if (options.columns && !options.columns.includes('url')) {
         delete post.url;
@@ -36,15 +36,15 @@ const urlsForPost = (post, options) => {
             // are being passed by reference in tags/authors. Might be refactored into more explicit call
             // in the future, but is good enough for current use-case
             if (relation === 'tags' && post.tags) {
-                post.tags = post.tags.map(tag => urlsForTag(tag, options));
+                post.tags = post.tags.map(tag => urlsForTag(tag.id, tag, options));
             }
 
             if (relation === 'author' && post.author) {
-                post.author = urlsForUser(post.author, options);
+                post.author = urlsForUser(post.author.id, post.author, options);
             }
 
             if (relation === 'authors' && post.authors) {
-                post.authors = post.authors.map(author => urlsForUser(author, options));
+                post.authors = post.authors.map(author => urlsForUser(author.id, author, options));
             }
         });
     }
@@ -52,11 +52,13 @@ const urlsForPost = (post, options) => {
     return post;
 };
 
-const urlsForUser = (user, options) => {
+const urlsForUser = (id, user, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
-        user.url = urlFor({
-            relativeUrl: urlService.getUrlByResourceId(user.id)
-        }, true);
+        if (id) {
+            user.url = urlFor({
+                relativeUrl: urlService.getUrlByResourceId(id)
+            }, true);
+        }
 
         if (user.profile_image) {
             user.profile_image = urlFor('image', {image: user.profile_image}, true);
@@ -70,11 +72,13 @@ const urlsForUser = (user, options) => {
     return user;
 };
 
-const urlsForTag = (tag, options) => {
+const urlsForTag = (id, tag, options) => {
     if (options && options.context && options.context.public && options.absolute_urls) {
-        tag.url = urlFor({
-            relativeUrl: urlService.getUrlByResourceId(tag.id)
-        }, true);
+        if (id) {
+            tag.url = urlFor({
+                relativeUrl: urlService.getUrlByResourceId(tag.id)
+            }, true);
+        }
 
         if (tag.feature_image) {
             tag.feature_image = urlFor('image', {image: tag.feature_image}, true);

--- a/core/server/api/v0.1/posts.js
+++ b/core/server/api/v0.1/posts.js
@@ -61,7 +61,7 @@ posts = {
             return models.Post.findPage(options)
                 .then(({data, meta}) => {
                     return {
-                        posts: data.map(model => urlsForPost(model.toJSON(options), options)),
+                        posts: data.map(model => urlsForPost(model.id, model.toJSON(options), options)),
                         meta: meta
                     };
                 });
@@ -110,7 +110,7 @@ posts = {
                     }
 
                     return {
-                        posts: [urlsForPost(model.toJSON(options), options)]
+                        posts: [urlsForPost(model.id, model.toJSON(options), options)]
                     };
                 });
         }
@@ -156,7 +156,7 @@ posts = {
                         }));
                     }
 
-                    const post = urlsForPost(model.toJSON(options), options);
+                    const post = urlsForPost(model.id, model.toJSON(options), options);
 
                     // If previously was not published and now is (or vice versa), signal the change
                     // @TODO: `statusChanged` get's added for the API headers only. Reconsider this.
@@ -204,7 +204,7 @@ posts = {
         function modelQuery(options) {
             return models.Post.add(options.data.posts[0], omit(options, ['data']))
                 .then((model) => {
-                    const post = urlsForPost(model.toJSON(options), options);
+                    const post = urlsForPost(model.id, model.toJSON(options), options);
 
                     if (post.status === 'published') {
                         // When creating a new post that is published right now, signal the change

--- a/core/server/api/v0.1/tags.js
+++ b/core/server/api/v0.1/tags.js
@@ -37,7 +37,7 @@ tags = {
             return models.Tag.findPage(options)
                 .then(({data, meta}) => {
                     return {
-                        tags: data.map(model => urlsForTag(model.toJSON(options), options)),
+                        tags: data.map(model => urlsForTag(model.id, model.toJSON(options), options)),
                         meta: meta
                     };
                 });
@@ -81,7 +81,7 @@ tags = {
                     }
 
                     return {
-                        tags: [urlsForTag(model.toJSON(options), options)]
+                        tags: [urlsForTag(model.id, model.toJSON(options), options)]
                     };
                 });
         }
@@ -116,7 +116,7 @@ tags = {
             return models.Tag.add(options.data.tags[0], _.omit(options, ['data']))
                 .then((model) => {
                     return {
-                        tags: [urlsForTag(model.toJSON(options), options)]
+                        tags: [urlsForTag(model.id, model.toJSON(options), options)]
                     };
                 });
         }
@@ -159,7 +159,7 @@ tags = {
                     }
 
                     return {
-                        tags: [urlsForTag(model.toJSON(options), options)]
+                        tags: [urlsForTag(model.id, model.toJSON(options), options)]
                     };
                 });
         }

--- a/core/server/api/v0.1/users.js
+++ b/core/server/api/v0.1/users.js
@@ -41,7 +41,7 @@ users = {
             return models.User.findPage(options)
                 .then(({data, meta}) => {
                     return {
-                        users: data.map(model => urlsForUser(model.toJSON(options), options)),
+                        users: data.map(model => urlsForUser(model.id, model.toJSON(options), options)),
                         meta: meta
                     };
                 });
@@ -90,7 +90,7 @@ users = {
                     }
 
                     return {
-                        users: [urlsForUser(model.toJSON(options), options)]
+                        users: [urlsForUser(model.id, model.toJSON(options), options)]
                     };
                 });
         }
@@ -151,7 +151,7 @@ users = {
                     }
 
                     return {
-                        users: [urlsForUser(model.toJSON(options), options)]
+                        users: [urlsForUser(model.id, model.toJSON(options), options)]
                     };
                 });
         }

--- a/core/test/functional/api/v0.1/public_api_spec.js
+++ b/core/test/functional/api/v0.1/public_api_spec.js
@@ -270,6 +270,26 @@ describe('Public API', function () {
             });
     });
 
+    it('browse posts: request only url fields ', function (done) {
+        request.get(localUtils.API.getApiQuery('posts/?client_id=ghost-admin&client_secret=not_available&fields=url'))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.exist(res.body.posts);
+
+                should.equal(res.body.posts[0].id, undefined);
+                res.body.posts[0].url.should.eql('/welcome/');
+
+                done();
+            });
+    });
+
     it('browse posts: request to include tags and authors with absolute_urls', function (done) {
         request.get(localUtils.API.getApiQuery('posts/?client_id=ghost-admin&client_secret=not_available&absolute_urls=true&include=tags,authors'))
             .set('Origin', testUtils.API.getURL())

--- a/core/test/functional/api/v0.1/public_api_spec.js
+++ b/core/test/functional/api/v0.1/public_api_spec.js
@@ -280,10 +280,11 @@ describe('Public API', function () {
                 if (err) {
                     return done(err);
                 }
+                const jsonResponse = res.body;
 
-                should.exist(res.body.posts);
+                should.exist(jsonResponse.posts);
 
-                should.equal(res.body.posts[0].id, undefined);
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post', false, false, ['url']);
                 res.body.posts[0].url.should.eql('/welcome/');
                 done();
             });
@@ -299,12 +300,13 @@ describe('Public API', function () {
                 if (err) {
                     return done(err);
                 }
+                const jsonResponse = res.body;
 
-                should.exist(res.body.posts);
+                should.exist(jsonResponse.posts);
 
-                should.equal(res.body.posts[0].id, undefined);
-                res.body.posts[0].url.should.eql('http://127.0.0.1:2369/welcome/');
-                res.body.posts[0].tags[0].url.should.eql('http://127.0.0.1:2369/tag/getting-started/');
+                testUtils.API.checkResponse(jsonResponse.posts[0], 'post', false, false, ['url','tags']);
+                jsonResponse.posts[0].url.should.eql('http://127.0.0.1:2369/welcome/');
+                jsonResponse.posts[0].tags[0].url.should.eql('http://127.0.0.1:2369/tag/getting-started/');
                 done();
             });
     });

--- a/core/test/functional/api/v0.1/public_api_spec.js
+++ b/core/test/functional/api/v0.1/public_api_spec.js
@@ -270,7 +270,7 @@ describe('Public API', function () {
             });
     });
 
-    it('browse posts: request only url fields ', function (done) {
+    it('browse posts: request only url fields', function (done) {
         request.get(localUtils.API.getApiQuery('posts/?client_id=ghost-admin&client_secret=not_available&fields=url'))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
@@ -285,7 +285,26 @@ describe('Public API', function () {
 
                 should.equal(res.body.posts[0].id, undefined);
                 res.body.posts[0].url.should.eql('/welcome/');
+                done();
+            });
+    });
 
+    it('browse posts: request only url fields with include and absolute_urls', function (done) {
+        request.get(localUtils.API.getApiQuery('posts/?client_id=ghost-admin&client_secret=not_available&fields=url&include=tags&absolute_urls=true'))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .end(function (err, res) {
+                if (err) {
+                    return done(err);
+                }
+
+                should.exist(res.body.posts);
+
+                should.equal(res.body.posts[0].id, undefined);
+                res.body.posts[0].url.should.eql('http://127.0.0.1:2369/welcome/');
+                res.body.posts[0].tags[0].url.should.eql('http://127.0.0.1:2369/tag/getting-started/');
                 done();
             });
     });

--- a/core/test/unit/api/v0.1/decorators/urls_spec.js
+++ b/core/test/unit/api/v0.1/decorators/urls_spec.js
@@ -23,7 +23,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 columns: [],
             };
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(1, object, options);
 
             should.equal(Object.keys(object).length, 0);
         });
@@ -35,7 +35,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
             };
             urlService.getUrlByResourceId.withArgs(object.id).returns('url');
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(object.id, object, options);
 
             object.url.should.equal('url');
         });
@@ -51,7 +51,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(object.id, object, options);
 
             const urlObject = url.parse(object.feature_image);
             should.exist(urlObject.protocol);
@@ -69,7 +69,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(object.id, object, options);
 
             const urlObject = url.parse(object.twitter_image);
 
@@ -88,7 +88,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(object.id, object, options);
 
             const urlObject = url.parse(object.og_image);
 
@@ -107,7 +107,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForPost(object, options);
+            urls.urlsForPost(object.id, object, options);
 
             const imgSrc = object.html.match(/src="([^"]+)"/)[1];
             const imgSrcUrlObject = url.parse(imgSrc);
@@ -128,7 +128,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
             };
             urlService.getUrlByResourceId.withArgs(object.id).returns('url');
 
-            urls.urlsForUser(object, options);
+            urls.urlsForUser(object.id, object, options);
             const urlObject = url.parse(object.url);
 
             should.exist(urlObject.protocol);
@@ -146,7 +146,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForUser(object, options);
+            urls.urlsForUser(object.id, object, options);
             const urlObject = url.parse(object.profile_image);
 
             should.exist(urlObject.protocol);
@@ -164,7 +164,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForUser(object, options);
+            urls.urlsForUser(object.id, object, options);
             const urlObject = url.parse(object.cover_image);
 
             should.exist(urlObject.protocol);
@@ -183,7 +183,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
             };
             urlService.getUrlByResourceId.withArgs(object.id).returns('url');
 
-            urls.urlsForTag(object, options);
+            urls.urlsForTag(object.id, object, options);
             const urlObject = url.parse(object.url);
 
             should.exist(urlObject.protocol);
@@ -201,7 +201,7 @@ describe('Unit: api:v0.1:decorators:urls', function () {
                 }
             };
 
-            urls.urlsForTag(object, options);
+            urls.urlsForTag(object.id, object, options);
             const urlObject = url.parse(object.feature_image);
 
             should.exist(urlObject.protocol);


### PR DESCRIPTION
closes #9962

- Fixed the bug with url being set to `/404` when id was not present on the model
- Added a functional test to cover this bug
- Refactored url decorating methods to be more clear about the nature of passed parameters

Note: have split this into 3 separate commits to be more clear for the review. Will need to change the message before it's ready to go into master.