### PR TITLE
Added HTTP BREAD for integrations resource

### DIFF
--- a/core/server/api/v2/index.js
+++ b/core/server/api/v2/index.js
@@ -6,6 +6,10 @@ module.exports = {
         return shared.http;
     },
 
+    get integrations() {
+        return shared.pipeline(require('./integrations'), localUtils);
+    },
+
     // @TODO: transform
     get session() {
         return require('./session');

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -1,9 +1,40 @@
+const common = require('../../lib/common');
 const models = require('../../models');
 
 module.exports = {
     docName: 'integrations',
     browse: {},
-    read: {},
+    read: {
+        permissions: true,
+        data: [
+            'id'
+        ],
+        options: [
+            'include'
+        ],
+        validation: {
+            data: {
+                id: {
+                    required: true
+                }
+            },
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Integration.findOne(data, Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                });
+        }
+    },
     edit: {},
     add: {
         permissions: true,

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -3,7 +3,23 @@ const models = require('../../models');
 
 module.exports = {
     docName: 'integrations',
-    browse: {},
+    browse: {
+        permissions: true,
+        options: [
+            'include',
+            'limit'
+        ],
+        validation: {
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({options}) {
+            return models.Integration.findPage(options);
+        }
+    },
     read: {
         permissions: true,
         data: [

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -125,5 +125,27 @@ module.exports = {
             });
         }
     },
-    destroy: {}
+    destroy: {
+        permissions: true,
+        options: [
+            'id'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                }
+            }
+        },
+        query({options}) {
+            return models.Integration.destroy(Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                });
+        }
+    }
 };

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -51,7 +51,42 @@ module.exports = {
                 });
         }
     },
-    edit: {},
+    edit: {
+        permissions: true,
+        data: [
+            'name',
+            'icon_image',
+            'description',
+            'webhooks'
+        ],
+        options: [
+            'id',
+            'include'
+        ],
+        validation: {
+            options: {
+                id: {
+                    required: true
+                },
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Integration.edit(data, Object.assign(options, {require: true}))
+                .catch(models.Integration.NotFoundError, () => {
+                    throw new common.errors.NotFoundError({
+                        message: common.i18n.t('errors.api.resource.resourceNotFound', {
+                            resource: 'Integration'
+                        })
+                    });
+                })
+                .then((model) => {
+                    return model.fetch(options);
+                });
+        }
+    },
     add: {
         permissions: true,
         data: [

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -81,9 +81,6 @@ module.exports = {
                             resource: 'Integration'
                         })
                     });
-                })
-                .then((model) => {
-                    return model.fetch(options);
                 });
         }
     },
@@ -111,18 +108,13 @@ module.exports = {
             }
         },
         query({data, options}) {
-            return models.Base.transaction((transacting) => {
-                const optionsWithTransacting = Object.assign({transacting}, options);
-                const dataWithApiKeys = Object.assign({
-                    api_keys: [
-                        {type: 'content'},
-                        {type: 'admin'}
-                    ]
-                }, data);
-                return models.Integration.add(dataWithApiKeys, optionsWithTransacting);
-            }).then((model) => {
-                return model.fetch(options);
-            });
+            const dataWithApiKeys = Object.assign({
+                api_keys: [
+                    {type: 'content'},
+                    {type: 'admin'}
+                ]
+            }, data);
+            return models.Integration.add(dataWithApiKeys, options);
         }
     },
     destroy: {

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -1,0 +1,47 @@
+const models = require('../../models');
+
+module.exports = {
+    docName: 'integrations',
+    browse: {},
+    read: {},
+    edit: {},
+    add: {
+        permissions: true,
+        data: [
+            'name',
+            'icon_image',
+            'description',
+            'webhooks'
+        ],
+        options: [
+            'include'
+        ],
+        validation: {
+            data: {
+                name: {
+                    required: true
+                }
+            },
+            options: {
+                include: {
+                    values: ['api_keys', 'webhooks']
+                }
+            }
+        },
+        query({data, options}) {
+            return models.Base.transaction((transacting) => {
+                const optionsWithTransacting = Object.assign({transacting}, options);
+                const dataWithApiKeys = Object.assign({
+                    api_keys: [
+                        {type: 'content'},
+                        {type: 'admin'}
+                    ]
+                }, data);
+                return models.Integration.add(dataWithApiKeys, optionsWithTransacting);
+            }).then((model) => {
+                return model.fetch(options);
+            });
+        }
+    },
+    destroy: {}
+};

--- a/core/server/api/v2/integrations.js
+++ b/core/server/api/v2/integrations.js
@@ -85,6 +85,7 @@ module.exports = {
         }
     },
     add: {
+        statusCode: 201,
         permissions: true,
         data: [
             'name',
@@ -118,6 +119,7 @@ module.exports = {
         }
     },
     destroy: {
+        statusCode: 204,
         permissions: true,
         options: [
             'id'

--- a/core/server/api/v2/utils/serializers/input/index.js
+++ b/core/server/api/v2/utils/serializers/input/index.js
@@ -1,4 +1,7 @@
 module.exports = {
+    get integrations() {
+        return require('./integrations');
+    },
     get pages() {
         return require('./pages');
     },

--- a/core/server/api/v2/utils/serializers/input/integrations.js
+++ b/core/server/api/v2/utils/serializers/input/integrations.js
@@ -1,0 +1,10 @@
+const _ = require('lodash');
+const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:integrations');
+
+module.exports = {
+    add(apiConfig, frame) {
+        debug('add');
+
+        frame.data = _.pick(frame.data.integrations[0], apiConfig.data);
+    }
+};

--- a/core/server/api/v2/utils/serializers/input/integrations.js
+++ b/core/server/api/v2/utils/serializers/input/integrations.js
@@ -6,5 +6,10 @@ module.exports = {
         debug('add');
 
         frame.data = _.pick(frame.data.integrations[0], apiConfig.data);
+    },
+    edit(apiConfig, frame) {
+        debug('edit');
+
+        frame.data = _.pick(frame.data.integrations[0], apiConfig.data);
     }
 };

--- a/core/server/api/v2/utils/serializers/output/index.js
+++ b/core/server/api/v2/utils/serializers/output/index.js
@@ -1,4 +1,8 @@
 module.exports = {
+    get integrations() {
+        return require('./integrations');
+    },
+
     get pages() {
         return require('./pages');
     },

--- a/core/server/api/v2/utils/serializers/output/integrations.js
+++ b/core/server/api/v2/utils/serializers/output/integrations.js
@@ -1,0 +1,12 @@
+const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:integrations');
+
+module.exports = {
+    add(model, apiConfig, frame) {
+        debug('add');
+
+        frame.response = {
+            integrations: [model.toJSON()]
+        };
+    }
+};
+

--- a/core/server/api/v2/utils/serializers/output/integrations.js
+++ b/core/server/api/v2/utils/serializers/output/integrations.js
@@ -1,6 +1,14 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:integrations');
 
 module.exports = {
+    browse({data, meta}, apiConfig, frame) {
+        debug('browse');
+
+        frame.response = {
+            integrations: data.map(model => model.toJSON(frame.options)),
+            meta
+        };
+    },
     read(model, apiConfig, frame) {
         debug('read');
 

--- a/core/server/api/v2/utils/serializers/output/integrations.js
+++ b/core/server/api/v2/utils/serializers/output/integrations.js
@@ -1,6 +1,13 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:output:integrations');
 
 module.exports = {
+    read(model, apiConfig, frame) {
+        debug('read');
+
+        frame.response = {
+            integrations: [model.toJSON()]
+        };
+    },
     add(model, apiConfig, frame) {
         debug('add');
 

--- a/core/server/api/v2/utils/serializers/output/integrations.js
+++ b/core/server/api/v2/utils/serializers/output/integrations.js
@@ -13,21 +13,21 @@ module.exports = {
         debug('read');
 
         frame.response = {
-            integrations: [model.toJSON()]
+            integrations: [model.toJSON(frame.options)]
         };
     },
     add(model, apiConfig, frame) {
         debug('add');
 
         frame.response = {
-            integrations: [model.toJSON()]
+            integrations: [model.toJSON(frame.options)]
         };
     },
     edit(model, apiConfig, frame) {
         debug('edit');
 
         frame.response = {
-            integrations: [model.toJSON()]
+            integrations: [model.toJSON(frame.options)]
         };
     }
 };

--- a/core/server/api/v2/utils/serializers/output/integrations.js
+++ b/core/server/api/v2/utils/serializers/output/integrations.js
@@ -22,6 +22,13 @@ module.exports = {
         frame.response = {
             integrations: [model.toJSON()]
         };
+    },
+    edit(model, apiConfig, frame) {
+        debug('edit');
+
+        frame.response = {
+            integrations: [model.toJSON()]
+        };
     }
 };
 

--- a/core/server/models/integration.js
+++ b/core/server/models/integration.js
@@ -10,6 +10,44 @@ const Integration = ghostBookshelf.Model.extend({
         webhooks: 'webhooks'
     },
 
+    add(data, options) {
+        const addIntegration = () => {
+            return ghostBookshelf.Model.add.call(this, data, options)
+                .then(({id}) => {
+                    return this.findOne({id}, options);
+                });
+        };
+
+        if (!options.transacting) {
+            return ghostBookshelf.transaction((transacting) => {
+                options.transacting = transacting;
+
+                return addIntegration();
+            });
+        }
+
+        return addIntegration();
+    },
+
+    edit(data, options) {
+        const editIntegration = () => {
+            return ghostBookshelf.Model.edit.call(this, data, options)
+                .then(({id}) => {
+                    return this.findOne({id}, options);
+                });
+        };
+
+        if (!options.transacting) {
+            return ghostBookshelf.transaction((transacting) => {
+                options.transacting = transacting;
+
+                return editIntegration();
+            });
+        }
+
+        return editIntegration();
+    },
+
     onSaving(newIntegration, attr, options) {
         if (this.hasChanged('slug') || !this.get('slug')) {
             // Pass the new slug through the generator to strip illegal characters, detect duplicates

--- a/core/server/translations/en.json
+++ b/core/server/translations/en.json
@@ -357,6 +357,9 @@
                 "missingFile": "Please select a JSON file.",
                 "invalidFile": "Please select a valid JSON file to import."
             },
+            "resource": {
+                "resourceNotFound": "{resource} not found."
+            },
             "routes": {
                 "missingFile": "Please select a YAML file.",
                 "invalidFile": "Please select a valid YAML file to import."

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -39,6 +39,7 @@ module.exports = function apiRoutes() {
     router.get('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.read));
     router.post('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.add));
     router.put('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.edit));
+    router.del('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.destroy));
 
     // ## Schedules
     router.put('/schedules/posts/:id', [

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -35,6 +35,7 @@ module.exports = function apiRoutes() {
 
     // # Integrations
 
+    router.get('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.browse));
     router.get('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.read));
     router.post('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.add));
 

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -38,6 +38,7 @@ module.exports = function apiRoutes() {
     router.get('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.browse));
     router.get('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.read));
     router.post('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.add));
+    router.put('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.edit));
 
     // ## Schedules
     router.put('/schedules/posts/:id', [

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -33,6 +33,10 @@ module.exports = function apiRoutes() {
     router.put('/posts/:id', mw.authAdminAPI, apiv2.http(apiv2.posts.edit));
     router.del('/posts/:id', mw.authAdminAPI, apiv2.http(apiv2.posts.destroy));
 
+    // # Integrations
+
+    router.post('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.add));
+
     // ## Schedules
     router.put('/schedules/posts/:id', [
         auth.authenticate.authenticateClient,

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -35,6 +35,7 @@ module.exports = function apiRoutes() {
 
     // # Integrations
 
+    router.get('/integrations/:id', mw.authAdminAPI, apiv2.http(apiv2.integrations.read));
     router.post('/integrations', mw.authAdminAPI, apiv2.http(apiv2.integrations.add));
 
     // ## Schedules

--- a/core/test/functional/api/v2/admin/integrations_spec.js
+++ b/core/test/functional/api/v2/admin/integrations_spec.js
@@ -335,4 +335,53 @@ describe('Integrations API', function () {
                 .end(done);
         });
     });
+
+    describe('DELETE /integrations/:id', function () {
+        it('Can succesfully delete a created integration', function (done) {
+            request.post(localUtils.API.getApiQuery('integrations/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    integrations: [{
+                        name: 'Short Lived Integration'
+                    }]
+                })
+                .expect(200)
+                .end(function (err, {body}) {
+                    if (err) {
+                        return done(err);
+                    }
+                    const [createdIntegration] = body.integrations;
+
+                    request.del(localUtils.API.getApiQuery(`integrations/${createdIntegration.id}/`))
+                        .set('Origin', config.get('url'))
+                        .expect(200)
+                        .end(function (err) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            request.get(localUtils.API.getApiQuery(`integrations/${createdIntegration.id}/`))
+                                .set('Origin', config.get('url'))
+                                .expect(404)
+                                .end(done);
+                        });
+                });
+        });
+
+        it('Will 404 if the integration does not exist', function (done) {
+            request.del(localUtils.API.getApiQuery(`integrations/012345678901234567890123/`))
+                .set('Origin', config.get('url'))
+                .expect(404)
+                .end(done);
+        });
+
+        it('Will delete the associated api_keys and webhooks', function () {
+            /**
+             * @TODO
+             *
+             * We do not have the /apikeys or /webhooks endpoints yet
+             * This will be manually tested by egg before merging
+             */
+        });
+    });
 });

--- a/core/test/functional/api/v2/admin/integrations_spec.js
+++ b/core/test/functional/api/v2/admin/integrations_spec.js
@@ -1,0 +1,93 @@
+const should = require('should');
+const supertest = require('supertest');
+const config = require('../../../../../../core/server/config');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+
+const ghost = testUtils.startGhost;
+
+describe('Integrations API', function () {
+    let request;
+
+    before(function () {
+        return ghost()
+            .then(() => {
+                request = supertest.agent(config.get('url'));
+            })
+            .then(() => {
+                return localUtils.doAuth(request, 'integrations');
+            });
+    });
+
+    const findKey = type => object => object.type === type;
+
+    describe('POST /integrations/', function () {
+        it('Can successfully create a single integration with auto generated content and admin api key', function (done) {
+            request.post(localUtils.API.getApiQuery('integrations/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    integrations: [{
+                        name: 'Dis-Integrate!!'
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, {body}) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.equal(body.integrations.length, 1);
+
+                    const [integration] = body.integrations;
+                    should.equal(integration.name, 'Dis-Integrate!!');
+
+                    should.equal(integration.api_keys.length, 2);
+
+                    const contentApiKey = integration.api_keys.find(findKey('content'));
+                    should.equal(contentApiKey.integration_id, integration.id);
+
+                    const adminApiKey = integration.api_keys.find(findKey('admin'));
+                    should.equal(adminApiKey.integration_id, integration.id);
+
+                    done();
+                });
+        });
+
+        it('Can successfully create a single integration with a webhook', function (done) {
+            request.post(localUtils.API.getApiQuery('integrations/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    integrations: [{
+                        name: 'Integratatron4000',
+                        webhooks: [{
+                            event: 'something',
+                            target_url: 'http://example.com',
+                        }]
+                    }]
+                })
+                .expect('Content-Type', /json/)
+                .expect('Cache-Control', testUtils.cacheRules.private)
+                .expect(200)
+                .end(function (err, {body}) {
+                    if (err) {
+                        return done(err);
+                    }
+
+                    should.equal(body.integrations.length, 1);
+
+                    const [integration] = body.integrations;
+                    should.equal(integration.name, 'Integratatron4000');
+
+                    should.equal(integration.webhooks.length, 1);
+
+                    const webhook = integration.webhooks[0];
+                    should.equal(webhook.integration_id, integration.id);
+
+                    done();
+                });
+        });
+    });
+});
+

--- a/core/test/functional/api/v2/admin/integrations_spec.js
+++ b/core/test/functional/api/v2/admin/integrations_spec.js
@@ -32,7 +32,7 @@ describe('Integrations API', function () {
                 })
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -69,7 +69,7 @@ describe('Integrations API', function () {
                 })
                 .expect('Content-Type', /json/)
                 .expect('Cache-Control', testUtils.cacheRules.private)
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -99,7 +99,7 @@ describe('Integrations API', function () {
                         name: 'Interrogation Integration'
                     }]
                 })
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -147,7 +147,7 @@ describe('Integrations API', function () {
                         name: 'Integrate with this!'
                     }]
                 })
-                .expect(200)
+                .expect(201)
                 .end(function (err) {
                     if (err) {
                         return done(err);
@@ -159,7 +159,7 @@ describe('Integrations API', function () {
                                 name: 'Winter-(is)-great'
                             }]
                         })
-                        .expect(200)
+                        .expect(201)
                         .end(function (err) {
                             if (err) {
                                 return done(err);
@@ -201,7 +201,7 @@ describe('Integrations API', function () {
                         name: 'Rubbish Integration Name'
                     }]
                 })
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -250,7 +250,7 @@ describe('Integrations API', function () {
                         name: 'Webhook-less Integration',
                     }]
                 })
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -345,7 +345,7 @@ describe('Integrations API', function () {
                         name: 'Short Lived Integration'
                     }]
                 })
-                .expect(200)
+                .expect(201)
                 .end(function (err, {body}) {
                     if (err) {
                         return done(err);
@@ -354,7 +354,7 @@ describe('Integrations API', function () {
 
                     request.del(localUtils.API.getApiQuery(`integrations/${createdIntegration.id}/`))
                         .set('Origin', config.get('url'))
-                        .expect(200)
+                        .expect(204)
                         .end(function (err) {
                             if (err) {
                                 return done(err);

--- a/core/test/functional/api/v2/admin/integrations_spec.js
+++ b/core/test/functional/api/v2/admin/integrations_spec.js
@@ -89,5 +89,53 @@ describe('Integrations API', function () {
                 });
         });
     });
+
+    describe('GET /integrations/:id', function () {
+        it('Can successfully get a created integration', function (done) {
+            request.post(localUtils.API.getApiQuery('integrations/'))
+                .set('Origin', config.get('url'))
+                .send({
+                    integrations: [{
+                        name: 'Interrogation Integration'
+                    }]
+                })
+                .expect(200)
+                .end(function (err, {body}) {
+                    if (err) {
+                        return done(err);
+                    }
+                    const [createdIntegration] = body.integrations;
+
+                    request.get(localUtils.API.getApiQuery(`integrations/${createdIntegration.id}/`))
+                        .set('Origin', config.get('url'))
+                        .expect('Content-Type', /json/)
+                        .expect('Cache-Control', testUtils.cacheRules.private)
+                        .expect(200)
+                        .end(function (err, {body}) {
+                            if (err) {
+                                return done(err);
+                            }
+
+                            should.equal(body.integrations.length, 1);
+
+                            const [integration] = body.integrations;
+
+                            should.equal(integration.id, createdIntegration.id);
+                            should.equal(integration.name, createdIntegration.name);
+                            should.equal(integration.slug, createdIntegration.slug);
+                            should.equal(integration.description, createdIntegration.description);
+                            should.equal(integration.icon_image, createdIntegration.icon_image);
+                            done();
+                        });
+                });
+        });
+
+        it('Will 404 if the integration does not exist', function (done) {
+            request.get(localUtils.API.getApiQuery(`integrations/012345678901234567890123/`))
+                .set('Origin', config.get('url'))
+                .expect(404)
+                .end(done);
+        });
+    });
 });
 


### PR DESCRIPTION
:wave: refs #9865 :wave:

:warning: :warning: If you want to run this locally you'll need to run `knex-migrator migrate --v 2.3 --force` :warning: :warning: 


This adds the controller, and wires up the endpoint for BREADing with integrations
- Browse
 - [x] include=api_keys
 - [x] limit=all
- Read
 - [x] include=api_keys
- Edit
 - [x] edit name,slug,description&icon_image
- Add
 - [x] Create admin api key when creating integration
 - [x] Create content api key when creating integration
 - [x] Create all resources in a single transaction
- Destroy
 - [x] Delete integration
 - [x] Delete api_keys