### PR TITLE
Img helper size config

### DIFF
--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -57,9 +57,9 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
         return imagePath;
     }
 
-    const imageSizeConfig = imageSizes[requestedSize];
+    const {width, height} = imageSizes[requestedSize];
 
-    if (!imageSizeConfig.width && !imageSizeConfig.height) {
+    if (!width && !height) {
         return imagePath;
     }
 

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -10,8 +10,6 @@
 const path = require('path');
 const proxy = require('./proxy');
 const urlService = proxy.urlService;
-const activeTheme = proxy.activeTheme;
-const IMAGE_SIZES_CONFIG = 'image_sizes';
 const STATIC_IMAGE_URL_PREFIX = `/${urlService.utils.STATIC_IMAGE_URL_PREFIX}`;
 
 module.exports = function imgUrl(attr, options) {
@@ -23,7 +21,10 @@ module.exports = function imgUrl(attr, options) {
 
     const absolute = options && options.hash && options.hash.absolute;
 
-    const image = getImageWithSize(attr, options && options.hash && options.hash.size);
+    const size = options && options.hash && options.hash.size;
+    const imageSizes = options && options.data && options.data.config && options.data.config.image_sizes;
+
+    const image = getImageWithSize(attr, size, imageSizes);
 
     // CASE: if attribute is passed, but it is undefined, then the attribute was
     // an unknown value, e.g. {{img_url feature_img}} and we also show a warning
@@ -40,7 +41,7 @@ module.exports = function imgUrl(attr, options) {
     // in this case we don't show a warning
 };
 
-function getImageWithSize(imagePath, requestedSize) {
+function getImageWithSize(imagePath, requestedSize, imageSizes) {
     if (!imagePath) {
         return imagePath;
     }
@@ -52,13 +53,11 @@ function getImageWithSize(imagePath, requestedSize) {
         return imagePath;
     }
 
-    const themeImageSizes = activeTheme.get().config(IMAGE_SIZES_CONFIG);
-
-    if (!themeImageSizes || !themeImageSizes[requestedSize]) {
+    if (!imageSizes || !imageSizes[requestedSize]) {
         return imagePath;
     }
 
-    const imageSizeConfig = themeImageSizes[requestedSize];
+    const imageSizeConfig = imageSizes[requestedSize];
 
     if (!imageSizeConfig.width && !imageSizeConfig.height) {
         return imagePath;

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -7,8 +7,8 @@
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 
-var proxy = require('./proxy'),
-    urlService = proxy.urlService;
+const proxy = require('./proxy');
+const urlService = proxy.urlService;
 
 module.exports = function imgUrl(attr, options) {
     // CASE: if no attribute is passed, e.g. `{{img_url}}` we show a warning
@@ -17,7 +17,7 @@ module.exports = function imgUrl(attr, options) {
         return;
     }
 
-    var absolute = options && options.hash && options.hash.absolute;
+    const absolute = options && options.hash && options.hash.absolute;
 
     // CASE: if attribute is passed, but it is undefined, then the attribute was
     // an unknown value, e.g. {{img_url feature_img}} and we also show a warning

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -65,5 +65,11 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
 
     const imageName = path.relative(STATIC_IMAGE_URL_PREFIX, imagePath);
 
-    return path.join(STATIC_IMAGE_URL_PREFIX, `/size/${requestedSize}/`, imageName);
+    const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
+
+    return path.join(STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}/`, imageName);
+}
+
+function prefixIfPresent(prefix, string) {
+    return string ? prefix + string : '';
 }

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -9,6 +9,8 @@
 
 const proxy = require('./proxy');
 const urlService = proxy.urlService;
+const activeTheme = proxy.activeTheme;
+const IMAGE_SIZES_CONFIG = 'image_sizes';
 
 module.exports = function imgUrl(attr, options) {
     // CASE: if no attribute is passed, e.g. `{{img_url}}` we show a warning
@@ -33,3 +35,22 @@ module.exports = function imgUrl(attr, options) {
     // CASE: if you pass e.g. cover_image, but it is not set, then attr is null!
     // in this case we don't show a warning
 };
+
+function getImageWithSize(imageName, requestedSize) {
+    if (!imageName) {
+        return imageName;
+    }
+    if (!requestedSize) {
+        return imageName;
+    }
+
+    const themeImageSizes = activeTheme.get().config(IMAGE_SIZES_CONFIG);
+
+    if (!themeImageSizes || !themeImageSizes[requestedSize]) {
+        return imageName;
+    }
+
+    const imageNameParts = imageName.split('.');
+    imageNameParts.splice(-1, 0, requestedSize);
+    return imageNameParts.join('.');
+}

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -65,5 +65,5 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
 
     const imageName = path.relative(STATIC_IMAGE_URL_PREFIX, imagePath);
 
-    return path.join(STATIC_IMAGE_URL_PREFIX, `/sizes/${requestedSize}/`, imageName);
+    return path.join(STATIC_IMAGE_URL_PREFIX, `/size/${requestedSize}/`, imageName);
 }

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -7,6 +7,7 @@
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 
+const path = require('path');
 const proxy = require('./proxy');
 const urlService = proxy.urlService;
 const activeTheme = proxy.activeTheme;
@@ -52,7 +53,8 @@ function getImageWithSize(imagePath, requestedSize) {
         return imagePath;
     }
 
-    const imagePathParts = imagePath.split('.');
-    imagePathParts.splice(-1, 0, requestedSize);
-    return imagePathParts.join('.');
+    const imageDir = path.dirname(imagePath);
+    const imageName = path.basename(imagePath);
+
+    return path.join(imageDir, requestedSize, imageName);
 }

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -38,21 +38,21 @@ module.exports = function imgUrl(attr, options) {
     // in this case we don't show a warning
 };
 
-function getImageWithSize(imageName, requestedSize) {
-    if (!imageName) {
-        return imageName;
+function getImageWithSize(imagePath, requestedSize) {
+    if (!imagePath) {
+        return imagePath;
     }
     if (!requestedSize) {
-        return imageName;
+        return imagePath;
     }
 
     const themeImageSizes = activeTheme.get().config(IMAGE_SIZES_CONFIG);
 
     if (!themeImageSizes || !themeImageSizes[requestedSize]) {
-        return imageName;
+        return imagePath;
     }
 
-    const imageNameParts = imageName.split('.');
-    imageNameParts.splice(-1, 0, requestedSize);
-    return imageNameParts.join('.');
+    const imagePathParts = imagePath.split('.');
+    imagePathParts.splice(-1, 0, requestedSize);
+    return imagePathParts.join('.');
 }

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -21,15 +21,17 @@ module.exports = function imgUrl(attr, options) {
 
     const absolute = options && options.hash && options.hash.absolute;
 
+    const image = getImageWithSize(attr, options && options.hash && options.hash.size);
+
     // CASE: if attribute is passed, but it is undefined, then the attribute was
     // an unknown value, e.g. {{img_url feature_img}} and we also show a warning
-    if (attr === undefined) {
+    if (image === undefined) {
         proxy.logging.warn(proxy.i18n.t('warnings.helpers.img_url.attrIsRequired'));
         return;
     }
 
-    if (attr) {
-        return urlService.utils.urlFor('image', {image: attr}, absolute);
+    if (image) {
+        return urlService.utils.urlFor('image', {image}, absolute);
     }
 
     // CASE: if you pass e.g. cover_image, but it is not set, then attr is null!

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -7,7 +7,6 @@
 // Returns the URL for the current object scope i.e. If inside a post scope will return image permalink
 // `absolute` flag outputs absolute URL, else URL is relative.
 
-const path = require('path');
 const proxy = require('./proxy');
 const urlService = proxy.urlService;
 const STATIC_IMAGE_URL_PREFIX = `/${urlService.utils.STATIC_IMAGE_URL_PREFIX}`;
@@ -67,7 +66,7 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
 
     const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
 
-    return path.join(imgBlogUrl, STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}/`, imageName);
+    return [imgBlogUrl, STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}`, imageName].join('');
 }
 
 function prefixIfPresent(prefix, string) {

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -48,6 +48,10 @@ function getImageWithSize(imagePath, requestedSize) {
         return imagePath;
     }
 
+    if (/https?:\/\//.test(imagePath)) {
+        return imagePath;
+    }
+
     const themeImageSizes = activeTheme.get().config(IMAGE_SIZES_CONFIG);
 
     if (!themeImageSizes || !themeImageSizes[requestedSize]) {

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -54,6 +54,12 @@ function getImageWithSize(imagePath, requestedSize) {
         return imagePath;
     }
 
+    const imageSizeConfig = themeImageSizes[requestedSize];
+
+    if (!imageSizeConfig.width && !imageSizeConfig.height) {
+        return imagePath;
+    }
+
     const imageName = path.relative(STATIC_IMAGE_URL_PREFIX, imagePath);
 
     return path.join(STATIC_IMAGE_URL_PREFIX, `/sizes/${requestedSize}/`, imageName);

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -49,7 +49,7 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
         return imagePath;
     }
 
-    if (/https?:\/\//.test(imagePath)) {
+    if (/https?:\/\//.test(imagePath) && !imagePath.startsWith(urlService.utils.getBlogUrl())) {
         return imagePath;
     }
 
@@ -63,11 +63,11 @@ function getImageWithSize(imagePath, requestedSize, imageSizes) {
         return imagePath;
     }
 
-    const imageName = path.relative(STATIC_IMAGE_URL_PREFIX, imagePath);
+    const [imgBlogUrl, imageName] = imagePath.split(STATIC_IMAGE_URL_PREFIX);
 
     const sizeDirectoryName = prefixIfPresent('w', width) + prefixIfPresent('h', height);
 
-    return path.join(STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}/`, imageName);
+    return path.join(imgBlogUrl, STATIC_IMAGE_URL_PREFIX, `/size/${sizeDirectoryName}/`, imageName);
 }
 
 function prefixIfPresent(prefix, string) {

--- a/core/server/helpers/img_url.js
+++ b/core/server/helpers/img_url.js
@@ -12,6 +12,7 @@ const proxy = require('./proxy');
 const urlService = proxy.urlService;
 const activeTheme = proxy.activeTheme;
 const IMAGE_SIZES_CONFIG = 'image_sizes';
+const STATIC_IMAGE_URL_PREFIX = `/${urlService.utils.STATIC_IMAGE_URL_PREFIX}`;
 
 module.exports = function imgUrl(attr, options) {
     // CASE: if no attribute is passed, e.g. `{{img_url}}` we show a warning
@@ -53,8 +54,7 @@ function getImageWithSize(imagePath, requestedSize) {
         return imagePath;
     }
 
-    const imageDir = path.dirname(imagePath);
-    const imageName = path.basename(imagePath);
+    const imageName = path.relative(STATIC_IMAGE_URL_PREFIX, imagePath);
 
-    return path.join(imageDir, requestedSize, imageName);
+    return path.join(STATIC_IMAGE_URL_PREFIX, `/sizes/${requestedSize}/`, imageName);
 }

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -40,8 +40,6 @@ module.exports = {
         isPrivacyDisabled: config.isPrivacyDisabled.bind(config)
     },
 
-    activeTheme: require('../services/themes/active'),
-
     // Labs utils for enabling/disabling helpers
     labs: require('../services/labs'),
 

--- a/core/server/helpers/proxy.js
+++ b/core/server/helpers/proxy.js
@@ -40,6 +40,8 @@ module.exports = {
         isPrivacyDisabled: config.isPrivacyDisabled.bind(config)
     },
 
+    activeTheme: require('../services/themes/active'),
+
     // Labs utils for enabling/disabling helpers
     labs: require('../services/labs'),
 

--- a/core/server/services/themes/config/index.js
+++ b/core/server/services/themes/config/index.js
@@ -1,6 +1,6 @@
 var _ = require('lodash'),
     defaultConfig = require('./defaults'),
-    allowedKeys = ['posts_per_page'];
+    allowedKeys = ['posts_per_page', 'image_sizes'];
 
 module.exports.create = function configLoader(packageJson) {
     var config = _.cloneDeep(defaultConfig);

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -71,6 +71,7 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
 
     if (activeTheme.get()) {
         themeData.posts_per_page = activeTheme.get().config('posts_per_page');
+        themeData.image_sizes = activeTheme.get().config('image_sizes');
     }
 
     // Request-specific information

--- a/core/test/unit/helpers/img_url_spec.js
+++ b/core/test/unit/helpers/img_url_spec.js
@@ -92,4 +92,49 @@ describe('{{image}} helper', function () {
             rendered.should.equal('http://example.com/picture.jpg');
         });
     });
+
+    describe('image_sizes', function () {
+        before(function () {
+            configUtils.set({url: 'http://localhost:82832'});
+        });
+        after(function () {
+            configUtils.restore();
+        });
+        it('should output correct url for absolute paths which are internal', function () {
+            var rendered = helpers.img_url('http://localhost:82832/content/images/my-coole-img.jpg', {
+                hash: {
+                    size: 'medium',
+                },
+                data: {
+                    config: {
+                        image_sizes: {
+                            medium: {
+                                width: 400
+                            }
+                        }
+                    }
+                }
+            });
+            should.exist(rendered);
+            rendered.should.equal('http://localhost:82832/content/images/size/w400/my-coole-img.jpg');
+    });
+        it('should output the correct url for relative paths', function () {
+            var rendered = helpers.img_url('/content/images/my-coole-img.jpg', {
+                hash: {
+                    size: 'medium',
+                },
+                data: {
+                    config: {
+                        image_sizes: {
+                            medium: {
+                                width: 400
+                            }
+                        }
+                    }
+                }
+            });
+            should.exist(rendered);
+            rendered.should.equal('/content/images/size/w400/my-coole-img.jpg');
+        });
+    });
 });

--- a/core/test/unit/services/themes/middleware_spec.js
+++ b/core/test/unit/services/themes/middleware_spec.js
@@ -95,7 +95,7 @@ describe('Themes', function () {
 
         describe('updateTemplateData', function () {
             var updateTemplateData = middleware[1],
-                themeDataExpectedProps = ['posts_per_page'],
+                themeDataExpectedProps = ['posts_per_page', 'image_sizes'],
                 blogDataExpectedProps = [
                     'url', 'title', 'description', 'logo', 'cover_image', 'icon', 'twitter', 'facebook', 'navigation',
                     'timezone', 'amp'


### PR DESCRIPTION
refs #10181 
Given a theme with a `package.json` with an `image_sizes` object like this:
_(N.B. the `small` key must have at least a height or a width, or both)_
```json
{
  "config": {
    "image_sizes": {
      "small": {
        "width": 300,
        "height": 200
      },
      "wide": {
        "width": 2000
      },
      "tall": {
        "height": 2000
      }
    }
  }
}
```

Using the `img_url` helper in the theme like
```hbs
<img src="{{img_url profile_image}}">
<img src="{{img_url profile_image size="small"}}">
<img src="{{img_url profile_image size="wide"}}">
<img src="{{img_url profile_image size="tall"}}">
<img src="{{img_url profile_image size="unknown-size!!!"}}">
```

Will render to
```html
<img src="/content/images/path/to/profile_image.ext">
<img src="/content/images/size/w300h200/path/to/profile_image.ext">
<img src="/content/images/size/w2000/path/to/profile_image.ext">
<img src="/content/images/size/h2000/path/to/profile_image.ext">
<img src="/content/images/path/to/profile_image.ext">
```

If the `package.json` of the theme does not define the `image_sizes` object or the requested size is not included in the `image_sizes` object, the original image will be served.
