### PR TITLE
Updated error message log and lastTriggeredError for webhook requests

### DIFF
--- a/core/server/services/webhooks/trigger.js
+++ b/core/server/services/webhooks/trigger.js
@@ -40,22 +40,13 @@ function makeRequests(webhooksCollection, payload, options) {
                     common.logging.warn(`Unable to destroy webhook ${webhookId}`);
                 });
             }
-            let lastTriggeredError = err.statusCode ? '' : `Failed to send request to ${targetUrl}`;
+            let lastTriggeredError = err.statusCode ? '' : `Request failed: ${err.code || ''}`;
             updateWebhookTriggerData(webhookId, {
                 last_triggered_at: triggeredAt,
                 last_triggered_status: err.statusCode,
                 last_triggered_error: lastTriggeredError
             });
-
-            common.logging.error(new common.errors.GhostError({
-                err: err,
-                context: {
-                    id: webhookId,
-                    event: event,
-                    target_url: targetUrl,
-                    payload: payload
-                }
-            }));
+            common.logging.warn(`Request to ${targetUrl} failed ${err.code || ''}.`);
         });
     });
 }


### PR DESCRIPTION
closes #10145

- Updated lastTriggeredError message in case of failure
- Removed GhostError in case of request failure and added proper warning
