### PR TITLE
"Corrected" spelling of Referer header

### DIFF
--- a/core/server/services/auth/session/middleware.js
+++ b/core/server/services/auth/session/middleware.js
@@ -10,9 +10,9 @@ const urlService = require('../../url');
 
 const getOrigin = (req) => {
     const origin = req.get('origin');
-    const referrer = req.get('referrer');
+    const referer = req.get('referer');
 
-    if (!origin && !referrer) {
+    if (!origin && !referer) {
         return null;
     }
 
@@ -21,7 +21,7 @@ const getOrigin = (req) => {
     }
 
     try {
-        return new URL(req.get('referrer')).origin;
+        return new URL(referer).origin;
     } catch (e) {
         return null;
     }

--- a/core/test/unit/services/auth/session/index_spec.js
+++ b/core/test/unit/services/auth/session/index_spec.js
@@ -38,11 +38,11 @@ describe('Session Service', function () {
     };
 
     describe('createSession', function () {
-        it('calls next with a BadRequestError if there is no Origin or Refferer', function (done) {
+        it('calls next with a BadRequestError if there is no Origin or Referer', function (done) {
             const req = fakeReq();
             sandbox.stub(req, 'get')
                 .withArgs('origin').returns('')
-                .withArgs('referrer').returns('');
+                .withArgs('referer').returns('');
 
             sessionService.createSession(req, fakeRes(), function next(err) {
                 should.equal(err instanceof BadRequestError, true);


### PR DESCRIPTION
refs #9972

Referrer is not how you spell Referer according to the HTTP spec.
