### PR TITLE
Default resource order in Content API

### DIFF
--- a/core/server/api/v2/utils/serializers/input/authors.js
+++ b/core/server/api/v2/utils/serializers/input/authors.js
@@ -1,5 +1,4 @@
-const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:tags');
-const url = require('./utils/url');
+const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:authors');
 const utils = require('../../index');
 
 function setDefaultOrder(frame) {
@@ -23,15 +22,5 @@ module.exports = {
         if (utils.isContentAPI(frame)) {
             setDefaultOrder(frame);
         }
-    },
-
-    add(apiConfig, frame) {
-        debug('add');
-        frame.data.tags[0] = url.forTag(Object.assign({}, frame.data.tags[0]));
-    },
-
-    edit(apiConfig, frame) {
-        debug('edit');
-        this.add(apiConfig, frame);
     }
 };

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -8,6 +8,12 @@ function removeMobiledocFormat(frame) {
     }
 }
 
+function setDefaultOrder(frame) {
+    if (!frame.options.order) {
+        frame.options.order = 'title asc';
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -28,6 +34,8 @@ module.exports = {
 
         removeMobiledocFormat(frame);
 
+        setDefaultOrder(frame);
+
         debug(frame.options);
     },
 
@@ -36,6 +44,8 @@ module.exports = {
 
         frame.data.page = true;
         removeMobiledocFormat(frame);
+
+        setDefaultOrder(frame);
 
         debug(frame.options);
     }

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -13,7 +13,8 @@ function setDefaultOrder(frame) {
     let includesOrderedRelations = false;
 
     if (frame.options.withRelated) {
-        includesOrderedRelations = _.intersection(['authors', 'tags'], frame.options.withRelated).length > 0;
+        const orderedRelations = ['author', 'authors', 'tag', 'tags'];
+        includesOrderedRelations = _.intersection(orderedRelations, frame.options.withRelated).length > 0;
     }
 
     if (!frame.options.order && !includesOrderedRelations) {

--- a/core/server/api/v2/utils/serializers/input/pages.js
+++ b/core/server/api/v2/utils/serializers/input/pages.js
@@ -1,3 +1,4 @@
+const _ = require('lodash');
 const debug = require('ghost-ignition').debug('api:v2:utils:serializers:input:pages');
 
 function removeMobiledocFormat(frame) {
@@ -9,7 +10,13 @@ function removeMobiledocFormat(frame) {
 }
 
 function setDefaultOrder(frame) {
-    if (!frame.options.order) {
+    let includesOrderedRelations = false;
+
+    if (frame.options.withRelated) {
+        includesOrderedRelations = _.intersection(['authors', 'tags'], frame.options.withRelated).length > 0;
+    }
+
+    if (!frame.options.order && !includesOrderedRelations) {
         frame.options.order = 'title asc';
     }
 }

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -24,7 +24,8 @@ function setDefaultOrder(frame) {
     let includesOrderedRelations = false;
 
     if (frame.options.withRelated) {
-        includesOrderedRelations = _.intersection(['authors', 'tags'], frame.options.withRelated).length > 0;
+        const orderedRelations = ['author', 'authors', 'tag', 'tags'];
+        includesOrderedRelations = _.intersection(orderedRelations, frame.options.withRelated).length > 0;
     }
 
     if (!frame.options.order && !includesOrderedRelations) {

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -21,7 +21,13 @@ function includeTags(frame) {
 }
 
 function setDefaultOrder(frame) {
-    if (!frame.options.order) {
+    let includesOrderedRelations = false;
+
+    if (frame.options.withRelated) {
+        includesOrderedRelations = _.intersection(['authors', 'tags'], frame.options.withRelated).length > 0;
+    }
+
+    if (!frame.options.order && !includesOrderedRelations) {
         frame.options.order = 'published_at desc';
     }
 }

--- a/core/server/api/v2/utils/serializers/input/posts.js
+++ b/core/server/api/v2/utils/serializers/input/posts.js
@@ -20,6 +20,12 @@ function includeTags(frame) {
     }
 }
 
+function setDefaultOrder(frame) {
+    if (!frame.options.order) {
+        frame.options.order = 'published_at desc';
+    }
+}
+
 module.exports = {
     browse(apiConfig, frame) {
         debug('browse');
@@ -53,6 +59,8 @@ module.exports = {
             if (labs.isSet('members')) {
                 includeTags(frame);
             }
+
+            setDefaultOrder(frame);
         }
 
         debug(frame.options);
@@ -76,6 +84,8 @@ module.exports = {
                 // CASE: Members needs to have the tags to check if its allowed access
                 includeTags(frame);
             }
+
+            setDefaultOrder(frame);
         }
 
         debug(frame.options);

--- a/core/server/api/v2/utils/serializers/input/tags.js
+++ b/core/server/api/v2/utils/serializers/input/tags.js
@@ -17,12 +17,10 @@ module.exports = {
         }
     },
 
-    read(apiConfig, frame) {
+    read() {
         debug('read');
 
-        if (utils.isContentAPI(frame)) {
-            setDefaultOrder(frame);
-        }
+        this.browse(...arguments);
     },
 
     add(apiConfig, frame) {

--- a/core/test/functional/api/v2/content/authors_spec.js
+++ b/core/test/functional/api/v2/content/authors_spec.js
@@ -50,6 +50,10 @@ describe('Authors Content API V2', function () {
                 // We don't expose the email address, status and other attrs.
                 localUtils.API.checkResponse(jsonResponse.authors[0], 'author', ['url'], null, null);
 
+                // Default order 'name asc' check
+                jsonResponse.authors[0].name.should.eql('Ghost');
+                jsonResponse.authors[2].name.should.eql('Slimer McEctoplasm');
+
                 should.exist(res.body.authors[0].url);
                 should.exist(url.parse(res.body.authors[0].url).protocol);
                 should.exist(url.parse(res.body.authors[0].url).host);

--- a/core/test/functional/api/v2/content/posts_spec.js
+++ b/core/test/functional/api/v2/content/posts_spec.js
@@ -52,7 +52,7 @@ describe('Posts', function () {
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
                 _.isBoolean(jsonResponse.posts[0].featured).should.eql(true);
 
-                // Default order check
+                // Default order 'published_at desc' check
                 jsonResponse.posts[0].slug.should.eql('welcome');
                 jsonResponse.posts[6].slug.should.eql('themes');
 

--- a/core/test/functional/api/v2/content/tags_spec.js
+++ b/core/test/functional/api/v2/content/tags_spec.js
@@ -46,6 +46,10 @@ describe('Tags Content API V2', function () {
                 localUtils.API.checkResponse(jsonResponse.tags[0], 'tag', ['url']);
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
 
+                // Default order 'name asc' check
+                jsonResponse.tags[0].name.should.eql('bacon');
+                jsonResponse.tags[3].name.should.eql('kitchen sink');
+
                 should.exist(res.body.tags[0].url);
                 should.exist(url.parse(res.body.tags[0].url).protocol);
                 should.exist(url.parse(res.body.tags[0].url).host);

--- a/core/test/functional/api/v2/content/tags_spec.js
+++ b/core/test/functional/api/v2/content/tags_spec.js
@@ -47,8 +47,15 @@ describe('Tags Content API V2', function () {
                 localUtils.API.checkResponse(jsonResponse.meta.pagination, 'pagination');
 
                 // Default order 'name asc' check
-                jsonResponse.tags[0].name.should.eql('bacon');
-                jsonResponse.tags[3].name.should.eql('kitchen sink');
+                // the ordering difference is described in https://github.com/TryGhost/Ghost/issues/6104
+                // this condition should be removed once issue mentioned above ^ is resolved
+                if (process.env.NODE_ENV === 'testing-mysql') {
+                    jsonResponse.tags[0].name.should.eql('bacon');
+                    jsonResponse.tags[3].name.should.eql('kitchen sink');
+                } else {
+                    jsonResponse.tags[0].name.should.eql('Getting Started');
+                    jsonResponse.tags[3].name.should.eql('kitchen sink');
+                }
 
                 should.exist(res.body.tags[0].url);
                 should.exist(url.parse(res.body.tags[0].url).protocol);


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/issues/10354

Probably need to add at least one more `page` to pages_spec [suite](https://github.com/TryGhost/Ghost/blob/master/core/test/functional/api/v2/content/pages_spec.js#L42) to test order for them as well :thinking: 