### PR TITLE
Updated contextUser to handle context.api_key_id

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -394,17 +394,17 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     },
 
     // Get the user from the options object
-    contextUser: function contextUser(options) {
-        options = options || {};
-        options.context = options.context || {};
+    contextUser: function contextUser(options = {}) {
+        const context = options.context || {};
 
-        if (options.context.user || ghostBookshelf.Model.isExternalUser(options.context.user)) {
-            return options.context.user;
-        } else if (options.context.internal) {
+
+        if (context.user || ghostBookshelf.Model.isExternalUser(context.user)) {
+            return context.user;
+        } else if (context.internal) {
             return ghostBookshelf.Model.internalUser;
         } else if (this.get('id')) {
             return this.get('id');
-        } else if (options.context.external) {
+        } else if (context.external) {
             return ghostBookshelf.Model.externalUser;
         } else {
             throw new common.errors.NotFoundError({

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -397,6 +397,9 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
     contextUser: function contextUser(options = {}) {
         const context = options.context || {};
 
+        if (context.api_key_id && context.api_key_user && context.api_key_user.get('id')) {
+            return context.api_key_user.get('id');
+        }
 
         if (context.user || ghostBookshelf.Model.isExternalUser(context.user)) {
             return context.user;

--- a/core/test/unit/models/base/index_spec.js
+++ b/core/test/unit/models/base/index_spec.js
@@ -18,6 +18,21 @@ describe('Models: base', function () {
         sandbox.restore();
     });
 
+    describe('contextUser', function () {
+        it('returns the id of the api_key_user if api_key_id is present and api_key_user has an id', function () {
+            const fakeOptions = {
+                context: {
+                    api_key_id: 'mmhmmm',
+                    api_key_user: models.User.forge({id: 'eieio'})
+                }
+            };
+
+            const result = models.Base.Model.prototype.contextUser(fakeOptions);
+
+            should.equal(result, 'eieio');
+        });
+    });
+
     describe('generateSlug', function () {
         let Model;
         let options = {};


### PR DESCRIPTION
:information_source: Split out from https://github.com/TryGhost/Ghost/pull/9869 :information_source: 

:open_hands: refs #9865 :open_hands: 

This updates the contextUser method to use the id of
context.api_key_user. This means we can set the api_key_user context and
all updated_by/created_by will use the correct user for the api key.