### PR TITLE
Changed String.proptype.length to Buffer.byteLength(result)

### DIFF
--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -21,7 +21,7 @@ const disposition = {
         return {
             'Content-Disposition': options.value,
             'Content-Type': 'application/json',
-            'Content-Length': JSON.stringify(result).length
+            'Content-Length': Buffer.byteLength(result)
         };
     },
 
@@ -29,7 +29,7 @@ const disposition = {
         return {
             'Content-Disposition': options.value,
             'Content-Type': 'application/yaml',
-            'Content-Length': JSON.stringify(result).length
+            'Content-Length': Buffer.byteLength(result)
         };
     }
 };

--- a/core/server/api/v0.1/index.js
+++ b/core/server/api/v0.1/index.js
@@ -229,7 +229,7 @@ const addHeaders = (apiMethod, req, res, result) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'application/json',
-                    'Content-Length': JSON.stringify(result).length
+                    'Content-Length': Buffer.byteLength(result)
                 });
             });
     }
@@ -241,7 +241,7 @@ const addHeaders = (apiMethod, req, res, result) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'application/yaml',
-                    'Content-Length': JSON.stringify(result).length
+                    'Content-Length': Buffer.byteLength(result)
                 });
             });
     }


### PR DESCRIPTION
Closes #10041 

I found two places where `String.prototype.length` is used to calculate Content-Length. 
The files are,
`\current\core\server\api\shared\headers.js`  
`versions\2.3.0\core\server\api\v0.1\index.js`.

I switched `JSON.stringify(result).length` to `Buffer.byteLength(result)`.

The test results were the same as **before and after** the change with 4 failing tests:
![image](https://user-images.githubusercontent.com/8231763/47382524-7d634700-d6d0-11e8-82f2-0f7e1d80303d.png)
