### PR TITLE
Remove wp-admin redirect

### DIFF
--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -24,7 +24,7 @@
         "reserved": ["admin", "app", "apps", "categories",
             "category", "dashboard", "feed", "ghost-admin", "login", "logout",
             "page", "pages", "post", "posts", "public", "register", "setup",
-            "signin", "signout", "signup", "user", "users", "wp-login"],
+            "signin", "signout", "signup", "user", "users"],
         "protected": ["ghost", "rss", "amp"]
     },
     "uploads": {

--- a/core/server/config/overrides.json
+++ b/core/server/config/overrides.json
@@ -24,7 +24,7 @@
         "reserved": ["admin", "app", "apps", "categories",
             "category", "dashboard", "feed", "ghost-admin", "login", "logout",
             "page", "pages", "post", "posts", "public", "register", "setup",
-            "signin", "signout", "signup", "user", "users", "wp-admin", "wp-login"],
+            "signin", "signout", "signup", "user", "users", "wp-login"],
         "protected": ["ghost", "rss", "amp"]
     },
     "uploads": {

--- a/core/server/web/shared/middlewares/admin-redirects.js
+++ b/core/server/web/shared/middlewares/admin-redirects.js
@@ -14,7 +14,7 @@ module.exports = function adminRedirects() {
     router.get(/^\/(logout|signout)\/$/, adminRedirect('#/signout/'));
     router.get(/^\/signup\/$/, adminRedirect('#/signup/'));
     // redirect to /ghost and let that do the authentication to prevent redirects to /ghost//admin etc.
-    router.get(/^\/((ghost-admin|admin|wp-admin|dashboard|signin|login)\/?)$/, adminRedirect('/'));
+    router.get(/^\/((ghost-admin|admin|dashboard|signin|login)\/?)$/, adminRedirect('/'));
 
     return router;
 };


### PR DESCRIPTION
I dunno if there's a specific reason for this in the first place, but for me it looks useless. If you're using a Ghost app, you shouldn't be trying to access `wp-admin` (I'd argue people using Wordpress blogs also don't, they just go to `/admin` or `/login` and get redirected). The only use I can see for this would be migrating from a Wordpress blog (which can now use the redirects feature) or bots trying to hack Wordpress websites from google search.

If you still wanna keep this redirect, please consider adding it to the default redirects file instead of hardcoding it into the core, so people who don't need it can disable it.

This change was also [requested in the forum](https://forum.ghost.org/t/remove-wp-admin-and-admin-redirects/3474/3).