### PR TITLE
Updated permissible methods for hasApiKeyPermissions

### DIFF
--- a/core/server/models/invite.js
+++ b/core/server/models/invite.js
@@ -42,11 +42,11 @@ Invite = ghostBookshelf.Model.extend({
         return ghostBookshelf.Model.add.call(this, data, options);
     },
 
-    permissible(inviteModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission /*result*/) {
+    permissible(inviteModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
         const isAdd = (action === 'add');
 
         if (!isAdd) {
-            if (hasUserPermission && hasAppPermission) {
+            if (hasUserPermission && hasAppPermission && hasApiKeyPermission) {
                 return Promise.resolve();
             }
 
@@ -86,7 +86,7 @@ Invite = ghostBookshelf.Model.extend({
                     });
                 }
 
-                if (hasUserPermission && hasAppPermission) {
+                if (hasUserPermission && hasAppPermission && hasApiKeyPermission) {
                     return Promise.resolve();
                 }
 

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -816,7 +816,7 @@ Post = ghostBookshelf.Model.extend({
     },
 
     // NOTE: the `authors` extension is the parent of the post model. It also has a permissible function.
-    permissible: function permissible(postModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+    permissible: function permissible(postModel, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
         let isContributor, isEdit, isAdd, isDestroy;
 
         function isChanging(attr) {
@@ -857,7 +857,7 @@ Post = ghostBookshelf.Model.extend({
             excludedAttrs.push('tags');
         }
 
-        if (hasUserPermission && hasAppPermission) {
+        if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
             return Promise.resolve({excludedAttrs});
         }
 

--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -247,7 +247,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
             return destroyPost();
         },
 
-        permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+        permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
             var self = this,
                 postModel = postModelOrId,
                 origArgs, isContributor, isAuthor, isEdit, isAdd, isDestroy;
@@ -336,7 +336,7 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                 hasUserPermission = hasUserPermission || isPrimaryAuthor();
             }
 
-            if (hasUserPermission && hasAppPermission) {
+            if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
                 return Post.permissible.call(
                     this,
                     postModelOrId,
@@ -344,7 +344,8 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
                     unsafeAttrs,
                     loadedPermissions,
                     hasUserPermission,
-                    hasAppPermission
+                    hasAppPermission,
+                    hasApiKeyPermission
                 ).then(({excludedAttrs}) => {
                     // @TODO: we need a concept for making a diff between incoming authors and existing authors
                     // @TODO: for now we simply re-use the new concept of `excludedAttrs`

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -50,7 +50,7 @@ Role = ghostBookshelf.Model.extend({
         return options;
     },
 
-    permissible: function permissible(roleModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+    permissible: function permissible(roleModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
         // If we passed in an id instead of a model, get the model
         // then check the permissions
         if (_.isNumber(roleModelOrId) || _.isString(roleModelOrId)) {
@@ -95,7 +95,7 @@ Role = ghostBookshelf.Model.extend({
             }
         }
 
-        if (hasUserPermission && hasAppPermission) {
+        if (hasUserPermission && hasAppPermission && hasApiKeyPermission) {
             return Promise.resolve();
         }
 

--- a/core/server/models/subscriber.js
+++ b/core/server/models/subscriber.js
@@ -53,7 +53,7 @@ Subscriber = ghostBookshelf.Model.extend({
         return options;
     },
 
-    permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+    permissible: function permissible(postModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
         // CASE: external is only allowed to add and edit subscribers
         if (context.external) {
             if (['add', 'edit'].indexOf(action) !== -1) {
@@ -61,7 +61,7 @@ Subscriber = ghostBookshelf.Model.extend({
             }
         }
 
-        if (hasUserPermission && hasAppPermission) {
+        if (hasUserPermission && hasAppPermission && hasApiKeyPermission) {
             return Promise.resolve();
         }
 

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -611,7 +611,7 @@ User = ghostBookshelf.Model.extend({
         });
     },
 
-    permissible: function permissible(userModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
+    permissible: function permissible(userModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission, hasApiKeyPermission) {
         var self = this,
             userModel = userModelOrId,
             origArgs;
@@ -701,7 +701,7 @@ User = ghostBookshelf.Model.extend({
                 .then((owner) => {
                     // CASE: owner can assign role to any user
                     if (context.user === owner.id) {
-                        if (hasUserPermission && hasAppPermission) {
+                        if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
                             return Promise.resolve();
                         }
 
@@ -723,7 +723,7 @@ User = ghostBookshelf.Model.extend({
                         // e.g. admin can assign admin role to a user, but not owner
                         return permissions.canThis(context).assign.role(role)
                             .then(() => {
-                                if (hasUserPermission && hasAppPermission) {
+                                if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
                                     return Promise.resolve();
                                 }
 
@@ -733,7 +733,7 @@ User = ghostBookshelf.Model.extend({
                             });
                     }
 
-                    if (hasUserPermission && hasAppPermission) {
+                    if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
                         return Promise.resolve();
                     }
 
@@ -743,7 +743,7 @@ User = ghostBookshelf.Model.extend({
                 });
         }
 
-        if (hasUserPermission && hasAppPermission) {
+        if (hasUserPermission && hasApiKeyPermission && hasAppPermission) {
             return Promise.resolve();
         }
 

--- a/core/test/unit/models/invite_spec.js
+++ b/core/test/unit/models/invite_spec.js
@@ -124,28 +124,28 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -158,28 +158,28 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite editor', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite author', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -192,7 +192,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -203,7 +203,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -214,14 +214,14 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
 
                 it('invite contributor', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true);
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, true, true, true);
                 });
             });
 
@@ -234,7 +234,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -245,7 +245,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -256,7 +256,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -267,7 +267,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -284,7 +284,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Administrator');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -295,7 +295,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Editor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -306,7 +306,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Author');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);
@@ -317,7 +317,7 @@ describe('Unit: models/invite', function () {
                     sandbox.stub(models.Role, 'findOne').withArgs({id: 'role_id'}).resolves(roleModel);
                     roleModel.get.withArgs('name').returns('Contributor');
 
-                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false)
+                    return models.Invite.permissible(inviteModel, 'add', context, unsafeAttrs, loadedPermissions, false, false, true)
                         .then(Promise.reject)
                         .catch((err) => {
                             (err instanceof common.errors.NoPermissionError).should.eql(true);

--- a/core/test/unit/models/post_spec.js
+++ b/core/test/unit/models/post_spec.js
@@ -1533,7 +1533,8 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
-                        false
+                        false,
+                        true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
                     }).catch((error) => {
@@ -1561,6 +1562,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1589,6 +1591,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1618,6 +1621,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then((result) => {
                         should.exist(result);
@@ -1647,6 +1651,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1677,6 +1682,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1707,6 +1713,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then((result) => {
                         should.exist(result);
@@ -1732,6 +1739,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1756,6 +1764,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1780,6 +1789,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1804,6 +1814,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1828,6 +1839,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1852,6 +1864,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then((result) => {
                         should.exist(result);
@@ -1875,6 +1888,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then((result) => {
                         should.exist(result);
@@ -1901,6 +1915,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         {},
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1929,6 +1944,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         {},
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -1957,6 +1973,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         {},
                         testUtils.permissions.contributor,
                         false,
+                        true,
                         true
                     ).then((result) => {
                         should.exist(result);
@@ -1988,6 +2005,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2016,6 +2034,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2045,6 +2064,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2073,6 +2093,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2102,6 +2123,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2131,6 +2153,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2160,6 +2183,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         should(mockPostObj.get.calledOnce).be.true();
@@ -2183,6 +2207,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2210,6 +2235,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         done(new Error('Permissible function should have rejected.'));
@@ -2234,6 +2260,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                         unsafeAttrs,
                         testUtils.permissions.author,
                         false,
+                        true,
                         true
                     ).then(() => {
                         should(mockPostObj.get.called).be.false();
@@ -2261,6 +2288,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     unsafeAttrs,
                     testUtils.permissions.editor,
                     false,
+                    true,
                     true
                 ).then(() => {
                     done(new Error('Permissible function should have rejected.'));
@@ -2287,6 +2315,7 @@ describe('Unit: models/post: uses database (@TODO: fix me)', function () {
                     context,
                     unsafeAttrs,
                     testUtils.permissions.editor,
+                    true,
                     true,
                     true
                 ).then(() => {

--- a/core/test/unit/models/user_spec.js
+++ b/core/test/unit/models/user_spec.js
@@ -195,7 +195,7 @@ describe('Unit: models/user', function () {
             var mockUser = getUserModel(1, 'Owner'),
                 context = {user: 1};
 
-            models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true).then(() => {
+            models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.owner, true, true, true).then(() => {
                 done(new Error('Permissible function should have errored'));
             }).catch((error) => {
                 error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -208,7 +208,7 @@ describe('Unit: models/user', function () {
             var mockUser = getUserModel(3, 'Contributor'),
                 context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true).then(() => {
+            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true).then(() => {
                 should(mockUser.get.calledOnce).be.true();
             });
         });
@@ -217,7 +217,7 @@ describe('Unit: models/user', function () {
             var mockUser = getUserModel(3, 'Editor'),
                 context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {status: 'inactive'}, testUtils.permissions.editor, false, true)
+            return models.User.permissible(mockUser, 'edit', context, {status: 'inactive'}, testUtils.permissions.editor, false, true, true)
                 .then(Promise.reject)
                 .catch((err) => {
                     err.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -233,7 +233,7 @@ describe('Unit: models/user', function () {
             const mockUser = {id: 3, related: sandbox.stub().returns()};
             const context = {user: 3};
 
-            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true)
+            return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.contributor, false, true, true)
                 .then(() => {
                     models.User.findOne.calledOnce.should.be.true();
                 });
@@ -274,7 +274,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.admin.context;
                 const unsafeAttrs = testUtils.permissions.editor.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -286,7 +286,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.owner.context;
                 const unsafeAttrs = testUtils.permissions.owner.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.owner, false, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.owner, false, true, true)
                     .then(() => {
                         models.User.getOwnerUser.calledOnce.should.be.true();
                     });
@@ -297,7 +297,7 @@ describe('Unit: models/user', function () {
                 const context = testUtils.context.admin.context;
                 const unsafeAttrs = testUtils.permissions.editor.user;
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -315,7 +315,7 @@ describe('Unit: models/user', function () {
                     }
                 });
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, true, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.admin, true, true, true)
                     .then(() => {
                         models.User.getOwnerUser.calledOnce.should.be.true();
                         permissions.canThis.calledOnce.should.be.true();
@@ -333,7 +333,7 @@ describe('Unit: models/user', function () {
                     }
                 });
 
-                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.author, false, true)
+                return models.User.permissible(mockUser, 'edit', context, unsafeAttrs, testUtils.permissions.author, false, true, true)
                     .then(Promise.reject)
                     .catch((err) => {
                         err.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -346,7 +346,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -360,7 +360,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Owner'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -374,7 +374,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Administrator'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -388,7 +388,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Author'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -398,7 +398,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Contributor'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'edit', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -408,7 +408,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 3};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -418,7 +418,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Editor'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -432,7 +432,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Administrator'),
                     context = {user: 2};
 
-                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     done(new Error('Permissible function should have errored'));
                 }).catch((error) => {
                     error.should.be.an.instanceof(common.errors.NoPermissionError);
@@ -446,7 +446,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Author'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });
@@ -456,7 +456,7 @@ describe('Unit: models/user', function () {
                 var mockUser = getUserModel(3, 'Contributor'),
                     context = {user: 2};
 
-                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true).then(() => {
+                return models.User.permissible(mockUser, 'destroy', context, {}, testUtils.permissions.editor, true, true, true).then(() => {
                     should(mockUser.hasRole.called).be.true();
                     should(mockUser.get.calledOnce).be.true();
                 });


### PR DESCRIPTION
:wave: refs #9865 :wave:  
:information_source: This is split out from https://github.com/TryGhost/Ghost/pull/9869/ :information_source: 

This updates all current permissible methods to use the new function
signature which includes the hasApiKeyPermissions parameter. It also
makes sure that the hasApiKeyPermissions argument is taken into account
whenever checking before returning a resolved promise.

It does _not_ add any custom permission logic for apikeys
