### PR TITLE
Checked options.include when filtering tags

### DIFF
--- a/core/server/api/v2/utils/serializers/output/utils/members.js
+++ b/core/server/api/v2/utils/serializers/output/utils/members.js
@@ -21,8 +21,10 @@ const forPost = (attrs, frame) => {
     }
     if (labs.isSet('members')) {
         // CASE: Members always adds tags, remove if the user didn't originally ask for them
-        const origQuery = frame.original.query || {};
-        if (!origQuery.include || !origQuery.include.includes('tags')) {
+        const origQueryOrOptions = frame.original.query || frame.original.options || {};
+        const origInclude = origQueryOrOptions.include;
+
+        if (!origInclude || !origInclude.includes('tags')) {
             delete attrs.tags;
         }
     }


### PR DESCRIPTION
no-issue

Was only checking the `query` before and not the `options` which is used from the internal api calls