### PR TITLE
Added api_key_user to the context object

### DIFF
--- a/core/server/api/shared/http.js
+++ b/core/server/api/shared/http.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const debug = require('ghost-ignition').debug('api:shared:http');
 const shared = require('../shared');
 const models = require('../../models');
@@ -6,25 +7,36 @@ const http = (apiImpl) => {
     return (req, res, next) => {
         debug('request');
 
-        const frame = new shared.Frame({
-            body: req.body,
-            file: req.file,
-            files: req.files,
-            query: req.query,
-            params: req.params,
-            user: req.user,
-            context: {
-                api_key_id: (req.api_key && req.api_key.id) ? req.api_key.id : null,
-                user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null
-            }
-        });
+        const setupFrame = () => {
+            const frameDependencies = {
+                api_key_user: (req.api_key && req.api_key.id) ? models.User.getOwnerUser() : Promise.resolve(null)
+            };
+            return Promise.props(frameDependencies).then((loadedDependencies) => {
+                const frame = new shared.Frame({
+                    body: req.body,
+                    file: req.file,
+                    files: req.files,
+                    query: req.query,
+                    params: req.params,
+                    user: req.user,
+                    context: {
+                        api_key_user: loadedDependencies.api_key_user,
+                        api_key_id: (req.api_key && req.api_key.id) ? req.api_key.id : null,
+                        user: ((req.user && req.user.id) || (req.user && models.User.isExternalUser(req.user.id))) ? req.user.id : null
+                    }
+                });
 
-        frame.configure({
-            options: apiImpl.options,
-            data: apiImpl.data
-        });
+                frame.configure({
+                    options: apiImpl.options,
+                    data: apiImpl.data
+                });
 
-        apiImpl(frame)
+                return frame;
+            });
+        };
+
+        setupFrame()
+            .then(apiImpl)
             .then((result) => {
                 debug(result);
 


### PR DESCRIPTION
refs #9865

This is because currently whenever an api key interacts with an object,
it needs to have a user for things like last modified by.