### PR TITLE
Cleanup image manipulator

### DIFF
--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -8,19 +8,8 @@ const fs = require('fs-extra');
  * We currently can't enable compression or having more config options, because of
  * https://github.com/lovell/sharp/issues/1360.
  */
-const process = (options = {}) => {
-    let sharp, img, originalData, originalSize;
-
-    try {
-        sharp = require('sharp');
-    } catch (err) {
-        return Promise.reject(new common.errors.InternalServerError({
-            message: 'Sharp wasn\'t installed',
-            code: 'SHARP_INSTALLATION',
-            err: err
-        }));
-    }
-
+const unsafeProcess = (options = {}) => {
+    const sharp = require('sharp');
     // @NOTE: workaround for Windows as libvips keeps a reference to the input file
     //        which makes it impossible to fs.unlink() it on cleanup stage
     sharp.cache(false);
@@ -82,7 +71,18 @@ const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
         });
 };
 
-module.exports.process = process;
+module.exports.process = (options) => {
+    try {
+        require('sharp');
+    } catch (err) {
+        return Promise.reject(new common.errors.InternalServerError({
+            message: 'Sharp wasn\'t installed',
+            code: 'SHARP_INSTALLATION',
+            err: err
+        }));
+    }
+    return unsafeProcess(options)
+};
 module.exports.resizeImage = (buffer, options) => {
     try {
         require('sharp');

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -11,7 +11,6 @@ const fs = require('fs-extra');
 
 const unsafeProcess = (options = {}) => {
     return fs.readFile(options.in)
-        .catch()
         .then((data) => {
             return unsafeResizeImage(data, {
                 width: options.width

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -40,13 +40,6 @@ const unsafeProcess = (options = {}) => {
             } else {
                 return fs.writeFile(options.out, data);
             }
-        })
-        .catch((err) => {
-            throw new common.errors.InternalServerError({
-                message: 'Unable to manipulate image.',
-                err: err,
-                code: 'IMAGE_PROCESSING'
-            });
         });
 };
 
@@ -62,12 +55,6 @@ const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
         .toBuffer()
         .then((resizedBuffer) => {
             return resizedBuffer.length < originalBuffer.length ? resizedBuffer : originalBuffer;
-        }).catch((err) => {
-            throw new common.errors.InternalServerError({
-                message: 'Unable to manipulate image.',
-                err: err,
-                code: 'IMAGE_PROCESSING'
-            });
         });
 };
 
@@ -81,7 +68,13 @@ const makeSafe = fn => (...args) => {
             err: err
         }));
     }
-    return fn(...args);
+    return fn(...args).catch((err) => {
+        throw new common.errors.InternalServerError({
+            message: 'Unable to manipulate image.',
+            err: err,
+            code: 'IMAGE_PROCESSING'
+        });
+    });
 };
 
 module.exports.process = makeSafe(unsafeProcess);

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -61,7 +61,7 @@ const process = (options = {}) => {
         });
 };
 
-const resizeImage = (originalBuffer, {width, height} = {}) => {
+const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
     const sharp = require('sharp');
     return sharp(originalBuffer)
         .resize(width, height, {
@@ -83,7 +83,7 @@ const resizeImage = (originalBuffer, {width, height} = {}) => {
 };
 
 module.exports.process = process;
-module.exports.safeResizeImage = (buffer, options) => {
+module.exports.resizeImage = (buffer, options) => {
     try {
         require('sharp');
     } catch (err) {
@@ -93,5 +93,5 @@ module.exports.safeResizeImage = (buffer, options) => {
             err: err
         }));
     }
-    return resizeImage(buffer, options);
+    return unsafeResizeImage(buffer, options);
 };

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -71,7 +71,7 @@ const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
         });
 };
 
-module.exports.process = (options) => {
+const makeSafe = fn => (...args) => {
     try {
         require('sharp');
     } catch (err) {
@@ -81,17 +81,8 @@ module.exports.process = (options) => {
             err: err
         }));
     }
-    return unsafeProcess(options)
+    return fn(...args);
 };
-module.exports.resizeImage = (buffer, options) => {
-    try {
-        require('sharp');
-    } catch (err) {
-        return Promise.reject(new common.errors.InternalServerError({
-            message: 'Sharp wasn\'t installed',
-            code: 'SHARP_INSTALLATION',
-            err: err
-        }));
-    }
-    return unsafeResizeImage(buffer, options);
-};
+
+module.exports.process = makeSafe(unsafeProcess);
+module.exports.resizeImage = makeSafe(unsafeResizeImage);

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -73,6 +73,12 @@ const resizeImage = (originalBuffer, {width, height} = {}) => {
         .toBuffer()
         .then((resizedBuffer) => {
             return resizedBuffer.length < originalBuffer.length ? resizedBuffer : originalBuffer;
+        }).catch((err) => {
+            throw new common.errors.InternalServerError({
+                message: 'Unable to manipulate image.',
+                err: err,
+                code: 'IMAGE_PROCESSING'
+            });
         });
 };
 
@@ -80,8 +86,12 @@ module.exports.process = process;
 module.exports.safeResizeImage = (buffer, options) => {
     try {
         require('sharp');
-        return resizeImage(buffer, options);
-    } catch (e) {
-        return Promise.resolve(buffer);
+    } catch (err) {
+        return Promise.reject(new common.errors.InternalServerError({
+            message: 'Sharp wasn\'t installed',
+            code: 'SHARP_INSTALLATION',
+            err: err
+        }));
     }
+    return resizeImage(buffer, options);
 };

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -51,7 +51,7 @@ module.exports = function (req, res, next) {
 
         return storageInstance.read({path: originalImagePath})
             .then((originalImageBuffer) => {
-                return image.manipulator.safeResizeImage(originalImageBuffer, imageDimensionConfig);
+                return image.manipulator.resizeImage(originalImageBuffer, imageDimensionConfig);
             })
             .then((resizedImageBuffer) => {
                 return storageInstance.saveRaw(resizedImageBuffer, req.url);

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -58,5 +58,10 @@ module.exports = function (req, res, next) {
             });
     }).then(() => {
         next();
-    }).catch(next);
+    }).catch(function (err) {
+        if (err.code === 'SHARP_INSTALLATION') {
+            return redirectToOriginal();
+        }
+        next(err);
+    });
 };


### PR DESCRIPTION
This cleans up the image manipulator library to reuse code where possible - including errors :+1:

The biggest change is refactoring the process method to use the imageResize method so we're not duplicating logic. 