### PR TITLE
Brute protect content api

### DIFF
--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -60,7 +60,7 @@
         },
         "content_api_key": {
             "minWait": 3600000,
-            "maxWait": 3600000,
+            "maxWait": 86400000,
             "lifetime": 3600,
             "freeRetries": 99
         }

--- a/core/server/config/defaults.json
+++ b/core/server/config/defaults.json
@@ -57,6 +57,12 @@
             "maxWait": 3600000,
             "lifetime": 3600,
             "freeRetries":99
+        },
+        "content_api_key": {
+            "minWait": 3600000,
+            "maxWait": 3600000,
+            "lifetime": 3600,
+            "freeRetries": 99
         }
     },
     "caching": {

--- a/core/server/web/api/v2/content/middleware.js
+++ b/core/server/web/api/v2/content/middleware.js
@@ -14,6 +14,7 @@ const shared = require('../../../shared');
  * Authentication for public endpoints
  */
 module.exports.authenticatePublic = [
+    shared.middlewares.brute.contentApiKey,
     auth.authenticate.authenticateContentApi,
     auth.authorize.authorizeContentApi,
     cors(),

--- a/core/server/web/shared/middlewares/api/spam-prevention.js
+++ b/core/server/web/shared/middlewares/api/spam-prevention.js
@@ -10,6 +10,7 @@ const spamGlobalBlock = spam.global_block || {};
 const spamGlobalReset = spam.global_reset || {};
 const spamUserReset = spam.user_reset || {};
 const spamUserLogin = spam.user_login || {};
+const spamContentApiKey = spam.content_api_key || {};
 
 let store;
 let privateBlogInstance;
@@ -17,6 +18,7 @@ let globalResetInstance;
 let globalBlockInstance;
 let userLoginInstance;
 let userResetInstance;
+let contentApiKeyInstance;
 
 const spamConfigKeys = ['freeRetries', 'minWait', 'maxWait', 'lifetime'];
 
@@ -203,10 +205,40 @@ const privateBlog = () => {
     return privateBlogInstance;
 };
 
+const contentApiKey = () => {
+    const ExpressBrute = require('express-brute');
+    const BruteKnex = require('brute-knex');
+    const db = require('../../../../data/db');
+
+    store = store || new BruteKnex({
+        tablename: 'brute',
+        createTable: false,
+        knex: db.knex
+    });
+
+    contentApiKeyInstance = contentApiKeyInstance || new ExpressBrute(store,
+        extend({
+            attachResetToRequest: true,
+            failCallback(req, res, next) {
+                const err = new common.errors.GhostError({
+                    message: common.i18n.t('errors.middleware.spamprevention.tooManyAttempts')
+                });
+
+                common.logging.error(err);
+                return next(err);
+            },
+            handleStoreError: handleStoreError
+        }, pick(spamContentApiKey, spamConfigKeys))
+    );
+
+    return contentApiKeyInstance;
+};
+
 module.exports = {
     globalBlock: globalBlock,
     globalReset: globalReset,
     userLogin: userLogin,
     userReset: userReset,
-    privateBlog: privateBlog
+    privateBlog: privateBlog,
+    contentApiKey: contentApiKey
 };

--- a/core/server/web/shared/middlewares/brute.js
+++ b/core/server/web/shared/middlewares/brute.js
@@ -73,5 +73,26 @@ module.exports = {
                 next('privateblog');
             }
         })(req, res, next);
+    },
+
+    /*
+     * protect content api from brute force
+     */
+    contentApiKey(req, res, next) {
+        return spamPrevention.contentApiKey().getMiddleware({
+            ignoreIP: false
+        })(req, res, function (err, ...rest) {
+            if (!err) {
+                // Reset any blocks if the request is authorized
+                // This ensures that the count only goes up for
+                // unauthorized requests.
+                res.on('finish', function () {
+                    if (res.statusCode < 400) {
+                        req.brute.reset();
+                    }
+                });
+            }
+            return next(err, ...rest);
+        });
     }
 };


### PR DESCRIPTION
This adds a new method to the brute middleware - for blocking brute force attacks on the content api.

We put a rate limit on the content api, and reset it per ip when a request is successful, this results in virtually no limit if you have a correct content-api key, and being blocked if you don't.

