### PR TITLE
Public Settings API Endpoint

### DIFF
--- a/core/server/api/v0.1/settings.js
+++ b/core/server/api/v0.1/settings.js
@@ -30,14 +30,14 @@ let settings,
  * @returns {*}
  */
 settingsFilter = (settings, filter) => {
-    return _.fromPairs(_.toPairs(settings).filter((setting) => {
-        if (filter) {
-            return _.some(filter.split(','), (f) => {
-                return setting[1].type === f;
-            });
+    let filteredTypes = filter ? filter.split(',') : false;
+    return _.filter(settings, (setting) => {
+        if (filteredTypes) {
+            return _.includes(filteredTypes, setting.type);
         }
+
         return true;
-    }));
+    });
 };
 
 /**

--- a/core/server/api/v2/index.js
+++ b/core/server/api/v2/index.js
@@ -93,5 +93,9 @@ module.exports = {
 
     get configuration() {
         return shared.pipeline(require('./configuration'), localUtils);
+    },
+
+    get publicSettings() {
+        return shared.pipeline(require('./settings-public'), localUtils);
     }
 };

--- a/core/server/api/v2/settings-public.js
+++ b/core/server/api/v2/settings-public.js
@@ -1,0 +1,12 @@
+const settingsCache = require('../../services/settings/cache');
+
+module.exports = {
+    docName: 'settings',
+
+    browse: {
+        permissions: true,
+        query() {
+            return settingsCache.getPublic();
+        }
+    }
+};

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -28,7 +28,7 @@ module.exports = {
             // CASE: omit core settings unless internal request
             if (!frame.options.context.internal) {
                 settings = _.filter(settings, (setting) => {
-                    return setting.type !== 'core' && setting.key !== 'permalinks';
+                    return setting.type !== 'core';
                 });
             }
 

--- a/core/server/api/v2/utils/serializers/output/settings.js
+++ b/core/server/api/v2/utils/serializers/output/settings.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const utils = require('../../index');
 const _private = {};
 const deprecatedSettings = ['force_i18n', 'permalinks'];
 
@@ -23,7 +24,13 @@ _private.settingsFilter = (settings, filter) => {
 
 module.exports = {
     browse(models, apiConfig, frame) {
-        let filteredSettings = _.values(_private.settingsFilter(models, frame.options.type));
+        let filteredSettings;
+        // If this is public, we already have the right data, we just need to add an Array wrapper
+        if (utils.isContentAPI(frame)) {
+            filteredSettings = models;
+        } else {
+            filteredSettings = _.values(_private.settingsFilter(models, frame.options.type));
+        }
 
         frame.response = {
             settings: filteredSettings,

--- a/core/server/api/v2/utils/serializers/output/settings.js
+++ b/core/server/api/v2/utils/serializers/output/settings.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const _private = {};
+const deprecatedSettings = ['force_i18n', 'permalinks'];
 
 /**
  * ### Settings Filter
@@ -10,14 +11,14 @@ const _private = {};
  * @returns {*}
  */
 _private.settingsFilter = (settings, filter) => {
-    return _.fromPairs(_.toPairs(settings).filter((setting) => {
-        if (filter) {
-            return _.some(filter.split(','), (f) => {
-                return setting[1].type === f;
-            });
+    let filteredTypes = filter ? filter.split(',') : false;
+    return _.filter(settings, (setting) => {
+        if (filteredTypes) {
+            return _.includes(filteredTypes, setting.type) && !_.includes(deprecatedSettings, setting.key);
         }
-        return true;
-    }));
+
+        return !_.includes(deprecatedSettings, setting.key);
+    });
 };
 
 module.exports = {

--- a/core/server/apps/amp/lib/views/amp.hbs
+++ b/core/server/apps/amp/lib/views/amp.hbs
@@ -29,7 +29,7 @@
     {{#post}}
     <header class="main-header">
         <nav class="blog-title">
-            <a href="{{@blog.url}}">{{@blog.title}}</a>
+            <a href="{{@site.url}}">{{@site.title}}</a>
         </nav>
     </header>
 
@@ -58,7 +58,7 @@
     </main>
     {{/post}}
     <footer class="site-footer clearfix">
-        <section class="copyright"><a href="{{@blog.url}}">{{@blog.title}}</a> &copy; {{date format="YYYY"}}</section>
+        <section class="copyright"><a href="{{@site.url}}">{{@site.title}}</a> &copy; {{date format="YYYY"}}</section>
         <section class="poweredby">Proudly published with <a href="https://ghost.org">Ghost</a></section>
     </footer>
 </body>

--- a/core/server/apps/private-blogging/lib/views/private.hbs
+++ b/core/server/apps/private-blogging/lib/views/private.hbs
@@ -5,7 +5,7 @@
         <meta http-equiv="Content-Type" content="text/html" charset="UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 
-        <title>{{@blog.title}} - Private Site Access</title>
+        <title>{{@site.title}} - Private Site Access</title>
 
         <meta name="HandheldFriendly" content="True">
         <meta name="MobileOptimized" content="320">

--- a/core/server/apps/subscribers/lib/views/subscribe.hbs
+++ b/core/server/apps/subscribers/lib/views/subscribe.hbs
@@ -24,7 +24,7 @@
             <div class="gh-flow">
                 <header class="gh-flow-head">
                     <nav class="gh-flow-nav">
-                        <a href="{{#if subscribed_url}}{{subscribed_url}}{{else}}{{@blog.url}}{{/if}}" class="gh-flow-back">
+                        <a href="{{#if subscribed_url}}{{subscribed_url}}{{else}}{{@site.url}}{{/if}}" class="gh-flow-back">
                             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
                             <svg width="17px" height="27px" viewBox="0 0 17 27" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <!-- Generator: Sketch 39.1 (31720) - http://www.bohemiancoding.com/sketch -->
@@ -46,7 +46,7 @@
                     <section class="gh-flow-content">
                         {{^if success}}
                             <header>
-                                <h1>Subscribe to {{@blog.title}}</h1>
+                                <h1>Subscribe to {{@site.title}}</h1>
                             </header>
 
                             {{subscribe_form
@@ -62,7 +62,7 @@
                             </header>
 
                             <p>
-                                You've successfully subscribed to <em>{{@blog.title}}</em>
+                                You've successfully subscribed to <em>{{@site.title}}</em>
                                 with the email address <em>{{email}}</em>.
                             </p>
                         {{/if}}

--- a/core/server/data/importer/importers/data/settings.js
+++ b/core/server/data/importer/importers/data/settings.js
@@ -3,7 +3,7 @@ const debug = require('ghost-ignition').debug('importer:settings'),
     _ = require('lodash'),
     BaseImporter = require('./base'),
     models = require('../../../../models'),
-    defaultSettings = require('../../../schema/default-settings.json'),
+    defaultSettings = require('../../../schema').defaultSettings,
     labsDefaults = JSON.parse(defaultSettings.blog.labs.defaultValue);
 
 class SettingsImporter extends BaseImporter {

--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -1,0 +1,22 @@
+/**
+ * The settings with type "blog" were originally meant to be public
+ * This has been misused - unsplash and slack are incorrectly stored there
+ * https://github.com/TryGhost/Ghost/issues/10318
+ *
+ * This file acts as a new whitelist for "public" settings
+ */
+
+module.exports = {
+    title: 'title',
+    description: 'description',
+    logo: 'logo',
+    icon: 'icon',
+    cover_image: 'cover_image',
+    facebook: 'facebook',
+    twitter: 'twitter',
+    default_locale: 'lang',
+    active_timezone: 'timezone',
+    ghost_head: 'ghost_head',
+    ghost_foot: 'ghost_foot',
+    navigation: 'navigation'
+};

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -45,7 +45,7 @@ themeMiddleware.ensureActiveTheme = function ensureActiveTheme(req, res, next) {
 themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next) {
     // Static information, same for every request unless the settings change
     // @TODO: bind this once and then update based on events?
-    var blogData = settingsCache.getPublic(),
+    var siteData = settingsCache.getPublic(),
         labsData = _.cloneDeep(settingsCache.get('labs')),
         themeData = {};
 
@@ -66,7 +66,7 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
     // Request-specific information
     // These things are super dependent on the request, so they need to be in middleware
     // Serve the blog url without trailing slash
-    blogData.url = urlService.utils.urlFor('home', {secure: req.secure, trailingSlash: false}, true);
+    siteData.url = urlService.utils.urlFor('home', {secure: req.secure, trailingSlash: false}, true);
 
     // Pass 'secure' flag to the view engine
     // so that templates can choose to render https or http 'url', see url utility
@@ -75,7 +75,8 @@ themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next)
     // @TODO: only do this if something changed?
     hbs.updateTemplateOptions({
         data: {
-            blog: blogData,
+            blog: siteData,
+            site: siteData,
             labs: labsData,
             config: themeData
         }

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -45,18 +45,7 @@ themeMiddleware.ensureActiveTheme = function ensureActiveTheme(req, res, next) {
 themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next) {
     // Static information, same for every request unless the settings change
     // @TODO: bind this once and then update based on events?
-    var blogData = {
-            title: settingsCache.get('title'),
-            description: settingsCache.get('description'),
-            facebook: settingsCache.get('facebook'),
-            twitter: settingsCache.get('twitter'),
-            timezone: settingsCache.get('active_timezone'),
-            navigation: settingsCache.get('navigation'),
-            icon: settingsCache.get('icon'),
-            cover_image: settingsCache.get('cover_image'),
-            logo: settingsCache.get('logo'),
-            amp: settingsCache.get('amp')
-        },
+    var blogData = settingsCache.getPublic(),
         labsData = _.cloneDeep(settingsCache.get('labs')),
         themeData = {};
 

--- a/core/server/services/url/utils.js
+++ b/core/server/services/url/utils.js
@@ -316,7 +316,7 @@ function urlFor(context, data, absolute) {
         urlPath = getBlogUrl(secure);
 
         // CASE: there are cases where urlFor('home') needs to be returned without trailing
-        // slash e. g. the `{{@blog.url}}` helper. See https://github.com/TryGhost/Ghost/issues/8569
+        // slash e. g. the `{{@site.url}}` helper. See https://github.com/TryGhost/Ghost/issues/8569
         if (data && data.trailingSlash === false) {
             urlPath = urlPath.replace(/\/$/, '');
         }

--- a/core/server/views/error.hbs
+++ b/core/server/views/error.hbs
@@ -32,7 +32,7 @@
                     <section class="error-message">
                       <h1 class="error-code">{{statusCode}}</h1>
                       <h2 class="error-description">{{message}}</h2>
-                      <a class="error-link" href="{{@blog.url}}">Go to the front page →</a>
+                      <a class="error-link" href="{{@site.url}}">Go to the front page →</a>
                     </section>
                   </section>
                 </section>

--- a/core/server/web/api/v2/content/routes.js
+++ b/core/server/web/api/v2/content/routes.js
@@ -28,5 +28,8 @@ module.exports = function apiRoutes() {
     router.get('/tags/:id', mw.authenticatePublic, apiv2.http(apiv2.tagsPublic.read));
     router.get('/tags/slug/:slug', mw.authenticatePublic, apiv2.http(apiv2.tagsPublic.read));
 
+    // ## Settings
+    router.get('/settings', mw.authenticatePublic, apiv2.http(apiv2.publicSettings.browse));
+
     return router;
 };

--- a/core/test/functional/api/v2/content/settings_spec.js
+++ b/core/test/functional/api/v2/content/settings_spec.js
@@ -1,0 +1,60 @@
+const should = require('should');
+const supertest = require('supertest');
+const _ = require('lodash');
+const testUtils = require('../../../../utils');
+const localUtils = require('./utils');
+const config = require('../../../../../server/config');
+
+// Values to test against
+const publicSettings = require('../../../../../server/services/settings/public');
+const defaultSettings = require('../../../../../server/data/schema').defaultSettings.blog;
+
+const ghost = testUtils.startGhost;
+let request;
+
+describe('Settings', function () {
+    before(function () {
+        return ghost()
+            .then(function () {
+                request = supertest.agent(config.get('url'));
+            }).then(function () {
+                return testUtils.initFixtures('api_keys');
+            });
+    });
+
+    it('browse settings', function () {
+        const key = localUtils.getValidKey();
+        return request.get(localUtils.API.getApiQuery(`settings/?key=${key}`))
+            .set('Origin', testUtils.API.getURL())
+            .expect('Content-Type', /json/)
+            .expect('Cache-Control', testUtils.cacheRules.private)
+            .expect(200)
+            .then((res) => {
+                res.headers.vary.should.eql('Accept-Encoding');
+                should.exist(res.headers['access-control-allow-origin']);
+                should.not.exist(res.headers['x-cache-invalidate']);
+
+                const jsonResponse = res.body;
+                should.exist(jsonResponse.settings);
+                should.exist(jsonResponse.meta);
+
+                jsonResponse.settings.should.be.an.Object();
+                const settings = jsonResponse.settings;
+
+                // Verify we have the right keys for settings
+                settings.should.have.properties(_.values(publicSettings));
+
+                // Verify that we are returning the defaults for each value
+                _.forEach(settings, (value, key) => {
+                    let defaultKey = _.findKey(publicSettings, (v) => v === key);
+                    let defaultValue = _.find(defaultSettings, (setting) => setting.key === defaultKey).defaultValue;
+
+                    if (defaultKey === 'navigation') {
+                        defaultValue = JSON.parse(defaultValue);
+                    }
+
+                    value.should.eql(defaultValue);
+                });
+            });
+    });
+});

--- a/core/test/unit/services/settings/cache_spec.js
+++ b/core/test/unit/services/settings/cache_spec.js
@@ -1,10 +1,16 @@
-var rewire = require('rewire'),
-    should = require('should'),
-    cache = rewire('../../../../server/services/settings/cache');
+const rewire = require('rewire');
+const should = require('should');
+const _ = require('lodash');
+const publicSettings = require('../../../../server/services/settings/public');
+let cache = rewire('../../../../server/services/settings/cache');
 
 should.equal(true, true);
 
 describe('UNIT: settings cache', function () {
+    beforeEach(function () {
+        cache = rewire('../../../../server/services/settings/cache');
+    });
+
     it('does not auto convert string into number', function () {
         cache.set('key1', {value: '1'});
         (typeof cache.get('key1')).should.eql('string');
@@ -22,5 +28,29 @@ describe('UNIT: settings cache', function () {
         cache.get('key2').b.should.eql('hallo');
         cache.get('key2').c.should.eql({d: []});
         cache.get('key2').e.should.eql(2);
+    });
+
+    it('can get all values', function () {
+        cache.set('key1', {value: '1'});
+        cache.get('key1').should.eql('1');
+        cache.getAll().should.eql({key1: {value: '1'}});
+    });
+
+    it('correctly filters and formats public values', function () {
+        cache.set('key1', {value: 'something'});
+        cache.set('title', {value: 'hello world'});
+        cache.set('active_timezone', {value: 'PST'});
+
+        cache.getAll().should.eql({
+            key1: {value: 'something'},
+            title: {value: 'hello world'},
+            active_timezone: {value: 'PST'}
+        });
+
+        let values = _.zipObject(_.values(publicSettings), _.fill(Array(_.size(publicSettings)), ''));
+        values.title = 'hello world';
+        values.timezone = 'PST';
+
+        cache.getPublic().should.eql(values);
     });
 });

--- a/core/test/unit/services/themes/middleware_spec.js
+++ b/core/test/unit/services/themes/middleware_spec.js
@@ -16,7 +16,7 @@ describe('Themes', function () {
     });
 
     describe('Middleware', function () {
-        var req, res, blogApp, getActiveThemeStub, settingsCacheStub;
+        var req, res, blogApp, getActiveThemeStub, settingsCacheStub, settingPublicStub;
 
         beforeEach(function () {
             req = sandbox.spy();
@@ -28,6 +28,7 @@ describe('Themes', function () {
 
             getActiveThemeStub = sandbox.stub(activeTheme, 'get');
             settingsCacheStub = sandbox.stub(settingsCache, 'get');
+            settingPublicStub = sandbox.stub(settingsCache, 'getPublic').returns({});
         });
 
         describe('ensureActiveTheme', function () {
@@ -96,16 +97,11 @@ describe('Themes', function () {
         describe('updateTemplateData', function () {
             var updateTemplateData = middleware[1],
                 themeDataExpectedProps = ['posts_per_page', 'image_sizes'],
-                blogDataExpectedProps = [
-                    'url', 'title', 'description', 'logo', 'cover_image', 'icon', 'twitter', 'facebook', 'navigation',
-                    'timezone', 'amp'
-                ],
                 updateOptionsStub;
 
             beforeEach(function () {
                 updateOptionsStub = sandbox.stub(hbs, 'updateTemplateOptions');
 
-                settingsCacheStub.withArgs('title').returns('Bloggy McBlogface');
                 settingsCacheStub.withArgs('labs').returns({});
 
                 getActiveThemeStub.returns({
@@ -130,15 +126,11 @@ describe('Themes', function () {
                     // posts per page should be set according to the stub
                     templateOptions.data.config.posts_per_page.should.eql(2);
 
-                    // Check blog config
-                    // blog should have all the right properties
-                    templateOptions.data.blog.should.be.an.Object()
-                        .with.properties(blogDataExpectedProps)
-                        .and.size(blogDataExpectedProps.length);
+                    // Check blog config tried to call public settings
+                    settingPublicStub.calledOnce.should.be.true();
+
                     // url should be correct
                     templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369');
-                    // should get the title
-                    templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 
                     // Check labs config
                     templateOptions.data.labs.should.be.an.Object();
@@ -167,15 +159,11 @@ describe('Themes', function () {
                     // posts per page should NOT be set as there's no active theme
                     should.not.exist(templateOptions.data.config.posts_per_page);
 
-                    // Check blog config
-                    // blog should have all the right properties
-                    templateOptions.data.blog.should.be.an.Object()
-                        .with.properties(blogDataExpectedProps)
-                        .and.size(blogDataExpectedProps.length);
+                    // Check blog config tried to call public settings
+                    settingPublicStub.calledOnce.should.be.true();
+
                     // url should be correct
                     templateOptions.data.blog.url.should.eql('http://127.0.0.1:2369');
-                    // should get the title
-                    templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 
                     // Check labs config
                     templateOptions.data.labs.should.be.an.Object();
@@ -203,15 +191,10 @@ describe('Themes', function () {
                     // posts per page should be set according to the stub
                     templateOptions.data.config.posts_per_page.should.eql(2);
 
-                    // Check blog config
-                    // blog should have all the right properties
-                    templateOptions.data.blog.should.be.an.Object()
-                        .with.properties(blogDataExpectedProps)
-                        .and.size(blogDataExpectedProps.length);
+                    // Check blog config tried to call public settings
+                    settingPublicStub.calledOnce.should.be.true();
                     // url should be correct HTTPS!
                     templateOptions.data.blog.url.should.eql('https://127.0.0.1:2369');
-                    // should get the title
-                    templateOptions.data.blog.title.should.eql('Bloggy McBlogface');
 
                     // Check labs config
                     templateOptions.data.labs.should.be.an.Object();


### PR DESCRIPTION
refs #10318 

This PR bundles a few changes around settings.

## Small / simple changes:

- Unused old settings have been removed from the v2 Admin API
- A weird require was changed in the importer 
- @blog was aliased to @site, and swapped in all of our internal templates

## Bigger changes:

I've added a new concept of settingsCache.getPublic(), which returns an object containing all of our public settings, e.g, with the default values, it will return:

```
{ title: 'Ghost',
  description: 'The professional publishing platform',
  logo: 'https://static.ghost.org/v1.0.0/images/ghost-logo.svg',
  icon: '',
  cover_image: 'https://static.ghost.org/v1.0.0/images/blog-cover.jpg',
  facebook: 'ghost',
  twitter: 'tryghost',
  lang: 'en',
  timezone: 'Etc/UTC',
  ghost_head: '',
  ghost_foot: '',
  navigation: [ 
     { label: 'Home', url: '/' },
     { label: 'Tag', url: '/tag/getting-started/' },
     { label: 'Author', url: '/author/ghost/' },
     { label: 'Help', url: 'https://help.ghost.org' } 
  ]
}
```

This new method is used in two places -

First, in a new settings-public API endpoint, i.e

`GET ghost/api/v2/content/settings/`

Where it returns this object wrapped in our standard API structure:

```
{settings: { 
  title: 'Ghost',
  description: 'The professional publishing platform',
  logo: 'https://static.ghost.org/v1.0.0/images/ghost-logo.svg',
  icon: '',
  cover_image: 'https://static.ghost.org/v1.0.0/images/blog-cover.jpg',
  facebook: 'ghost',
  twitter: 'tryghost',
  lang: 'en',
  timezone: 'Etc/UTC',
  ghost_head: '',
  ghost_foot: '',
  navigation: [ 
     { label: 'Home', url: '/' },
     { label: 'Tag', url: '/tag/getting-started/' },
     { label: 'Author', url: '/author/ghost/' },
     { label: 'Help', url: 'https://help.ghost.org' } 
  ]
}}
```

Second, in the theme middleware, which is used to populate the `{{@blog}}` global in themes. 
Note: This does constitute a change, as `amp` has been removed and `ghost_head` and `ghost_foot` added, however there is no docs nor usecase for `amp` (as there wasn't for `permalinks`) and I believe it is safe to remove this without waiting for a major version bump. We can always put it back if we have to.

