### PR TITLE
🐛 Redirected to original image for gifs & svgs

### DIFF
--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -36,6 +36,10 @@ const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
         });
 };
 
+// NOTE: .gif optimization is currently not supported by sharp but will be soon
+//       as there has been support added in underlying libvips library https://github.com/lovell/sharp/issues/1372
+//       As for .svg files, sharp only supports conversion to png, and this does not
+//       play well with animated svg files
 const canTransformFileExtension = ext => !['.gif', '.svg', '.svgz'].includes(ext);
 
 const makeSafe = fn => (...args) => {

--- a/core/server/lib/image/manipulator.js
+++ b/core/server/lib/image/manipulator.js
@@ -36,6 +36,8 @@ const unsafeResizeImage = (originalBuffer, {width, height} = {}) => {
         });
 };
 
+const canTransformFileExtension = ext => !['.gif', '.svg', '.svgz'].includes(ext);
+
 const makeSafe = fn => (...args) => {
     try {
         require('sharp');
@@ -55,5 +57,6 @@ const makeSafe = fn => (...args) => {
     });
 };
 
+module.exports.canTransformFileExtension = canTransformFileExtension;
 module.exports.process = makeSafe(unsafeProcess);
 module.exports.resizeImage = makeSafe(unsafeResizeImage);

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -16,7 +16,7 @@ module.exports = function (req, res, next) {
         return res.redirect(url);
     };
 
-    // CASE: image manipulator is uncapable of transforming file (e.g. .gif))
+    // CASE: image manipulator is uncapable of transforming file (e.g. .gif)
     const requestUrlFileExtension = path.parse(req.url).ext;
     if (!image.manipulator.canTransformFileExtension(requestUrlFileExtension)) {
         return redirectToOriginal();

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -4,7 +4,7 @@ const storage = require('../../../../adapters/storage');
 const activeTheme = require('../../../../services/themes/active');
 
 const SIZE_PATH_REGEX = /^\/size\/([^/]+)\//;
-const UNRESIZABLE_FILETYPE_REGEX = /\.(?:gif|svgz?)$/;
+const UNRESIZABLE_FILETYPES = ['.gif', '.svg', '.svgz'];
 
 module.exports = function (req, res, next) {
     if (!SIZE_PATH_REGEX.test(req.url)) {
@@ -18,7 +18,8 @@ module.exports = function (req, res, next) {
     };
 
     // CASE: url ends in .gif OR .svg (OR .svgz)
-    if (UNRESIZABLE_FILETYPE_REGEX.test(req.url)) {
+    const requestUrlFileExtension = path.parse(req.url).ext;
+    if (UNRESIZABLE_FILETYPES.includes(requestUrlFileExtension)) {
         return redirectToOriginal();
     }
 

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -4,6 +4,7 @@ const storage = require('../../../../adapters/storage');
 const activeTheme = require('../../../../services/themes/active');
 
 const SIZE_PATH_REGEX = /^\/size\/([^/]+)\//;
+const UNRESIZABLE_FILETYPE_REGEX = /\.(?:gif|svgz?)$/;
 
 module.exports = function (req, res, next) {
     if (!SIZE_PATH_REGEX.test(req.url)) {
@@ -15,6 +16,11 @@ module.exports = function (req, res, next) {
         const url = req.originalUrl.replace(`/size/${requestedDimension}`, '');
         return res.redirect(url);
     };
+
+    // CASE: url ends in .gif OR .svg (OR .svgz)
+    if (UNRESIZABLE_FILETYPE_REGEX.test(req.url)) {
+        return redirectToOriginal();
+    }
 
     const imageSizes = activeTheme.get().config('image_sizes');
     // CASE: no image_sizes config

--- a/core/server/web/shared/middlewares/image/handle-image-sizes.js
+++ b/core/server/web/shared/middlewares/image/handle-image-sizes.js
@@ -4,7 +4,6 @@ const storage = require('../../../../adapters/storage');
 const activeTheme = require('../../../../services/themes/active');
 
 const SIZE_PATH_REGEX = /^\/size\/([^/]+)\//;
-const UNRESIZABLE_FILETYPES = ['.gif', '.svg', '.svgz'];
 
 module.exports = function (req, res, next) {
     if (!SIZE_PATH_REGEX.test(req.url)) {
@@ -17,9 +16,9 @@ module.exports = function (req, res, next) {
         return res.redirect(url);
     };
 
-    // CASE: url ends in .gif OR .svg (OR .svgz)
+    // CASE: image manipulator is uncapable of transforming file (e.g. .gif))
     const requestUrlFileExtension = path.parse(req.url).ext;
-    if (UNRESIZABLE_FILETYPES.includes(requestUrlFileExtension)) {
+    if (!image.manipulator.canTransformFileExtension(requestUrlFileExtension)) {
         return redirectToOriginal();
     }
 

--- a/core/server/web/shared/middlewares/image/normalize.js
+++ b/core/server/web/shared/middlewares/image/normalize.js
@@ -7,11 +7,8 @@ const image = require('../../../../lib/image');
 module.exports = function normalize(req, res, next) {
     const imageOptimizationOptions = config.get('imageOptimization');
 
-    // NOTE: .gif optimization is currently not supported by sharp but will be soon
-    //       as there has been support added in underlying libvips library https://github.com/lovell/sharp/issues/1372
-    //       As for .svg files, sharp only supports conversion to png, and this does not
-    //       play well with animated svg files
-    if (!imageOptimizationOptions.resize || !image.manipulator.canTransformFileExtension(req.file.ext)) {
+    // CASE: image manipulator is uncapable of transforming file (e.g. .gif)
+    if (!image.manipulator.canTransformFileExtension(req.file.ext) || !imageOptimizationOptions.resize) {
         return next();
     }
 

--- a/core/server/web/shared/middlewares/image/normalize.js
+++ b/core/server/web/shared/middlewares/image/normalize.js
@@ -11,7 +11,7 @@ module.exports = function normalize(req, res, next) {
     //       as there has been support added in underlying libvips library https://github.com/lovell/sharp/issues/1372
     //       As for .svg files, sharp only supports conversion to png, and this does not
     //       play well with animated svg files
-    if (!imageOptimizationOptions.resize || ['.gif', '.svg', '.svgz'].includes(req.file.ext)) {
+    if (!imageOptimizationOptions.resize || !image.manipulator.canTransformFileExtension(req.file.ext)) {
         return next();
     }
 

--- a/core/test/unit/lib/image/manipulator_spec.js
+++ b/core/test/unit/lib/image/manipulator_spec.js
@@ -12,6 +12,27 @@ describe('lib/image: manipulator', function () {
         testUtils.unmockNotExistingModule();
     });
 
+    describe('canTransformFileExtension', function () {
+        it('returns false for ".gif"', function () {
+            should.equal(
+                manipulator.canTransformFileExtension('.gif'),
+                false
+            );
+        });
+        it('returns false for ".svg"', function () {
+            should.equal(
+                manipulator.canTransformFileExtension('.svg'),
+                false
+            );
+        });
+        it('returns false for ".svgz"', function () {
+            should.equal(
+                manipulator.canTransformFileExtension('.svgz'),
+                false
+            );
+        });
+    });
+
     describe('cases', function () {
         let sharp, sharpInstance;
 


### PR DESCRIPTION
closes #10301 

ronseal really - if the image is gif/svg, redirect to unresized version.

it might be worth pulling the regex out into the image module maybe? and having a test for it?