### PR TITLE
Fixed redirects to forward hashes correctly

### DIFF
--- a/core/server/web/shared/middlewares/custom-redirects.js
+++ b/core/server/web/shared/middlewares/custom-redirects.js
@@ -23,6 +23,13 @@ _private.registerRoutes = () => {
 
         redirects.forEach((redirect) => {
             /**
+             * Extract target info, such as hash.
+             * 
+             * Required to re-formulate the correct endpoint.
+             */
+            const parsedTo = url.parse(redirect.to);
+
+            /**
              * Detect case insensitive modifier when regex is enclosed by
              * / ... /i
              */
@@ -55,10 +62,10 @@ _private.registerRoutes = () => {
                 res.set({
                     'Cache-Control': `public, max-age=${maxAge}`
                 });
-
                 res.redirect(redirect.permanent ? 301 : 302, url.format({
-                    pathname: parsedUrl.pathname.replace(new RegExp(redirect.from, options), redirect.to),
-                    search: parsedUrl.search
+                    pathname: parsedUrl.pathname.replace(new RegExp(redirect.from, options), parsedTo.pathname),
+                    search: parsedUrl.search,
+                    hash: parsedTo.hash
                 }));
             });
         });


### PR DESCRIPTION
closes #10290 
See that discussion for some details, and note that we aren't handling search params in any special way in the `to` directive to keep change simple.