### PR TITLE
fix: ignored order from dynamic routes

### DIFF
--- a/core/server/services/settings/validate.js
+++ b/core/server/services/settings/validate.js
@@ -77,7 +77,7 @@ _private.validateData = function validateData(object) {
             type: ['read', 'browse'],
             resource: _.map(RESOURCE_CONFIG.QUERY, 'resource')
         };
-        const allowedQueryOptions = ['limit', 'filter', 'include', 'slug', 'visibility', 'status'];
+        const allowedQueryOptions = ['limit', 'order', 'filter', 'include', 'slug', 'visibility', 'status'];
         const allowedRouterOptions = ['redirect', 'slug'];
         const defaultRouterOptions = {
             redirect: true


### PR DESCRIPTION
New PR for https://github.com/TryGhost/Ghost/pull/10143 because I did not expect making more than one from my master branch:

When using `data` within dynamic routes, the `order` was ignored (but should be supported based on the [router data docs](https://docs.ghost.org/concepts/routing/#data))

```yaml
  /tags/:
    permalink: /{slug}/
    template:
      - tags
    data:
      alltags:
        resource: tags
        type: browse
        limit: all
        order: slug asc # <-- had no effect
        include: count.posts

``` 

