### PR TITLE
Added posts events to webhook listener

### DIFF
--- a/core/server/lib/common/events.js
+++ b/core/server/lib/common/events.js
@@ -16,6 +16,6 @@ EventRegistry.prototype.onMany = function (arr, onEvent) {
 };
 
 EventRegistryInstance = new EventRegistry();
-EventRegistryInstance.setMaxListeners(100);
+EventRegistryInstance.setMaxListeners(101);
 
 module.exports = EventRegistryInstance;

--- a/core/server/services/webhooks/listen.js
+++ b/core/server/services/webhooks/listen.js
@@ -36,6 +36,7 @@ function generatePayload(event, model) {
 function listener(event, model, options) {
     let payload = {};
     if (model) {
+        options = [];
         payload = generatePayload(event, model);
     }
     payload.event = event;
@@ -51,6 +52,9 @@ function listener(event, model, options) {
 // TODO: use a wildcard with the new event emitter or use the webhooks API to
 // register listeners only for events that have webhooks
 function listen() {
+    common.events.on('post.published', _.partial(listener, 'post.published'));
+    common.events.on('post.published.edited', _.partial(listener, 'post.published.edited'));
+    common.events.on('post.unpublished', _.partial(listener, 'post.unpublished'));
     common.events.on('subscriber.added', _.partial(listener, 'subscriber.added'));
     common.events.on('subscriber.deleted', _.partial(listener, 'subscriber.deleted'));
     common.events.on('site.changed', _.partial(listener, 'site.changed'));

--- a/core/test/unit/services/webhooks_spec.js
+++ b/core/test/unit/services/webhooks_spec.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const should = require('should');
+const assert = require('assert');
 const sinon = require('sinon');
 const rewire = require('rewire');
 const testUtils = require('../../utils');
@@ -25,7 +26,7 @@ describe('Webhooks', function () {
 
     it('listen() should initialise events correctly', function () {
         webhooks.listen();
-        eventStub.calledThrice.should.be.true();
+        assert.equal(eventStub.callCount, 6);
     });
 
     it('listener() with "subscriber.added" event calls webhooks.trigger with toJSONified model', function () {
@@ -98,6 +99,90 @@ describe('Webhooks', function () {
         triggerArgs[0].should.eql('site.changed');
         triggerArgs[1].should.eql({
             event: 'site.changed'
+        });
+
+        resetWebhooks();
+    });
+
+    it('listener() with "post.published" event calls webhooks.trigger with toJSONified model', function () {
+        var testPost = _.clone(testUtils.DataGenerator.Content.posts[1]),
+            testModel = {
+                toJSON: function () {
+                    return testPost;
+                }
+            },
+            webhooksStub = {
+                trigger: sandbox.stub()
+            },
+            resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
+            listener = webhooks.listen.__get__('listener'),
+            triggerArgs;
+
+        listener('post.published', testModel);
+
+        webhooksStub.trigger.calledOnce.should.be.true();
+
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
+        triggerArgs[0].should.eql('post.published');
+        triggerArgs[1].should.deepEqual({
+            posts: [testPost],
+            event: 'post.published'
+        });
+
+        resetWebhooks();
+    });
+
+    it('listener() with "post.unpublished" event calls webhooks.trigger with toJSONified model', function () {
+        var testPost = _.clone(testUtils.DataGenerator.Content.posts[1]),
+            testModel = {
+                toJSON: function () {
+                    return testPost;
+                }
+            },
+            webhooksStub = {
+                trigger: sandbox.stub()
+            },
+            resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
+            listener = webhooks.listen.__get__('listener'),
+            triggerArgs;
+
+        listener('post.unpublished', testModel);
+
+        webhooksStub.trigger.calledOnce.should.be.true();
+
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
+        triggerArgs[0].should.eql('post.unpublished');
+        triggerArgs[1].should.deepEqual({
+            posts: [testPost],
+            event: 'post.unpublished'
+        });
+
+        resetWebhooks();
+    });
+
+    it('listener() with "post.published.edited" event calls webhooks.trigger with toJSONified model', function () {
+        var testPost = _.clone(testUtils.DataGenerator.Content.posts[1]),
+            testModel = {
+                toJSON: function () {
+                    return testPost;
+                }
+            },
+            webhooksStub = {
+                trigger: sandbox.stub()
+            },
+            resetWebhooks = webhooks.listen.__set__('webhooks', webhooksStub),
+            listener = webhooks.listen.__get__('listener'),
+            triggerArgs;
+
+        listener('post.published.edited', testModel);
+
+        webhooksStub.trigger.calledOnce.should.be.true();
+
+        triggerArgs = webhooksStub.trigger.getCall(0).args;
+        triggerArgs[0].should.eql('post.published.edited');
+        triggerArgs[1].should.deepEqual({
+            posts: [testPost],
+            event: 'post.published.edited'
         });
 
         resetWebhooks();

--- a/core/test/utils/fixtures/data-generator.js
+++ b/core/test/utils/fixtures/data-generator.js
@@ -371,6 +371,21 @@ DataGenerator.Content = {
             id: ObjectId.generate(),
             event: 'subscriber.removed',
             target_url: 'https://example.com/webhooks/subscriber-removed'
+        },
+        {
+            id: ObjectId.generate(),
+            event: 'post.published',
+            target_url: 'https://example.com/webhooks/post-published'
+        },
+        {
+            id: ObjectId.generate(),
+            event: 'post.unpublished',
+            target_url: 'https://example.com/webhooks/subscriber-removed'
+        },
+        {
+            id: ObjectId.generate(),
+            event: 'post.published.edited',
+            target_url: 'https://example.com/webhooks/post-published-edited'
         }
     ],
 


### PR DESCRIPTION
no issue

I needed to integrate ghost with a platform through the webhooks interface, so it can be always synchronized with newly published posts. At first, I tried to use `site.changed` event but it doesn't contain any payload.

So I thought that will be nice to share with you this little piece of code that I developed and that fits my purpose, which is webhook calls triggered by post-related events.

Enabled post events:
- `post.published`
- `post.published.edited`
- `post.unpublished`

I've already have these events enabled on admin client, and the PR related to this change will be submited for review, if this PR is accepted.

Thank you in advance.