### PR TITLE
[WIP] [DEMO] [Do not merge] serverside rendering members content

### DIFF
--- a/core/server/services/auth/members/index.js
+++ b/core/server/services/auth/members/index.js
@@ -26,6 +26,13 @@ module.exports = {
                 algorithm: 'RS512',
                 secret: membersService.api.publicKey,
                 getToken(req) {
+                    if (req.get('cookie')) {
+                        const memberTokenMatch = req.get('cookie').match(/member=([a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]*)/);
+                        if (memberTokenMatch) {
+                            return memberTokenMatch[1];
+                        }
+                    }
+
                     if (!req.get('authorization')) {
                         return null;
                     }

--- a/core/server/services/routing/controllers/entry.js
+++ b/core/server/services/routing/controllers/entry.js
@@ -12,6 +12,8 @@ const debug = require('ghost-ignition').debug('services:routing:controllers:entr
 module.exports = function entryController(req, res, next) {
     debug('entryController', res.routerOptions);
 
+    res.locals.member = req.member;
+
     return helpers.entryLookup(req.path, res.routerOptions, res.locals)
         .then(function then(lookup) {
             // Format data 1

--- a/core/server/services/routing/helpers/entry-lookup.js
+++ b/core/server/services/routing/helpers/entry-lookup.js
@@ -36,7 +36,7 @@ function entryLookup(postUrl, routerOptions, locals) {
      * @deprecated: `author`, will be removed in Ghost 3.0
      */
     return api[routerOptions.query.controller]
-        .read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,authors,tags'}))
+        .read(_.extend(_.pick(params, 'slug', 'id'), {include: 'author,authors,tags', context: {member: locals.member}}))
         .then(function then(result) {
             const entry = result[routerOptions.query.resource][0];
 

--- a/core/server/web/site/app.js
+++ b/core/server/web/site/app.js
@@ -8,6 +8,7 @@ const apps = require('../../services/apps');
 const constants = require('../../lib/constants');
 const storage = require('../../adapters/storage');
 const urlService = require('../../services/url');
+const members = require('../../services/auth/members');
 const sitemapHandler = require('../../data/xml/sitemap/handler');
 const themeMiddleware = require('../../services/themes').middleware;
 const siteRoutes = require('./routes');
@@ -110,6 +111,9 @@ module.exports = function setupSiteApp(options = {}) {
 
     // Fetch the frontend client into res.locals
     siteApp.use(shared.middlewares.frontendClient);
+
+    // Set req.member if a cookie is set
+    siteApp.use(members.authenticateMembersToken);
 
     debug('General middleware done');
 


### PR DESCRIPTION
@ErisDS This is the Ghost part of members content being rendered on the server. 

The casper part just adds some code to the drop in script which does something along the lines of:
and can be found https://github.com/allouis/Casper/tree/members-serverside

```javascript
onSignin() {
  const token = getToken()
  document.cookie = `member=${token};`;
}

onSignout() {
  document.cookie = 'member=null;';
}
```

If you wanna run this locally you can probably do

```
cd Ghost
git remote add egg git@github.com:allouis/Ghost.git
git fetch egg
git checkout members-serverside
cd content/themes/casper
git remote add egg git@github.com:allouis/Casper.git
git fetch egg
git checkout members-serverside
cd -
node index.js
```

Then create a post with the #members tag and a custom excerpt (optional) and visit the post in the browser
