### PR TITLE
Allow marking the subscribe input as required

### DIFF
--- a/core/server/apps/subscribers/lib/helpers/input_email.js
+++ b/core/server/apps/subscribers/lib/helpers/input_email.js
@@ -20,6 +20,10 @@ module.exports = function input_email(options) { // eslint-disable-line camelcas
         extras += 'autofocus="autofocus"';
     }
 
+    if (options.hash.required) {
+        extras += ' required';
+    }
+
     if (options.hash.placeholder) {
         extras += ` placeholder="${options.hash.placeholder}"`;
     }


### PR DESCRIPTION
Right now, when you click the subscribe button without entering any email, you get redirected to the subscribe page with a validation error. This would be fixed by marking the email field as required.

**Should I default this instead of making it an option?**