### PR TITLE
🐛Fix for files not being deleted from cache

### DIFF
--- a/core/server/api/v0.1/themes.js
+++ b/core/server/api/v0.1/themes.js
@@ -141,14 +141,6 @@ themes = {
             })
             .finally(() => {
                 // @TODO we should probably do this as part of saving the theme
-                // remove zip upload from multer
-                // happens in background
-                fs.remove(zip.path)
-                    .catch((err) => {
-                        common.logging.error(new common.errors.GhostError({err: err}));
-                    });
-
-                // @TODO we should probably do this as part of saving the theme
                 // remove extracted dir from gscan
                 // happens in background
                 if (checkedTheme) {

--- a/core/server/api/v2/subscribers.js
+++ b/core/server/api/v2/subscribers.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra');
 const Promise = require('bluebird');
 const models = require('../../models');
 const fsLib = require('../../lib/fs');
@@ -208,9 +207,6 @@ const subscribers = {
                         }
                     }
                 };
-            }).finally(() => {
-                // Remove uploaded file from tmp location
-                return fs.unlink(filePath);
             });
         }
     }

--- a/core/server/api/v2/upload.js
+++ b/core/server/api/v2/upload.js
@@ -1,4 +1,3 @@
-const fs = require('fs-extra');
 const storage = require('../../adapters/storage');
 
 module.exports = {
@@ -10,22 +9,11 @@ module.exports = {
             const store = storage.getStorage();
 
             if (frame.files) {
-                return Promise.map(frame.files, (file) => {
-                    return store
-                        .save(file)
-                        .finally(() => {
-                            // Remove uploaded file from tmp location
-                            return fs.unlink(file.path);
-                        });
-                }).then((paths) => {
-                    return paths[0];
-                });
+                return Promise
+                    .map(frame.files, file => store.save(file))
+                    .then(paths => paths[0]);
             }
-
-            return store.save(frame.file).finally(() => {
-                // Remove uploaded file from tmp location
-                return fs.unlink(frame.file.path);
-            });
+            return store.save(frame.file);
         }
     }
 };

--- a/core/server/data/importer/index.js
+++ b/core/server/data/importer/index.js
@@ -31,8 +31,8 @@ defaults = {
 function ImportManager() {
     this.importers = [ImageImporter, DataImporter];
     this.handlers = [ImageHandler, JSONHandler, MarkdownHandler];
-    // Keep track of files to cleanup at the end
-    this.filesToDelete = [];
+    // Keep track of file to cleanup at the end
+    this.fileToDelete = null;
 }
 
 /**
@@ -102,22 +102,23 @@ _.extend(ImportManager.prototype, {
      * @returns {Function}
      */
     cleanUp: function () {
-        var filesToDelete = this.filesToDelete;
-        return function (result) {
-            _.each(filesToDelete, function (fileToDelete) {
-                fs.remove(fileToDelete, function (err) {
-                    if (err) {
-                        common.logging.error(new common.errors.GhostError({
-                            err: err,
-                            context: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.error'),
-                            help: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.context')
-                        }));
-                    }
-                });
-            });
+        var self = this;
 
-            return result;
-        };
+        if (self.fileToDelete === null) {
+            return;
+        }
+
+        fs.remove(self.fileToDelete, function (err) {
+            if (err) {
+                common.logging.error(new common.errors.GhostError({
+                    err: err,
+                    context: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.error'),
+                    help: common.i18n.t('errors.data.importer.index.couldNotCleanUpFile.context')
+                }));
+            }
+
+            self.fileToDelete = null;
+        });
     },
     /**
      * Return true if the given file is a Zip
@@ -168,8 +169,9 @@ _.extend(ImportManager.prototype, {
      * @returns {Promise[]} Files
      */
     extractZip: function (filePath) {
-        var tmpDir = path.join(os.tmpdir(), uuid.v4());
-        this.filesToDelete.push(tmpDir);
+        const tmpDir = path.join(os.tmpdir(), uuid.v4());
+        this.fileToDelete = tmpDir;
+
         return Promise.promisify(extract)(filePath, {dir: tmpDir}).then(function () {
             return tmpDir;
         });
@@ -293,9 +295,6 @@ _.extend(ImportManager.prototype, {
     loadFile: function (file) {
         var self = this,
             ext = path.extname(file.name).toLowerCase();
-
-        this.filesToDelete.push(file.path);
-
         return this.isZip(ext) ? self.processZip(file) : self.processFile(file, ext);
     },
     /**
@@ -367,10 +366,8 @@ _.extend(ImportManager.prototype, {
             return self.doImport(importData, importOptions);
         }).then(function (importData) {
             // Step 4: Report on the import
-            return self.generateReport(importData)
-            // Step 5: Cleanup any files
-                .finally(self.cleanUp());
-        });
+            return self.generateReport(importData);
+        }).finally(() => self.cleanUp()); // Step 5: Cleanup any files
     }
 });
 

--- a/core/server/web/api/v0.1/routes.js
+++ b/core/server/web/api/v0.1/routes.js
@@ -11,8 +11,7 @@ const cors = require('../../shared/middlewares/api/cors');
 const brute = require('../../shared/middlewares/brute');
 
 // Handling uploads & imports
-const tmpdir = require('os').tmpdir;
-const upload = require('multer')({dest: tmpdir()});
+const upload = require('../../shared/middlewares/upload');
 const validation = require('../../shared/middlewares/validation');
 const image = require('../../shared/middlewares/image');
 

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -1,6 +1,4 @@
 const express = require('express');
-const os = require('os');
-const multer = require('multer');
 const api = require('../../../../api');
 const apiv2 = require('../../../../api/v2');
 const mw = require('./middleware');
@@ -9,8 +7,7 @@ const auth = require('../../../../services/auth');
 const shared = require('../../../shared');
 
 // Handling uploads & imports
-const tmpdir = os.tmpdir;
-const upload = multer({dest: tmpdir()});
+const upload = shared.middlewares.upload;
 
 module.exports = function apiRoutes() {
     const router = express.Router();

--- a/core/server/web/shared/middlewares/index.js
+++ b/core/server/web/shared/middlewares/index.js
@@ -19,6 +19,10 @@ module.exports = {
         return require('./brute');
     },
 
+    get upload() {
+        return require('./upload');
+    },
+
     get cacheControl() {
         return require('./cache-control');
     },

--- a/core/server/web/shared/middlewares/upload.js
+++ b/core/server/web/shared/middlewares/upload.js
@@ -1,0 +1,43 @@
+const config = require('../../../config');
+const os = require('os');
+const multer = require('multer');
+const fs = require('fs-extra');
+const common = require('../../../lib/common');
+
+const upload = {
+    enabledClear: config.get('uploadClear') || true,
+    multer: multer({dest: os.tmpdir()})
+};
+
+const deleteSingleFile = file => fs.unlink(file.path).catch(err => common.logging.error(err));
+
+const single = name => (req, res, next) => {
+    const singleUpload = upload.multer.single(name);
+    singleUpload(req, res, (err) => {
+        if (err) {
+            return next(err);
+        }
+        if (upload.enabledClear) {
+            const deleteFiles = () => {
+                res.removeListener('finish', deleteFiles);
+                res.removeListener('close', deleteFiles);
+                if (!req.disableUploadClear) {
+                    if (req.files) {
+                        return req.files.forEach(deleteSingleFile);
+                    }
+
+                    if (req.file) {
+                        return deleteSingleFile(req.file);
+                    }
+                }
+            };
+            if (!req.disableUploadClear) {
+                res.on('finish', deleteFiles);
+                res.on('close', deleteFiles);
+            }
+        }
+        next();
+    });
+};
+
+module.exports = {single};


### PR DESCRIPTION
Fixes #10174 
This is an upgrade from #10175 @gargol @kirrg001 
And for the unzipped theme deletion on failure, I opened a [PR in the gscan repo](https://github.com/TryGhost/gscan/pull/172), as I explained there, it makes more sense to me to have the fix added to gscan.
***
This PR additions:
- [x] Detects when a response ends
- [x]  Uses a middleware
- [x] Deletes req.file.path
- [x] Deletes req.files[...].path 

Because some files are deleted manually in Ghost, the unlink fails sometimes and triggers an error (tries to delete a non existing path). This isn't an issue for me, but maybe some people may find that annoying? I don't know. 

So I don't know what to do here. Ignore it, leaving it as it is or maybe checking if the path exists before calling unlink, or even removing the manual deletion of files written before in the Ghost core? What do you think is the best solution?

Edited:
-------
Another question I have, should I add the middleware to the v0.1 API? It's just on the v2 right now.