### PR TITLE
Shorten api key lengths

### DIFF
--- a/core/server/data/schema/schema.js
+++ b/core/server/data/schema/schema.js
@@ -350,7 +350,7 @@ module.exports = {
             maxlength: 191,
             nullable: false,
             unique: true,
-            validations: {isLength: {min: 128, max: 128}}
+            validations: {isLength: {min: 26, max: 128}}
         },
         role_id: {type: 'string', maxlength: 24, nullable: true},
         // integration_id is nullable to allow "internal" API keys that don't show in the UI

--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -2,14 +2,32 @@ const crypto = require('crypto');
 const ghostBookshelf = require('./base');
 const {Role} = require('./role');
 
-const createSecret = () => crypto.randomBytes(64).toString('hex');
+/*
+ * Uses birthday problem estimation to calculate chance of collision
+ * d = 16^26        // 26 char hex string
+ * n = 10,000,000   // 10 million
+ *
+ *       (-n x (n-1)) / 2d
+ * 1 - e^
+ *
+ *
+ *           17
+ * ~= 4 x 10^
+ *
+ * ref: https://medium.freecodecamp.org/how-long-should-i-make-my-api-key-833ebf2dc26f
+ * ref: https://en.wikipedia.org/wiki/Birthday_problem#Approximations
+ */
+const createSecret = (type) => {
+    const bytes = type === 'content' ? 13 : 64;
+    return crypto.randomBytes(bytes).toString('hex');
+};
 
 const ApiKey = ghostBookshelf.Model.extend({
     tableName: 'api_keys',
 
     defaults() {
         // 512bit key for HS256 JWT signing
-        const secret = createSecret();
+        const secret = createSecret(this.get('type'));
 
         return {
             secret

--- a/core/server/models/api-key.js
+++ b/core/server/models/api-key.js
@@ -16,6 +16,9 @@ const {Role} = require('./role');
  *
  * ref: https://medium.freecodecamp.org/how-long-should-i-make-my-api-key-833ebf2dc26f
  * ref: https://en.wikipedia.org/wiki/Birthday_problem#Approximations
+ *
+ * 26 char hex string = 13 bytes
+ * 512 bit JWT secret     = 64 bytes
  */
 const createSecret = (type) => {
     const bytes = type === 'content' ? 13 : 64;
@@ -26,7 +29,6 @@ const ApiKey = ghostBookshelf.Model.extend({
     tableName: 'api_keys',
 
     defaults() {
-        // 512bit key for HS256 JWT signing
         const secret = createSecret(this.get('type'));
 
         return {

--- a/core/test/unit/models/api-key_spec.js
+++ b/core/test/unit/models/api-key_spec.js
@@ -29,6 +29,16 @@ describe('Unit: models/api_key', function () {
             });
         });
 
+        it('sets default secret for content key', function () {
+            const attrs = {
+                type: 'content'
+            };
+
+            return models.ApiKey.add(attrs).then((api_key) => {
+                api_key.get('secret').length.should.eql(26);
+            });
+        });
+
         it('sets hardcoded role for key type', function () {
             // roles[5] = 'Admin Integration'
             const role_id = testUtils.DataGenerator.forKnex.roles[5].id;


### PR DESCRIPTION
refs #10156

This addresses the length of Content API Keys only, so I'm not 100% sure if we should leave the issue open for when Admin API access is done too

