### PR TITLE
[WIP] ✨ added db import polling endpoints

### DIFF
--- a/core/server/api/v2/db.js
+++ b/core/server/api/v2/db.js
@@ -6,15 +6,9 @@ const AbstractPoller = require('../../lib/abstract-poller');
 const common = require('../../lib/common');
 const models = require('../../models');
 
-const transformImportSuccess = (result) => {
-    return {
-        // NOTE: response can contain 2 objects if images are imported
-        problems: result[result.length === 2 ? 1 : 0].problems
-    };
-};
+const callImport = (...args) => importer.importFromFile(...args);
 
-const transformImportFailure = error => ({errors: [error]});
-const asyncImporter = new AbstractPoller(importer.importFromFile, transformImportSuccess, transformImportFailure);
+const asyncImporter = new AbstractPoller(callImport);
 
 module.exports = {
     docName: 'db',

--- a/core/server/api/v2/utils/serializers/output/db.js
+++ b/core/server/api/v2/utils/serializers/output/db.js
@@ -46,6 +46,21 @@ module.exports = {
         status.importing = status.busy;
         delete status.busy;
 
+        if (status.lastResult) {
+            if (status.lastResult.error) {
+                status.lastResult.errors = [status.lastResult.error];
+                delete status.lastResult.error;
+            }
+
+            if (status.lastResult.result) {
+                const {result} = status.lastResult;
+                // NOTE: response can contain 2 objects if images are imported
+                status.lastResult.problems = result[result.length === 2 ? 1 : 0].problems;
+                delete status.lastResult.result;
+            }
+        }
+
+
         frame.response = status;
     },
 

--- a/core/server/api/v2/utils/serializers/output/db.js
+++ b/core/server/api/v2/utils/serializers/output/db.js
@@ -31,6 +31,24 @@ module.exports = {
         };
     },
 
+    importContentAsync(response, apiConfig, frame) {
+        debug('importContentAsync');
+
+        frame.response = {
+            db: [],
+            importId: response
+        };
+    },
+
+    asyncImportStatus(status, apiConfig, frame) {
+        debug('asyncImportStatus');
+
+        status.importing = status.busy;
+        delete status.busy;
+
+        frame.response = status;
+    },
+
     deleteAllContent(response, apiConfig, frame) {
         frame.response = {
             db: []

--- a/core/server/lib/abstract-poller.js
+++ b/core/server/lib/abstract-poller.js
@@ -1,13 +1,7 @@
-const basicSuccessTransformer = () => ({});
-const basicFailTransformer = error => ({error});
-
 class AbstractPolling {
-    constructor(polledFunction, transformSuccess = basicSuccessTransformer, transformFailure = basicFailTransformer) {
+    constructor(polledFunction) {
         this.promise = false;
-
         this.polledFunction = polledFunction;
-        this.transformSuccess = transformSuccess;
-        this.transformFailure = transformFailure;
     }
 
     get isRunning() {
@@ -28,8 +22,8 @@ class AbstractPolling {
         }
 
         this.promise = this.polledFunction(...args)
-            .then(result => this.pollingFailed(result))
-            .catch(error => this.pollingSucceeded(error))
+            .then(result => this.pollingSucceeded(result))
+            .catch(error => this.pollingFailed(error))
             .finally(() => {
                 this.id = false;
                 this.promise = false;
@@ -39,18 +33,20 @@ class AbstractPolling {
         return this.id;
     }
 
-    pollingSucceeded(response) {
-        this.lastResult = Object.assign({
+    pollingSucceeded(result) {
+        this.lastResult = {
             id: this.id,
-            success: true
-        }, this.transformSuccess(response));
+            success: true,
+            result
+        }
     }
 
     pollingFailed(error) {
-        this.lastResult = Object.assign({
+        this.lastResult = {
             id: this.id,
-            success: false
-        }, this.transformFailure(error));
+            success: false,
+            error
+        };
     }
 }
 

--- a/core/server/lib/abstract-poller.js
+++ b/core/server/lib/abstract-poller.js
@@ -1,0 +1,57 @@
+const basicSuccessTransformer = () => ({});
+const basicFailTransformer = error => ({error});
+
+class AbstractPolling {
+    constructor(polledFunction, transformSuccess = basicSuccessTransformer, transformFailure = basicFailTransformer) {
+        this.promise = false;
+
+        this.polledFunction = polledFunction;
+        this.transformSuccess = transformSuccess;
+        this.transformFailure = transformFailure;
+    }
+
+    get isRunning() {
+        return this.promise !== false;
+    }
+
+    get state() {
+        return {
+            busy: this.isRunning,
+            lastResult: this.lastResult
+        };
+    }
+
+    run(...args) {
+        if (this.isRunning) {
+            // @todo: use a proper Ghost Error
+            return Promise.reject(new Error('An import is already running. Please wait until the current import finishes before starting a new one'));
+        }
+
+        this.promise = this.polledFunction(...args)
+            .then(result => this.pollingFailed(result))
+            .catch(error => this.pollingSucceeded(error))
+            .finally(() => {
+                this.id = false;
+                this.promise = false;
+            });
+
+        this.id = Math.floor(Math.random() * 1000);
+        return this.id;
+    }
+
+    pollingSucceeded(response) {
+        this.lastResult = Object.assign({
+            id: this.id,
+            success: true
+        }, this.transformSuccess(response));
+    }
+
+    pollingFailed(error) {
+        this.lastResult = Object.assign({
+            id: this.id,
+            success: false
+        }, this.transformFailure(error));
+    }
+}
+
+module.exports = AbstractPolling;

--- a/core/server/web/api/v2/admin/routes.js
+++ b/core/server/web/api/v2/admin/routes.js
@@ -150,6 +150,13 @@ module.exports = function apiRoutes() {
         mw.authenticateClient('Ghost Backup'),
         apiv2.http(apiv2.db.backupContent)
     );
+    router.get('/db/import', mw.authAdminApi, apiv2.http(apiv2.db.asyncImportStatus));
+    router.post('/db/import',
+        mw.authAdminApi,
+        upload.single('importfile'),
+        shared.middlewares.validation.upload({type: 'db'}),
+        apiv2.http(apiv2.db.importContentAsync)
+    );
 
     // ## Mail
     router.post('/mail', mw.authAdminApi, apiv2.http(apiv2.mail.send));


### PR DESCRIPTION
refs #9388 (this is just the backend)

- Add GET /ghost/api/v2/admin/db/import
  - returns the import state (currently importing or not) as well as the result of the last import

schema:
```js
{
  db: [],
  importing: Boolean,
  lastResult: {
    id: Number,
    success: Boolean,
    errors: undefined (success) | Array (!success)
    problems: Array (success) | undefined (!success)
  }
}
```

- Add POST /ghost/api/v2/admin/db/import
  - takes a file to import
  - returns a randomly generated id which will be included in the `lastResult` field of the GET endpoint