### PR TITLE
🐛 Fix last seen for users

### DIFF
--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -5,6 +5,7 @@ var moment = require('moment-timezone'),
     sequence = require('../../lib/promise/sequence');
 
 /**
+ * @TODO REMOVE WHEN v0.1 IS DROPPED
  * WHEN access token is created we will update last_seen for user.
  */
 common.events.on('token.added', function (tokenModel) {

--- a/core/server/models/base/listeners.js
+++ b/core/server/models/base/listeners.js
@@ -8,7 +8,10 @@ var moment = require('moment-timezone'),
  * WHEN access token is created we will update last_seen for user.
  */
 common.events.on('token.added', function (tokenModel) {
-    models.User.edit({last_seen: moment().toDate()}, {id: tokenModel.get('user_id')})
+    models.User.findOne({id: tokenModel.get('user_id')})
+        .then(function (user) {
+            return user.updateLastSeen();
+        })
         .catch(function (err) {
             common.logging.error(new common.errors.GhostError({err: err, level: 'critical'}));
         });

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -783,6 +783,10 @@ User = ghostBookshelf.Model.extend({
                 return self.isPasswordCorrect({plainPassword: object.password, hashedPassword: user.get('password')})
                     .then(function then() {
                         return user.updateLastSeen();
+                    })
+                    .then(function then() {
+                        user.set({status: 'active'});
+                        return user.save();
                     });
             })
             .catch(function (err) {

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -259,6 +259,11 @@ User = ghostBookshelf.Model.extend({
         });
     },
 
+    updateLastSeen: function updateLastSeen() {
+        this.set({last_seen: new Date()});
+        return this.save();
+    },
+
     enforcedFilters: function enforcedFilters(options) {
         if (options.context && options.context.internal) {
             return null;

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -761,7 +761,7 @@ User = ghostBookshelf.Model.extend({
         var self = this;
 
         return this.getByEmail(object.email)
-            .then(function then(user) {
+            .then((user) => {
                 if (!user) {
                     throw new common.errors.NotFoundError({
                         message: common.i18n.t('errors.models.user.noUserWithEnteredEmailAddr')
@@ -781,15 +781,15 @@ User = ghostBookshelf.Model.extend({
                 }
 
                 return self.isPasswordCorrect({plainPassword: object.password, hashedPassword: user.get('password')})
-                    .then(function then() {
+                    .then(() => {
                         return user.updateLastSeen();
                     })
-                    .then(function then() {
+                    .then(() => {
                         user.set({status: 'active'});
                         return user.save();
                     });
             })
-            .catch(function (err) {
+            .catch((err) => {
                 if (err.message === 'NotFound' || err.message === 'EmptyResponse') {
                     throw new common.errors.NotFoundError({
                         message: common.i18n.t('errors.models.user.noUserWithEnteredEmailAddr')

--- a/core/server/models/user.js
+++ b/core/server/models/user.js
@@ -782,8 +782,7 @@ User = ghostBookshelf.Model.extend({
 
                 return self.isPasswordCorrect({plainPassword: object.password, hashedPassword: user.get('password')})
                     .then(function then() {
-                        user.set({status: 'active', last_seen: new Date()});
-                        return user.save();
+                        return user.updateLastSeen();
                     });
             })
             .catch(function (err) {

--- a/core/server/web/api/v2/admin/middleware.js
+++ b/core/server/web/api/v2/admin/middleware.js
@@ -7,6 +7,7 @@ const shared = require('../../../shared');
 module.exports.authAdminAPI = [
     auth.authenticate.authenticateAdminAPI,
     auth.authorize.authorizeAdminAPI,
+    shared.middlewares.updateUserLastSeen,
     shared.middlewares.api.cors,
     shared.middlewares.urlRedirects.adminRedirect,
     shared.middlewares.prettyUrls

--- a/core/server/web/shared/middlewares/index.js
+++ b/core/server/web/shared/middlewares/index.js
@@ -75,6 +75,10 @@ module.exports = {
         return require('./url-redirects');
     },
 
+    get updateUserLastSeen() {
+        return require('./update-user-last-seen');
+    },
+
     get emitEvents() {
         return require('./emit-events');
     }

--- a/core/server/web/shared/middlewares/update-user-last-seen.js
+++ b/core/server/web/shared/middlewares/update-user-last-seen.js
@@ -1,0 +1,8 @@
+module.exports = function updateUserLastSeenMiddleware(req, res, next) {
+    if (!req.user) {
+        return next();
+    }
+    req.user.updateLastSeen().then(() => {
+        next();
+    }, next);
+};

--- a/core/server/web/shared/middlewares/update-user-last-seen.js
+++ b/core/server/web/shared/middlewares/update-user-last-seen.js
@@ -1,7 +1,14 @@
+const constants = require('../../../lib/constants');
+
 module.exports = function updateUserLastSeenMiddleware(req, res, next) {
     if (!req.user) {
         return next();
     }
+
+    if (Date.now() - req.user.get('last_seen') < constants.ONE_HOUR_MS) {
+        return next();
+    }
+
     req.user.updateLastSeen().then(() => {
         next();
     }, next);

--- a/core/test/functional/api/v2/admin/slack_spec.js
+++ b/core/test/functional/api/v2/admin/slack_spec.js
@@ -43,7 +43,6 @@ describe('Slack API', function () {
                 should.not.exist(res.headers['x-cache-invalidate']);
                 const jsonResponse = res.body;
                 should.exist(jsonResponse);
-                eventSpy.calledOnce.should.be.true();
                 eventSpy.calledWith('slack.test').should.be.true();
                 done();
             });

--- a/core/test/unit/models/user_spec.js
+++ b/core/test/unit/models/user_spec.js
@@ -24,6 +24,32 @@ describe('Unit: models/user', function () {
         sandbox.restore();
     });
 
+    describe('updateLastSeen method', function () {
+        it('exists', function () {
+            should.equal(typeof models.User.prototype.updateLastSeen, 'function');
+        });
+
+        it('sets the last_seen property to new Date and returns a call to save', function () {
+            const instance = {
+                set: sandbox.spy(),
+                save: sandbox.stub().resolves()
+            };
+
+            const now = new Date();
+            const clock = sinon.useFakeTimers(now.getTime());
+
+            const returnVal = models.User.prototype.updateLastSeen.call(instance);
+
+            should.deepEqual(instance.set.args[0][0], {
+                last_seen: now
+            });
+
+            should.equal(returnVal, instance.save.returnValues[0]);
+
+            clock.restore();
+        });
+    });
+
     describe('validation', function () {
         beforeEach(function () {
             sandbox.stub(security.password, 'hash').resolves('$2a$10$we16f8rpbrFZ34xWj0/ZC.LTPUux8ler7bcdTs5qIleN6srRHhilG');

--- a/core/test/unit/web/middleware/update-user-last-seen_spec.js
+++ b/core/test/unit/web/middleware/update-user-last-seen_spec.js
@@ -1,5 +1,6 @@
 const should = require('should');
 const sinon = require('sinon');
+const constants = require('../../../../server/lib/constants');
 const updateUserLastSeenMiddleware = require('../../../../server/web/shared/middlewares').updateUserLastSeen;
 
 describe('updateUserLastSeenMiddleware', function () {
@@ -20,26 +21,43 @@ describe('updateUserLastSeenMiddleware', function () {
         });
     });
 
-    it('calls updateLastSeen on the req.user, calling next with nothing if success', function (done) {
+    it('calls next with no error if the current last_seen is less than an hour before now', function (done) {
+        const fakeLastSeen = new Date();
         const fakeUser = {
-            updateLastSeen: sandbox.stub().resolves()
+            get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen)
         };
         updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
             should.equal(err, undefined);
-            should.equal(fakeUser.updateLastSeen.callCount, 1);
             done();
         });
     });
 
-    it('calls updateLastSeen on the req.user, calling next with err if error', function (done) {
-        const fakeError = new Error('gonna need a bigger boat');
-        const fakeUser = {
-            updateLastSeen: sandbox.stub().rejects(fakeError)
-        };
-        updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
-            should.equal(err, fakeError);
-            should.equal(fakeUser.updateLastSeen.callCount, 1);
-            done();
+    describe('when the last_seen is longer than an hour ago', function () {
+        it('calls updateLastSeen on the req.user, calling next with nothing if success', function (done) {
+            const fakeLastSeen = new Date(Date.now() - constants.ONE_HOURS_MS);
+            const fakeUser = {
+                get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen),
+                updateLastSeen: sandbox.stub().resolves()
+            };
+            updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
+                should.equal(err, undefined);
+                should.equal(fakeUser.updateLastSeen.callCount, 1);
+                done();
+            });
+        });
+
+        it('calls updateLastSeen on the req.user, calling next with err if error', function (done) {
+            const fakeLastSeen = new Date(Date.now() - constants.ONE_HOURS_MS);
+            const fakeError = new Error('gonna need a bigger boat');
+            const fakeUser = {
+                get: sandbox.stub().withArgs('last_seen').returns(fakeLastSeen),
+                updateLastSeen: sandbox.stub().rejects(fakeError)
+            };
+            updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
+                should.equal(err, fakeError);
+                should.equal(fakeUser.updateLastSeen.callCount, 1);
+                done();
+            });
         });
     });
 });

--- a/core/test/unit/web/middleware/update-user-last-seen_spec.js
+++ b/core/test/unit/web/middleware/update-user-last-seen_spec.js
@@ -1,0 +1,45 @@
+const should = require('should');
+const sinon = require('sinon');
+const updateUserLastSeenMiddleware = require('../../../../server/web/shared/middlewares').updateUserLastSeen;
+
+describe('updateUserLastSeenMiddleware', function () {
+    let sandbox;
+
+    before(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('calls next with no error if there is no user on the request', function (done) {
+        updateUserLastSeenMiddleware({}, {}, function next(err) {
+            should.equal(err, undefined);
+            done();
+        });
+    });
+
+    it('calls updateLastSeen on the req.user, calling next with nothing if success', function (done) {
+        const fakeUser = {
+            updateLastSeen: sandbox.stub().resolves()
+        };
+        updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
+            should.equal(err, undefined);
+            should.equal(fakeUser.updateLastSeen.callCount, 1);
+            done();
+        });
+    });
+
+    it('calls updateLastSeen on the req.user, calling next with err if error', function (done) {
+        const fakeError = new Error('gonna need a bigger boat');
+        const fakeUser = {
+            updateLastSeen: sandbox.stub().rejects(fakeError)
+        };
+        updateUserLastSeenMiddleware({user: fakeUser}, {}, function next(err) {
+            should.equal(err, fakeError);
+            should.equal(fakeUser.updateLastSeen.callCount, 1);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
closes #10138 

This adds an `updateLastSeen` method to the user model instance, refactors the codebase to use this method anywhere the last_seen is updated and adds middleware to the admin api to ensure that we always update the last_seen property when a user accesses the API.