### PR TITLE
Added brute protection to content api

### DIFF
--- a/core/server/web/api/v2/content/middleware.js
+++ b/core/server/web/api/v2/content/middleware.js
@@ -14,9 +14,7 @@ const shared = require('../../../shared');
  * Authentication for public endpoints
  */
 module.exports.authenticatePublic = [
-    /* @TODO: put this back
-     * shared.middlewares.brute.contentApiKey,
-     */
+    shared.middlewares.brute.contentApiKey,
     auth.authenticate.authenticateContentApi,
     auth.authorize.authorizeContentApi,
     cors(),

--- a/core/server/web/shared/middlewares/api/spam-prevention.js
+++ b/core/server/web/shared/middlewares/api/spam-prevention.js
@@ -215,7 +215,7 @@ const contentApiKey = () => {
         extend({
             attachResetToRequest: true,
             failCallback(req, res, next) {
-                const err = new common.errors.GhostError({
+                const err = new common.errors.TooManyRequestsError({
                     message: common.i18n.t('errors.middleware.spamprevention.tooManyAttempts')
                 });
 

--- a/core/server/web/shared/middlewares/api/spam-prevention.js
+++ b/core/server/web/shared/middlewares/api/spam-prevention.js
@@ -13,6 +13,7 @@ const spamUserLogin = spam.user_login || {};
 const spamContentApiKey = spam.content_api_key || {};
 
 let store;
+let memoryStore;
 let privateBlogInstance;
 let globalResetInstance;
 let globalBlockInstance;
@@ -207,16 +208,10 @@ const privateBlog = () => {
 
 const contentApiKey = () => {
     const ExpressBrute = require('express-brute');
-    const BruteKnex = require('brute-knex');
-    const db = require('../../../../data/db');
 
-    store = store || new BruteKnex({
-        tablename: 'brute',
-        createTable: false,
-        knex: db.knex
-    });
+    memoryStore = memoryStore || new ExpressBrute.MemoryStore();
 
-    contentApiKeyInstance = contentApiKeyInstance || new ExpressBrute(store,
+    contentApiKeyInstance = contentApiKeyInstance || new ExpressBrute(memoryStore,
         extend({
             attachResetToRequest: true,
             failCallback(req, res, next) {

--- a/core/test/unit/web/api/v2/content/middleware_spec.js
+++ b/core/test/unit/web/api/v2/content/middleware_spec.js
@@ -6,7 +6,7 @@ describe('Content Api v2 middleware', function () {
         should.exist(middleware.authenticatePublic);
     });
 
-    describe.skip('authenticatePublic', function () {
+    describe('authenticatePublic', function () {
         it('uses brute content api middleware as the first middleware in the chain', function () {
             const firstMiddleware = middleware.authenticatePublic[0];
             const brute = require('../../../../../../server/web/shared/middlewares/brute');


### PR DESCRIPTION
closes #10359 

This PR puts back the usage of `express-brute`, switching out the knex store, for an in memory one.

When the limit of non successful requests has been made, nothing can reset the count apart from a server restart.
Until that time, the count can be reset by a successful request.

To explain this easier, let's image you can make 3 "bad" requests before the block happens
```
 1. good req - fine
 2. bad req - 401
 3. bad req - 401
 4. good req - fine
 5. bad req - 401
 6. bad req - 401
 7. good req - fine
 8. bad req - 401
 9. bad req - 401
10. bad req - 401  // third bad req means blocked
11. bad req - 429 TooManyRequests
12. good req - 429 TooManyRequests
13. ...until timeout
```

The current default values are here: https://github.com/TryGhost/Ghost/blob/master/core/server/config/defaults.json#L61-L66

---

Benefits/downsides of using memory store over db:
- ✅ no deadlocks
- ✅ no need for db calls on every request
- ❌ marginally higher memory usage
- ❌ counts are reset on restart (do we already do that anyway?)

Regarding memory usage, the memorystore will only store a count for IP addresses that have used an invalid key and those counts will only be kept until they reach their timeout.