### PR TITLE
Added spam prevention for v2 sessions

### DIFF
--- a/core/server/api/v2/session.js
+++ b/core/server/api/v2/session.js
@@ -25,8 +25,13 @@ const session = {
             password: object.password
         }).then((user) => {
             return Promise.resolve((req, res, next) => {
-                req.user = user;
-                auth.session.createSession(req, res, next);
+                req.brute.reset(function (err) {
+                    if (err) {
+                        return next(err);
+                    }
+                    req.user = user;
+                    auth.session.createSession(req, res, next);
+                });
             });
         }).catch((err) => {
             throw new common.errors.UnauthorizedError({

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -148,7 +148,11 @@ module.exports = function apiRoutes() {
     // ## Sessions
     router.get('/session', mw.authAdminAPI, api.http(apiv2.session.read));
     // We don't need auth when creating a new session (logging in)
-    router.post('/session', api.http(apiv2.session.add));
+    router.post('/session',
+        shared.middlewares.brute.globalBlock,
+        shared.middlewares.brute.userLogin,
+        api.http(apiv2.session.add)
+    );
     router.del('/session', mw.authAdminAPI, api.http(apiv2.session.delete));
 
     // ## Authentication


### PR DESCRIPTION
* Added spam prevention to POST /session

> This blocks repeated requests the the /session endpoint preventing brute
> force password attacks

* Updated session controller to reset brute middleware

> This updates the session controller to reset the brute force protection
> on a successful login. This is required so that a user is not locked out
> forever :o!!