### PR TITLE
:bug: Fixed session auth for blogs running on sub dir

### DIFF
--- a/core/server/services/auth/session/middleware.js
+++ b/core/server/services/auth/session/middleware.js
@@ -39,7 +39,7 @@ const getSession = (req, res, next) => {
             cookie: {
                 maxAge: constants.SIX_MONTH_MS,
                 httpOnly: true,
-                path: '/ghost',
+                path: urlService.utils.getSubdir() + '/ghost',
                 sameSite: 'lax',
                 secure: urlService.utils.isSSL(config.get('url'))
             }


### PR DESCRIPTION
closes #9982

This adds the subdirectory to the path for the session cookie, enabling
cookies to be sent/set/parsed for the session authentication to work.