### PR TITLE
Allowed page option for users and posts browse

### DIFF
--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -15,6 +15,7 @@ module.exports = {
             'status',
             'limit',
             'order',
+            'page',
             'debug'
         ],
         validation: {

--- a/core/server/api/v2/tags.js
+++ b/core/server/api/v2/tags.js
@@ -13,6 +13,7 @@ module.exports = {
             'fields',
             'limit',
             'order',
+            'page',
             'debug'
         ],
         validation: {

--- a/core/server/api/v2/users.js
+++ b/core/server/api/v2/users.js
@@ -16,6 +16,7 @@ module.exports = {
             'limit',
             'status',
             'order',
+            'page',
             'debug'
         ],
         validation: {

--- a/core/test/functional/api/v2/admin/posts_spec.js
+++ b/core/test/functional/api/v2/admin/posts_spec.js
@@ -206,6 +206,23 @@ describe('Posts API V2', function () {
                         done();
                     });
             });
+
+            it('supports usage of the page param', function (done) {
+                request.get(localUtils.API.getApiQuery('posts/?page=2'))
+                    .set('Origin', config.get('url'))
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const jsonResponse = res.body;
+                        should.equal(jsonResponse.meta.pagination.page, 2);
+                        done();
+                    });
+            });
         });
 
         describe('read', function () {

--- a/core/test/functional/api/v2/admin/tags_spec.js
+++ b/core/test/functional/api/v2/admin/tags_spec.js
@@ -51,6 +51,18 @@ describe('Tag API V2', function () {
             });
     });
 
+    it('browse accepts the page parameter', function () {
+        return request
+            .get(localUtils.API.getApiQuery('tags/?page=2'))
+            .set('Origin', config.get('url'))
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                should.equal(res.body.meta.pagination.page, 2);
+            });
+    });
+
     it('read', function () {
         return request
             .get(localUtils.API.getApiQuery(`tags/${testUtils.existingData.tags[0].id}/?include=count.posts`))

--- a/core/test/functional/api/v2/admin/users_spec.js
+++ b/core/test/functional/api/v2/admin/users_spec.js
@@ -113,6 +113,23 @@ describe('User API V2', function () {
                         done();
                     });
             });
+
+            it('supports usage of the page param', function (done) {
+                request.get(localUtils.API.getApiQuery('users/?page=2'))
+                    .set('Origin', config.get('url'))
+                    .expect('Content-Type', /json/)
+                    .expect('Cache-Control', testUtils.cacheRules.private)
+                    .expect(200)
+                    .end(function (err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const jsonResponse = res.body;
+                        should.equal(jsonResponse.meta.pagination.page, 2);
+                        done();
+                    });
+            });
         });
 
         describe('Read', function () {


### PR DESCRIPTION
closes #10029

The page query param was not forwarding to the query, meaning that when
the admin client requested the next page of users or posts, it would
recieve the first page again.