### PR TITLE
Removed duplicate shortcut icon link

### DIFF
--- a/core/server/apps/amp/lib/views/amp.hbs
+++ b/core/server/apps/amp/lib/views/amp.hbs
@@ -11,9 +11,6 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
-    {{!-- Brand icon --}}
-    <link rel="shortcut icon" href="{{asset "favicon.ico"}}">
-
     {{amp_ghost_head}}
 
     {{!-- Styles'n'Scripts --}}


### PR DESCRIPTION
no issues

Before change

<img width="678" src="https://user-images.githubusercontent.com/6166576/49686717-89498200-fb33-11e8-8e5e-7fd0dfa99a33.png">

Because `{{amp_ghost_head}}` already provides this

