### PR TITLE
Fixes: #9584 Added exception when the import is a draft post as published_by is null

### DIFF
--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -190,13 +190,16 @@ class Base {
             // CASE: you import null, fallback to owner
             if (!obj[key]) {
                 // Exception: If the imported post is a draft published_by will be null. Not a userReferenceProblem.
-                if (key !== 'published_by' && obj.status !== 'draft') {
-                    if (!userReferenceProblems[obj.id]) {
-                        userReferenceProblems[obj.id] = {obj: _.cloneDeep(obj), keys: []};
-                    }
-                    userReferenceProblems[obj.id].keys.push(key);
-                    obj[key] = ownerUserId;
+                if (key === 'published_by' && obj.status === 'draft') {
+                    return;
                 }
+
+                if (!userReferenceProblems[obj.id]) {
+                    userReferenceProblems[obj.id] = {obj: _.cloneDeep(obj), keys: []};
+                }
+
+                userReferenceProblems[obj.id].keys.push(key);
+                obj[key] = ownerUserId;
                 return;
             }
 

--- a/core/server/data/importer/importers/data/base.js
+++ b/core/server/data/importer/importers/data/base.js
@@ -189,12 +189,14 @@ class Base {
 
             // CASE: you import null, fallback to owner
             if (!obj[key]) {
-                if (!userReferenceProblems[obj.id]) {
-                    userReferenceProblems[obj.id] = {obj: _.cloneDeep(obj), keys: []};
+                // Exception: If the imported post is a draft published_by will be null. Not a userReferenceProblem.
+                if (key !== 'published_by' && obj.status !== 'draft') {
+                    if (!userReferenceProblems[obj.id]) {
+                        userReferenceProblems[obj.id] = {obj: _.cloneDeep(obj), keys: []};
+                    }
+                    userReferenceProblems[obj.id].keys.push(key);
+                    obj[key] = ownerUserId;
                 }
-
-                userReferenceProblems[obj.id].keys.push(key);
-                obj[key] = ownerUserId;
                 return;
             }
 


### PR DESCRIPTION
Fixes: #9584

This PR adds an exception in core\server\data\importer\importers\data\base.js replaceIdentifiers() to skip adding a userReferenceProblem when the import is status: draft and user reference is published_by.