### PR TITLE
Stopped api key from assigning the 'Owner' role

### DIFF
--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -51,33 +51,29 @@ Role = ghostBookshelf.Model.extend({
     },
 
     permissible: function permissible(roleModelOrId, action, context, unsafeAttrs, loadedPermissions, hasUserPermission, hasAppPermission) {
-        var self = this,
-            checkAgainst = [],
-            origArgs;
-
         // If we passed in an id instead of a model, get the model
         // then check the permissions
         if (_.isNumber(roleModelOrId) || _.isString(roleModelOrId)) {
-            // Grab the original args without the first one
-            origArgs = _.toArray(arguments).slice(1);
-
             // Get the actual role model
             return this.findOne({id: roleModelOrId, status: 'all'})
-                .then(function then(foundRoleModel) {
+                .then((foundRoleModel) => {
                     if (!foundRoleModel) {
                         throw new common.errors.NotFoundError({
                             message: common.i18n.t('errors.models.role.roleNotFound')
                         });
                     }
 
-                    // Build up the original args but substitute with actual model
-                    var newArgs = [foundRoleModel].concat(origArgs);
+                    // Grab the original args without the first one
+                    const origArgs = _.toArray(arguments).slice(1);
 
-                    return self.permissible.apply(self, newArgs);
+                    return this.permissible(foundRoleModel, ...origArgs);
                 });
         }
 
+        const roleModel = roleModelOrId;
+
         if (action === 'assign' && loadedPermissions.user) {
+            let checkAgainst;
             if (_.some(loadedPermissions.user.roles, {name: 'Owner'})) {
                 checkAgainst = ['Owner', 'Administrator', 'Editor', 'Author', 'Contributor'];
             } else if (_.some(loadedPermissions.user.roles, {name: 'Administrator'})) {
@@ -87,7 +83,7 @@ Role = ghostBookshelf.Model.extend({
             }
 
             // Role in the list of permissible roles
-            hasUserPermission = roleModelOrId && _.includes(checkAgainst, roleModelOrId.get('name'));
+            hasUserPermission = roleModelOrId && _.includes(checkAgainst, roleModel.get('name'));
         }
 
         if (action === 'assign' && loadedPermissions.apiKey) {

--- a/core/server/models/role.js
+++ b/core/server/models/role.js
@@ -90,6 +90,15 @@ Role = ghostBookshelf.Model.extend({
             hasUserPermission = roleModelOrId && _.includes(checkAgainst, roleModelOrId.get('name'));
         }
 
+        if (action === 'assign' && loadedPermissions.apiKey) {
+            // apiKey cannot 'assign' the 'Owner' role
+            if (roleModel.get('name') === 'Owner') {
+                return Promise.reject(new common.errors.NoPermissionError({
+                    message: common.i18n.t('errors.models.role.notEnoughPermission')
+                }));
+            }
+        }
+
         if (hasUserPermission && hasAppPermission) {
             return Promise.resolve();
         }

--- a/core/test/unit/models/role_spec.js
+++ b/core/test/unit/models/role_spec.js
@@ -1,4 +1,5 @@
 const models = require('../../../server/models');
+const {NoPermissionError} = require('../../../server/lib/common/errors');
 const ghostBookshelf = require('../../../server/models/base');
 const testUtils = require('../../utils');
 const should = require('should');
@@ -23,6 +24,25 @@ describe('Unit: models/role', function () {
                 .then(() => checkRolePermissionsCount(2))
                 .then(() => models.Role.destroy(adminRole))
                 .then(() => checkRolePermissionsCount(0));
+        });
+    });
+
+    describe('permissible', function () {
+        it('does not let api key assign the owner role', function () {
+            return models.Role.permissible(
+                models.Role.forge({name: 'Owner'}), // Owner role
+                'assign',                           // assign action
+                {},
+                {},
+                {apiKey: {}},                       // apiKey loaded permissions
+                true,
+                true,
+                true
+            ).then(() => {
+                throw new Error('models.Role.permissible should have thrown!');
+            }, (err) => {
+                should.equal(err instanceof NoPermissionError, true);
+            });
         });
     });
 });


### PR DESCRIPTION
:wave: refs #9865 :wave: 
:information_source: split out from https://github.com/TryGhost/Ghost/pull/9869 :information_source: 

We do not want api keys to be able to assign the Owner role to any other
key or user.