### PR TITLE
Fixed frame context being empty

### DIFF
--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -6,7 +6,14 @@ module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
 
-        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+        // @TODO: `api_key_id` does not work long term, because it can be either a content or an admin api key?
+        /**
+         * ## current cases:
+         * - context object is empty (functional call, content api access)
+         * - api_key_id exists? content api access
+         * - user exists? admin api access
+         */
+        if (Object.keys(frame.options.context).length === 0 || (!frame.options.context.user && frame.options.context.api_key_id)) {
             // CASE: the content api endpoints for posts should only return non page type resources
             if (frame.options.filter) {
                 if (frame.options.filter.match(/page:\w+\+?/)) {
@@ -29,7 +36,14 @@ module.exports = {
     read(apiConfig, frame) {
         debug('read');
 
-        if (!_.get(frame, 'options.context.user') && _.get(frame, 'options.context.api_key_id')) {
+        // @TODO: `api_key_id` does not work long term, because it can be either a content or an admin api key?
+        /**
+         * ## current cases:
+         * - context object is empty (functional call, content api access)
+         * - api_key_id exists? content api access
+         * - user exists? admin api access
+         */
+        if (Object.keys(frame.options.context).length === 0 || (!frame.options.context.user && frame.options.context.api_key_id)) {
             frame.data.page = false;
         }
 

--- a/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
+++ b/core/test/unit/api/v2/utils/serializers/input/posts_spec.js
@@ -23,6 +23,9 @@ describe('Unit: v2/utils/serializers/input/posts', function () {
             const apiConfig = {};
             const frame = {
                 options: {
+                    context: {
+                        user: 1
+                    }
                 }
             };
 


### PR DESCRIPTION
no issue

See code comment.
Any functional call e.g. `api.posts.browse()` which does not pass a context, ends in `frame.options.context = {}`. This is expected. But the serializers need to respect and interpret this as a content api access. This is the default behaviour for routing.