### PR TITLE
Removed OPTIONS cors middleware from content api

### DIFF
--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -1,17 +1,10 @@
 const express = require('express');
 const api = require('../../../../api');
 const apiv2 = require('../../../../api/v2');
-const shared = require('../../../shared');
 const mw = require('./middleware');
 
 module.exports = function apiRoutes() {
     const router = express.Router();
-
-    // alias delete with del
-    router.del = router.delete;
-
-    // ## CORS pre-flight check
-    router.options('*', shared.middlewares.api.cors);
 
     // ## Configuration
     router.get('/configuration', api.http(api.configuration.read));


### PR DESCRIPTION
no-issue

The content API only supports GET requests so has no need for cors
middleware on OPTIONS. This also removes the router.del helper as it's
not used
