### PR TITLE
Remove formats property from private posts in content api

### DIFF
--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -49,6 +49,7 @@ module.exports = {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
             if (labs.isSet('members')) {
+                // CASE: Members needs to have the tags to check if its allowed access
                 includeTags(frame);
             }
         }
@@ -71,6 +72,7 @@ module.exports = {
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
             if (labs.isSet('members')) {
+                // CASE: Members needs to have the tags to check if its allowed access
                 includeTags(frame);
             }
         }

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
 const utils = require('../../index');
+const labsUtil = require('../../../../../../services/labs');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -47,7 +48,9 @@ module.exports = {
             }
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
-            includeTags(frame);
+            if (labsUtil.isSet('members')) {
+                includeTags(frame);
+            }
         }
 
         debug(frame.options);
@@ -67,7 +70,9 @@ module.exports = {
             frame.data.page = false;
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
-            includeTags(frame);
+            if (labsUtil.isSet('members')) {
+                includeTags(frame);
+            }
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -11,6 +11,14 @@ function removeMobiledocFormat(frame) {
     }
 }
 
+function includeTags(frame) {
+    if (!frame.options.include) {
+        frame.options.include = ['tags'];
+    } else if (!frame.options.include.includes('tags')) {
+        frame.options.include.push('tags');
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -39,6 +47,7 @@ module.exports = {
             }
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
+            includeTags(frame);
         }
 
         debug(frame.options);
@@ -58,6 +67,7 @@ module.exports = {
             frame.data.page = false;
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
+            includeTags(frame);
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
 const utils = require('../../index');
-const labs = require('../../../../../../services/labs');
+const labs = require('../../../../../services/labs');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:posts');
 const url = require('./utils/url');
 const utils = require('../../index');
-const labsUtil = require('../../../../../../services/labs');
+const labs = require('../../../../../../services/labs');
 
 function removeMobiledocFormat(frame) {
     if (frame.options.formats && frame.options.formats.includes('mobiledoc')) {
@@ -48,7 +48,7 @@ module.exports = {
             }
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
-            if (labsUtil.isSet('members')) {
+            if (labs.isSet('members')) {
                 includeTags(frame);
             }
         }
@@ -70,7 +70,7 @@ module.exports = {
             frame.data.page = false;
             // CASE: the content api endpoint for posts should not return mobiledoc
             removeMobiledocFormat(frame);
-            if (labsUtil.isSet('members')) {
+            if (labs.isSet('members')) {
                 includeTags(frame);
             }
         }

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -12,10 +12,10 @@ function removeMobiledocFormat(frame) {
 }
 
 function includeTags(frame) {
-    if (!frame.options.include) {
-        frame.options.include = ['tags'];
-    } else if (!frame.options.include.includes('tags')) {
-        frame.options.include.push('tags');
+    if (!frame.options.withRelated) {
+        frame.options.withRelated = ['tags'];
+    } else if (!frame.options.withRelated.includes('tags')) {
+        frame.options.withRelated.push('tags');
     }
 }
 

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -11,10 +11,6 @@ const mapPost = (model, frame) => {
     if (utils.isContentAPI(frame)) {
         date.forPost(jsonModel);
         members.forPost(jsonModel, frame);
-        const origQuery = frame.original.query || {};
-        if (!origQuery.include || !origQuery.include.includes('tags')) {
-            delete jsonModel.tags;
-        }
     }
 
     if (frame.options && frame.options.withRelated) {

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -11,6 +11,9 @@ const mapPost = (model, frame) => {
     if (utils.isContentAPI(frame)) {
         date.forPost(jsonModel);
         members.forPost(jsonModel, frame);
+        if (!frame.original.query.include.includes('tags')) {
+            delete jsonModel.tags;
+        }
     }
 
     if (frame.options && frame.options.withRelated) {

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -11,7 +11,8 @@ const mapPost = (model, frame) => {
     if (utils.isContentAPI(frame)) {
         date.forPost(jsonModel);
         members.forPost(jsonModel, frame);
-        if (!frame.original.query.include.includes('tags')) {
+        const origQuery = frame.original.query || {};
+        if (!origQuery.include || !origQuery.include.includes('tags')) {
             delete jsonModel.tags;
         }
     }

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -1,6 +1,7 @@
 const utils = require('../../../index');
 const url = require('./url');
 const date = require('./date');
+const members = require('./members');
 
 const mapPost = (model, frame) => {
     const jsonModel = model.toJSON(frame.options);
@@ -9,6 +10,7 @@ const mapPost = (model, frame) => {
 
     if (utils.isContentAPI(frame)) {
         date.forPost(jsonModel);
+        members.forPost(jsonModel, frame);
     }
 
     if (frame.options && frame.options.withRelated) {

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,6 +1,7 @@
 const labsUtil = require('../../../../../../services/labs');
 const MEMBER_TAG = '#members';
 
+// Checks if request should hide memnbers only content
 function hideMembersOnlyContent(attrs, frame) {
     let hasMemberTag = false;
     if (labsUtil.isSet('members') && !frame.original.context.member && attrs.tags) {

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -12,8 +12,8 @@ function hideMembersOnlyContent(attrs, frame) {
 }
 
 const forPost = (attrs, frame) => {
-    const hideMemberOnlyContent = hideMembersOnlyContent(attrs, frame);
-    if (hideMemberOnlyContent) {
+    const hideFormatsData = hideMembersOnlyContent(attrs, frame);
+    if (hideFormatsData) {
         ['plaintext', 'html'].forEach((field) => {
             attrs[field] = '';
         });

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -19,6 +19,12 @@ const forPost = (attrs, frame) => {
             attrs[field] = '';
         });
     }
+    if (labsUtil.isSet('members')) {
+        const origQuery = frame.original.query || {};
+        if (!origQuery.include || !origQuery.include.includes('tags')) {
+            delete attrs.tags;
+        }
+    }
 
     return attrs;
 };

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,7 +1,7 @@
 const labsUtil = require('../../../../../../services/labs');
 
 const forPost = (attrs, frame) => {
-    const hideMemberOnlyContent = labsUtil.isSet('members') && !frame.context.member;
+    const hideMemberOnlyContent = labsUtil.isSet('members') && !frame.original.context.member;
     if (hideMemberOnlyContent) {
         ['plaintext', 'html'].forEach((field) => {
             attrs[field] = '';

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,7 +1,18 @@
 const labsUtil = require('../../../../../../services/labs');
+const MEMBER_TAG = '#members';
+
+function hideMembersOnlyContent(attrs, frame) {
+    let hasMemberTag = false;
+    if (labsUtil.isSet('members') && !frame.original.context.member && attrs.tags) {
+        hasMemberTag = attrs.tags.find((tag) => {
+            return (tag.name === MEMBER_TAG);
+        }).length > 0;
+    }
+    return hasMemberTag;
+}
 
 const forPost = (attrs, frame) => {
-    const hideMemberOnlyContent = labsUtil.isSet('members') && !frame.original.context.member;
+    const hideMemberOnlyContent = hideMembersOnlyContent(attrs, frame);
     if (hideMemberOnlyContent) {
         ['plaintext', 'html'].forEach((field) => {
             attrs[field] = '';

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,0 +1,14 @@
+const labsUtil = require('../../../../../../services/labs');
+
+const forPost = (attrs, frame) => {
+    const hideMemberOnlyContent = labsUtil.isSet('members') && !frame.context.member;
+    if (hideMemberOnlyContent) {
+        ['plaintext', 'html'].forEach((field) => {
+            attrs[field] = '';
+        });
+    }
+
+    return attrs;
+};
+
+module.exports.forPost = forPost;

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -1,13 +1,13 @@
-const labsUtil = require('../../../../../../services/labs');
+const labs = require('../../../../../../services/labs');
 const MEMBER_TAG = '#members';
 
 // Checks if request should hide memnbers only content
 function hideMembersOnlyContent(attrs, frame) {
     let hasMemberTag = false;
-    if (labsUtil.isSet('members') && !frame.original.context.member && attrs.tags) {
+    if (labs.isSet('members') && !frame.original.context.member && attrs.tags) {
         hasMemberTag = attrs.tags.find((tag) => {
             return (tag.name === MEMBER_TAG);
-        }).length > 0;
+        });
     }
     return hasMemberTag;
 }
@@ -19,7 +19,7 @@ const forPost = (attrs, frame) => {
             attrs[field] = '';
         });
     }
-    if (labsUtil.isSet('members')) {
+    if (labs.isSet('members')) {
         const origQuery = frame.original.query || {};
         if (!origQuery.include || !origQuery.include.includes('tags')) {
             delete attrs.tags;

--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -20,6 +20,7 @@ const forPost = (attrs, frame) => {
         });
     }
     if (labs.isSet('members')) {
+        // CASE: Members always adds tags, remove if the user didn't originally ask for them
         const origQuery = frame.original.query || {};
         if (!origQuery.include || !origQuery.include.includes('tags')) {
             delete attrs.tags;


### PR DESCRIPTION
closes #10118 

- Uses post serializer, members lab setting and `jwt` members token to identify and serialize content(`formats`) data, sets it empty in response of content API posts/pages requests. 
- Currently uses hardcoded `#members` tag as identifier for members-only content

