### PR TITLE
Removed auto-assign of author_id for apikeys

### DIFF
--- a/core/server/models/relations/authors.js
+++ b/core/server/models/relations/authors.js
@@ -79,6 +79,14 @@ module.exports.extendModel = function extendModel(Post, Posts, ghostBookshelf) {
 
         // NOTE: sending `post.author = {}` was always ignored [unsupported]
         onCreating: function onCreating(model, attrs, options) {
+            // there is no context.user for API Key requests so we can't
+            // auto-assign the currently logged in user
+            if (options.context && options.context.api_key_id && !model.get('author_id')) {
+                throw new common.errors.ValidationError({
+                    message: 'At least one author is required.'
+                });
+            }
+
             if (!model.get('author_id')) {
                 model.set('author_id', this.contextUser(options));
             }


### PR DESCRIPTION
:wave: refs #9865 :wave:
:information_source: split out from #9869 :information_source: 

An api key does not have an associated user with it, so we cannot auto
assign any author_id.