### PR TITLE
Refactored routing config for multiple api versions

### DIFF
--- a/core/server/apps/amp/lib/router.js
+++ b/core/server/apps/amp/lib/router.js
@@ -64,7 +64,7 @@ function getPostData(req, res, next) {
     }
 
     // @NOTE: amp is not supported for static pages
-    helpers.entryLookup(urlWithoutSubdirectoryWithoutAmp, {permalinks, query: {resource: 'posts'}}, res.locals)
+    helpers.entryLookup(urlWithoutSubdirectoryWithoutAmp, {permalinks, query: {controller: 'posts', resource: 'posts'}}, res.locals)
         .then((result) => {
             if (result && result.entry) {
                 req.body.post = result.entry;

--- a/core/server/services/routing/CollectionRouter.js
+++ b/core/server/services/routing/CollectionRouter.js
@@ -8,8 +8,10 @@ const middlewares = require('./middlewares');
 const RSSRouter = require('./RSSRouter');
 
 class CollectionRouter extends ParentRouter {
-    constructor(mainRoute, object) {
+    constructor(mainRoute, object, RESOURCE_CONFIG) {
         super('CollectionRouter');
+
+        this.RESOURCE_CONFIG = RESOURCE_CONFIG.QUERY.post;
 
         this.routerName = mainRoute === '/' ? 'index' : mainRoute.replace(/\//g, '');
 
@@ -94,10 +96,7 @@ class CollectionRouter extends ParentRouter {
             order: this.order,
             permalinks: this.permalinks.getValue({withUrlOptions: true}),
             resourceType: this.getResourceType(),
-            query: {
-                alias: 'posts',
-                resource: 'posts'
-            },
+            query: this.RESOURCE_CONFIG,
             context: this.context,
             frontPageTemplate: 'home',
             templates: this.templates,
@@ -142,7 +141,7 @@ class CollectionRouter extends ParentRouter {
     }
 
     getResourceType() {
-        return 'posts';
+        return this.RESOURCE_CONFIG.resourceAlias || this.RESOURCE_CONFIG.resource;
     }
 
     getRoute(options) {

--- a/core/server/services/routing/PreviewRouter.js
+++ b/core/server/services/routing/PreviewRouter.js
@@ -3,8 +3,10 @@ const urlService = require('../url');
 const controllers = require('./controllers');
 
 class PreviewRouter extends ParentRouter {
-    constructor() {
+    constructor(RESOURCE_CONFIG) {
         super('PreviewRouter');
+
+        this.RESOURCE_CONFIG = RESOURCE_CONFIG.QUERY.preview;
 
         this.route = {value: '/p/'};
 
@@ -20,10 +22,7 @@ class PreviewRouter extends ParentRouter {
     _prepareContext(req, res, next) {
         res.routerOptions = {
             type: 'entry',
-            query: {
-                alias: 'preview',
-                resource: 'posts'
-            }
+            query: this.RESOURCE_CONFIG
         };
 
         next();

--- a/core/server/services/routing/TaxonomyRouter.js
+++ b/core/server/services/routing/TaxonomyRouter.js
@@ -5,13 +5,13 @@ const RSSRouter = require('./RSSRouter');
 const urlService = require('../url');
 const controllers = require('./controllers');
 const middlewares = require('./middlewares');
-const RESOURCE_CONFIG = require('./assets/resource-config');
 
 class TaxonomyRouter extends ParentRouter {
-    constructor(key, permalinks) {
+    constructor(key, permalinks, RESOURCE_CONFIG) {
         super('Taxonomy');
 
         this.taxonomyKey = key;
+        this.RESOURCE_CONFIG = RESOURCE_CONFIG;
 
         this.permalinks = {
             value: permalinks
@@ -53,8 +53,8 @@ class TaxonomyRouter extends ParentRouter {
             type: 'channel',
             name: this.taxonomyKey,
             permalinks: this.permalinks.getValue(),
-            data: {[this.taxonomyKey]: RESOURCE_CONFIG.QUERY[this.taxonomyKey]},
-            filter: RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].filter,
+            data: {[this.taxonomyKey]: this.RESOURCE_CONFIG.QUERY[this.taxonomyKey]},
+            filter: this.RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].filter,
             resourceType: this.getResourceType(),
             context: [this.taxonomyKey],
             slugTemplate: true,
@@ -65,11 +65,11 @@ class TaxonomyRouter extends ParentRouter {
     }
 
     _redirectEditOption(req, res) {
-        urlService.utils.redirectToAdmin(302, res, RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].editRedirect.replace(':slug', req.params.slug));
+        urlService.utils.redirectToAdmin(302, res, this.RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].editRedirect.replace(':slug', req.params.slug));
     }
 
     getResourceType() {
-        return RESOURCE_CONFIG.QUERY[this.taxonomyKey].alias;
+        return this.RESOURCE_CONFIG.TAXONOMIES[this.taxonomyKey].resource;
     }
 
     getRoute() {

--- a/core/server/services/routing/config/v0.1.js
+++ b/core/server/services/routing/config/v0.1.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 module.exports.QUERY = {
     tag: {
-        alias: 'tags',
+        controller: 'tags',
         type: 'read',
         resource: 'tags',
         options: {
@@ -10,7 +10,8 @@ module.exports.QUERY = {
         }
     },
     author: {
-        alias: 'authors',
+        resourceAlias: 'authors',
+        controller: 'users',
         type: 'read',
         resource: 'users',
         options: {
@@ -19,7 +20,8 @@ module.exports.QUERY = {
         }
     },
     user: {
-        alias: 'authors',
+        resourceAlias: 'authors',
+        controller: 'users',
         type: 'read',
         resource: 'users',
         options: {
@@ -28,7 +30,7 @@ module.exports.QUERY = {
         }
     },
     post: {
-        alias: 'posts',
+        controller: 'posts',
         type: 'read',
         resource: 'posts',
         options: {
@@ -38,7 +40,7 @@ module.exports.QUERY = {
         }
     },
     page: {
-        alias: 'pages',
+        controller: 'posts',
         type: 'read',
         resource: 'posts',
         options: {
@@ -46,17 +48,23 @@ module.exports.QUERY = {
             status: 'published',
             page: 1
         }
+    },
+    preview: {
+        controller: 'posts',
+        resource: 'posts'
     }
 };
 
 module.exports.TAXONOMIES = {
     tag: {
         filter: 'tags:\'%s\'+tags.visibility:public',
-        editRedirect: '#/settings/tags/:slug/'
+        editRedirect: '#/settings/tags/:slug/',
+        resource: 'tags'
     },
     author: {
         filter: 'authors:\'%s\'',
-        editRedirect: '#/team/:slug/'
+        editRedirect: '#/team/:slug/',
+        resource: 'authors'
     }
 };
 /* eslint-enable */

--- a/core/server/services/routing/config/v2.js
+++ b/core/server/services/routing/config/v2.js
@@ -1,0 +1,54 @@
+/* eslint-disable */
+module.exports.QUERY = {
+    tag: {
+        controller: 'tagsPublic',
+        type: 'read',
+        resource: 'tags',
+        options: {
+            slug: '%s',
+            visibility: 'public'
+        }
+    },
+    author: {
+        controller: 'authors',
+        type: 'read',
+        resource: 'authors',
+        options: {
+            slug: '%s'
+        }
+    },
+    post: {
+        controller: 'posts',
+        type: 'read',
+        resource: 'posts',
+        options: {
+            slug: '%s'
+        }
+    },
+    page: {
+        controller: 'pages',
+        type: 'read',
+        resource: 'pages',
+        options: {
+            slug: '%s'
+        }
+    },
+    preview: {
+        controller: 'preview',
+        resource: 'preview'
+    }
+};
+
+module.exports.TAXONOMIES = {
+    tag: {
+        filter: 'tags:\'%s\'+tags.visibility:public',
+        editRedirect: '#/settings/tags/:slug/',
+        resource: 'tags'
+    },
+    author: {
+        filter: 'authors:\'%s\'',
+        editRedirect: '#/team/:slug/',
+        resource: 'authors'
+    }
+};
+/* eslint-enable */

--- a/core/server/services/routing/controllers/preview.js
+++ b/core/server/services/routing/controllers/preview.js
@@ -14,10 +14,10 @@ module.exports = function previewController(req, res, next) {
         include: 'author,authors,tags'
     };
 
-    (api[res.routerOptions.query.alias] || api[res.routerOptions.query.resource])
+    api[res.routerOptions.query.controller]
         .read(params)
         .then(function then(result) {
-            const post = (result[res.routerOptions.query.alias] || result[res.routerOptions.query.resource])[0];
+            const post = result[res.routerOptions.query.resource][0];
 
             if (!post) {
                 return next();

--- a/core/server/services/routing/controllers/static.js
+++ b/core/server/services/routing/controllers/static.js
@@ -18,7 +18,7 @@ function processQuery(query, locals) {
     }
 
     // Return a promise for the api query
-    return (api[query.alias] || api[query.resource])[query.type](query.options);
+    return api[query.controller][query.type](query.options);
 }
 
 module.exports = function staticController(req, res, next) {
@@ -41,7 +41,7 @@ module.exports = function staticController(req, res, next) {
                     if (config.type === 'browse') {
                         response.data[name] = result[name];
                     } else {
-                        response.data[name] = result[name][config.alias] || result[name][config.resource];
+                        response.data[name] = result[name][config.resource];
                     }
                 });
             }

--- a/core/server/services/routing/helpers/entry-lookup.js
+++ b/core/server/services/routing/helpers/entry-lookup.js
@@ -10,7 +10,6 @@ function entryLookup(postUrl, routerOptions, locals) {
     const api = require('../../../api')[locals.apiVersion];
     const targetPath = url.parse(postUrl).path;
     const permalinks = routerOptions.permalinks;
-
     let isEditURL = false;
 
     // CASE: e.g. /:slug/ -> { slug: 'value' }
@@ -36,10 +35,10 @@ function entryLookup(postUrl, routerOptions, locals) {
      * Query database to find entry.
      * @deprecated: `author`, will be removed in Ghost 3.0
      */
-    return (api[routerOptions.query.alias] || api[routerOptions.query.resource])
+    return api[routerOptions.query.controller]
         .read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,authors,tags'}))
         .then(function then(result) {
-            const entry = (result[routerOptions.query.alias] || result[routerOptions.query.resource])[0];
+            const entry = result[routerOptions.query.resource][0];
 
             if (!entry) {
                 return Promise.resolve();

--- a/core/server/services/routing/helpers/fetch-data.js
+++ b/core/server/services/routing/helpers/fetch-data.js
@@ -9,7 +9,7 @@ const Promise = require('bluebird');
 const queryDefaults = {
     type: 'browse',
     resource: 'posts',
-    alias: 'posts',
+    controller: 'posts',
     options: {}
 };
 
@@ -51,7 +51,7 @@ function processQuery(query, slugParam, locals) {
     });
 
     // Return a promise for the api query
-    return (api[query.alias] || api[query.resource])[query.type](query.options);
+    return api[query.controller][query.type](query.options);
 }
 
 /**
@@ -103,7 +103,7 @@ function fetchData(pathOptions, routerOptions, locals) {
                     if (config.type === 'browse') {
                         response.data[name] = results[name];
                     } else {
-                        response.data[name] = results[name][config.alias] || results[name][config.resource];
+                        response.data[name] = results[name][config.resource];
                     }
                 });
             }

--- a/core/test/integration/web/site_spec.js
+++ b/core/test/integration/web/site_spec.js
@@ -4,9 +4,8 @@ const should = require('should'),
     cheerio = require('cheerio'),
     testUtils = require('../../utils'),
     configUtils = require('../../utils/configUtils'),
-    api = require('../../../server/api'),
     settingsService = require('../../../server/services/settings'),
-    themeConfig = require('../../../server/services/themes/config'),
+    themeService = require('../../../server/services/themes'),
     siteApp = require('../../../server/web/parent-app'),
     sandbox = sinon.sandbox.create();
 
@@ -16,347 +15,44 @@ describe('Integration - Web - Site', function () {
     before(testUtils.teardown);
     before(testUtils.setup('users:roles', 'posts'));
 
-    describe('default routes.yaml', function () {
-        before(function () {
-            sandbox.stub(themeConfig, 'create').returns({
-                posts_per_page: 2
-            });
+    describe('v0.1', function () {
+        const api = require('../../../server/api')["v0.1"];
 
-            testUtils.integrationTesting.urlService.resetGenerators();
-            testUtils.integrationTesting.defaultMocks(sandbox);
-            testUtils.integrationTesting.overrideGhostConfig(configUtils);
+        describe('default routes.yaml', function () {
+            before(function () {
+                testUtils.integrationTesting.urlService.resetGenerators();
+                testUtils.integrationTesting.defaultMocks(sandbox);
+                testUtils.integrationTesting.overrideGhostConfig(configUtils);
 
-            return testUtils.integrationTesting.initGhost()
-                .then(function () {
-                    app = siteApp({start: true});
-                    return testUtils.integrationTesting.urlService.waitTillFinished();
-                });
-        });
+                return testUtils.integrationTesting.initGhost()
+                    .then(function () {
+                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
 
-        beforeEach(function () {
-            configUtils.set('url', 'http://example.com');
-
-            sandbox.spy(api.posts, 'browse');
-        });
-
-        afterEach(function () {
-            api.posts.browse.restore();
-        });
-
-        after(function () {
-            configUtils.restore();
-            sandbox.restore();
-        });
-
-        describe('behaviour: default cases', function () {
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
+                        app = siteApp({start: true});
+                        return testUtils.integrationTesting.urlService.waitTillFinished();
                     });
             });
 
-            it('post not found', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/not-found/',
-                    host: 'example.com'
-                };
+            beforeEach(function () {
+                configUtils.set('url', 'http://example.com');
 
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
+                sandbox.spy(api.posts, 'browse');
             });
 
-            it('serve static page', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/static-page-test/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
-                    });
+            afterEach(function () {
+                api.posts.browse.restore();
             });
 
-            it('serve author', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/author/joe-bloggs/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('author');
-
-                        $('.author-bio').length.should.equal(1);
-                    });
+            after(function () {
+                configUtils.restore();
+                sandbox.restore();
             });
 
-            it('serve tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/tag/bacon/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('tag');
-
-                        api.posts.browse.args[0][0].filter.should.eql('tags:\'bacon\'+tags.visibility:public');
-                        api.posts.browse.args[0][0].page.should.eql(1);
-                        api.posts.browse.args[0][0].limit.should.eql(2);
-                    });
-            });
-
-            it('serve tag rss', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/tag/bacon/rss/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-
-            it('serve collection', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(2);
-
-                        should.exist(response.res.locals.context);
-                        should.exist(response.res.locals.version);
-                        should.exist(response.res.locals.safeVersion);
-                        should.exist(response.res.locals.safeVersion);
-                        should.exist(response.res.locals.relativeUrl);
-                        should.exist(response.res.locals.secure);
-                        should.exist(response.res.routerOptions);
-                    });
-            });
-
-            it('serve collection: page 2', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/page/2/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(2);
-                    });
-            });
-
-            it('serve public asset', function () {
-                const req = {
-                    secure: false,
-                    method: 'GET',
-                    url: '/public/ghost-sdk.js',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-
-            it('serve theme asset', function () {
-                //configUtils.set('url', 'https://example.com');
-
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/assets/css/screen.css',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-        });
-
-        describe('behaviour: prettify', function () {
-            it('url without slash', function () {
-                const req = {
-                    secure: false,
-                    method: 'GET',
-                    url: '/prettify-me',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/prettify-me/');
-                    });
-            });
-        });
-
-        describe('behaviour: url redirects', function () {
-            describe('url options', function () {
-                it('should not redirect /edit/', function () {
+            describe('behaviour: default cases', function () {
+                it('serve post', function () {
                     const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/edit/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(404);
-                        });
-                });
-
-                it('should redirect static page /edit/', function () {
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/static-page-test/edit/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(302);
-                        });
-                });
-
-                it('should redirect post /edit/', function () {
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/html-ipsum/edit/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(302);
-                        });
-                });
-            });
-
-            describe('pagination', function () {
-                it('redirect /page/1/ to /', function () {
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/page/1/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('/');
-                        });
-                });
-            });
-
-            describe('rss', function () {
-                it('redirect /feed/ to /rss/', function () {
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/feed/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('/rss/');
-                        });
-                });
-
-                it('redirect /rss/1/ to /rss/', function () {
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/rss/1/'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('/rss/');
-                        });
-                });
-            });
-
-            describe('protocol', function () {
-                it('blog is https, request is http', function () {
-                    configUtils.set('url', 'https://example.com');
-
-                    const req = {
-                        secure: false,
-                        host: 'example.com',
-                        method: 'GET',
-                        url: '/html-ipsum'
-                    };
-
-                    return testUtils.mocks.express.invoke(app, req)
-                        .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('https://example.com/html-ipsum/');
-                        });
-                });
-
-                it('blog is https, request is http, trailing slash exists already', function () {
-                    configUtils.set('url', 'https://example.com');
-
-                    const req = {
-                        secure: false,
+                        secure: true,
                         method: 'GET',
                         url: '/html-ipsum/',
                         host: 'example.com'
@@ -364,16 +60,140 @@ describe('Integration - Web - Site', function () {
 
                     return testUtils.mocks.express.invoke(app, req)
                         .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('https://example.com/html-ipsum/');
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
                         });
                 });
-            });
 
-            describe('assets', function () {
-                it('blog is https, request is http', function () {
-                    configUtils.set('url', 'https://example.com');
+                it('post not found', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/not-found/',
+                        host: 'example.com'
+                    };
 
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve static page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('author');
+
+                            $('.author-bio').length.should.equal(1);
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('tag');
+
+                            api.posts.browse.args[0][0].filter.should.eql('tags:\'bacon\'+tags.visibility:public');
+                            api.posts.browse.args[0][0].page.should.eql(1);
+                            api.posts.browse.args[0][0].limit.should.eql(2);
+                        });
+                });
+
+                it('serve tag rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+
+                            should.exist(response.res.locals.context);
+                            should.exist(response.res.locals.version);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.relativeUrl);
+                            should.exist(response.res.locals.secure);
+                            should.exist(response.res.routerOptions);
+                        });
+                });
+
+                it('serve collection: page 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/page/2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve public asset', function () {
                     const req = {
                         secure: false,
                         method: 'GET',
@@ -383,78 +203,1484 @@ describe('Integration - Web - Site', function () {
 
                     return testUtils.mocks.express.invoke(app, req)
                         .then(function (response) {
-                            response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('https://example.com/public/ghost-sdk.js');
+                            response.statusCode.should.eql(200);
                         });
                 });
 
-                it('blog is https, request is http', function () {
-                    configUtils.set('url', 'https://example.com');
+                it('serve theme asset', function () {
+                    //configUtils.set('url', 'https://example.com');
 
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/assets/css/screen.css',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+
+            describe('behaviour: prettify', function () {
+                it('url without slash', function () {
                     const req = {
                         secure: false,
                         method: 'GET',
-                        url: '/favicon.png',
+                        url: '/prettify-me',
                         host: 'example.com'
                     };
 
                     return testUtils.mocks.express.invoke(app, req)
                         .then(function (response) {
                             response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('https://example.com/favicon.png');
+                            response.headers.location.should.eql('/prettify-me/');
+                        });
+                });
+            });
+
+            describe('behaviour: url redirects', function () {
+                describe('url options', function () {
+                    it('should not redirect /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(404);
+                            });
+                    });
+
+                    it('should redirect static page /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/static-page-test/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(302);
+                            });
+                    });
+
+                    it('should redirect post /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/html-ipsum/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(302);
+                            });
+                    });
+                });
+
+                describe('pagination', function () {
+                    it('redirect /page/1/ to /', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/page/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/');
+                            });
+                    });
+                });
+
+                describe('rss', function () {
+                    it('redirect /feed/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/feed/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+
+                    it('redirect /rss/1/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/rss/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+                });
+
+                describe('protocol', function () {
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/html-ipsum'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/html-ipsum/');
+                            });
+                    });
+
+                    it('blog is https, request is http, trailing slash exists already', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/html-ipsum/',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/html-ipsum/');
+                            });
+                    });
+                });
+
+                describe('assets', function () {
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/public/ghost-sdk.js',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/public/ghost-sdk.js');
+                            });
+                    });
+
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/favicon.png',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/favicon.png');
+                            });
+                    });
+
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/assets/css/main.css',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/assets/css/main.css');
+                            });
+                    });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: collections', function () {
+            describe('2 collections', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/': 'home'
+                        },
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/podcast/:slug/',
+                                filter: 'featured:true'
+                            },
+
+                            '/something/': {
+                                permalink: '/something/:slug/',
+                                filter: 'featured:false'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
                         });
                 });
 
-                it('blog is https, request is http', function () {
-                    configUtils.set('url', 'https://example.com');
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
 
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve static route', function () {
                     const req = {
-                        secure: false,
+                        secure: true,
                         method: 'GET',
-                        url: '/assets/css/main.css',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve collection: podcast', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve collection: something', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+            });
+
+            describe('no collections', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/test/': 'test'
+                        },
+                        collections: {},
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve route', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('static permalink route', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/featured/',
+                                filter: 'featured:true'
+                            },
+
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/featured/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            // We can't find a post with the slug "featured"
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+            });
+
+            describe('primary author permalink', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/:primary_author/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/joe-bloggs/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('primary tag permalink', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/something/:primary_tag/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/kitchen-sink/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('collection with data key', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/food/': {
+                                permalink: '/food/:slug/',
+                                filter: 'tag:bacon',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tags',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                }
+                            },
+                            '/sport/': {
+                                permalink: '/sport/:slug/',
+                                filter: 'tag:pollo',
+                                data: {
+                                    query: {
+                                        apollo: {
+                                            controller: 'tags',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'pollo'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: false, slug: 'bacon'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve /food/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/food/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve bacon tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/bacon/',
                         host: 'example.com'
                     };
 
                     return testUtils.mocks.express.invoke(app, req)
                         .then(function (response) {
                             response.statusCode.should.eql(301);
-                            response.headers.location.should.eql('https://example.com/assets/css/main.css');
+                        });
+                });
+
+                it('serve /sport/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/sport/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve pollo tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/pollo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
                         });
                 });
             });
         });
-    });
 
-    describe('extended routes.yaml: collections', function () {
-        describe('2 collections', function () {
+        describe('extended routes.yaml: templates', function () {
+            describe('default template, no template', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/'
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve second collectiom', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+            });
+
+            describe('two templates', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('home.hbs priority', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('home');
+                        });
+                });
+
+                it('serve second page collection: should use index.hbs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('something');
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: routes', function () {
+            describe('channels', function () {
+                before(testUtils.teardown);
+                before(testUtils.setup('users:roles', 'posts'));
+
+                before(function () {
+                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme-channels'});
+
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/channel1/': {
+                                controller: 'channel',
+                                filter: 'tag:kitchen-sink',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tags',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'kitchen-sink'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'kitchen-sink'}]
+                                    }
+                                }
+                            },
+
+                            '/channel2/': {
+                                controller: 'channel',
+                                filter: 'tag:bacon',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tags',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                },
+                                templates: ['default']
+                            },
+
+                            '/channel3/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs',
+                                data: {
+                                    query: {
+                                        joe: {
+                                            controller: 'users',
+                                            resource: 'users',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel4/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs'
+                            },
+
+                            '/channel5/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'users',
+                                            resource: 'users',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel6/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        post: {
+                                            controller: 'posts',
+                                            resource: 'posts',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'html-ipsum',
+                                                redirect: true
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        posts: [{redirect: true, slug: 'html-ipsum'}]
+                                    }
+                                }
+                            },
+
+                            '/channel7/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        post: {
+                                            controller: 'posts',
+                                            resource: 'posts',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'static-page-test',
+                                                redirect: true
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        posts: [{redirect: true, slug: 'static-page-test'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/tag/:slug/',
+                            author: '/author/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve channel 1', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve channel 1: rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.headers['content-type'].should.eql('text/xml; charset=UTF-8');
+                        });
+                });
+
+                it('serve channel 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+
+                            // default tempalte does not list posts
+                            $('.post-card').length.should.equal(0);
+                        });
+                });
+
+                it('serve channel 3', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel3/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('channel3');
+                        });
+                });
+
+                it('serve channel 4', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel4/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 5', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel5/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 6', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel6/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 7', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel7/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve kitching-sink: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/kitchen-sink/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel1/');
+                        });
+                });
+
+                it('serve html-ipsum: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel6/');
+                        });
+                });
+
+                it('serve html-ipsum: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel7/');
+                        });
+                });
+
+                it('serve chorizo: no redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/chorizo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve joe-bloggs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml (5): rss override', function () {
             before(function () {
                 sandbox.stub(settingsService, 'get').returns({
                     routes: {
-                        '/': 'home'
+                        '/about/': 'about',
+                        '/podcast/rss/': {
+                            templates: ['podcast/rss'],
+                            content_type: 'xml'
+                        },
+                        '/cooking/': {
+                            controller: 'channel',
+                            rss: false
+                        },
+                        '/flat/': {
+                            controller: 'channel'
+                        }
                     },
 
                     collections: {
                         '/podcast/': {
-                            permalink: '/podcast/:slug/',
-                            filter: 'featured:true'
+                            permalink: '/:slug/',
+                            filter: 'featured:true',
+                            templates: ['home'],
+                            rss: false
                         },
-
-                        '/something/': {
-                            permalink: '/something/:slug/'
+                        '/music/': {
+                            permalink: '/:slug/',
+                            rss: false
+                        },
+                        '/': {
+                            permalink: '/:slug/'
                         }
                     },
 
-                    taxonomies: {
-                        tag: '/categories/:slug/',
-                        author: '/authors/:slug/'
-                    }
+                    taxonomies: {}
                 });
 
                 testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
+                testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
+                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v0.1');
+                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
                     });
@@ -472,22 +1698,63 @@ describe('Integration - Web - Site', function () {
                 sandbox.restore();
             });
 
-            it('serve static route', function () {
+            it('serve /rss/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
-                    url: '/',
+                    url: '/rss/',
                     host: 'example.com'
                 };
 
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
                     });
             });
 
-            it('serve rss', function () {
+            it('serve /music/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/music/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /cooking/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/cooking/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /flat/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/flat/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(200);
+                    });
+            });
+
+            it('serve /podcast/rss/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
@@ -498,25 +1765,13 @@ describe('Integration - Web - Site', function () {
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         response.statusCode.should.eql(200);
+                        response.template.should.eql('podcast/rss');
+                        response.headers['content-type'].should.eql('text/xml; charset=utf-8');
+                        response.body.match(/<link>/g).length.should.eql(2);
                     });
             });
 
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/something/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
-                    });
-            });
-
-            it('serve collection: podcast', function () {
+            it('serve /podcast/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
@@ -527,634 +1782,1615 @@ describe('Integration - Web - Site', function () {
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
-
                         response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(2);
-                    });
-            });
-
-            it('serve collection: something', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/something/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(2);
+                        $('head link')[2].attribs.href.should.eql('https://127.0.0.1:2369/rss/');
                     });
             });
         });
+    });
 
-        describe('no collections', function () {
+    describe('v2', function () {
+        let postSpy;
+
+        describe('default routes.yaml', function () {
             before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {
-                        '/test/': 'test'
-                    },
-                    collections: {},
-                    taxonomies: {}
-                });
-
                 testUtils.integrationTesting.urlService.resetGenerators();
                 testUtils.integrationTesting.defaultMocks(sandbox);
+                testUtils.integrationTesting.overrideGhostConfig(configUtils);
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
+                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
                     });
             });
 
             beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                const postsAPI = require('../../../server/api/v2/posts');
+                configUtils.set('url', 'http://example.com');
+                postSpy = sandbox.spy(postsAPI.browse, 'query');
             });
 
             afterEach(function () {
-                configUtils.restore();
+                postSpy.restore();
             });
 
             after(function () {
+                configUtils.restore();
                 sandbox.restore();
             });
 
-            it('serve route', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/test/',
-                    host: 'example.com'
-                };
+            describe('behaviour: default cases', function () {
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
 
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post not found', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/not-found/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve static page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('author');
+
+                            $('.author-bio').length.should.equal(1);
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('tag');
+
+                            postSpy.args[0][0].options.filter.should.eql('tags:\'bacon\'+page:false');
+                            postSpy.args[0][0].options.page.should.eql(1);
+                            postSpy.args[0][0].options.limit.should.eql(2);
+                        });
+                });
+
+                it('serve tag rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+
+                            should.exist(response.res.locals.context);
+                            should.exist(response.res.locals.version);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.safeVersion);
+                            should.exist(response.res.locals.relativeUrl);
+                            should.exist(response.res.locals.secure);
+                            should.exist(response.res.routerOptions);
+                        });
+                });
+
+                it('serve collection: page 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/page/2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve public asset', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/public/ghost-sdk.js',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve theme asset', function () {
+                    //configUtils.set('url', 'https://example.com');
+
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/assets/css/screen.css',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+
+            describe('behaviour: prettify', function () {
+                it('url without slash', function () {
+                    const req = {
+                        secure: false,
+                        method: 'GET',
+                        url: '/prettify-me',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/prettify-me/');
+                        });
+                });
+            });
+
+            describe('behaviour: url redirects', function () {
+                describe('url options', function () {
+                    it('should not redirect /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(404);
+                            });
                     });
+
+                    it('should redirect static page /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/static-page-test/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(302);
+                            });
+                    });
+
+                    it('should redirect post /edit/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/html-ipsum/edit/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(302);
+                            });
+                    });
+                });
+
+                describe('pagination', function () {
+                    it('redirect /page/1/ to /', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/page/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/');
+                            });
+                    });
+                });
+
+                describe('rss', function () {
+                    it('redirect /feed/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/feed/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+
+                    it('redirect /rss/1/ to /rss/', function () {
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/rss/1/'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('/rss/');
+                            });
+                    });
+                });
+
+                describe('protocol', function () {
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            host: 'example.com',
+                            method: 'GET',
+                            url: '/html-ipsum'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/html-ipsum/');
+                            });
+                    });
+
+                    it('blog is https, request is http, trailing slash exists already', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/html-ipsum/',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/html-ipsum/');
+                            });
+                    });
+                });
+
+                describe('assets', function () {
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/public/ghost-sdk.js',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/public/ghost-sdk.js');
+                            });
+                    });
+
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/favicon.png',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/favicon.png');
+                            });
+                    });
+
+                    it('blog is https, request is http', function () {
+                        configUtils.set('url', 'https://example.com');
+
+                        const req = {
+                            secure: false,
+                            method: 'GET',
+                            url: '/assets/css/main.css',
+                            host: 'example.com'
+                        };
+
+                        return testUtils.mocks.express.invoke(app, req)
+                            .then(function (response) {
+                                response.statusCode.should.eql(301);
+                                response.headers.location.should.eql('https://example.com/assets/css/main.css');
+                            });
+                    });
+                });
             });
         });
 
-        describe('static permalink route', function () {
+        describe('extended routes.yaml: collections', function () {
+            describe('2 collections', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/': 'home'
+                        },
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/podcast/:slug/',
+                                filter: 'featured:true'
+                            },
+
+                            '/something/': {
+                                permalink: '/something/:slug/',
+                                filter: 'featured:false'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve static route', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve collection: podcast', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/podcast/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve collection: something', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+            });
+
+            describe('no collections', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/test/': 'test'
+                        },
+                        collections: {},
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve route', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('static permalink route', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/podcast/': {
+                                permalink: '/featured/',
+                                filter: 'featured:true'
+                            },
+
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/featured/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            // We can't find a post with the slug "featured"
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('serve author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('serve tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+            });
+
+            describe('primary author permalink', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/:primary_author/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/joe-bloggs/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without author', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('primary tag permalink', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/something/': {
+                                permalink: '/something/:primary_tag/:slug/'
+                            }
+                        },
+
+                        taxonomies: {}
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve post', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/kitchen-sink/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('post');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/something/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('post without tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(404);
+                            response.template.should.eql('error-404');
+                        });
+                });
+
+                it('page', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/static-page-test/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('page');
+                        });
+                });
+            });
+
+            describe('collection with data key', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/food/': {
+                                permalink: '/food/:slug/',
+                                filter: 'tag:bacon+tag:-chorizo',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                }
+                            },
+                            '/sport/': {
+                                permalink: '/sport/:slug/',
+                                filter: 'tag:chorizo+tag:-bacon',
+                                data: {
+                                    query: {
+                                        apollo: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'chorizo'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: false, slug: 'chorizo'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/categories/:slug/',
+                            author: '/authors/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve /food/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/food/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve bacon tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/bacon/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                        });
+                });
+
+                it('serve /sport/', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/sport/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+
+                it('serve chorizo tag', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/categories/chorizo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: templates', function () {
+            describe('default template, no template', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/'
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+
+                it('serve second collectiom', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+                        });
+                });
+            });
+
+            describe('two templates', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox);
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+                        });
+                });
+            });
+
+            describe('home.hbs priority', function () {
+                before(function () {
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {},
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/',
+                                templates: ['something', 'default']
+                            },
+                            '/magic/': {
+                                permalink: '/magic/:slug/',
+                                templates: ['something', 'default']
+                            }
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve collection', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('home');
+                        });
+                });
+
+                it('serve second page collection: should use index.hbs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/magic/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('something');
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml: routes', function () {
+            describe('channels', function () {
+                before(testUtils.teardown);
+                before(testUtils.setup('users:roles', 'posts'));
+
+                before(function () {
+                    testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme-channels'});
+
+                    sandbox.stub(settingsService, 'get').returns({
+                        routes: {
+                            '/channel1/': {
+                                controller: 'channel',
+                                filter: 'tag:kitchen-sink',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'kitchen-sink'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'kitchen-sink'}]
+                                    }
+                                }
+                            },
+
+                            '/channel2/': {
+                                controller: 'channel',
+                                filter: 'tag:bacon',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'tagsPublic',
+                                            resource: 'tags',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'bacon'
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        tags: [{redirect: true, slug: 'bacon'}]
+                                    }
+                                },
+                                templates: ['default']
+                            },
+
+                            '/channel3/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs',
+                                data: {
+                                    query: {
+                                        joe: {
+                                            controller: 'authors',
+                                            resource: 'authors',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel4/': {
+                                controller: 'channel',
+                                filter: 'author:joe-bloggs'
+                            },
+
+                            '/channel5/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        tag: {
+                                            controller: 'authors',
+                                            resource: 'authors',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'joe-bloggs',
+                                                redirect: false
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        authors: [{redirect: false, slug: 'joe-bloggs'}]
+                                    }
+                                }
+                            },
+
+                            '/channel6/': {
+                                controller: 'channel',
+                                data: {
+                                    query: {
+                                        post: {
+                                            controller: 'posts',
+                                            resource: 'posts',
+                                            type: 'read',
+                                            options: {
+                                                slug: 'html-ipsum',
+                                                redirect: true
+                                            }
+                                        }
+                                    },
+                                    router: {
+                                        posts: [{redirect: true, slug: 'html-ipsum'}]
+                                    }
+                                }
+                            }
+                        },
+
+                        collections: {
+                            '/': {
+                                permalink: '/:slug/'
+                            }
+                        },
+
+                        taxonomies: {
+                            tag: '/tag/:slug/',
+                            author: '/author/:slug/'
+                        }
+                    });
+
+                    testUtils.integrationTesting.urlService.resetGenerators();
+
+                    return testUtils.integrationTesting.initGhost()
+                        .then(function () {
+                            sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                            sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(10);
+
+                            app = siteApp({start: true});
+                            return testUtils.integrationTesting.urlService.waitTillFinished();
+                        });
+                });
+
+                beforeEach(function () {
+                    testUtils.integrationTesting.overrideGhostConfig(configUtils);
+                });
+
+                afterEach(function () {
+                    configUtils.restore();
+                });
+
+                after(function () {
+                    sandbox.restore();
+                });
+
+                it('serve channel 1', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(2);
+                        });
+                });
+
+                it('serve channel 1: rss', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel1/rss/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                            response.headers['content-type'].should.eql('text/xml; charset=UTF-8');
+                        });
+                });
+
+                it('serve channel 2', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel2/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('default');
+
+                            // default tempalte does not list posts
+                            $('.post-card').length.should.equal(0);
+                        });
+                });
+
+                it('serve channel 3', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel3/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('channel3');
+                        });
+                });
+
+                it('serve channel 4', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel4/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 5', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel5/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve channel 6', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/channel6/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            const $ = cheerio.load(response.body);
+
+                            response.statusCode.should.eql(200);
+                            response.template.should.eql('index');
+
+                            $('.post-card').length.should.equal(4);
+                        });
+                });
+
+                it('serve kitching-sink: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/kitchen-sink/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel1/');
+                        });
+                });
+
+                it('serve html-ipsum: redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/html-ipsum/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(301);
+                            response.headers.location.should.eql('/channel6/');
+                        });
+                });
+
+                it('serve chorizo: no redirect', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/tag/chorizo/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+
+                it('serve joe-bloggs', function () {
+                    const req = {
+                        secure: true,
+                        method: 'GET',
+                        url: '/author/joe-bloggs/',
+                        host: 'example.com'
+                    };
+
+                    return testUtils.mocks.express.invoke(app, req)
+                        .then(function (response) {
+                            response.statusCode.should.eql(200);
+                        });
+                });
+            });
+        });
+
+        describe('extended routes.yaml (5): rss override', function () {
             before(function () {
                 sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
+                    routes: {
+                        '/about/': 'about',
+                        '/podcast/rss/': {
+                            templates: ['podcast/rss'],
+                            content_type: 'xml'
+                        },
+                        '/cooking/': {
+                            controller: 'channel',
+                            rss: false
+                        },
+                        '/flat/': {
+                            controller: 'channel'
+                        }
+                    },
 
                     collections: {
                         '/podcast/': {
-                            permalink: '/featured/',
-                            filter: 'featured:true'
+                            permalink: '/:slug/',
+                            filter: 'featured:true',
+                            templates: ['home'],
+                            rss: false
                         },
-
+                        '/music/': {
+                            permalink: '/:slug/',
+                            rss: false
+                        },
                         '/': {
                             permalink: '/:slug/'
                         }
                     },
 
                     taxonomies: {}
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/featured/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        // We can't find a post with the slug "featured"
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
-                    });
-            });
-
-            it('serve author', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/author/joe-bloggs/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-
-            it('serve tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/tag/bacon/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-        });
-
-        describe('primary author permalink', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/something/': {
-                            permalink: '/:primary_author/:slug/'
-                        }
-                    },
-
-                    taxonomies: {}
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/joe-bloggs/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
-                    });
-            });
-
-            it('post without author', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-
-            it('page', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/static-page-test/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
-                    });
-            });
-        });
-
-        describe('primary tag permalink', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/something/': {
-                            permalink: '/something/:primary_tag/:slug/'
-                        }
-                    },
-
-                    taxonomies: {}
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve post', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/something/kitchen-sink/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('post');
-                    });
-            });
-
-            it('post without tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/something/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-
-            it('post without tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(404);
-                        response.template.should.eql('error-404');
-                    });
-            });
-
-            it('page', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/static-page-test/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('page');
-                    });
-            });
-        });
-
-        describe('collection with data key', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/food/': {
-                            permalink: '/food/:slug/',
-                            filter: 'tag:bacon',
-                            data: {
-                                query: {
-                                    tag: {
-                                        alias: 'tags',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'bacon'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'bacon'}]
-                                }
-                            }
-                        },
-                        '/sport/': {
-                            permalink: '/sport/:slug/',
-                            filter: 'tag:pollo',
-                            data: {
-                                query: {
-                                    apollo: {
-                                        alias: 'tags',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'pollo'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: false, slug: 'bacon'}]
-                                }
-                            }
-                        }
-                    },
-
-                    taxonomies: {
-                        tag: '/categories/:slug/',
-                        author: '/authors/:slug/'
-                    }
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve /food/', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/food/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-                    });
-            });
-
-            it('serve bacon tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/categories/bacon/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(301);
-                    });
-            });
-
-            it('serve /sport/', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/sport/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-                    });
-            });
-
-            it('serve pollo tag', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/categories/pollo/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-        });
-    });
-
-    describe('extended routes.yaml: templates', function () {
-        describe('default template, no template', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/': {
-                            permalink: '/:slug/',
-                            templates: ['default']
-                        },
-                        '/magic/': {
-                            permalink: '/magic/:slug/'
-                        }
-                    }
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve collection', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
-                    });
-            });
-
-            it('serve second collectiom', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/magic/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-                    });
-            });
-        });
-
-        describe('two templates', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/': {
-                            permalink: '/:slug/',
-                            templates: ['something', 'default']
-                        }
-                    }
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-                testUtils.integrationTesting.defaultMocks(sandbox);
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
-                    });
-            });
-
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve collection', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
-                    });
-            });
-        });
-
-        describe('home.hbs priority', function () {
-            before(function () {
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {},
-
-                    collections: {
-                        '/': {
-                            permalink: '/:slug/',
-                            templates: ['something', 'default']
-                        },
-                        '/magic/': {
-                            permalink: '/magic/:slug/',
-                            templates: ['something', 'default']
-                        }
-                    }
                 });
 
                 testUtils.integrationTesting.urlService.resetGenerators();
@@ -1162,6 +3398,9 @@ describe('Integration - Web - Site', function () {
 
                 return testUtils.integrationTesting.initGhost()
                     .then(function () {
+                        sandbox.stub(themeService.getActive(), 'engine').withArgs('ghost-api').returns('v2');
+                        sandbox.stub(themeService.getActive(), 'config').withArgs('posts_per_page').returns(2);
+
                         app = siteApp({start: true});
                         return testUtils.integrationTesting.urlService.waitTillFinished();
                     });
@@ -1179,575 +3418,94 @@ describe('Integration - Web - Site', function () {
                 sandbox.restore();
             });
 
-            it('serve collection', function () {
+            it('serve /rss/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
-                    url: '/',
+                    url: '/rss/',
                     host: 'example.com'
                 };
 
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         response.statusCode.should.eql(200);
-                        response.template.should.eql('home');
                     });
             });
 
-            it('serve second page collection: should use index.hbs', function () {
+            it('serve /music/rss/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
-                    url: '/magic/',
+                    url: '/music/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /cooking/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/cooking/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(404);
+                    });
+            });
+
+            it('serve /flat/rss/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/flat/rss/',
                     host: 'example.com'
                 };
 
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         response.statusCode.should.eql(200);
-                        response.template.should.eql('something');
-                    });
-            });
-        });
-    });
-
-    describe('extended routes.yaml: routes', function () {
-        describe('channels', function () {
-            before(testUtils.teardown);
-            before(testUtils.setup('users:roles', 'posts'));
-
-            before(function () {
-                testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme-channels'});
-
-                sandbox.stub(settingsService, 'get').returns({
-                    routes: {
-                        '/channel1/': {
-                            controller: 'channel',
-                            filter: 'tag:kitchen-sink',
-                            data: {
-                                query: {
-                                    tag: {
-                                        alias: 'tags',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'kitchen-sink'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'kitchen-sink'}]
-                                }
-                            }
-                        },
-
-                        '/channel2/': {
-                            controller: 'channel',
-                            filter: 'tag:bacon',
-                            data: {
-                                query: {
-                                    tag: {
-                                        alias: 'tags',
-                                        resource: 'tags',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'bacon'
-                                        }
-                                    }
-                                },
-                                router: {
-                                    tags: [{redirect: true, slug: 'bacon'}]
-                                }
-                            },
-                            templates: ['default']
-                        },
-
-                        '/channel3/': {
-                            controller: 'channel',
-                            filter: 'author:joe-bloggs',
-                            data: {
-                                query: {
-                                    tag: {
-                                        alias: 'authors',
-                                        resource: 'users',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'joe-bloggs',
-                                            redirect: false
-                                        }
-                                    }
-                                },
-                                router: {
-                                    users: [{redirect: false, slug: 'joe-bloggs'}]
-                                }
-                            }
-                        },
-
-                        '/channel4/': {
-                            controller: 'channel',
-                            filter: 'author:joe-bloggs'
-                        },
-
-                        '/channel5/': {
-                            controller: 'channel',
-                            data: {
-                                query: {
-                                    tag: {
-                                        alias: 'authors',
-                                        resource: 'users',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'joe-bloggs',
-                                            redirect: false
-                                        }
-                                    }
-                                },
-                                router: {
-                                    users: [{redirect: false, slug: 'joe-bloggs'}]
-                                }
-                            }
-                        },
-
-                        '/channel6/': {
-                            controller: 'channel',
-                            data: {
-                                query: {
-                                    post: {
-                                        resource: 'posts',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'html-ipsum',
-                                            redirect: true
-                                        }
-                                    }
-                                },
-                                router: {
-                                    posts: [{redirect: true, slug: 'html-ipsum'}]
-                                }
-                            }
-                        },
-
-                        '/channel7/': {
-                            controller: 'channel',
-                            data: {
-                                query: {
-                                    post: {
-                                        resource: 'posts',
-                                        type: 'read',
-                                        options: {
-                                            slug: 'static-page-test',
-                                            redirect: true
-                                        }
-                                    }
-                                },
-                                router: {
-                                    posts: [{redirect: true, slug: 'static-page-test'}]
-                                }
-                            }
-                        }
-                    },
-
-                    collections: {
-                        '/': {
-                            permalink: '/:slug/'
-                        }
-                    },
-
-                    taxonomies: {
-                        tag: '/tag/:slug/',
-                        author: '/author/:slug/'
-                    }
-                });
-
-                testUtils.integrationTesting.urlService.resetGenerators();
-
-                return testUtils.integrationTesting.initGhost()
-                    .then(function () {
-                        app = siteApp({start: true});
-                        return testUtils.integrationTesting.urlService.waitTillFinished();
                     });
             });
 
-            beforeEach(function () {
-                testUtils.integrationTesting.overrideGhostConfig(configUtils);
-            });
-
-            afterEach(function () {
-                configUtils.restore();
-            });
-
-            after(function () {
-                sandbox.restore();
-            });
-
-            it('serve channel 1', function () {
+            it('serve /podcast/rss/', function () {
                 const req = {
                     secure: true,
                     method: 'GET',
-                    url: '/channel1/',
+                    url: '/podcast/rss/',
+                    host: 'example.com'
+                };
+
+                return testUtils.mocks.express.invoke(app, req)
+                    .then(function (response) {
+                        response.statusCode.should.eql(200);
+                        response.template.should.eql('podcast/rss');
+                        response.headers['content-type'].should.eql('text/xml; charset=utf-8');
+                        response.body.match(/<link>/g).length.should.eql(2);
+                    });
+            });
+
+            it('serve /podcast/', function () {
+                const req = {
+                    secure: true,
+                    method: 'GET',
+                    url: '/podcast/',
                     host: 'example.com'
                 };
 
                 return testUtils.mocks.express.invoke(app, req)
                     .then(function (response) {
                         const $ = cheerio.load(response.body);
-
                         response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(2);
+                        $('head link')[2].attribs.href.should.eql('https://127.0.0.1:2369/rss/');
                     });
             });
-
-            it('serve channel 1: rss', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel1/rss/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                        response.headers['content-type'].should.eql('text/xml; charset=UTF-8');
-                    });
-            });
-
-            it('serve channel 2', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel2/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('default');
-
-                        // default tempalte does not list posts
-                        $('.post-card').length.should.equal(0);
-                    });
-            });
-
-            it('serve channel 3', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel3/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('channel3');
-                    });
-            });
-
-            it('serve channel 4', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel4/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(4);
-                    });
-            });
-
-            it('serve channel 5', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel5/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(4);
-                    });
-            });
-
-            it('serve channel 6', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel6/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(4);
-                    });
-            });
-
-            it('serve channel 7', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/channel7/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        const $ = cheerio.load(response.body);
-
-                        response.statusCode.should.eql(200);
-                        response.template.should.eql('index');
-
-                        $('.post-card').length.should.equal(4);
-                    });
-            });
-
-            it('serve kitching-sink: redirect', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/tag/kitchen-sink/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/channel1/');
-                    });
-            });
-
-            it('serve html-ipsum: redirect', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/html-ipsum/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/channel6/');
-                    });
-            });
-
-            it('serve html-ipsum: redirect', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/static-page-test/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(301);
-                        response.headers.location.should.eql('/channel7/');
-                    });
-            });
-
-            it('serve chorizo: no redirect', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/tag/chorizo/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-
-            it('serve joe-bloggs', function () {
-                const req = {
-                    secure: true,
-                    method: 'GET',
-                    url: '/author/joe-bloggs/',
-                    host: 'example.com'
-                };
-
-                return testUtils.mocks.express.invoke(app, req)
-                    .then(function (response) {
-                        response.statusCode.should.eql(200);
-                    });
-            });
-        });
-    });
-
-    describe('extended routes.yaml (5): rss override', function () {
-        before(function () {
-            sandbox.stub(settingsService, 'get').returns({
-                routes: {
-                    '/about/': 'about',
-                    '/podcast/rss/': {
-                        templates: ['podcast/rss'],
-                        content_type: 'xml'
-                    },
-                    '/cooking/': {
-                        controller: 'channel',
-                        rss: false
-                    },
-                    '/flat/': {
-                        controller: 'channel'
-                    }
-                },
-
-                collections: {
-                    '/podcast/': {
-                        permalink: '/:slug/',
-                        filter: 'featured:true',
-                        templates: ['home'],
-                        rss: false
-                    },
-                    '/music/': {
-                        permalink: '/:slug/',
-                        rss: false
-                    },
-                    '/': {
-                        permalink: '/:slug/'
-                    }
-                },
-
-                taxonomies: {}
-            });
-
-            testUtils.integrationTesting.urlService.resetGenerators();
-            testUtils.integrationTesting.defaultMocks(sandbox, {theme: 'test-theme'});
-
-            return testUtils.integrationTesting.initGhost()
-                .then(function () {
-                    app = siteApp({start: true});
-                    return testUtils.integrationTesting.urlService.waitTillFinished();
-                });
-        });
-
-        beforeEach(function () {
-            testUtils.integrationTesting.overrideGhostConfig(configUtils);
-        });
-
-        afterEach(function () {
-            configUtils.restore();
-        });
-
-        after(function () {
-            sandbox.restore();
-        });
-
-        it('serve /rss/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/rss/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    response.statusCode.should.eql(200);
-                });
-        });
-
-        it('serve /music/rss/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/music/rss/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    response.statusCode.should.eql(404);
-                });
-        });
-
-        it('serve /cooking/rss/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/cooking/rss/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    response.statusCode.should.eql(404);
-                });
-        });
-
-        it('serve /flat/rss/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/flat/rss/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    response.statusCode.should.eql(200);
-                });
-        });
-
-        it('serve /podcast/rss/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/podcast/rss/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    response.statusCode.should.eql(200);
-                    response.template.should.eql('podcast/rss');
-                    response.headers['content-type'].should.eql('text/xml; charset=utf-8');
-                    response.body.match(/<link>/g).length.should.eql(2);
-                });
-        });
-
-        it('serve /podcast/', function () {
-            const req = {
-                secure: true,
-                method: 'GET',
-                url: '/podcast/',
-                host: 'example.com'
-            };
-
-            return testUtils.mocks.express.invoke(app, req)
-                .then(function (response) {
-                    const $ = cheerio.load(response.body);
-                    response.statusCode.should.eql(200);
-                    $('head link')[2].attribs.href.should.eql('https://127.0.0.1:2369/rss/');
-                });
         });
     });
 });

--- a/core/test/integration/web/site_spec.js
+++ b/core/test/integration/web/site_spec.js
@@ -1901,7 +1901,7 @@ describe('Integration - Web - Site', function () {
                             response.statusCode.should.eql(200);
                             response.template.should.eql('tag');
 
-                            postSpy.args[0][0].options.filter.should.eql('tags:\'bacon\'+page:false');
+                            postSpy.args[0][0].options.filter.should.eql('tags:\'bacon\'+tags.visibility:public+page:false');
                             postSpy.args[0][0].options.page.should.eql(1);
                             postSpy.args[0][0].options.limit.should.eql(2);
                         });

--- a/core/test/unit/apps/amp/router_spec.js
+++ b/core/test/unit/apps/amp/router_spec.js
@@ -123,9 +123,10 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlService.getPermalinkByUrl.withArgs('/welcome/').returns('/:slug/');
 
-            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {resource: 'posts'}}).resolves({
-                entry: post
-            });
+            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'posts', resource: 'posts'}})
+                .resolves({
+                    entry: post
+                });
 
             ampController.getPostData(req, res, function () {
                 req.body.post.should.be.eql(post);
@@ -139,7 +140,7 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlService.getPermalinkByUrl.withArgs('/welcome/').returns('/:slug/');
 
-            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {resource: 'posts'}}).resolves({
+            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'posts', resource: 'posts'}}).resolves({
                 entry: post
             });
 
@@ -154,7 +155,7 @@ describe('Unit - apps/amp/lib/router', function () {
 
             urlService.getPermalinkByUrl.withArgs('/welcome/').returns('/:slug/');
 
-            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {resource: 'posts'}})
+            helpers.entryLookup.withArgs('/welcome/', {permalinks: '/:slug/', query: {controller: 'posts', resource: 'posts'}})
                 .rejects(new common.errors.NotFoundError());
 
             ampController.getPostData(req, res, function (err) {

--- a/core/test/unit/services/routing/CollectionRouter_spec.js
+++ b/core/test/unit/services/routing/CollectionRouter_spec.js
@@ -5,7 +5,8 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     CollectionRouter = require('../../../../server/services/routing/CollectionRouter'),
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.sandbox.create(),
+    RESOURCE_CONFIG = {QUERY: {post: {controller: 'posts', resource: 'posts'}}};
 
 describe('UNIT - services/routing/CollectionRouter', function () {
     let req, res, next;
@@ -32,7 +33,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
     describe('instantiate', function () {
         it('default', function () {
-            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/'});
+            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
             should.exist(collectionRouter.router);
 
@@ -67,9 +68,9 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         });
 
         it('router name', function () {
-            const collectionRouter1 = new CollectionRouter('/', {permalink: '/:slug/'});
-            const collectionRouter2 = new CollectionRouter('/podcast/', {permalink: '/:slug/'});
-            const collectionRouter3 = new CollectionRouter('/hello/world/', {permalink: '/:slug/'});
+            const collectionRouter1 = new CollectionRouter('/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
+            const collectionRouter2 = new CollectionRouter('/podcast/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
+            const collectionRouter3 = new CollectionRouter('/hello/world/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
             collectionRouter1.routerName.should.eql('index');
             collectionRouter2.routerName.should.eql('podcast');
@@ -81,7 +82,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         });
 
         it('collection lives under /blog/', function () {
-            const collectionRouter = new CollectionRouter('/blog/', {permalink: '/blog/:year/:slug/'});
+            const collectionRouter = new CollectionRouter('/blog/', {permalink: '/blog/:year/:slug/'}, RESOURCE_CONFIG);
 
             should.exist(collectionRouter.router);
 
@@ -115,13 +116,13 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         });
 
         it('with custom filter', function () {
-            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/', filter: 'featured:true'});
+            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/', filter: 'featured:true'}, RESOURCE_CONFIG);
 
             collectionRouter.getFilter().should.eql('featured:true');
         });
 
         it('with templates', function () {
-            const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/', templates: ['home', 'index']});
+            const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/', templates: ['home', 'index']}, RESOURCE_CONFIG);
 
             // they are getting reversed because we unshift the templates in the helper
             collectionRouter.templates.should.eql(['index', 'home']);
@@ -130,7 +131,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
     describe('fn: _prepareEntriesContext', function () {
         it('index collection', function () {
-            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/'});
+            const collectionRouter = new CollectionRouter('/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
@@ -139,7 +140,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',
-                query: {alias: 'posts', resource: 'posts'},
+                query: {controller: 'posts', resource: 'posts'},
                 frontPageTemplate: 'home',
                 templates: [],
                 identifier: collectionRouter.identifier,
@@ -153,7 +154,12 @@ describe('UNIT - services/routing/CollectionRouter', function () {
         });
 
         it('with templates, with order + limit, no index collection', function () {
-            const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/', order: 'published asc', limit: 19, templates: ['home', 'index']});
+            const collectionRouter = new CollectionRouter('/magic/', {
+                permalink: '/:slug/',
+                order: 'published asc',
+                limit: 19,
+                templates: ['home', 'index']
+            }, RESOURCE_CONFIG);
 
             collectionRouter._prepareEntriesContext(req, res, next);
 
@@ -162,7 +168,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
                 type: 'collection',
                 filter: undefined,
                 permalinks: '/:slug/:options(edit)?/',
-                query: {alias: 'posts', resource: 'posts'},
+                query: {controller: 'posts', resource: 'posts'},
                 frontPageTemplate: 'home',
                 templates: ['index', 'home'],
                 identifier: collectionRouter.identifier,
@@ -179,7 +185,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
     describe('timezone changes', function () {
         describe('no dated permalink', function () {
             it('default', function () {
-                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'});
+                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
                 sandbox.stub(collectionRouter, 'emit');
 
@@ -192,7 +198,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             });
 
             it('tz has not changed', function () {
-                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'});
+                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:slug/'}, RESOURCE_CONFIG);
 
                 sandbox.stub(collectionRouter, 'emit');
 
@@ -207,7 +213,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
 
         describe('with dated permalink', function () {
             it('default', function () {
-                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'});
+                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'}, RESOURCE_CONFIG);
 
                 sandbox.stub(collectionRouter, 'emit');
 
@@ -220,7 +226,7 @@ describe('UNIT - services/routing/CollectionRouter', function () {
             });
 
             it('tz has not changed', function () {
-                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'});
+                const collectionRouter = new CollectionRouter('/magic/', {permalink: '/:year/:slug/'}, RESOURCE_CONFIG);
 
                 sandbox.stub(collectionRouter, 'emit');
 

--- a/core/test/unit/services/routing/TaxonomyRouter_spec.js
+++ b/core/test/unit/services/routing/TaxonomyRouter_spec.js
@@ -5,7 +5,7 @@ const should = require('should'),
     common = require('../../../../server/lib/common'),
     controllers = require('../../../../server/services/routing/controllers'),
     TaxonomyRouter = require('../../../../server/services/routing/TaxonomyRouter'),
-    RESOURCE_CONFIG = require('../../../../server/services/routing/assets/resource-config'),
+    RESOURCE_CONFIG = require('../../../../server/services/routing/config/v2'),
     sandbox = sinon.sandbox.create();
 
 describe('UNIT - services/routing/TaxonomyRouter', function () {
@@ -63,7 +63,7 @@ describe('UNIT - services/routing/TaxonomyRouter', function () {
     });
 
     it('fn: _prepareContext', function () {
-        const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/');
+        const taxonomyRouter = new TaxonomyRouter('tag', '/tag/:slug/', RESOURCE_CONFIG);
         taxonomyRouter._prepareContext(req, res, next);
         next.calledOnce.should.eql(true);
 

--- a/core/test/unit/services/routing/controllers/preview_spec.js
+++ b/core/test/unit/services/routing/controllers/preview_spec.js
@@ -46,7 +46,7 @@ describe('Unit - services/routing/controllers/preview', function () {
 
             res = {
                 routerOptions: {
-                    query: {alias: 'preview', resource: 'posts'}
+                    query: {controller: 'posts', resource: 'posts'}
                 },
                 locals: {
                     apiVersion: 'v0.1'
@@ -165,7 +165,7 @@ describe('Unit - services/routing/controllers/preview', function () {
 
             res = {
                 routerOptions: {
-                    query: {alias: 'preview', resource: 'posts'}
+                    query: {controller: 'preview', resource: 'preview'}
                 },
                 locals: {
                     apiVersion: 'v2'

--- a/core/test/unit/services/routing/controllers/static_spec.js
+++ b/core/test/unit/services/routing/controllers/static_spec.js
@@ -90,6 +90,7 @@ describe('Unit - services/routing/controllers/static', function () {
     it('extra data to fetch', function (done) {
         res.routerOptions.data = {
             tag: {
+                controller: 'tags',
                 resource: 'tags',
                 type: 'read',
                 options: {

--- a/core/test/unit/services/routing/helpers/entry-lookup_spec.js
+++ b/core/test/unit/services/routing/helpers/entry-lookup_spec.js
@@ -23,7 +23,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('static pages', function () {
             const routerOptions = {
                 permalinks: '/:slug/',
-                query: {alias: 'pages', resource: 'posts'}
+                query: {controller: 'posts', resource: 'posts'}
             };
 
             let pages;
@@ -54,7 +54,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('Permalinks: /:slug/', function () {
             const routerOptions = {
                 permalinks: '/:slug/',
-                query: {alias: 'pages', resource: 'posts'}
+                query: {controller: 'posts', resource: 'posts'}
             };
 
             beforeEach(function () {
@@ -122,7 +122,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('Permalinks: /:year/:month/:day/:slug/', function () {
             const routerOptions = {
                 permalinks: '/:year/:month/:day/:slug/',
-                query: {alias: 'pages', resource: 'posts'}
+                query: {controller: 'posts', resource: 'posts'}
             };
 
             beforeEach(function () {
@@ -194,7 +194,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('with url options', function () {
             const routerOptions = {
                 permalinks: '/:slug/:options(edit)?',
-                query: {alias: 'pages', resource: 'posts'}
+                query: {controller: 'posts', resource: 'posts'}
             };
 
             beforeEach(function () {
@@ -274,7 +274,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('static pages', function () {
             const routerOptions = {
                 permalinks: '/:slug/',
-                query: {alias: 'pages', resource: 'posts'}
+                query: {controller: 'pages', resource: 'pages'}
             };
 
             let pages;
@@ -325,7 +325,7 @@ describe('Unit - services/routing/helpers/entry-lookup', function () {
         describe('posts', function () {
             const routerOptions = {
                 permalinks: '/:slug/',
-                query: {alias: 'posts', resource: 'posts'}
+                query: {controller: 'posts', resource: 'posts'}
             };
 
             let posts;

--- a/core/test/unit/services/routing/helpers/fetch-data_spec.js
+++ b/core/test/unit/services/routing/helpers/fetch-data_spec.js
@@ -154,7 +154,7 @@ describe('Unit - services/routing/helpers/fetch-data', function () {
             filter: 'tags:%s',
             data: {
                 tag: {
-                    alias: 'tags',
+                    controller: 'tags',
                     type: 'read',
                     resource: 'tags',
                     options: {slug: '%s'}

--- a/core/test/unit/services/settings/loader_spec.js
+++ b/core/test/unit/services/settings/loader_spec.js
@@ -29,10 +29,13 @@ describe('UNIT > Settings Service:', function () {
             },
             taxonomies: {tag: '/tag/{slug}/', author: '/author/{slug}/'}
         };
+
         let yamlParserStub;
+        let validateStub;
 
         beforeEach(function () {
             yamlParserStub = sinon.stub();
+            validateStub = sinon.stub();
         });
 
         it('can find yaml settings file and returns a settings object', function () {
@@ -40,7 +43,10 @@ describe('UNIT > Settings Service:', function () {
             const expectedSettingsFile = path.join(__dirname, '../../../utils/fixtures/settings/goodroutes.yaml');
 
             yamlParserStub.returns(yamlStubFile);
+            validateStub.returns({routes: {}, collections: {}, taxonomies: {}});
+
             loadSettings.__set__('yamlParser', yamlParserStub);
+            loadSettings.__set__('validate', validateStub);
 
             const setting = loadSettings('goodroutes');
             should.exist(setting);

--- a/core/test/unit/services/settings/validate_spec.js
+++ b/core/test/unit/services/settings/validate_spec.js
@@ -1,754 +1,829 @@
-const should = require('should'),
-    common = require('../../../../server/lib/common'),
-    validate = require('../../../../server/services/settings/validate');
+const should = require('should');
+const sinon = require('sinon');
+const common = require('../../../../server/lib/common');
+const themesService = require('../../../../server/services/themes');
+const validate = require('../../../../server/services/settings/validate');
+const sandbox = sinon.sandbox.create();
 
 should.equal(true, true);
 
 describe('UNIT: services/settings/validate', function () {
-    it('no type definitions / empty yaml file', function () {
-        const object = validate({});
+    let apiVersion;
 
-        object.should.eql({collections: {}, routes: {}, taxonomies: {}});
+    before(function () {
+        sandbox.stub(themesService, 'getActive').returns({
+            engine: () => {
+                return apiVersion;
+            }
+        });
     });
 
-    it('throws error when using :\w+ notiation in collection', function () {
-        try {
+    after(function () {
+        sandbox.restore();
+    });
+
+    describe('v0.1', function () {
+        before(function () {
+            apiVersion = 'v0.1';
+        });
+
+        it('no type definitions / empty yaml file', function () {
+            const object = validate({});
+
+            object.should.eql({collections: {}, routes: {}, taxonomies: {}});
+        });
+
+        it('throws error when using :\w+ notiation in collection', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/magic/{slug}/'
+                        },
+                        '/': {
+                            permalink: '/:slug/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when using :\w+ notiation in taxonomies', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        tag: '/categories/:slug/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when using an undefined taxonomy', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        sweet_baked_good: '/patisserie/{slug}'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when permalink is missing (collection)', function () {
+            try {
+                validate({
+                    collections: {
+                        permalink: '/{slug}/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        about: 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        '/about': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        'about/': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        'magic/': {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        magic: {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic': {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('no validation error for routes', function () {
+            validate({
+                routes: {
+                    '/': 'home'
+                }
+            });
+        });
+
+        it('no validation error for / collection', function () {
             validate({
                 collections: {
+                    '/': {
+                        permalink: '/{primary_tag}/{slug}/'
+                    }
+                }
+            });
+        });
+
+        it('transforms {.*} notation into :\w+', function () {
+            const object = validate({
+                collections: {
                     '/magic/': {
-                        permalink: '/magic/{slug}/'
+                        permalink: '/magic/{year}/{slug}/'
                     },
                     '/': {
-                        permalink: '/:slug/'
+                        permalink: '/{slug}/'
                     }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error when using :\w+ notiation in taxonomies', function () {
-        try {
-            validate({
+                },
                 taxonomies: {
-                    tag: '/categories/:slug/'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error when using an undefined taxonomy', function () {
-        try {
-            validate({
-                taxonomies: {
-                    sweet_baked_good: '/patisserie/{slug}'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error when permalink is missing (collection)', function () {
-        try {
-            validate({
-                collections: {
-                    permalink: '/{slug}/'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                routes: {
-                    about: 'about'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                routes: {
-                    '/about': 'about'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                routes: {
-                    'about/': 'about'
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                collections: {
-                    'magic/': {
-                        permalink: '/{slug}/'
-                    }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                collections: {
-                    magic: {
-                        permalink: '/{slug}/'
-                    }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                collections: {
-                    '/magic': {
-                        permalink: '/{slug}/'
-                    }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                collections: {
-                    '/magic/': {
-                        permalink: '/{slug}'
-                    }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('throws error without leading or trailing slashes', function () {
-        try {
-            validate({
-                collections: {
-                    '/magic/': {
-                        permalink: '{slug}'
-                    }
-                }
-            });
-        } catch (err) {
-            (err instanceof common.errors.ValidationError).should.be.true();
-            return;
-        }
-
-        throw new Error('should fail');
-    });
-
-    it('no validation error for routes', function () {
-        validate({
-            routes: {
-                '/': 'home'
-            }
-        });
-    });
-
-    it('no validation error for / collection', function () {
-        validate({
-            collections: {
-                '/': {
-                    permalink: '/{primary_tag}/{slug}/'
-                }
-            }
-        });
-    });
-
-    it('transforms {.*} notation into :\w+', function () {
-        const object = validate({
-            collections: {
-                '/magic/': {
-                    permalink: '/magic/{year}/{slug}/'
-                },
-                '/': {
-                    permalink: '/{slug}/'
-                }
-            },
-            taxonomies: {
-                tag: '/tags/{slug}/',
-                author: '/authors/{slug}/',
-            }
-        });
-
-        object.should.eql({
-            routes: {},
-            taxonomies: {
-                tag: '/tags/:slug/',
-                author: '/authors/:slug/'
-            },
-            collections: {
-                '/magic/': {
-                    permalink: '/magic/:year/:slug/',
-                    templates: []
-                },
-                '/': {
-                    permalink: '/:slug/',
-                    templates: []
-                }
-            }
-        });
-    });
-
-    describe('template definitions', function () {
-        it('single value', function () {
-            const object = validate({
-                routes: {
-                    '/about/': 'about',
-                    '/me/': {
-                        template: 'me'
-                    }
-                },
-                collections: {
-                    '/': {
-                        permalink: '/{slug}/',
-                        template: 'test'
-                    }
+                    tag: '/tags/{slug}/',
+                    author: '/authors/{slug}/',
                 }
             });
 
             object.should.eql({
-                taxonomies: {},
-                routes: {
-                    '/about/': {
-                        templates: ['about']
-                    },
-                    '/me/': {
-                        templates: ['me']
-                    }
+                routes: {},
+                taxonomies: {
+                    tag: '/tags/:slug/',
+                    author: '/authors/:slug/'
                 },
                 collections: {
+                    '/magic/': {
+                        permalink: '/magic/:year/:slug/',
+                        templates: []
+                    },
                     '/': {
                         permalink: '/:slug/',
-                        templates: ['test']
+                        templates: []
                     }
                 }
             });
         });
 
-        it('array', function () {
-            const object = validate({
-                routes: {
-                    '/about/': 'about',
-                    '/me/': {
-                        template: ['me']
+        describe('template definitions', function () {
+            it('single value', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: 'me'
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'test'
+                        }
                     }
-                },
-                collections: {
-                    '/': {
-                        permalink: '/{slug}/',
-                        template: ['test']
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
                     }
-                }
+                });
             });
 
-            object.should.eql({
-                taxonomies: {},
-                routes: {
-                    '/about/': {
-                        templates: ['about']
+            it('array', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: ['me']
+                        }
                     },
-                    '/me/': {
-                        templates: ['me']
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: ['test']
+                        }
                     }
-                },
-                collections: {
-                    '/': {
-                        permalink: '/:slug/',
-                        templates: ['test']
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
                     }
-                }
+                });
             });
         });
-    });
 
-    describe('data definitions', function () {
-        it('shortform', function () {
-            const object = validate({
-                routes: {
-                    '/food/': {
-                        data: 'tag.food'
-                    },
-                    '/music/': {
-                        data: 'tag.music'
-                    },
-                    '/ghost/': {
-                        data: 'user.ghost'
-                    },
-                    '/sleep/': {
-                        data: {
-                            bed: 'tag.bed',
-                            dream: 'tag.dream'
+        describe('data definitions', function () {
+            it('shortform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: 'tag.food'
+                        },
+                        '/music/': {
+                            data: 'tag.music'
+                        },
+                        '/ghost/': {
+                            data: 'user.ghost'
+                        },
+                        '/sleep/': {
+                            data: {
+                                bed: 'tag.bed',
+                                dream: 'tag.dream'
+                            }
+                        },
+                        '/lala/': {
+                            data: 'author.carsten'
                         }
                     },
-                    '/lala/': {
-                        data: 'author.carsten'
+                    collections: {
+                        '/more/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                home: 'page.home'
+                            }
+                        },
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            data: {
+                                something: 'tag.something'
+                            }
+                        },
+                        '/': {
+                            permalink: '/{slug}/',
+                            data: 'tag.sport'
+                        }
                     }
-                },
-                collections: {
-                    '/more/': {
-                        permalink: '/{slug}/',
-                        data: {
-                            home: 'page.home'
-                        }
-                    },
-                    '/podcast/': {
-                        permalink: '/podcast/{slug}/',
-                        data: {
-                            something: 'tag.something'
-                        }
-                    },
-                    '/': {
-                        permalink: '/{slug}/',
-                        data: 'tag.sport'
-                    }
-                }
-            });
+                });
 
-            object.should.eql({
-                taxonomies: {},
-                routes: {
-                    '/food/': {
-                        data: {
-                            query: {
-                                tag: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'food',
-                                        visibility: 'public'
-                                    }
-                                }
-                            },
-                            router: {
-                                tags: [{redirect: true, slug: 'food'}]
-                            }
-                        },
-                        templates: []
-                    },
-                    '/ghost/': {
-                        data: {
-                            query: {
-                                user: {
-                                    alias: 'authors',
-                                    resource: 'users',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'ghost',
-                                        visibility: 'public'
-                                    }
-                                }
-                            },
-                            router: {
-                                authors: [{redirect: true, slug: 'ghost'}]
-                            }
-                        },
-                        templates: []
-                    },
-                    '/music/': {
-                        data: {
-                            query: {
-                                tag: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'music',
-                                        visibility: 'public'
-                                    }
-                                }
-                            },
-                            router: {
-                                tags: [{redirect: true, slug: 'music'}]
-                            }
-                        },
-                        templates: []
-                    },
-                    '/sleep/': {
-                        data: {
-                            query: {
-                                bed: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'bed',
-                                        visibility: 'public'
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'food',
+                                            visibility: 'public'
+                                        }
                                     }
                                 },
-                                dream: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'dream',
-                                        visibility: 'public'
-                                    }
+                                router: {
+                                    tags: [{redirect: true, slug: 'food'}]
                                 }
                             },
-                            router: {
-                                tags: [{redirect: true, slug: 'bed'}, {redirect: true, slug: 'dream'}]
-                            }
+                            templates: []
                         },
-                        templates: []
+                        '/ghost/': {
+                            data: {
+                                query: {
+                                    user: {
+                                        controller: 'users',
+                                        resource: 'users',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'ghost',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'ghost'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/music/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'music',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'music'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/sleep/': {
+                            data: {
+                                query: {
+                                    bed: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'bed',
+                                            visibility: 'public'
+                                        }
+                                    },
+                                    dream: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'dream',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'bed'}, {redirect: true, slug: 'dream'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/lala/': {
+                            data: {
+                                query: {
+                                    author: {
+                                        controller: 'users',
+                                        resource: 'users',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'carsten',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'carsten'}]
+                                }
+                            },
+                            templates: []
+                        }
                     },
-                    '/lala/': {
-                        data: {
-                            query: {
-                                author: {
-                                    alias: 'authors',
-                                    resource: 'users',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'carsten',
-                                        visibility: 'public'
+                    collections: {
+                        '/more/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    home: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            page: 1,
+                                            slug: 'home',
+                                            status: 'published'
+                                        }
                                     }
+                                },
+                                router: {
+                                    posts: [{redirect: true, slug: 'home'}]
                                 }
                             },
-                            router: {
-                                authors: [{redirect: true, slug: 'carsten'}]
-                            }
+                            templates: []
                         },
-                        templates: []
+                        '/podcast/': {
+                            permalink: '/podcast/:slug/',
+                            data: {
+                                query: {
+                                    something: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'something',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'something'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tags',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'sport',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'sport'}]
+                                }
+                            },
+                            templates: []
+                        }
                     }
-                },
-                collections: {
-                    '/more/': {
-                        permalink: '/:slug/',
-                        data: {
-                            query: {
-                                home: {
-                                    alias: 'pages',
-                                    resource: 'posts',
-                                    type: 'read',
-                                    options: {
-                                        page: 1,
-                                        slug: 'home',
-                                        status: 'published'
-                                    }
-                                }
-                            },
-                            router: {
-                                pages: [{redirect: true, slug: 'home'}]
-                            }
-                        },
-                        templates: []
-                    },
-                    '/podcast/': {
-                        permalink: '/podcast/:slug/',
-                        data: {
-                            query: {
-                                something: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'something',
-                                        visibility: 'public'
-                                    }
-                                }
-                            },
-                            router: {
-                                tags: [{redirect: true, slug: 'something'}]
-                            }
-                        },
-                        templates: []
-                    },
-                    '/': {
-                        permalink: '/:slug/',
-                        data: {
-                            query: {
-                                tag: {
-                                    alias: 'tags',
-                                    resource: 'tags',
-                                    type: 'read',
-                                    options: {
-                                        slug: 'sport',
-                                        visibility: 'public'
-                                    }
-                                }
-                            },
-                            router: {
-                                tags: [{redirect: true, slug: 'sport'}]
-                            }
-                        },
-                        templates: []
-                    }
-                }
+                });
             });
-        });
 
-        it('longform', function () {
-            const object = validate({
-                routes: {
-                    '/food/': {
-                        data: {
-                            food: {
-                                resource: 'posts',
-                                type: 'browse'
-                            }
-                        }
-                    },
-                    '/wellness/': {
-                        data: {
-                            posts: {
-                                resource: 'posts',
-                                type: 'read',
-                                redirect: false
-                            }
-                        }
-                    },
-                    '/partyparty/': {
-                        data: {
-                            people: {
-                                resource: 'users',
-                                type: 'read',
-                                slug: 'djgutelaune',
-                                redirect: true
-                            }
-                        }
-                    }
-                },
-                collections: {
-                    '/yoga/': {
-                        permalink: '/{slug}/',
-                        data: {
-                            gym: {
-                                resource: 'posts',
-                                type: 'read',
-                                slug: 'ups',
-                                status: 'draft'
-                            }
-                        }
-                    },
-                }
-            });
-
-            object.should.eql({
-                taxonomies: {},
-                routes: {
-                    '/food/': {
-                        data: {
-                            query: {
+            it('longform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: {
                                 food: {
-                                    alias: 'posts',
                                     resource: 'posts',
-                                    type: 'browse',
-                                    options: {}
+                                    type: 'browse'
                                 }
-                            },
-                            router: {
-                                posts: [{redirect: true}]
                             }
                         },
-                        templates: []
-                    },
-                    '/wellness/': {
-                        data: {
-                            query: {
+                        '/wellness/': {
+                            data: {
                                 posts: {
-                                    alias: 'posts',
                                     resource: 'posts',
                                     type: 'read',
-                                    options: {
-                                        status: 'published',
-                                        slug: '%s',
-                                        page: 0
-                                    }
+                                    redirect: false
                                 }
-                            },
-                            router: {
-                                posts: [{redirect: false}]
                             }
                         },
-                        templates: []
-                    },
-                    '/partyparty/': {
-                        data: {
-                            query: {
+                        '/partyparty/': {
+                            data: {
                                 people: {
-                                    alias: 'authors',
                                     resource: 'users',
                                     type: 'read',
-                                    options: {
-                                        slug: 'djgutelaune',
-                                        visibility: 'public'
-                                    }
+                                    slug: 'djgutelaune',
+                                    redirect: true
                                 }
-                            },
-                            router: {
-                                authors: [{redirect: true, slug: 'djgutelaune'}]
                             }
-                        },
-                        templates: []
-                    }
-                },
-                collections: {
-                    '/yoga/': {
-                        permalink: '/:slug/',
-                        data: {
-                            query: {
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/{slug}/',
+                            data: {
                                 gym: {
-                                    alias: 'posts',
                                     resource: 'posts',
                                     type: 'read',
-                                    options: {
-                                        page: 0,
-                                        slug: 'ups',
-                                        status: 'draft'
-                                    }
+                                    slug: 'ups',
+                                    status: 'draft'
                                 }
-                            },
-                            router: {
-                                posts: [{redirect: true, slug: 'ups'}]
                             }
                         },
-                        templates: []
                     }
-                }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    food: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'browse',
+                                        options: {}
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/wellness/': {
+                            data: {
+                                query: {
+                                    posts: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            status: 'published',
+                                            slug: '%s',
+                                            page: 0
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: false}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/partyparty/': {
+                            data: {
+                                query: {
+                                    people: {
+                                        controller: 'users',
+                                        resource: 'users',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'djgutelaune',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'djgutelaune'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    gym: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            page: 0,
+                                            slug: 'ups',
+                                            status: 'draft'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true, slug: 'ups'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    }
+                });
             });
-        });
 
-        it('errors: data shortform incorrect', function () {
-            try {
-                validate({
-                    collections: {
-                        '/magic/': {
-                            permalink: '/{slug}/',
-                            data: 'tag:test'
-                        }
-                    }
-                });
-            } catch (err) {
-                (err instanceof common.errors.ValidationError).should.be.true();
-                return;
-            }
-
-            throw new Error('should fail');
-        });
-
-        it('errors: data longform resource is missing', function () {
-            try {
-                validate({
-                    collections: {
-                        '/magic/': {
-                            permalink: '/{slug}/',
-                            data: {
-                                type: 'edit'
+            it('errors: data shortform incorrect', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: 'tag:test'
                             }
                         }
-                    }
-                });
-            } catch (err) {
-                (err instanceof common.errors.ValidationError).should.be.true();
-                return;
-            }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
 
-            throw new Error('should fail');
-        });
+                throw new Error('should fail');
+            });
 
-        it('errors: data longform type is missing', function () {
-            try {
-                validate({
-                    collections: {
-                        '/magic/': {
-                            permalink: '/{slug}/',
-                            data: {
-                                resource: 'subscribers'
+            it('errors: data longform resource is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    type: 'edit'
+                                }
                             }
                         }
-                    }
-                });
-            } catch (err) {
-                (err instanceof common.errors.ValidationError).should.be.true();
-                return;
-            }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
 
-            throw new Error('should fail');
-        });
+                throw new Error('should fail');
+            });
 
-        it('errors: data longform name is author', function () {
-            try {
-                validate({
-                    collections: {
-                        '/magic/': {
-                            permalink: '/{slug}/',
-                            data: {
-                                author: {
+            it('errors: data longform type is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    resource: 'subscribers'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform name is author', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    author: {
+                                        resource: 'users'
+                                    }
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform does not use a custom name at all', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
                                     resource: 'users'
                                 }
                             }
                         }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+        });
+    });
+
+    describe('v2', function () {
+        before(function () {
+            apiVersion = 'v2';
+        });
+
+        it('no type definitions / empty yaml file', function () {
+            const object = validate({});
+
+            object.should.eql({collections: {}, routes: {}, taxonomies: {}});
+        });
+
+        it('throws error when using :\w+ notiation in collection', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/magic/{slug}/'
+                        },
+                        '/': {
+                            permalink: '/:slug/'
+                        }
                     }
                 });
             } catch (err) {
@@ -759,15 +834,102 @@ describe('UNIT: services/settings/validate', function () {
             throw new Error('should fail');
         });
 
-        it('errors: data longform does not use a custom name at all', function () {
+        it('throws error when using :\w+ notiation in taxonomies', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        tag: '/categories/:slug/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when using an undefined taxonomy', function () {
+            try {
+                validate({
+                    taxonomies: {
+                        sweet_baked_good: '/patisserie/{slug}'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error when permalink is missing (collection)', function () {
             try {
                 validate({
                     collections: {
-                        '/magic/': {
-                            permalink: '/{slug}/',
-                            data: {
-                                resource: 'users'
-                            }
+                        permalink: '/{slug}/'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        about: 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        '/about': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    routes: {
+                        'about/': 'about'
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        'magic/': {
+                            permalink: '/{slug}/'
                         }
                     }
                 });
@@ -777,6 +939,640 @@ describe('UNIT: services/settings/validate', function () {
             }
 
             throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        magic: {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic': {
+                            permalink: '/{slug}/'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '/{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('throws error without leading or trailing slashes', function () {
+            try {
+                validate({
+                    collections: {
+                        '/magic/': {
+                            permalink: '{slug}'
+                        }
+                    }
+                });
+            } catch (err) {
+                (err instanceof common.errors.ValidationError).should.be.true();
+                return;
+            }
+
+            throw new Error('should fail');
+        });
+
+        it('no validation error for routes', function () {
+            validate({
+                routes: {
+                    '/': 'home'
+                }
+            });
+        });
+
+        it('no validation error for / collection', function () {
+            validate({
+                collections: {
+                    '/': {
+                        permalink: '/{primary_tag}/{slug}/'
+                    }
+                }
+            });
+        });
+
+        it('transforms {.*} notation into :\w+', function () {
+            const object = validate({
+                collections: {
+                    '/magic/': {
+                        permalink: '/magic/{year}/{slug}/'
+                    },
+                    '/': {
+                        permalink: '/{slug}/'
+                    }
+                },
+                taxonomies: {
+                    tag: '/tags/{slug}/',
+                    author: '/authors/{slug}/',
+                }
+            });
+
+            object.should.eql({
+                routes: {},
+                taxonomies: {
+                    tag: '/tags/:slug/',
+                    author: '/authors/:slug/'
+                },
+                collections: {
+                    '/magic/': {
+                        permalink: '/magic/:year/:slug/',
+                        templates: []
+                    },
+                    '/': {
+                        permalink: '/:slug/',
+                        templates: []
+                    }
+                }
+            });
+        });
+
+        describe('template definitions', function () {
+            it('single value', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: 'me'
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: 'test'
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
+                    }
+                });
+            });
+
+            it('array', function () {
+                const object = validate({
+                    routes: {
+                        '/about/': 'about',
+                        '/me/': {
+                            template: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/{slug}/',
+                            template: ['test']
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/about/': {
+                            templates: ['about']
+                        },
+                        '/me/': {
+                            templates: ['me']
+                        }
+                    },
+                    collections: {
+                        '/': {
+                            permalink: '/:slug/',
+                            templates: ['test']
+                        }
+                    }
+                });
+            });
+        });
+
+        describe('data definitions', function () {
+            it('shortform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: 'tag.food'
+                        },
+                        '/music/': {
+                            data: 'tag.music'
+                        },
+                        '/ghost/': {
+                            data: 'author.ghost'
+                        },
+                        '/sleep/': {
+                            data: {
+                                bed: 'tag.bed',
+                                dream: 'tag.dream'
+                            }
+                        },
+                        '/lala/': {
+                            data: 'author.carsten'
+                        }
+                    },
+                    collections: {
+                        '/more/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                home: 'page.home'
+                            }
+                        },
+                        '/podcast/': {
+                            permalink: '/podcast/{slug}/',
+                            data: {
+                                something: 'tag.something'
+                            }
+                        },
+                        '/': {
+                            permalink: '/{slug}/',
+                            data: 'tag.sport'
+                        }
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'food',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'food'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/ghost/': {
+                            data: {
+                                query: {
+                                    author: {
+                                        controller: 'authors',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'ghost'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'ghost'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/music/': {
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'music',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'music'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/sleep/': {
+                            data: {
+                                query: {
+                                    bed: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'bed',
+                                            visibility: 'public'
+                                        }
+                                    },
+                                    dream: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'dream',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'bed'}, {redirect: true, slug: 'dream'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/lala/': {
+                            data: {
+                                query: {
+                                    author: {
+                                        controller: 'authors',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'carsten'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'carsten'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    },
+                    collections: {
+                        '/more/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    home: {
+                                        controller: 'pages',
+                                        resource: 'pages',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'home'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    pages: [{redirect: true, slug: 'home'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/podcast/': {
+                            permalink: '/podcast/:slug/',
+                            data: {
+                                query: {
+                                    something: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'something',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'something'}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    tag: {
+                                        controller: 'tagsPublic',
+                                        resource: 'tags',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'sport',
+                                            visibility: 'public'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    tags: [{redirect: true, slug: 'sport'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    }
+                });
+            });
+
+            it('longform', function () {
+                const object = validate({
+                    routes: {
+                        '/food/': {
+                            data: {
+                                food: {
+                                    resource: 'posts',
+                                    type: 'browse'
+                                }
+                            }
+                        },
+                        '/wellness/': {
+                            data: {
+                                posts: {
+                                    resource: 'posts',
+                                    type: 'read',
+                                    redirect: false
+                                }
+                            }
+                        },
+                        '/partyparty/': {
+                            data: {
+                                people: {
+                                    resource: 'authors',
+                                    type: 'read',
+                                    slug: 'djgutelaune',
+                                    redirect: true
+                                }
+                            }
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/{slug}/',
+                            data: {
+                                gym: {
+                                    resource: 'posts',
+                                    type: 'read',
+                                    slug: 'ups',
+                                    status: 'draft'
+                                }
+                            }
+                        },
+                    }
+                });
+
+                object.should.eql({
+                    taxonomies: {},
+                    routes: {
+                        '/food/': {
+                            data: {
+                                query: {
+                                    food: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'browse',
+                                        options: {}
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/wellness/': {
+                            data: {
+                                query: {
+                                    posts: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            slug: '%s'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: false}]
+                                }
+                            },
+                            templates: []
+                        },
+                        '/partyparty/': {
+                            data: {
+                                query: {
+                                    people: {
+                                        controller: 'authors',
+                                        resource: 'authors',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'djgutelaune'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    authors: [{redirect: true, slug: 'djgutelaune'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    },
+                    collections: {
+                        '/yoga/': {
+                            permalink: '/:slug/',
+                            data: {
+                                query: {
+                                    gym: {
+                                        controller: 'posts',
+                                        resource: 'posts',
+                                        type: 'read',
+                                        options: {
+                                            slug: 'ups',
+                                            status: 'draft'
+                                        }
+                                    }
+                                },
+                                router: {
+                                    posts: [{redirect: true, slug: 'ups'}]
+                                }
+                            },
+                            templates: []
+                        }
+                    }
+                });
+            });
+
+            it('errors: data shortform incorrect', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: 'tag:test'
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform resource is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    type: 'edit'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform type is missing', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    resource: 'subscribers'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform name is author', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    author: {
+                                        resource: 'users'
+                                    }
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
+
+            it('errors: data longform does not use a custom name at all', function () {
+                try {
+                    validate({
+                        collections: {
+                            '/magic/': {
+                                permalink: '/{slug}/',
+                                data: {
+                                    resource: 'users'
+                                }
+                            }
+                        }
+                    });
+                } catch (err) {
+                    (err instanceof common.errors.ValidationError).should.be.true();
+                    return;
+                }
+
+                throw new Error('should fail');
+            });
         });
     });
 });


### PR DESCRIPTION
refs #10124

- one clean v0.1 and v2 config file for routing!
- solves one underlying bug reported in #10124
- the alias handling was just a hotfix to support v2 for the site
- but it was hard to read and now we have two clean configs
