### PR TITLE
Aliased ghost_head & ghost_foot

### DIFF
--- a/core/server/api/v2/settings-public.js
+++ b/core/server/api/v2/settings-public.js
@@ -6,6 +6,8 @@ module.exports = {
     browse: {
         permissions: true,
         query() {
+            // @TODO: decouple settings cache from API knowledge
+            // The controller fetches models (or cached models) and the API frame for the target API version formats the response.
             return settingsCache.getPublic();
         }
     }

--- a/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
+++ b/core/server/api/v2/utils/serializers/output/utils/extra-attrs.js
@@ -11,3 +11,28 @@ module.exports.forPost = (frame, model, attrs) => {
         }
     }
 };
+
+// @NOTE: ghost_head & ghost_foot are deprecated, remove in Ghost 3.0
+module.exports.forSettings = (attrs) => {
+    const _ = require('lodash');
+
+    // @TODO: https://github.com/TryGhost/Ghost/issues/10106
+    // @NOTE: Admin & Content API return a different format, need to mappers
+    if (_.isArray(attrs)) {
+        const ghostHead = _.cloneDeep(_.find(attrs, {key: 'ghost_head'}));
+        const ghostFoot = _.cloneDeep(_.find(attrs, {key: 'ghost_foot'}));
+
+        if (ghostHead) {
+            ghostHead.key = 'codeinjection_head';
+            attrs.push(ghostHead);
+        }
+
+        if (ghostFoot) {
+            ghostFoot.key = 'codeinjection_foot';
+            attrs.push(ghostFoot);
+        }
+    } else {
+        attrs.codeinjection_head = attrs.ghost_head;
+        attrs.codeinjection_foot = attrs.ghost_foot;
+    }
+};

--- a/core/server/api/v2/utils/serializers/output/utils/mapper.js
+++ b/core/server/api/v2/utils/serializers/output/utils/mapper.js
@@ -72,6 +72,7 @@ const mapPost = (model, frame) => {
 
 const mapSettings = (attrs) => {
     url.forSettings(attrs);
+    extraAttrs.forSettings(attrs);
     return attrs;
 };
 

--- a/core/server/services/themes/middleware.js
+++ b/core/server/services/themes/middleware.js
@@ -45,6 +45,7 @@ themeMiddleware.ensureActiveTheme = function ensureActiveTheme(req, res, next) {
 themeMiddleware.updateTemplateData = function updateTemplateData(req, res, next) {
     // Static information, same for every request unless the settings change
     // @TODO: bind this once and then update based on events?
+    // @TODO: decouple theme layer from settings cache using the Content API
     var siteData = settingsCache.getPublic(),
         labsData = _.cloneDeep(settingsCache.get('labs')),
         themeData = {};

--- a/core/test/functional/api/v2/content/settings_spec.js
+++ b/core/test/functional/api/v2/content/settings_spec.js
@@ -46,6 +46,19 @@ describe('Settings', function () {
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {
+                    /**
+                     * @TODO:
+                     * This test is coupled with the settings cache and the model schema.
+                     * This test should compare against the API result using the test utility.
+                     * The settings cache should only cache model responses and should not know about
+                     * API or theme formats.
+                     *
+                     * This is just a hack to be able to alias ghost_head & ghost_foot quickly.
+                     */
+                    if (['codeinjection_head', 'codeinjection_foot'].includes(key)) {
+                        return;
+                    }
+
                     let defaultKey = _.findKey(publicSettings, (v) => v === key);
                     let defaultValue = _.find(defaultSettings, (setting) => setting.key === defaultKey).defaultValue;
 


### PR DESCRIPTION
closes #10373

- added a quick fix
- need to raise a decoupling refactoring issue for this

This is rly quick & dirty for now.

We now serve an alias for both fields for v2 admin & content API.

ghost_head & ghost_foot become deprecated and should be removed in v3. This will require a large refactoring e.g. on db and code level.
