### PR TITLE
Custom fields

### DIFF
--- a/core/server/api/v0.1/posts.js
+++ b/core/server/api/v0.1/posts.js
@@ -12,7 +12,7 @@ const Promise = require('bluebird'),
      * @deprecated: `author`, will be removed in Ghost 3.0
      */
     allowedIncludes = [
-        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors', 'authors.roles'
+        'created_by', 'updated_by', 'published_by', 'author', 'tags', 'fields', 'authors', 'authors.roles', 'custom_field_values'
     ],
     unsafeAttrs = ['author_id', 'status', 'authors'];
 

--- a/core/server/api/v2/posts.js
+++ b/core/server/api/v2/posts.js
@@ -1,7 +1,7 @@
 const models = require('../../models');
 const common = require('../../lib/common');
 const urlService = require('../../services/url');
-const allowedIncludes = ['created_by', 'updated_by', 'published_by', 'author', 'tags', 'authors', 'authors.roles'];
+const allowedIncludes = ['created_by', 'updated_by', 'published_by', 'author', 'tags', 'authors', 'authors.roles', 'custom_field_values'];
 const unsafeAttrs = ['author_id', 'status', 'authors'];
 
 module.exports = {

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -113,6 +113,15 @@ module.exports = {
                 return setting.key === 'type';
             });
 
+            // Update custom fields
+            let customFieldSetting = frame.data.settings.find((setting) => {
+                return setting.key === 'custom_fields';
+            });
+            if (customFieldSetting !== undefined) {
+                let customFields = JSON.parse(customFieldSetting.value);
+                models.CustomField.edit(customFields, frame.options);
+            }
+
             return models.Settings.edit(frame.data.settings, frame.options);
         }
     },

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -32,7 +32,18 @@ module.exports = {
                 });
             }
 
-            return settings;
+            // CASE: append custom fields
+            return models.CustomField.findAll()
+                .then((models) => {
+                    const fields = models.map((field) => {
+                        return field.toJSON();
+                    });
+                    
+                    var index = _.findIndex(settings, {key: 'custom_fields'});
+                    settings[index].value = JSON.stringify(fields);
+
+                    return settings;
+                });
         }
     },
 

--- a/core/server/data/migrations/versions/2.3/3-add-custom-fields-table.js
+++ b/core/server/data/migrations/versions/2.3/3-add-custom-fields-table.js
@@ -1,0 +1,35 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+const table = 'custom_fields';
+const message1 = 'Adding table: ' + table;
+const message2 = 'Dropping table: ' + table;
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return;
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return;
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/migrations/versions/2.3/4-add-custom-field-values-table.js
+++ b/core/server/data/migrations/versions/2.3/4-add-custom-field-values-table.js
@@ -1,0 +1,35 @@
+const common = require('../../../../lib/common');
+const commands = require('../../../schema').commands;
+const table = 'custom_field_values';
+const message1 = 'Adding table: ' + table;
+const message2 = 'Dropping table: ' + table;
+
+module.exports.up = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (exists) {
+                common.logging.warn(message1);
+                return;
+            }
+
+            common.logging.info(message1);
+            return commands.createTable(table, connection);
+        });
+};
+
+module.exports.down = (options) => {
+    const connection = options.connection;
+
+    return connection.schema.hasTable(table)
+        .then(function (exists) {
+            if (!exists) {
+                common.logging.warn(message2);
+                return;
+            }
+
+            common.logging.info(message2);
+            return commands.deleteTable(table, connection);
+        });
+};

--- a/core/server/data/schema/default-settings.json
+++ b/core/server/data/schema/default-settings.json
@@ -88,6 +88,9 @@
         "navigation": {
             "defaultValue": "[{\"label\":\"Home\", \"url\":\"/\"},{\"label\":\"Tag\", \"url\":\"/tag/getting-started/\"}, {\"label\":\"Author\", \"url\":\"/author/ghost/\"},{\"label\":\"Help\", \"url\":\"https://help.ghost.org\"}]"
         },
+        "custom_fields": {
+            "defaultValue": "[]"
+        },
         "slack": {
             "defaultValue": "[{\"url\":\"\", \"username\":\"Ghost\"}]"
         },

--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -378,5 +378,24 @@ module.exports = {
         created_by: {type: 'string', maxlength: 24, nullable: false},
         updated_at: {type: 'dateTime', nullable: true},
         updated_by: {type: 'string', maxlength: 24, nullable: true}
+    },
+    custom_fields: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        type: {
+            type: 'string',
+            maxlength: 50,
+            nullable: false,
+            validations: {isIn: [['Text', 'Number', 'Boolean']]}
+        },
+        name: {type: 'string', maxlength: 191, nullable: false}
+    },
+    custom_field_values: {
+        id: {type: 'string', maxlength: 24, nullable: false, primary: true},
+        field_id: {type: 'string', maxlength: 24, nullable: false, references: 'custom_fields.id'},
+        post_id: {type: 'string', maxlength: 24, nullable: false, references: 'posts.id'},
+        created_at: {type: 'dateTime', nullable: false},
+        created_by: {type: 'string', maxlength: 24, nullable: false},
+        updated_at: {type: 'dateTime', nullable: true},
+        value: {type: 'string', maxlength: 2000, nullable: false}
     }
 };

--- a/core/server/models/custom-field-value.js
+++ b/core/server/models/custom-field-value.js
@@ -1,0 +1,55 @@
+let ghostBookshelf = require('./base'),
+    CustomFieldValue,
+    CustomFieldValues;
+
+CustomFieldValue = ghostBookshelf.Model.extend({
+    tableName: 'custom_field_values',
+    serialize() {
+        return {
+            id: this.get('id'),
+            field_id: this.get('field_id'),
+            value: this.get('value')
+        };
+    }
+}, {
+    edit: function (values, options) {
+        return Promise.map(values, function (item) {
+            // TODO: some validation
+            return CustomFieldValue
+                .forge({field_id: item.field_id, post_id: options.id})
+                .fetch()
+                .then((customValue) => {
+                    if (customValue) {
+                        if (item.value === null || item.value === '') {
+                            return customValue.destroy();
+                        }
+
+                        customValue.set('value', item.value);
+
+                        if (customValue.hasChanged()) {
+                            return customValue.save(null, {});
+                        }
+
+                        return customValue;
+                    }
+
+                    if (item.value !== null) {
+                        return CustomFieldValue.forge({
+                            field_id: item.field_id, 
+                            post_id: options.id, 
+                            value: item.value
+                        }).save(null, {});
+                    }
+                });
+        });
+    }
+});
+
+CustomFieldValues = ghostBookshelf.Collection.extend({
+    model: CustomFieldValue
+});
+
+module.exports = {
+    CustomFieldValue: ghostBookshelf.model('CustomFieldValue', CustomFieldValue),
+    CustomFieldValues: ghostBookshelf.collection('CustomFieldValues', CustomFieldValues)
+};

--- a/core/server/models/custom-field.js
+++ b/core/server/models/custom-field.js
@@ -3,7 +3,44 @@ let ghostBookshelf = require('./base'),
     CustomFields;
 
 CustomField = ghostBookshelf.Model.extend({
-    tableName: 'custom_fields'
+    tableName: 'custom_fields',
+    custom_field_values() {
+        return this.hasMany('CustomFieldValue', 'field_id');
+    }
+}, {
+    edit: function (data, options) {
+        return Promise.map(data, function (item) {
+            // TODO: some validation
+            return CustomField.forge({name: item.name})
+                .fetch(options)
+                .then((customField) => {
+                    if (customField) {
+                        customField.set('type', item.type);
+                        customField.set('name', item.name);
+
+                        if (customField.hasChanged()) {
+                            return customField.save(null, options);
+                        }
+
+                        return customField;
+                    }
+
+                    return CustomField.forge(item).save(null, options);
+                });
+        }).then(() => {
+            options.withRelated = ['custom_field_values'];
+
+            return CustomField.where('name', 'NOT IN', data.map(item => item.name))
+                .fetchAll(options)
+                .then((collection) => {
+                    collection.forEach((customField) => {
+                        return customField.related('custom_field_values')
+                            .invokeThen('destroy', options)
+                            .then(() => customField.destroy(null, options));
+                    });
+                });
+        });
+    }
 });
 
 CustomFields = ghostBookshelf.Collection.extend({

--- a/core/server/models/custom-field.js
+++ b/core/server/models/custom-field.js
@@ -1,0 +1,16 @@
+let ghostBookshelf = require('./base'),
+    CustomField,
+    CustomFields;
+
+CustomField = ghostBookshelf.Model.extend({
+    tableName: 'custom_fields'
+});
+
+CustomFields = ghostBookshelf.Collection.extend({
+    model: CustomField
+});
+
+module.exports = {
+    CustomField: ghostBookshelf.model('CustomField', CustomField),
+    CustomFields: ghostBookshelf.collection('CustomFields', CustomFields)
+};

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -35,7 +35,8 @@ models = [
     'integration',
     'api-key',
     'mobiledoc-revision',
-    'member'
+    'member',
+    'custom-field'
 ];
 
 function init() {

--- a/core/server/models/index.js
+++ b/core/server/models/index.js
@@ -36,7 +36,8 @@ models = [
     'api-key',
     'mobiledoc-revision',
     'member',
-    'custom-field'
+    'custom-field',
+    'custom-field-value'
 ];
 
 function init() {

--- a/core/server/models/post.js
+++ b/core/server/models/post.js
@@ -438,6 +438,10 @@ Post = ghostBookshelf.Model.extend({
         return this.hasMany('MobiledocRevision', 'post_id');
     },
 
+    custom_field_values() {
+        return this.hasMany('CustomFieldValue', 'post_id');
+    },
+
     /**
      * @NOTE:
      * If you are requesting models with `columns`, you try to only receive some fields of the model/s.
@@ -684,6 +688,12 @@ Post = ghostBookshelf.Model.extend({
 
         const editPost = () => {
             options.forUpdate = true;
+
+            // Update custom field values
+            let customValues = data.custom_field_values;
+            if (customValues !== null) {
+                ghostBookshelf.model('CustomFieldValue').edit(customValues, options);
+            }
 
             return ghostBookshelf.Model.edit.call(this, data, options)
                 .then((post) => {

--- a/core/test/functional/api/v0.1/db_spec.js
+++ b/core/test/functional/api/v0.1/db_spec.js
@@ -89,7 +89,7 @@ describe('DB API', function () {
                 var jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(25);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
                 done();
             });
     });
@@ -107,7 +107,7 @@ describe('DB API', function () {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(29);
                 done();
             });
     });

--- a/core/test/functional/api/v2/admin/db_spec.js
+++ b/core/test/functional/api/v2/admin/db_spec.js
@@ -67,7 +67,7 @@ describe('DB API', () => {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(25);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
             });
     });
 
@@ -80,7 +80,7 @@ describe('DB API', () => {
                 const jsonResponse = res.body;
                 should.exist(jsonResponse.db);
                 jsonResponse.db.should.have.length(1);
-                Object.keys(jsonResponse.db[0].data).length.should.eql(27);
+                Object.keys(jsonResponse.db[0].data).length.should.eql(29);
             });
     });
 

--- a/core/test/unit/data/schema/integrity_spec.js
+++ b/core/test/unit/data/schema/integrity_spec.js
@@ -19,7 +19,7 @@ var should = require('should'),
  */
 describe('DB version integrity', function () {
     // Only these variables should need updating
-    const currentSchemaHash = 'b865478398cd2b0a1e5eaffebccdb88c';
+    const currentSchemaHash = '9bfd3312371057f397f5b5bdfc299a6b';
     const currentFixturesHash = '8b36d1e72c29b7f9073612142b5a8783';
 
     // If this test is failing, then it is likely a change has been made that requires a DB version bump,


### PR DESCRIPTION
**Issue**: https://github.com/TryGhost/Ghost/issues/9020 and https://forum.ghost.org/t/custom-fields-for-posts/1124/8
**Use in conjunction with**: https://github.com/TryGhost/Ghost-Admin/pull/1089

---

This PR adds custom field logic in two new tables: `custom_field` storing type and name, and `custom_field_value` storing the value with reference to field and post. In the `settings` endpoint fields are returned and can be added/removed/updated. In the `posts` endpoint custom field values are included and can be updated. When a field is removed related values are removed, and when a post is deleted corresponding values are also removed.

NOTE: I have very limited experience with Ghost. Even though the linter and tests pass, I am not convinced this PR meets all coding standards. I don't have a lot of time coming few months, so by all means contribute or hijack this branch/PR to improve :)