### PR TITLE
Removed `invitedBy` from admin API: invitation endpoint

### DIFF
--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -466,10 +466,7 @@ authentication = {
                         return {invitation: [{valid: false}]};
                     }
 
-                    return models.User.findOne({id: invite.get('created_by')})
-                        .then((user) => {
-                            return {invitation: [{valid: true, invitedBy: user.get('name')}]};
-                        });
+                    return {invitation: [{valid: true}]};
                 });
         }
 


### PR DESCRIPTION
refs #10286

- we want to deprecate all `x_by` fields
- we would like to get rid of all usages to be able to easily remove the fields in the future
- `invitedBy` is not used in the admin client
- the v2 authentication controller is missing still, see #10060 
- admin API is not documented

