### PR TITLE
Removed clients endpoint from v2 content api

### DIFF
--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -38,8 +38,5 @@ module.exports = function apiRoutes() {
     // @TODO: find a way than `middlewares.labs`
     router.post('/subscribers', shared.middlewares.labs.subscribers, mw.authenticatePublic, api.http(api.subscribers.add));
 
-    // ## Clients
-    router.get('/clients/slug/:slug', api.http(api.clients.read));
-
     return router;
 };


### PR DESCRIPTION
refs #9865

The client resource is a v0.1 specific thing, we have no use for it on
the v2 content api.