### PR TITLE
Added clause in validation for include to not error

### DIFF
--- a/core/server/api/shared/validators/input/all.js
+++ b/core/server/api/shared/validators/input/all.js
@@ -63,6 +63,12 @@ const validate = (config, attrs) => {
                 });
 
                 if (unallowedValues.length) {
+                    // CASE: we do not error for invalid includes, just silently remove
+                    if (key === 'include') {
+                        attrs.include = valuesAsArray.filter(x => allowedValues.includes(x));
+                        return;
+                    }
+
                     errors.push(new common.errors.ValidationError({
                         message: common.i18n.t('notices.data.validation.index.validationFailed', {
                             validationName: 'AllowedValues',

--- a/core/test/functional/api/v2/content/authors_spec.js
+++ b/core/test/functional/api/v2/content/authors_spec.js
@@ -63,18 +63,18 @@ describe('Authors Content API V2', function () {
             });
     });
 
-    it('browse authors: throws error if trying to fetch roles', function (done) {
+    it('browse authors: does not give back roles if trying to fetch roles', function (done) {
         request.get(localUtils.API.getApiQuery(`authors/?key=${validKey}&include=roles`))
             .set('Origin', testUtils.API.getURL())
             .expect('Content-Type', /json/)
             .expect('Cache-Control', testUtils.cacheRules.private)
-            .expect(422)
+            .expect(200)
             .end(function (err, res) {
                 if (err) {
                     return done(err);
                 }
 
-                should.not.exist(res.headers['x-cache-invalidate']);
+                should.not.exist(res.body.authors[0].roles);
                 done();
             });
     });

--- a/core/test/unit/api/shared/validators/input/all_spec.js
+++ b/core/test/unit/api/shared/validators/input/all_spec.js
@@ -132,7 +132,7 @@ describe('Unit: api/shared/validators/input/all', function () {
                 });
         });
 
-        it('fails', function () {
+        it('does not fail', function () {
             const frame = {
                 options: {
                     context: {},
@@ -151,11 +151,11 @@ describe('Unit: api/shared/validators/input/all', function () {
             return shared.validators.input.all.all(apiConfig, frame)
                 .then(Promise.reject)
                 .catch((err) => {
-                    should.exist(err);
+                    should.not.exist(err);
                 });
         });
 
-        it('fails include array notation', function () {
+        it('does not fail include array notation', function () {
             const frame = {
                 options: {
                     context: {},
@@ -172,7 +172,7 @@ describe('Unit: api/shared/validators/input/all', function () {
             return shared.validators.input.all.all(apiConfig, frame)
                 .then(Promise.reject)
                 .catch((err) => {
-                    should.exist(err);
+                    should.not.exist(err);
                 });
         });
 


### PR DESCRIPTION
refs #10337

Here we forgo erroring when an invalid property for include is sent, and
instead remove the invalid properties.
