### PR TITLE
🐛 Used unoptimized image when possible for dynamic images

### DIFF
--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -47,9 +47,12 @@ module.exports = function (req, res, next) {
             return;
         }
 
-        const originalImagePath = path.relative(sizeImageDir, req.url);
+        const imagePath = path.relative(sizeImageDir, req.url);
 
-        return storageInstance.read({path: originalImagePath})
+        return Promise.resolve(imagePath)
+            .then((path) => {
+                return storageInstance.read({path});
+            })
             .then((originalImageBuffer) => {
                 return image.manipulator.resizeImage(originalImageBuffer, imageDimensionConfig);
             })


### PR DESCRIPTION
closes #10283 

Updated middleware for dynamic image sizes to attempt to read the unoptimized image first, taking into account the `-n` suffix for duplicate image names, by using a regex.