### PR TITLE
🐛 Update express-hbs fixing asyn helper replace issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "downsize": "0.0.8",
     "express": "4.16.4",
     "express-brute": "1.0.1",
-    "express-hbs": "1.0.4",
+    "express-hbs": "^2.0.1",
     "express-jwt": "5.3.1",
     "express-query-boolean": "2.0.0",
     "express-session": "1.15.6",


### PR DESCRIPTION
closes #9716

The issue came down to express-hbs uses string replace for anonymous helpers but
was using the string version instead of the function version which allows for some
special replacement patterns. This was switch to the function version which does not
use this and just returns the cached value.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

Here was the commit in express-hbs that fixed this issue: https://github.com/barc/express-hbs/commit/1327601c69e0a3445d9127ecd27782989fe08509
