### PR TITLE
Correct handling of 'Content-Length' header by using Buffer.byteLength

### DIFF
--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -21,7 +21,7 @@ const disposition = {
         return {
             'Content-Disposition': options.value,
             'Content-Type': 'application/json',
-            'Content-Length': JSON.stringify(result).length
+            'Content-Length': Buffer.byteLength(JSON.stringify(result))
         };
     },
 
@@ -29,7 +29,7 @@ const disposition = {
         return {
             'Content-Disposition': options.value,
             'Content-Type': 'application/yaml',
-            'Content-Length': JSON.stringify(result).length
+            'Content-Length': Buffer.byteLength(JSON.stringify(result))
         };
     }
 };

--- a/core/server/api/v0.1/index.js
+++ b/core/server/api/v0.1/index.js
@@ -229,7 +229,7 @@ const addHeaders = (apiMethod, req, res, result) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'application/json',
-                    'Content-Length': JSON.stringify(result).length
+                    'Content-Length': Buffer.byteLength(JSON.stringify(result))
                 });
             });
     }
@@ -241,7 +241,7 @@ const addHeaders = (apiMethod, req, res, result) => {
                 res.set({
                     'Content-Disposition': header,
                     'Content-Type': 'application/yaml',
-                    'Content-Length': JSON.stringify(result).length
+                    'Content-Length': Buffer.byteLength(JSON.stringify(result))
                 });
             });
     }


### PR DESCRIPTION
Closes #10041

1. Why is this change neccesary?
String.prototype.length returns the number of code units in the string (number
of characters) while Buffer.byteLength returns the actual byute length of a
string.

2. How does it address the issue?
Places that use String.prototype.length to calculate Content-Length
were switched to Buffer.byteLength instead.

- ✅ There's a clear use-case for this code change
- ✅ Commit message has a short title & references relevant issues
- ✅ The build will pass (run `npm test`)