### PR TITLE
🐛 Fixed get helper when API v0.1 is disabled

### DIFF
--- a/core/server/helpers/get.js
+++ b/core/server/helpers/get.js
@@ -130,7 +130,7 @@ get = function get(resource, options) {
 
     const self = this;
     const data = createFrame(options.data);
-    const apiVersion = data.root._locals.apiVersion;
+    const apiVersion = _.get(data, 'root._locals.apiVersion');
     let apiOptions = options.hash;
 
     if (!options.fn) {
@@ -182,16 +182,23 @@ get = function get(resource, options) {
 };
 
 module.exports = function getLabsWrapper() {
-    var self = this,
-        args = arguments;
+    const self = this;
+    const args = arguments;
+    const apiVersion = _.get(args, '[1].data.root._locals.apiVersion');
 
-    return labs.enabledHelper({
-        flagKey: 'publicAPI',
-        flagName: 'Public API',
-        helperName: 'get',
-        helpUrl: 'https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta',
-        async: true
-    }, function executeHelper() {
-        return get.apply(self, args);
-    });
+    // If the API version is v0.1 return the labs enabled version of the helper
+    if (apiVersion === 'v0.1') {
+        return labs.enabledHelper({
+            flagKey: 'publicAPI',
+            flagName: 'Public API',
+            helperName: 'get',
+            helpUrl: 'https://help.ghost.org/hc/en-us/articles/115000301672-Public-API-Beta',
+            async: true
+        }, function executeHelper() {
+            return get.apply(self, args);
+        });
+    }
+
+    // Else, we just apply the helper normally
+    return get.apply(self, args);
 };

--- a/core/test/unit/helpers/get_spec.js
+++ b/core/test/unit/helpers/get_spec.js
@@ -37,7 +37,7 @@ describe('{{#get}} helper', function () {
         helpers.get.call(
             {},
             'posts',
-            {hash: {}, fn: fn, inverse: inverse}
+            {hash: {}, data: locals, fn: fn, inverse: inverse}
         ).then(function (result) {
             labsStub.calledOnce.should.be.true();
             fn.called.should.be.false();
@@ -326,7 +326,8 @@ describe('{{#get}} helper', function () {
                 'users',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                labsStub.calledOnce.should.be.true();
+                // We don't use the labs helper for v2
+                labsStub.calledOnce.should.be.false();
 
                 fn.called.should.be.true();
                 fn.firstCall.args[0].should.be.an.Object().with.property('authors');
@@ -358,7 +359,8 @@ describe('{{#get}} helper', function () {
                 'authors',
                 {hash: {}, data: locals, fn: fn, inverse: inverse}
             ).then(function () {
-                labsStub.calledOnce.should.be.true();
+                // We don't use the labs helper for v2
+                labsStub.calledOnce.should.be.false();
 
                 fn.called.should.be.true();
                 fn.firstCall.args[0].should.be.an.Object().with.property('authors');


### PR DESCRIPTION
closes #10266

- the Public API labs flag refers to the v0.1 API only
- if it is disabled, the v0.1 API should be disabled
- if the theme is using v2 API, then the get helper should be available regardless

