### PR TITLE
Added quick fix to handle integration upserts for `x_by` columns

### DIFF
--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -404,6 +404,31 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
 
         if (options.context.user || ghostBookshelf.Model.isExternalUser(options.context.user)) {
             return options.context.user;
+        } else if (options.context.integration) {
+            /**
+             * @NOTE:
+             *
+             * This is a dirty hotfix for v0.1 only.
+             * The `x_by` columns are getting deprecated soon (https://github.com/TryGhost/Ghost/issues/10286).
+             *
+             * We return the owner ID '1' in case an integration updates or creates
+             * resources. v0.1 will continue to use the `x_by` columns. v0.1 does not support integrations.
+             * API v2 will introduce a new feature to solve inserting/updating resources
+             * from users or integrations. API v2 won't expose `x_by` columns anymore.
+             *
+             * ---
+             *
+             * Why using ID '1'? WAIT. What???????
+             *
+             * See https://github.com/TryGhost/Ghost/issues/9299.
+             *
+             * We currently don't read the correct owner ID from the database and assume it's '1'.
+             * This is a leftover from switching from auto increment ID's to Object ID's.
+             * But this takes too long to refactor out now. If an internal update happens, we also
+             * use ID '1'. This logic exists for a LONG while now. The owner ID only changes from '1' to something else,
+             * if you transfer ownership.
+             */
+            return ghostBookshelf.Model.internalUser;
         } else if (options.context.internal) {
             return ghostBookshelf.Model.internalUser;
         } else if (this.get('id')) {

--- a/core/server/models/base/index.js
+++ b/core/server/models/base/index.js
@@ -427,6 +427,8 @@ ghostBookshelf.Model = ghostBookshelf.Model.extend({
              * But this takes too long to refactor out now. If an internal update happens, we also
              * use ID '1'. This logic exists for a LONG while now. The owner ID only changes from '1' to something else,
              * if you transfer ownership.
+             *
+             * @TODO: Update this code section as soon as we have decided between `context.api_key_id` and `context.integration`
              */
             return ghostBookshelf.Model.internalUser;
         } else if (options.context.internal) {


### PR DESCRIPTION
refs #10286

- this is just a hotfix for v0.1
- we keep the x_by fields for now and deprecate them
- as soon as an integration updates/inserts a resource, we just store the owner ID
- we currently work on a new concept for v2
- v2 no longer exposes or uses x_by, see https://github.com/TryGhost/Ghost/pull/10294
