### PR TITLE
🐛 Fixed migration from v1 to 2.2.1

### DIFF
--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -614,7 +614,7 @@ Post = ghostBookshelf.Model.extend({
      */
     defaultRelations: function defaultRelations(methodName, options) {
         if (['edit', 'add'].indexOf(methodName) !== -1) {
-            options.withRelated = _.union(this.prototype.relationships, options.withRelated || []);
+            options.withRelated = _.union(['authors', 'tags'], options.withRelated || []);
         }
 
         return options;


### PR DESCRIPTION
closes #9983

- everything is described in the target issue
- this PR fixes both problems described in the issue
- i will raise an issue in the CLI, that we should migrate from minor version to minor version and not directly, because the code base will change (https://github.com/TryGhost/Ghost-CLI/issues/839)

**I need to do a final QA in the morning with fresh eyes.**

- [x] sqlite3
- [x] mysql