### PR TITLE
Removed user_id constraint when upserting session

### DIFF
--- a/core/server/models/session.js
+++ b/core/server/models/session.js
@@ -53,7 +53,7 @@ const Session = ghostBookshelf.Model.extend({
         const sessionId = options.session_id;
         const sessionData = data.session_data;
         const userId = sessionData.user_id;
-        return this.findOne({session_id: sessionId, user_id: userId}, options)
+        return this.findOne({session_id: sessionId}, options)
             .then((model) => {
                 if (model) {
                     return this.edit({

--- a/core/test/unit/models/session_spec.js
+++ b/core/test/unit/models/session_spec.js
@@ -175,8 +175,7 @@ describe('Unit: models/session', function () {
                 should.equal(filterOptionsStub.args[0][1], 'upsert');
 
                 should.deepEqual(findOneStub.args[0][0], {
-                    session_id,
-                    user_id: data.session_data.user_id
+                    session_id
                 });
                 should.equal(findOneStub.args[0][1], filteredOptions);
 
@@ -215,8 +214,7 @@ describe('Unit: models/session', function () {
                 should.equal(filterOptionsStub.args[0][1], 'upsert');
 
                 should.deepEqual(findOneStub.args[0][0], {
-                    session_id,
-                    user_id: data.session_data.user_id
+                    session_id
                 });
                 should.equal(findOneStub.args[0][1], filteredOptions);
 


### PR DESCRIPTION
no-issue

This is to stop an issue when creating a session, if you already have an existing session.

Originally we find by session_id & user_id. This was to stop us "accidentally" changing the user of a session.

The session_id is always unique so we should search for that.

As for protecting us against "accidentally" changing the user of a session - this is a premature optimisation, and we should allow someone to create a new session before destroying their old one. 