### PR TITLE
Enabled members lab setting for developer experiment flag

### DIFF
--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -6,8 +6,10 @@ const common = require('../lib/common');
 const config = require('../config');
 let labs = module.exports = {};
 
-
 labs.isSet = function isSet(flag) {
+    /**
+     * TODO: Uses hard-check for members prototype, removed here when added to settings
+     */
     if (flag === 'members' && config.get('enableDeveloperExperiments')) {
         return true;
     }

--- a/core/server/services/labs.js
+++ b/core/server/services/labs.js
@@ -1,11 +1,16 @@
-var settingsCache = require('./settings/cache'),
-    _ = require('lodash'),
-    Promise = require('bluebird'),
-    SafeString = require('./themes/engine').SafeString,
-    common = require('../lib/common'),
-    labs = module.exports = {};
+const settingsCache = require('./settings/cache');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const SafeString = require('./themes/engine').SafeString;
+const common = require('../lib/common');
+const config = require('../config');
+let labs = module.exports = {};
+
 
 labs.isSet = function isSet(flag) {
+    if (flag === 'members' && config.get('enableDeveloperExperiments')) {
+        return true;
+    }
     var labsConfig = settingsCache.get('labs');
     return labsConfig && labsConfig[flag] && labsConfig[flag] === true;
 };

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -60,6 +60,15 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
         labsData = _.cloneDeep(settingsCache.get('labs')),
         themeData = {};
 
+    /**
+     * TODO: Uses hard-check for members prototype, removed here when added to settings
+    */
+    if (config.get('enableDeveloperExperiments')) {
+        Object.assign(labsData, {
+            members: true
+        });
+    }
+
     if (activeTheme.get()) {
         themeData.posts_per_page = activeTheme.get().config('posts_per_page');
     }


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10114

- Members lab enabled to be always true behind developer flag

*Note*: This change uses hard-coded labs value for members based on `enableDeveloperExperiments` flag, ideal implementation for later is to pick those value from settings.