### PR TITLE
Cleaned post, tag and author v2 API outputs to return null instead of “” for fields

### DIFF
--- a/core/server/api/v2/utils/serializers/output/utils/clean.js
+++ b/core/server/api/v2/utils/serializers/output/utils/clean.js
@@ -7,6 +7,17 @@ const tag = (attrs) => {
     delete attrs.created_at;
     delete attrs.updated_at;
 
+    // We are standardising on returning null from the Content API for any empty values
+    if (attrs.meta_title === '') {
+        attrs.meta_title = null;
+    }
+    if (attrs.meta_description === '') {
+        attrs.meta_description = null;
+    }
+    if (attrs.description === '') {
+        attrs.description = null;
+    }
+
     return attrs;
 };
 
@@ -24,6 +35,29 @@ const author = (attrs) => {
     delete attrs.tour;
     delete attrs.visibility;
 
+    // We are standardising on returning null from the Content API for any empty values
+    if (attrs.twitter === '') {
+        attrs.twitter = null;
+    }
+    if (attrs.bio === '') {
+        attrs.bio = null;
+    }
+    if (attrs.website === '') {
+        attrs.website = null;
+    }
+    if (attrs.facebook === '') {
+        attrs.facebook = null;
+    }
+    if (attrs.meta_title === '') {
+        attrs.meta_title = null;
+    }
+    if (attrs.meta_description === '') {
+        attrs.meta_description = null;
+    }
+    if (attrs.location === '') {
+        attrs.location = null;
+    }
+
     return attrs;
 };
 
@@ -36,6 +70,26 @@ const post = (attrs) => {
     // delete attrs.page;
     delete attrs.status;
     delete attrs.visibility;
+
+    // We are standardising on returning null from the Content API for any empty values
+    if (attrs.twitter_title === '') {
+        attrs.twitter_title = null;
+    }
+    if (attrs.twitter_description === '') {
+        attrs.twitter_description = null;
+    }
+    if (attrs.meta_title === '') {
+        attrs.meta_title = null;
+    }
+    if (attrs.meta_description === '') {
+        attrs.meta_description = null;
+    }
+    if (attrs.og_title === '') {
+        attrs.og_title = null;
+    }
+    if (attrs.og_description === '') {
+        attrs.og_description = null;
+    }
 
     return attrs;
 };


### PR DESCRIPTION
refs #10345

- Updated `posts`, `authors` and `tags` API to return `null` for nullable fields instead of `""`
- We are standardising on returning null from the Content API for any empty values
