### PR TITLE
Update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ npm install ghost-cli -g
 
 &nbsp;
 
-Then, if installing locally add the `local` flag to get up and running in under a minute - [Local install docs](https://docs.ghost.org/docs/install-local)
+Then, if installing locally add the `local` flag to get up and running in under a minute - [Local install docs](https://docs.ghost.org/install/local)
 
 ```
 $ ghost install local
@@ -77,7 +77,7 @@ $ ghost install local
 
 &nbsp;
 
-or on a server run the full install, including automatic SSL setup using LetsEncrypt - [Production install docs](https://docs.ghost.org/docs/install)
+or on a server run the full install, including automatic SSL setup using LetsEncrypt - [Production install docs](https://docs.ghost.org/install/ubuntu/)
 
 ```
 $ ghost install
@@ -85,7 +85,7 @@ $ ghost install
 
 &nbsp;
 
-Check out our [official documentation](https://docs.ghost.org/docs) for more information about our [recommended hosting stack](https://docs.ghost.org/docs/hosting) & properly [upgrading Ghost](https://docs.ghost.org/docs/upgrade), plus everything you need to develop your own Ghost [themes](https://themes.ghost.org/docs) or work with [our API](https://api.ghost.org/docs).
+Check out our [official documentation](https://docs.ghost.org) for more information about our [recommended hosting stack](https://docs.ghost.org/concepts/hosting) & properly [upgrading Ghost](https://docs.ghost.org/docs/upgrade), plus everything you need to develop your own Ghost [themes](https://docs.ghost.org/api/handlebars-themes) or work with [our API](https://api.ghost.org/docs).
 
 &nbsp;
 
@@ -101,7 +101,7 @@ To stay up to date with all the latest news and product updates, make sure you [
 
 # Contributors & Advanced Developers
 
-For anyone wishing to contribute to Ghost or to hack/customise core files we recommend following our full development setup guides: [General Contributor Guide](https://docs.ghost.org/docs/contributing) | [Developer Setup Instructions](https://docs.ghost.org/docs/working-with-ghost) | [Admin Client development guide](https://docs.ghost.org/docs/working-with-the-admin-client)
+For anyone wishing to contribute to Ghost or to hack/customise core files we recommend following our full development setup guides: [General Contributor Guide](https://docs.ghost.org/concepts/contributing) | [Developer Setup Instructions](https://docs.ghost.org/install/source) | [Admin Client development guide](https://docs.ghost.org/install/source/#ghost-admin)
 
 &nbsp;
 


### PR DESCRIPTION
https://docs.ghost.org/docs page is no longer available so the link leads to 404 error. Other links were updated where appropriate too.

I'm not sure about `https://docs.ghost.org/docs/upgrade` link which leads now to question about specific version (https://docs.ghost.org/faq/upgrade-to-ghost-2-0) so I left it as it is.