### PR TITLE
Removed ssoOriginCheck from signout endpoint

### DIFF
--- a/core/server/lib/members/index.js
+++ b/core/server/lib/members/index.js
@@ -140,7 +140,7 @@ module.exports = function MembersApi({
         }).catch(handleError(401, res));
     });
 
-    apiRouter.post('/signout', getData(), ssoOriginCheck, (req, res) => {
+    apiRouter.post('/signout', getData(), (req, res) => {
         res.writeHead(200, {
             'Set-Cookie': removeCookie()
         });


### PR DESCRIPTION
no-issue

the ssoOriginCheck exists to ensure that we only allow signin/signup to
be called from the specified auth page, this is a very minor security
feature in that it forces signins to go via the page you've designated.
signout however does not need this protection as the call to signout
completely bypasses any UI (this is the same for the call to /token)

This doesn't affect ghost blogs, as everyone shares the same origin,
but when using an external/third party frontend - this causes all logout
attempts to 403 :ghost: 