### PR TITLE
Using safe string for slug attribute in navigation helper; Adding base64 slug

### DIFF
--- a/core/server/helpers/navigation.js
+++ b/core/server/helpers/navigation.js
@@ -3,6 +3,7 @@
 // Outputs navigation menu of static urls
 
 var proxy = require('./proxy'),
+    string = require('../lib/security/string'),
     _ = require('lodash'),
     SafeString = proxy.SafeString,
     i18n = proxy.i18n,
@@ -41,7 +42,7 @@ module.exports = function navigation(options) {
     }
 
     function _slugify(label) {
-        return label.toLowerCase().replace(/[^\w ]+/g, '').replace(/ +/g, '-');
+        return string.safe(label);
     }
 
     // strips trailing slashes and compares urls


### PR DESCRIPTION
Trying to resolve #10258.

Changed:
+ `{{slug}}` attribute now uses [core.server.lib.security.string.safe](https://github.com/TryGhost/Ghost/blob/2.7.1/core/server/lib/security/string.js).

New:
+ Added a `{{slug_base64}}` attribute that generates utf-8 base64 of the navigation label.

Cultural invariant base64 is probably a better solution due to string.safe uses [unidecode](https://www.npmjs.com/package/unidecode) which provided a hilarious usage example:

```javascript
> unidecode("に間違いがないか、再度確認してください。再読み込みしてください。");
'niJian Wei iganaika, Zai Du Que Ren sitekudasai. Zai Du miIp misitekudasai. '
```

The string in question should be romanized as `nikanchigaiganaika, saidokakuninshitekudasai. saiyomikomishitekudasai.` (well I admit algorithmic CJK romanization is hard.) But since that will break backwards compatibility (?) I made a separate attribute instead.

Unquestionably, customizable slug is the ultimate solution - but that went beyond my abilities (and requires a change in [Ghost-Admin](https://github.com/TryGhost/Ghost-Admin/) as well).

I'm definitely new to javascript (and handlebars) - this PR will likely to fail CI tests. Corrections are greatly appreciated!