### PR TITLE
Controller framework options

### DIFF
--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -38,6 +38,11 @@ const validate = (config, attrs) => {
     _.each(attrs, (value, key) => {
         debug(key, value);
 
+        if (GLOBAL_VALIDATORS[key]) {
+            debug('global validation');
+            errors = errors.concat(validation.validate(value, key, GLOBAL_VALIDATORS[key]));
+        }
+
         if (config && config[key]) {
             const allowedValues = Array.isArray(config[key]) ? config[key] : config[key].values;
 
@@ -53,9 +58,6 @@ const validate = (config, attrs) => {
                     errors.push(new common.errors.ValidationError());
                 }
             }
-        } else if (GLOBAL_VALIDATORS[key]) {
-            debug('global validation');
-            errors = errors.concat(validation.validate(value, key, GLOBAL_VALIDATORS[key]));
         }
     });
 

--- a/core/test/unit/api/shared/validators/input/all_spec.js
+++ b/core/test/unit/api/shared/validators/input/all_spec.js
@@ -38,6 +38,29 @@ describe('Unit: api/shared/validators/input/all', function () {
                 });
         });
 
+        it('should run global validations on an type that has validation defined', function () {
+            const frame = {
+                options: {
+                    slug: 'not a valid slug %%%%% http://',
+                }
+            };
+
+            const apiConfig = {
+                options: {
+                    slug: {
+                        required: true
+                    }
+                }
+            };
+
+            return shared.validators.input.all.all(apiConfig, frame)
+                .then(() => {
+                    throw new Error('Should not resolve');
+                }, (err) => {
+                    should.exist(err);
+                });
+        });
+
         it('default include array notation', function () {
             const frame = {
                 options: {


### PR DESCRIPTION

## `disableGlobalValidator`

Currently if we add any form of validation - we will automatically lose out on the global validation defined in ghost, for example:

```js
module.exports = {
  docName: 'whatever',
  add: {
    data: ['slug'],
    validation: {slug: {required: true}}}
};
```

This will add the validation of making sure there _is_ a slug property - however it will no longer check if that slug _is_ a slug as defined by ghost.

This addition would change functionality by making that validation run by default.

However it adds the new property if you want the current behaviour (which most of the time you don't)

```js
module.exports = {
  docName: 'whatever',
  add: {
    data: ['slug'],
    validation: {slug: {required: true, disableGlobalValidator: true}}}
};
```
This now makes it very explicit that we do _not_ want to validate the slug property as if it is a slug.