### PR TITLE
New site.changed event and webhook trigger

### DIFF
--- a/core/server/services/webhooks/index.js
+++ b/core/server/services/webhooks/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+    get listen() {
+        return require('./listen');
+    },
+
+    get trigger() {
+        return require('./trigger');
+    }
+};

--- a/core/server/services/webhooks/trigger.js
+++ b/core/server/services/webhooks/trigger.js
@@ -18,7 +18,7 @@ function makeRequests(webhooksCollection, payload, options) {
         const reqPayload = JSON.stringify(payload);
 
         common.logging.info('webhook.trigger', event, targetUrl);
-        let triggeredAt = Date.now();
+        const triggeredAt = Date.now();
         request(targetUrl, {
             body: reqPayload,
             headers: {

--- a/core/server/services/webhooks/trigger.js
+++ b/core/server/services/webhooks/trigger.js
@@ -1,0 +1,76 @@
+const _ = require('lodash');
+const common = require('../../lib/common');
+const models = require('../../models');
+const pipeline = require('../../../server/lib/promise/pipeline');
+const request = require('../../../server/lib/request');
+
+function updateWebhookTriggerData(id, data) {
+    models.Webhook.edit(data, {id: id}).catch(() => {
+        common.logging.warn(`Unable to update last_triggered for webhook: ${id}`);
+    });
+}
+
+function makeRequests(webhooksCollection, payload, options) {
+    _.each(webhooksCollection.models, (webhook) => {
+        const event = webhook.get('event');
+        const targetUrl = webhook.get('target_url');
+        const webhookId = webhook.get('id');
+        const reqPayload = JSON.stringify(payload);
+
+        common.logging.info('webhook.trigger', event, targetUrl);
+        let triggeredAt = Date.now();
+        request(targetUrl, {
+            body: reqPayload,
+            headers: {
+                'Content-Length': Buffer.byteLength(reqPayload),
+                'Content-Type': 'application/json'
+            },
+            timeout: 2 * 1000,
+            retries: 5
+        }).then((res) => {
+            updateWebhookTriggerData(webhookId, {
+                last_triggered_at: triggeredAt,
+                last_triggered_status: res.statusCode
+            });
+        }).catch((err) => {
+            // when a webhook responds with a 410 Gone response we should remove the hook
+            if (err.statusCode === 410) {
+                common.logging.info('webhook.destroy (410 response)', event, targetUrl);
+                return models.Webhook.destroy({id: webhookId}, options).catch(() => {
+                    common.logging.warn(`Unable to destroy webhook ${webhookId}`);
+                });
+            }
+            updateWebhookTriggerData(webhookId, {
+                last_triggered_at: triggeredAt,
+                last_triggered_status: err.statusCode
+            });
+
+            common.logging.error(new common.errors.GhostError({
+                err: err,
+                context: {
+                    id: webhookId,
+                    event: event,
+                    target_url: targetUrl,
+                    payload: payload
+                }
+            }));
+        });
+    });
+}
+
+function trigger(event, payload, options) {
+    let tasks;
+
+    function doQuery(options) {
+        return models.Webhook.findAllByEvent(event, options);
+    }
+
+    tasks = [
+        doQuery,
+        _.partialRight(makeRequests, payload, options)
+    ];
+
+    return pipeline(tasks, options);
+}
+
+module.exports = trigger;

--- a/core/server/web/api/v2/admin/app.js
+++ b/core/server/web/api/v2/admin/app.js
@@ -28,6 +28,9 @@ module.exports = function setupApiApp() {
     // API shouldn't be cached
     apiApp.use(shared.middlewares.cacheControl('private'));
 
+    // Register event emmiter on req/res to trigger cache invalidation webhook event
+    apiApp.use(shared.middlewares.emitEvents);
+
     // Routing
     apiApp.use(routes());
 

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -17,7 +17,6 @@ module.exports = function setupParentApp(options = {}) {
     parentApp.enable('trust proxy');
 
     parentApp.use(shared.middlewares.logRequest);
-    parentApp.use(shared.middlewares.emitEvents);
 
     // enabled gzip compression by default
     if (config.get('compress') !== false) {

--- a/core/server/web/parent-app.js
+++ b/core/server/web/parent-app.js
@@ -17,6 +17,7 @@ module.exports = function setupParentApp(options = {}) {
     parentApp.enable('trust proxy');
 
     parentApp.use(shared.middlewares.logRequest);
+    parentApp.use(shared.middlewares.emitEvents);
 
     // enabled gzip compression by default
     if (config.get('compress') !== false) {

--- a/core/server/web/shared/middlewares/emit-events.js
+++ b/core/server/web/shared/middlewares/emit-events.js
@@ -1,0 +1,12 @@
+const common = require('../../../lib/common');
+
+module.exports = function emitEvents(req, res, next) {
+    res.on('finish', function triggerWebhookEvents() {
+        if (res.get('X-Cache-Invalidate') === '/*') {
+            common.events.emit('site.changed');
+        }
+
+        res.removeListener('finish', triggerWebhookEvents);
+    });
+    next();
+};

--- a/core/server/web/shared/middlewares/emit-events.js
+++ b/core/server/web/shared/middlewares/emit-events.js
@@ -1,12 +1,12 @@
 const common = require('../../../lib/common');
 
 module.exports = function emitEvents(req, res, next) {
-    res.on('finish', function triggerWebhookEvents() {
+    res.on('finish', function triggerEvents() {
         if (res.get('X-Cache-Invalidate') === '/*') {
             common.events.emit('site.changed');
         }
 
-        res.removeListener('finish', triggerWebhookEvents);
+        res.removeListener('finish', triggerEvents);
     });
     next();
 };

--- a/core/server/web/shared/middlewares/emit-events.js
+++ b/core/server/web/shared/middlewares/emit-events.js
@@ -1,8 +1,9 @@
 const common = require('../../../lib/common');
+const INVALIDATE_ALL = '/*';
 
 module.exports = function emitEvents(req, res, next) {
     res.on('finish', function triggerEvents() {
-        if (res.get('X-Cache-Invalidate') === '/*') {
+        if (res.get('X-Cache-Invalidate') === INVALIDATE_ALL) {
             common.events.emit('site.changed');
         }
 

--- a/core/server/web/shared/middlewares/index.js
+++ b/core/server/web/shared/middlewares/index.js
@@ -73,5 +73,9 @@ module.exports = {
 
     get urlRedirects() {
         return require('./url-redirects');
+    },
+
+    get emitEvents() {
+        return require('./emit-events');
     }
 };

--- a/core/test/unit/services/webhooks_spec.js
+++ b/core/test/unit/services/webhooks_spec.js
@@ -1,14 +1,16 @@
-var _ = require('lodash'),
-    should = require('should'),
-    sinon = require('sinon'),
-    rewire = require('rewire'),
-    testUtils = require('../../utils'),
-
+const _ = require('lodash');
+const should = require('should');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const testUtils = require('../../utils');
+const common = require('../../../server/lib/common');
     // Stuff we test
-    webhooks = rewire('../../../server/services/webhooks'),
-    common = require('../../../server/lib/common'),
+const webhooks = {
+    listen: rewire('../../../server/services/webhooks/listen'),
+    trigger: rewire('../../../server/services/webhooks/trigger')
+};
 
-    sandbox = sinon.sandbox.create();
+const sandbox = sinon.sandbox.create();
 
 describe('Webhooks', function () {
     var eventStub;
@@ -23,30 +25,28 @@ describe('Webhooks', function () {
 
     it('listen() should initialise events correctly', function () {
         webhooks.listen();
-        eventStub.calledTwice.should.be.true();
+        eventStub.calledThrice.should.be.true();
     });
 
-    it('listener() with "subscriber.added" event calls api.webhooks.trigger with toJSONified model', function () {
+    it('listener() with "subscriber.added" event calls webhooks.trigger with toJSONified model', function () {
         var testSubscriber = _.clone(testUtils.DataGenerator.Content.subscribers[0]),
             testModel = {
                 toJSON: function () {
                     return testSubscriber;
                 }
             },
-            apiStub = {
-                webhooks: {
-                    trigger: sandbox.stub()
-                }
+            webhooksStub = {
+                trigger: sandbox.stub()
             },
-            resetWebhooks = webhooks.__set__('api', apiStub),
-            listener = webhooks.__get__('listener'),
+            resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
+            listener = webhooks.listen.__get__('listener'),
             triggerArgs;
 
         listener('subscriber.added', testModel);
 
-        apiStub.webhooks.trigger.calledOnce.should.be.true();
+        webhooksStub.trigger.calledOnce.should.be.true();
 
-        triggerArgs = apiStub.webhooks.trigger.getCall(0).args;
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
         triggerArgs[0].should.eql('subscriber.added');
         triggerArgs[1].should.deepEqual({
             subscribers: [testSubscriber]
@@ -55,29 +55,46 @@ describe('Webhooks', function () {
         resetWebhooks();
     });
 
-    it('listener() with "subscriber.deleted" event calls api.webhooks.trigger with _previousAttributes values', function () {
+    it('listener() with "subscriber.deleted" event calls webhooks.trigger with _previousAttributes values', function () {
         var testSubscriber = _.clone(testUtils.DataGenerator.Content.subscribers[1]),
             testModel = {
                 _previousAttributes: testSubscriber
             },
-            apiStub = {
-                webhooks: {
-                    trigger: sandbox.stub()
-                }
+            webhooksStub = {
+                trigger: sandbox.stub()
             },
-            resetWebhooks = webhooks.__set__('api', apiStub),
-            listener = webhooks.__get__('listener'),
+            resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
+            listener = webhooks.listen.__get__('listener'),
             triggerArgs;
 
         listener('subscriber.deleted', testModel);
 
-        apiStub.webhooks.trigger.calledOnce.should.be.true();
+        webhooksStub.trigger.calledOnce.should.be.true();
 
-        triggerArgs = apiStub.webhooks.trigger.getCall(0).args;
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
         triggerArgs[0].should.eql('subscriber.deleted');
         triggerArgs[1].should.deepEqual({
             subscribers: [testSubscriber]
         });
+
+        resetWebhooks();
+    });
+
+    it('listener() with "site.changed" event calls webhooks.trigger ', function () {
+        const webhooksStub = {
+            trigger: sandbox.stub()
+        };
+        const resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub);
+        const listener = webhooks.listen.__get__('listener');
+        let triggerArgs;
+
+        listener('site.changed');
+
+        webhooksStub.trigger.calledOnce.should.be.true();
+
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
+        triggerArgs[0].should.eql('site.changed');
+        triggerArgs[1].should.eql({});
 
         resetWebhooks();
     });


### PR DESCRIPTION
refs #9942
requires https://github.com/TryGhost/Ghost/pull/10018

- Updated webhook services structure
- Added new middleware to emit events - triggers webhooks on cache invalidation

Todo
- [x] Update `last_triggered_at` for each webhook when triggered (needs https://github.com/TryGhost/Ghost/pull/10018)