### PR TITLE
Updated session middleware to support node v6

### DIFF
--- a/core/server/services/auth/session/middleware.js
+++ b/core/server/services/auth/session/middleware.js
@@ -1,4 +1,4 @@
-const {parse: parseUrl} = require('url');
+const url = require('url');
 const common = require('../../../lib/common');
 const constants = require('../../../lib/constants');
 const config = require('../../../config');
@@ -20,7 +20,7 @@ const getOrigin = (req) => {
         return origin;
     }
 
-    const {protocol, host} = parseUrl(referrer);
+    const {protocol, host} = url.parse(referrer);
     if (protocol && host) {
         return `${protocol}//${host}`;
     }

--- a/core/server/services/auth/session/middleware.js
+++ b/core/server/services/auth/session/middleware.js
@@ -1,4 +1,4 @@
-const {URL} = require('url');
+const {parse: parseUrl} = require('url');
 const common = require('../../../lib/common');
 const constants = require('../../../lib/constants');
 const config = require('../../../config');
@@ -20,11 +20,11 @@ const getOrigin = (req) => {
         return origin;
     }
 
-    try {
-        return new URL(req.get('referrer')).origin;
-    } catch (e) {
-        return null;
+    const {protocol, host} = parseUrl(referrer);
+    if (protocol && host) {
+        return `${protocol}//${host}`;
     }
+    return null;
 };
 
 let UNO_SESSIONIONA;

--- a/core/test/unit/services/auth/session/index_spec.js
+++ b/core/test/unit/services/auth/session/index_spec.js
@@ -50,6 +50,27 @@ describe('Session Service', function () {
             });
         });
 
+        it('sets req.session.origin from the Referer header', function (done) {
+            const req = fakeReq();
+            const res = fakeRes();
+
+            sandbox.stub(req, 'get')
+                .withArgs('user-agent').returns('')
+                .withArgs('origin').returns('')
+                .withArgs('referrer').returns('http://ghost.org/path');
+
+            req.ip = '127.0.0.1';
+            req.user = models.User.forge({id: 23});
+
+            sandbox.stub(res, 'sendStatus')
+                .callsFake(function (statusCode) {
+                    should.equal(req.session.origin, 'http://ghost.org');
+                    done();
+                });
+
+            sessionService.createSession(req, res);
+        });
+
         it('sets req.session.user_id,origin,user_agent,ip and calls sendStatus with 201 if the check succeeds', function (done) {
             const req = fakeReq();
             const res = fakeRes();


### PR DESCRIPTION
Node <v6.14.4 does not have the WHATWG URL class, causing parsing of the Referer header to throw. This removes use of the URL class in favour for the legacy url in node.