### PR TITLE
Refactored content-disposition header handling in API v2

### DIFF
--- a/core/server/api/shared/headers.js
+++ b/core/server/api/shared/headers.js
@@ -18,14 +18,14 @@ const disposition = {
         }
 
         return {
-            'Content-Disposition': value,
+            'Content-Disposition': `Attachment; filename="${value}"`,
             'Content-Type': 'text/csv'
         };
     },
 
     json(result, options = {}) {
         return {
-            'Content-Disposition': options.value,
+            'Content-Disposition': `Attachment; filename="${options.value}"`,
             'Content-Type': 'application/json',
             'Content-Length': Buffer.byteLength(JSON.stringify(result))
         };
@@ -33,7 +33,7 @@ const disposition = {
 
     yaml(result, options = {}) {
         return {
-            'Content-Disposition': options.value,
+            'Content-Disposition': `Attachment; filename="${options.value}"`,
             'Content-Type': 'application/yaml',
             'Content-Length': Buffer.byteLength(JSON.stringify(result))
         };

--- a/core/server/api/v2/settings.js
+++ b/core/server/api/v2/settings.js
@@ -177,7 +177,7 @@ module.exports = {
         headers: {
             disposition: {
                 type: 'yaml',
-                value: 'Attachment; filename="routes.yaml"'
+                value: 'routes.yaml'
             }
         },
         response: {

--- a/core/server/api/v2/subscribers.js
+++ b/core/server/api/v2/subscribers.js
@@ -143,7 +143,7 @@ const subscribers = {
                 type: 'csv',
                 value() {
                     const datetime = (new Date()).toJSON().substring(0, 10);
-                    return `Attachment; filename="subscribers.${datetime}.csv"`;
+                    return `subscribers.${datetime}.csv`;
                 }
             }
         },

--- a/core/test/unit/api/shared/headers_spec.js
+++ b/core/test/unit/api/shared/headers_spec.js
@@ -13,7 +13,7 @@ describe('Unit: api/shared/headers', function () {
             return shared.headers.get({}, {disposition: {type: 'json', value: 'value'}})
                 .then(result => {
                     result.should.eql({
-                        'Content-Disposition': 'value',
+                        'Content-Disposition': 'Attachment; filename=\"value\"',
                         'Content-Type': 'application/json',
                         'Content-Length': 2
                     });
@@ -24,7 +24,7 @@ describe('Unit: api/shared/headers', function () {
             return shared.headers.get({}, {disposition: {type: 'csv', value: 'my.csv'}})
                 .then(result => {
                     result.should.eql({
-                        'Content-Disposition': 'my.csv',
+                        'Content-Disposition': 'Attachment; filename=\"my.csv\"',
                         'Content-Type': 'text/csv'
                     });
                 });
@@ -34,7 +34,7 @@ describe('Unit: api/shared/headers', function () {
             return shared.headers.get('yaml file', {disposition: {type: 'yaml', value: 'my.yaml'}})
                 .then(result => {
                     result.should.eql({
-                        'Content-Disposition': 'my.yaml',
+                        'Content-Disposition': 'Attachment; filename=\"my.yaml\"',
                         'Content-Type': 'application/yaml',
                         'Content-Length': 11
                     });


### PR DESCRIPTION
closes https://github.com/TryGhost/Ghost/issues/10331

Only a filename part is left to be handled by controller configuration, the rest was extracted to more generic headers layer.