### PR TITLE
Passed apiImpl to input serializers

### DIFF
--- a/core/server/api/shared/pipeline.js
+++ b/core/server/api/shared/pipeline.js
@@ -32,7 +32,11 @@ const STAGES = {
     serialisation: {
         input(apiUtils, apiConfig, apiImpl, frame) {
             debug('stages: input serialisation');
-            return shared.serializers.handle.input(apiConfig, apiUtils.serializers.input, frame);
+            return shared.serializers.handle.input(
+                Object.assign({data: apiImpl.data}, apiConfig),
+                apiUtils.serializers.input,
+                frame
+            );
         },
         output(response, apiUtils, apiConfig, apiImpl, frame) {
             debug('stages: output serialisation');

--- a/core/test/unit/api/shared/serializers/handle_spec.js
+++ b/core/test/unit/api/shared/serializers/handle_spec.js
@@ -27,10 +27,10 @@ describe('Unit: api/shared/serializers/handle', function () {
                 });
         });
 
-        it('ensure serializers are called', function () {
-            const getStub = sandbox.stub();
+        it('ensure serializers are called with apiConfig and frame', function () {
+            const allStub = sandbox.stub();
             const addStub = sandbox.stub();
-            sandbox.stub(shared.serializers.input.all, 'all').get(() => getStub);
+            sandbox.stub(shared.serializers.input.all, 'all').get(() => allStub);
             sandbox.stub(shared.serializers.input.all, 'add').get(() => addStub);
 
             const apiSerializers = {
@@ -41,13 +41,24 @@ describe('Unit: api/shared/serializers/handle', function () {
                 }
             };
 
-            return shared.serializers.handle.input({docName: 'posts', method: 'add'}, apiSerializers, {})
+            const apiConfig = {docName: 'posts', method: 'add'};
+            const frame = {};
+
+            const stubsToCheck = [
+                allStub,
+                addStub,
+                apiSerializers.all,
+                apiSerializers.posts.all,
+                apiSerializers.posts.add
+            ];
+
+            return shared.serializers.handle.input(apiConfig, apiSerializers, frame)
                 .then(() => {
-                    getStub.calledOnce.should.be.true();
-                    addStub.calledOnce.should.be.true();
-                    apiSerializers.all.calledOnce.should.be.true();
-                    apiSerializers.posts.all.calledOnce.should.be.true();
-                    apiSerializers.posts.add.calledOnce.should.be.true();
+                    stubsToCheck.forEach((stub) => {
+                        stub.calledOnce.should.be.true();
+                        should.equal(stub.args[0][0], apiConfig);
+                        should.equal(stub.args[0][1], frame);
+                    });
                 });
         });
     });


### PR DESCRIPTION
no-issue

This is to allow serializers that are for methods which contain a body,
to remove unwanted keys from frame.data.

e.g.

```javascript
// api/v2/resources.js
module.exports = {
  docName: 'resources',
  add: {
    data: ['prop', 'key'],
    query(frame) {
      // frame.data will only have the prop and key properties if the data was read from the query
      // frame.data will have the entire body if the properties were read from the body
    }
  }
}
```

This PR allows us to have an input serializer like so

```javascript
// api/v2/utils/serializers/input/resources.js
const _ = require('lodash');
module.exports = {
  add(apiConfig, frame) {
    frame.data = _.pick(frame.data.resources[0], apiConfig.data);
  }
}
```