### PR TITLE
Added CORS support to the v2 Content API

### DIFF
--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -1,9 +1,12 @@
 const express = require('express');
+const cors = require('cors');
 const apiv2 = require('../../../../api/v2');
 const mw = require('./middleware');
 
 module.exports = function apiRoutes() {
     const router = express.Router();
+
+    router.options('*', cors());
 
     // ## Posts
     router.get('/posts', mw.authenticatePublic, apiv2.http(apiv2.posts.browse));


### PR DESCRIPTION
no-issue

When trying to use /api/v2/content from a different domain, the requests
were failing with CORS errors. This doesn't use the shared cors middleware,
because it should be open to all hosts, and not locked down via our
whitelist or trusted domains.
