### PR TITLE
Removed mobiledoc format from Content V2 API response

### DIFF
--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -1,5 +1,13 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pages');
 
+function removeMobiledocFormat(frame) {
+    if (_.get(frame, 'options.formats') && _.get(frame, 'options.formats').includes('mobiledoc')) {
+        frame.options.formats = frame.options.formats.filter((format) => {
+            return (format !== 'mobiledoc');
+        });
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -20,6 +28,11 @@ module.exports = {
             frame.options.filter = 'page:true';
         }
 
+        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
+        }
+
         debug(frame.options);
     },
 
@@ -27,6 +40,11 @@ module.exports = {
         debug('read');
 
         frame.data.page = true;
+
+        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
+        }
 
         debug(frame.options);
     }

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -1,5 +1,4 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pages');
-const utils = require('../../index');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -28,11 +27,7 @@ module.exports = {
         } else {
             frame.options.filter = 'page:true';
         }
-
-        if (utils.isContentAPI(frame)) {
-            // CASE: the content api endpoint for posts should not return mobiledoc
-            removeMobiledocFormat(frame);
-        }
+        removeMobiledocFormat(frame);
 
         debug(frame.options);
     },
@@ -41,11 +36,7 @@ module.exports = {
         debug('read');
 
         frame.data.page = true;
-
-        if (utils.isContentAPI(frame)) {
-            // CASE: the content api endpoint for posts should not return mobiledoc
-            removeMobiledocFormat(frame);
-        }
+        removeMobiledocFormat(frame);
 
         debug(frame.options);
     }

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -1,7 +1,8 @@
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pages');
+const utils = require('../../index');
 
 function removeMobiledocFormat(frame) {
-    if (_.get(frame, 'options.formats') && _.get(frame, 'options.formats').includes('mobiledoc')) {
+    if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
         frame.options.formats = frame.options.formats.filter((format) => {
             return (format !== 'mobiledoc');
         });
@@ -28,7 +29,7 @@ module.exports = {
             frame.options.filter = 'page:true';
         }
 
-        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+        if (utils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
         }

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -42,7 +42,7 @@ module.exports = {
 
         frame.data.page = true;
 
-        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+        if (utils.isContentAPI(frame)) {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
         }

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -2,6 +2,14 @@ const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
 
+function removeMobiledocFormat(frame) {
+    if (_.get(frame, 'options.formats') && _.get(frame, 'options.formats').includes('mobiledoc')) {
+        frame.options.formats = frame.options.formats.filter((format) => {
+            return (format !== 'mobiledoc');
+        });
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -28,6 +36,8 @@ module.exports = {
             } else {
                 frame.options.filter = 'page:false';
             }
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
         }
 
         debug(frame.options);
@@ -45,6 +55,8 @@ module.exports = {
          */
         if (Object.keys(frame.options.context).length === 0 || (!frame.options.context.user && frame.options.context.api_key_id)) {
             frame.data.page = false;
+            // CASE: the content api endpoint for posts should not return mobiledoc
+            removeMobiledocFormat(frame);
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -1,9 +1,10 @@
 const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
+const utils = require('../../index');
 
 function removeMobiledocFormat(frame) {
-    if (_.get(frame, 'options.formats') && _.get(frame, 'options.formats').includes('mobiledoc')) {
+    if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
         frame.options.formats = frame.options.formats.filter((format) => {
             return (format !== 'mobiledoc');
         });
@@ -21,7 +22,7 @@ module.exports = {
          * - api_key_id exists? content api access
          * - user exists? admin api access
          */
-        if (Object.keys(frame.options.context).length === 0 || (!frame.options.context.user && frame.options.context.api_key_id)) {
+        if (utils.isContentAPI(frame)) {
             // CASE: the content api endpoints for posts should only return non page type resources
             if (frame.options.filter) {
                 if (frame.options.filter.match(/page:\w+\+?/)) {
@@ -53,7 +54,7 @@ module.exports = {
          * - api_key_id exists? content api access
          * - user exists? admin api access
          */
-        if (Object.keys(frame.options.context).length === 0 || (!frame.options.context.user && frame.options.context.api_key_id)) {
+        if (utils.isContentAPI(frame)) {
             frame.data.page = false;
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);

--- a/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
@@ -53,7 +53,8 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    formats: ['html', 'mobiledoc', 'plaintext']
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
                 }
             };
 
@@ -98,7 +99,8 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    formats: ['html', 'mobiledoc', 'plaintext']
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
                 },
                 data: {
                     status: 'all',

--- a/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
@@ -6,7 +6,9 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
         it('default', function () {
             const apiConfig = {};
             const frame = {
-                options: {}
+                options: {
+                    context: {}
+                },
             };
 
             serializers.input.pages.browse(apiConfig, frame);
@@ -17,7 +19,8 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    filter: 'status:published+tag:eins'
+                    filter: 'status:published+tag:eins',
+                    context: {}
                 }
             };
 
@@ -29,7 +32,8 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    filter: 'page:false+tag:eins'
+                    filter: 'page:false+tag:eins',
+                    context: {}
                 }
             };
 
@@ -41,7 +45,8 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    filter: 'page:false'
+                    filter: 'page:false',
+                    context: {}
                 }
             };
 
@@ -69,7 +74,9 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
         it('default', function () {
             const apiConfig = {};
             const frame = {
-                options: {},
+                options: {
+                    context: {}
+                },
                 data: {
                     status: 'all'
                 }
@@ -83,7 +90,9 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
         it('overrides page', function () {
             const apiConfig = {};
             const frame = {
-                options: {},
+                options: {
+                    context: {}
+                },
                 data: {
                     status: 'all',
                     page: false

--- a/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/pages_spec.js
@@ -48,6 +48,20 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             serializers.input.pages.browse(apiConfig, frame);
             frame.options.filter.should.eql('page:true');
         });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext']
+                }
+            };
+
+            serializers.input.pages.browse(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
     });
 
     describe('read', function () {
@@ -78,6 +92,24 @@ describe('Unit: v2/utils/serializers/input/pages', function () {
             serializers.input.pages.read(apiConfig, frame);
             frame.data.status.should.eql('all');
             frame.data.page.should.eql(true);
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext']
+                },
+                data: {
+                    status: 'all',
+                    page: false
+                }
+            };
+
+            serializers.input.pages.read(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
         });
     });
 });

--- a/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
@@ -80,6 +80,20 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             serializers.input.posts.browse(apiConfig, frame);
             frame.options.filter.should.eql('page:false');
         });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext']
+                }
+            };
+
+            serializers.input.posts.browse(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
+        });
     });
 
     describe('read', function () {
@@ -151,6 +165,20 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
 
             serializers.input.posts.read(apiConfig, frame);
             frame.data.page.should.eql(true);
+        });
+
+        it('remove mobiledoc option from formats', function () {
+            const apiConfig = {};
+            const frame = {
+                options: {
+                    formats: ['html', 'mobiledoc', 'plaintext']
+                }
+            };
+
+            serializers.input.posts.read(apiConfig, frame);
+            frame.options.formats.should.not.containEql('mobiledoc');
+            frame.options.formats.should.containEql('html');
+            frame.options.formats.should.containEql('plaintext');
         });
     });
 

--- a/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
@@ -85,7 +85,8 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    formats: ['html', 'mobiledoc', 'plaintext']
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
                 }
             };
 
@@ -171,8 +172,10 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             const apiConfig = {};
             const frame = {
                 options: {
-                    formats: ['html', 'mobiledoc', 'plaintext']
-                }
+                    formats: ['html', 'mobiledoc', 'plaintext'],
+                    context: {}
+                },
+                data: {}
             };
 
             serializers.input.posts.read(apiConfig, frame);


### PR DESCRIPTION
closes #10097 

* Removed `mobiledoc` format from content API v2 input serializer