### PR TITLE
Updated member lib/auth service to use origin of site url

### DIFF
--- a/core/server/services/auth/members/index.js
+++ b/core/server/services/auth/members/index.js
@@ -1,7 +1,10 @@
+const URL = require('url').URL;
 const jwt = require('express-jwt');
 const membersService = require('../../members');
 const labs = require('../../labs');
 const config = require('../../../config');
+
+const siteOrigin = new URL(config.get('url')).origin;
 
 let UNO_MEMBERINO;
 
@@ -16,8 +19,8 @@ module.exports = {
             UNO_MEMBERINO = jwt({
                 credentialsRequired: false,
                 requestProperty: 'member',
-                audience: config.get('url'),
-                issuer: config.get('url'),
+                audience: siteOrigin,
+                issuer: siteOrigin,
                 algorithm: 'RS512',
                 secret: membersService.api.publicKey,
                 getToken(req) {

--- a/core/server/services/members/api.js
+++ b/core/server/services/members/api.js
@@ -60,8 +60,11 @@ const publicKey = settingsCache.get('members_public_key');
 const privateKey = settingsCache.get('members_private_key');
 const sessionSecret = settingsCache.get('members_session_secret');
 const passwordResetUrl = config.get('url');
-const issuer = config.get('url');
-const ssoOrigin = new URL(config.get('url')).origin;
+
+const siteOrigin = new URL(config.get('url')).origin;
+
+const issuer = siteOrigin;
+const ssoOrigin = siteOrigin;
 let mailer;
 
 function sendEmail(member, {token}) {


### PR DESCRIPTION
no-issue

The SDK uses the origin of the host to request the `audience` for the token, so we use the origin at the backend too for consistency

