### PR TITLE
Refactored config to handle direct calls for specific version

### DIFF
--- a/core/server/api/v0.1/index.js
+++ b/core/server/api/v0.1/index.js
@@ -115,7 +115,7 @@ const cacheInvalidationHeader = (req, result) => {
  * @return {String} Resolves to header string
  */
 const locationHeader = (req, result) => {
-    const apiRoot = urlService.utils.urlFor('api', {version: 'deprecated'});
+    const apiRoot = urlService.utils.urlFor('api', {version: 'v0.1'});
     let location,
         newObject,
         statusQuery;

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -67,12 +67,14 @@
     },
     "api": {
         "versions": {
-            "active": {
+            "active": "v2",
+            "stable": "",
+            "deprecated": "v0.1",
+            "v2": {
                 "admin": "v2/admin",
                 "content": "v2/content"
             },
-            "stable": {},
-            "deprecated": {
+            "v0.1": {
                 "admin": "v0.1",
                 "content": "v0.1"
             }

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -17,10 +17,13 @@ const moment = require('moment-timezone'),
  */
 function getApiPath(options) {
     const apiVersions = config.get('api:versions');
-    let version = options.version || 'deprecated';
-    let type = options.type || 'content';
-    let versionData = apiVersions[version];
-    let versionPath = versionData[type];
+    let requestedVersion = options.version || 'deprecated';
+    let requestedVersionType = options.type || 'content';
+    let versionData = apiVersions[requestedVersion];
+    if (typeof versionData === 'string') {
+        versionData = apiVersions[versionData];
+    }
+    let versionPath = versionData[requestedVersionType];
     return `${BASE_API_PATH}${versionPath}/`;
 }
 

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -38,10 +38,9 @@ module.exports = function setupParentApp(options = {}) {
     // Mount the  apps on the parentApp
     // API
     // @TODO: finish refactoring the API app
-    // @TODO: decide what to do with these paths - config defaults? config overrides?
-    parentApp.use(urlUtils.getApiPath({version: 'deprecated'}), require('./api/v0.1/app')());
-    parentApp.use(urlUtils.getApiPath({version: 'active', type: 'content'}), require('./api/v2/content/app')());
-    parentApp.use(urlUtils.getApiPath({version: 'active', type: 'admin'}), require('./api/v2/admin/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'v0.1'}), require('./api/v0.1/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'v2', type: 'content'}), require('./api/v2/content/app')());
+    parentApp.use(urlUtils.getApiPath({version: 'v2', type: 'admin'}), require('./api/v2/admin/app')());
 
     // ADMIN
     parentApp.use('/ghost', require('./admin')());

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -438,14 +438,16 @@ describe('Url', function () {
             urlService.utils.urlFor('admin', true).should.equal('http://something.com/blog/ghost/');
         });
 
-        ['deprecated', 'active'].forEach((apiVersion) => {
+        ['deprecated', 'active', 'v0.1', 'v2'].forEach((apiVersion) => {
             function getApiPath(options) {
                 const baseAPIPath = '/ghost/api/';
 
                 switch (options.version) {
                     case 'deprecated':
+                    case 'v0.1':
                         return `${baseAPIPath}v0.1/`;
                     case 'active':
+                    case 'v2':
                         if (options.versionType === 'admin') {
                             return `${baseAPIPath}v2/admin/`;
                         } else {

--- a/core/test/unit/services/url/utils_spec.js
+++ b/core/test/unit/services/url/utils_spec.js
@@ -583,6 +583,16 @@ describe('Url', function () {
                         .urlFor('api', {cors: true, version: apiVersion, versionType: 'admin'}, true)
                         .should.eql(`https://my-ghost-blog.com${getApiPath({version: apiVersion, versionType: 'admin'})}`);
                 });
+
+                it('api: with just version and no version type returns correct api path', function () {
+                    configUtils.set({
+                        url: 'https://my-ghost-blog.com'
+                    });
+
+                    urlService.utils
+                        .urlFor('api', {cors: true, version: apiVersion}, true)
+                        .should.eql(`https://my-ghost-blog.com${getApiPath({version: apiVersion})}`);
+                });
             });
         });
 


### PR DESCRIPTION
refs #9866

- Refactored overrides config to include direct version configs(v0.1, v2), supported versions map to direct version
- Refactored `getApiPath` util to handle direct versions as well as mappings of supported versions
