### PR TITLE
Ability to not send welcome email

### DIFF
--- a/core/server/api/v0.1/authentication.js
+++ b/core/server/api/v0.1/authentication.js
@@ -534,28 +534,32 @@ authentication = {
 
             common.events.emit('setup.completed', setupUser);
 
-            return mail.utils.generateContent({data: data, template: 'welcome'})
-                .then((content) => {
-                    const message = {
-                            to: setupUser.email,
-                            subject: common.i18n.t('common.api.authentication.mail.yourNewGhostBlog'),
-                            html: content.html,
-                            text: content.text
-                        },
-                        payload = {
-                            mail: [{
-                                message: message,
-                                options: {}
-                            }]
-                        };
+            if (config.get('sendWelcomeEmail')) {
+                return mail.utils.generateContent({data: data, template: 'welcome'})
+                    .then((content) => {
+                        const message = {
+                                to: setupUser.email,
+                                subject: common.i18n.t('common.api.authentication.mail.yourNewGhostBlog'),
+                                html: content.html,
+                                text: content.text
+                            },
+                            payload = {
+                                mail: [{
+                                    message: message,
+                                    options: {}
+                                }]
+                            };
 
-                    mailAPI.send(payload, {context: {internal: true}})
-                        .catch((err) => {
-                            err.context = common.i18n.t('errors.api.authentication.unableToSendWelcomeEmail');
-                            common.logging.error(err);
-                        });
-                })
-                .return(setupUser);
+                        mailAPI.send(payload, {context: {internal: true}})
+                            .catch((err) => {
+                                err.context = common.i18n.t('errors.api.authentication.unableToSendWelcomeEmail');
+                                common.logging.error(err);
+                            });
+                    })
+                    .return(setupUser);
+            }
+
+            return setupUser;
         }
 
         function formatResponse(setupUser) {

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -83,5 +83,6 @@
         "resize": true
     },
     "compress": true,
-    "preloadHeaders": false
+    "preloadHeaders": false,
+    "sendWelcomeEmail": true
 }


### PR DESCRIPTION
no issue

- We need to be able to not send the welcome email if needed
- Introduces a new possible config setting `sendWelcomeEmail` which is set to `true` by default