### PR TITLE
Allowed for repeated query parameters for arrays

### DIFF
--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -54,7 +54,7 @@ const validate = (config, attrs) => {
                     return;
                 }
 
-                const valuesAsArray = value.trim().toLowerCase().split(',');
+                const valuesAsArray = Array.isArray(value) ? value : value.trim().toLowerCase().split(',');
                 const unallowedValues = _.filter(valuesAsArray, (value) => {
                     return !allowedValues.includes(value);
                 });

--- a/core/test/unit/api/shared/validators/input/all_spec.js
+++ b/core/test/unit/api/shared/validators/input/all_spec.js
@@ -79,6 +79,34 @@ describe('Unit: api/shared/validators/input/all', function () {
             return shared.validators.input.all.all(apiConfig, frame);
         });
 
+        it('supports include being an array', function () {
+            const frame = {
+                options: {
+                    context: {},
+                    slug: 'slug',
+                    include: ['tags', 'authors'],
+                    page: 2
+                }
+            };
+
+            const apiConfig = {
+                options: {
+                    include: {
+                        values: ['tags', 'authors'],
+                        required: true
+                    }
+                }
+            };
+
+            return shared.validators.input.all.all(apiConfig, frame)
+                .then(() => {
+                    should.exist(frame.options.page);
+                    should.exist(frame.options.slug);
+                    should.exist(frame.options.include);
+                    should.exist(frame.options.context);
+                });
+        });
+
         it('default include array notation', function () {
             const frame = {
                 options: {


### PR DESCRIPTION
no-issue

There are a few libraries, including node core that when given an array
for a query parameter will encode it as repeated query params. e.g.

```js
{someParam: ['a', 'b']}
// becomes
'?someParam=a&someParam=b'
```

This adds a check for the value to stop us 500ing on repeated keys and
to add easier interop with http clients