### PR TITLE
🐛 Fixed cardWidth being lost on 2.0 imports

### DIFF
--- a/core/server/data/importer/importers/data/posts.js
+++ b/core/server/data/importer/importers/data/posts.js
@@ -164,6 +164,7 @@ class PostsImporter extends BaseImporter {
 
             // CASE 1: you are importing old editor posts
             // CASE 2: you are importing Koenig Beta posts
+            // CASE 3: you are importing Koenig 2.0 posts
             if (model.mobiledoc || (model.mobiledoc && model.html && model.html.match(/^<div class="kg-card-markdown">/))) {
                 let mobiledoc;
 
@@ -179,7 +180,8 @@ class PostsImporter extends BaseImporter {
                 }
 
                 mobiledoc.cards.forEach((card) => {
-                    if (card[0] === 'image') {
+                    // Koenig Beta = imageStyle, Ghost 2.0 Koenig = cardWidth
+                    if (card[0] === 'image' && card[1].imageStyle) {
                         card[1].cardWidth = card[1].imageStyle;
                         delete card[1].imageStyle;
                     }

--- a/core/test/integration/data/importer/importers/data_spec.js
+++ b/core/test/integration/data/importer/importers/data_spec.js
@@ -1008,7 +1008,7 @@ describe('Integration: Importer', function () {
         });
 
         it('import 2.0 Koenig post format', ()=> {
-            const exportData = exportedPreviousBody().db[0];
+            const exportData = exportedLatestBody().db[0];
 
             exportData.data.posts[0] = testUtils.DataGenerator.forKnex.createPost({
                 slug: 'post1',


### PR DESCRIPTION
Came across this whilst building our html->to->mobiledoc migration tooling. I'm correctly setting `cardWidth` in the parser plugins, and it's correctly being output in the mobiledoc, but Ghost import is throwing the cardWidth away.

no issue

- When importing Ghost 2.0 blogs into 2.0 blogs...
- The Koenig image card would lose it's cardWidth setting,
- because it'd be overridden by the imageStyle setting, which was null
- The importer previous _only_ kept the width if importing 1.0 blogs
